### PR TITLE
Fix synchronization bugs exposed by Synccheck

### DIFF
--- a/tirx_kernels/attention/flash_attention4.py
+++ b/tirx_kernels/attention/flash_attention4.py
@@ -731,10 +731,14 @@ def _kernel(
                 if apply_mask:
                     apply_causal_mask(s_chunk_buf, m_block_idx, i_kv)
                 row_max_old: T.f32
-                row_max_old = row_max[0]
                 if is_first:
                     Tx.max(tile_max, s_chunk_buf)
                 else:
+                    # row_max is initialized by the first softmax step.  Keep
+                    # its load inside the non-first specialization so the
+                    # first step does not read an uninitialized local value
+                    # whose result is dead on that path.
+                    row_max_old = row_max[0]
                     tile_max[0] = row_max_old
                     Tx.max(tile_max, s_chunk_buf, accum=True)
                 row_max_new: T.f32

--- a/tirx_kernels/gemm/fp8_blockwise_gemm.py
+++ b/tirx_kernels/gemm/fp8_blockwise_gemm.py
@@ -234,9 +234,7 @@ def _kernel(
     tid_in_wg = T.thread_id_in_wg([128])
     lane_id = T.lane_id([32])
     pool = T.SMEMPool()
-    barrier_leader = T.bitwise_and(T.cast(warp_id == 1, "uint32"), T.ptx.elect_sync()) != T.uint32(
-        0
-    )
+    barrier_leader = (wg_id == 0) & (warp_id == 1) & (T.ptx.elect_sync() != T.uint32(0))
     tmem_pool = T.TMEMPool(
         pool,
         total_cols=512,

--- a/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
@@ -223,9 +223,7 @@ def _kernel(
     tid_in_wg = T.thread_id_in_wg([128])
     lane_id = T.lane_id([32])
     pool = T.SMEMPool()
-    barrier_leader = T.bitwise_and(T.cast(warp_id == 1, "uint32"), T.ptx.elect_sync()) != T.uint32(
-        0
-    )
+    barrier_leader = (wg_id == 0) & (warp_id == 1) & (T.ptx.elect_sync() != T.uint32(0))
     tmem_pool = T.TMEMPool(
         pool,
         total_cols=512,


### PR DESCRIPTION
Companion kernel fixes for mlc-ai/tirx-kernels-dev#550.

- elect only warp 1 of warpgroup 0 for shared mbarrier initialization in the FP8 blockwise and grouped kernels
- avoid the first-iteration read of uninitialized row-max storage in FlashAttention-4

Validated on B200:
- FP8 blockwise `scale_slices_swap_ab_m16_n256_k512`: PASS
- grouped FP8 `small_g4_m256_n384_k512`: PASS
- FlashAttention-4 `s1024_h32kv4`: PASS