### PR TITLE
Add proxy fences to MQA shared stage reuse

### DIFF
--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -906,6 +906,9 @@ def get_kernel(**kwargs: Any):
                 q_pipe.full.wait(q_stage_idx, q_phase)
                 if num_kv_blocks > T.uint32(0):
                     Tx.warpgroup.copy(cached_weights, smem_weights[q_stage_idx])
+                    # Publish the generic-proxy weight reads before this
+                    # consumer releases the Q stage for a later TMA overwrite.
+                    T.ptx.fence.proxy_async("shared::cta")
                     for q_off_i in T.unroll(0, block_q):
                         q_row_offsets[q_off_i] = T.cast(
                             q_idx * T.uint32(block_q) + T.uint32(q_off_i), "uint64"

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -716,6 +716,9 @@ def get_kernel(**kwargs: Any):
                             "f32",
                             space="shared",
                         )
+                # Publish the generic-proxy weight reads before this consumer
+                # eventually releases the Q stage for a subsequent TMA overwrite.
+                T.ptx.fence.proxy_async("shared::cta")
                 kv_idx: T.uint32 = T.uint32(0)
                 while kv_idx < num_kv_blocks:
                     kv_stage_idx: T.uint32 = (num_total_kv_blocks + kv_idx) % T.uint32(
@@ -734,6 +737,9 @@ def get_kernel(**kwargs: Any):
                     umma_pipe.full.wait(
                         warpgroup_idx_local, (num_total_kv_blocks + kv_idx) & T.uint32(1)
                     )
+                    # Order the generic-proxy scale read before the producer
+                    # reuses this KV stage through the async proxy.
+                    T.ptx.fence.proxy_async("shared::cta")
                     kv_pipe.empty.arrive(kv_stage_idx)
                     kv_offset: T.uint32 = kv_start + kv_idx * T.uint32(block_kv) + math_thread_idx
                     for q_inner_i in T.unroll(0, block_q):


### PR DESCRIPTION
## Summary

- publish the FP4 MQA Q-stage generic shared-memory reads before the stage is released for a later TMA overwrite
- publish the FP8 MQA weight and scale reads before their Q/KV stages are released for async-proxy reuse
- prevent generic/async shared-proxy races without changing the pipeline schedule

## Testing

- native Racecheck across 8 FP4/FP8 MQA configurations
