### PR TITLE
refactor(kernel): adopt flattened tvm backend operator paths

### DIFF
--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1527,8 +1527,8 @@ def get_kernel(
     emit_nvl_barrier_timeout_printf: bool = True,
 ):
     from tvm.backend.cuda.op import cuda_func_call
-    from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.tirx.layout import S, TCol, TileLayout, TLane
 

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -307,11 +307,11 @@ def _mqa_fp4_wrelu_reduce_src(num_heads: int) -> str:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import (
+    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import (
         sf_smem_layout,
         sf_tmem_layout,
     )
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import MBarrier, Pipeline

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -305,7 +305,7 @@ def _mqa_fp8_wrelu_reduce_src(num_heads: int) -> str:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -352,7 +352,7 @@ class TF32HCBenchCase:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline, TCGen05Bar

--- a/tirx_kernels/flashmla/sparse_decode_head64.py
+++ b/tirx_kernels/flashmla/sparse_decode_head64.py
@@ -12,7 +12,7 @@ import torch
 
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._tma import tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.ir import PointerType, PrimType
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import leader_mbar, tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import leader_mbar, tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/gemm/fp16_bf16_gemm.py
+++ b/tirx_kernels/gemm/fp16_bf16_gemm.py
@@ -30,7 +30,7 @@ _DTYPE_MAP = {"fp16": tvm.DataType("float16"), "bf16": tvm.DataType("bfloat16")}
 def _swizzle_for_row_bytes(row_bytes):
     """Pick the MMA-shared swizzle atom matching the tile row width (the 128/64/32B
     swizzle is selected from the row byte width)."""
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 
     if row_bytes % 128 == 0:
         return SwizzleMode.SWIZZLE_128B_ATOM

--- a/tirx_kernels/gemm/fp8_blockwise_gemm.py
+++ b/tirx_kernels/gemm/fp8_blockwise_gemm.py
@@ -6,7 +6,7 @@ import os
 import torch
 from deep_gemm.utils.math import per_block_cast_to_fp8, per_token_cast_to_fp8
 
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench

--- a/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
@@ -12,7 +12,7 @@ from tvm.backend.loader import load
 load("cuda")
 
 import tvm
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench

--- a/tirx_kernels/gemm/nvfp4_gemm.py
+++ b/tirx_kernels/gemm/nvfp4_gemm.py
@@ -11,8 +11,8 @@ import torch
 from flashinfer import SfLayout, nvfp4_quantize
 
 import tvm
-from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import sf_smem_layout
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_smem_layout
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench


### PR DESCRIPTION
## Summary

Companion to apache/tvm#20081: tvm moved `backend/cuda/operator/{intrinsics,tile_primitive}` up to `backend/cuda/` and removed the pass-through `operator` package. This updates the kernel imports to the new paths (12 files, one line each).

The branch is cherry-picked onto upstream `main`; the fork-only megakernel package is not part of this PR, and its one overlapping file (`tirx_kernels/megakernel/kernels/gemm.py`) is therefore untouched here.

**Depends on the tvm PR landing first** — without it these imports fail.

## Test

- `tirx_kernels.registry --cc 10 --strict` import gate: green (against the tvm PR's tree).
- The fork-side equivalents of this change passed the full TIRx suite on 8x B200: `2620 passed, 41 skipped, 3 xpassed`, with `bench_suite --check-imports` and registry gates green.
