### PR TITLE
fix(gemm): fence NVFP4 mbarrier initialization

### DIFF
--- a/tirx_kernels/gemm/nvfp4_gemm.py
+++ b/tirx_kernels/gemm/nvfp4_gemm.py
@@ -365,6 +365,8 @@ def _kernel(
     tmem_finished = MBarrier(pool, 1, leader=mbar_leader)
     tmem_finished.init(1)
     pool.commit()
+    if mbar_leader:
+        T.ptx.fence.mbarrier_init()
     tmem_pool = T.TMEMPool(pool, total_cols=512, cta_group=CTA_GROUP, tmem_addr=tmem_addr)
     tmem = tmem_pool.alloc((CTA_M, 512), "float32")
     A_smem = A_smem_packed.view("float4_e2m1fn")


### PR DESCRIPTION
## Summary

- issue `fence.mbarrier_init` from the same `mbar_leader` that initializes the NVFP4 pipeline barriers
- keep the existing cluster release/acquire publication path unchanged before any barrier first-use

## Testing

- targeted full-launch NVFP4 Synccheck + Racecheck: `2 passed`
- `python -m pytest -q`: `2 passed`
- `python -m ruff check tirx_kernels/gemm/nvfp4_gemm.py`
- `python -m ruff format --check tirx_kernels/gemm/nvfp4_gemm.py`
- `python -m tirx_kernels.registry --format json`
