### PR TITLE
docs: point TIRx link to apache/tvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tirx-kernels
 
-High-performance GPU kernels written in [TIRx](https://github.com/mlc-ai/tir).
+High-performance GPU kernels written in [TIRx](https://github.com/apache/tvm).
 
 ## Kernels
 


### PR DESCRIPTION
## Summary
- Fix the TIRx link in README to point at https://github.com/apache/tvm instead of the stale mlc-ai/tir URL.

## Test plan
- [ ] Open README link target in browser