### PR TITLE
Fix TCGEN synchronization exposed by native Racecheck

### DIFF
--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -779,6 +779,15 @@ def get_kernel(**kwargs: Any):
                 q_pipe.full.wait(q_stage_idx, q_phase)
                 Tx.warp.permute_layout(smem_sf_q_post[q_stage_idx, :], smem_sf_q[q_stage_idx, :])
                 T.ptx.fence.proxy_async("shared::cta")
+                # Each tmem_pipe.full arrive commits all prior asynchronous
+                # TCGEN work from this issuer. Wait for the final commit from
+                # the preceding q block before overwriting its SFQ TMEM input.
+                if tmem_iter_idx > T.uint32(0):
+                    previous_tmem_iter: T.uint32 = tmem_iter_idx - T.uint32(1)
+                    tmem_pipe.full.wait(
+                        previous_tmem_iter % T.uint32(num_tmem_stages),
+                        (previous_tmem_iter // T.uint32(num_tmem_stages)) & T.uint32(1),
+                    )
                 if T.ptx.elect_sync():
                     Tx.copy_async(sfq_tmem, smem_sf_q_cp[T.cast(q_stage_idx, "int32")], cta_group=1)
                 T.cuda.warp_sync()

--- a/tirx_kernels/gemm/nvfp4_gemm.py
+++ b/tirx_kernels/gemm/nvfp4_gemm.py
@@ -379,11 +379,12 @@ def _kernel(
     SFB_tmem = tmem_pool.alloc_sf(
         (128 * SFB_n_chunks, sf_mma_k * MMA_K_BLOCKS), "float8_e4m3fn", sf_per_mma=sf_mma_k
     )
+    # Publish the weak shared-memory store performed by tcgen05.alloc through
+    # the existing cluster release/acquire before any other warp consumes the
+    # TMEM base address.
+    tmem_pool.commit()
     T.ptx.barrier.cluster.arrive(sem="release", aligned=True)
     T.ptx.barrier.cluster.wait(acquire=True, aligned=False)
-    # Alloc TMEM after the cluster sync, warp-0-only, before the role split, so
-    # the TMA warp overlaps its first loads with the alloc.
-    tmem_pool.commit()
     if tid_in_cta < 32:
         T.ptx.tcgen05.relinquish_alloc_permit(cta_group=CTA_GROUP)
     pair_mask: T.int32


### PR DESCRIPTION
## Summary

- wait for the preceding FP4 MQA query block final committed TCGEN work before overwriting the reused SFQ TMEM columns
- move NVFP4 GEMM `tcgen05.alloc` before the existing cluster release/acquire, publishing its weak shared-memory address store before any other warp consumes `tmem_pool.addr`
- leave FlashAttention4 unchanged; the corrected Racecheck implicit-MMA pipeline model does not require kernel-side waits
- add no test-only or stress configuration to the kernel package

PTX defines the `tcgen05.alloc` destination store as a weak memory operation. The original NVFP4 ordering placed that store after its only cluster release/acquire, so the epilogue warp shared-address read had no happens-before edge. The change reuses the existing barrier instead of adding a new synchronization operation.

These fixes are the canonical-kernel dependency pinned by [tirx-kernels-dev#558](https://github.com/mlc-ai/tirx-kernels-dev/pull/558).

## Validation

- kernel package: `python -m pytest -q` — 2 passed
- lint: `python -m ruff check .` — passed
- tirx-wiki validation — passed
- targeted native Racecheck for FP4 MQA and NVFP4 — 5 passed
- targeted native Synccheck for FP4 MQA and NVFP4 — 2 passed
- related NumSim corpus fixtures — 19 passed
- NVFP4 GPU correctness, `1024x1024x1024` — passed
- custom FP4 MQA two-SM repeated SFQ-reuse GPU validation — 20 consecutive runs, worst output difference 0
- FP4 MQA `2048x4096` kernel-only timing — 54.560 us; the prior four-case wait/no-wait A/B measured at most +0.49% overhead
