### PR TITLE
fix(gemm): guard grouped FP8 MMA issue explicitly

### DIFF
--- a/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
@@ -407,8 +407,8 @@ def _kernel(
             accum: T.int32
             mma_issue: T.uint32
 
-            # Keep waits and pipeline state warp-uniform so ptxas can use URs;
-            # elect a single lane only for tcgen05 issue and commit instructions.
+            # Keep waits and pipeline state warp-uniform; elect a single lane
+            # only for tcgen05 issue and commit instructions.
             @T.inline
             def mma(ks, sf_off: T.constexpr, copy_sf: T.constexpr):
                 ks_desc: T.int32
@@ -428,7 +428,6 @@ def _kernel(
                             accum=accum,
                             dispatch="tcgen05",
                             cta_group=CTA_GROUP,
-                            pred=mma_issue,
                         )
                     else:
                         Tx.gemm_async(
@@ -440,7 +439,6 @@ def _kernel(
                             accum=accum,
                             dispatch="tcgen05",
                             cta_group=CTA_GROUP,
-                            pred=mma_issue,
                         )
 
                 mma_issue = T.ptx.elect_sync()
@@ -448,10 +446,12 @@ def _kernel(
                     if mma_issue:
                         Tx.copy_async(SFA_tmem[tmem_idx], SFA_smem_fp8[ks], cta_group=CTA_GROUP)
                         Tx.copy_async(SFB_tmem[tmem_idx], SFB_smem_fp8[ks], cta_group=CTA_GROUP)
-                gemm_with_sf(sf_off)
+                if mma_issue:
+                    gemm_with_sf(sf_off)
                 accum = 1
                 T.cuda.warp_sync()
-                smem_pipe.empty.arrive(ks, cta_group=CTA_GROUP, cta_mask=CTA_MASK, pred=mma_issue)
+                if mma_issue:
+                    smem_pipe.empty.arrive(ks, cta_group=CTA_GROUP, cta_mask=CTA_MASK)
                 T.cuda.warp_sync()
 
             @T.inline
@@ -470,9 +470,8 @@ def _kernel(
                     mma_state.advance()
                     mma(mma_state.stage, 3 * K_ITERS, False)
                     mma_state.advance()
-                tmem_pipe.full.arrive(
-                    tmem_idx, cta_group=CTA_GROUP, cta_mask=CTA_MASK, pred=mma_issue
-                )
+                if mma_issue:
+                    tmem_pipe.full.arrive(tmem_idx, cta_group=CTA_GROUP, cta_mask=CTA_MASK)
                 T.cuda.warp_sync()
 
             while tile_scheduler.valid():


### PR DESCRIPTION
## Motivation

`grouped_fp8_gemm_contiguous` currently relies on the proposed
`Tx.gemm_async(..., pred=...)` API to issue `tcgen05` MMA and commit operations
from one elected lane. It is the only known kernel using that API.

A B200 A/B comparison showed that guarding the issue operations with the
existing `if mma_issue:` form does not cause a measurable regression, and
ptxas still uses uniform registers for the MMA descriptor path. Keeping the
kernel on the existing explicit-guard form avoids requiring the additional TVM
API proposed in https://github.com/apache/tvm/pull/20072.

## Summary

- guard `gemm_async` with the elected-lane predicate instead of passing it as an
  instruction predicate
- apply the same explicit guard to the matching SMEM and TMEM pipeline arrivals
- keep waits, pipeline state updates, and warp synchronization warp-uniform

## Validation

- `pre-commit run --files tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py`
- packaged GPU correctness tests on B200: `2 passed`
- Synccheck: clean, 0 findings
- Racecheck: no errors; only the two existing auditable
  `alias_stale_read` reviews for the SFA/SFB post-layout views
- production A/B output: bitwise equal

Representative B200 benchmark
(`num_groups=4, M=32160, N=4096, K=4096`, same inputs and output address,
300 initial A/B pairs, 60 order-alternating rounds, 25 launches per sample):

| Version | Mean latency |
| --- | ---: |
| `pred=mma_issue` | 417.933 us |
| explicit `if mma_issue:` | 418.457 us |

The order-balanced median delta was `+0.028%`, with a bootstrap 95% interval
of `[-0.093%, +0.195%]`, so the difference is not distinguishable from noise.
Across the seven production configurations runnable with the current compiler,
the order-balanced deltas ranged from `-0.105%` to `+0.120%`.
