### PR TITLE
feat(kernel): add flashkda bf16 fused m128 recurrent KDA prefill kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ All kernels target `sm_100a`. Names are the registry names accepted by the
 | `nvfp4_gemm` | nvfp4 | Dense GEMM |
 | `flash_attention4` | bf16 | FlashAttention-4 |
 | `rmsnorm` | fp16 / bf16 | RMSNorm |
+| `megakernel_moe` | bf16 | Fused MoE megakernel |
 | `allgather_gemm` | fp16 | AllGather + GEMM (multi-GPU, NVSHMEM) |
 | `gemm_reduce_scatter` | fp16 | GEMM + ReduceScatter (multi-GPU, NVSHMEM) |
 
@@ -36,7 +37,7 @@ DeepGEMM ports:
 | `deepgemm_sm100_fp4_paged_mqa_logits` | fp4 / bf16 | Paged-KV MQA attention logits |
 | `deepgemm_sm100_fp8_paged_mqa_logits` | fp8 / bf16 | Paged-KV MQA attention logits |
 | `deepgemm_sm100_tf32_hc_prenorm_gemm` | tf32 / bf16 | Prenorm GEMM |
-| `deepgemm_fp8_fp4_mega_moe` | fp8 + fp4 | Fused MoE (MegaMoE) |
+| `deepgemm_fp8_fp4_mega_moe` | fp8 + fp4 | Fused MoE megakernel (MegaMoE) |
 
 ## Performance
 
@@ -66,7 +67,7 @@ them — they are only needed to actually compile/run a kernel:
 | `tvm.tirx`       | all kernels (compile + run)        | The TIRx compiler. Put it on `PYTHONPATH`, e.g. `/path/to/tir/python`. |
 | `torch`          | all kernels                        | CUDA build matching your GPU.                          |
 | `deep_gemm`      | FP8 GEMM and `deepgemm_*` baselines | Used for optimized reference kernels. |
-| `flashinfer`     | `nvfp4_gemm` data/baseline | Used for nvfp4 quantization and reference impls. |
+| `flashinfer`     | `nvfp4_gemm` data/baseline, `megakernel_moe` baseline | Used for nvfp4 quantization and reference impls. |
 | `sglang` (+ CUTLASS DSL) | `deepgemm_sm100_fp8_paged_mqa_logits` reference | `sglang_cutedsl` reference; checkout on `PYTHONPATH`. |
 | `flash_mla`      | `sparse_flashmla_*` / `flash_mla_sparse_fwd` baselines | Reference impls. |
 | NVSHMEM          | `allgather_gemm`, `gemm_reduce_scatter` | Required to compile/run the GemmComm kernels. |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ FlashKDA ports (FlashInfer frozen kernels):
 | ------ | ----- | ---------- |
 | `flashkda_bf16_fused_m128` | bf16 | Recurrent KDA prefill, M128 schedule |
 
+Testing/benching against the `flashinfer_frozen_m128` reference requires
+`FLASHKDA_PR_WORKTREE` pointing at the flashinfer-ai/flashinfer#4262 head
+worktree (which contains the frozen m128 kernel).
+
 ## Performance
 
 Per-workload numbers — our kernel time, every reference impl, and the

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ DeepGEMM ports:
 | `deepgemm_sm100_tf32_hc_prenorm_gemm` | tf32 / bf16 | Prenorm GEMM |
 | `deepgemm_fp8_fp4_mega_moe` | fp8 + fp4 | Fused MoE megakernel (MegaMoE) |
 
+FlashKDA ports (FlashInfer frozen kernels):
+
+| Kernel | dtype | What it is |
+| ------ | ----- | ---------- |
+| `flashkda_bf16_fused_m128` | bf16 | Recurrent KDA prefill, M128 schedule |
+
 ## Performance
 
 Per-workload numbers — our kernel time, every reference impl, and the

--- a/tests/test_bench_suite.py
+++ b/tests/test_bench_suite.py
@@ -12,6 +12,8 @@ from tirx_kernels.bench_suite.baseline_view import render_markdown
 from tirx_kernels.bench_suite.ratio_diff import build_report
 from tirx_kernels.gemm_comm.allgather_gemm import CONFIGS as ALLGATHER_GEMM_CONFIGS
 from tirx_kernels.gemm_comm.gemm_reduce_scatter import CONFIGS as GEMM_RS_CONFIGS
+from tirx_kernels.megakernel.moe import BENCH_CONFIGS as MEGAKERNEL_MOE_BENCH_CONFIGS
+from tirx_kernels.megakernel.moe import _estimate_bench_launch_slots
 
 
 class _ScheduledJobsPool:
@@ -50,6 +52,17 @@ def test_finalize_bench_record_rejects_baseline_errors() -> None:
     assert row["error"] == "baseline error(s): deepgemm: setup failed"
 
 
+def test_default_workloads_include_full_megakernel_moe_sweep() -> None:
+    workloads = run.load_workloads(run.DEFAULT_WORKLOADS)
+    megakernel_moe_workloads = [w for w in workloads if w["kernel"] == "megakernel_moe"]
+
+    assert {w["config"] for w in megakernel_moe_workloads} == {
+        config["label"] for config in MEGAKERNEL_MOE_BENCH_CONFIGS
+    }
+    assert all(w["num_gpus"] == 1 for w in megakernel_moe_workloads)
+    assert all("timer" not in w for w in megakernel_moe_workloads)
+
+
 def test_default_workloads_include_manual_tp1_gemm_comm_kineto_profiles() -> None:
     workloads = run.load_workloads(run.DEFAULT_WORKLOADS)
     selected = [
@@ -83,6 +96,17 @@ def test_bench_suite_defaults_to_five_round_arithmetic_mean() -> None:
     assert row["status"] == "ok"
 
 
+def test_megakernel_moe_launch_slots_include_runtime_estimate_headroom() -> None:
+    slots = _estimate_bench_launch_slots(
+        runtime_us=1000.0, warmup=None, repeat=None, rounds=5, preflight_launches=1
+    )
+
+    # Defaults produce 25 warmup and 100 repeat launches.  Capacity includes
+    # 25% headroom on those runtime-derived loops, while keeping the one-call
+    # setup, five-call estimate, and final guard unchanged.
+    assert slots == 1 + 5 * (1 + 5 + 157) + 16
+
+
 def test_default_workloads_do_not_override_standard_timer_budgets() -> None:
     workloads = run.load_workloads(run.DEFAULT_WORKLOADS)
 
@@ -100,7 +124,7 @@ def test_ratio_report_keeps_grouped_tir_schedulers_out_of_references() -> None:
     baseline = {
         "results": [
             {
-                "kernel": "grouped_moe",
+                "kernel": "megakernel_moe",
                 "label": "moe_a3b_bs1_all",
                 "status": "ok",
                 "impls": {
@@ -116,7 +140,7 @@ def test_ratio_report_keeps_grouped_tir_schedulers_out_of_references() -> None:
     current = {
         "results": [
             {
-                "kernel": "grouped_moe",
+                "kernel": "megakernel_moe",
                 "label": "moe_a3b_bs1_all",
                 "status": "ok",
                 "impls": {
@@ -133,9 +157,9 @@ def test_ratio_report_keeps_grouped_tir_schedulers_out_of_references() -> None:
     report, regressions = build_report(baseline, current)
 
     assert regressions == 0
-    assert "| grouped_moe | moe_a3b_bs1_all | tir_static | sglang_full |" in report
-    assert "| grouped_moe | moe_a3b_bs1_all | tir_dynamic | sglang_full |" in report
-    assert "| grouped_moe | moe_a3b_bs1_all | tir_unfused | sglang_full |" in report
+    assert "| megakernel_moe | moe_a3b_bs1_all | tir_static | sglang_full |" in report
+    assert "| megakernel_moe | moe_a3b_bs1_all | tir_dynamic | sglang_full |" in report
+    assert "| megakernel_moe | moe_a3b_bs1_all | tir_unfused | sglang_full |" in report
 
 
 def test_baseline_view_renders_grouped_implementations_in_one_row() -> None:
@@ -145,7 +169,7 @@ def test_baseline_view_renders_grouped_implementations_in_one_row() -> None:
         "git": {},
         "results": [
             {
-                "kernel": "grouped_moe",
+                "kernel": "megakernel_moe",
                 "label": "moe_a3b_bs128_all",
                 "status": "ok",
                 "impls": {
@@ -157,7 +181,7 @@ def test_baseline_view_renders_grouped_implementations_in_one_row() -> None:
                 },
             },
             {
-                "kernel": "grouped_moe",
+                "kernel": "megakernel_moe",
                 "label": "moe_a3b_bs1_all",
                 "status": "ok",
                 "impls": {

--- a/tests/test_megakernel_runtime.py
+++ b/tests/test_megakernel_runtime.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Runtime tests for MegaKernelMOE."""
+
+import pytest
+
+from tirx_kernels.megakernel import moe
+from tirx_kernels.runner import run_kernel_test
+
+
+@pytest.mark.parametrize("batch_size", [1, 128])
+def test_megakernel_moe(batch_size):
+    run_kernel_test("megakernel_moe", {"batch_size": batch_size, "world_size": 1})
+
+
+def test_run_test_all_schedulers_uses_flashinfer_reference_once(monkeypatch):
+    compiled = []
+    tir_runs = []
+    reference_builds = {}
+    reference_calls = {"flashinfer": 0}
+    validations = []
+    synchronizations = []
+
+    def compile_schedulers(schedulers, batch_size, world_size, profiler_on):
+        compiled.append((schedulers, batch_size, world_size, profiler_on))
+        return object(), {scheduler: object() for scheduler in schedulers}
+
+    def make_tir_case(*, scheduler, **kwargs):
+        return {"scheduler": scheduler}
+
+    def build_reference(name):
+        def build(*args, **kwargs):
+            reference_builds[name] = (args, kwargs)
+
+            def run(case):
+                reference_calls[name] += 1
+                return name
+
+            return run
+
+        return build
+
+    monkeypatch.setattr(moe, "_require_cuda_sm100", lambda: None)
+    monkeypatch.setattr(moe, "_compile_moe_schedulers", compile_schedulers)
+    monkeypatch.setattr(moe, "_reset_prepare_data_cache", lambda: None)
+    monkeypatch.setattr(moe, "prepare_data", lambda batch_size, mk: {})
+    monkeypatch.setattr(moe, "_make_tir_case", make_tir_case)
+    monkeypatch.setattr(
+        moe,
+        "_run_tir_case_and_check_finite",
+        lambda case: tir_runs.append(case["tir"]["scheduler"]),
+    )
+    monkeypatch.setattr(moe, "_build_flashinfer_full_reference", build_reference("flashinfer"))
+    monkeypatch.setattr(
+        moe,
+        "_build_sglang_full_reference",
+        lambda mk: pytest.fail("run_test must not build the SGLang benchmark reference"),
+    )
+    monkeypatch.setattr(
+        moe,
+        "_validate_tir_matches_reference",
+        lambda case, reference: validations.append((case["tir"]["scheduler"], reference)),
+    )
+    monkeypatch.setattr(moe.torch.cuda, "synchronize", lambda: synchronizations.append(True))
+
+    moe.run_test(batch_size=512)
+
+    assert compiled == [(moe._SUPPORTED_SCHEDULERS, 512, 1, False)]
+    assert tir_runs == list(moe._SUPPORTED_SCHEDULERS)
+    assert reference_builds["flashinfer"][1] == {"tune": False}
+    assert reference_calls == {"flashinfer": 1}
+    assert validations == [(scheduler, "flashinfer") for scheduler in moe._SUPPORTED_SCHEDULERS]
+    assert synchronizations == [True]

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -1255,6 +1255,142 @@
       }
     },
     {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs1024_all",
+      "label": "moe_a3b_bs1024_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 260.3319666727019,
+        "tir_dynamic": 256.43904246586357,
+        "tir_unfused": 274.0186843046738,
+        "sglang_full": 335.96671631802514,
+        "flashinfer_full": 311.66465435466444
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs128_all",
+      "label": "moe_a3b_bs128_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 223.41903075120936,
+        "tir_dynamic": 219.2493048823826,
+        "tir_unfused": 227.14321488461698,
+        "sglang_full": 245.05980521395728,
+        "flashinfer_full": 248.44393300216663
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs1_all",
+      "label": "moe_a3b_bs1_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 33.65353503563663,
+        "tir_dynamic": 36.96890793226583,
+        "tir_unfused": 34.79088707144742,
+        "sglang_full": 56.010359334512906,
+        "flashinfer_full": 65.07261364403668
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs2048_all",
+      "label": "moe_a3b_bs2048_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 338.4891929120119,
+        "tir_dynamic": 339.494418456061,
+        "tir_unfused": 357.90457684533663,
+        "sglang_full": 431.9870584377305,
+        "flashinfer_full": 391.46567872632227
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs32_all",
+      "label": "moe_a3b_bs32_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 190.32097997810504,
+        "tir_dynamic": 192.191575597882,
+        "tir_unfused": 199.6875291155722,
+        "sglang_full": 223.84275606220038,
+        "flashinfer_full": 222.42723208004705
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs4096_all",
+      "label": "moe_a3b_bs4096_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 563.0525144385831,
+        "tir_dynamic": 558.4132929411765,
+        "tir_unfused": 573.442198088161,
+        "sglang_full": 665.7489859807733,
+        "flashinfer_full": 606.7888952492668
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs512_all",
+      "label": "moe_a3b_bs512_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 237.77595029894752,
+        "tir_dynamic": 230.41276427433954,
+        "tir_unfused": 243.28616138718203,
+        "sglang_full": 288.8538545087485,
+        "flashinfer_full": 276.8774290678039
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "megakernel_moe",
+      "config": "moe_a3b_bs8_all",
+      "label": "moe_a3b_bs8_all",
+      "status": "ok",
+      "impls": {
+        "tir_static": 95.6029155826643,
+        "tir_dynamic": 99.94910741421258,
+        "tir_unfused": 104.51417933669386,
+        "sglang_full": 129.94199100683306,
+        "flashinfer_full": 134.83030262942145
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
       "kernel": "nvfp4_gemm",
       "config": "1024x1024x1024",
       "label": "1024x1024x1024",

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -3,7 +3,7 @@
 - Timestamp: `14`
 - Label:     `post-refactor`
 - Git:       `{'tir': 'fabb698a', 'tirx-kernels': '6c2af771', 'tirx-bench-ci': None}`
-- Workloads: 105 ok, 0 failed
+- Workloads: 113 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -149,6 +149,19 @@ Grouped workloads show one row per config and one timing column per implementati
 | `large_g8_m4096_n4096_k4096` | tir | 354.3510 | deepgemm | 359.8891 | 1.016 | — |
 | `large_g8_m4096_n6144_k7168` | tir | 1071.8308 | deepgemm | 1095.4849 | 1.022 | — |
 | `large_g8_m4096_n7168_k3072` | tir | 506.7036 | deepgemm | 535.0379 | 1.056 | — |
+
+## megakernel_moe
+
+| config | tir_static (µs) | tir_dynamic (µs) | tir_unfused (µs) | sglang_full (µs) | flashinfer_full (µs) |
+|---|---:|---:|---:|---:|---:|
+| `moe_a3b_bs1_all` | 33.6535 | 36.9689 | 34.7909 | 56.0104 | 65.0726 |
+| `moe_a3b_bs8_all` | 95.6029 | 99.9491 | 104.5142 | 129.9420 | 134.8303 |
+| `moe_a3b_bs32_all` | 190.3210 | 192.1916 | 199.6875 | 223.8428 | 222.4272 |
+| `moe_a3b_bs128_all` | 223.4190 | 219.2493 | 227.1432 | 245.0598 | 248.4439 |
+| `moe_a3b_bs512_all` | 237.7760 | 230.4128 | 243.2862 | 288.8539 | 276.8774 |
+| `moe_a3b_bs1024_all` | 260.3320 | 256.4390 | 274.0187 | 335.9667 | 311.6647 |
+| `moe_a3b_bs2048_all` | 338.4892 | 339.4944 | 357.9046 | 431.9871 | 391.4657 |
+| `moe_a3b_bs4096_all` | 563.0525 | 558.4133 | 573.4422 | 665.7490 | 606.7889 |
 
 ## nvfp4_gemm
 

--- a/tirx_kernels/bench_suite/workloads.yaml
+++ b/tirx_kernels/bench_suite/workloads.yaml
@@ -34,6 +34,22 @@ workloads:
   config: tp1_m8192_n16384_k53248_fp16_dynamic
   timer: kineto
   num_gpus: 1
+- kernel: megakernel_moe
+  config: moe_a3b_bs1_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs8_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs32_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs128_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs512_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs1024_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs2048_all
+- kernel: megakernel_moe
+  config: moe_a3b_bs4096_all
 - kernel: deepgemm_fp8_fp4_mega_moe
   config: t64_m64_h7168_i3072_e384_k6_g1
   timer: megamoe

--- a/tirx_kernels/bench_suite/workloads_flashkda_bf16_fused_m128.yaml
+++ b/tirx_kernels/bench_suite/workloads_flashkda_bf16_fused_m128.yaml
@@ -1,0 +1,13 @@
+# Complete in-scope performance matrix for the FlashKDA bf16 fused m128
+# (SM100) port: exactly the module's five BENCH_CONFIGS cases, covering the
+# head-count / packed / state variants that dispatch to this kernel.
+
+defaults:
+  # Timer, warmup, repeat, rounds, and cooldown use bench-suite defaults.
+
+workloads:
+  - {kernel: flashkda_bf16_fused_m128, config: h96_fixed8192}
+  - {kernel: flashkda_bf16_fused_m128, config: h96_mixed}
+  - {kernel: flashkda_bf16_fused_m128, config: h96_uniform}
+  - {kernel: flashkda_bf16_fused_m128, config: h64_mixed}
+  - {kernel: flashkda_bf16_fused_m128, config: h64_uniform}

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1527,8 +1527,8 @@ def get_kernel(
     emit_nvl_barrier_timeout_printf: bool = True,
 ):
     from tvm.backend.cuda.op import cuda_func_call
-    from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.tirx.layout import S, TCol, TileLayout, TLane
 

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -307,11 +307,11 @@ def _mqa_fp4_wrelu_reduce_src(num_heads: int) -> str:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import (
+    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import (
         sf_smem_layout,
         sf_tmem_layout,
     )
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import MBarrier, Pipeline

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -305,7 +305,7 @@ def _mqa_fp8_wrelu_reduce_src(num_heads: int) -> str:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -352,7 +352,7 @@ class TF32HCBenchCase:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
     from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline, TCGen05Bar

--- a/tirx_kernels/flashkda/__init__.py
+++ b/tirx_kernels/flashkda/__init__.py
@@ -1,0 +1,1 @@
+"""FlashKDA kernel ports."""

--- a/tirx_kernels/flashkda/bf16_fused_m128.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128.py
@@ -112,9 +112,6 @@ TMA_SLOT_OUT = 640
 
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
 
-# PR head worktree that contains the frozen m128 kernel (flashinfer-ai/flashinfer#4262).
-_FLASHKDA_PR_WORKTREE_DEFAULT = "/home/bohanhou/worktree/recurrent-kda/flashinfer-pr4262"
-
 # ---------------------------------------------------------------------------
 # CUDA device helpers, transcribed in source order from
 # csrc/kda/flashkda_bf16_fused_m128.cu:110-496.
@@ -130,13 +127,6 @@ _FLASHKDA_SRCS = {
     asm volatile(
         "fence.proxy.tensormap::generic.acquire.gpu [%0], 128;\n"
         :: "l"(tmap_ptr) : "memory");
-}
-""",
-    "flashkda_cp_async_cg_16_zfill": r"""// .cu:1280-1281 (cp.async.cg 16B with src-size zero-fill predicate)
-__device__ __forceinline__ void flashkda_cp_async_cg_16_zfill(
-    int dst, const void *src, int src_bytes) {
-    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
-        :: "r"(dst), "l"(src), "r"(src_bytes));
 }
 """,
     "flashkda_tanh_approx": r"""// tanh.approx.f32 (sigmoid via tanh; used throughout the prep role)
@@ -235,18 +225,6 @@ def _mma_final_2step(taddr_d, b_lo, taddr_a, enable_d):
                 pred=leader,
             )
         )
-
-
-def _cp_async_cg_16_zfill(dst, src, src_bytes):
-    # .cu:1280-1281 (cp.async.cg 16B with src-size zero-fill predicate)
-    return T.cuda.func_call(
-        "flashkda_cp_async_cg_16_zfill",
-        dst,
-        src,
-        src_bytes,
-        source_code=_FLASHKDA_SRCS["flashkda_cp_async_cg_16_zfill"],
-        return_type="void",
-    )
 
 
 def _ld_global_v4_u32(dst, ptr):
@@ -895,10 +873,23 @@ def _reference_torch(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
 def _load_frozen_recurrent_kda():
     """Import flashinfer.recurrent_kda from the PR head worktree (frozen m128).
 
+    The worktree (flashinfer-ai/flashinfer#4262 head, which contains the frozen
+    m128 kernel) is located via the FLASHKDA_PR_WORKTREE environment variable.
     Handles the case where an installed flashinfer (main, without kda.py) was
     already imported by purging it and re-importing from the worktree.
     """
-    worktree = os.environ.get("FLASHKDA_PR_WORKTREE", _FLASHKDA_PR_WORKTREE_DEFAULT)
+    worktree = os.environ.get("FLASHKDA_PR_WORKTREE")
+    if worktree is None:
+        try:
+            from flashinfer.kda import recurrent_kda
+
+            return recurrent_kda
+        except ImportError as e:
+            raise RuntimeError(
+                "flashinfer.kda is unavailable; set FLASHKDA_PR_WORKTREE to the "
+                "flashinfer-ai/flashinfer#4262 head worktree containing the "
+                "frozen m128 kernel"
+            ) from e
     if worktree not in sys.path:
         sys.path.insert(0, worktree)
     import flashinfer
@@ -1650,19 +1641,13 @@ def _kernel(
                             True,
                             4,
                             ".b16",
-                            smem_raw.ptr_to(
-                                [
-                                    T.cast(out_stage_addr, "uint32")
-                                    - smem
-                                    + T.cast(stsm_offset, "uint32")
-                                ]
-                            ),
+                            smem_raw.ptr_to([T.cast(out_stage_addr, "uint32") - smem + T.cast(stsm_offset, "uint32")]),
                             T.address_of(out_packed[pack_base]),
                             T.address_of(out_packed[pack_base + 1]),
                             T.address_of(out_packed[pack_base + 2]),
                             T.address_of(out_packed[pack_base + 3]),
                             shape="m8n8",
-                        )
+                        )  # fmt: skip
                 _fence_async_shared()  # .cu:1050
                 T.ptx.bar.sync(9, 128)  # .cu:1051
                 if epilogue_local_warp == 0:  # .cu:1052-1057
@@ -1898,13 +1883,13 @@ def _kernel(
                     v_src: T.int64 = (
                         token * T.cast(h, "int64") + T.cast(head_idx_2, "int64")
                     ) * 128 + T.cast(segment * 8, "int64")  # .cu:1279
-                    _cp_async_cg_16_zfill(
-                        smem_v_addr
-                        + T.cast(load_stage, "int32") * 41984
-                        + (row * 128 + segment * 8) * 2,
+                    T.ptx.cp_async(
+                        smem_raw.ptr_to([SMEM_SMEM_V_OFF + T.cast(load_stage, "int32") * 41984 + (row * 128 + segment * 8) * 2]),
                         v.ptr_to([v_src]),
-                        T.if_then_else(token_valid != 0, 16, 0),
-                    )  # .cu:1280-1281
+                        16,
+                        predicate=token_valid,
+                        fill_mode="zero",
+                    )  # .cu:1280-1281  # fmt: skip
                 T.ptx.cp_async.commit_group()  # .cu:1283
                 T.ptx.cp_async.wait_group(0)  # .cu:1284
             T.ptx.bar.sync(8, 32)  # .cu:1286 barrier.sync 8, 32
@@ -1978,14 +1963,9 @@ def _kernel(
                 if prep_local_warp == 0:  # .cu:1349-1357
                     if T.ptx.elect_sync():
                         _mbarrier_arrive_expect_tx(
-                            smem_raw.ptr_to(
-                                [
-                                    (mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8)
-                                    - T.cast(smem, "int32")
-                                ]
-                            ),
+                            smem_raw.ptr_to([(mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8) - T.cast(smem, "int32")]),
                             8704,
-                        )  # .cu:1351
+                        )  # .cu:1351  # fmt: skip
                         _tma_3d_gmem2smem(
                             smem_raw,
                             T.cast(smem, "int32"),
@@ -2006,14 +1986,9 @@ def _kernel(
                             mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8,
                         )  # .cu:1353
                         _mbarrier_arrive_expect_tx(
-                            smem_raw.ptr_to(
-                                [
-                                    (mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8)
-                                    - T.cast(smem, "int32")
-                                ]
-                            ),
+                            smem_raw.ptr_to([(mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8) - T.cast(smem, "int32")]),
                             16384,
-                        )  # .cu:1354
+                        )  # .cu:1354  # fmt: skip
                         _tma_4d_gmem2smem(
                             smem_raw,
                             T.cast(smem, "int32"),
@@ -2036,11 +2011,8 @@ def _kernel(
                     beta_raw_pair[0] = _ld_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_beta_raw_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + lane * 16
-                        + head_idx_3 % 8 // 2 * 4,
-                    )  # .cu:1361
+                        smem_beta_raw_addr + T.cast(prep_stage, "int32") * 41984 + lane * 16 + head_idx_3 % 8 // 2 * 4,
+                    )  # .cu:1361  # fmt: skip
                     beta_raw_pair_fp32: T.f32[2]  # .cu:1362
                     for _pair in T.unroll(1):  # .cu:1363-1372
                         beta_raw_pair_fp32[_pair * 2] = T.cuda.uint_as_float(
@@ -2101,11 +2073,13 @@ def _kernel(
                     gate_load_base: T.int64 = (
                         gate_load_token * T.cast(h, "int64") + T.cast(head_idx_3, "int64")
                     ) * 128 + T.cast(gate_load_segment * 8, "int64")  # .cu:1408
-                    _cp_async_cg_16_zfill(
-                        smem_g_raw_addr + T.cast(prep_stage, "int32") * 41984 + gate_load_item * 16,
+                    T.ptx.cp_async(
+                        smem_raw.ptr_to([SMEM_SMEM_G_RAW_OFF + T.cast(prep_stage, "int32") * 41984 + gate_load_item * 16]),
                         g.ptr_to([gate_load_base]),
-                        T.if_then_else(gate_load_token < eos_4, 16, 0),
-                    )  # .cu:1409-1410
+                        16,
+                        predicate=T.if_then_else(gate_load_token < eos_4, 1, 0),
+                        fill_mode="zero",
+                    )  # .cu:1409-1410  # fmt: skip
             if chunk_is_full_2 == 0:  # .cu:1413-1429
                 T.ptx.cp_async.commit_group()  # .cu:1414
                 T.ptx.cp_async.wait_group(0)  # .cu:1415
@@ -2216,22 +2190,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed,
-                        smem_q_raw_prefetch_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    segment_1 * 8 // 64 * 4096
-                                    + row_1 * 128
-                                    + segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:1526-1528
+                        smem_q_raw_prefetch_addr + T.cast(prep_stage, "int32") * 41984 + (segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ ((segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:1526-1528  # fmt: skip
                     packed_fp32: T.f32[8]  # .cu:1529
                     for _pair in T.unroll(4):  # .cu:1530-1539
                         packed_fp32[_pair * 2] = T.cuda.uint_as_float(
@@ -2247,22 +2207,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0,
-                        smem_kd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    segment_1 * 8 // 64 * 4096
-                                    + row_1 * 128
-                                    + segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:1545-1547
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ ((segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:1545-1547  # fmt: skip
                     packed_0_fp32: T.f32[8]  # .cu:1548
                     for _pair in T.unroll(4):  # .cu:1549-1558
                         packed_0_fp32[_pair * 2] = T.cuda.uint_as_float(
@@ -2372,24 +2318,9 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_qd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    segment_1 * 8 // 64 * 4096
-                                    + row_1 * 128
-                                    + segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        )
-                        + word * 4,
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ ((segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word * 4,
                         packed_1[word],
-                    )
+                    )  # fmt: skip
                 packed_0_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1674
                 for _lp in T.unroll(4):  # .cu:1675-1679
                     packed_0_1[_lp] = T.cuda.float22bfloat162_rn(
@@ -2399,24 +2330,9 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_kd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    segment_1 * 8 // 64 * 4096
-                                    + row_1 * 128
-                                    + segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        )
-                        + word_1 * 4,
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ ((segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word_1 * 4,
                         packed_0_1[word_1],
-                    )
+                    )  # fmt: skip
                 packed_1_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1684
                 for _lp in T.unroll(4):  # .cu:1685-1689
                     packed_1_1[_lp] = T.cuda.float22bfloat162_rn(
@@ -2426,24 +2342,9 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_ki_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    segment_1 * 8 // 64 * 4096
-                                    + row_1 * 128
-                                    + segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        )
-                        + word_2 * 4,
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ ((segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word_2 * 4,
                         packed_1_1[word_2],
-                    )
+                    )  # fmt: skip
             if prep_instance == 0:  # .cu:1695-1707
                 T.ptx.bar.sync(11, 128)
             elif prep_instance == 1:
@@ -2466,55 +2367,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    lane // 16 // 8 * 256
-                                    + (pair_row_base + lane % 16) * 8
-                                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4))
-                                    // 16
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    lane % 16 // 8 // 8 * 256
-                                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                    + (
-                                        lane % 16 // 8 % 8 * 16
-                                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
-                                    )
-                                    // 16
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
                 # .cu:1728-1741 chain step 1
@@ -2522,74 +2390,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            lane % 16 // 8 // 8 * 256
-                                            + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                            + (
-                                                lane % 16 // 8 % 8 * 16
-                                                ^ (
-                                                    (
-                                                        pair_col_base + 8 * (lane // 16) + lane % 8
-                                                        & 7
-                                                    )
-                                                    << 4
-                                                )
-                                            )
-                                            // 16
-                                        )
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1742-1755 chain step 2
@@ -2597,82 +2413,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane % 16 // 8 // 8 * 256
-                                                + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                                + (
-                                                    lane % 16 // 8 % 8 * 16
-                                                    ^ (
-                                                        (
-                                                            pair_col_base
-                                                            + 8 * (lane // 16)
-                                                            + lane % 8
-                                                            & 7
-                                                        )
-                                                        << 4
-                                                    )
-                                                )
-                                                // 16
-                                            )
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1756-1769 chain step 3
@@ -2680,89 +2436,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    lane % 16 // 8 // 8 * 256
-                                                    + (pair_col_base + 8 * (lane // 16) + lane % 8)
-                                                    * 8
-                                                    + (
-                                                        lane % 16 // 8 % 8 * 16
-                                                        ^ (
-                                                            (
-                                                                pair_col_base
-                                                                + 8 * (lane // 16)
-                                                                + lane % 8
-                                                                & 7
-                                                            )
-                                                            << 4
-                                                        )
-                                                    )
-                                                    // 16
-                                                )
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1770-1783 chain step 4
@@ -2770,103 +2459,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            lane // 16 // 8 * 256
-                                            + (pair_row_base + lane % 16) * 8
-                                            + (
-                                                lane // 16 % 8 * 16
-                                                ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                            )
-                                            // 16
-                                        )
-                                        ^ 2
-                                        ^ 6
-                                        ^ 2
-                                        ^ 6
-                                    )
-                                    + 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        lane % 16 // 8 // 8 * 256
-                                                        + (
-                                                            pair_col_base
-                                                            + 8 * (lane // 16)
-                                                            + lane % 8
-                                                        )
-                                                        * 8
-                                                        + (
-                                                            lane % 16 // 8 % 8 * 16
-                                                            ^ (
-                                                                (
-                                                                    pair_col_base
-                                                                    + 8 * (lane // 16)
-                                                                    + lane % 8
-                                                                    & 7
-                                                                )
-                                                                << 4
-                                                            )
-                                                        )
-                                                        // 16
-                                                    )
-                                                    + 256
-                                                    ^ 2
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 6
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    + 256
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1784-1797 chain step 5
@@ -2874,111 +2482,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            lane % 16 // 8 // 8 * 256
-                                                            + (
-                                                                pair_col_base
-                                                                + 8 * (lane // 16)
-                                                                + lane % 8
-                                                            )
-                                                            * 8
-                                                            + (
-                                                                lane % 16 // 8 % 8 * 16
-                                                                ^ (
-                                                                    (
-                                                                        pair_col_base
-                                                                        + 8 * (lane // 16)
-                                                                        + lane % 8
-                                                                        & 7
-                                                                    )
-                                                                    << 4
-                                                                )
-                                                            )
-                                                            // 16
-                                                        )
-                                                        + 256
-                                                        ^ 2
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 6
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        + 256
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1798-1811 chain step 6
@@ -2986,117 +2505,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            (
-                                                                lane % 16 // 8 // 8 * 256
-                                                                + (
-                                                                    pair_col_base
-                                                                    + 8 * (lane // 16)
-                                                                    + lane % 8
-                                                                )
-                                                                * 8
-                                                                + (
-                                                                    lane % 16 // 8 % 8 * 16
-                                                                    ^ (
-                                                                        (
-                                                                            pair_col_base
-                                                                            + 8 * (lane // 16)
-                                                                            + lane % 8
-                                                                            & 7
-                                                                        )
-                                                                        << 4
-                                                                    )
-                                                                )
-                                                                // 16
-                                                            )
-                                                            + 256
-                                                            ^ 2
-                                                        )
-                                                        - 256
-                                                        + 256
-                                                        ^ 6
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 2
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 6
-                                            )
-                                            + 256
-                                            - 256
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 # .cu:1812-1825 chain step 7
@@ -3104,123 +2528,22 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_kd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            (
-                                                                (
-                                                                    lane % 16 // 8 // 8 * 256
-                                                                    + (
-                                                                        pair_col_base
-                                                                        + 8 * (lane // 16)
-                                                                        + lane % 8
-                                                                    )
-                                                                    * 8
-                                                                    + (
-                                                                        lane % 16 // 8 % 8 * 16
-                                                                        ^ (
-                                                                            (
-                                                                                pair_col_base
-                                                                                + 8 * (lane // 16)
-                                                                                + lane % 8
-                                                                                & 7
-                                                                            )
-                                                                            << 4
-                                                                        )
-                                                                    )
-                                                                    // 16
-                                                                )
-                                                                + 256
-                                                                ^ 2
-                                                            )
-                                                            - 256
-                                                            + 256
-                                                            ^ 6
-                                                        )
-                                                        - 256
-                                                        + 256
-                                                        ^ 2
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 6
-                                                )
-                                                + 256
-                                                - 256
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 row0: T.int32 = pair_row_base + lane // 4  # .cu:1826
@@ -3278,754 +2601,176 @@ def _kernel(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    lane // 16 // 8 * 256
-                                    + (pair_row_base + lane % 16) * 8
-                                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4))
-                                    // 16
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    lane % 16 // 8 // 8 * 256
-                                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                    + (
-                                        lane % 16 // 8 % 8 * 16
-                                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
-                                    )
-                                    // 16
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            lane % 16 // 8 // 8 * 256
-                                            + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                            + (
-                                                lane % 16 // 8 % 8 * 16
-                                                ^ (
-                                                    (
-                                                        pair_col_base + 8 * (lane // 16) + lane % 8
-                                                        & 7
-                                                    )
-                                                    << 4
-                                                )
-                                            )
-                                            // 16
-                                        )
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane % 16 // 8 // 8 * 256
-                                                + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                                                + (
-                                                    lane % 16 // 8 % 8 * 16
-                                                    ^ (
-                                                        (
-                                                            pair_col_base
-                                                            + 8 * (lane // 16)
-                                                            + lane % 8
-                                                            & 7
-                                                        )
-                                                        << 4
-                                                    )
-                                                )
-                                                // 16
-                                            )
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        lane // 16 // 8 * 256
-                                        + (pair_row_base + lane % 16) * 8
-                                        + (
-                                            lane // 16 % 8 * 16
-                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                        )
-                                        // 16
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    lane % 16 // 8 // 8 * 256
-                                                    + (pair_col_base + 8 * (lane // 16) + lane % 8)
-                                                    * 8
-                                                    + (
-                                                        lane % 16 // 8 % 8 * 16
-                                                        ^ (
-                                                            (
-                                                                pair_col_base
-                                                                + 8 * (lane // 16)
-                                                                + lane % 8
-                                                                & 7
-                                                            )
-                                                            << 4
-                                                        )
-                                                    )
-                                                    // 16
-                                                )
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            lane // 16 // 8 * 256
-                                            + (pair_row_base + lane % 16) * 8
-                                            + (
-                                                lane // 16 % 8 * 16
-                                                ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                            )
-                                            // 16
-                                        )
-                                        ^ 2
-                                        ^ 6
-                                        ^ 2
-                                        ^ 6
-                                    )
-                                    + 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        lane % 16 // 8 // 8 * 256
-                                                        + (
-                                                            pair_col_base
-                                                            + 8 * (lane // 16)
-                                                            + lane % 8
-                                                        )
-                                                        * 8
-                                                        + (
-                                                            lane % 16 // 8 % 8 * 16
-                                                            ^ (
-                                                                (
-                                                                    pair_col_base
-                                                                    + 8 * (lane // 16)
-                                                                    + lane % 8
-                                                                    & 7
-                                                                )
-                                                                << 4
-                                                            )
-                                                        )
-                                                        // 16
-                                                    )
-                                                    + 256
-                                                    ^ 2
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 6
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    + 256
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            lane % 16 // 8 // 8 * 256
-                                                            + (
-                                                                pair_col_base
-                                                                + 8 * (lane // 16)
-                                                                + lane % 8
-                                                            )
-                                                            * 8
-                                                            + (
-                                                                lane % 16 // 8 % 8 * 16
-                                                                ^ (
-                                                                    (
-                                                                        pair_col_base
-                                                                        + 8 * (lane // 16)
-                                                                        + lane % 8
-                                                                        & 7
-                                                                    )
-                                                                    << 4
-                                                                )
-                                                            )
-                                                            // 16
-                                                        )
-                                                        + 256
-                                                        ^ 2
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 6
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        + 256
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            (
-                                                                lane % 16 // 8 // 8 * 256
-                                                                + (
-                                                                    pair_col_base
-                                                                    + 8 * (lane // 16)
-                                                                    + lane % 8
-                                                                )
-                                                                * 8
-                                                                + (
-                                                                    lane % 16 // 8 % 8 * 16
-                                                                    ^ (
-                                                                        (
-                                                                            pair_col_base
-                                                                            + 8 * (lane // 16)
-                                                                            + lane % 8
-                                                                            & 7
-                                                                        )
-                                                                        << 4
-                                                                    )
-                                                                )
-                                                                // 16
-                                                            )
-                                                            + 256
-                                                            ^ 2
-                                                        )
-                                                        - 256
-                                                        + 256
-                                                        ^ 6
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 2
-                                                )
-                                                - 256
-                                                + 256
-                                                ^ 6
-                                            )
-                                            + 256
-                                            - 256
-                                            + 256
-                                            ^ 2
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 6
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + ((((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                lane // 16 // 8 * 256
-                                                + (pair_row_base + lane % 16) * 8
-                                                + (
-                                                    lane // 16 % 8 * 16
-                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
-                                                )
-                                                // 16
-                                            )
-                                            ^ 2
-                                            ^ 6
-                                            ^ 2
-                                            ^ 6
-                                        )
-                                        + 256
-                                    )
-                                    ^ 2
-                                    ^ 6
-                                    ^ 2
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + ((((lane // 16 // 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16) ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16) - T.cast(smem, "int32")]),
                     T.address_of(a_frag[0]),
                     T.address_of(a_frag[1]),
                     T.address_of(a_frag[2]),
                     T.address_of(a_frag[3]),
-                )
+                )  # fmt: skip
                 T.ptx.ldmatrix(
                     False,
                     4,
                     ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_ki_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (
-                                    (
-                                        (
-                                            (
-                                                (
-                                                    (
-                                                        (
-                                                            (
-                                                                (
-                                                                    lane % 16 // 8 // 8 * 256
-                                                                    + (
-                                                                        pair_col_base
-                                                                        + 8 * (lane // 16)
-                                                                        + lane % 8
-                                                                    )
-                                                                    * 8
-                                                                    + (
-                                                                        lane % 16 // 8 % 8 * 16
-                                                                        ^ (
-                                                                            (
-                                                                                pair_col_base
-                                                                                + 8 * (lane // 16)
-                                                                                + lane % 8
-                                                                                & 7
-                                                                            )
-                                                                            << 4
-                                                                        )
-                                                                    )
-                                                                    // 16
-                                                                )
-                                                                + 256
-                                                                ^ 2
-                                                            )
-                                                            - 256
-                                                            + 256
-                                                            ^ 6
-                                                        )
-                                                        - 256
-                                                        + 256
-                                                        ^ 2
-                                                    )
-                                                    - 256
-                                                    + 256
-                                                    ^ 6
-                                                )
-                                                + 256
-                                                - 256
-                                                + 256
-                                                ^ 2
-                                            )
-                                            - 256
-                                            + 256
-                                            ^ 6
-                                        )
-                                        - 256
-                                        + 256
-                                        ^ 2
-                                    )
-                                    - 256
-                                )
-                                * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
+                    smem_raw.ptr_to([(smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (((((((((lane % 16 // 8 // 8 * 256 + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8 + (lane % 16 // 8 % 8 * 16 ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)) // 16) + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16) - T.cast(smem, "int32")]),
                     T.address_of(b_frag[0]),
                     T.address_of(b_frag[1]),
                     T.address_of(b_frag[2]),
                     T.address_of(b_frag[3]),
-                )
+                )  # fmt: skip
                 _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
                 _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
             else:  # .cu:1991-2000
@@ -4115,24 +2860,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_2,
-                        smem_qd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment * 8 // 64 * 4096
-                            + restore_row * 128
-                            + restore_segment * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment * 8 // 64 * 4096
-                                    + restore_row * 128
-                                    + restore_segment * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2087-2089
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2087-2089  # fmt: skip
                     packed_fp32_1: T.f32[8]  # .cu:2090
                     for _pair in T.unroll(4):  # .cu:2091-2100
                         packed_fp32_1[_pair * 2] = T.cuda.uint_as_float(
@@ -4148,24 +2877,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0_2,
-                        smem_kd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment * 8 // 64 * 4096
-                            + restore_row * 128
-                            + restore_segment * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment * 8 // 64 * 4096
-                                    + restore_row * 128
-                                    + restore_segment * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2106-2108
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2106-2108  # fmt: skip
                     packed_0_fp32_1: T.f32[8]  # .cu:2109
                     for _pair in T.unroll(4):  # .cu:2110-2119
                         packed_0_fp32_1[_pair * 2] = T.cuda.uint_as_float(
@@ -4181,24 +2894,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_1_2,
-                        smem_ki_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment * 8 // 64 * 4096
-                            + restore_row * 128
-                            + restore_segment * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment * 8 // 64 * 4096
-                                    + restore_row * 128
-                                    + restore_segment * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2125-2127
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2125-2127  # fmt: skip
                     packed_1_fp32: T.f32[8]  # .cu:2128
                     for _pair in T.unroll(4):  # .cu:2129-2138
                         packed_1_fp32[_pair * 2] = T.cuda.uint_as_float(
@@ -4241,26 +2938,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_qd_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment * 8 // 64 * 4096
-                                + restore_row * 128
-                                + restore_segment * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment * 8 // 64 * 4096
-                                        + restore_row * 128
-                                        + restore_segment * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_3 * 4,
+                            smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + word_3 * 4,
                             packed_2_1[word_3],
-                        )
+                        )  # fmt: skip
                     packed_3 = T.alloc_local((4,), "uint32", align=4)  # .cu:2166
                     for _lp in T.unroll(4):  # .cu:2167-2171
                         packed_3[_lp] = T.cuda.float22bfloat162_rn(
@@ -4270,26 +2950,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_kd_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment * 8 // 64 * 4096
-                                + restore_row * 128
-                                + restore_segment * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment * 8 // 64 * 4096
-                                        + restore_row * 128
-                                        + restore_segment * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_4 * 4,
+                            smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + word_4 * 4,
                             packed_3[word_4],
-                        )
+                        )  # fmt: skip
                     packed_4 = T.alloc_local((4,), "uint32", align=4)  # .cu:2176
                     for _lp in T.unroll(4):  # .cu:2177-2181
                         packed_4[_lp] = T.cuda.float22bfloat162_rn(
@@ -4299,26 +2962,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_kr_trans_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment * 8 // 64 * 4096
-                                + restore_row * 128
-                                + restore_segment * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment * 8 // 64 * 4096
-                                        + restore_row * 128
-                                        + restore_segment * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_5 * 4,
+                            smem_kr_trans_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ ((restore_segment * 8 // 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + word_5 * 4,
                             packed_4[word_5],
-                        )
+                        )  # fmt: skip
             if prep_local_warp == 0:  # .cu:2188-2250
                 inverse_row: T.int32 = lane  # .cu:2189
                 diag_block: T.int32 = inverse_row // 8  # .cu:2190
@@ -4505,12 +3151,9 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_inv_work_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + swizzled_off_2
-                        + word_6 * 4,
+                        smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_2 + word_6 * 4,
                         packed_0_3[word_6],
-                    )
+                    )  # fmt: skip
             if prep_local_warp < 2:  # .cu:2251-2256
                 if T.ptx.elect_sync():
                     _mbarrier_arrive(
@@ -4813,24 +3456,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_6,
-                        smem_qd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment_1 * 8 // 64 * 4096
-                            + restore_row_1 * 128
-                            + restore_segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment_1 * 8 // 64 * 4096
-                                    + restore_row_1 * 128
-                                    + restore_segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2422-2424
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2422-2424  # fmt: skip
                     packed_fp32_3: T.f32[8]  # .cu:2425
                     for _pair in T.unroll(4):  # .cu:2426-2435
                         packed_fp32_3[_pair * 2] = T.cuda.uint_as_float(
@@ -4846,24 +3473,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0_4,
-                        smem_kd_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment_1 * 8 // 64 * 4096
-                            + restore_row_1 * 128
-                            + restore_segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment_1 * 8 // 64 * 4096
-                                    + restore_row_1 * 128
-                                    + restore_segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2441-2443
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2441-2443  # fmt: skip
                     packed_0_fp32_2: T.f32[8]  # .cu:2444
                     for _pair in T.unroll(4):  # .cu:2445-2454
                         packed_0_fp32_2[_pair * 2] = T.cuda.uint_as_float(
@@ -4879,24 +3490,8 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_1_3,
-                        smem_ki_addr
-                        + T.cast(prep_stage, "int32") * 41984
-                        + (
-                            restore_segment_1 * 8 // 64 * 4096
-                            + restore_row_1 * 128
-                            + restore_segment_1 * 8 % 64 * 2
-                            ^ (
-                                (
-                                    restore_segment_1 * 8 // 64 * 4096
-                                    + restore_row_1 * 128
-                                    + restore_segment_1 * 8 % 64 * 2
-                                    >> 7
-                                    & 7
-                                )
-                                << 4
-                            )
-                        ),
-                    )  # .cu:2460-2462
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)),
+                    )  # .cu:2460-2462  # fmt: skip
                     packed_1_fp32_1: T.f32[8]  # .cu:2463
                     for _pair in T.unroll(4):  # .cu:2464-2473
                         packed_1_fp32_1[_pair * 2] = T.cuda.uint_as_float(
@@ -4939,26 +3534,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_qd_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment_1 * 8 // 64 * 4096
-                                + restore_row_1 * 128
-                                + restore_segment_1 * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment_1 * 8 // 64 * 4096
-                                        + restore_row_1 * 128
-                                        + restore_segment_1 * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_7 * 4,
+                            smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word_7 * 4,
                             packed_2_2[word_7],
-                        )
+                        )  # fmt: skip
                     packed_3_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:2501
                     for _lp in T.unroll(4):  # .cu:2502-2506
                         packed_3_1[_lp] = T.cuda.float22bfloat162_rn(
@@ -4968,26 +3546,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_kd_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment_1 * 8 // 64 * 4096
-                                + restore_row_1 * 128
-                                + restore_segment_1 * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment_1 * 8 // 64 * 4096
-                                        + restore_row_1 * 128
-                                        + restore_segment_1 * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_8 * 4,
+                            smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word_8 * 4,
                             packed_3_1[word_8],
-                        )
+                        )  # fmt: skip
                     packed_4_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:2511
                     for _lp in T.unroll(4):  # .cu:2512-2516
                         packed_4_1[_lp] = T.cuda.float22bfloat162_rn(
@@ -4997,26 +3558,9 @@ def _kernel(
                         _st_shared_b32(
                             smem_raw,
                             T.cast(smem, "int32"),
-                            smem_kr_trans_addr
-                            + T.cast(prep_stage, "int32") * 41984
-                            + (
-                                restore_segment_1 * 8 // 64 * 4096
-                                + restore_row_1 * 128
-                                + restore_segment_1 * 8 % 64 * 2
-                                ^ (
-                                    (
-                                        restore_segment_1 * 8 // 64 * 4096
-                                        + restore_row_1 * 128
-                                        + restore_segment_1 * 8 % 64 * 2
-                                        >> 7
-                                        & 7
-                                    )
-                                    << 4
-                                )
-                            )
-                            + word_9 * 4,
+                            smem_kr_trans_addr + T.cast(prep_stage, "int32") * 41984 + (restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ ((restore_segment_1 * 8 // 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + word_9 * 4,
                             packed_4_1[word_9],
-                        )
+                        )  # fmt: skip
             _fence_async_shared()  # .cu:2523
             if prep_instance == 0:  # .cu:2524-2536
                 T.ptx.bar.sync(11, 128)

--- a/tirx_kernels/flashkda/bf16_fused_m128.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128.py
@@ -2205,8 +2205,6 @@ def _kernel(
                 ) * 128 + T.cast(segment_1 * 8, "int64")  # .cu:1505
                 # q/k smem swizzle byte offset (spelled inline at each .cu use site:
                 # 1528, 1547, 1672, 1682, 1692)
-                _qk_swz: T.int32 = segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
-                _qk_swz = _qk_swz ^ ((_qk_swz >> 7 & 7) << 4)
                 q_raw_vec: T.f32[8]  # .cu:1506
                 k_raw_vec: T.f32[8]  # .cu:1507
                 for _zi in T.unroll(8):  # .cu:1508-1523
@@ -2218,7 +2216,21 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed,
-                        smem_q_raw_prefetch_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz,
+                        smem_q_raw_prefetch_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    segment_1 * 8 // 64 * 4096
+                                    + row_1 * 128
+                                    + segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:1526-1528
                     packed_fp32: T.f32[8]  # .cu:1529
                     for _pair in T.unroll(4):  # .cu:1530-1539
@@ -2235,7 +2247,21 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0,
-                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz,
+                        smem_kd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    segment_1 * 8 // 64 * 4096
+                                    + row_1 * 128
+                                    + segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:1545-1547
                     packed_0_fp32: T.f32[8]  # .cu:1548
                     for _pair in T.unroll(4):  # .cu:1549-1558
@@ -2346,7 +2372,22 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word * 4,
+                        smem_qd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    segment_1 * 8 // 64 * 4096
+                                    + row_1 * 128
+                                    + segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        )
+                        + word * 4,
                         packed_1[word],
                     )
                 packed_0_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1674
@@ -2358,7 +2399,22 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word_1 * 4,
+                        smem_kd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    segment_1 * 8 // 64 * 4096
+                                    + row_1 * 128
+                                    + segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        )
+                        + word_1 * 4,
                         packed_0_1[word_1],
                     )
                 packed_1_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1684
@@ -2370,7 +2426,22 @@ def _kernel(
                     _st_shared_b32(
                         smem_raw,
                         T.cast(smem, "int32"),
-                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word_2 * 4,
+                        smem_ki_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    segment_1 * 8 // 64 * 4096
+                                    + row_1 * 128
+                                    + segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        )
+                        + word_2 * 4,
                         packed_1_1[word_2],
                     )
             if prep_instance == 0:  # .cu:1695-1707
@@ -2390,29 +2461,6 @@ def _kernel(
             b_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:1711
             acc = T.alloc_local((8,), "float32", align=4)  # .cu:1712
             if pair_row_base >= pair_col_base:  # .cu:1713-1990
-                _kd_a0: T.int32 = (
-                    lane // 16 // 8 * 256
-                    + (pair_row_base + lane % 16) * 8
-                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16
-                )
-                _ki_b0: T.int32 = (
-                    lane % 16 // 8 // 8 * 256
-                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
-                    + (
-                        lane % 16 // 8 % 8 * 16
-                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
-                    )
-                    // 16
-                )
-                # ki b-side chain steps (.cu:1720-1818); C precedence is
-                # additive > xor, so each step is parenthesized explicitly.
-                _kb1 = (_ki_b0 + 256) ^ 2
-                _kb2 = (_kb1 - 256 + 256) ^ 6
-                _kb3 = (_kb2 - 256 + 256) ^ 2
-                _kb4 = (_kb3 - 256 + 256) ^ 6
-                _kb5 = (_kb4 + 256 - 256 + 256) ^ 2
-                _kb6 = (_kb5 - 256 + 256) ^ 6
-                _kb7 = (_kb6 - 256 + 256) ^ 2
                 # .cu:1714-1727 chain step 0 (kd a, ki b, 2x zero-C mma)
                 T.ptx.ldmatrix(
                     False,
@@ -2420,7 +2468,17 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _kd_a0 * 16)
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    lane // 16 // 8 * 256
+                                    + (pair_row_base + lane % 16) * 8
+                                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4))
+                                    // 16
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2435,7 +2493,20 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _ki_b0 * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    lane % 16 // 8 // 8 * 256
+                                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                    + (
+                                        lane % 16 // 8 % 8 * 16
+                                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
+                                    )
+                                    // 16
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2453,7 +2524,23 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (_kd_a0 ^ 2) * 16)
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2468,7 +2555,33 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb1 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            lane % 16 // 8 // 8 * 256
+                                            + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                            + (
+                                                lane % 16 // 8 % 8 * 16
+                                                ^ (
+                                                    (
+                                                        pair_col_base + 8 * (lane // 16) + lane % 8
+                                                        & 7
+                                                    )
+                                                    << 4
+                                                )
+                                            )
+                                            // 16
+                                        )
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2489,7 +2602,20 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (_kd_a0 ^ 2 ^ 6) * 16
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2505,7 +2631,40 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb2 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane % 16 // 8 // 8 * 256
+                                                + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                                + (
+                                                    lane % 16 // 8 % 8 * 16
+                                                    ^ (
+                                                        (
+                                                            pair_col_base
+                                                            + 8 * (lane // 16)
+                                                            + lane % 8
+                                                            & 7
+                                                        )
+                                                        << 4
+                                                    )
+                                                )
+                                                // 16
+                                            )
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2526,7 +2685,21 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (_kd_a0 ^ 2 ^ 6 ^ 2) * 16
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                    ^ 2
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2542,7 +2715,46 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb3 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    lane % 16 // 8 // 8 * 256
+                                                    + (pair_col_base + 8 * (lane // 16) + lane % 8)
+                                                    * 8
+                                                    + (
+                                                        lane % 16 // 8 % 8 * 16
+                                                        ^ (
+                                                            (
+                                                                pair_col_base
+                                                                + 8 * (lane // 16)
+                                                                + lane % 8
+                                                                & 7
+                                                            )
+                                                            << 4
+                                                        )
+                                                    )
+                                                    // 16
+                                                )
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2563,7 +2775,25 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + ((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16
+                                + (
+                                    (
+                                        (
+                                            lane // 16 // 8 * 256
+                                            + (pair_row_base + lane % 16) * 8
+                                            + (
+                                                lane // 16 % 8 * 16
+                                                ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                            )
+                                            // 16
+                                        )
+                                        ^ 2
+                                        ^ 6
+                                        ^ 2
+                                        ^ 6
+                                    )
+                                    + 256
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2582,7 +2812,52 @@ def _kernel(
                             (
                                 smem_ki_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (_kb4 + 256 - 256) * 16
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        lane % 16 // 8 // 8 * 256
+                                                        + (
+                                                            pair_col_base
+                                                            + 8 * (lane // 16)
+                                                            + lane % 8
+                                                        )
+                                                        * 8
+                                                        + (
+                                                            lane % 16 // 8 % 8 * 16
+                                                            ^ (
+                                                                (
+                                                                    pair_col_base
+                                                                    + 8 * (lane // 16)
+                                                                    + lane % 8
+                                                                    & 7
+                                                                )
+                                                                << 4
+                                                            )
+                                                        )
+                                                        // 16
+                                                    )
+                                                    + 256
+                                                    ^ 2
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 6
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    + 256
+                                    - 256
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2604,7 +2879,28 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2620,7 +2916,61 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb5 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            lane % 16 // 8 // 8 * 256
+                                                            + (
+                                                                pair_col_base
+                                                                + 8 * (lane // 16)
+                                                                + lane % 8
+                                                            )
+                                                            * 8
+                                                            + (
+                                                                lane % 16 // 8 % 8 * 16
+                                                                ^ (
+                                                                    (
+                                                                        pair_col_base
+                                                                        + 8 * (lane // 16)
+                                                                        + lane % 8
+                                                                        & 7
+                                                                    )
+                                                                    << 4
+                                                                )
+                                                            )
+                                                            // 16
+                                                        )
+                                                        + 256
+                                                        ^ 2
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 6
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        + 256
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2641,7 +2991,29 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2657,7 +3029,66 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb6 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            (
+                                                                lane % 16 // 8 // 8 * 256
+                                                                + (
+                                                                    pair_col_base
+                                                                    + 8 * (lane // 16)
+                                                                    + lane % 8
+                                                                )
+                                                                * 8
+                                                                + (
+                                                                    lane % 16 // 8 % 8 * 16
+                                                                    ^ (
+                                                                        (
+                                                                            pair_col_base
+                                                                            + 8 * (lane // 16)
+                                                                            + lane % 8
+                                                                            & 7
+                                                                        )
+                                                                        << 4
+                                                                    )
+                                                                )
+                                                                // 16
+                                                            )
+                                                            + 256
+                                                            ^ 2
+                                                        )
+                                                        - 256
+                                                        + 256
+                                                        ^ 6
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 2
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 6
+                                            )
+                                            + 256
+                                            - 256
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2678,7 +3109,30 @@ def _kernel(
                             (
                                 smem_kd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                    ^ 2
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2694,7 +3148,71 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb7 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            (
+                                                                (
+                                                                    lane % 16 // 8 // 8 * 256
+                                                                    + (
+                                                                        pair_col_base
+                                                                        + 8 * (lane // 16)
+                                                                        + lane % 8
+                                                                    )
+                                                                    * 8
+                                                                    + (
+                                                                        lane % 16 // 8 % 8 * 16
+                                                                        ^ (
+                                                                            (
+                                                                                pair_col_base
+                                                                                + 8 * (lane // 16)
+                                                                                + lane % 8
+                                                                                & 7
+                                                                            )
+                                                                            << 4
+                                                                        )
+                                                                    )
+                                                                    // 16
+                                                                )
+                                                                + 256
+                                                                ^ 2
+                                                            )
+                                                            - 256
+                                                            + 256
+                                                            ^ 6
+                                                        )
+                                                        - 256
+                                                        + 256
+                                                        ^ 2
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 6
+                                                )
+                                                + 256
+                                                - 256
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2762,146 +3280,16 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _kd_a0 * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(a_frag[0]),
-                    T.address_of(a_frag[1]),
-                    T.address_of(a_frag[2]),
-                    T.address_of(a_frag[3]),
-                )
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _ki_b0 * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(b_frag[0]),
-                    T.address_of(b_frag[1]),
-                    T.address_of(b_frag[2]),
-                    T.address_of(b_frag[3]),
-                )
-                _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
-                _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (_kd_a0 ^ 2) * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(a_frag[0]),
-                    T.address_of(a_frag[1]),
-                    T.address_of(a_frag[2]),
-                    T.address_of(a_frag[3]),
-                )
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb1 - 256) * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(b_frag[0]),
-                    T.address_of(b_frag[1]),
-                    T.address_of(b_frag[2]),
-                    T.address_of(b_frag[3]),
-                )
-                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
-                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
                             (
                                 smem_qd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (_kd_a0 ^ 2 ^ 6) * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(a_frag[0]),
-                    T.address_of(a_frag[1]),
-                    T.address_of(a_frag[2]),
-                    T.address_of(a_frag[3]),
-                )
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb2 - 256) * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(b_frag[0]),
-                    T.address_of(b_frag[1]),
-                    T.address_of(b_frag[2]),
-                    T.address_of(b_frag[3]),
-                )
-                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
-                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + (_kd_a0 ^ 2 ^ 6 ^ 2) * 16
-                            )
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(a_frag[0]),
-                    T.address_of(a_frag[1]),
-                    T.address_of(a_frag[2]),
-                    T.address_of(a_frag[3]),
-                )
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb3 - 256) * 16)
-                            - T.cast(smem, "int32")
-                        ]
-                    ),
-                    T.address_of(b_frag[0]),
-                    T.address_of(b_frag[1]),
-                    T.address_of(b_frag[2]),
-                    T.address_of(b_frag[3]),
-                )
-                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
-                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
-                T.ptx.ldmatrix(
-                    False,
-                    4,
-                    ".b16",
-                    smem_raw.ptr_to(
-                        [
-                            (
-                                smem_qd_addr
-                                + T.cast(prep_stage, "int32") * 41984
-                                + ((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16
+                                + (
+                                    lane // 16 // 8 * 256
+                                    + (pair_row_base + lane % 16) * 8
+                                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4))
+                                    // 16
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2920,7 +3308,90 @@ def _kernel(
                             (
                                 smem_ki_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (_kb4 + 256 - 256) * 16
+                                + (
+                                    lane % 16 // 8 // 8 * 256
+                                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                    + (
+                                        lane % 16 // 8 % 8 * 16
+                                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
+                                    )
+                                    // 16
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            lane % 16 // 8 // 8 * 256
+                                            + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                            + (
+                                                lane % 16 // 8 % 8 * 16
+                                                ^ (
+                                                    (
+                                                        pair_col_base + 8 * (lane // 16) + lane % 8
+                                                        & 7
+                                                    )
+                                                    << 4
+                                                )
+                                            )
+                                            // 16
+                                        )
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2941,7 +3412,20 @@ def _kernel(
                             (
                                 smem_qd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2957,7 +3441,40 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb5 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane % 16 // 8 // 8 * 256
+                                                + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                                                + (
+                                                    lane % 16 // 8 % 8 * 16
+                                                    ^ (
+                                                        (
+                                                            pair_col_base
+                                                            + 8 * (lane // 16)
+                                                            + lane % 8
+                                                            & 7
+                                                        )
+                                                        << 4
+                                                    )
+                                                )
+                                                // 16
+                                            )
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -2977,7 +3494,21 @@ def _kernel(
                             (
                                 smem_qd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16
+                                + (
+                                    (
+                                        lane // 16 // 8 * 256
+                                        + (pair_row_base + lane % 16) * 8
+                                        + (
+                                            lane // 16 % 8 * 16
+                                            ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                        )
+                                        // 16
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                    ^ 2
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -2993,7 +3524,46 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb6 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    lane % 16 // 8 // 8 * 256
+                                                    + (pair_col_base + 8 * (lane // 16) + lane % 8)
+                                                    * 8
+                                                    + (
+                                                        lane % 16 // 8 % 8 * 16
+                                                        ^ (
+                                                            (
+                                                                pair_col_base
+                                                                + 8 * (lane // 16)
+                                                                + lane % 8
+                                                                & 7
+                                                            )
+                                                            << 4
+                                                        )
+                                                    )
+                                                    // 16
+                                                )
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -3013,7 +3583,25 @@ def _kernel(
                             (
                                 smem_qd_addr
                                 + T.cast(prep_stage, "int32") * 41984
-                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16
+                                + (
+                                    (
+                                        (
+                                            lane // 16 // 8 * 256
+                                            + (pair_row_base + lane % 16) * 8
+                                            + (
+                                                lane // 16 % 8 * 16
+                                                ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                            )
+                                            // 16
+                                        )
+                                        ^ 2
+                                        ^ 6
+                                        ^ 2
+                                        ^ 6
+                                    )
+                                    + 256
+                                )
+                                * 16
                             )
                             - T.cast(smem, "int32")
                         ]
@@ -3029,7 +3617,407 @@ def _kernel(
                     ".b16",
                     smem_raw.ptr_to(
                         [
-                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb7 - 256) * 16)
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        lane % 16 // 8 // 8 * 256
+                                                        + (
+                                                            pair_col_base
+                                                            + 8 * (lane // 16)
+                                                            + lane % 8
+                                                        )
+                                                        * 8
+                                                        + (
+                                                            lane % 16 // 8 % 8 * 16
+                                                            ^ (
+                                                                (
+                                                                    pair_col_base
+                                                                    + 8 * (lane // 16)
+                                                                    + lane % 8
+                                                                    & 7
+                                                                )
+                                                                << 4
+                                                            )
+                                                        )
+                                                        // 16
+                                                    )
+                                                    + 256
+                                                    ^ 2
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 6
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    + 256
+                                    - 256
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            lane % 16 // 8 // 8 * 256
+                                                            + (
+                                                                pair_col_base
+                                                                + 8 * (lane // 16)
+                                                                + lane % 8
+                                                            )
+                                                            * 8
+                                                            + (
+                                                                lane % 16 // 8 % 8 * 16
+                                                                ^ (
+                                                                    (
+                                                                        pair_col_base
+                                                                        + 8 * (lane // 16)
+                                                                        + lane % 8
+                                                                        & 7
+                                                                    )
+                                                                    << 4
+                                                                )
+                                                            )
+                                                            // 16
+                                                        )
+                                                        + 256
+                                                        ^ 2
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 6
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        + 256
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            (
+                                                                lane % 16 // 8 // 8 * 256
+                                                                + (
+                                                                    pair_col_base
+                                                                    + 8 * (lane // 16)
+                                                                    + lane % 8
+                                                                )
+                                                                * 8
+                                                                + (
+                                                                    lane % 16 // 8 % 8 * 16
+                                                                    ^ (
+                                                                        (
+                                                                            pair_col_base
+                                                                            + 8 * (lane // 16)
+                                                                            + lane % 8
+                                                                            & 7
+                                                                        )
+                                                                        << 4
+                                                                    )
+                                                                )
+                                                                // 16
+                                                            )
+                                                            + 256
+                                                            ^ 2
+                                                        )
+                                                        - 256
+                                                        + 256
+                                                        ^ 6
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 2
+                                                )
+                                                - 256
+                                                + 256
+                                                ^ 6
+                                            )
+                                            + 256
+                                            - 256
+                                            + 256
+                                            ^ 2
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 6
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                lane // 16 // 8 * 256
+                                                + (pair_row_base + lane % 16) * 8
+                                                + (
+                                                    lane // 16 % 8 * 16
+                                                    ^ ((pair_row_base + lane % 16 & 7) << 4)
+                                                )
+                                                // 16
+                                            )
+                                            ^ 2
+                                            ^ 6
+                                            ^ 2
+                                            ^ 6
+                                        )
+                                        + 256
+                                    )
+                                    ^ 2
+                                    ^ 6
+                                    ^ 2
+                                )
+                                * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            (
+                                                                (
+                                                                    lane % 16 // 8 // 8 * 256
+                                                                    + (
+                                                                        pair_col_base
+                                                                        + 8 * (lane // 16)
+                                                                        + lane % 8
+                                                                    )
+                                                                    * 8
+                                                                    + (
+                                                                        lane % 16 // 8 % 8 * 16
+                                                                        ^ (
+                                                                            (
+                                                                                pair_col_base
+                                                                                + 8 * (lane // 16)
+                                                                                + lane % 8
+                                                                                & 7
+                                                                            )
+                                                                            << 4
+                                                                        )
+                                                                    )
+                                                                    // 16
+                                                                )
+                                                                + 256
+                                                                ^ 2
+                                                            )
+                                                            - 256
+                                                            + 256
+                                                            ^ 6
+                                                        )
+                                                        - 256
+                                                        + 256
+                                                        ^ 2
+                                                    )
+                                                    - 256
+                                                    + 256
+                                                    ^ 6
+                                                )
+                                                + 256
+                                                - 256
+                                                + 256
+                                                ^ 2
+                                            )
+                                            - 256
+                                            + 256
+                                            ^ 6
+                                        )
+                                        - 256
+                                        + 256
+                                        ^ 2
+                                    )
+                                    - 256
+                                )
+                                * 16
+                            )
                             - T.cast(smem, "int32")
                         ]
                     ),
@@ -3122,18 +4110,28 @@ def _kernel(
                     restore_qd_values: T.f32[8]  # .cu:2083
                     restore_kd_values: T.f32[8]  # .cu:2084
                     restore_ki_values: T.f32[8]  # .cu:2085
-                    _rs_swz: T.int32 = (
-                        restore_segment * 8 // 64 * 4096
-                        + restore_row * 128
-                        + restore_segment * 8 % 64 * 2
-                    )
-                    _rs_swz = _rs_swz ^ ((_rs_swz >> 7 & 7) << 4)
                     packed_2 = T.alloc_local((4,), "uint32", align=16)  # .cu:2086
                     _ld_shared_v4(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_2,
-                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                        smem_qd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment * 8 // 64 * 4096
+                            + restore_row * 128
+                            + restore_segment * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment * 8 // 64 * 4096
+                                    + restore_row * 128
+                                    + restore_segment * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2087-2089
                     packed_fp32_1: T.f32[8]  # .cu:2090
                     for _pair in T.unroll(4):  # .cu:2091-2100
@@ -3150,7 +4148,23 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0_2,
-                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                        smem_kd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment * 8 // 64 * 4096
+                            + restore_row * 128
+                            + restore_segment * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment * 8 // 64 * 4096
+                                    + restore_row * 128
+                                    + restore_segment * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2106-2108
                     packed_0_fp32_1: T.f32[8]  # .cu:2109
                     for _pair in T.unroll(4):  # .cu:2110-2119
@@ -3167,7 +4181,23 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_1_2,
-                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                        smem_ki_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment * 8 // 64 * 4096
+                            + restore_row * 128
+                            + restore_segment * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment * 8 // 64 * 4096
+                                    + restore_row * 128
+                                    + restore_segment * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2125-2127
                     packed_1_fp32: T.f32[8]  # .cu:2128
                     for _pair in T.unroll(4):  # .cu:2129-2138
@@ -3213,7 +4243,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_qd_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz
+                            + (
+                                restore_segment * 8 // 64 * 4096
+                                + restore_row * 128
+                                + restore_segment * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment * 8 // 64 * 4096
+                                        + restore_row * 128
+                                        + restore_segment * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_3 * 4,
                             packed_2_1[word_3],
                         )
@@ -3228,7 +4272,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_kd_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz
+                            + (
+                                restore_segment * 8 // 64 * 4096
+                                + restore_row * 128
+                                + restore_segment * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment * 8 // 64 * 4096
+                                        + restore_row * 128
+                                        + restore_segment * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_4 * 4,
                             packed_3[word_4],
                         )
@@ -3243,7 +4301,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_kr_trans_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz
+                            + (
+                                restore_segment * 8 // 64 * 4096
+                                + restore_row * 128
+                                + restore_segment * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment * 8 // 64 * 4096
+                                        + restore_row * 128
+                                        + restore_segment * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_5 * 4,
                             packed_4[word_5],
                         )
@@ -3736,18 +4808,28 @@ def _kernel(
                     restore_qd_values_1: T.f32[8]  # .cu:2418
                     restore_kd_values_1: T.f32[8]  # .cu:2419
                     restore_ki_values_1: T.f32[8]  # .cu:2420
-                    _rs_swz_1: T.int32 = (
-                        restore_segment_1 * 8 // 64 * 4096
-                        + restore_row_1 * 128
-                        + restore_segment_1 * 8 % 64 * 2
-                    )
-                    _rs_swz_1 = _rs_swz_1 ^ ((_rs_swz_1 >> 7 & 7) << 4)
                     packed_6 = T.alloc_local((4,), "uint32", align=16)  # .cu:2421
                     _ld_shared_v4(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_6,
-                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                        smem_qd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment_1 * 8 // 64 * 4096
+                            + restore_row_1 * 128
+                            + restore_segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment_1 * 8 // 64 * 4096
+                                    + restore_row_1 * 128
+                                    + restore_segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2422-2424
                     packed_fp32_3: T.f32[8]  # .cu:2425
                     for _pair in T.unroll(4):  # .cu:2426-2435
@@ -3764,7 +4846,23 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_0_4,
-                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                        smem_kd_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment_1 * 8 // 64 * 4096
+                            + restore_row_1 * 128
+                            + restore_segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment_1 * 8 // 64 * 4096
+                                    + restore_row_1 * 128
+                                    + restore_segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2441-2443
                     packed_0_fp32_2: T.f32[8]  # .cu:2444
                     for _pair in T.unroll(4):  # .cu:2445-2454
@@ -3781,7 +4879,23 @@ def _kernel(
                         smem_raw,
                         T.cast(smem, "int32"),
                         packed_1_3,
-                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                        smem_ki_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + (
+                            restore_segment_1 * 8 // 64 * 4096
+                            + restore_row_1 * 128
+                            + restore_segment_1 * 8 % 64 * 2
+                            ^ (
+                                (
+                                    restore_segment_1 * 8 // 64 * 4096
+                                    + restore_row_1 * 128
+                                    + restore_segment_1 * 8 % 64 * 2
+                                    >> 7
+                                    & 7
+                                )
+                                << 4
+                            )
+                        ),
                     )  # .cu:2460-2462
                     packed_1_fp32_1: T.f32[8]  # .cu:2463
                     for _pair in T.unroll(4):  # .cu:2464-2473
@@ -3827,7 +4941,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_qd_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz_1
+                            + (
+                                restore_segment_1 * 8 // 64 * 4096
+                                + restore_row_1 * 128
+                                + restore_segment_1 * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment_1 * 8 // 64 * 4096
+                                        + restore_row_1 * 128
+                                        + restore_segment_1 * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_7 * 4,
                             packed_2_2[word_7],
                         )
@@ -3842,7 +4970,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_kd_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz_1
+                            + (
+                                restore_segment_1 * 8 // 64 * 4096
+                                + restore_row_1 * 128
+                                + restore_segment_1 * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment_1 * 8 // 64 * 4096
+                                        + restore_row_1 * 128
+                                        + restore_segment_1 * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_8 * 4,
                             packed_3_1[word_8],
                         )
@@ -3857,7 +4999,21 @@ def _kernel(
                             T.cast(smem, "int32"),
                             smem_kr_trans_addr
                             + T.cast(prep_stage, "int32") * 41984
-                            + _rs_swz_1
+                            + (
+                                restore_segment_1 * 8 // 64 * 4096
+                                + restore_row_1 * 128
+                                + restore_segment_1 * 8 % 64 * 2
+                                ^ (
+                                    (
+                                        restore_segment_1 * 8 // 64 * 4096
+                                        + restore_row_1 * 128
+                                        + restore_segment_1 * 8 % 64 * 2
+                                        >> 7
+                                        & 7
+                                    )
+                                    << 4
+                                )
+                            )
                             + word_9 * 4,
                             packed_4_1[word_9],
                         )

--- a/tirx_kernels/flashkda/bf16_fused_m128.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128.py
@@ -1,0 +1,3989 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""TIRx port of FlashInfer's frozen FlashKDA SM100a BF16 recurrent-KDA prefill
+M128 kernel (flashinfer-ai/flashinfer#4262, head e835e0f5).
+
+Source CUDA: csrc/kda/flashkda_bf16_fused_m128.cu (kernel body at line 504),
+launched by RunM128 in csrc/kda/flashkda_bf16_fused_m128_binding.cu with
+shared launch helpers in csrc/kda/flashkda_binding_common.cuh.
+
+One frozen instance: BF16, head_dim 128, sm_100a, grid = num_seqs * num_heads,
+1024 threads, 227328 B dynamic smem, six host-encoded TMA descriptors.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from dataclasses import dataclass, fields
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+D_HEAD = 128
+THREADS = 1024
+SMEM_TOTAL = 227328
+DEFAULT_LOWER_BOUND = -5.0
+
+# .cu:29-106 (#define block, source order).
+TMEM_TMEM_STATE_OFFSET = 64
+TMEM_TMEM_STATE_INP_OFFSET = 0
+TMEM_TMEM_U_ACC_OFFSET = 224
+TMEM_TMEM_U2_INP_OFFSET = 224
+TMEM_TMEM_U2_ACC_OFFSET = 0
+TMEM_TMEM_OUT_OFFSET = 192
+TMEM_TMEM_STATE_OUT_OFFSET = 64
+SMEM_SMEM_QD_OFF = 1024
+SMEM_SMEM_G_RAW_OFF = 1024
+SMEM_SMEM_KD_OFF = 9216
+SMEM_SMEM_Q_RAW_PREFETCH_OFF = 17408
+SMEM_SMEM_FINAL_TRANS_OFF = 17408
+SMEM_SMEM_KR_TRANS_OFF = 17408
+SMEM_SMEM_MQK_TRANS_OFF = 25600
+SMEM_SMEM_INV_OFF = 29696
+SMEM_SMEM_V_OFF = 32384
+SMEM_SMEM_KI_OFF = 17408
+SMEM_SMEM_GATE_OFF = 25600
+SMEM_SMEM_BETA_RAW_OFF = 41984
+SMEM_SMEM_INV_WORK_OFF = 32384
+SMEM_SMEM_OUT_OFF = 210944
+SMEM_SMEM_G_RAW_ALL_OFF = 1024
+SMEM_SMEM_G_RAW_ALL_STAGE_BYTES = 176128
+SMEM_SMEM_RESTORE_FACTOR_ALL_OFF = 41984
+SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES = 168452
+SMEM_SMEM_GT_PREFIX_ALL_OFF = 41472
+SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES = 168448
+SMEM_SMEM_GT_ALL_OFF = 31744
+SMEM_SMEM_GT_ALL_STAGE_BYTES = 168448
+SMEM_SMEM_PREP_BETA_ALL_OFF = 42500
+SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES = 168064
+SMEM_SMEM_GATE_RATE_ALL_OFF = 42628
+SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES = 167940
+SMEM_SMEM_V_ALL_OFF = 32384
+SMEM_SMEM_V_ALL_STAGE_BYTES = 176128
+SMEM_SMEM_GATE_ALL_OFF = 25600
+SMEM_SMEM_GATE_ALL_STAGE_BYTES = 184320
+
+# Mbarrier group byte offsets within the smem barrier area (.cu:695-711).
+MBAR_QK_FULL_OFF = 0
+MBAR_GATE_RAW_FULL_OFF = 40
+MBAR_QK_RAW_FULL_OFF = 80
+MBAR_V_FULL_OFF = 120
+MBAR_V_FREE_OFF = 160
+MBAR_SMEM_FREE_OFF = 200
+MBAR_RAW_INPUTS_FREE_OFF = 240
+MBAR_STATE_INP_READY_OFF = 280
+MBAR_OLD_OUT_READY_OFF = 320
+MBAR_U_INP_READY_OFF = 360
+MBAR_U2_ACC_READY_OFF = 400
+MBAR_U2_INP_READY_OFF = 440
+MBAR_FINAL_READY_OFF = 480
+MBAR_OUT_EMPTY_OFF = 520
+MBAR_TMEM_DEALLOC_READY_OFF = 528
+MBAR_PREP_DIAG_READY_OFF = 536
+MBAR_PREP_INV16_READY_OFF = 576
+SMEM_TMEM_ADDR_STORAGE_OFF = 616
+
+# TMA descriptor byte slots inside descriptor_storage (binding_common.cuh:435-440).
+TMA_SLOT_Q = 0
+TMA_SLOT_K = 128
+TMA_SLOT_V = 256
+TMA_SLOT_G = 384
+TMA_SLOT_BETA = 512
+TMA_SLOT_OUT = 640
+
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+
+# PR head worktree that contains the frozen m128 kernel (flashinfer-ai/flashinfer#4262).
+_FLASHKDA_PR_WORKTREE_DEFAULT = "/home/bohanhou/worktree/recurrent-kda/flashinfer-pr4262"
+
+# ---------------------------------------------------------------------------
+# CUDA device helpers, transcribed in source order from
+# csrc/kda/flashkda_bf16_fused_m128.cu:110-496.
+#
+# Helpers whose PTX instruction form has an exact T.ptx/T.cuda wrapper use that
+# wrapper.  Helpers with no exact wrapper (token-returning waits, ticks waits,
+# raw-descriptor MMA, raw tensor-map TMA) keep the verbatim CUDA body behind a
+# target-local T.cuda.func_call inline fallback (see tirx_dsl_improve.md).
+# ---------------------------------------------------------------------------
+
+_FLASHKDA_SRCS = {
+    "flashkda_tensormap_acquire": r"""__device__ __forceinline__ void flashkda_tensormap_acquire(const void *tmap_ptr) {
+    asm volatile(
+        "fence.proxy.tensormap::generic.acquire.gpu [%0], 128;\n"
+        :: "l"(tmap_ptr) : "memory");
+}
+""",
+    "flashkda_cp_async_cg_16_zfill": r"""// .cu:1280-1281 (cp.async.cg 16B with src-size zero-fill predicate)
+__device__ __forceinline__ void flashkda_cp_async_cg_16_zfill(
+    int dst, const void *src, int src_bytes) {
+    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+        :: "r"(dst), "l"(src), "r"(src_bytes));
+}
+""",
+    "flashkda_tanh_approx": r"""// tanh.approx.f32 (sigmoid via tanh; used throughout the prep role)
+__device__ __forceinline__ float flashkda_tanh_approx(float x) {
+    float y;
+    asm volatile("tanh.approx.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+""",
+    "flashkda_fmaf_rn": r"""// __fmaf_rn (value form of fma.rn.f32)
+__device__ __forceinline__ float flashkda_fmaf_rn(float a, float b, float c) {
+    return __fmaf_rn(a, b, c);
+}
+""",
+    "flashkda_rsqrtf": r"""// rsqrtf
+__device__ __forceinline__ float flashkda_rsqrtf(float x) {
+    return rsqrtf(x);
+}
+""",
+}
+
+
+def _mma_qk_8step(taddr_d, b_lo, taddr_a, enable_d):
+    # .cu:1114-1150 and .cu:1153-1189 (same verbatim block, two call sites) ->
+    # 8 native tcgen05.mma issues: b_lo offsets 0,2,4,6,256,258,260,262 (adds 2,2,2,250,2,2,2),
+    # taddr_a +8 per step, dhi=0x40004040, idesc=134743184, step0 enable_d / steps1-7 tied 1,
+    # all @leader-predicated. Native emits the explicit default disable-output-lane {0,0,0,0}.
+    leader = T.ptx.elect_sync()
+    b_lo32 = T.cast(b_lo, "uint32")
+    for _i in range(8):
+        _b_desc = (T.uint64(0x40004040) << T.uint64(32)) | T.cast(
+            b_lo32 + T.uint32((0, 2, 4, 6, 256, 258, 260, 262)[_i]), "uint64"
+        )
+        T.evaluate(
+            T.ptx.tcgen05.mma(
+                taddr_d,
+                taddr_a + 8 * _i,
+                _b_desc,
+                T.uint32(134743184),
+                d_dtype="float32",
+                a_dtype="bfloat16",
+                b_dtype="bfloat16",
+                use_a_tmem=True,
+                cta_group=1,
+                enable_input_d=enable_d if _i == 0 else 1,
+                pred=leader,
+            )
+        )
+
+
+def _mma_inv_2step(taddr_d, b_lo, taddr_a, enable_d):
+    # .cu:1194-1212 -> 2 native tcgen05.mma issues (b_lo add 64; dhi=0xC0004010)
+    leader = T.ptx.elect_sync()
+    b_lo32 = T.cast(b_lo, "uint32")
+    for _i in range(2):
+        _b_desc = (T.uint64(0xC0004010) << T.uint64(32)) | T.cast(
+            b_lo32 + T.uint32(64 * _i), "uint64"
+        )
+        T.evaluate(
+            T.ptx.tcgen05.mma(
+                taddr_d,
+                taddr_a + 8 * _i,
+                _b_desc,
+                T.uint32(134743184),
+                d_dtype="float32",
+                a_dtype="bfloat16",
+                b_dtype="bfloat16",
+                use_a_tmem=True,
+                cta_group=1,
+                enable_input_d=enable_d if _i == 0 else 1,
+                pred=leader,
+            )
+        )
+
+
+def _mma_final_2step(taddr_d, b_lo, taddr_a, enable_d):
+    # .cu:1217-1235 -> 2 native tcgen05.mma issues (b_lo add 128; dhi=0x40004040)
+    leader = T.ptx.elect_sync()
+    b_lo32 = T.cast(b_lo, "uint32")
+    for _i in range(2):
+        _b_desc = (T.uint64(0x40004040) << T.uint64(32)) | T.cast(
+            b_lo32 + T.uint32(128 * _i), "uint64"
+        )
+        T.evaluate(
+            T.ptx.tcgen05.mma(
+                taddr_d,
+                taddr_a + 8 * _i,
+                _b_desc,
+                T.uint32(136905872),
+                d_dtype="float32",
+                a_dtype="bfloat16",
+                b_dtype="bfloat16",
+                use_a_tmem=True,
+                cta_group=1,
+                enable_input_d=enable_d if _i == 0 else 1,
+                pred=leader,
+            )
+        )
+
+
+def _cp_async_cg_16_zfill(dst, src, src_bytes):
+    # .cu:1280-1281 (cp.async.cg 16B with src-size zero-fill predicate)
+    return T.cuda.func_call(
+        "flashkda_cp_async_cg_16_zfill",
+        dst,
+        src,
+        src_bytes,
+        source_code=_FLASHKDA_SRCS["flashkda_cp_async_cg_16_zfill"],
+        return_type="void",
+    )
+
+
+def _ld_global_v4_u32(dst, ptr):
+    # verbatim plain uint4 load (.cu:783-806/1564-1601 pattern; plain ld.global.v4, NOT .nc)
+    return T.ptx.ld(
+        ptr,
+        "uint32",
+        "b32",
+        dst=(
+            T.address_of(dst[0]),
+            T.address_of(dst[1]),
+            T.address_of(dst[2]),
+            T.address_of(dst[3]),
+        ),
+        vec="v4",
+    )
+
+
+def _tanh_approx(x):
+    # tanh.approx.f32 (prep-role sigmoid)
+    return T.cuda.func_call(
+        "flashkda_tanh_approx",
+        x,
+        source_code=_FLASHKDA_SRCS["flashkda_tanh_approx"],
+        return_type="float32",
+    )
+
+
+def _expf(x):
+    # .cu:1317 __expf -> ex2.approx.ftz.f32(x * log2(e)) under -use_fast_math
+    return T.ptx.exp2(x * T.float32(1.4426950408889634))
+
+
+def _rsqrtf(x):
+    # rsqrtf verbatim
+    return T.cuda.func_call(
+        "flashkda_rsqrtf", x, source_code=_FLASHKDA_SRCS["flashkda_rsqrtf"], return_type="float32"
+    )
+
+
+def _fmaf_rn(a, b, c):
+    # __fmaf_rn verbatim (value form)
+    return T.cuda.func_call(
+        "flashkda_fmaf_rn",
+        a,
+        b,
+        c,
+        source_code=_FLASHKDA_SRCS["flashkda_fmaf_rn"],
+        return_type="float32",
+    )
+
+
+def _ld_shared_b32(smem_raw, smem, addr):
+    # ld.shared.b32
+    return T.ptx.ld(smem_raw.ptr_to([addr - smem]), "uint32", "b32", space="shared")
+
+
+def _ld_shared_v4(smem_raw, smem, dst, addr):
+    # ld.shared.v4.b32 (dst: 4-elem uint32 local array)
+    return T.ptx.ld(
+        smem_raw.ptr_to([addr - smem]),
+        "uint32",
+        "b32",
+        space="shared",
+        dst=(
+            T.address_of(dst[0]),
+            T.address_of(dst[1]),
+            T.address_of(dst[2]),
+            T.address_of(dst[3]),
+        ),
+        vec="v4",
+    )
+
+
+def _st_shared_b32(smem_raw, smem, addr, val):
+    # st.shared.b32
+    return T.ptx.st(smem_raw.ptr_to([addr - smem]), val, space="shared", ptx_type="b32")
+
+
+def _mma_m16n8k16_bf16_zero(acc, a, b):
+    # mma.sync m16n8k16 bf16, zero C (acc/a/b: local arrays) -> native register-fragment
+    # form; c_ptrs=None feeds "f"(0.f) per C slot == inline's 0f00000000 literals
+    return T.ptx.mma(
+        "m16n8k16",
+        "row",
+        "col",
+        "float32",
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        [T.address_of(acc[i]) for i in range(4)],
+        [T.address_of(a[i]) for i in range(4)],
+        [T.address_of(b[i]) for i in range(2)],
+    )
+
+
+def _mma_m16n8k16_bf16_acc(acc, a, b):
+    # mma.sync m16n8k16 bf16, accumulating C (c_ptrs alias acc == inline "+f" tied regs)
+    return T.ptx.mma(
+        "m16n8k16",
+        "row",
+        "col",
+        "float32",
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        [T.address_of(acc[i]) for i in range(4)],
+        [T.address_of(a[i]) for i in range(4)],
+        [T.address_of(b[i]) for i in range(2)],
+        [T.address_of(acc[i]) for i in range(4)],
+    )
+
+
+def _mma_m16n8k8_bf16_zero(acc, a, b):
+    # mma.sync m16n8k8 bf16, zero C -> native register-fragment form
+    return T.ptx.mma(
+        "m16n8k8",
+        "row",
+        "col",
+        "float32",
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        [T.address_of(acc[i]) for i in range(4)],
+        [T.address_of(a[i]) for i in range(2)],
+        [T.address_of(b[i]) for i in range(1)],
+    )
+
+
+def _mma_m16n8k16_bf16_zero_off4(acc, a, b):
+    # second zero-C mma writing acc[4..7] with b_frag[2..3] (e.g. .cu:1725-1727)
+    return T.ptx.mma(
+        "m16n8k16",
+        "row",
+        "col",
+        "float32",
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        [T.address_of(acc[4 + i]) for i in range(4)],
+        [T.address_of(a[i]) for i in range(4)],
+        [T.address_of(b[2 + i]) for i in range(2)],
+    )
+
+
+def _mma_m16n8k16_bf16_acc_off4(acc, a, b):
+    # second accumulating mma writing acc[4..7] with b_frag[2..3]
+    return T.ptx.mma(
+        "m16n8k16",
+        "row",
+        "col",
+        "float32",
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        [T.address_of(acc[4 + i]) for i in range(4)],
+        [T.address_of(a[i]) for i in range(4)],
+        [T.address_of(b[2 + i]) for i in range(2)],
+        [T.address_of(acc[4 + i]) for i in range(4)],
+    )
+
+
+def _st_global_v4_u32(ptr, a, b, c, d):
+    # verbatim uint4 store (STG.128 shape) used by the final-state store path
+    return T.ptx.st(ptr, a, b, c, d, space="global", vec="v4", ptx_type="b32")
+
+
+def _mbarrier_wait(smem_raw, smem, mbar_addr, phase):
+    # .cu:158-171 -> native T.ptx.mbarrier.try_wait: same LAB_WAIT spin loop with
+    # ticks=0x989680; mbarrier.try_wait.parity.shared::cta defaults to .acquire.cta
+    # (the token/cluster wait variants at .cu:130-156,173-198 had no call sites)
+    return T.ptx.mbarrier.try_wait(smem_raw.ptr_to([mbar_addr - smem]), phase)
+
+
+def _elect_commit(mbar_addr):
+    # .cu:239-248
+    leader = T.ptx.elect_sync()
+    return T.ptx.tcgen05.commit(mbar_addr, cta_group=1, pred=leader)
+
+
+def _mbarrier_arrive(smem_raw, smem, mbar_addr):
+    # .cu:251-255 -> native; emits the same mbarrier.arrive.release.cta.shared::cta.b64 _, [addr]
+    return T.ptx.mbarrier.arrive(
+        smem_raw.ptr_to([mbar_addr - smem]), sem="release", scope="cta", space="shared::cta"
+    )
+
+
+def _mbarrier_arrive_expect_tx(mbar_addr, bytes_):
+    # .cu:258-262
+    return T.ptx.mbarrier.arrive.expect_tx(
+        mbar_addr, bytes_, sem="release", scope="cta", space="shared::cta"
+    )
+
+
+def _tmem_ld_x32(dst, tmem_addr):
+    # .cu:265-281
+    return T.ptx.tcgen05.ld(tmem_addr, *[dst[j] for j in range(32)], shape="32x32b", num=32)
+
+
+def _tmem_st_x32_f32(tmem_addr, src):
+    # .cu:297-313
+    return T.ptx.tcgen05.st(tmem_addr, *[src[j] for j in range(32)], shape="32x32b", num=32)
+
+
+def _approx_exp2(x):
+    # .cu:326-330
+    return T.ptx.exp2(x)
+
+
+def _mul_f32x2_inplace(a, b):
+    # .cu:342-345
+    return T.ptx.mul_f32x2(a, b, rounding="rn", ftz=True, dps=False)
+
+
+def _sub_f32x2_inplace(a, b):
+    # .cu:352-355
+    return T.ptx.sub_f32x2(a, b, rounding="rn", ftz=True, dps=False)
+
+
+def _fence_async_shared():
+    # .cu:416-418
+    return T.ptx.fence.proxy_async("shared::cta")
+
+
+def _tma_3d_gmem2smem(smem_raw, smem, dst, tmap_ptr, x, y, z, mbar_addr):
+    # .cu:430-438 (raw tensor-map pointer form) -> native; on sm_100 the wrapper emits
+    # the explicit default .cta_group::1 suffix for the unqualified inline instruction
+    return T.ptx.cp_async.bulk.tensor.g2s_cta(
+        3,
+        smem_raw.ptr_to([dst - smem]),
+        mbar_addr,
+        T.reinterpret("uint64", tmap_ptr),
+        1,
+        "",
+        x,
+        y,
+        z,
+        mbar_is_shared_addr=True,
+    )
+
+
+def _tma_2d_gmem2smem(smem_raw, smem, dst, tmap_ptr, x, y, mbar_addr):
+    # .cu:441-449 -> native (see _tma_3d_gmem2smem note)
+    return T.ptx.cp_async.bulk.tensor.g2s_cta(
+        2,
+        smem_raw.ptr_to([dst - smem]),
+        mbar_addr,
+        T.reinterpret("uint64", tmap_ptr),
+        1,
+        "",
+        x,
+        y,
+        mbar_is_shared_addr=True,
+    )
+
+
+def _tma_4d_gmem2smem(smem_raw, smem, dst, tmap_ptr, x, y, z, w, mbar_addr):
+    # .cu:452-460 -> native (see _tma_3d_gmem2smem note)
+    return T.ptx.cp_async.bulk.tensor.g2s_cta(
+        4,
+        smem_raw.ptr_to([dst - smem]),
+        mbar_addr,
+        T.reinterpret("uint64", tmap_ptr),
+        1,
+        "",
+        x,
+        y,
+        z,
+        w,
+        mbar_is_shared_addr=True,
+    )
+
+
+def _tma_store_4d(smem_raw, smem, tmap, x, y, z, w, smem_addr):
+    # .cu:463-469 -> native s2g (cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group)
+    return T.ptx.cp_async.bulk.tensor.s2g(
+        4, smem_raw.ptr_to([smem_addr - smem]), T.reinterpret("uint64", tmap), "", x, y, z, w
+    )
+
+
+def _tmem_st_x8_u32(addr, src):
+    # .cu:480-487
+    return T.ptx.tcgen05.st(addr, *[src[j] for j in range(8)], shape="32x32b", num=8)
+
+
+def _make_warp_uniform(val):
+    # .cu:490-495
+    return T.cuda._shfl_sync(T.uint32(0xFFFFFFFF), val, 0, 32)
+
+
+@dataclass(frozen=True)
+class FlashKDABf16FusedM128Config:
+    label: str
+    num_heads: int
+    seq_lens: tuple[int, ...]
+    packed: bool
+    use_initial_state: bool = False
+    store_final_state: bool = False
+    lower_bound: float = DEFAULT_LOWER_BOUND
+    seed: int = 0
+
+    def validate(self) -> None:
+        if self.num_heads <= 0:
+            raise ValueError("num_heads must be positive")
+        if not self.seq_lens or any(t <= 0 for t in self.seq_lens):
+            raise ValueError("seq_lens must be non-empty and positive")
+        if not math.isfinite(self.lower_bound) or self.lower_bound >= 0.0:
+            raise ValueError("lower_bound must be finite and negative")
+        if self.packed:
+            if sum(self.seq_lens) <= len(self.seq_lens):
+                raise ValueError("packed prefill requires total_tokens > num_seqs")
+        else:
+            if len(set(self.seq_lens)) != 1:
+                raise ValueError("fixed layout requires uniform seq_lens")
+            if self.seq_lens[0] <= 1:
+                raise ValueError("fixed prefill requires T > 1")
+            if len(self.seq_lens) == 1 and self.num_heads == 64:
+                raise ValueError("fixed B=1 H=64 dispatches to the m64 kernel (out of scope)")
+
+    @property
+    def num_seqs(self) -> int:
+        return len(self.seq_lens)
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(self.seq_lens)
+
+    @property
+    def beta_tma_tokens(self) -> int:
+        return max(self.total_tokens, 32)
+
+    @property
+    def beta_tma_heads(self) -> int:
+        return max(self.num_heads, 8)
+
+
+def _cu_tensor_map_encode_tiled(
+    data_ptr: int,
+    rank: int,
+    global_dim: list[int],
+    global_strides: list[int],
+    box_dim: list[int],
+    swizzle: int,
+) -> bytes:
+    """ctypes replication of the host cuTensorMapEncodeTiled calls in
+    flashkda_binding_common.cuh (BF16, interleave/L2/OOB all NONE)."""
+    import ctypes
+
+    libcuda = ctypes.CDLL("libcuda.so.1")
+    tensor_map = (ctypes.c_uint64 * 16)()  # 128 B, opaque
+    dims = (ctypes.c_uint64 * rank)(*global_dim)
+    strides = (ctypes.c_uint64 * (rank - 1))(*global_strides)
+    box = (ctypes.c_uint32 * rank)(*box_dim)
+    elem_strides = (ctypes.c_uint32 * rank)(*([1] * rank))
+    result = libcuda.cuTensorMapEncodeTiled(
+        ctypes.byref(tensor_map),
+        9,  # CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+        rank,
+        ctypes.c_void_p(data_ptr),
+        dims,
+        strides,
+        box,
+        elem_strides,
+        0,  # CU_TENSOR_MAP_INTERLEAVE_NONE
+        swizzle,
+        0,  # CU_TENSOR_MAP_L2_PROMOTION_NONE
+        0,  # CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    )
+    if result != 0:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with CUresult={result}")
+    return bytes(tensor_map)
+
+
+_CU_TENSOR_MAP_SWIZZLE_128B = 3
+_CU_TENSOR_MAP_SWIZZLE_NONE = 0
+
+
+def _encode_tma_descriptors(case: dict[str, Any]) -> None:
+    """Publish the six CUtensorMaps into descriptor_storage (host side of
+    EncodeTmaPointers<128> in flashkda_binding_common.cuh)."""
+    cfg: FlashKDABf16FusedM128Config = case["config"]
+    tokens = cfg.total_tokens
+    h = cfg.num_heads
+    maps = bytearray()
+    # EncodeQkTma(q/k): 4D {64, tokens, H, 2}, strides {H*256, 256, 128},
+    # box {64, 32, 1, 2}, SWIZZLE_128B.
+    for tensor in (case["q"], case["k"]):
+        maps += _cu_tensor_map_encode_tiled(
+            tensor.data_ptr(),
+            4,
+            [64, tokens, h, D_HEAD // 64],
+            [h * D_HEAD * 2, D_HEAD * 2, 64 * 2],
+            [64, 32, 1, 2],
+            _CU_TENSOR_MAP_SWIZZLE_128B,
+        )
+    # EncodeValueTma<128>(v) / EncodeGateTma(g): 3D {128, H, tokens},
+    # strides {256, 256*H}, box {128, 1, 32}, SWIZZLE_NONE.
+    for tensor in (case["v"], case["g"]):
+        maps += _cu_tensor_map_encode_tiled(
+            tensor.data_ptr(),
+            3,
+            [D_HEAD, h, tokens],
+            [D_HEAD * 2, D_HEAD * h * 2],
+            [128, 1, 32],
+            _CU_TENSOR_MAP_SWIZZLE_NONE,
+        )
+    # EncodeBetaTma(beta_tma): 2D {max(H,8), max(tokens,32)}, box {8, 32}.
+    maps += _cu_tensor_map_encode_tiled(
+        case["beta_tma"].data_ptr(),
+        2,
+        [cfg.beta_tma_heads, cfg.beta_tma_tokens],
+        [cfg.beta_tma_heads * 2],
+        [8, 32],
+        _CU_TENSOR_MAP_SWIZZLE_NONE,
+    )
+    # EncodeOutputTma<128>(out): same layout as q/k, SWIZZLE_128B.
+    maps += _cu_tensor_map_encode_tiled(
+        case["out"].data_ptr(),
+        4,
+        [64, tokens, h, D_HEAD // 64],
+        [h * D_HEAD * 2, D_HEAD * 2, 64 * 2],
+        [64, 32, 1, 2],
+        _CU_TENSOR_MAP_SWIZZLE_128B,
+    )
+    case["descriptor_storage"].copy_(
+        torch.frombuffer(maps, dtype=torch.uint8).to(case["descriptor_storage"].device)
+    )
+
+
+def _m128_dispatch_reason(cfg: FlashKDABf16FusedM128Config) -> str:
+    if not cfg.packed and cfg.num_seqs == 1 and cfg.num_heads == 64:
+        return "out_of_scope: fixed B=1 H=64 dispatches to kernel_flashkda_bf16_fused_m64"
+    layout = "packed" if cfg.packed else "fixed"
+    return (
+        f"m128: sm100a BF16 {layout} prefill dispatches to "
+        "kernel_flashkda_bf16_fused_m128 (_select_flash_kda_prefill_variant)"
+    )
+
+
+_MIXED_SEQ_LENS = (1300, 547, 2048, 963, 271, 3063)
+
+CONFIGS = [
+    # Mirrors tests/kda/test_recurrent_kda_prefill.py::test_frozen_prefill_matches_reference.
+    {"label": "fixed_h2_t4", "num_heads": 2, "seq_lens": (4, 4), "packed": False},
+    {"label": "packed_h2_3_5", "num_heads": 2, "seq_lens": (3, 5), "packed": True},
+    {
+        "label": "fixed_h2_t4_state",
+        "num_heads": 2,
+        "seq_lens": (4, 4),
+        "packed": False,
+        "use_initial_state": True,
+        "store_final_state": True,
+    },
+    {
+        "label": "packed_h2_3_5_state",
+        "num_heads": 2,
+        "seq_lens": (3, 5),
+        "packed": True,
+        "use_initial_state": True,
+        "store_final_state": True,
+    },
+    # Multi-chunk coverage: sequences longer than one 128-token chunk exercise the
+    # 5-stage chunk pipeline; mixed lengths exercise packed boundary handling.
+    {"label": "fixed_h4_t256", "num_heads": 4, "seq_lens": (256, 256), "packed": False},
+    {"label": "packed_h4_chunks", "num_heads": 4, "seq_lens": (200, 264, 128), "packed": True},
+]
+
+BENCH_CONFIGS = [
+    # Mirrors benchmarks/bench_recurrent_kda_prefill.py CASES, minus h64_fixed8192
+    # which dispatches to the m64 kernel (out of scope for this module).
+    {
+        "label": "h96_fixed8192",
+        "num_heads": 96,
+        "seq_lens": (8192,),
+        "packed": False,
+        "use_initial_state": True,
+        "seed": 10000,
+    },
+    {
+        "label": "h96_mixed",
+        "num_heads": 96,
+        "seq_lens": _MIXED_SEQ_LENS,
+        "packed": True,
+        "use_initial_state": True,
+        "seed": 10001,
+    },
+    {
+        "label": "h96_uniform",
+        "num_heads": 96,
+        "seq_lens": (1024,) * 8,
+        "packed": True,
+        "use_initial_state": True,
+        "seed": 10002,
+    },
+    {
+        "label": "h64_mixed",
+        "num_heads": 64,
+        "seq_lens": _MIXED_SEQ_LENS,
+        "packed": True,
+        "use_initial_state": True,
+        "seed": 10004,
+    },
+    {
+        "label": "h64_uniform",
+        "num_heads": 64,
+        "seq_lens": (1024,) * 8,
+        "packed": True,
+        "use_initial_state": True,
+        "seed": 10005,
+    },
+]
+
+KERNEL_META = {"name": "flashkda_bf16_fused_m128", "category": "flashkda", "compute_capability": 10}
+
+
+def _cfg(**kwargs: Any) -> FlashKDABf16FusedM128Config:
+    cfg_fields = {field.name for field in fields(FlashKDABf16FusedM128Config)}
+    cfg_kwargs = {key: value for key, value in kwargs.items() if key in cfg_fields}
+    if "seq_lens" in cfg_kwargs:
+        cfg_kwargs["seq_lens"] = tuple(int(t) for t in cfg_kwargs["seq_lens"])
+    if "label" not in cfg_kwargs:
+        cfg_kwargs["label"] = "custom"
+    cfg = FlashKDABf16FusedM128Config(**cfg_kwargs)
+    cfg.validate()
+    return cfg
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    cfg = _cfg(**kwargs)
+    device = kwargs.get("device", "cuda")
+    gen = torch.Generator(device=device)
+    gen.manual_seed(cfg.seed)
+
+    total_tokens = cfg.total_tokens
+    shape = (total_tokens, cfg.num_heads, D_HEAD)
+    q = torch.randn(shape, device=device, dtype=torch.float32, generator=gen).to(torch.bfloat16)
+    k = torch.randn(shape, device=device, dtype=torch.float32, generator=gen).to(torch.bfloat16)
+    v = torch.randn(shape, device=device, dtype=torch.float32, generator=gen).to(torch.bfloat16)
+    g = torch.randn(shape, device=device, dtype=torch.float32, generator=gen).to(torch.bfloat16)
+    beta = torch.randn(
+        (total_tokens, cfg.num_heads), device=device, dtype=torch.float32, generator=gen
+    ).to(torch.bfloat16)
+    A_log = 0.1 * torch.randn((cfg.num_heads,), device=device, dtype=torch.float32, generator=gen)
+    dt_bias = 0.1 * torch.randn(
+        (cfg.num_heads, D_HEAD), device=device, dtype=torch.float32, generator=gen
+    )
+
+    # Host-side beta TMA padding (flashinfer/kda_prefill.py::_beta_tma_source):
+    # [max(tokens, 32), max(H, 8)], zero-filled padding.
+    beta_tma = torch.zeros(
+        (cfg.beta_tma_tokens, cfg.beta_tma_heads), device=device, dtype=torch.bfloat16
+    )
+    beta_tma[:total_tokens, : cfg.num_heads] = beta
+
+    offsets = [0]
+    for seq_len in cfg.seq_lens:
+        offsets.append(offsets[-1] + seq_len)
+    cu_seqlens = torch.tensor(offsets, dtype=torch.int64, device=device)
+    # Packed bench mirrors the PR benchmark: order sequences by descending length
+    # for better tail utilization; correctness configs keep the identity order.
+    if cfg.packed and cfg.total_tokens > 512:
+        order = sorted(range(cfg.num_seqs), key=lambda i: -cfg.seq_lens[i])
+    else:
+        order = list(range(cfg.num_seqs))
+    seq_order = torch.tensor(order, dtype=torch.int32, device=device)
+
+    state_shape = (cfg.num_seqs, cfg.num_heads, D_HEAD, D_HEAD)
+    if cfg.use_initial_state:
+        initial_state = (
+            0.1 * torch.randn(state_shape, device=device, dtype=torch.float32, generator=gen)
+        ).to(torch.bfloat16)
+    else:
+        initial_state = torch.empty(state_shape, device=device, dtype=torch.bfloat16)
+    final_state = torch.empty(state_shape, device=device, dtype=torch.bfloat16)
+    out = torch.empty(shape, device=device, dtype=torch.bfloat16)
+    # Six CUtensorMap descriptors, 128 B each, 64 B aligned (torch storages are
+    # 512 B aligned); the frozen kernel publishes descriptors here.
+    descriptor_storage = torch.empty((768,), device=device, dtype=torch.uint8)
+
+    case = {
+        "config": cfg,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "beta_tma": beta_tma,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "cu_seqlens": cu_seqlens,
+        "seq_order": seq_order,
+        "initial_state": initial_state,
+        "out": out,
+        "final_state": final_state,
+        "descriptor_storage": descriptor_storage,
+        "scale": 1.0 / math.sqrt(D_HEAD),
+        "dispatch_reason": _m128_dispatch_reason(cfg),
+    }
+    if device != "cpu" and torch.device(device).type != "cpu":
+        _encode_tma_descriptors(case)
+    return case
+
+
+def _reference_torch(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Token-serial reference, mirrors tests/kda/test_recurrent_kda_prefill.py::_reference.
+
+    O(total_tokens) python loop; intended for the small correctness configs.
+    """
+    import torch.nn.functional as F
+
+    cfg: FlashKDABf16FusedM128Config = case["config"]
+    scale = case["scale"]
+    q_flat = F.normalize(case["q"].float(), dim=-1)
+    k_flat = F.normalize(case["k"].float(), dim=-1)
+    v_flat = case["v"].float()
+    g_flat = case["g"].float()
+    beta_flat = torch.sigmoid(case["beta"].float())
+    gate = cfg.lower_bound * torch.sigmoid(
+        torch.exp(case["A_log"]).reshape(1, cfg.num_heads, 1)
+        * (g_flat + case["dt_bias"].reshape(1, cfg.num_heads, D_HEAD))
+    )
+    decay = torch.exp(gate)
+    if cfg.use_initial_state:
+        state = case["initial_state"].clone()
+    else:
+        state = torch.zeros(
+            (cfg.num_seqs, cfg.num_heads, D_HEAD, D_HEAD),
+            dtype=torch.bfloat16,
+            device=case["q"].device,
+        )
+    out = torch.empty_like(q_flat)
+    offsets = [0, *torch.cumsum(torch.tensor(cfg.seq_lens), dim=0).tolist()]
+    for sequence in range(cfg.num_seqs):
+        for token in range(offsets[sequence], offsets[sequence + 1]):
+            state_f32 = state[sequence].float()
+            decayed = state_f32 * decay[token].unsqueeze(1)
+            predicted = torch.einsum("hk,hvk->hv", k_flat[token], decayed)
+            residual = beta_flat[token].unsqueeze(-1) * (v_flat[token] - predicted)
+            updated = decayed + residual.unsqueeze(-1) * k_flat[token].unsqueeze(1)
+            state[sequence] = updated.to(torch.bfloat16)
+            projected = torch.einsum("hk,hvk->hv", q_flat[token], state[sequence].float())
+            out[token] = (scale * projected).to(torch.bfloat16)
+    return out.to(torch.bfloat16), state
+
+
+def _load_frozen_recurrent_kda():
+    """Import flashinfer.recurrent_kda from the PR head worktree (frozen m128).
+
+    Handles the case where an installed flashinfer (main, without kda.py) was
+    already imported by purging it and re-importing from the worktree.
+    """
+    worktree = os.environ.get("FLASHKDA_PR_WORKTREE", _FLASHKDA_PR_WORKTREE_DEFAULT)
+    if worktree not in sys.path:
+        sys.path.insert(0, worktree)
+    import flashinfer
+
+    if not str(getattr(flashinfer, "__file__", "")).startswith(worktree):
+        for mod_name in [
+            m for m in list(sys.modules) if m == "flashinfer" or m.startswith("flashinfer.")
+        ]:
+            del sys.modules[mod_name]
+        import flashinfer
+
+        if not str(getattr(flashinfer, "__file__", "")).startswith(worktree):
+            raise RuntimeError(
+                f"failed to import flashinfer from PR worktree {worktree}; "
+                f"got {getattr(flashinfer, '__file__', None)}"
+            )
+    from flashinfer.kda import recurrent_kda
+
+    return recurrent_kda
+
+
+def _frozen_cuda_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run the frozen m128 CUDA kernel via flashinfer.recurrent_kda on the same inputs."""
+    cfg: FlashKDABf16FusedM128Config = case["config"]
+    recurrent_kda = _load_frozen_recurrent_kda()
+    batch = 1 if cfg.packed else cfg.num_seqs
+    seq_len = cfg.total_tokens if cfg.packed else cfg.seq_lens[0]
+
+    def reshaped(t: torch.Tensor) -> torch.Tensor:
+        return t.reshape(batch, seq_len, cfg.num_heads, -1)
+
+    ref_out, ref_state = recurrent_kda(
+        q=reshaped(case["q"]),
+        k=reshaped(case["k"]),
+        v=reshaped(case["v"]),
+        g=reshaped(case["g"]),
+        beta=case["beta"].reshape(batch, seq_len, cfg.num_heads),
+        A_log=case["A_log"],
+        dt_bias=case["dt_bias"],
+        scale=case["scale"],
+        initial_state=case["initial_state"] if cfg.use_initial_state else None,
+        output_final_state=cfg.store_final_state,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=cfg.lower_bound,
+        cu_seqlens=case["cu_seqlens"] if cfg.packed else None,
+        beta_is_logit=True,
+        seq_order=case["seq_order"] if cfg.packed else None,
+    )
+    return ref_out.reshape(cfg.total_tokens, cfg.num_heads, D_HEAD), ref_state
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g"].reshape(-1),
+        case["beta"].reshape(-1),
+        case["beta_tma"],
+        case["A_log"],
+        case["dt_bias"].reshape(-1),
+        case["cu_seqlens"],
+        case["seq_order"],
+        case["initial_state"].reshape(-1),
+        case["out"].reshape(-1),
+        case["final_state"].reshape(-1),
+        case["descriptor_storage"],
+    )
+
+
+@T.jit
+def _kernel(
+    q: T.Buffer((total_tokens * h * D_HEAD,), "bfloat16"),
+    k: T.Buffer((total_tokens * h * D_HEAD,), "bfloat16"),
+    v: T.Buffer((total_tokens * h * D_HEAD,), "bfloat16"),
+    g: T.Buffer((total_tokens * h * D_HEAD,), "bfloat16"),
+    beta: T.Buffer((total_tokens * h,), "bfloat16"),
+    beta_tma: T.Buffer((beta_tma_tokens, beta_tma_heads), "bfloat16"),
+    A_log: T.Buffer((h,), "float32"),
+    dt_bias: T.Buffer((h * D_HEAD,), "float32"),
+    cu_seqlens: T.Buffer((num_seqs + 1,), "int64"),
+    seq_order: T.Buffer((num_seqs,), "int32"),
+    initial_state: T.Buffer((num_seqs * h * D_HEAD * D_HEAD,), "bfloat16"),
+    out: T.Buffer((total_tokens * h * D_HEAD,), "bfloat16"),
+    final_state: T.Buffer((num_seqs * h * D_HEAD * D_HEAD,), "bfloat16"),
+    descriptor_storage: T.Buffer((768,), "uint8"),
+    *,
+    total_tokens: T.constexpr,
+    h: T.constexpr,
+    num_seqs: T.constexpr,
+    beta_tma_tokens: T.constexpr,
+    beta_tma_heads: T.constexpr,
+    scale: T.constexpr,
+    lower_bound: T.constexpr,
+    use_initial_state: T.constexpr,
+    store_final_state: T.constexpr,
+):
+    T.device_entry()
+    T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+    # CUDA_TRANSCRIBE_START: kernel_flashkda_bf16_fused_m128,
+    # flashkda_bf16_fused_m128.cu:504 (tensor-map acquire fences), then source
+    # order. Grid = num_seqs * h CTAs, 1024 threads, SMEM_TOTAL dynamic smem.
+    block_idx = T.cta_id([num_seqs * h])
+    thread_idx = T.thread_id([THREADS])
+    T.warpgroup_id([THREADS // 128])
+    T.warp_id_in_wg([4])
+    T.lane_id([32])
+    T.thread_id_in_wg([128])
+
+    pool = T.SMEMPool()
+    smem_raw = pool.alloc((SMEM_TOTAL,), "uint8", align=1024)
+    tmem_addr_storage = T.decl_buffer(
+        (1,),
+        "int32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_TMEM_ADDR_STORAGE_OFF,
+        align=4,
+    )
+    smem_g_raw_all = T.decl_buffer(
+        (SMEM_SMEM_G_RAW_ALL_STAGE_BYTES // 2,),
+        "bfloat16",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_G_RAW_ALL_OFF,
+        align=1024,
+    )
+    smem_v_all = T.decl_buffer(
+        (SMEM_SMEM_V_ALL_STAGE_BYTES // 2,),
+        "bfloat16",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_V_ALL_OFF,
+        align=1024,
+    )
+    smem_gate_all = T.decl_buffer(
+        (SMEM_SMEM_GATE_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_GATE_ALL_OFF,
+        align=1024,
+    )
+    smem_gt_all = T.decl_buffer(
+        (SMEM_SMEM_GT_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_GT_ALL_OFF,
+        align=1024,
+    )
+    smem_gt_prefix_all = T.decl_buffer(
+        (SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_GT_PREFIX_ALL_OFF,
+        align=1024,
+    )
+    smem_restore_factor_all = T.decl_buffer(
+        (SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_RESTORE_FACTOR_ALL_OFF,
+        align=1024,
+    )
+    smem_prep_beta_all = T.decl_buffer(
+        (SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_PREP_BETA_ALL_OFF,
+        align=1024,
+    )
+    smem_gate_rate_all = T.decl_buffer(
+        (SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES // 4,),
+        "float32",
+        data=smem_raw.data,
+        scope="shared.dyn",
+        byte_offset=SMEM_SMEM_GATE_RATE_ALL_OFF,
+        align=1024,
+    )
+    pool.commit()
+
+    # Kernel TMA descriptor pointers (descriptor_storage slots, .cu:501 ABI).
+    q_tma = descriptor_storage.ptr_to([TMA_SLOT_Q])
+    k_tma = descriptor_storage.ptr_to([TMA_SLOT_K])
+    v_tma = descriptor_storage.ptr_to([TMA_SLOT_V])
+    g_tma = descriptor_storage.ptr_to([TMA_SLOT_G])
+    beta_tma_tmap = descriptor_storage.ptr_to([TMA_SLOT_BETA])
+    out_tma = descriptor_storage.ptr_to([TMA_SLOT_OUT])
+
+    # .cu:504-521 (FLASHINFER INTEGRATION: acquire global tensor maps).
+    if thread_idx == 0:
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            q_tma,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            k_tma,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            v_tma,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            g_tma,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            beta_tma_tmap,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+        T.cuda.func_call(
+            "flashkda_tensormap_acquire",
+            out_tma,
+            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
+            return_type="void",
+        )
+    T.cuda.cta_sync()  # .cu:520 __syncthreads()
+
+    # .cu:522-524
+    tid: T.let = thread_idx
+    warp = _make_warp_uniform(T.cast(tid, "uint32") // T.uint32(32))
+    lane: T.let = tid % 32
+    # .cu:526-528
+    smem: T.uint32 = T.cuda.cvta_generic_to_shared(T.address_of(smem_raw[0]))
+    # .cu:530-531
+    bid: T.let = block_idx
+    num_bids: T.let = num_seqs * h
+
+    # .cu:533-577 Kernel setup ops (smem aliases; int addresses).
+    smem_qd_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_QD_OFF
+    smem_g_raw_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_G_RAW_OFF
+    smem_g_raw_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_G_RAW_ALL_OFF
+    smem_kd_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_KD_OFF
+    smem_q_raw_prefetch_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_Q_RAW_PREFETCH_OFF
+    smem_final_trans_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_FINAL_TRANS_OFF
+    smem_kr_trans_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_KR_TRANS_OFF
+    smem_mqk_trans_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_MQK_TRANS_OFF
+    smem_inv_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_INV_OFF
+    smem_v_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_V_OFF
+    smem_ki_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_KI_OFF
+    smem_gate_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_GATE_OFF
+    smem_beta_raw_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_BETA_RAW_OFF
+    smem_inv_work_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_INV_WORK_OFF
+    smem_out_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_OUT_OFF
+    smem_restore_factor_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_RESTORE_FACTOR_ALL_OFF
+    smem_gt_prefix_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_GT_PREFIX_ALL_OFF
+    smem_gt_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_GT_ALL_OFF
+    smem_prep_beta_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_PREP_BETA_ALL_OFF
+    smem_gate_rate_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_GATE_RATE_ALL_OFF
+    smem_v_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_V_ALL_OFF
+    smem_gate_all_addr: T.int32 = T.cast(smem, "int32") + SMEM_SMEM_GATE_ALL_OFF
+
+    # .cu:579-682 Mbarrier init (17 groups, 77 barriers at smem_raw[0..616)).
+    if warp == 0:
+        leader = T.ptx.elect_sync()
+        if leader:
+            # qk_full: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([0]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([8]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([16]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([24]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([32]), 1)
+            # gate_raw_full: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([40]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([48]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([56]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([64]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([72]), 1)
+            # qk_raw_full: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([80]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([88]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([96]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([104]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([112]), 1)
+            # v_full: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([120]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([128]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([136]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([144]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([152]), 1)
+            # v_free: 5 barriers, init_count=4
+            T.ptx.mbarrier.init(smem_raw.ptr_to([160]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([168]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([176]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([184]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([192]), 4)
+            # smem_free: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([200]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([208]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([216]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([224]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([232]), 1)
+            # raw_inputs_free: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([240]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([248]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([256]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([264]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([272]), 1)
+            # state_inp_ready: 5 barriers, init_count=4
+            T.ptx.mbarrier.init(smem_raw.ptr_to([280]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([288]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([296]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([304]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([312]), 4)
+            # old_out_ready: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([320]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([328]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([336]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([344]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([352]), 1)
+            # u_inp_ready: 5 barriers, init_count=4
+            T.ptx.mbarrier.init(smem_raw.ptr_to([360]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([368]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([376]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([384]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([392]), 4)
+            # u2_acc_ready: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([400]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([408]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([416]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([424]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([432]), 1)
+            # u2_inp_ready: 5 barriers, init_count=4
+            T.ptx.mbarrier.init(smem_raw.ptr_to([440]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([448]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([456]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([464]), 4)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([472]), 4)
+            # final_ready: 5 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([480]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([488]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([496]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([504]), 1)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([512]), 1)
+            # out_empty: 1 barriers, init_count=1
+            T.ptx.mbarrier.init(smem_raw.ptr_to([520]), 1)
+            # tmem_dealloc_ready: 1 barriers, init_count=2
+            T.ptx.mbarrier.init(smem_raw.ptr_to([528]), 2)
+            # prep_diag_ready: 5 barriers, init_count=2
+            T.ptx.mbarrier.init(smem_raw.ptr_to([536]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([544]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([552]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([560]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([568]), 2)
+            # prep_inv16_ready: 5 barriers, init_count=2
+            T.ptx.mbarrier.init(smem_raw.ptr_to([576]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([584]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([592]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([600]), 2)
+            T.ptx.mbarrier.init(smem_raw.ptr_to([608]), 2)
+        T.ptx.fence.mbarrier_init()  # .cu:679 fence.mbarrier_init.release.cluster
+    T.cuda.cta_sync()  # .cu:682 __syncthreads()
+
+    # .cu:684-689 TMEM alloc (256 columns, 256 used).
+    if warp == 0:
+        T.ptx.tcgen05.alloc(T.address_of(tmem_addr_storage[0]), n_cols=256, cta_group=1)
+    T.cuda.cta_sync()  # .cu:691 __syncthreads()
+    T.ptx.tcgen05.fence.after_thread_sync()  # .cu:692
+
+    # .cu:694-712 mbarrier group bases + taddr read (volatile int load).
+    mbar_base: T.int32 = T.cast(smem, "int32")
+    taddr: T.int32 = T.ptx.ld_volatile(
+        T.address_of(tmem_addr_storage[0]), "int32", "s32", space="shared"
+    )
+
+    # .cu:714-721 Kernel post-init ops (TMEM column offsets).
+    tmem_tmem_state: T.int32 = taddr + TMEM_TMEM_STATE_OFFSET
+    tmem_tmem_state_inp: T.int32 = taddr + TMEM_TMEM_STATE_INP_OFFSET
+    tmem_tmem_u_acc: T.int32 = taddr + TMEM_TMEM_U_ACC_OFFSET
+    tmem_tmem_u2_inp: T.int32 = taddr + TMEM_TMEM_U2_INP_OFFSET
+    tmem_tmem_u2_acc: T.int32 = taddr + TMEM_TMEM_U2_ACC_OFFSET
+    tmem_tmem_out: T.int32 = taddr + TMEM_TMEM_OUT_OFFSET
+    tmem_tmem_state_out: T.int32 = taddr + TMEM_TMEM_STATE_OUT_OFFSET
+
+    # .cu:723-727 Register redistribution: dec phase first (warps 8-11).
+    if warp >= 8 and warp <= 11:
+        T.ptx.setmaxnreg(False, 48)
+
+    # ---- Role dispatch (.cu:729-2550); role bodies transcribed in source order.
+    if warp <= 3:
+        # ---- Role: compute (.cu:730-963) ----
+        T.ptx.setmaxnreg(True, 168)  # .cu:731
+        # .cu:732 compute_main
+        task_idx: T.int32 = bid  # .cu:733
+        seq_idx: T.int32 = seq_order[task_idx // h]  # .cu:734
+        head_idx: T.int32 = task_idx % h  # .cu:735
+        bos: T.int64 = cu_seqlens[seq_idx]  # .cu:736
+        eos: T.int64 = cu_seqlens[seq_idx + 1]  # .cu:737
+        seq_len: T.int32 = T.cast(eos - bos, "int32")  # .cu:738
+        num_chunks: T.int32 = (seq_len + 32 - 1) // 32  # .cu:739
+        warp_in_wg: T.int32 = warp % 4  # .cu:740
+        tmem_row_base: T.int32 = (warp_in_wg * 32) << 16  # .cu:741
+        state_row: T.int32 = warp_in_wg * 32 + lane  # .cu:742
+        warp_id_in_role: T.int32 = warp - 0  # .cu:743
+        compute_local_warp: T.int32 = warp_id_in_role  # .cu:744
+        state_base: T.int64 = (
+            (T.cast(seq_idx, "int64") * T.cast(h, "int64") + T.cast(head_idx, "int64")) * 128
+            + T.cast(state_row, "int64")
+        ) * 128  # .cu:745
+        initial_state_u32 = T.decl_buffer(
+            (num_seqs * h * D_HEAD * D_HEAD // 2,), "uint32", data=initial_state.data
+        )
+        final_state_u32 = T.decl_buffer(
+            (num_seqs * h * D_HEAD * D_HEAD // 2,), "uint32", data=final_state.data
+        )
+        for state_col_block in T.unroll(4):  # .cu:746-822 (#pragma unroll)
+            state_frag: T.f32[32]
+            for _zi in T.unroll(32):  # .cu:749-780
+                state_frag[_zi] = T.float32(0.0)
+            if use_initial_state:  # .cu:781
+                # .cu:783-800: 2x uint4 loads + bf16->f32 shl/and unpack (frag 0-15)
+                for _blk in T.unroll(2):
+                    _vld = T.alloc_local((4,), "uint32", align=16)
+                    _ld_global_v4_u32(
+                        _vld,
+                        initial_state_u32.ptr_to(
+                            [(state_base + state_col_block * 32) // 2 + _blk * 4]
+                        ),
+                    )
+                    for _pair in T.unroll(4):
+                        state_frag[0 + _blk * 8 + _pair * 2] = T.cuda.uint_as_float(
+                            _vld[_pair] << T.uint32(16)
+                        )
+                        state_frag[0 + _blk * 8 + _pair * 2 + 1] = T.cuda.uint_as_float(
+                            _vld[_pair] & T.uint32(0xFFFF0000)
+                        )
+                # .cu:801-819: same at +16 elements (frag 16-31)
+                for _blk in T.unroll(2):
+                    _vld1 = T.alloc_local((4,), "uint32", align=16)
+                    _ld_global_v4_u32(
+                        _vld1,
+                        initial_state_u32.ptr_to(
+                            [(state_base + state_col_block * 32 + 16) // 2 + _blk * 4]
+                        ),
+                    )
+                    for _pair in T.unroll(4):
+                        state_frag[16 + _blk * 8 + _pair * 2] = T.cuda.uint_as_float(
+                            _vld1[_pair] << T.uint32(16)
+                        )
+                        state_frag[16 + _blk * 8 + _pair * 2 + 1] = T.cuda.uint_as_float(
+                            _vld1[_pair] & T.uint32(0xFFFF0000)
+                        )
+            _tmem_st_x32_f32(
+                taddr + 64 + tmem_row_base + state_col_block * 32, state_frag
+            )  # .cu:821
+        T.ptx.tcgen05.wait.st()  # .cu:823 tcgen05.wait::st.sync.aligned
+        compute_stage: T.uint32 = 0  # .cu:824
+        _phase_qk_full: T.uint32 = 0  # .cu:825
+        _phase_v_full: T.uint32 = 0  # .cu:826
+        _phase_old_out_ready: T.uint32 = 0  # .cu:827
+        _phase_u2_acc_ready: T.uint32 = 0  # .cu:828
+        _phase_final_ready: T.uint32 = 0  # .cu:829
+        for chunk_idx in T.serial(0, num_chunks, unroll=False):  # .cu:830-831 (#pragma unroll 1)
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_QK_FULL_OFF + compute_stage * 8,
+                _phase_qk_full,
+            )  # .cu:832
+            for state_col_block_1 in T.serial(0, 4, unroll=False):  # .cu:833-834 (#pragma unroll 1)
+                state_addr: T.int32 = taddr + 64 + tmem_row_base + state_col_block_1 * 32  # .cu:835
+                _tmem_load_0: T.f32[32]
+                _tmem_ld_x32(_tmem_load_0, state_addr)  # .cu:836-837
+                _tmem_load_0_bf16: T.uint32[16]
+                for _lp in T.unroll(16):  # .cu:839-843
+                    _tmem_load_0_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        _tmem_load_0[_lp * 2 + 0], _tmem_load_0[_lp * 2 + 1 + 0]
+                    )
+                # .cu:844-848 (inline tcgen05.st x16 of packed bf16 pairs)
+                T.ptx.tcgen05.st(
+                    taddr + tmem_row_base + state_col_block_1 * 16,
+                    *[_tmem_load_0_bf16[_j] for _j in range(16)],
+                    shape="32x32b",
+                    num=16,
+                )
+                state_scale: T.f32[16]
+                for state_half in T.unroll(2):  # .cu:850-859
+                    for state_col in T.unroll(16):
+                        state_scale[state_col] = smem_gt_all[
+                            compute_stage * 10496
+                            + state_col_block_1 * 32
+                            + state_half * 16
+                            + state_col
+                        ]  # .cu:854
+                    for _ls in T.unroll(8):  # .cu:857-858
+                        _pk = _mul_f32x2_inplace(
+                            T.cuda.make_float2(
+                                _tmem_load_0[state_half * 16 + _ls * 2],
+                                _tmem_load_0[state_half * 16 + _ls * 2 + 1],
+                            ),
+                            T.cuda.make_float2(state_scale[_ls * 2], state_scale[_ls * 2 + 1]),
+                        )
+                        _tmem_load_0[state_half * 16 + _ls * 2] = T.cuda.float2_x(_pk)
+                        _tmem_load_0[state_half * 16 + _ls * 2 + 1] = T.cuda.float2_y(_pk)
+                _tmem_st_x32_f32(state_addr, _tmem_load_0)  # .cu:860
+            T.ptx.tcgen05.wait.st()  # .cu:862
+            if T.ptx.elect_sync():  # .cu:863-865
+                _mbarrier_arrive(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_STATE_INP_READY_OFF + compute_stage * 8,
+                )
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_V_FULL_OFF + compute_stage * 8,
+                _phase_v_full,
+            )  # .cu:866
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_OLD_OUT_READY_OFF + compute_stage * 8,
+                _phase_old_out_ready,
+            )  # .cu:867
+            _tmem_load_1: T.f32[32]
+            _tmem_ld_x32(_tmem_load_1, taddr + 224 + tmem_row_base)  # .cu:868-869
+            for residual_half in T.unroll(2):  # .cu:870-895
+                residual_v: T.f32[16]
+                residual_beta: T.f32[16]
+                for residual_col in T.unroll(16):  # .cu:874-881
+                    token_col: T.int32 = residual_half * 16 + residual_col  # .cu:876
+                    residual_v[residual_col] = T.cuda.bfloat162float(
+                        smem_v_all[compute_stage * 20992 + token_col * 128 + state_row]
+                    )  # .cu:877-879
+                    residual_beta[residual_col] = smem_prep_beta_all[
+                        compute_stage * 10496 + token_col
+                    ]  # .cu:880
+                for _ls in T.unroll(8):  # .cu:882-884
+                    _pk = _sub_f32x2_inplace(
+                        T.cuda.make_float2(residual_v[_ls * 2], residual_v[_ls * 2 + 1]),
+                        T.cuda.make_float2(
+                            _tmem_load_1[residual_half * 16 + _ls * 2],
+                            _tmem_load_1[residual_half * 16 + _ls * 2 + 1],
+                        ),
+                    )
+                    residual_v[_ls * 2] = T.cuda.float2_x(_pk)
+                    residual_v[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _ls in T.unroll(8):  # .cu:885-887
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(residual_v[_ls * 2], residual_v[_ls * 2 + 1]),
+                        T.cuda.make_float2(residual_beta[_ls * 2], residual_beta[_ls * 2 + 1]),
+                    )
+                    residual_v[_ls * 2] = T.cuda.float2_x(_pk)
+                    residual_v[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                residual_v_bf16: T.uint32[8]
+                for _lp in T.unroll(8):  # .cu:888-893
+                    residual_v_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        residual_v[_lp * 2 + 0], residual_v[_lp * 2 + 1 + 0]
+                    )
+                _tmem_st_x8_u32(
+                    taddr + 224 + tmem_row_base + residual_half * 8, residual_v_bf16
+                )  # .cu:894
+            T.ptx.tcgen05.wait.st()  # .cu:896
+            if T.ptx.elect_sync():  # .cu:897-900
+                _mbarrier_arrive(
+                    smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_V_FREE_OFF + compute_stage * 8
+                )
+                _mbarrier_arrive(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_U_INP_READY_OFF + compute_stage * 8,
+                )
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_U2_ACC_READY_OFF + compute_stage * 8,
+                _phase_u2_acc_ready,
+            )  # .cu:901
+            _tmem_load_2: T.f32[32]
+            _tmem_ld_x32(_tmem_load_2, taddr + tmem_row_base)  # .cu:902-903
+            _tmem_load_2_bf16: T.uint32[16]
+            for _lp in T.unroll(16):  # .cu:904-909
+                _tmem_load_2_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                    _tmem_load_2[_lp * 2 + 0], _tmem_load_2[_lp * 2 + 1 + 0]
+                )
+            # .cu:910-914 (inline tcgen05.st x16)
+            T.ptx.tcgen05.st(
+                taddr + 224 + tmem_row_base,
+                *[_tmem_load_2_bf16[_j] for _j in range(16)],
+                shape="32x32b",
+                num=16,
+            )
+            T.ptx.tcgen05.wait.st()  # .cu:915
+            if T.ptx.elect_sync():  # .cu:916-918
+                _mbarrier_arrive(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_U2_INP_READY_OFF + compute_stage * 8,
+                )
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_FINAL_READY_OFF + compute_stage * 8,
+                _phase_final_ready,
+            )  # .cu:919
+            compute_stage += 1  # .cu:920
+            if compute_stage == 5:  # .cu:921
+                compute_stage = T.uint32(0)
+                _phase_qk_full = _phase_qk_full ^ T.uint32(1)
+                _phase_v_full = _phase_v_full ^ T.uint32(1)
+                _phase_old_out_ready = _phase_old_out_ready ^ T.uint32(1)
+                _phase_u2_acc_ready = _phase_u2_acc_ready ^ T.uint32(1)
+                _phase_final_ready = _phase_final_ready ^ T.uint32(1)
+        if store_final_state:  # .cu:923-955
+            for state_col_block_2 in T.unroll(4):
+                _tmem_load_3: T.f32[32]
+                _tmem_ld_x32(
+                    _tmem_load_3, taddr + 64 + tmem_row_base + state_col_block_2 * 32
+                )  # .cu:926-927
+                for _half2 in T.unroll(2):  # .cu:928-953 (two 16-float groups)
+                    _pk: T.uint32[8]
+                    for _pj in T.unroll(8):
+                        _pk[_pj] = T.cuda.float22bfloat162_rn(
+                            _tmem_load_3[_half2 * 16 + _pj * 2],
+                            _tmem_load_3[_half2 * 16 + _pj * 2 + 1],
+                        )
+                    _st_global_v4_u32(
+                        final_state_u32.ptr_to(
+                            [(state_base + state_col_block_2 * 32 + _half2 * 16) // 2]
+                        ),
+                        _pk[0],
+                        _pk[1],
+                        _pk[2],
+                        _pk[3],
+                    )  # .cu:938/951 first uint4
+                    _st_global_v4_u32(
+                        final_state_u32.ptr_to(
+                            [(state_base + state_col_block_2 * 32 + _half2 * 16) // 2 + 4]
+                        ),
+                        _pk[4],
+                        _pk[5],
+                        _pk[6],
+                        _pk[7],
+                    )  # .cu:939/952 second uint4
+        T.ptx.bar.sync(10, 128)  # .cu:956 barrier.sync 10, 128
+        if compute_local_warp == 0:  # .cu:957-961
+            if T.ptx.elect_sync():
+                _mbarrier_arrive(
+                    smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_TMEM_DEALLOC_READY_OFF
+                )
+    elif warp >= 4 and warp <= 7:
+        # ---- Role: epilogue (.cu:964-1090) ----
+        T.ptx.setmaxnreg(False, 48)  # .cu:965
+        # .cu:966 epilogue_main
+        task_idx_1: T.int32 = bid  # .cu:967
+        seq_idx_1: T.int32 = seq_order[task_idx_1 // h]  # .cu:968
+        head_idx_1: T.int32 = task_idx_1 % h  # .cu:969
+        bos_1: T.int64 = cu_seqlens[seq_idx_1]  # .cu:970
+        eos_1: T.int64 = cu_seqlens[seq_idx_1 + 1]  # .cu:971
+        seq_len_1: T.int32 = T.cast(eos_1 - bos_1, "int32")  # .cu:972
+        num_chunks_1: T.int32 = (seq_len_1 + 32 - 1) // 32  # .cu:973
+        warp_id_in_role_1: T.int32 = warp - 4  # .cu:974
+        epilogue_local_warp: T.int32 = warp_id_in_role_1  # .cu:975
+        warp_in_wg_1: T.int32 = warp % 4  # .cu:976
+        tmem_row_base_1: T.int32 = (warp_in_wg_1 * 32) << 16  # .cu:977
+        state_row_1: T.int32 = warp_in_wg_1 * 32 + lane  # .cu:978
+        epilogue_stage: T.uint32 = 0  # .cu:979
+        output_stage: T.uint32 = 0  # .cu:980
+        _phase_final_ready_1: T.uint32 = 0  # .cu:981
+        for chunk_idx_1 in T.serial(0, num_chunks_1, unroll=False):  # .cu:982-983
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_FINAL_READY_OFF + epilogue_stage * 8,
+                _phase_final_ready_1,
+            )  # .cu:984
+            chunk_is_full: T.int32 = T.if_then_else(
+                seq_len_1 >= (chunk_idx_1 + 1) * 32, 1, 0
+            )  # .cu:985
+            if chunk_is_full != 0:  # .cu:986
+                # .cu:987-993 (inline tcgen05.ld.16x256b.x4, 16 uint32 regs)
+                _tmem_load_4: T.uint32[16]
+                T.ptx.tcgen05.ld(
+                    taddr + 192 + tmem_row_base_1,
+                    *[_tmem_load_4[_j] for _j in range(16)],
+                    shape="16x256b",
+                    num=4,
+                )
+                # .cu:994-1000 (same at TMEM row +16)
+                _tmem_load_5: T.uint32[16]
+                T.ptx.tcgen05.ld(
+                    taddr + 192 + tmem_row_base_1 + 1048576,
+                    *[_tmem_load_5[_j] for _j in range(16)],
+                    shape="16x256b",
+                    num=4,
+                )
+                T.ptx.tcgen05.wait.ld()  # .cu:1001
+                T.ptx.bar.sync(9, 128)  # .cu:1002 barrier.sync 9, 128
+                if epilogue_local_warp == 0:  # .cu:1003-1007
+                    if T.ptx.elect_sync():
+                        _mbarrier_arrive(
+                            smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_OUT_EMPTY_OFF
+                        )
+                if epilogue_local_warp == 0:  # .cu:1008-1012
+                    if chunk_idx_1 >= 2:
+                        T.ptx.cp_async.bulk.wait_group(1, read=True)
+                T.ptx.bar.sync(9, 128)  # .cu:1013
+                out_stage_addr: T.int32 = (
+                    smem_out_addr + T.cast(output_stage, "int32") * 8192
+                )  # .cu:1014
+                for dim_half in T.unroll(2):  # .cu:1015-1049
+                    out_packed = T.alloc_local((8,), "uint32", align=4)  # .cu:1017
+                    if dim_half == 0:  # .cu:1018-1023
+                        for _lp in T.unroll(8):
+                            out_packed[_lp] = T.cuda.float22bfloat162_rn(
+                                T.cuda.uint_as_float(_tmem_load_4[_lp * 2 + 0]),
+                                T.cuda.uint_as_float(_tmem_load_4[_lp * 2 + 1 + 0]),
+                            )
+                    else:  # .cu:1024-1030
+                        for _lp in T.unroll(8):
+                            out_packed[_lp] = T.cuda.float22bfloat162_rn(
+                                T.cuda.uint_as_float(_tmem_load_5[_lp * 2 + 0]),
+                                T.cuda.uint_as_float(_tmem_load_5[_lp * 2 + 1 + 0]),
+                            )
+                    for token_group in T.unroll(2):  # .cu:1031-1048
+                        mtx_idx: T.int32 = lane // 8  # .cu:1033
+                        row_addr: T.int32 = lane & 7  # .cu:1034
+                        dim_base: T.int32 = (
+                            epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8
+                        )  # .cu:1035
+                        token_base: T.int32 = token_group * 16 + mtx_idx // 2 * 8  # .cu:1036
+                        token_addr: T.int32 = token_base + row_addr  # .cu:1037
+                        token_pair: T.int32 = token_addr // 2  # .cu:1038
+                        token_parity: T.int32 = token_addr & 1  # .cu:1039
+                        raw_row: T.int32 = token_pair + dim_base // 64 * 16  # .cu:1040
+                        raw_col: T.int32 = (
+                            dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3
+                        ) + token_parity * 64  # .cu:1041
+                        stsm_offset: T.int32 = (raw_row * 128 + raw_col) * 2  # .cu:1042
+                        pack_base: T.int32 = token_group * 4  # .cu:1043
+                        # .cu:1044-1047 stmatrix.x4.trans
+                        T.ptx.stmatrix(
+                            True,
+                            4,
+                            ".b16",
+                            smem_raw.ptr_to(
+                                [
+                                    T.cast(out_stage_addr, "uint32")
+                                    - smem
+                                    + T.cast(stsm_offset, "uint32")
+                                ]
+                            ),
+                            T.address_of(out_packed[pack_base]),
+                            T.address_of(out_packed[pack_base + 1]),
+                            T.address_of(out_packed[pack_base + 2]),
+                            T.address_of(out_packed[pack_base + 3]),
+                            shape="m8n8",
+                        )
+                _fence_async_shared()  # .cu:1050
+                T.ptx.bar.sync(9, 128)  # .cu:1051
+                if epilogue_local_warp == 0:  # .cu:1052-1057
+                    if T.ptx.elect_sync():
+                        _tma_store_4d(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            out_tma,
+                            0,
+                            T.cast(bos_1 + T.cast(chunk_idx_1 * 32, "int64"), "int32"),
+                            head_idx_1,
+                            0,
+                            T.cast(smem_out_addr + T.cast(output_stage, "int32") * 8192, "uint32"),
+                        )  # .cu:1054
+                    T.ptx.cp_async.bulk.commit_group()  # .cu:1056
+                output_stage = output_stage ^ T.uint32(1)  # .cu:1058
+            else:  # .cu:1059-1077 (partial chunk: scalar out stores)
+                _tmem_load_6: T.f32[32]
+                _tmem_ld_x32(_tmem_load_6, taddr + 192 + tmem_row_base_1)  # .cu:1060-1061
+                T.ptx.tcgen05.wait.ld()  # .cu:1062
+                T.ptx.bar.sync(9, 128)  # .cu:1063
+                if epilogue_local_warp == 0:  # .cu:1064-1068
+                    if T.ptx.elect_sync():
+                        _mbarrier_arrive(
+                            smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_OUT_EMPTY_OFF
+                        )
+                for token_col_1 in T.unroll(32):  # .cu:1069-1076
+                    out_token: T.int64 = bos_1 + T.cast(
+                        chunk_idx_1 * 32 + token_col_1, "int64"
+                    )  # .cu:1071
+                    if out_token < eos_1:  # .cu:1072
+                        out_idx: T.int64 = (
+                            out_token * T.cast(h, "int64") + T.cast(head_idx_1, "int64")
+                        ) * 128 + T.cast(state_row_1, "int64")  # .cu:1073
+                        out[out_idx] = T.cast(_tmem_load_6[token_col_1], "bfloat16")  # .cu:1074
+            epilogue_stage += 1  # .cu:1078
+            if epilogue_stage == 5:  # .cu:1079
+                epilogue_stage = T.uint32(0)
+                _phase_final_ready_1 = _phase_final_ready_1 ^ T.uint32(1)
+        if epilogue_local_warp == 0:  # .cu:1081-1083
+            T.ptx.cp_async.bulk.wait_group(0, read=False)
+        T.ptx.bar.sync(9, 128)  # .cu:1084
+        if epilogue_local_warp == 0:  # .cu:1085-1089
+            if T.ptx.elect_sync():
+                _mbarrier_arrive(
+                    smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_TMEM_DEALLOC_READY_OFF
+                )
+    elif warp == 9:
+        # ---- Role: mma (.cu:1092-1247) ----
+        # .cu:1093 mma_main
+        task_idx_2: T.int32 = bid  # .cu:1094
+        seq_idx_2: T.int32 = seq_order[task_idx_2 // h]  # .cu:1095
+        bos_2: T.int64 = cu_seqlens[seq_idx_2]  # .cu:1096
+        eos_2: T.int64 = cu_seqlens[seq_idx_2 + 1]  # .cu:1097
+        seq_len_2: T.int32 = T.cast(eos_2 - bos_2, "int32")  # .cu:1098
+        num_chunks_2: T.int32 = (seq_len_2 + 32 - 1) // 32  # .cu:1099
+        mma_stage: T.uint32 = 0  # .cu:1100
+        _phase_qk_full_1: T.uint32 = 0  # .cu:1101
+        _phase_state_inp_ready: T.uint32 = 0  # .cu:1102
+        _phase_out_empty_0: T.uint32 = 1  # .cu:1103
+        _phase_u_inp_ready: T.uint32 = 0  # .cu:1104
+        _phase_u2_inp_ready: T.uint32 = 0  # .cu:1105
+        for _chunk_idx in T.serial(0, num_chunks_2, unroll=False):  # .cu:1106-1107
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_QK_FULL_OFF + mma_stage * 8,
+                _phase_qk_full_1,
+            )  # .cu:1108
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_STATE_INP_READY_OFF + mma_stage * 8,
+                _phase_state_inp_ready,
+            )  # .cu:1109
+            _mbarrier_wait(
+                smem_raw, T.cast(smem, "int32"), mbar_base + MBAR_OUT_EMPTY_OFF, _phase_out_empty_0
+            )  # .cu:1110
+            _phase_out_empty_0 = _phase_out_empty_0 ^ T.uint32(1)  # .cu:1111
+            _mma_b_addr_0: T.int32 = smem_qd_addr + T.cast(mma_stage, "int32") * 41984  # .cu:1112
+            _mma_b_lo_0 = _make_warp_uniform(
+                T.cast((_mma_b_addr_0 >> 4) & 0x3FFF, "uint32")
+            )  # .cu:1113
+            _mma_qk_8step(
+                tmem_tmem_out, T.cast(_mma_b_lo_0, "int32"), tmem_tmem_state_inp, 0
+            )  # .cu:1114-1150
+            _mma_b_addr_1: T.int32 = smem_kd_addr + T.cast(mma_stage, "int32") * 41984  # .cu:1151
+            _mma_b_lo_1 = _make_warp_uniform(
+                T.cast((_mma_b_addr_1 >> 4) & 0x3FFF, "uint32")
+            )  # .cu:1152
+            _mma_qk_8step(
+                tmem_tmem_u_acc, T.cast(_mma_b_lo_1, "int32"), tmem_tmem_state_inp, 0
+            )  # .cu:1153-1189
+            # .cu:1190 elect_commit2(old_out_ready + stage*8, raw_inputs_free + stage*8)
+            _leader_1190 = T.ptx.elect_sync()
+            T.ptx.tcgen05.commit(
+                smem_raw.ptr_to(
+                    [(mbar_base + MBAR_OLD_OUT_READY_OFF + mma_stage * 8) - T.cast(smem, "int32")]
+                ),
+                cta_group=1,
+                pred=_leader_1190,
+            )
+            T.ptx.tcgen05.commit(
+                smem_raw.ptr_to(
+                    [(mbar_base + MBAR_RAW_INPUTS_FREE_OFF + mma_stage * 8) - T.cast(smem, "int32")]
+                ),
+                cta_group=1,
+                pred=_leader_1190,
+            )
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_U_INP_READY_OFF + mma_stage * 8,
+                _phase_u_inp_ready,
+            )  # .cu:1191
+            _mma_b_addr_2: T.int32 = smem_inv_addr + T.cast(mma_stage, "int32") * 41984  # .cu:1192
+            _mma_b_lo_2 = _make_warp_uniform(
+                T.cast((_mma_b_addr_2 >> 4) & 0x3FFF, "uint32")
+            )  # .cu:1193
+            _mma_inv_2step(
+                tmem_tmem_u2_acc, T.cast(_mma_b_lo_2, "int32"), tmem_tmem_u2_inp, 0
+            )  # .cu:1194-1212
+            _elect_commit(
+                smem_raw.ptr_to(
+                    [(mbar_base + MBAR_U2_ACC_READY_OFF + mma_stage * 8) - T.cast(smem, "int32")]
+                )
+            )  # .cu:1213
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_U2_INP_READY_OFF + mma_stage * 8,
+                _phase_u2_inp_ready,
+            )  # .cu:1214
+            _mma_b_addr_3: T.int32 = (
+                smem_final_trans_addr + T.cast(mma_stage, "int32") * 41984
+            )  # .cu:1215
+            _mma_b_lo_3 = _make_warp_uniform(
+                T.cast(((_mma_b_addr_3 >> 4) & 0x3FFF) | 0x1000000, "uint32")
+            )  # .cu:1216
+            _mma_final_2step(
+                tmem_tmem_state_out, T.cast(_mma_b_lo_3, "int32"), tmem_tmem_u2_inp, 1
+            )  # .cu:1217-1235
+            # .cu:1236 elect_commit2(final_ready + stage*8, smem_free + stage*8)
+            _leader_1236 = T.ptx.elect_sync()
+            T.ptx.tcgen05.commit(
+                smem_raw.ptr_to(
+                    [(mbar_base + MBAR_FINAL_READY_OFF + mma_stage * 8) - T.cast(smem, "int32")]
+                ),
+                cta_group=1,
+                pred=_leader_1236,
+            )
+            T.ptx.tcgen05.commit(
+                smem_raw.ptr_to(
+                    [(mbar_base + MBAR_SMEM_FREE_OFF + mma_stage * 8) - T.cast(smem, "int32")]
+                ),
+                cta_group=1,
+                pred=_leader_1236,
+            )
+            mma_stage += 1  # .cu:1237
+            if mma_stage == 5:  # .cu:1238
+                mma_stage = T.uint32(0)
+                _phase_qk_full_1 = _phase_qk_full_1 ^ T.uint32(1)
+                _phase_state_inp_ready = _phase_state_inp_ready ^ T.uint32(1)
+                _phase_u_inp_ready = _phase_u_inp_ready ^ T.uint32(1)
+                _phase_u2_inp_ready = _phase_u2_inp_ready ^ T.uint32(1)
+        _phase_tmem_dealloc_ready_0: T.uint32 = 0  # .cu:1240
+        _mbarrier_wait(
+            smem_raw,
+            T.cast(smem, "int32"),
+            mbar_base + MBAR_TMEM_DEALLOC_READY_OFF,
+            _phase_tmem_dealloc_ready_0,
+        )  # .cu:1241
+        _phase_tmem_dealloc_ready_0 = _phase_tmem_dealloc_ready_0 ^ T.uint32(1)  # .cu:1242
+        _tmem_dealloc_addr: T.int32 = T.ptx.ld_volatile(
+            T.address_of(tmem_addr_storage[0]), "int32", "s32", space="shared"
+        )  # .cu:1243
+        T.ptx.tcgen05.dealloc(_tmem_dealloc_addr, 256, cta_group=1)  # .cu:1244
+        T.ptx.tcgen05.relinquish_alloc_permit(cta_group=1)  # .cu:1245
+    elif warp == 10:
+        # ---- Role: load (.cu:1248-1296) ----
+        # .cu:1249 load_main
+        task_idx_3: T.int32 = bid  # .cu:1250
+        seq_idx_3: T.int32 = seq_order[task_idx_3 // h]  # .cu:1251
+        head_idx_2: T.int32 = task_idx_3 % h  # .cu:1252
+        bos_3: T.int64 = cu_seqlens[seq_idx_3]  # .cu:1253
+        eos_3: T.int64 = cu_seqlens[seq_idx_3 + 1]  # .cu:1254
+        seq_len_3: T.int32 = T.cast(eos_3 - bos_3, "int32")  # .cu:1255
+        num_chunks_3: T.int32 = (seq_len_3 + 32 - 1) // 32  # .cu:1256
+        load_stage: T.uint32 = 0  # .cu:1257
+        _phase_v_free: T.uint32 = 1  # .cu:1258
+        _phase_qk_full_2: T.uint32 = 0  # .cu:1259
+        for chunk_idx_2 in T.serial(0, num_chunks_3, unroll=False):  # .cu:1260-1261
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_V_FREE_OFF + load_stage * 8,
+                _phase_v_free,
+            )  # .cu:1262
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_QK_FULL_OFF + load_stage * 8,
+                _phase_qk_full_2,
+            )  # .cu:1263
+            chunk_is_full_1: T.int32 = T.if_then_else(
+                seq_len_3 >= (chunk_idx_2 + 1) * 32, 1, 0
+            )  # .cu:1264
+            if T.ptx.elect_sync():  # .cu:1265-1270
+                if chunk_is_full_1 != 0:
+                    _mbarrier_arrive_expect_tx(
+                        smem_raw.ptr_to(
+                            [(mbar_base + MBAR_V_FULL_OFF + load_stage * 8) - T.cast(smem, "int32")]
+                        ),
+                        8192,
+                    )  # .cu:1267
+                    _tma_3d_gmem2smem(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_v_addr + T.cast(load_stage, "int32") * 41984,
+                        v_tma,
+                        0,
+                        head_idx_2,
+                        T.cast(bos_3 + T.cast(chunk_idx_2 * 32, "int64"), "int32"),
+                        mbar_base + MBAR_V_FULL_OFF + load_stage * 8,
+                    )  # .cu:1268
+            if chunk_is_full_1 == 0:  # .cu:1271-1285
+                for v_load_iter in T.unroll(16):  # .cu:1272-1282
+                    v_item: T.int32 = v_load_iter * 32 + lane  # .cu:1274
+                    row: T.int32 = v_item // 16  # .cu:1275
+                    segment: T.int32 = v_item % 16  # .cu:1276
+                    token: T.int64 = bos_3 + T.cast(chunk_idx_2 * 32 + row, "int64")  # .cu:1277
+                    token_valid: T.int32 = T.if_then_else(token < eos_3, 1, 0)  # .cu:1278
+                    v_src: T.int64 = (
+                        token * T.cast(h, "int64") + T.cast(head_idx_2, "int64")
+                    ) * 128 + T.cast(segment * 8, "int64")  # .cu:1279
+                    _cp_async_cg_16_zfill(
+                        smem_v_addr
+                        + T.cast(load_stage, "int32") * 41984
+                        + (row * 128 + segment * 8) * 2,
+                        v.ptr_to([v_src]),
+                        T.if_then_else(token_valid != 0, 16, 0),
+                    )  # .cu:1280-1281
+                T.ptx.cp_async.commit_group()  # .cu:1283
+                T.ptx.cp_async.wait_group(0)  # .cu:1284
+            T.ptx.bar.sync(8, 32)  # .cu:1286 barrier.sync 8, 32
+            if T.ptx.elect_sync():  # .cu:1287-1292
+                if chunk_is_full_1 == 0:
+                    _fence_async_shared()  # .cu:1289
+                    _mbarrier_arrive(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        mbar_base + MBAR_V_FULL_OFF + load_stage * 8,
+                    )  # .cu:1290
+            load_stage += 1  # .cu:1293
+            if load_stage == 5:  # .cu:1294
+                load_stage = T.uint32(0)
+                _phase_v_free = _phase_v_free ^ T.uint32(1)
+                _phase_qk_full_2 = _phase_qk_full_2 ^ T.uint32(1)
+    elif warp >= 12 and warp <= 31:
+        # ---- Role: prep (.cu:1298-2550) ----
+        T.ptx.setmaxnreg(False, 48)  # .cu:1299
+        # .cu:1300 prep_main
+        task_idx_4: T.int32 = bid  # .cu:1301
+        seq_idx_4: T.int32 = seq_order[task_idx_4 // h]  # .cu:1302
+        head_idx_3: T.int32 = task_idx_4 % h  # .cu:1303
+        bos_4: T.int64 = cu_seqlens[seq_idx_4]  # .cu:1304
+        eos_4: T.int64 = cu_seqlens[seq_idx_4 + 1]  # .cu:1305
+        seq_len_4: T.int32 = T.cast(eos_4 - bos_4, "int32")  # .cu:1306
+        num_chunks_4: T.int32 = (seq_len_4 + 32 - 1) // 32  # .cu:1307
+        instance_id: T.int32 = (warp - 12) // 4  # .cu:1308
+        prep_instance: T.int32 = instance_id  # .cu:1309
+        warp_id_in_role_2: T.int32 = warp - 12  # .cu:1310
+        prep_local_warp: T.int32 = warp_id_in_role_2 - prep_instance * 4  # .cu:1311
+        prep_tid: T.int32 = prep_local_warp * 32 + lane  # .cu:1312
+        num_prep_iters: T.int32 = (num_chunks_4 + 4 - prep_instance) // 5  # .cu:1313
+        prep_stage: T.uint32 = T.cast(prep_instance, "uint32")  # .cu:1314
+        gate_rate_stage_f32: T.int32 = prep_instance * 10496  # .cu:1315
+        if prep_tid == 0:  # .cu:1316-1319
+            smem_gate_rate_all[gate_rate_stage_f32] = _expf(A_log[head_idx_3])
+        if prep_instance == 0:  # .cu:1320-1332
+            T.ptx.bar.sync(11, 128)
+        elif prep_instance == 1:
+            T.ptx.bar.sync(12, 128)
+        else:
+            if prep_instance == 2:
+                T.ptx.bar.sync(13, 128)
+            elif prep_instance == 3:
+                T.ptx.bar.sync(14, 128)
+            else:
+                T.ptx.bar.sync(15, 128)
+        _phase_raw_inputs_free: T.uint32 = 1  # .cu:1333
+        _phase_gate_raw_full: T.uint32 = 0  # .cu:1334
+        _phase_smem_free: T.uint32 = 1  # .cu:1335
+        _phase_qk_raw_full: T.uint32 = 0  # .cu:1336
+        _phase_prep_diag_ready: T.uint32 = 0  # .cu:1337
+        _phase_prep_inv16_ready: T.uint32 = 0  # .cu:1338
+        for prep_iter in T.serial(0, num_prep_iters, unroll=False):  # .cu:1339-1340
+            chunk_idx_3: T.int32 = prep_iter * 5 + prep_instance  # .cu:1341
+            stage_f32: T.int32 = T.cast(prep_stage, "int32") * 10496  # .cu:1342
+            stage_bf16: T.int32 = T.cast(prep_stage, "int32") * 20992  # .cu:1343
+            chunk_is_full_2: T.int32 = T.if_then_else(
+                seq_len_4 >= (chunk_idx_3 + 1) * 32, 1, 0
+            )  # .cu:1344
+            early_beta_value: T.f32 = T.float32(0.0)  # .cu:1345
+            early_gate0: T.f32 = T.float32(0.0)  # .cu:1346
+            if chunk_is_full_2 != 0:  # .cu:1347-1392
+                _mbarrier_wait(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_RAW_INPUTS_FREE_OFF + prep_stage * 8,
+                    _phase_raw_inputs_free,
+                )  # .cu:1348
+                if prep_local_warp == 0:  # .cu:1349-1357
+                    if T.ptx.elect_sync():
+                        _mbarrier_arrive_expect_tx(
+                            smem_raw.ptr_to(
+                                [
+                                    (mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8)
+                                    - T.cast(smem, "int32")
+                                ]
+                            ),
+                            8704,
+                        )  # .cu:1351
+                        _tma_3d_gmem2smem(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_g_raw_addr + T.cast(prep_stage, "int32") * 41984,
+                            g_tma,
+                            0,
+                            head_idx_3,
+                            T.cast(bos_4 + T.cast(chunk_idx_3 * 32, "int64"), "int32"),
+                            mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8,
+                        )  # .cu:1352
+                        _tma_2d_gmem2smem(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_beta_raw_addr + T.cast(prep_stage, "int32") * 41984,
+                            beta_tma_tmap,
+                            head_idx_3 // 8 * 8,
+                            T.cast(bos_4 + T.cast(chunk_idx_3 * 32, "int64"), "int32"),
+                            mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8,
+                        )  # .cu:1353
+                        _mbarrier_arrive_expect_tx(
+                            smem_raw.ptr_to(
+                                [
+                                    (mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8)
+                                    - T.cast(smem, "int32")
+                                ]
+                            ),
+                            16384,
+                        )  # .cu:1354
+                        _tma_4d_gmem2smem(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_kd_addr + T.cast(prep_stage, "int32") * 41984,
+                            k_tma,
+                            0,
+                            T.cast(bos_4 + T.cast(chunk_idx_3 * 32, "int64"), "int32"),
+                            head_idx_3,
+                            0,
+                            mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8,
+                        )  # .cu:1355
+                _mbarrier_wait(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_GATE_RAW_FULL_OFF + prep_stage * 8,
+                    _phase_gate_raw_full,
+                )  # .cu:1358
+                if prep_local_warp == 2 and lane < 32:  # .cu:1359-1380
+                    beta_raw_pair = T.alloc_local((1,), "uint32", align=4)  # .cu:1360
+                    beta_raw_pair[0] = _ld_shared_b32(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_beta_raw_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + lane * 16
+                        + head_idx_3 % 8 // 2 * 4,
+                    )  # .cu:1361
+                    beta_raw_pair_fp32: T.f32[2]  # .cu:1362
+                    for _pair in T.unroll(1):  # .cu:1363-1372
+                        beta_raw_pair_fp32[_pair * 2] = T.cuda.uint_as_float(
+                            beta_raw_pair[_pair + 0] << T.uint32(16)
+                        )
+                        beta_raw_pair_fp32[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            beta_raw_pair[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    beta_logit: T.f32 = beta_raw_pair_fp32[0]  # .cu:1373
+                    if head_idx_3 % 2 != 0:  # .cu:1374-1376
+                        beta_logit = beta_raw_pair_fp32[1]
+                    early_beta_value = _tanh_approx(beta_logit * T.float32(0.5)) * T.float32(
+                        0.5
+                    ) + T.float32(0.5)  # .cu:1377-1379
+                if prep_tid < 128:  # .cu:1381-1391
+                    early_gate_rate: T.f32 = smem_gate_rate_all[stage_f32]  # .cu:1382
+                    early_gate_bias: T.f32 = dt_bias[head_idx_3 * 128 + prep_tid]  # .cu:1383
+                    early_gate_raw: T.f32 = T.cuda.bfloat162float(
+                        smem_g_raw_all[stage_bf16 + prep_tid]
+                    )  # .cu:1384-1385
+                    early_gate_arg: T.f32 = early_gate_rate * (
+                        early_gate_raw + early_gate_bias
+                    )  # .cu:1386
+                    early_gate_sigmoid: T.f32 = _tanh_approx(
+                        early_gate_arg * T.float32(0.5)
+                    ) * T.float32(0.5) + T.float32(0.5)  # .cu:1387-1389
+                    early_gate0 = (
+                        T.float32(lower_bound) * T.float32(1.4426950408889634) * early_gate_sigmoid
+                    )  # .cu:1390
+            _mbarrier_wait(
+                smem_raw,
+                T.cast(smem, "int32"),
+                mbar_base + MBAR_SMEM_FREE_OFF + prep_stage * 8,
+                _phase_smem_free,
+            )  # .cu:1393
+            if chunk_is_full_2 != 0:  # .cu:1394-1400
+                if prep_local_warp == 0:
+                    if T.ptx.elect_sync():
+                        _tma_4d_gmem2smem(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_q_raw_prefetch_addr + T.cast(prep_stage, "int32") * 41984,
+                            q_tma,
+                            0,
+                            T.cast(bos_4 + T.cast(chunk_idx_3 * 32, "int64"), "int32"),
+                            head_idx_3,
+                            0,
+                            mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8,
+                        )  # .cu:1397
+            if chunk_is_full_2 == 0:  # .cu:1401-1412
+                for gate_load_pass in T.unroll(4):
+                    gate_load_item: T.int32 = gate_load_pass * 128 + prep_tid  # .cu:1404
+                    gate_load_row: T.int32 = gate_load_item // 16  # .cu:1405
+                    gate_load_segment: T.int32 = gate_load_item % 16  # .cu:1406
+                    gate_load_token: T.int64 = bos_4 + T.cast(
+                        chunk_idx_3 * 32 + gate_load_row, "int64"
+                    )  # .cu:1407
+                    gate_load_base: T.int64 = (
+                        gate_load_token * T.cast(h, "int64") + T.cast(head_idx_3, "int64")
+                    ) * 128 + T.cast(gate_load_segment * 8, "int64")  # .cu:1408
+                    _cp_async_cg_16_zfill(
+                        smem_g_raw_addr + T.cast(prep_stage, "int32") * 41984 + gate_load_item * 16,
+                        g.ptr_to([gate_load_base]),
+                        T.if_then_else(gate_load_token < eos_4, 16, 0),
+                    )  # .cu:1409-1410
+            if chunk_is_full_2 == 0:  # .cu:1413-1429
+                T.ptx.cp_async.commit_group()  # .cu:1414
+                T.ptx.cp_async.wait_group(0)  # .cu:1415
+                if prep_instance == 0:
+                    T.ptx.bar.sync(11, 128)
+                elif prep_instance == 1:
+                    T.ptx.bar.sync(12, 128)
+                else:
+                    if prep_instance == 2:
+                        T.ptx.bar.sync(13, 128)
+                    elif prep_instance == 3:
+                        T.ptx.bar.sync(14, 128)
+                    else:
+                        T.ptx.bar.sync(15, 128)
+            if prep_local_warp == 2 and lane < 32:  # .cu:1430-1442
+                beta_value: T.f32 = early_beta_value  # .cu:1431
+                if chunk_is_full_2 == 0:  # .cu:1432-1440
+                    beta_token: T.int64 = bos_4 + T.cast(chunk_idx_3 * 32 + lane, "int64")
+                    if beta_token < eos_4:
+                        beta_logit_1: T.f32 = T.cast(
+                            beta[beta_token * T.cast(h, "int64") + T.cast(head_idx_3, "int64")],
+                            "float32",
+                        )  # .cu:1435
+                        beta_value = _tanh_approx(beta_logit_1 * T.float32(0.5)) * T.float32(
+                            0.5
+                        ) + T.float32(0.5)  # .cu:1436-1438
+                smem_prep_beta_all[stage_f32 + lane] = beta_value  # .cu:1441
+            if prep_tid < 128:  # .cu:1443-1472
+                gate_col: T.int32 = prep_tid  # .cu:1444
+                gate_rate: T.f32 = smem_gate_rate_all[stage_f32]  # .cu:1445
+                gate_bias: T.f32 = dt_bias[head_idx_3 * 128 + gate_col]  # .cu:1446
+                prefix_log2: T.f32 = T.float32(0.0)  # .cu:1447
+                for gate_row in T.serial(0, 32):  # .cu:1448-1471
+                    gate_token: T.int64 = bos_4 + T.cast(
+                        chunk_idx_3 * 32 + gate_row, "int64"
+                    )  # .cu:1449
+                    gate_log2: T.f32 = T.float32(0.0)  # .cu:1450
+                    gate_needs_compute: T.int32 = 1  # .cu:1451
+                    if gate_row == 0:  # .cu:1452-1457
+                        if chunk_is_full_2 != 0:
+                            gate_log2 = early_gate0
+                            gate_needs_compute = 0
+                    if gate_needs_compute != 0:  # .cu:1458-1468
+                        if gate_token < eos_4:
+                            gate_raw: T.f32 = T.cuda.bfloat162float(
+                                smem_g_raw_all[stage_bf16 + gate_row * 128 + gate_col]
+                            )  # .cu:1460-1461
+                            gate_arg: T.f32 = gate_rate * (gate_raw + gate_bias)  # .cu:1462
+                            gate_sigmoid: T.f32 = _tanh_approx(
+                                gate_arg * T.float32(0.5)
+                            ) * T.float32(0.5) + T.float32(0.5)  # .cu:1463-1465
+                            gate_log2 = (
+                                T.float32(lower_bound)
+                                * T.float32(1.4426950408889634)
+                                * gate_sigmoid
+                            )  # .cu:1466
+                    prefix_log2 += gate_log2  # .cu:1469
+                    smem_gate_all[stage_f32 + gate_row * 128 + gate_col] = prefix_log2  # .cu:1470
+            if prep_instance == 0:  # .cu:1473-1485
+                T.ptx.bar.sync(11, 128)
+            elif prep_instance == 1:
+                T.ptx.bar.sync(12, 128)
+            else:
+                if prep_instance == 2:
+                    T.ptx.bar.sync(13, 128)
+                elif prep_instance == 3:
+                    T.ptx.bar.sync(14, 128)
+                else:
+                    T.ptx.bar.sync(15, 128)
+            if chunk_is_full_2 != 0:  # .cu:1486-1488
+                _mbarrier_wait(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_QK_RAW_FULL_OFF + prep_stage * 8,
+                    _phase_qk_raw_full,
+                )
+            if prep_tid < 128:  # .cu:1489-1493
+                total_log2: T.f32 = smem_gt_prefix_all[stage_f32 + prep_tid]  # .cu:1490
+                smem_restore_factor_all[stage_f32 + prep_tid] = _approx_exp2(
+                    total_log2
+                    - T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                )  # .cu:1491-1492
+            if prep_tid == 0:  # .cu:1494-1497
+                smem_restore_factor_all[stage_f32 + 128] = _approx_exp2(
+                    T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                )
+            q_u32 = T.decl_buffer((total_tokens * h * D_HEAD // 2,), "uint32", data=q.data)
+            k_u32 = T.decl_buffer((total_tokens * h * D_HEAD // 2,), "uint32", data=k.data)
+            for work_pass in T.serial(0, 4, unroll=False):  # .cu:1498-1694 (#pragma unroll 1)
+                work_item: T.int32 = work_pass * 128 + prep_tid  # .cu:1500
+                row_1: T.int32 = work_item // 16  # .cu:1501
+                segment_1: T.int32 = work_item % 16  # .cu:1502
+                token_1: T.int64 = bos_4 + T.cast(chunk_idx_3 * 32 + row_1, "int64")  # .cu:1503
+                token_valid_1: T.int32 = T.if_then_else(token_1 < eos_4, 1, 0)  # .cu:1504
+                gmem_base: T.int64 = (
+                    token_1 * T.cast(h, "int64") + T.cast(head_idx_3, "int64")
+                ) * 128 + T.cast(segment_1 * 8, "int64")  # .cu:1505
+                # q/k smem swizzle byte offset (spelled inline at each .cu use site:
+                # 1528, 1547, 1672, 1682, 1692)
+                _qk_swz: T.int32 = segment_1 * 8 // 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2
+                _qk_swz = _qk_swz ^ ((_qk_swz >> 7 & 7) << 4)
+                q_raw_vec: T.f32[8]  # .cu:1506
+                k_raw_vec: T.f32[8]  # .cu:1507
+                for _zi in T.unroll(8):  # .cu:1508-1523
+                    q_raw_vec[_zi] = T.float32(0.0)
+                    k_raw_vec[_zi] = T.float32(0.0)
+                if chunk_is_full_2 != 0:  # .cu:1524-1562
+                    packed = T.alloc_local((4,), "uint32", align=16)  # .cu:1525
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed,
+                        smem_q_raw_prefetch_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz,
+                    )  # .cu:1526-1528
+                    packed_fp32: T.f32[8]  # .cu:1529
+                    for _pair in T.unroll(4):  # .cu:1530-1539
+                        packed_fp32[_pair * 2] = T.cuda.uint_as_float(
+                            packed[_pair + 0] << T.uint32(16)
+                        )
+                        packed_fp32[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx in T.unroll(8):  # .cu:1540-1543
+                        q_raw_vec[value_idx] = packed_fp32[value_idx]
+                    packed_0 = T.alloc_local((4,), "uint32", align=16)  # .cu:1544
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_0,
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz,
+                    )  # .cu:1545-1547
+                    packed_0_fp32: T.f32[8]  # .cu:1548
+                    for _pair in T.unroll(4):  # .cu:1549-1558
+                        packed_0_fp32[_pair * 2] = T.cuda.uint_as_float(
+                            packed_0[_pair + 0] << T.uint32(16)
+                        )
+                        packed_0_fp32[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_0[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_1 in T.unroll(8):  # .cu:1559-1562
+                        k_raw_vec[value_idx_1] = packed_0_fp32[value_idx_1]
+                elif token_valid_1 != 0:  # .cu:1563-1602
+                    for _blk in T.unroll(1):  # .cu:1564-1582
+                        _vldq = T.alloc_local((4,), "uint32", align=16)
+                        _ld_global_v4_u32(_vldq, q_u32.ptr_to([gmem_base // 2 + _blk * 4]))
+                        for _pair in T.unroll(4):
+                            q_raw_vec[0 + _blk * 8 + _pair * 2] = T.cuda.uint_as_float(
+                                _vldq[_pair] << T.uint32(16)
+                            )
+                            q_raw_vec[0 + _blk * 8 + _pair * 2 + 1] = T.cuda.uint_as_float(
+                                _vldq[_pair] & T.uint32(0xFFFF0000)
+                            )
+                    for _blk in T.unroll(1):  # .cu:1583-1601
+                        _vldk = T.alloc_local((4,), "uint32", align=16)
+                        _ld_global_v4_u32(_vldk, k_u32.ptr_to([gmem_base // 2 + _blk * 4]))
+                        for _pair in T.unroll(4):
+                            k_raw_vec[0 + _blk * 8 + _pair * 2] = T.cuda.uint_as_float(
+                                _vldk[_pair] << T.uint32(16)
+                            )
+                            k_raw_vec[0 + _blk * 8 + _pair * 2 + 1] = T.cuda.uint_as_float(
+                                _vldk[_pair] & T.uint32(0xFFFF0000)
+                            )
+                q_sum: T.f32 = T.float32(0.0)  # .cu:1603
+                k_sum: T.f32 = T.float32(0.0)  # .cu:1604
+                for elem_in_segment in T.serial(0, 8):  # .cu:1605-1612
+                    q_sum = _fmaf_rn(
+                        q_raw_vec[elem_in_segment], q_raw_vec[elem_in_segment], q_sum
+                    )  # .cu:1608
+                    k_sum = _fmaf_rn(
+                        k_raw_vec[elem_in_segment], k_raw_vec[elem_in_segment], k_sum
+                    )  # .cu:1610
+                q_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), q_sum, 8, 32)  # .cu:1613-1614
+                k_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), k_sum, 8, 32)  # .cu:1615-1616
+                q_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), q_sum, 4, 32)  # .cu:1617-1618
+                k_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), k_sum, 4, 32)  # .cu:1619-1620
+                q_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), q_sum, 2, 32)  # .cu:1621-1622
+                k_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), k_sum, 2, 32)  # .cu:1623-1624
+                q_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), q_sum, 1, 32)  # .cu:1625-1626
+                k_sum += T.cuda._shfl_xor_sync(T.uint32(0xFFFFFFFF), k_sum, 1, 32)  # .cu:1627-1628
+                q_inv: T.f32 = _rsqrtf(q_sum + T.float32(1e-06))  # .cu:1629-1630
+                k_inv: T.f32 = _rsqrtf(k_sum + T.float32(1e-06))  # .cu:1631-1632
+                for _ls in T.unroll(4):  # .cu:1633-1636
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(q_raw_vec[_ls * 2], q_raw_vec[_ls * 2 + 1]),
+                        T.cuda.make_float2(q_inv, q_inv),
+                    )
+                    q_raw_vec[_ls * 2] = T.cuda.float2_x(_pk)
+                    q_raw_vec[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _ls in T.unroll(4):  # .cu:1637-1640
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(k_raw_vec[_ls * 2], k_raw_vec[_ls * 2 + 1]),
+                        T.cuda.make_float2(k_inv, k_inv),
+                    )
+                    k_raw_vec[_ls * 2] = T.cuda.float2_x(_pk)
+                    k_raw_vec[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                qd_vec: T.f32[8]  # .cu:1641
+                kd_vec: T.f32[8]  # .cu:1642
+                ki_vec: T.f32[8]  # .cu:1643
+                for elem_in_segment_1 in T.serial(0, 8):  # .cu:1644-1653
+                    col: T.int32 = segment_1 * 8 + elem_in_segment_1  # .cu:1645
+                    prefix: T.f32 = smem_gate_all[stage_f32 + row_1 * 128 + col]  # .cu:1646
+                    common_log2: T.f32 = (
+                        T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                    )  # .cu:1647
+                    decay: T.f32 = _approx_exp2(prefix - common_log2)  # .cu:1648-1649
+                    qd_vec[elem_in_segment_1] = decay  # .cu:1650
+                    kd_vec[elem_in_segment_1] = decay  # .cu:1651
+                    ki_vec[elem_in_segment_1] = T.cuda.fdividef(
+                        k_raw_vec[elem_in_segment_1], decay
+                    )  # .cu:1652 (-use_fast_math: / -> div.approx.f32)
+                for _ls in T.unroll(4):  # .cu:1654-1656
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(qd_vec[_ls * 2], qd_vec[_ls * 2 + 1]),
+                        T.cuda.make_float2(q_raw_vec[_ls * 2], q_raw_vec[_ls * 2 + 1]),
+                    )
+                    qd_vec[_ls * 2] = T.cuda.float2_x(_pk)
+                    qd_vec[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _ls in T.unroll(4):  # .cu:1657-1660
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(qd_vec[_ls * 2], qd_vec[_ls * 2 + 1]),
+                        T.cuda.make_float2(T.float32(scale), T.float32(scale)),
+                    )
+                    qd_vec[_ls * 2] = T.cuda.float2_x(_pk)
+                    qd_vec[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _ls in T.unroll(4):  # .cu:1661-1663
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(kd_vec[_ls * 2], kd_vec[_ls * 2 + 1]),
+                        T.cuda.make_float2(k_raw_vec[_ls * 2], k_raw_vec[_ls * 2 + 1]),
+                    )
+                    kd_vec[_ls * 2] = T.cuda.float2_x(_pk)
+                    kd_vec[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                packed_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1664
+                for _lp in T.unroll(4):  # .cu:1665-1669
+                    packed_1[_lp] = T.cuda.float22bfloat162_rn(
+                        qd_vec[_lp * 2 + 0], qd_vec[_lp * 2 + 1 + 0]
+                    )
+                for word in T.unroll(4):  # .cu:1670-1673
+                    _st_shared_b32(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word * 4,
+                        packed_1[word],
+                    )
+                packed_0_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1674
+                for _lp in T.unroll(4):  # .cu:1675-1679
+                    packed_0_1[_lp] = T.cuda.float22bfloat162_rn(
+                        kd_vec[_lp * 2 + 0], kd_vec[_lp * 2 + 1 + 0]
+                    )
+                for word_1 in T.unroll(4):  # .cu:1680-1683
+                    _st_shared_b32(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word_1 * 4,
+                        packed_0_1[word_1],
+                    )
+                packed_1_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:1684
+                for _lp in T.unroll(4):  # .cu:1685-1689
+                    packed_1_1[_lp] = T.cuda.float22bfloat162_rn(
+                        ki_vec[_lp * 2 + 0], ki_vec[_lp * 2 + 1 + 0]
+                    )
+                for word_2 in T.unroll(4):  # .cu:1690-1693
+                    _st_shared_b32(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _qk_swz + word_2 * 4,
+                        packed_1_1[word_2],
+                    )
+            if prep_instance == 0:  # .cu:1695-1707
+                T.ptx.bar.sync(11, 128)
+            elif prep_instance == 1:
+                T.ptx.bar.sync(12, 128)
+            else:
+                if prep_instance == 2:
+                    T.ptx.bar.sync(13, 128)
+                elif prep_instance == 3:
+                    T.ptx.bar.sync(14, 128)
+                else:
+                    T.ptx.bar.sync(15, 128)
+            pair_row_base: T.int32 = prep_local_warp // 2 * 16  # .cu:1708
+            pair_col_base: T.int32 = prep_local_warp % 2 * 16  # .cu:1709
+            a_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:1710
+            b_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:1711
+            acc = T.alloc_local((8,), "float32", align=4)  # .cu:1712
+            if pair_row_base >= pair_col_base:  # .cu:1713-1990
+                _kd_a0: T.int32 = (
+                    lane // 16 // 8 * 256
+                    + (pair_row_base + lane % 16) * 8
+                    + (lane // 16 % 8 * 16 ^ ((pair_row_base + lane % 16 & 7) << 4)) // 16
+                )
+                _ki_b0: T.int32 = (
+                    lane % 16 // 8 // 8 * 256
+                    + (pair_col_base + 8 * (lane // 16) + lane % 8) * 8
+                    + (
+                        lane % 16 // 8 % 8 * 16
+                        ^ ((pair_col_base + 8 * (lane // 16) + lane % 8 & 7) << 4)
+                    )
+                    // 16
+                )
+                # ki b-side chain steps (.cu:1720-1818); C precedence is
+                # additive > xor, so each step is parenthesized explicitly.
+                _kb1 = (_ki_b0 + 256) ^ 2
+                _kb2 = (_kb1 - 256 + 256) ^ 6
+                _kb3 = (_kb2 - 256 + 256) ^ 2
+                _kb4 = (_kb3 - 256 + 256) ^ 6
+                _kb5 = (_kb4 + 256 - 256 + 256) ^ 2
+                _kb6 = (_kb5 - 256 + 256) ^ 6
+                _kb7 = (_kb6 - 256 + 256) ^ 2
+                # .cu:1714-1727 chain step 0 (kd a, ki b, 2x zero-C mma)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _kd_a0 * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _ki_b0 * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
+                # .cu:1728-1741 chain step 1
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + (_kd_a0 ^ 2) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb1 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1742-1755 chain step 2
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kd_a0 ^ 2 ^ 6) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb2 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1756-1769 chain step 3
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kd_a0 ^ 2 ^ 6 ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb3 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1770-1783 chain step 4
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + ((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kb4 + 256 - 256) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1784-1797 chain step 5
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb5 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1798-1811 chain step 6
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb6 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                # .cu:1812-1825 chain step 7
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_kd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb7 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                row0: T.int32 = pair_row_base + lane // 4  # .cu:1826
+                row1: T.int32 = row0 + 8  # .cu:1827
+                col0: T.int32 = pair_col_base + lane % 4 * 2  # .cu:1828
+                beta0: T.f32 = smem_prep_beta_all[stage_f32 + row0]  # .cu:1829
+                beta1: T.f32 = smem_prep_beta_all[stage_f32 + row1]  # .cu:1830
+                seed: T.f32[8]  # .cu:1831
+                for _zi in T.unroll(8):  # .cu:1832-1839
+                    seed[_zi] = T.float32(0.0)
+                if row0 > col0:  # .cu:1840-1842
+                    seed[0] = acc[0] * beta0
+                if row0 > col0 + 1:  # .cu:1843-1845
+                    seed[1] = acc[1] * beta0
+                if row1 > col0:  # .cu:1846-1848
+                    seed[2] = acc[2] * beta1
+                if row1 > col0 + 1:  # .cu:1849-1851
+                    seed[3] = acc[3] * beta1
+                if row0 > col0 + 8:  # .cu:1852-1854
+                    seed[4] = acc[4] * beta0
+                if row0 > col0 + 9:  # .cu:1855-1857
+                    seed[5] = acc[5] * beta0
+                if row1 > col0 + 8:  # .cu:1858-1860
+                    seed[6] = acc[6] * beta1
+                if row1 > col0 + 9:  # .cu:1861-1863
+                    seed[7] = acc[7] * beta1
+                seed_packed = T.alloc_local((4,), "uint32", align=4)  # .cu:1864
+                for _lp in T.unroll(4):  # .cu:1865-1869
+                    seed_packed[_lp] = T.cuda.float22bfloat162_rn(
+                        seed[_lp * 2 + 0], seed[_lp * 2 + 1 + 0]
+                    )
+                seed_lane_row: T.int32 = lane % 16  # .cu:1870
+                seed_lane_col: T.int32 = lane // 16 * 8  # .cu:1871
+                byte_off: T.int32 = (pair_row_base + seed_lane_row) * 128 + (
+                    pair_col_base + seed_lane_col
+                ) * 2  # .cu:1872
+                swizzled_off: T.int32 = byte_off ^ ((byte_off >> 7 & 7) << 4)  # .cu:1873
+                seed_addr: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off
+                )  # .cu:1874
+                # .cu:1875-1878 stmatrix.x4 (seed into inv_work)
+                T.ptx.stmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(seed_addr) - T.cast(smem, "int32")]),
+                    T.address_of(seed_packed[0]),
+                    T.address_of(seed_packed[1]),
+                    T.address_of(seed_packed[2]),
+                    T.address_of(seed_packed[3]),
+                    shape="m8n8",
+                )
+                # .cu:1879-1990 second chain (qd a-side, ki b-side), same address pattern
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _kd_a0 * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _ki_b0 * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_zero(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_zero_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + (_kd_a0 ^ 2) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb1 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kd_a0 ^ 2 ^ 6) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb2 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kd_a0 ^ 2 ^ 6 ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb3 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + ((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_ki_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (_kb4 + 256 - 256) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb5 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb6 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (
+                                smem_qd_addr
+                                + T.cast(prep_stage, "int32") * 41984
+                                + (((_kd_a0 ^ 2 ^ 6 ^ 2 ^ 6) + 256) ^ 2 ^ 6 ^ 2) * 16
+                            )
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(a_frag[0]),
+                    T.address_of(a_frag[1]),
+                    T.address_of(a_frag[2]),
+                    T.address_of(a_frag[3]),
+                )
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to(
+                        [
+                            (smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + (_kb7 - 256) * 16)
+                            - T.cast(smem, "int32")
+                        ]
+                    ),
+                    T.address_of(b_frag[0]),
+                    T.address_of(b_frag[1]),
+                    T.address_of(b_frag[2]),
+                    T.address_of(b_frag[3]),
+                )
+                _mma_m16n8k16_bf16_acc(acc, a_frag, b_frag)
+                _mma_m16n8k16_bf16_acc_off4(acc, a_frag, b_frag)
+            else:  # .cu:1991-2000
+                for _zi in T.unroll(8):
+                    acc[_zi] = T.float32(0.0)
+            row0_1: T.int32 = pair_row_base + lane // 4  # .cu:2001
+            row1_1: T.int32 = row0_1 + 8  # .cu:2002
+            col0_1: T.int32 = pair_col_base + lane % 4 * 2  # .cu:2003
+            mqk: T.f32[8]  # .cu:2004
+            for _zi in T.unroll(8):  # .cu:2005-2012
+                mqk[_zi] = T.float32(0.0)
+            if row0_1 >= col0_1:  # .cu:2013-2015
+                mqk[0] = acc[0]
+            if row0_1 >= col0_1 + 1:  # .cu:2016-2018
+                mqk[1] = acc[1]
+            if row1_1 >= col0_1:  # .cu:2019-2021
+                mqk[2] = acc[2]
+            if row1_1 >= col0_1 + 1:  # .cu:2022-2024
+                mqk[3] = acc[3]
+            if row0_1 >= col0_1 + 8:  # .cu:2025-2027
+                mqk[4] = acc[4]
+            if row0_1 >= col0_1 + 9:  # .cu:2028-2030
+                mqk[5] = acc[5]
+            if row1_1 >= col0_1 + 8:  # .cu:2031-2033
+                mqk[6] = acc[6]
+            if row1_1 >= col0_1 + 9:  # .cu:2034-2036
+                mqk[7] = acc[7]
+            mqk_packed = T.alloc_local((4,), "uint32", align=4)  # .cu:2037
+            for _lp in T.unroll(4):  # .cu:2038-2042
+                mqk_packed[_lp] = T.cuda.float22bfloat162_rn(mqk[_lp * 2 + 0], mqk[_lp * 2 + 1 + 0])
+            for publish_pair in T.unroll(2):  # .cu:2043-2051
+                publish_row: T.int32 = pair_col_base + publish_pair * 8 + (lane & 7)  # .cu:2045
+                publish_col: T.int32 = 128 + pair_row_base + lane // 8 * 8  # .cu:2046
+                _pub_base: T.int32 = (
+                    publish_col // 64 * 4096 + publish_row * 128 + publish_col % 64 * 2
+                )
+                _pub_addr: T.int32 = (
+                    smem_final_trans_addr
+                    + T.cast(prep_stage, "int32") * 41984
+                    + (_pub_base ^ ((_pub_base >> 7 & 7) << 4))
+                )  # .cu:2047
+                # .cu:2048-2050 stmatrix.x2.trans
+                T.ptx.stmatrix(
+                    True,
+                    2,
+                    ".b16",
+                    smem_raw.ptr_to([(_pub_addr) - T.cast(smem, "int32")]),
+                    T.address_of(mqk_packed[publish_pair * 2]),
+                    T.address_of(mqk_packed[publish_pair * 2 + 1]),
+                    shape="m8n8",
+                )
+            if prep_instance == 0:  # .cu:2052-2064
+                T.ptx.bar.sync(11, 128)
+            elif prep_instance == 1:
+                T.ptx.bar.sync(12, 128)
+            else:
+                if prep_instance == 2:
+                    T.ptx.bar.sync(13, 128)
+                elif prep_instance == 3:
+                    T.ptx.bar.sync(14, 128)
+                else:
+                    T.ptx.bar.sync(15, 128)
+            if prep_tid < 128:  # .cu:2065-2069
+                total_log2_1: T.f32 = smem_gt_prefix_all[stage_f32 + prep_tid]  # .cu:2066
+                smem_gt_all[stage_f32 + prep_tid] = _approx_exp2(total_log2_1)  # .cu:2067-2068
+            if prep_local_warp >= 2:  # .cu:2070-2187
+                stage_f32_0: T.int32 = T.cast(prep_stage, "int32") * 10496  # .cu:2071
+                restore_scale: T.f32 = smem_restore_factor_all[stage_f32_0 + 128]  # .cu:2072
+                restore_factor: T.f32[8]  # .cu:2073
+                restore_segment: T.int32 = lane & 15  # .cu:2074
+                for restore_elem in T.unroll(8):  # .cu:2075-2079
+                    restore_col: T.int32 = restore_segment * 8 + restore_elem  # .cu:2077
+                    restore_factor[restore_elem] = smem_restore_factor_all[
+                        stage_f32_0 + restore_col
+                    ]  # .cu:2078
+                for restore_pass in T.serial(
+                    0, 6, unroll=False
+                ):  # .cu:2080-2081 (#pragma unroll 1)
+                    restore_row: T.int32 = (
+                        8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4)
+                    )  # .cu:2082
+                    restore_qd_values: T.f32[8]  # .cu:2083
+                    restore_kd_values: T.f32[8]  # .cu:2084
+                    restore_ki_values: T.f32[8]  # .cu:2085
+                    _rs_swz: T.int32 = (
+                        restore_segment * 8 // 64 * 4096
+                        + restore_row * 128
+                        + restore_segment * 8 % 64 * 2
+                    )
+                    _rs_swz = _rs_swz ^ ((_rs_swz >> 7 & 7) << 4)
+                    packed_2 = T.alloc_local((4,), "uint32", align=16)  # .cu:2086
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_2,
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                    )  # .cu:2087-2089
+                    packed_fp32_1: T.f32[8]  # .cu:2090
+                    for _pair in T.unroll(4):  # .cu:2091-2100
+                        packed_fp32_1[_pair * 2] = T.cuda.uint_as_float(
+                            packed_2[_pair + 0] << T.uint32(16)
+                        )
+                        packed_fp32_1[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_2[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_2 in T.unroll(8):  # .cu:2101-2104
+                        restore_qd_values[value_idx_2] = packed_fp32_1[value_idx_2]
+                    packed_0_2 = T.alloc_local((4,), "uint32", align=16)  # .cu:2105
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_0_2,
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                    )  # .cu:2106-2108
+                    packed_0_fp32_1: T.f32[8]  # .cu:2109
+                    for _pair in T.unroll(4):  # .cu:2110-2119
+                        packed_0_fp32_1[_pair * 2] = T.cuda.uint_as_float(
+                            packed_0_2[_pair + 0] << T.uint32(16)
+                        )
+                        packed_0_fp32_1[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_0_2[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_3 in T.unroll(8):  # .cu:2120-2123
+                        restore_kd_values[value_idx_3] = packed_0_fp32_1[value_idx_3]
+                    packed_1_2 = T.alloc_local((4,), "uint32", align=16)  # .cu:2124
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_1_2,
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz,
+                    )  # .cu:2125-2127
+                    packed_1_fp32: T.f32[8]  # .cu:2128
+                    for _pair in T.unroll(4):  # .cu:2129-2138
+                        packed_1_fp32[_pair * 2] = T.cuda.uint_as_float(
+                            packed_1_2[_pair + 0] << T.uint32(16)
+                        )
+                        packed_1_fp32[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_1_2[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_4 in T.unroll(8):  # .cu:2139-2142
+                        restore_ki_values[value_idx_4] = packed_1_fp32[value_idx_4]
+                    restore_kr_values: T.f32[8]  # .cu:2143
+                    for restore_elem_1 in T.unroll(8):  # .cu:2144-2147
+                        restore_kr_values[restore_elem_1] = (
+                            restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1]
+                        )  # .cu:2146
+                    for _ls in T.unroll(4):  # .cu:2148-2151
+                        _pk = _mul_f32x2_inplace(
+                            T.cuda.make_float2(
+                                restore_qd_values[_ls * 2], restore_qd_values[_ls * 2 + 1]
+                            ),
+                            T.cuda.make_float2(restore_scale, restore_scale),
+                        )
+                        restore_qd_values[_ls * 2] = T.cuda.float2_x(_pk)
+                        restore_qd_values[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                    for _ls in T.unroll(4):  # .cu:2152-2155
+                        _pk = _mul_f32x2_inplace(
+                            T.cuda.make_float2(
+                                restore_kd_values[_ls * 2], restore_kd_values[_ls * 2 + 1]
+                            ),
+                            T.cuda.make_float2(restore_scale, restore_scale),
+                        )
+                        restore_kd_values[_ls * 2] = T.cuda.float2_x(_pk)
+                        restore_kd_values[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                    packed_2_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:2156
+                    for _lp in T.unroll(4):  # .cu:2157-2161
+                        packed_2_1[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_qd_values[_lp * 2 + 0], restore_qd_values[_lp * 2 + 1 + 0]
+                        )
+                    for word_3 in T.unroll(4):  # .cu:2162-2165
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_qd_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz
+                            + word_3 * 4,
+                            packed_2_1[word_3],
+                        )
+                    packed_3 = T.alloc_local((4,), "uint32", align=4)  # .cu:2166
+                    for _lp in T.unroll(4):  # .cu:2167-2171
+                        packed_3[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_kd_values[_lp * 2 + 0], restore_kd_values[_lp * 2 + 1 + 0]
+                        )
+                    for word_4 in T.unroll(4):  # .cu:2172-2175
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_kd_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz
+                            + word_4 * 4,
+                            packed_3[word_4],
+                        )
+                    packed_4 = T.alloc_local((4,), "uint32", align=4)  # .cu:2176
+                    for _lp in T.unroll(4):  # .cu:2177-2181
+                        packed_4[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_kr_values[_lp * 2 + 0], restore_kr_values[_lp * 2 + 1 + 0]
+                        )
+                    for word_5 in T.unroll(4):  # .cu:2182-2185
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_kr_trans_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz
+                            + word_5 * 4,
+                            packed_4[word_5],
+                        )
+            if prep_local_warp == 0:  # .cu:2188-2250
+                inverse_row: T.int32 = lane  # .cu:2189
+                diag_block: T.int32 = inverse_row // 8  # .cu:2190
+                lane_in_diag: T.int32 = lane & 7  # .cu:2191
+                inv_row: T.f32[8]  # .cu:2192
+                packed_5 = T.alloc_local((4,), "uint32", align=16)  # .cu:2193
+                byte_off_1: T.int32 = inverse_row * 128 + diag_block * 8 * 2  # .cu:2194
+                swizzled_off_1: T.int32 = byte_off_1 ^ ((byte_off_1 >> 7 & 7) << 4)  # .cu:2195
+                _ld_shared_v4(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    packed_5,
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_1,
+                )  # .cu:2196-2198
+                packed_fp32_2: T.f32[8]  # .cu:2199
+                for _pair in T.unroll(4):  # .cu:2200-2209
+                    packed_fp32_2[_pair * 2] = T.cuda.uint_as_float(
+                        packed_5[_pair + 0] << T.uint32(16)
+                    )
+                    packed_fp32_2[_pair * 2 + 1] = T.cuda.uint_as_float(
+                        packed_5[_pair + 0] & T.uint32(0xFFFF0000)
+                    )
+                for value_idx_5 in T.unroll(8):  # .cu:2210-2213
+                    inv_row[value_idx_5] = packed_fp32_2[value_idx_5]
+                for diag_elem in T.unroll(8):  # .cu:2214-2219
+                    if lane_in_diag == diag_elem:
+                        inv_row[diag_elem] = T.float32(1.0)
+                diag_group_base: T.int32 = lane - lane_in_diag  # .cu:2220
+                row_scale: T.f32 = -inv_row[0]  # .cu:2223 (statically-expanded pivot row 0)
+                if lane_in_diag > 0:  # .cu:2234-2236
+                    inv_row[0] = row_scale
+                row_scale_1: T.f32 = -inv_row[1]  # .cu:2223 (statically-expanded pivot row 1)
+                pivot_lane_1_0: T.int32 = diag_group_base + 1  # .cu:2226
+                pivot_1_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_1_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 1:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_1, pivot_1_0, inv_row[0])  # .cu:2230-2231
+                if lane_in_diag > 1:  # .cu:2234-2236
+                    inv_row[1] = row_scale_1
+                row_scale_2: T.f32 = -inv_row[2]  # .cu:2223 (statically-expanded pivot row 2)
+                pivot_lane_2_0: T.int32 = diag_group_base + 2  # .cu:2226
+                pivot_2_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_2_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 2:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_2, pivot_2_0, inv_row[0])  # .cu:2230-2231
+                pivot_lane_2_1: T.int32 = diag_group_base + 2  # .cu:2226
+                pivot_2_1: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[1], pivot_lane_2_1, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 2:  # .cu:2229-2232
+                    inv_row[1] = _fmaf_rn(row_scale_2, pivot_2_1, inv_row[1])  # .cu:2230-2231
+                if lane_in_diag > 2:  # .cu:2234-2236
+                    inv_row[2] = row_scale_2
+                row_scale_3: T.f32 = -inv_row[3]  # .cu:2223 (statically-expanded pivot row 3)
+                pivot_lane_3_0: T.int32 = diag_group_base + 3  # .cu:2226
+                pivot_3_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_3_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 3:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_3, pivot_3_0, inv_row[0])  # .cu:2230-2231
+                pivot_lane_3_1: T.int32 = diag_group_base + 3  # .cu:2226
+                pivot_3_1: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[1], pivot_lane_3_1, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 3:  # .cu:2229-2232
+                    inv_row[1] = _fmaf_rn(row_scale_3, pivot_3_1, inv_row[1])  # .cu:2230-2231
+                pivot_lane_3_2: T.int32 = diag_group_base + 3  # .cu:2226
+                pivot_3_2: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[2], pivot_lane_3_2, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 3:  # .cu:2229-2232
+                    inv_row[2] = _fmaf_rn(row_scale_3, pivot_3_2, inv_row[2])  # .cu:2230-2231
+                if lane_in_diag > 3:  # .cu:2234-2236
+                    inv_row[3] = row_scale_3
+                row_scale_4: T.f32 = -inv_row[4]  # .cu:2223 (statically-expanded pivot row 4)
+                pivot_lane_4_0: T.int32 = diag_group_base + 4  # .cu:2226
+                pivot_4_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_4_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 4:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_4, pivot_4_0, inv_row[0])  # .cu:2230-2231
+                pivot_lane_4_1: T.int32 = diag_group_base + 4  # .cu:2226
+                pivot_4_1: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[1], pivot_lane_4_1, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 4:  # .cu:2229-2232
+                    inv_row[1] = _fmaf_rn(row_scale_4, pivot_4_1, inv_row[1])  # .cu:2230-2231
+                pivot_lane_4_2: T.int32 = diag_group_base + 4  # .cu:2226
+                pivot_4_2: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[2], pivot_lane_4_2, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 4:  # .cu:2229-2232
+                    inv_row[2] = _fmaf_rn(row_scale_4, pivot_4_2, inv_row[2])  # .cu:2230-2231
+                pivot_lane_4_3: T.int32 = diag_group_base + 4  # .cu:2226
+                pivot_4_3: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[3], pivot_lane_4_3, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 4:  # .cu:2229-2232
+                    inv_row[3] = _fmaf_rn(row_scale_4, pivot_4_3, inv_row[3])  # .cu:2230-2231
+                if lane_in_diag > 4:  # .cu:2234-2236
+                    inv_row[4] = row_scale_4
+                row_scale_5: T.f32 = -inv_row[5]  # .cu:2223 (statically-expanded pivot row 5)
+                pivot_lane_5_0: T.int32 = diag_group_base + 5  # .cu:2226
+                pivot_5_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_5_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 5:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_5, pivot_5_0, inv_row[0])  # .cu:2230-2231
+                pivot_lane_5_1: T.int32 = diag_group_base + 5  # .cu:2226
+                pivot_5_1: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[1], pivot_lane_5_1, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 5:  # .cu:2229-2232
+                    inv_row[1] = _fmaf_rn(row_scale_5, pivot_5_1, inv_row[1])  # .cu:2230-2231
+                pivot_lane_5_2: T.int32 = diag_group_base + 5  # .cu:2226
+                pivot_5_2: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[2], pivot_lane_5_2, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 5:  # .cu:2229-2232
+                    inv_row[2] = _fmaf_rn(row_scale_5, pivot_5_2, inv_row[2])  # .cu:2230-2231
+                pivot_lane_5_3: T.int32 = diag_group_base + 5  # .cu:2226
+                pivot_5_3: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[3], pivot_lane_5_3, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 5:  # .cu:2229-2232
+                    inv_row[3] = _fmaf_rn(row_scale_5, pivot_5_3, inv_row[3])  # .cu:2230-2231
+                pivot_lane_5_4: T.int32 = diag_group_base + 5  # .cu:2226
+                pivot_5_4: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[4], pivot_lane_5_4, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 5:  # .cu:2229-2232
+                    inv_row[4] = _fmaf_rn(row_scale_5, pivot_5_4, inv_row[4])  # .cu:2230-2231
+                if lane_in_diag > 5:  # .cu:2234-2236
+                    inv_row[5] = row_scale_5
+                row_scale_6: T.f32 = -inv_row[6]  # .cu:2223 (statically-expanded pivot row 6)
+                pivot_lane_6_0: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_0: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[0], pivot_lane_6_0, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[0] = _fmaf_rn(row_scale_6, pivot_6_0, inv_row[0])  # .cu:2230-2231
+                pivot_lane_6_1: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_1: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[1], pivot_lane_6_1, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[1] = _fmaf_rn(row_scale_6, pivot_6_1, inv_row[1])  # .cu:2230-2231
+                pivot_lane_6_2: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_2: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[2], pivot_lane_6_2, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[2] = _fmaf_rn(row_scale_6, pivot_6_2, inv_row[2])  # .cu:2230-2231
+                pivot_lane_6_3: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_3: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[3], pivot_lane_6_3, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[3] = _fmaf_rn(row_scale_6, pivot_6_3, inv_row[3])  # .cu:2230-2231
+                pivot_lane_6_4: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_4: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[4], pivot_lane_6_4, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[4] = _fmaf_rn(row_scale_6, pivot_6_4, inv_row[4])  # .cu:2230-2231
+                pivot_lane_6_5: T.int32 = diag_group_base + 6  # .cu:2226
+                pivot_6_5: T.f32 = T.cuda._shfl_sync(
+                    T.uint32(0xFFFFFFFF), inv_row[5], pivot_lane_6_5, 32
+                )  # .cu:2227-2228
+                if lane_in_diag > 6:  # .cu:2229-2232
+                    inv_row[5] = _fmaf_rn(row_scale_6, pivot_6_5, inv_row[5])  # .cu:2230-2231
+                if lane_in_diag > 6:  # .cu:2234-2236
+                    inv_row[6] = row_scale_6
+                packed_0_3 = T.alloc_local((4,), "uint32", align=4)  # .cu:2238
+                for _lp in T.unroll(4):  # .cu:2239-2243
+                    packed_0_3[_lp] = T.cuda.float22bfloat162_rn(
+                        inv_row[_lp * 2 + 0], inv_row[_lp * 2 + 1 + 0]
+                    )
+                byte_off_1_1: T.int32 = inverse_row * 128 + diag_block * 8 * 2  # .cu:2244
+                swizzled_off_2: T.int32 = byte_off_1_1 ^ ((byte_off_1_1 >> 7 & 7) << 4)  # .cu:2245
+                for word_6 in T.unroll(4):  # .cu:2246-2249
+                    _st_shared_b32(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        smem_inv_work_addr
+                        + T.cast(prep_stage, "int32") * 41984
+                        + swizzled_off_2
+                        + word_6 * 4,
+                        packed_0_3[word_6],
+                    )
+            if prep_local_warp < 2:  # .cu:2251-2256
+                if T.ptx.elect_sync():
+                    _mbarrier_arrive(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        mbar_base + MBAR_PREP_DIAG_READY_OFF + prep_stage * 8,
+                    )
+                _mbarrier_wait(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_PREP_DIAG_READY_OFF + prep_stage * 8,
+                    _phase_prep_diag_ready,
+                )
+            if prep_local_warp < 2:  # .cu:2257-2322
+                lane_row: T.int32 = lane & 7  # .cu:2258
+                byte_off_2: T.int32 = (prep_local_warp * 16 + 8 + lane_row) * 128 + (
+                    prep_local_warp * 16 + 8
+                ) * 2  # .cu:2259
+                swizzled_off_3: T.int32 = byte_off_2 ^ ((byte_off_2 >> 7 & 7) << 4)  # .cu:2260
+                d_addr: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_3
+                )  # .cu:2261
+                byte_off_0: T.int32 = (prep_local_warp * 16 + 8 + lane_row) * 128 + (
+                    prep_local_warp * 16 * 2
+                )  # .cu:2262
+                swizzled_off_1_1: T.int32 = byte_off_0 ^ ((byte_off_0 >> 7 & 7) << 4)  # .cu:2263
+                c_addr: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_1_1
+                )  # .cu:2264
+                byte_off_2_1: T.int32 = (prep_local_warp * 16 + lane_row) * 128 + (
+                    prep_local_warp * 16 * 2
+                )  # .cu:2265
+                swizzled_off_3_1: T.int32 = byte_off_2_1 ^ (
+                    (byte_off_2_1 >> 7 & 7) << 4
+                )  # .cu:2266
+                a_addr: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_3_1
+                )  # .cu:2267
+                d_frag = T.alloc_local((2,), "uint32", align=4)  # .cu:2268
+                c_frag = T.alloc_local((1,), "uint32", align=4)  # .cu:2269
+                dc_acc = T.alloc_local((4,), "float32", align=4)  # .cu:2270
+                dc_bf16 = T.alloc_local((2,), "uint32", align=4)  # .cu:2271
+                inv_a_frag = T.alloc_local((1,), "uint32", align=4)  # .cu:2272
+                o_acc = T.alloc_local((4,), "float32", align=4)  # .cu:2273
+                o_bf16 = T.alloc_local((2,), "uint32", align=4)  # .cu:2274
+                # .cu:2275-2278 ldmatrix.x1 d_frag[0]
+                T.ptx.ldmatrix(
+                    False,
+                    1,
+                    ".b16",
+                    smem_raw.ptr_to([(d_addr) - T.cast(smem, "int32")]),
+                    T.address_of(d_frag[0]),
+                )
+                # .cu:2279-2282 ldmatrix.x1 d_frag[1] (same address)
+                T.ptx.ldmatrix(
+                    False,
+                    1,
+                    ".b16",
+                    smem_raw.ptr_to([(d_addr) - T.cast(smem, "int32")]),
+                    T.address_of(d_frag[1]),
+                )
+                # .cu:2283-2286 ldmatrix.x1.trans c_frag
+                T.ptx.ldmatrix(
+                    True,
+                    1,
+                    ".b16",
+                    smem_raw.ptr_to([(c_addr) - T.cast(smem, "int32")]),
+                    T.address_of(c_frag[0]),
+                )
+                _mma_m16n8k8_bf16_zero(dc_acc, d_frag, c_frag)  # .cu:2287-2289
+                for _ls in T.unroll(2):  # .cu:2290-2293
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(dc_acc[_ls * 2], dc_acc[_ls * 2 + 1]),
+                        T.cuda.make_float2(T.float32(-1.0), T.float32(-1.0)),
+                    )
+                    dc_acc[_ls * 2] = T.cuda.float2_x(_pk)
+                    dc_acc[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _lp in T.unroll(2):  # .cu:2294-2298
+                    dc_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        dc_acc[_lp * 2 + 0], dc_acc[_lp * 2 + 1 + 0]
+                    )
+                # .cu:2299-2302 ldmatrix.x1.trans inv_a_frag
+                T.ptx.ldmatrix(
+                    True,
+                    1,
+                    ".b16",
+                    smem_raw.ptr_to([(a_addr) - T.cast(smem, "int32")]),
+                    T.address_of(inv_a_frag[0]),
+                )
+                _mma_m16n8k8_bf16_zero(o_acc, dc_bf16, inv_a_frag)  # .cu:2303-2305
+                for _lp in T.unroll(2):  # .cu:2306-2310
+                    o_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        o_acc[_lp * 2 + 0], o_acc[_lp * 2 + 1 + 0]
+                    )
+                byte_off_4: T.int32 = (prep_local_warp * 16 + 8 + lane_row) * 128 + (
+                    prep_local_warp * 16 * 2
+                )  # .cu:2311
+                swizzled_off_5: T.int32 = byte_off_4 ^ ((byte_off_4 >> 7 & 7) << 4)  # .cu:2312
+                o_addr: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_5
+                )  # .cu:2313
+                # .cu:2314-2317 stmatrix.x1
+                T.ptx.stmatrix(
+                    False,
+                    1,
+                    ".b16",
+                    smem_raw.ptr_to([(o_addr) - T.cast(smem, "int32")]),
+                    T.address_of(o_bf16[0]),
+                    shape="m8n8",
+                )
+                if T.ptx.elect_sync():  # .cu:2318-2320
+                    _mbarrier_arrive(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        mbar_base + MBAR_PREP_INV16_READY_OFF + prep_stage * 8,
+                    )
+                _mbarrier_wait(
+                    smem_raw,
+                    T.cast(smem, "int32"),
+                    mbar_base + MBAR_PREP_INV16_READY_OFF + prep_stage * 8,
+                    _phase_prep_inv16_ready,
+                )  # .cu:2321
+            if prep_local_warp == 0:  # .cu:2323-2404
+                lane_row_1: T.int32 = lane % 16  # .cu:2324
+                lane_col: T.int32 = lane // 16 * 8  # .cu:2325
+                byte_off_3: T.int32 = (16 + lane_row_1) * 128 + (16 + lane_col) * 2  # .cu:2326
+                swizzled_off_4: T.int32 = byte_off_3 ^ ((byte_off_3 >> 7 & 7) << 4)  # .cu:2327
+                d_addr_1: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_4
+                )  # .cu:2328
+                byte_off_0_1: T.int32 = (16 + lane_row_1) * 128 + lane_col * 2  # .cu:2329
+                swizzled_off_1_2: T.int32 = byte_off_0_1 ^ (
+                    (byte_off_0_1 >> 7 & 7) << 4
+                )  # .cu:2330
+                c_addr_1: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_1_2
+                )  # .cu:2331
+                byte_off_2_2: T.int32 = lane_row_1 * 128 + lane_col * 2  # .cu:2332
+                swizzled_off_3_2: T.int32 = byte_off_2_2 ^ (
+                    (byte_off_2_2 >> 7 & 7) << 4
+                )  # .cu:2333
+                a_addr_1: T.int32 = (
+                    smem_inv_work_addr + T.cast(prep_stage, "int32") * 41984 + swizzled_off_3_2
+                )  # .cu:2334
+                d32_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:2335
+                c32_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:2336
+                dc32_acc = T.alloc_local((8,), "float32", align=4)  # .cu:2337
+                dc32_bf16 = T.alloc_local((4,), "uint32", align=4)  # .cu:2338
+                a32_frag = T.alloc_local((4,), "uint32", align=4)  # .cu:2339
+                o32_acc = T.alloc_local((8,), "float32", align=4)  # .cu:2340
+                o32_bf16 = T.alloc_local((4,), "uint32", align=4)  # .cu:2341
+                zero32_bf16 = T.alloc_local((4,), "uint32", align=4)  # .cu:2342
+                # .cu:2343-2346 ldmatrix.x4 d32
+                T.ptx.ldmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(d_addr_1) - T.cast(smem, "int32")]),
+                    T.address_of(d32_frag[0]),
+                    T.address_of(d32_frag[1]),
+                    T.address_of(d32_frag[2]),
+                    T.address_of(d32_frag[3]),
+                )
+                _dpb: T.int32 = (
+                    (16 + lane_col) // 16 * 1024 + (16 + lane_row_1) * 32 + (16 + lane_col) % 16 * 2
+                )
+                d_publish_addr: T.int32 = (
+                    smem_inv_addr
+                    + T.cast(prep_stage, "int32") * 41984
+                    + (_dpb ^ ((_dpb >> 7 & 1) << 4))
+                )  # .cu:2347
+                # .cu:2348-2351 stmatrix.x4 d32 publish
+                T.ptx.stmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(d_publish_addr) - T.cast(smem, "int32")]),
+                    T.address_of(d32_frag[0]),
+                    T.address_of(d32_frag[1]),
+                    T.address_of(d32_frag[2]),
+                    T.address_of(d32_frag[3]),
+                    shape="m8n8",
+                )
+                # .cu:2352-2355 ldmatrix.x4.trans c32
+                T.ptx.ldmatrix(
+                    True,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(c_addr_1) - T.cast(smem, "int32")]),
+                    T.address_of(c32_frag[0]),
+                    T.address_of(c32_frag[1]),
+                    T.address_of(c32_frag[2]),
+                    T.address_of(c32_frag[3]),
+                )
+                _mma_m16n8k16_bf16_zero(dc32_acc, d32_frag, c32_frag)  # .cu:2356-2358
+                _mma_m16n8k16_bf16_zero_off4(dc32_acc, d32_frag, c32_frag)  # .cu:2359-2361
+                for _ls in T.unroll(4):  # .cu:2362-2365
+                    _pk = _mul_f32x2_inplace(
+                        T.cuda.make_float2(dc32_acc[_ls * 2], dc32_acc[_ls * 2 + 1]),
+                        T.cuda.make_float2(T.float32(-1.0), T.float32(-1.0)),
+                    )
+                    dc32_acc[_ls * 2] = T.cuda.float2_x(_pk)
+                    dc32_acc[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                for _lp in T.unroll(4):  # .cu:2366-2370
+                    dc32_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        dc32_acc[_lp * 2 + 0], dc32_acc[_lp * 2 + 1 + 0]
+                    )
+                # .cu:2371-2374 ldmatrix.x4.trans a32
+                T.ptx.ldmatrix(
+                    True,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(a_addr_1) - T.cast(smem, "int32")]),
+                    T.address_of(a32_frag[0]),
+                    T.address_of(a32_frag[1]),
+                    T.address_of(a32_frag[2]),
+                    T.address_of(a32_frag[3]),
+                )
+                _apb: T.int32 = lane_col // 16 * 1024 + lane_row_1 * 32 + lane_col % 16 * 2
+                a_publish_addr: T.int32 = (
+                    smem_inv_addr
+                    + T.cast(prep_stage, "int32") * 41984
+                    + (_apb ^ ((_apb >> 7 & 1) << 4))
+                )  # .cu:2375
+                # .cu:2376-2379 stmatrix.x4.trans a32 publish
+                T.ptx.stmatrix(
+                    True,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(a_publish_addr) - T.cast(smem, "int32")]),
+                    T.address_of(a32_frag[0]),
+                    T.address_of(a32_frag[1]),
+                    T.address_of(a32_frag[2]),
+                    T.address_of(a32_frag[3]),
+                    shape="m8n8",
+                )
+                _mma_m16n8k16_bf16_zero(o32_acc, dc32_bf16, a32_frag)  # .cu:2380-2382
+                _mma_m16n8k16_bf16_zero_off4(o32_acc, dc32_bf16, a32_frag)  # .cu:2383-2385
+                for _lp in T.unroll(4):  # .cu:2386-2390
+                    o32_bf16[_lp] = T.cuda.float22bfloat162_rn(
+                        o32_acc[_lp * 2 + 0], o32_acc[_lp * 2 + 1 + 0]
+                    )
+                _opb: T.int32 = lane_col // 16 * 1024 + (16 + lane_row_1) * 32 + lane_col % 16 * 2
+                o_publish_addr: T.int32 = (
+                    smem_inv_addr
+                    + T.cast(prep_stage, "int32") * 41984
+                    + (_opb ^ ((_opb >> 7 & 1) << 4))
+                )  # .cu:2391
+                # .cu:2392-2395 stmatrix.x4 o32 publish
+                T.ptx.stmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(o_publish_addr) - T.cast(smem, "int32")]),
+                    T.address_of(o32_bf16[0]),
+                    T.address_of(o32_bf16[1]),
+                    T.address_of(o32_bf16[2]),
+                    T.address_of(o32_bf16[3]),
+                    shape="m8n8",
+                )
+                for zero_word in T.unroll(4):  # .cu:2396-2399
+                    zero32_bf16[zero_word] = T.uint32(0)
+                _zpb: T.int32 = (
+                    (16 + lane_col) // 16 * 1024 + lane_row_1 * 32 + (16 + lane_col) % 16 * 2
+                )
+                zero_publish_addr: T.int32 = (
+                    smem_inv_addr
+                    + T.cast(prep_stage, "int32") * 41984
+                    + (_zpb ^ ((_zpb >> 7 & 1) << 4))
+                )  # .cu:2400
+                # .cu:2401-2404 stmatrix.x4 zero publish
+                T.ptx.stmatrix(
+                    False,
+                    4,
+                    ".b16",
+                    smem_raw.ptr_to([(zero_publish_addr) - T.cast(smem, "int32")]),
+                    T.address_of(zero32_bf16[0]),
+                    T.address_of(zero32_bf16[1]),
+                    T.address_of(zero32_bf16[2]),
+                    T.address_of(zero32_bf16[3]),
+                    shape="m8n8",
+                )
+            elif prep_local_warp == 1:  # .cu:2405-2522
+                stage_f32_0_1: T.int32 = T.cast(prep_stage, "int32") * 10496  # .cu:2406
+                restore_scale_1: T.f32 = smem_restore_factor_all[stage_f32_0_1 + 128]  # .cu:2407
+                restore_factor_1: T.f32[8]  # .cu:2408
+                restore_segment_1: T.int32 = lane & 15  # .cu:2409
+                for restore_elem_2 in T.unroll(8):  # .cu:2410-2414
+                    restore_col_1: T.int32 = restore_segment_1 * 8 + restore_elem_2  # .cu:2412
+                    restore_factor_1[restore_elem_2] = smem_restore_factor_all[
+                        stage_f32_0_1 + restore_col_1
+                    ]  # .cu:2413
+                for restore_pass_1 in T.serial(0, 4, unroll=False):  # .cu:2415-2416
+                    restore_row_1: T.int32 = restore_pass_1 * 2 + (lane >> 4)  # .cu:2417
+                    restore_qd_values_1: T.f32[8]  # .cu:2418
+                    restore_kd_values_1: T.f32[8]  # .cu:2419
+                    restore_ki_values_1: T.f32[8]  # .cu:2420
+                    _rs_swz_1: T.int32 = (
+                        restore_segment_1 * 8 // 64 * 4096
+                        + restore_row_1 * 128
+                        + restore_segment_1 * 8 % 64 * 2
+                    )
+                    _rs_swz_1 = _rs_swz_1 ^ ((_rs_swz_1 >> 7 & 7) << 4)
+                    packed_6 = T.alloc_local((4,), "uint32", align=16)  # .cu:2421
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_6,
+                        smem_qd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                    )  # .cu:2422-2424
+                    packed_fp32_3: T.f32[8]  # .cu:2425
+                    for _pair in T.unroll(4):  # .cu:2426-2435
+                        packed_fp32_3[_pair * 2] = T.cuda.uint_as_float(
+                            packed_6[_pair + 0] << T.uint32(16)
+                        )
+                        packed_fp32_3[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_6[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_6 in T.unroll(8):  # .cu:2436-2439
+                        restore_qd_values_1[value_idx_6] = packed_fp32_3[value_idx_6]
+                    packed_0_4 = T.alloc_local((4,), "uint32", align=16)  # .cu:2440
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_0_4,
+                        smem_kd_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                    )  # .cu:2441-2443
+                    packed_0_fp32_2: T.f32[8]  # .cu:2444
+                    for _pair in T.unroll(4):  # .cu:2445-2454
+                        packed_0_fp32_2[_pair * 2] = T.cuda.uint_as_float(
+                            packed_0_4[_pair + 0] << T.uint32(16)
+                        )
+                        packed_0_fp32_2[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_0_4[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_7 in T.unroll(8):  # .cu:2455-2458
+                        restore_kd_values_1[value_idx_7] = packed_0_fp32_2[value_idx_7]
+                    packed_1_3 = T.alloc_local((4,), "uint32", align=16)  # .cu:2459
+                    _ld_shared_v4(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        packed_1_3,
+                        smem_ki_addr + T.cast(prep_stage, "int32") * 41984 + _rs_swz_1,
+                    )  # .cu:2460-2462
+                    packed_1_fp32_1: T.f32[8]  # .cu:2463
+                    for _pair in T.unroll(4):  # .cu:2464-2473
+                        packed_1_fp32_1[_pair * 2] = T.cuda.uint_as_float(
+                            packed_1_3[_pair + 0] << T.uint32(16)
+                        )
+                        packed_1_fp32_1[_pair * 2 + 1] = T.cuda.uint_as_float(
+                            packed_1_3[_pair + 0] & T.uint32(0xFFFF0000)
+                        )
+                    for value_idx_8 in T.unroll(8):  # .cu:2474-2477
+                        restore_ki_values_1[value_idx_8] = packed_1_fp32_1[value_idx_8]
+                    restore_kr_values_1: T.f32[8]  # .cu:2478
+                    for restore_elem_3 in T.unroll(8):  # .cu:2479-2482
+                        restore_kr_values_1[restore_elem_3] = (
+                            restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3]
+                        )  # .cu:2481
+                    for _ls in T.unroll(4):  # .cu:2483-2486
+                        _pk = _mul_f32x2_inplace(
+                            T.cuda.make_float2(
+                                restore_qd_values_1[_ls * 2], restore_qd_values_1[_ls * 2 + 1]
+                            ),
+                            T.cuda.make_float2(restore_scale_1, restore_scale_1),
+                        )
+                        restore_qd_values_1[_ls * 2] = T.cuda.float2_x(_pk)
+                        restore_qd_values_1[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                    for _ls in T.unroll(4):  # .cu:2487-2490
+                        _pk = _mul_f32x2_inplace(
+                            T.cuda.make_float2(
+                                restore_kd_values_1[_ls * 2], restore_kd_values_1[_ls * 2 + 1]
+                            ),
+                            T.cuda.make_float2(restore_scale_1, restore_scale_1),
+                        )
+                        restore_kd_values_1[_ls * 2] = T.cuda.float2_x(_pk)
+                        restore_kd_values_1[_ls * 2 + 1] = T.cuda.float2_y(_pk)
+                    packed_2_2 = T.alloc_local((4,), "uint32", align=4)  # .cu:2491
+                    for _lp in T.unroll(4):  # .cu:2492-2496
+                        packed_2_2[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_qd_values_1[_lp * 2 + 0], restore_qd_values_1[_lp * 2 + 1 + 0]
+                        )
+                    for word_7 in T.unroll(4):  # .cu:2497-2500
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_qd_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz_1
+                            + word_7 * 4,
+                            packed_2_2[word_7],
+                        )
+                    packed_3_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:2501
+                    for _lp in T.unroll(4):  # .cu:2502-2506
+                        packed_3_1[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_kd_values_1[_lp * 2 + 0], restore_kd_values_1[_lp * 2 + 1 + 0]
+                        )
+                    for word_8 in T.unroll(4):  # .cu:2507-2510
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_kd_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz_1
+                            + word_8 * 4,
+                            packed_3_1[word_8],
+                        )
+                    packed_4_1 = T.alloc_local((4,), "uint32", align=4)  # .cu:2511
+                    for _lp in T.unroll(4):  # .cu:2512-2516
+                        packed_4_1[_lp] = T.cuda.float22bfloat162_rn(
+                            restore_kr_values_1[_lp * 2 + 0], restore_kr_values_1[_lp * 2 + 1 + 0]
+                        )
+                    for word_9 in T.unroll(4):  # .cu:2517-2520
+                        _st_shared_b32(
+                            smem_raw,
+                            T.cast(smem, "int32"),
+                            smem_kr_trans_addr
+                            + T.cast(prep_stage, "int32") * 41984
+                            + _rs_swz_1
+                            + word_9 * 4,
+                            packed_4_1[word_9],
+                        )
+            _fence_async_shared()  # .cu:2523
+            if prep_instance == 0:  # .cu:2524-2536
+                T.ptx.bar.sync(11, 128)
+            elif prep_instance == 1:
+                T.ptx.bar.sync(12, 128)
+            else:
+                if prep_instance == 2:
+                    T.ptx.bar.sync(13, 128)
+                elif prep_instance == 3:
+                    T.ptx.bar.sync(14, 128)
+                else:
+                    T.ptx.bar.sync(15, 128)
+            if prep_local_warp == 0:  # .cu:2537-2541
+                if T.ptx.elect_sync():
+                    _mbarrier_arrive(
+                        smem_raw,
+                        T.cast(smem, "int32"),
+                        mbar_base + MBAR_QK_FULL_OFF + prep_stage * 8,
+                    )
+            for _advance in T.serial(0, 5):  # .cu:2542-2545
+                prep_stage += 1
+                if prep_stage == 5:
+                    prep_stage = T.uint32(0)
+                    _phase_raw_inputs_free = _phase_raw_inputs_free ^ T.uint32(1)
+                    _phase_gate_raw_full = _phase_gate_raw_full ^ T.uint32(1)
+                    _phase_smem_free = _phase_smem_free ^ T.uint32(1)
+                    _phase_qk_raw_full = _phase_qk_raw_full ^ T.uint32(1)
+                    _phase_prep_diag_ready = _phase_prep_diag_ready ^ T.uint32(1)
+                    _phase_prep_inv16_ready = _phase_prep_inv16_ready ^ T.uint32(1)
+
+
+def get_kernel(**kwargs: Any):
+    cfg = _cfg(**kwargs)
+    kernel = _kernel.specialize(
+        total_tokens=cfg.total_tokens,
+        h=cfg.num_heads,
+        num_seqs=cfg.num_seqs,
+        beta_tma_tokens=cfg.beta_tma_tokens,
+        beta_tma_heads=cfg.beta_tma_heads,
+        scale=1.0 / math.sqrt(D_HEAD),
+        lower_bound=cfg.lower_bound,
+        use_initial_state=cfg.use_initial_state,
+        store_final_state=cfg.store_final_state,
+    )
+    return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+def run_test(**kwargs: Any) -> None:
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA is required for FlashKDA bf16 fused m128")
+
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    cfg: FlashKDABf16FusedM128Config = case["config"]
+    if not case["dispatch_reason"].startswith("m128:"):
+        raise SkipTest(case["dispatch_reason"])
+    prim_func = get_kernel(**kwargs)
+    ex = compile_kernel(prim_func)
+    ex(*_tirx_args(case))
+    torch.cuda.synchronize()
+
+    ref_out, ref_state = _reference_torch(case)
+    torch.testing.assert_close(case["out"], ref_out, rtol=4.01 / 128, atol=5e-3)
+    if cfg.store_final_state:
+        torch.testing.assert_close(case["final_state"], ref_state, rtol=4.01 / 128, atol=5e-3)
+
+    frozen_out, frozen_state = _frozen_cuda_reference(case)
+    torch.testing.assert_close(case["out"], frozen_out, rtol=4.01 / 128, atol=5e-3)
+    if cfg.store_final_state and frozen_state is not None:
+        torch.testing.assert_close(
+            case["final_state"],
+            frozen_state.reshape(case["final_state"].shape),
+            rtol=4.01 / 128,
+            atol=5e-3,
+        )
+    cfg.validate()
+
+
+def run_bench(
+    *, warmup: int | None = None, repeat: int | None = None, timer: str | None = None, **kwargs: Any
+) -> dict[str, Any]:
+    _rounds = kwargs.pop("rounds", 1)
+    _cooldown_s = kwargs.pop("cooldown_s", 1.0)
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA is required for FlashKDA bf16 fused m128 benchmark")
+
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    cfg: FlashKDABf16FusedM128Config = case["config"]
+    if not case["dispatch_reason"].startswith("m128:"):
+        raise SkipTest(case["dispatch_reason"])
+    prim_func = get_kernel(**kwargs)
+    ex = compile_kernel(prim_func)
+
+    args = _tirx_args(case)
+    funcs = {"tirx": lambda: ex(*args)}
+
+    def _frozen_builder():
+        _load_frozen_recurrent_kda()  # warm the frozen module outside the timed region
+        return lambda: _frozen_cuda_reference(case)
+
+    references = {"flashinfer_frozen_m128": _frozen_builder}
+
+    return bench(
+        funcs,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references=references,
+        rounds=_rounds,
+        cooldown_s=_cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashmla/sparse_decode_head64.py
+++ b/tirx_kernels/flashmla/sparse_decode_head64.py
@@ -12,7 +12,7 @@ import torch
 
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._tma import tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.ir import PointerType, PrimType
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import leader_mbar, tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import leader_mbar, tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -11,7 +11,7 @@ import torch
 from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
 from tirx_kernels.flashmla._tma import tma_config
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler

--- a/tirx_kernels/gemm/fp16_bf16_gemm.py
+++ b/tirx_kernels/gemm/fp16_bf16_gemm.py
@@ -30,7 +30,7 @@ _DTYPE_MAP = {"fp16": tvm.DataType("float16"), "bf16": tvm.DataType("bfloat16")}
 def _swizzle_for_row_bytes(row_bytes):
     """Pick the MMA-shared swizzle atom matching the tile row width (the 128/64/32B
     swizzle is selected from the row byte width)."""
-    from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+    from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 
     if row_bytes % 128 == 0:
         return SwizzleMode.SWIZZLE_128B_ATOM

--- a/tirx_kernels/gemm/fp8_blockwise_gemm.py
+++ b/tirx_kernels/gemm/fp8_blockwise_gemm.py
@@ -6,7 +6,7 @@ import os
 import torch
 from deep_gemm.utils.math import per_block_cast_to_fp8, per_token_cast_to_fp8
 
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench

--- a/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
@@ -12,7 +12,7 @@ from tvm.backend.loader import load
 load("cuda")
 
 import tvm
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench

--- a/tirx_kernels/gemm/nvfp4_gemm.py
+++ b/tirx_kernels/gemm/nvfp4_gemm.py
@@ -11,8 +11,8 @@ import torch
 from flashinfer import SfLayout, nvfp4_quantize
 
 import tvm
-from tvm.backend.cuda.operator.tile_primitive.gemm_async.tcgen05 import sf_smem_layout
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode
+from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_smem_layout
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench

--- a/tirx_kernels/gemm_comm/README.md
+++ b/tirx_kernels/gemm_comm/README.md
@@ -19,8 +19,9 @@ under the License.
 
 # Distributed GEMM kernels
 
-This category contains SM100, tensor-parallel kernels. Both workloads
-register TP1 and TP4 specializations for eight model shapes:
+This category contains the SM100, tensor-parallel kernels recovered from the
+megakernel performance branch. Both workloads register TP1 and TP4
+specializations for eight model shapes:
 
 | Registry name | Global operation | Rank-local result |
 | --- | --- | --- |
@@ -41,8 +42,8 @@ the local module, and owns its Device API streams. No Disco session or remote
 runtime object is created. Mutable queues, semaphores, workspaces, and outputs
 are reset independently on every rank before each measured launch.
 
-Both registry entries are direct kernel ports with no scheduling policy,
-execution region, or MoE change. AllGather+GEMM keeps
+Both registry entries are direct kernel ports. This PR contains no megakernel
+DSL, scheduling policy, execution region, or MoE change. AllGather+GEMM keeps
 the already validated dynamic queue implementation. GEMM+ReduceScatter uses
 the hand-transcribed fused persistent kernel in `gemm_reduce_scatter.py`: a
 two-CTA GEMM queue feeds an initially

--- a/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
+++ b/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
@@ -1060,7 +1060,7 @@ def get_kernel(
     scheduler: str = "dynamic",
     **_kwargs: Any,
 ) -> tvm.IRModule:
-    """Build the hand-transcribed fused kernel directly."""
+    """Build the hand-transcribed fused kernel directly, without the megakernel DSL."""
 
     config = _config(M, N, K, world_size, dtype, scheduler)
     return build_kernel(config)

--- a/tirx_kernels/megakernel/README.md
+++ b/tirx_kernels/megakernel/README.md
@@ -1,0 +1,568 @@
+# MegaKernelMOE Task Reference
+
+This document describes the current `MegaKernelMOE` as a set of operators.
+Read each task the same way you would read a PyTorch operator reference:
+
+```python
+output = op(input0, input1, ...)
+```
+
+For each task, the signature says what tensors it consumes and returns.  The
+`Scheduler edge` section says which event makes the consumer safe to run, and
+the `Tile instances` section says how that logical op is split into
+`(m_idx, n_idx, k_idx)` work items.
+
+The current code does not have a standalone `TaskSpec` class.  The operator
+contract is implemented by:
+
+- `MegaKernelMOE.task_impl_*`: passes tensors into the tile and issues
+  `wait` / `notify` / `pre_notify_and_push`;
+- `MegaKernelMOE._set_events`: allocates dependency counters;
+- `generate_exec_queue_moe`: creates the static queue and the dynamic initial
+  queue;
+- `Tile.run(m_idx, n_idx, k_idx, ...)`: implements one task instance.
+
+## Notation
+
+The benchmark shape is Qwen3-30B-A3B MoE:
+
+| Symbol | Meaning | Value |
+| --- | --- | --- |
+| `B` | input tokens / batch size | runtime config |
+| `H` | hidden size | 2048 |
+| `I` | intermediate size | 768 |
+| `E` | number of experts | 128 |
+| `K` | top-k experts per token | 8 |
+| `P` | expert-major block size, `MOE_M_PAD_SIZE` | 128 |
+| `S` | router split-k factor | 4 |
+| `BN` | grouped GEMM output tile columns, `GroupGEMMTileSM100.BLK_N` | 128 |
+| `T` | routed entries before padding | `B * K` |
+| `TP` | routed entries after expert padding | runtime `num_tokens_post_pad[0]` |
+| `TP_MAX` | maximum padded routed entries | `get_max_num_tokens_padded(B, K, E, P)` |
+
+Shapes in this document use logical valid ranges.  Allocated workspaces usually
+use `TP_MAX`, while runtime work only covers `TP`.
+
+## SGLang Source Baseline
+
+The optional SGLang fused-MoE baseline is imported lazily from a source
+checkout.  It does not require installing the `sglang` package:
+
+```bash
+export WORKSPACE=/path/to/workspace
+export SGLANG_PATH=$HOME/kernel-libs/sglang
+export PYTHONPATH="${SGLANG_PATH}/python:${WORKSPACE}/tirx-kernels:${WORKSPACE}/tvm/python"
+export TVM_LIBRARY_PATH="${WORKSPACE}/tvm/build/lib"
+
+python -m tirx_kernels.bench \
+  --kernel megakernel_moe \
+  --config moe_a3b_bs1_all
+```
+
+SGLang module import, runtime-context setup, and Triton JIT compilation happen
+outside the timed region.  The timed `sglang_full` callable includes the same
+FP32 router matmul, softmax, top-k, and expert computation as the full TIRx MoE
+scope.  Both implementations receive the same logical input and weights.  The
+result metadata includes one validation record per scheduler; treat a missing or
+failed validation as a benchmark failure. The grouped benchmark compiles static,
+dynamic, and unfused once and measures them against the same logical input and
+the same SGLang and FlashInfer references.
+
+The module includes B200 configs under `sglang_moe_configs/` for SGLang commit
+`96a04cb13f9c3ed86028e090784a9eb059cf5318` and Triton 3.6.0.  They were generated
+with SGLang's separated fused-MoE tuner over its complete 1920-config search
+space for `B = [1, 8, 32, 128, 512, 1024, 2048, 4096]`.  Tuning used 100
+fixed-seed, uniformly routed top-k tensors with distinct expert IDs per token.
+The two config files independently select gate/up and down-projection settings,
+including the down TMA decision.  Set `SGLANG_MOE_CONFIG_DIR` to override the
+packaged configs with a retuned directory for another GPU or Triton version.
+
+## Forward Pipeline
+
+The logical computation is:
+
+```python
+gating_output = moe_gating(
+    hidden_state,          # f16[B, H]
+    gate_weight,           # f16[E, H]
+)
+
+topk_weights, topk_indices = moe_topk_softmax(
+    gating_output,         # f32[B, E]
+    top_k=K,
+    renormalize=False,
+)
+
+routing = moe_align(
+    topk_indices,          # i32[B, K]
+    num_experts=E,
+    block_size=P,
+)
+
+sorted_token_ids, reordered_hidden_state = moe_count_and_sort(
+    hidden_state,          # f16[B, H]
+    topk_indices,          # i32[B, K]
+    routing,
+)
+
+silu_mul_output = moe_group_gemm_gate_up_silu(
+    reordered_hidden_state,  # f16[TP, H]
+    grp_gate_up_weight,      # f16[E, 2 * I, H]
+    routing,
+)
+
+topk_reduce_output = moe_group_gemm_down(
+    silu_mul_output,       # f16[TP, I]
+    grp_down_weight,       # f16[E, H, I]
+    topk_weights,          # f32[B, K]
+    routing,
+)
+```
+
+`routing` is not a Python object in the kernel.  It names the set of routing
+metadata produced by `moe_align` and consumed by later tasks:
+
+```python
+routing = {
+    "num_tokens_post_pad": i32[1],
+    "cumsum_buffer": i32[E + 1],
+    "expert_ids": i32[TP_MAX / P],
+    "num_valid_tokens": i32[TP_MAX / P],
+    "sorted_token_ids": i32[TP_MAX],
+}
+```
+
+`sorted_token_ids[row]` stores a flattened route id:
+
+```python
+route_id = token_id * K + route_slot
+token_id = route_id // K
+route_slot = route_id % K
+expert_id = topk_indices[token_id, route_slot]
+route_weight = topk_weights[token_id, route_slot]
+```
+
+Padding rows use sentinel `T`.
+
+## How Tasks Connect
+
+Two task specs connect when the producer's return value is a named input in the
+consumer's signature, and the consumer waits on the event notified by the
+producer.
+
+Example:
+
+```python
+gating_output = moe_gating(hidden_state, gate_weight)
+topk_weights, topk_indices = moe_topk_softmax(gating_output, top_k=K)
+```
+
+The connection is valid because:
+
+- `moe_gating` returns `gating_output`;
+- `moe_topk_softmax` takes `gating_output`;
+- gating has `S * ceildiv(B, 128)` tile instances;
+- `evt_gating` is initialized to exactly that producer count;
+- every gating instance notifies `evt_gating`;
+- every top-k/softmax instance waits on `evt_gating` before reading
+  `gating_output`;
+- the dynamic scheduler pushes top-k/softmax instances when `evt_gating`
+  reaches its trigger.
+
+That is the contract every producer/consumer pair must satisfy.
+
+## Task Reference
+
+### `moe_gating`
+
+Signature:
+
+```python
+moe_gating(
+    hidden_state: f16[B, H],
+    gate_weight: f16[E, H],
+) -> gating_output: f32[B, E]
+```
+
+Semantics:
+
+```python
+gating_output[token, expert] = dot(hidden_state[token, :], gate_weight[expert, :])
+```
+
+Tile instances:
+
+```text
+JobType.MOE_GATING
+m_idx in [0, ceildiv(B, 128))   # token block
+n_idx = 0
+k_idx in [0, S)                 # split-k shard over H
+```
+
+Scheduler edge:
+
+- Waits on: nothing.
+- Notifies: `evt_gating`.
+- Event count: `S * ceildiv(B, 128)`.
+- Dynamic successor: pushes all `moe_topk_softmax` persistent shards.
+
+Implementation:
+
+- Tile: `GemmTile`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_gating`.
+- Static queue entries: `push_moe_tasks`.
+
+### `moe_topk_softmax`
+
+Signature:
+
+```python
+moe_topk_softmax(
+    gating_output: f32[B, E],
+    *,
+    top_k: int = K,
+    renormalize: bool = False,
+) -> tuple[
+    topk_weights: f32[B, K],
+    topk_indices: i32[B, K],
+]
+```
+
+Semantics:
+
+```python
+routing = softmax(gating_output[token, :])
+topk_weights[token, :], topk_indices[token, :] = topk(routing, K)
+```
+
+The current call uses `renormalize=False`, so `topk_weights` are probabilities
+from the full expert softmax, not probabilities re-normalized over the selected
+top-k experts.
+
+Tile instances:
+
+```text
+JobType.MOE_TOPK_SOFTMAX
+m_idx in [0, KernelConfig.SM_NUMBER)   # persistent shard id
+n_idx = 0
+k_idx = 0
+```
+
+Scheduler edge:
+
+- Waits on: `evt_gating`.
+- Notifies: `evt_topk_softmax`.
+- Event count: `KernelConfig.SM_NUMBER`.
+- Dynamic successor: pushes one `moe_align` task.
+
+Implementation:
+
+- Tile: `TopkSoftmaxTile`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_topk_softmax`.
+
+### `moe_align`
+
+Signature:
+
+```python
+moe_align(
+    topk_indices: i32[B, K],
+    *,
+    num_experts: int = E,
+    block_size: int = P,
+) -> routing
+```
+
+Returns:
+
+```python
+routing = {
+    "num_tokens_post_pad": i32[1],        # TP
+    "cumsum_buffer": i32[E + 1],          # expert prefix offsets
+    "expert_ids": i32[TP_MAX / P],        # expert id per padded block
+    "num_valid_tokens": i32[TP_MAX / P],  # valid rows per padded block
+    "sorted_token_ids": i32[TP_MAX],      # initialized to sentinel T for padding
+}
+```
+
+Semantics:
+
+1. Count routes per expert from `topk_indices.view(-1)`.
+2. Round every expert count up to a multiple of `P`.
+3. Prefix-sum padded counts into `cumsum_buffer`.
+4. Write `num_tokens_post_pad[0] = TP`.
+5. For each padded expert-major block, write `expert_ids[block]`.
+6. Optionally write `num_valid_tokens[block]`.
+7. Initialize padded `sorted_token_ids` rows with sentinel `T`.
+
+Tile instances:
+
+```text
+JobType.MOE_ALIGN
+m_idx = 0
+n_idx = 0
+k_idx = 0
+```
+
+Scheduler edge:
+
+- Waits on: `evt_topk_softmax`.
+- Notifies: `evt_moe_align`.
+- Event count: `1`.
+- Dynamic successor: pushes all `moe_count_and_sort` persistent shards.
+
+Dynamic scheduler side effect:
+
+- Initializes the dynamic `evt_group_gemm_down` count after runtime `TP` is
+  known.
+
+Implementation:
+
+- Tile: `MOEAlignTile`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_align`.
+
+### `moe_count_and_sort`
+
+Signature:
+
+```python
+moe_count_and_sort(
+    hidden_state: f16[B, H],
+    topk_indices: i32[B, K],
+    routing,
+) -> tuple[
+    sorted_token_ids: i32[TP_MAX],
+    reordered_hidden_state: f16[TP_MAX, H],
+]
+```
+
+Semantics:
+
+For each flattened route id:
+
+```python
+route_id = token_id * K + route_slot
+expert_id = topk_indices[token_id, route_slot]
+row = atomic_add(routing.cumsum_buffer[expert_id], 1)
+sorted_token_ids[row] = route_id
+reordered_hidden_state[row, :] = hidden_state[token_id, :]
+```
+
+After this task, valid rows of `reordered_hidden_state` are expert-major:
+all routes for the same expert occupy contiguous padded blocks.  Padding rows
+remain sentinel-filled in `sorted_token_ids`.
+
+`cumsum_buffer` is mutated while assigning rows.  Treat it as scratch after this
+task, not as an immutable prefix table.
+
+Tile instances:
+
+```text
+JobType.MOE_COUNT_AND_SORT
+m_idx in [0, KernelConfig.SM_NUMBER)   # persistent shard id
+n_idx = 0
+k_idx = 0
+```
+
+Scheduler edge:
+
+- Waits on: `evt_moe_align`.
+- Notifies: `evt_count_and_sort`.
+- Event count: `KernelConfig.SM_NUMBER`.
+- Dynamic successor: pushes runtime `moe_group_gemm_gate_up_silu` tiles:
+
+```text
+m_idx in [0, TP / P)
+n_idx in [0, (2 * I) / BN)
+k_idx = 0
+```
+
+Implementation:
+
+- Tile: `CountAndSortExpertTokens`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_count_and_sort`.
+
+### `moe_group_gemm_gate_up_silu`
+
+Signature:
+
+```python
+moe_group_gemm_gate_up_silu(
+    reordered_hidden_state: f16[TP_MAX, H],
+    grp_gate_up_weight: f16[E, 2 * I, H],
+    routing,
+) -> silu_mul_output: f16[TP_MAX, I]
+```
+
+Semantics:
+
+For each valid expert-major row:
+
+```python
+expert = routing.expert_ids[row // P]
+gate_up = grp_gate_up_weight[expert] @ reordered_hidden_state[row, :]
+gate = gate_up[:I]
+up = gate_up[I:]
+silu_mul_output[row, :] = silu(gate) * up
+```
+
+The implementation computes this as grouped GEMM tiles.  `n_idx` covers a
+128-column tile of the `2 * I` gate/up projection; each such tile produces the
+corresponding `BN / 2` columns of `silu_mul_output`.
+
+Tile instances:
+
+```text
+JobType.MOE_GROUP_GEMM_GATE_UP_SILU
+m_idx in [0, TP / P)          # expert-major block
+n_idx in [0, (2 * I) / BN)    # gate/up output column tile
+k_idx = 0
+```
+
+Static scheduling enqueues the max task space for `TP_MAX / P`; runtime-invalid
+blocks are skipped by checking `m_idx < num_tokens_post_pad[0] / P`.
+
+Scheduler edge:
+
+- Waits on: `evt_count_and_sort`.
+- Notifies: `evt_group_gemm_gate_up[m_idx]` in fused static/dynamic mode.
+- Event count per expert-major block: `(2 * I) / BN`.
+- Dynamic successor: pushes down-projection tiles for the same `m_idx`.
+
+Implementation note:
+
+- Tile: `GroupGEMMSiluTile`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_group_gemm_gate_up_silu`.
+- The shared grouped-GEMM call signature passes `topk_weights`, but this stage
+  does not apply routing weights.  Routing weights are applied in
+  `moe_group_gemm_down`.
+
+### `moe_group_gemm_down`
+
+Signature:
+
+```python
+moe_group_gemm_down(
+    silu_mul_output: f16[TP_MAX, I],
+    grp_down_weight: f16[E, H, I],
+    topk_weights: f32[B, K],
+    routing,
+) -> topk_reduce_output: f16[B, H]
+```
+
+Semantics:
+
+For each valid expert-major row:
+
+```python
+route_id = routing.sorted_token_ids[row]
+token_id = route_id // K
+route_slot = route_id % K
+expert = routing.expert_ids[row // P]
+partial = grp_down_weight[expert] @ silu_mul_output[row, :]
+topk_reduce_output[token_id, :] += topk_weights[token_id, route_slot] * partial
+```
+
+The output is a reduce-add across the `K` selected experts for every token.
+
+Tile instances:
+
+```text
+JobType.MOE_GROUP_GEMM_DOWN
+m_idx in [0, TP / P)                         # expert-major block
+n_idx in [0, H / BN / down_proj_task_size)   # hidden output tile group
+k_idx = 0
+```
+
+Inside one scheduled down task, the wrapper may run `down_proj_task_size`
+neighboring hidden-column tiles to amortize dynamic scheduling overhead.
+
+Static scheduling enqueues the max task space for `TP_MAX / P`; runtime-invalid
+blocks are skipped by checking `m_idx < num_tokens_post_pad[0] / P`.
+
+Scheduler edge:
+
+- Waits on: `evt_group_gemm_gate_up[m_idx]` in fused static/dynamic mode.
+- In `unfused` comparison mode, waits on global `evt_group_gemm_gate_up[0]`.
+- Dynamic mode notifies `evt_group_gemm_down`.
+- Dynamic successor: pushes `END` tasks after all runtime down tiles have been
+  dispatched.
+
+Implementation:
+
+- Tile: `GroupGEMMTileSM100`.
+- Wrapper: `MegaKernelMOE.task_impl_moe_group_gemm_down`.
+
+## Scheduler Summary
+
+Static scheduling builds the whole work queue before launch:
+
+```text
+INIT_ETENSOR*
+MOE_GATING*
+WAIT_ETENSOR_INIT*
+MOE_TOPK_SOFTMAX*
+MOE_ALIGN
+MOE_COUNT_AND_SORT*
+MOE_GROUP_GEMM_GATE_UP_SILU*  # max TP_MAX task space
+MOE_GROUP_GEMM_DOWN*          # max TP_MAX task space
+END*
+```
+
+The queue order is not a cross-SM barrier.  Correctness still comes from the
+events in each task wrapper.
+
+Dynamic scheduling starts with only:
+
+```text
+INIT_ETENSOR*
+MOE_GATING*
+```
+
+Then each event trigger pushes the next operator's task instances:
+
+| Trigger | Pushed work |
+| --- | --- |
+| `evt_gating` | all `moe_topk_softmax` shards |
+| `evt_topk_softmax` | one `moe_align` task |
+| `evt_moe_align` | all `moe_count_and_sort` shards |
+| `evt_count_and_sort` | runtime `moe_group_gemm_gate_up_silu` tiles using `TP` |
+| `evt_group_gemm_gate_up[m_idx]` | runtime `moe_group_gemm_down` tiles for that `m_idx` |
+| `evt_group_gemm_down` | `END` tasks |
+
+Dynamic notify is two-phase:
+
+1. `pre_notify_and_push` runs before the tile body so successors can be queued
+   as soon as the last producer has been dispatched.
+2. The normal `notify` runs after the tile body, and consumers still wait for
+   that ready state before reading producer outputs.
+
+The push can happen early; the read cannot.
+
+## Adding a Task
+
+Do not start by writing scheduler code.  First write the operator spec:
+
+```python
+new_output = new_task(named_input0, named_input1, ...)
+```
+
+Then make it executable:
+
+1. Define the output tensor names and shapes.
+2. Define the input tensor names and shapes.
+3. Define the tile instance space in `(m_idx, n_idx, k_idx)`.
+4. Add a `JobType`.
+5. Implement `Tile.run(m_idx, n_idx, k_idx, ...)`.
+6. Add a `task_impl_*` wrapper that passes the named inputs and outputs.
+7. For each producer/consumer edge, allocate an event with the producer task
+   count.
+8. Make the producer notify that event after writing its output.
+9. Make the consumer wait on that event before reading the output.
+10. Add static queue entries for the consumer task space.
+11. Add a dynamic `pre_notify_and_push` rule for the same consumer task space.
+12. Add or update `run_test` coverage so the final output is compared with a
+    trusted reference.
+
+If the signature of two neighboring tasks does not line up, or the event count
+does not equal the producer task count, the graph is not well specified.

--- a/tirx_kernels/megakernel/__init__.py
+++ b/tirx_kernels/megakernel/__init__.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["kernels", "moe", "utils"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tirx_kernels/megakernel/kernels/__init__.py
+++ b/tirx_kernels/megakernel/kernels/__init__.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .gemm import GemmTile
+from .group_gemm_sm100 import GroupGEMMSiluTile
+from .group_gemm_sm100 import GroupGEMMTile as GroupGEMMTileSM100
+from .moe_align import CountAndSortExpertTokens, MOEAlignTile
+from .topk_softmax import TopkSoftmaxTile
+
+__all__ = [
+    "CountAndSortExpertTokens",
+    "GemmTile",
+    "GroupGEMMSiluTile",
+    "GroupGEMMTileSM100",
+    "MOEAlignTile",
+    "TopkSoftmaxTile",
+]

--- a/tirx_kernels/megakernel/kernels/gate_up_silu.py
+++ b/tirx_kernels/megakernel/kernels/gate_up_silu.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tirx_kernels.megakernel.utils.base import SmemManager
+from tirx_kernels.megakernel.utils.config import KernelConfig, ProfileEventType
+from tirx_kernels.megakernel.utils.utils import silu
+from tvm.script import tirx as T
+from tvm.script.tirx import tile as Tx
+from tvm.tirx.bench import CudaProfiler
+from tvm.tirx.layout import S, TileLayout
+from tvm.tirx.layout import tid_in_wg as axis_tid_in_wg
+
+from .gemm import GemmTile
+
+
+class GateUpSiluTile(GemmTile):
+    need_init = False
+
+    def _alloc_buffer(self, smem_manager: SmemManager):
+        self.smem_manager = smem_manager
+        self.A_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.MAX_BLK_M, self.BLK_K),
+            self.a_type,
+            layout=self.A_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.B_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.BLK_N, self.BLK_K),
+            self.b_type,
+            layout=self.B_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.D_layout = T.TileLayout(
+            T.S[
+                (GemmTile.TMEM_PIPE_DEPTH, GemmTile.EPI_TILE, GemmTile.MMA_N // 2) : (
+                    GemmTile.EPI_TILE * GemmTile.MMA_N // 2,
+                    GemmTile.MMA_N // 2,
+                    1,
+                )
+            ]
+        )
+        self.output_smem = smem_manager.alloc(
+            (self.TMEM_PIPE_DEPTH, self.EPI_TILE, self.MMA_N // 2),
+            "float16",
+            layout=self.D_layout,
+            align=1024,
+            method="exclusive",
+        )
+
+    def _alloc_local(self, m_idx):
+        self.reg = T.alloc_buffer((self.TMEM_LD_SIZE,), "float32", scope="local")
+        self.reg_fp16 = T.alloc_buffer((self.TMEM_LD_SIZE // 2,), "float16", scope="local")
+        self.tmem_idx = T.local_scalar("int32")
+        self.tmem_phase = T.local_scalar("int32")
+        self.stage = T.local_scalar("int32")
+        self.wait_complete = T.local_scalar("bool")
+        self.off = T.local_scalar("int32")
+
+    @T.inline
+    def init(self, smem_manager: SmemManager):
+        self._alloc_buffer(smem_manager)
+
+    @T.inline
+    def _consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler):
+        tid_in_wg = T.thread_id_in_wg([128])
+        warp_id = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([32])
+        T.cuda.trap_when_assert_failed(self.tmem_addr[0] == 0)
+        if warp_id == 0:
+            self.smem_manager.wait_specific(lane_id, self.output_smem, 0)
+        T.ptx.bar.sync(10, 128)
+        self.phase[0] = 0
+        self.tmem_idx = self.tile_idx % self.TMEM_PIPE_DEPTH
+        self.tmem_phase = self.tile_idx // self.TMEM_PIPE_DEPTH & 1
+        self.mma2ld_bar.wait(self.tmem_idx, self.tmem_phase)
+        T.ptx.tcgen05.fence.after_thread_sync()
+        SILU_HANDLE_UNIT = T.meta_var(self.TMEM_LD_SIZE // 2)
+        self.off = T.if_then_else(lane_id < 16, SILU_HANDLE_UNIT, 0)
+        for ko in T.unroll(self.MMA_M // self.EPI_TILE):
+            self.stage = (self.tile_idx * self.MMA_M // self.EPI_TILE + ko) % self.TMEM_PIPE_DEPTH
+            if ko >= self.TMEM_PIPE_DEPTH:
+                if (lane_id == 0) & (warp_id == 0):
+                    T.ptx.cp_async.bulk.wait_group(self.TMEM_PIPE_DEPTH - 1)
+                T.cuda.warpgroup_sync(10)
+            for ki in T.unroll(self.EPI_TILE // self.TMEM_LD_SIZE):
+                reg_wg = self.reg.view(
+                    128,
+                    self.TMEM_LD_SIZE,
+                    layout=TileLayout(S[(128, self.TMEM_LD_SIZE) : (1 @ axis_tid_in_wg, 1)]),
+                )
+                reg = self.reg
+                col_st = T.meta_var(
+                    self.tmem_idx * self.M_pad_size + ko * self.EPI_TILE + ki * self.TMEM_LD_SIZE
+                )
+                Tx.wg.copy_async(reg_wg, self.tmem[:, col_st : col_st + self.TMEM_LD_SIZE])
+                T.ptx.tcgen05.wait.ld()
+                if self.profiler_on:
+                    profiler.start(ProfileEventType.SILU_MUL, lane_id == 0)
+                for kv in T.unroll(SILU_HANDLE_UNIT):
+                    reg[self.off + kv] = T.tvm_warp_shuffle_xor(
+                        4294967295, reg[self.off + kv], 16, 32, 32
+                    )
+                for kv in T.unroll(SILU_HANDLE_UNIT):
+                    reg[kv] = silu(reg[kv]) * reg[SILU_HANDLE_UNIT + kv]
+                Tx.thread.cast(self.reg_fp16[:], reg[0:SILU_HANDLE_UNIT], vec=SILU_HANDLE_UNIT)
+                st = T.meta_var(ki * self.TMEM_LD_SIZE + lane_id // 16 * SILU_HANDLE_UNIT)
+                Tx.thread.copy(
+                    self.output_smem[
+                        self.stage, st : st + SILU_HANDLE_UNIT, warp_id * 16 + lane_id % 16
+                    ],
+                    self.reg_fp16[:],
+                    vec=SILU_HANDLE_UNIT,
+                )
+                if self.profiler_on:
+                    profiler.end(ProfileEventType.SILU_MUL, lane_id == 0)
+            if ko == self.MMA_M // self.EPI_TILE - 1:
+                T.ptx.tcgen05.fence.before_thread_sync()
+                self.ld2mma_bar.arrive(self.tmem_idx)
+            T.ptx.fence.proxy_async("shared::cta")
+            T.cuda.warpgroup_sync(10)
+            if tid_in_wg == 0:
+                m_st = T.meta_var(m_idx * self.M_pad_size + ko * self.EPI_TILE)
+                n_st = T.meta_var(n_idx * self.BLK_N // 2)
+                tma_config = T.meta_var(
+                    {"dispatch": "tma_auto", "cta_group": KernelConfig.CTA_GROUP}
+                )
+                Tx.thread.copy_async(
+                    output[m_st : m_st + self.EPI_TILE, n_st : n_st + self.BLK_N // 2],
+                    self.output_smem[self.stage, :, :],
+                    **tma_config,
+                )
+                T.ptx.cp_async.bulk.commit_group()
+        if tid_in_wg == 0:
+            T.ptx.cp_async.bulk.wait_group(0)
+        T.cuda.warpgroup_sync(10)
+        self.tile_idx += 1
+        if warp_id == 0:
+            self.smem_manager.arrive_specific(lane_id, self.output_smem, 0)

--- a/tirx_kernels/megakernel/kernels/gemm.py
+++ b/tirx_kernels/megakernel/kernels/gemm.py
@@ -25,7 +25,7 @@ from tirx_kernels.megakernel.utils.config import (
     ProfileEventType,
 )
 from tirx_kernels.megakernel.utils.utils import ceildiv, mbarrier_try_wait
-from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
 from tvm.script import tirx as T
 from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import CudaProfiler

--- a/tirx_kernels/megakernel/kernels/gemm.py
+++ b/tirx_kernels/megakernel/kernels/gemm.py
@@ -1,0 +1,689 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Literal
+
+import tvm
+from tirx_kernels.megakernel.utils.base import Barriers, SmemManager, Tile
+from tirx_kernels.megakernel.utils.config import (
+    F16_BYTES,
+    F32_BYTES,
+    KernelConfig,
+    ProfileEventType,
+)
+from tirx_kernels.megakernel.utils.utils import ceildiv, mbarrier_try_wait
+from tvm.backend.cuda.operator.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
+from tvm.script import tirx as T
+from tvm.script.tirx import tile as Tx
+from tvm.tirx.bench import CudaProfiler
+from tvm.tirx.layout import S, TCol, TileLayout, TLane
+from tvm.tirx.layout import tid_in_wg as axis_tid_in_wg
+
+
+class BarTMA2MMA(Barriers):
+    @T.inline
+    def arrive(self, idx, expected_bytes):
+        T.ptx.mbarrier.arrive.expect_tx(self.mbar.ptr_to([idx]), expected_bytes)
+
+    @T.inline
+    def arrive_only(self, idx):
+        T.ptx.mbarrier.arrive(self.mbar.ptr_to([idx]))
+
+
+class BarMMA2LD(Barriers):
+    @T.inline
+    def arrive(self, idx):
+        T.ptx.tcgen05.commit(self.mbar.ptr_to([idx]), cta_group=KernelConfig.CTA_GROUP)
+
+
+class BarMMA2TMA(Barriers):
+    @T.inline
+    def arrive(self, idx):
+        T.ptx.tcgen05.commit(self.mbar.ptr_to([idx]), cta_group=KernelConfig.CTA_GROUP)
+
+
+class BarLD2MMA(Barriers):
+    @T.inline
+    def arrive(self, idx):
+        T.ptx.mbarrier.arrive(self.mbar.ptr_to([idx]), remote=0, pred=True)
+
+
+class GemmTile(Tile):
+    SMEM_PIPE_DEPTH = 6
+    TMEM_PIPE_DEPTH = 2
+    MAX_BLK_M, BLK_N, BLK_K = (128, 128, 64)
+    MMA_N, MMA_K = (128, 16)
+    EPI_TILE = 32
+    TMEM_LD_SIZE = 8
+    N_COLS = 512
+    SWIZZLE = 3
+    TMA2MMA_ARRIVE_COUNT = 1
+    SMEM_SIZE = (
+        SMEM_PIPE_DEPTH * MAX_BLK_M * BLK_K * F16_BYTES
+        + SMEM_PIPE_DEPTH * BLK_N * BLK_K * F16_BYTES
+        + TMEM_PIPE_DEPTH * EPI_TILE * MMA_N * F32_BYTES
+        + 1024
+    )
+    assert SMEM_SIZE <= 232448
+    assert TMEM_PIPE_DEPTH * MMA_N <= 512
+    tile_idx = None
+
+    def __init__(
+        self,
+        N,
+        K,
+        a_type,
+        b_type,
+        split_k_factor,
+        BLK_M,
+        MMA_M,
+        out_type=None,
+        use_tma_reduce=False,
+        low_batch=True,
+        prefetch_on=False,
+        profiler_on=False,
+    ):
+        super().__init__()
+        self.BLK_M = BLK_M
+        self.MMA_M = MMA_M
+        self.N = N
+        self.K = K
+        self.a_type = a_type
+        self.b_type = b_type
+        assert not (use_tma_reduce and split_k_factor == 1), (
+            "use_tma_reduce when split_k_factor == 1 is not supported"
+        )
+        if out_type is None:
+            self.out_type = "float32" if split_k_factor > 1 or use_tma_reduce else "float16"
+        else:
+            self.out_type = out_type
+        self.split_k_factor = split_k_factor
+        self.use_tma_reduce = use_tma_reduce
+        self.low_batch = low_batch
+        self.prefetch_on = prefetch_on
+        self.profiler_on = profiler_on
+        self.use_cp_async_input = False
+        self.use_tma_gather4 = False
+        self.TILE_K = ceildiv(ceildiv(self.K, self.split_k_factor), self.BLK_K) * self.BLK_K
+        self.PIPE_CIRCLE_NUM = self.TILE_K // self.BLK_K // self.SMEM_PIPE_DEPTH
+        self.PIPE_REMAIN_NUM = self.TILE_K // self.BLK_K % self.SMEM_PIPE_DEPTH
+        self.M_pad_size = BLK_M
+        self.A_layout = mma_shared_layout(
+            a_type,
+            SwizzleMode.SWIZZLE_128B_ATOM,
+            (self.SMEM_PIPE_DEPTH, self.MAX_BLK_M, self.BLK_K),
+        )
+        self.B_layout = mma_shared_layout(
+            b_type, SwizzleMode.SWIZZLE_128B_ATOM, (self.SMEM_PIPE_DEPTH, self.BLK_N, self.BLK_K)
+        )
+        self.D_layout = T.TileLayout(
+            T.S[
+                (self.TMEM_PIPE_DEPTH, self.EPI_TILE, self.MMA_N) : (
+                    self.EPI_TILE * self.MMA_N,
+                    self.MMA_N,
+                    1,
+                )
+            ]
+        )
+
+    def _alloc_buffer(self, smem_manager: SmemManager):
+        self.smem_manager = smem_manager
+        self.A_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.MAX_BLK_M, self.BLK_K),
+            self.a_type,
+            layout=self.A_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.B_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.BLK_N, self.BLK_K),
+            self.b_type,
+            layout=self.B_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.output_smem = smem_manager.alloc(
+            (self.TMEM_PIPE_DEPTH, self.EPI_TILE, self.MMA_N),
+            self.out_type,
+            layout=self.D_layout,
+            align=1024,
+            method="exclusive",
+        )
+
+    def _alloc_local(self, m_idx):
+        self.reg = T.alloc_buffer((self.TMEM_LD_SIZE,), "float32", scope="local")
+        if self.out_type == "float16":
+            self.reg_fp16 = T.alloc_buffer((self.TMEM_LD_SIZE,), self.out_type, scope="local")
+        self.tmem_idx = T.local_scalar("int32")
+        self.tmem_phase = T.local_scalar("int32")
+        self.stage = T.local_scalar("int32")
+        self.wait_complete = T.local_scalar("bool")
+
+    @classmethod
+    def _alloc_buffer_class_member(cls, smem_manager: SmemManager):
+        GemmTile.tmem_addr = smem_manager.alloc([1], "uint32", method="persistent")
+        GemmTile.tma2mma_bar = BarTMA2MMA(smem_manager, cls.SMEM_PIPE_DEPTH, True)
+        GemmTile.mma2tma_bar = BarMMA2TMA(smem_manager, cls.SMEM_PIPE_DEPTH, False)
+        GemmTile.mma2ld_bar = BarMMA2LD(smem_manager, cls.TMEM_PIPE_DEPTH, True)
+        GemmTile.ld2mma_bar = BarLD2MMA(smem_manager, cls.TMEM_PIPE_DEPTH, False)
+        GemmTile.tile_idx = T.local_scalar("int32")
+        GemmTile.phase = T.alloc_buffer((1,), "int32", scope="local")
+        GemmTile.tmem = T.decl_buffer(
+            (128, 512),
+            "float32",
+            scope="tmem",
+            allocated_addr=0,
+            layout=TileLayout(S[(128, 512) : (1 @ TLane, 1 @ TCol)]),
+        )
+
+    @classmethod
+    @T.inline
+    def class_init(cls, smem_manager: SmemManager):
+        warp_id = T.warp_id([KernelConfig.WG_NUMBER * KernelConfig.WARP_NUMBER])
+        cls._alloc_buffer_class_member(smem_manager)
+        cls.tile_idx = 0
+        if warp_id == 0:
+            T.ptx.tcgen05.alloc(T.address_of(cls.tmem_addr[0]), n_cols=cls.N_COLS, cta_group=1)
+            T.cuda.warp_sync()
+        cls.tma2mma_bar.init(cls.TMA2MMA_ARRIVE_COUNT)
+        cls.mma2ld_bar.init(1)
+        cls.mma2tma_bar.init(1)
+        cls.ld2mma_bar.init(KernelConfig.CTA_GROUP * 128)
+        cls.phase[0] = 0
+        T.ptx.fence.proxy_async("shared::cta")
+        T.ptx.fence.mbarrier_init()
+        T.tvm_storage_sync("shared")
+
+    @classmethod
+    @T.inline
+    def class_finalize(cls):
+        warp_id = T.warp_id([KernelConfig.WG_NUMBER * KernelConfig.WARP_NUMBER])
+        T.tvm_storage_sync("shared")
+        if warp_id == 0:
+            T.ptx.tcgen05.relinquish_alloc_permit(cta_group=1)
+            T.ptx.tcgen05.dealloc(cls.tmem_addr[0], n_cols=cls.N_COLS, cta_group=1)
+        T.tvm_storage_sync("shared")
+
+    @T.inline
+    def init(self, smem_manager: SmemManager):
+        self._alloc_buffer(smem_manager)
+
+    @T.inline
+    def host_init(self):
+        pass
+
+    @T.inline
+    def _tma(self, ks, buf, buf_name: Literal["A", "B"], mn_st, k_st, tma_config, predicate=True):
+        if predicate:
+            if buf_name == "A":
+                Tx.copy_async(
+                    self.A_smem[ks, 0 : self.BLK_M, :],
+                    buf[mn_st : mn_st + self.BLK_M, k_st : k_st + self.BLK_K],
+                    **tma_config,
+                )
+            elif buf_name == "B":
+                Tx.copy_async(
+                    self.B_smem[ks, 0 : self.BLK_N, :],
+                    buf[mn_st : mn_st + self.BLK_N, k_st : k_st + self.BLK_K],
+                    **tma_config,
+                )
+            else:
+                T.cuda.trap_when_assert_failed(False)
+
+    @T.inline
+    def _consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler):
+        tid_in_wg = T.thread_id_in_wg([128])
+        warp_id = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([32])
+        T.cuda.trap_when_assert_failed(self.tmem_addr[0] == 0)
+        if warp_id == 0:
+            self.smem_manager.wait_specific(lane_id, self.output_smem, 0)
+        T.cuda.warpgroup_sync(10)
+        self.phase[0] = 0
+        self.tmem_idx = self.tile_idx % self.TMEM_PIPE_DEPTH
+        self.tmem_phase = self.tile_idx // self.TMEM_PIPE_DEPTH & 1
+        self.mma2ld_bar.wait(self.tmem_idx, self.tmem_phase)
+        T.ptx.tcgen05.fence.after_thread_sync()
+        for ko in T.unroll(self.MMA_M // self.EPI_TILE):
+            self.stage = (self.tile_idx * self.MMA_M // self.EPI_TILE + ko) % self.TMEM_PIPE_DEPTH
+            if ko >= self.TMEM_PIPE_DEPTH:
+                if (lane_id == 0) & (warp_id == 0):
+                    T.ptx.cp_async.bulk.wait_group(self.TMEM_PIPE_DEPTH - 1)
+                T.cuda.warpgroup_sync(10)
+            for ki in T.unroll(self.EPI_TILE // self.TMEM_LD_SIZE):
+                reg_wg = self.reg.view(
+                    128,
+                    self.TMEM_LD_SIZE,
+                    layout=TileLayout(S[(128, self.TMEM_LD_SIZE) : (1 @ axis_tid_in_wg, 1)]),
+                )
+                col_st = T.meta_var(
+                    self.tmem_idx * self.M_pad_size + ko * self.EPI_TILE + ki * self.TMEM_LD_SIZE
+                )
+                Tx.wg.copy_async(reg_wg, self.tmem[:, col_st : col_st + self.TMEM_LD_SIZE])
+                T.ptx.tcgen05.wait.ld()
+                st = T.meta_var(ki * self.TMEM_LD_SIZE)
+                if self.out_type == "float16":
+                    reg_wg_fp16 = self.reg_fp16.view(
+                        128,
+                        self.TMEM_LD_SIZE,
+                        layout=TileLayout(S[(128, self.TMEM_LD_SIZE) : (1 @ axis_tid_in_wg, 1)]),
+                    )
+                    Tx.wg.cast(reg_wg_fp16, reg_wg)
+                    Tx.wg.copy(
+                        self.output_smem[self.stage, st : st + self.TMEM_LD_SIZE, 0:128],
+                        reg_wg_fp16.permute(1, 0),
+                        dispatch="ldstmatrix",
+                    )
+                else:
+                    Tx.wg.copy(
+                        self.output_smem[self.stage, st : st + self.TMEM_LD_SIZE, 0:128],
+                        reg_wg.permute(1, 0),
+                    )
+            if ko == self.MMA_M // self.EPI_TILE - 1:
+                T.ptx.tcgen05.fence.before_thread_sync()
+                self.ld2mma_bar.arrive(self.tmem_idx)
+            T.ptx.fence.proxy_async("shared::cta")
+            T.cuda.warpgroup_sync(10)
+            if tid_in_wg == 0:
+                m_st = T.meta_var(m_idx * self.M_pad_size + ko * self.EPI_TILE)
+                n_st = T.meta_var(n_idx * self.BLK_N)
+                tma_config = T.meta_var(
+                    {"dispatch": "tma_explicit", "cta_group": KernelConfig.CTA_GROUP}
+                    | (
+                        {"cache_hint": "evict_last" if self.low_batch else ""}
+                        if self.split_k_factor > 1
+                        else {}
+                    )
+                    | ({"use_tma_reduce": "add"} if self.use_tma_reduce else {})
+                )
+                if self.split_k_factor > 1 and (not self.use_tma_reduce):
+                    Tx.thread.copy_async(
+                        output[k_idx, m_st : m_st + self.EPI_TILE, n_st : n_st + self.BLK_N],
+                        self.output_smem[self.stage, :, :],
+                        **tma_config,
+                    )
+                else:
+                    Tx.thread.copy_async(
+                        output[m_st : m_st + self.EPI_TILE, n_st : n_st + self.BLK_N],
+                        self.output_smem[self.stage, :, :],
+                        **tma_config,
+                    )
+                T.ptx.cp_async.bulk.commit_group()
+        if tid_in_wg:
+            T.ptx.cp_async.bulk.wait_group(0)
+        T.cuda.warpgroup_sync(10)
+        self.tile_idx += 1
+        if warp_id == 0:
+            self.smem_manager.arrive_specific(lane_id, self.output_smem, 0)
+
+    @T.inline
+    def _run(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler = None):
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        T.warpgroup_id([KernelConfig.WG_NUMBER])
+        warp_id = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([32])
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        if wg_id == 1:
+            if warp_id == 3:
+                if self.use_tma_gather4:
+
+                    @T.inline
+                    def tma_gather4_stage(ks, k_st, first_stage):
+                        self.mma2tma_bar.wait(ks, self.phase[0])
+                        B_tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_auto",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_first" if self.low_batch else "",
+                            }
+                        )
+                        A_tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_explicit",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_last" if self.low_batch else "",
+                            }
+                        )
+                        if self.profiler_on:
+                            profiler.start(ProfileEventType.TMA, lane_id == 0)
+                        if first_stage:
+                            self.smem_manager.wait_specific_one_thread(self.A_smem, ks)
+                        self._tma_gather4_A(ks, A, m_idx, k_st, A_tma_config, tid, lane_id)
+                        if not self.prefetch_on and first_stage:
+                            self.smem_manager.wait_specific_one_thread(self.B_smem, ks)
+                        self._tma(
+                            ks,
+                            B,
+                            "B",
+                            n_idx * self.BLK_N,
+                            k_st,
+                            B_tma_config,
+                            predicate=tvm.tirx.Not(self.prefetch_on and first_stage),
+                        )
+                        if self.profiler_on:
+                            profiler.end(ProfileEventType.TMA, lane_id == 0)
+                        self.tma2mma_bar.arrive(
+                            ks,
+                            KernelConfig.CTA_GROUP
+                            * self.BLK_K
+                            * (self.BLK_M + self.BLK_N)
+                            * F16_BYTES,
+                        )
+
+                    self._preload_tma_gather4_A(m_idx, lane_id)
+                    if T.ptx.elect_sync():
+                        k_offset = k_idx * self.TILE_K
+                        for ko in T.serial(self.PIPE_CIRCLE_NUM):
+                            for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                                tma_gather4_stage(
+                                    ks,
+                                    (ko * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K + k_offset,
+                                    ko == 0,
+                                )
+                            self.phase[0] = self.phase[0] ^ 1
+                        if self.PIPE_REMAIN_NUM > 0:
+                            for ks in T.unroll(self.PIPE_REMAIN_NUM):
+                                tma_gather4_stage(
+                                    ks,
+                                    (self.PIPE_CIRCLE_NUM * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K
+                                    + k_offset,
+                                    self.PIPE_CIRCLE_NUM == 0,
+                                )
+                            for ks in T.unroll(self.PIPE_REMAIN_NUM, self.SMEM_PIPE_DEPTH):
+                                self.mma2tma_bar.wait(ks, self.phase[0])
+                                self.tma2mma_bar.arrive_only(ks)
+                            self.phase[0] = self.phase[0] ^ 1
+                elif self.use_cp_async_input:
+
+                    @T.inline
+                    def cp_async_stage(ks, k_st, first_stage):
+                        lane_id = T.lane_id([32])
+                        bytes_per_B_stage = T.meta_var(
+                            KernelConfig.CTA_GROUP * self.BLK_K * self.BLK_N * F16_BYTES
+                        )
+                        B_tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_auto",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_first" if self.low_batch else "",
+                            }
+                        )
+                        self.mma2tma_bar.wait(ks, self.phase[0])
+                        if T.ptx.elect_sync():
+                            if self.profiler_on:
+                                profiler.start(ProfileEventType.TMA, lane_id == 0)
+                            if first_stage:
+                                self.smem_manager.wait_specific_one_thread(self.A_smem, ks)
+                        self._cp_async_load_A_tile(
+                            m_idx, ks, k_st, tid, lane_id, A, self.tma2mma_bar.mbar.ptr_to([ks])
+                        )
+                        T.cuda.warp_sync()
+                        if T.ptx.elect_sync():
+                            if not self.prefetch_on and first_stage:
+                                self.smem_manager.wait_specific_one_thread(self.B_smem, ks)
+                            if self.prefetch_on:
+                                self.tma2mma_bar.arrive(
+                                    ks, T.if_then_else(first_stage, 0, bytes_per_B_stage)
+                                )
+                            else:
+                                self.tma2mma_bar.arrive(ks, bytes_per_B_stage)
+                            self._tma(
+                                ks,
+                                B,
+                                "B",
+                                n_idx * self.BLK_N,
+                                k_st,
+                                B_tma_config,
+                                predicate=tvm.tirx.Not(self.prefetch_on and first_stage),
+                            )
+                            if self.profiler_on:
+                                profiler.end(ProfileEventType.TMA, lane_id == 0)
+                        T.cuda.warp_sync()
+
+                    k_offset = k_idx * self.TILE_K
+                    for ko in T.serial(self.PIPE_CIRCLE_NUM):
+                        for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                            cp_async_stage(
+                                ks,
+                                (ko * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K + k_offset,
+                                ko == 0,
+                            )
+                        self.phase[0] = self.phase[0] ^ 1
+                    if self.PIPE_REMAIN_NUM > 0:
+                        for ks in T.unroll(self.PIPE_REMAIN_NUM):
+                            cp_async_stage(
+                                ks,
+                                (self.PIPE_CIRCLE_NUM * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K
+                                + k_offset,
+                                self.PIPE_CIRCLE_NUM == 0,
+                            )
+                        for ks in T.unroll(self.PIPE_REMAIN_NUM, self.SMEM_PIPE_DEPTH):
+                            self.mma2tma_bar.wait(ks, self.phase[0])
+                            self.tma2mma_bar.arrive_only(ks)
+                            if T.ptx.elect_sync():
+                                self.tma2mma_bar.arrive_only(ks)
+                        self.phase[0] = self.phase[0] ^ 1
+                else:
+
+                    @T.inline
+                    def tma_stage(ks, k_st, first_stage):
+                        self.mma2tma_bar.wait(ks, self.phase[0])
+                        B_tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_auto",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_first" if self.low_batch else "",
+                            }
+                        )
+                        A_tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_explicit",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_last" if self.low_batch else "",
+                                "oob": "zero",
+                            }
+                        )
+                        if self.profiler_on:
+                            profiler.start(ProfileEventType.TMA, lane_id == 0)
+                        if first_stage:
+                            self.smem_manager.wait_specific_one_thread(self.A_smem, ks)
+                        self._tma(ks, A, "A", m_idx * self.M_pad_size, k_st, A_tma_config)
+                        if not self.prefetch_on and first_stage:
+                            self.smem_manager.wait_specific_one_thread(self.B_smem, ks)
+                        self._tma(
+                            ks,
+                            B,
+                            "B",
+                            n_idx * self.BLK_N,
+                            k_st,
+                            B_tma_config,
+                            predicate=tvm.tirx.Not(self.prefetch_on and first_stage),
+                        )
+                        if self.profiler_on:
+                            profiler.end(ProfileEventType.TMA, lane_id == 0)
+                        self.tma2mma_bar.arrive(
+                            ks,
+                            KernelConfig.CTA_GROUP
+                            * self.BLK_K
+                            * (self.BLK_M + self.BLK_N)
+                            * F16_BYTES,
+                        )
+
+                    if T.ptx.elect_sync():
+                        k_offset = k_idx * self.TILE_K
+                        for ko in T.serial(self.PIPE_CIRCLE_NUM):
+                            for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                                tma_stage(
+                                    ks,
+                                    (ko * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K + k_offset,
+                                    ko == 0,
+                                )
+                            self.phase[0] = self.phase[0] ^ 1
+                        if self.PIPE_REMAIN_NUM > 0:
+                            for ks in T.unroll(self.PIPE_REMAIN_NUM):
+                                tma_stage(
+                                    ks,
+                                    (self.PIPE_CIRCLE_NUM * self.SMEM_PIPE_DEPTH + ks) * self.BLK_K
+                                    + k_offset,
+                                    self.PIPE_CIRCLE_NUM == 0,
+                                )
+                            for ks in T.unroll(self.PIPE_REMAIN_NUM, self.SMEM_PIPE_DEPTH):
+                                self.mma2tma_bar.wait(ks, self.phase[0])
+                                self.tma2mma_bar.arrive_only(ks)
+                            self.phase[0] = self.phase[0] ^ 1
+                T.ptx.bar.sync(13, 64)
+            elif warp_id == 0:
+
+                @T.inline
+                def mbar_try_wait(idx, phase):
+                    self.wait_complete = mbarrier_try_wait(
+                        self.tma2mma_bar.mbar.ptr_to([idx]), self.tma2mma_bar.init_phase ^ phase
+                    )
+
+                @T.inline
+                def mma_stage(ks, acc):
+                    if self.profiler_on:
+                        profiler.start(ProfileEventType.MMA, lane_id == 0)
+                    Tx.gemm_async(
+                        self.tmem[
+                            :,
+                            self.tmem_idx * self.M_pad_size : self.tmem_idx * self.M_pad_size
+                            + self.BLK_N,
+                        ],
+                        self.B_smem[ks, :, :],
+                        self.A_smem[ks, :, :],
+                        accum=acc,
+                        dispatch="tcgen05",
+                        cta_group=KernelConfig.CTA_GROUP,
+                    )
+                    if self.profiler_on:
+                        profiler.end(ProfileEventType.MMA, lane_id == 0)
+                    self.mma2tma_bar.arrive(ks)
+
+                if T.ptx.elect_sync():
+                    self.tmem_idx = self.tile_idx % self.TMEM_PIPE_DEPTH
+                    self.tmem_phase = self.tile_idx // self.TMEM_PIPE_DEPTH & 1
+                    self.ld2mma_bar.wait(self.tmem_idx, self.tmem_phase)
+                    T.ptx.tcgen05.fence.after_thread_sync()
+                    if self.use_cp_async_input:
+                        self.wait_complete = False
+                    else:
+                        mbar_try_wait(0, self.phase[0])
+                    for ko in T.serial(self.PIPE_CIRCLE_NUM):
+                        for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                            if self.use_cp_async_input:
+                                self.tma2mma_bar.wait(ks, self.phase[0])
+                            elif not self.wait_complete:
+                                self.tma2mma_bar.wait(ks, self.phase[0])
+                            if not self.use_cp_async_input and (
+                                self.PIPE_REMAIN_NUM > 0
+                                or ko != self.PIPE_REMAIN_NUM - 1
+                                or ks != self.SMEM_PIPE_DEPTH - 1
+                            ):
+                                mbar_try_wait(
+                                    (ks + 1) % self.SMEM_PIPE_DEPTH,
+                                    self.phase[0] ^ (1 if ks == self.SMEM_PIPE_DEPTH - 1 else 0),
+                                )
+                            mma_stage(ks, not ((ko == 0) & (ks == 0)))
+                        self.phase[0] = self.phase[0] ^ 1
+                    if self.PIPE_REMAIN_NUM > 0:
+                        for ks in T.unroll(self.PIPE_REMAIN_NUM):
+                            if self.use_cp_async_input:
+                                self.tma2mma_bar.wait(ks, self.phase[0])
+                            elif not self.wait_complete:
+                                self.tma2mma_bar.wait(ks, self.phase[0])
+                            if not self.use_cp_async_input and ks != self.PIPE_REMAIN_NUM - 1:
+                                mbar_try_wait((ks + 1) % self.SMEM_PIPE_DEPTH, self.phase[0])
+                            mma_stage(ks, not (self.PIPE_CIRCLE_NUM == 0 and ks == 0))
+                        self.mma2ld_bar.arrive(self.tmem_idx)
+                        for ks in T.unroll(self.PIPE_REMAIN_NUM, self.SMEM_PIPE_DEPTH):
+                            self.tma2mma_bar.wait(ks, self.phase[0])
+                            self.mma2tma_bar.arrive(ks)
+                        self.phase[0] = self.phase[0] ^ 1
+                    else:
+                        self.mma2ld_bar.arrive(self.tmem_idx)
+                self.tile_idx += 1
+            elif warp_id == 1:
+                self.smem_manager.wait_unused(lane_id, self)
+                self.smem_manager.arrive_unused(lane_id, self)
+            elif warp_id == 2:
+                self.phase[0] = self.phase[0] ^ self.PIPE_CIRCLE_NUM & 1
+                if self.PIPE_REMAIN_NUM > 0:
+                    self.phase[0] = self.phase[0] ^ 1
+                T.ptx.bar.sync(13, 64)
+                for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                    self.mma2tma_bar.wait(ks, self.phase[0])
+                    self.smem_manager.arrive_specific(lane_id, self.B_smem, ks)
+                    self.smem_manager.arrive_specific(lane_id, self.A_smem, ks)
+        if wg_id == 0:
+            self._consumer_wg(m_idx, n_idx, k_idx, A, B, output, profiler)
+
+    @T.inline
+    def prefetch(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler):
+        self._alloc_local(m_idx)
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        warp_id = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([32])
+        if (wg_id == 1) & (warp_id == 3):
+            k_offset = k_idx * self.TILE_K
+            if self.PIPE_CIRCLE_NUM > 0:
+                for ks in T.unroll(self.SMEM_PIPE_DEPTH):
+                    self.stage = ks
+                    self.smem_manager.wait_specific(lane_id, self.B_smem, ks)
+                    if self.profiler_on:
+                        profiler.start(ProfileEventType.TMA, lane_id == 0)
+                    if T.ptx.elect_sync():
+                        tma_config = T.meta_var(
+                            {
+                                "dispatch": "tma_auto",
+                                "cta_group": KernelConfig.CTA_GROUP,
+                                "mbar": self.tma2mma_bar.mbar.ptr_to([ks]),
+                                "cache_hint": "evict_first" if self.low_batch else "",
+                            }
+                        )
+                        self._tma(
+                            ks,
+                            B,
+                            "B",
+                            n_idx * self.BLK_N,
+                            self.stage * self.BLK_K + k_offset,
+                            tma_config,
+                        )
+                    if self.profiler_on:
+                        profiler.end(ProfileEventType.TMA, lane_id == 0)
+
+    @T.inline
+    def run(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler = None):
+        self._alloc_local(m_idx)
+        self._run(m_idx, n_idx, k_idx, A, B, output, profiler)
+        self.smem_manager.advance()
+
+    def _cp_async_load_A_tile(self, m_idx, ks, stage_k, tid, lane_id, A, mbar):
+        raise RuntimeError("cp.async input path is not implemented for this tile.")
+
+    @T.inline
+    def _preload_tma_gather4_A(self, m_idx, tid_in_wg):
+        pass
+
+    def _tma_gather4_A(self, ks, A, m_idx, k_st, tma_config, tid, lane_id):
+        raise RuntimeError("tma gather4 input path is not implemented for this tile.")

--- a/tirx_kernels/megakernel/kernels/group_gemm_sm100.py
+++ b/tirx_kernels/megakernel/kernels/group_gemm_sm100.py
@@ -1,0 +1,436 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Literal
+
+from tirx_kernels.megakernel.utils.base import SmemManager
+from tirx_kernels.megakernel.utils.config import F16_BYTES, F32_BYTES, KernelConfig
+from tvm.script import tirx as T
+from tvm.script.tirx import tile as Tx
+from tvm.tirx.bench import CudaProfiler
+from tvm.tirx.layout import S, TileLayout
+from tvm.tirx.layout import tid_in_wg as axis_tid_in_wg
+
+from .gate_up_silu import GateUpSiluTile
+from .gemm import GemmTile
+
+red_f16 = """
+__forceinline__ __device__ void red_f16_v4(half* address, half* reg) {
+    uint16_t* h_reg = (uint16_t*) reg;
+    asm volatile("red.global.v4.f16.add.noftz [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(address), "h"(h_reg[0]), "h"(h_reg[1]), "h"(h_reg[2]), "h"(h_reg[3])
+                 : "memory");
+}
+"""
+
+red_f32 = """
+__forceinline__ __device__ void red_f32_v4(float* address, float* reg) {
+    asm volatile("red.global.v4.f32.add [%0], {%1, %2, %3, %4};"
+                 :
+                 : "l"(address), "f"(reg[0]), "f"(reg[1]), "f"(reg[2]), "f"(reg[3])
+                 : "memory");
+}
+"""
+
+cp_async_mbarrier_arrive_noinc = """
+__forceinline__ __device__ void tvm_builtin_ptx_cp_async_mbarrier_arrive(void* barrier) {
+    unsigned int smem_int_ptr = __cvta_generic_to_shared(barrier);
+    asm volatile("cp.async.mbarrier.arrive.noinc.shared.b64 [%0];" :: "r"(smem_int_ptr));
+}
+"""
+
+
+########################################################################
+# F16-lowM SM100 GroupGEMM Megakernel-Tile
+########################################################################
+
+
+class GroupGEMMTile(GemmTile):
+    CP_ASYNC_VEC_LEN = 16 // F16_BYTES
+    CP_ASYNC_COMMIT_CHUNK = 32
+
+    def __init__(
+        self,
+        N,
+        K,
+        num_experts,
+        top_k,
+        numel,
+        a_type,
+        b_type,
+        low_batch=True,
+        acc_output=False,
+        prefetch_on=False,
+        profiler_on=False,
+        use_cp_async_input=False,
+        use_tma_gather4=False,
+    ):
+        super().__init__(
+            N,
+            K,
+            a_type,
+            b_type,
+            1,
+            BLK_M=-1,  # does not matter because we will set it later
+            MMA_M=-1,  # does not matter because we will set it later
+            out_type="float16" if not acc_output else "float32",
+            low_batch=low_batch,
+            prefetch_on=prefetch_on,
+            profiler_on=profiler_on,
+        )
+        self.num_experts = num_experts
+        self.top_k = top_k
+        self.numel = numel
+        self.acc_output = acc_output
+        self.VEC_LEN = 16 // F32_BYTES
+        self.BLK_M_candidate = [128, 64, 32]
+        self.M_pad_size = max(self.BLK_M_candidate)
+        self.use_cp_async_input = use_cp_async_input
+        self.use_tma_gather4 = use_tma_gather4
+        # cp.async A path uses 32 lane-local noinc-arrives + 1 elected arrive.expect_tx for B TMA.
+        self.__class__.TMA2MMA_ARRIVE_COUNT = 33 if self.use_cp_async_input else 1
+
+    def set_moe_info(self, expert_ids, routing_weights, sorted_token_ids):
+        self.expert_ids = expert_ids
+        self.routing_weights = routing_weights
+        self.sorted_token_ids = sorted_token_ids
+
+    @T.inline
+    def _cp_async_load_A_tile(self, m_idx, ks, stage_k, tid, lane_id, A, mbar):
+        vec_len = T.meta_var(self.CP_ASYNC_VEC_LEN)
+        total_vec = T.meta_var(self.BLK_M * self.BLK_K // self.CP_ASYNC_VEC_LEN)
+        idx = T.alloc_buffer([1], "int32", scope="local")
+        commit_count = T.alloc_buffer([1], "int32", scope="local")
+        row_base = m_idx * self.M_pad_size
+        idx[0] = lane_id
+        commit_count[0] = 0
+        while idx[0] < total_vec:
+            offset = idx[0] * vec_len
+            row = offset // self.BLK_K
+            col = offset % self.BLK_K
+            row_global = row_base + row
+            row_global_safe = T.min(row_global, self.sorted_token_ids.shape[0] - 1)
+            row_in_bound = row_global < self.sorted_token_ids.shape[0]
+            token_linear = T.alloc_buffer([1], "int32", scope="local")
+            tmp = self.sorted_token_ids[row_global_safe]
+            val = T.if_then_else(row_in_bound, tmp, self.numel)
+            token_linear[0] = T.min(T.max(val, 0), self.numel - 1)
+            stage_valid = stage_k + col + vec_len <= self.K
+            if stage_valid:
+                Tx.thread.copy_async(
+                    self.A_smem[ks, row, col : col + vec_len],
+                    A[
+                        (token_linear[0] if self.acc_output else token_linear[0] // self.top_k),
+                        stage_k + col : stage_k + col + vec_len,
+                    ],
+                    dispatch="ldgsts",
+                    direct=True,
+                )
+            else:
+                for v in T.serial(vec_len):
+                    if col + v < self.BLK_K:
+                        self.A_smem[ks, row, col + v] = T.cast(0, self.a_type)
+            idx[0] += 32
+            commit_count[0] += 1
+            if commit_count[0] == self.CP_ASYNC_COMMIT_CHUNK:
+                T.ptx.cp_async.commit_group()
+                commit_count[0] = 0
+        if commit_count[0] > 0:
+            T.ptx.cp_async.commit_group()
+        T.cuda.func_call(
+            "tvm_builtin_ptx_cp_async_mbarrier_arrive",
+            mbar,
+            source_code=cp_async_mbarrier_arrive_noinc,
+        )
+
+    def _alloc_local(self, m_idx):
+        super()._alloc_local(m_idx)
+        self.num_tokens_in_block = T.local_scalar("int32")
+        self.eid = T.local_scalar("int32")
+        T.buffer_store(self.eid.buffer, self.expert_ids[m_idx], 0)
+
+    @T.inline
+    def _tma(self, ks, buf, buf_name: Literal["A", "B"], mn_st, k_st, tma_config, predicate=True):
+        if predicate:
+            if buf_name == "A":
+                Tx.copy_async(
+                    self.A_smem[ks, 0 : self.BLK_M, :],
+                    buf[mn_st : mn_st + self.BLK_M, k_st : k_st + self.BLK_K],
+                    **tma_config,
+                )
+            elif buf_name == "B":
+                Tx.copy_async(
+                    self.B_smem[ks, 0 : self.BLK_N, :],
+                    buf[self.eid, mn_st : mn_st + self.BLK_N, k_st : k_st + self.BLK_K],
+                    **tma_config,
+                )
+            else:
+                T.cuda.trap_when_assert_failed(False)
+
+    @T.inline
+    def _preload_tma_gather4_A(self, m_idx, lane_id):
+        for i in T.unroll(0, self.BLK_M // 32):
+            idx = i * 32 + lane_id
+            row_global = T.min(m_idx * self.M_pad_size + idx, self.sorted_token_ids.shape[0] - 1)
+            token_linear = self.sorted_token_ids[row_global]
+            self.smem_sorted_token_ids_gather4[idx] = T.min(T.max(token_linear, 0), self.numel - 1)
+        T.cuda.warp_sync()
+
+    @T.inline
+    def _tma_gather4_A(self, ks, A, m_idx, k_st, tma_config, tid, lane_id):
+        A_stage = self.A_smem.sub[ks]
+        for rg in T.unroll(0, self.BLK_M // 8):
+            row_group = T.meta_var(rg * 8)
+            row_idx = T.alloc_buffer([8], "int32", scope="local")
+            if self.acc_output:
+                for r in T.vectorized(4):
+                    row_idx[r] = self.smem_sorted_token_ids_gather4[row_group + r]
+                for r in T.vectorized(4):
+                    row_idx[r + 4] = self.smem_sorted_token_ids_gather4[row_group + r + 4]
+            else:
+                for r in T.vectorized(4):
+                    row_idx[r] = self.smem_sorted_token_ids_gather4[row_group + r] // self.top_k
+                for r in T.vectorized(4):
+                    row_idx[r + 4] = (
+                        self.smem_sorted_token_ids_gather4[row_group + r + 4] // self.top_k
+                    )
+
+            Tx.copy_async(
+                A_stage[row_group : row_group + 4, :],
+                A[0:1, k_st : k_st + self.BLK_K],
+                gather4=[row_idx[0], row_idx[1], row_idx[2], row_idx[3]],
+                **tma_config,
+            )
+            Tx.copy_async(
+                A_stage[row_group + 4 : row_group + 8, :],
+                A[0:1, k_st : k_st + self.BLK_K],
+                gather4=[row_idx[4], row_idx[5], row_idx[6], row_idx[7]],
+                **tma_config,
+            )
+
+    @classmethod
+    def class_init(cls, smem_manager: SmemManager):
+        super().class_init(smem_manager)
+        cls.smem_sorted_token_ids = smem_manager.alloc(
+            [cls.MAX_BLK_M], "int32", method="persistent"
+        )
+        cls.smem_sorted_token_ids_gather4 = smem_manager.alloc(
+            [cls.MAX_BLK_M], "int32", method="persistent", align=16
+        )
+        cls.smem_routing_weights = smem_manager.alloc(
+            [cls.MAX_BLK_M], "float32", method="persistent"
+        )
+
+    @T.inline
+    def _consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler):
+        if not self.acc_output:
+            GemmTile._consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler)
+        else:
+            output_flat = output.view(-1)
+            tid_in_wg = T.thread_id_in_wg([128])
+            warp_id = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+            lane_id = T.lane_id([32])
+            T.cuda.trap_when_assert_failed(self.tmem_addr[0] == 0)
+            if tid_in_wg < self.M_pad_size:
+                idx = self.sorted_token_ids[m_idx * self.M_pad_size + tid_in_wg]
+                self.smem_sorted_token_ids[tid_in_wg] = idx
+                self.smem_routing_weights[tid_in_wg] = T.if_then_else(
+                    idx < self.numel, self.routing_weights[idx], 0.0
+                )
+            T.cuda.warpgroup_sync(10)
+            if warp_id == 0:
+                self.smem_manager.wait_specific(lane_id, self.output_smem, 0)
+            T.cuda.warpgroup_sync(10)
+            self.phase[0] = 0
+            self.tmem_idx = self.tile_idx % self.TMEM_PIPE_DEPTH
+            self.tmem_phase = (self.tile_idx // self.TMEM_PIPE_DEPTH) & 1
+
+            # flush previous tma
+            # wait for the completion of all the mma of the same tile
+            self.mma2ld_bar.wait(self.tmem_idx, self.tmem_phase)
+            T.ptx.tcgen05.fence.after_thread_sync()
+
+            for ko in T.unroll(self.MMA_M // self.EPI_TILE):
+                self.stage = (
+                    self.tile_idx * self.MMA_M // self.EPI_TILE + ko
+                ) % self.TMEM_PIPE_DEPTH
+                # tmem -> rf (ld) -> smem
+                for ki in T.unroll(self.EPI_TILE // self.TMEM_LD_SIZE):
+                    reg_wg = self.reg.view(
+                        128,
+                        self.TMEM_LD_SIZE,
+                        layout=TileLayout(S[(128, self.TMEM_LD_SIZE) : (1 @ axis_tid_in_wg, 1)]),
+                    )
+                    col_st = T.meta_var(
+                        self.tmem_idx * self.M_pad_size
+                        + ko * self.EPI_TILE
+                        + ki * self.TMEM_LD_SIZE
+                    )
+                    Tx.wg.copy_async(reg_wg, self.tmem[:, col_st : col_st + self.TMEM_LD_SIZE])
+                    T.ptx.tcgen05.wait.ld()
+                    st = T.meta_var(ki * self.TMEM_LD_SIZE)
+                    Tx.wg.copy(
+                        self.output_smem[self.stage, st : st + self.TMEM_LD_SIZE, 0:128],
+                        reg_wg.permute(1, 0),
+                    )
+                # the tmem can be overwritten
+                if ko == self.MMA_M // self.EPI_TILE - 1:
+                    T.ptx.tcgen05.fence.before_thread_sync()
+                    self.ld2mma_bar.arrive(self.tmem_idx)
+
+                T.ptx.fence.proxy_async("shared::cta")
+                T.cuda.warpgroup_sync(10)
+                # smem -> gmem
+                for i in range(self.EPI_TILE * self.BLK_N // (128 * self.VEC_LEN)):
+                    row_idx = (i * 128 + tid_in_wg) * self.VEC_LEN // self.BLK_N
+                    col_idx = (i * 128 + tid_in_wg) * self.VEC_LEN % self.BLK_N
+                    reordered_row_idx = self.smem_sorted_token_ids[ko * self.EPI_TILE + row_idx]
+                    if reordered_row_idx >= self.numel:
+                        break
+                    routing_weight = self.smem_routing_weights[ko * self.EPI_TILE + row_idx]
+                    # TODO: vectorize this
+                    if output.dtype == "float16":
+                        o_reg_f32 = T.alloc_buffer([self.VEC_LEN], "float32", scope="local")
+                        o_reg_f16 = T.alloc_buffer([self.VEC_LEN], "float16", scope="local")
+                        for v in range(self.VEC_LEN):
+                            o_reg_f32[v] = self.output_smem[self.stage, row_idx, col_idx + v]
+                        for v in T.unroll(self.VEC_LEN):
+                            o_reg_f16[v] = T.cast(o_reg_f32[v] * routing_weight, "float16")
+                        T.cuda.func_call(
+                            "red_f16_v4",
+                            T.address_of(
+                                output_flat[
+                                    (reordered_row_idx // self.top_k) * self.N
+                                    + n_idx * self.BLK_N
+                                    + col_idx
+                                ]
+                            ),
+                            T.address_of(o_reg_f16[0]),
+                            source_code=red_f16,
+                        )
+                    else:
+                        o_reg = T.alloc_buffer([self.VEC_LEN], "float32", scope="local")
+                        for v in range(self.VEC_LEN):
+                            o_reg[v] = self.output_smem[self.stage, row_idx, col_idx + v]
+                        for v in T.unroll(self.VEC_LEN):
+                            o_reg[v] = o_reg[v] * routing_weight
+                        T.cuda.func_call(
+                            "red_f32_v4",
+                            T.address_of(
+                                output_flat[
+                                    (reordered_row_idx // self.top_k) * self.N
+                                    + n_idx * self.BLK_N
+                                    + col_idx
+                                ]
+                            ),
+                            T.address_of(o_reg[0]),
+                            source_code=red_f32,
+                        )
+            T.cuda.warpgroup_sync(10)
+            self.tile_idx += 1
+            if warp_id == 0:
+                self.smem_manager.arrive_specific(lane_id, self.output_smem, 0)
+
+    def set_BLK_M(self, BLK_M):
+        assert BLK_M in self.BLK_M_candidate
+        self.BLK_M = BLK_M
+        self.MMA_M = BLK_M
+
+    @T.inline
+    def run(
+        self,
+        m_idx,
+        n_idx,
+        k_idx,
+        A,
+        B,
+        output,
+        expert_ids,
+        routing_weights,
+        sorted_token_ids,
+        valid_num_tokens,
+        profiler=None,
+    ):
+        self.set_moe_info(expert_ids, routing_weights, sorted_token_ids)
+        self._alloc_local(m_idx)
+        if valid_num_tokens is not None:
+            self.num_tokens_in_block = valid_num_tokens[m_idx]
+        num_tokens_in_block = T.meta_var(
+            self.num_tokens_in_block
+            if valid_num_tokens is not None
+            else 32
+            if self.low_batch
+            else self.M_pad_size
+        )
+        tid = T.thread_id([256])
+        if num_tokens_in_block <= 32:
+            self.set_BLK_M(32)
+            GemmTile._run(self, m_idx, n_idx, k_idx, A, B, output, profiler)
+        elif num_tokens_in_block <= 64:
+            self.set_BLK_M(64)
+            GemmTile._run(self, m_idx, n_idx, k_idx, A, B, output, profiler)
+        else:
+            self.set_BLK_M(128)
+            GemmTile._run(self, m_idx, n_idx, k_idx, A, B, output, profiler)
+        self.smem_manager.advance()
+
+
+########################################################################
+# F16-lowM SM100 GroupGEMM-Silu Megakernel-Tile
+########################################################################
+
+
+class GroupGEMMSiluTile(GroupGEMMTile, GateUpSiluTile):
+    def _alloc_buffer(self, smem_manager: SmemManager):
+        self.smem_manager = smem_manager
+        # alloc shared memory
+        self.A_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.MAX_BLK_M, self.BLK_K),
+            self.a_type,
+            layout=self.A_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.B_smem = smem_manager.alloc(
+            (self.SMEM_PIPE_DEPTH, self.BLK_N, self.BLK_K),
+            self.b_type,
+            layout=self.B_layout,
+            align=1024,
+            split=self.SMEM_PIPE_DEPTH,
+            method="exclusive",
+        )
+        self.D_layout = T.TileLayout(
+            T.S[
+                (GemmTile.TMEM_PIPE_DEPTH, GemmTile.EPI_TILE, GemmTile.MMA_N // 2) : (
+                    GemmTile.EPI_TILE * GemmTile.MMA_N // 2,
+                    GemmTile.MMA_N // 2,
+                    1,
+                )
+            ]
+        )
+        self.output_smem = smem_manager.alloc(
+            (self.TMEM_PIPE_DEPTH, self.EPI_TILE, self.MMA_N // 2),
+            "float16",
+            layout=self.D_layout,
+            align=1024,
+            method="exclusive",
+        )
+
+    @T.inline
+    def _consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler: CudaProfiler):
+        GateUpSiluTile._consumer_wg(self, m_idx, n_idx, k_idx, A, B, output, profiler)

--- a/tirx_kernels/megakernel/kernels/moe_align.py
+++ b/tirx_kernels/megakernel/kernels/moe_align.py
@@ -1,0 +1,252 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from tirx_kernels.megakernel.utils.base import SmemManager, Tile
+from tirx_kernels.megakernel.utils.config import F16_BYTES, KernelConfig
+from tirx_kernels.megakernel.utils.utils import ceildiv, next_power_of_two
+from tvm.script import tirx as T
+from tvm.script.tirx import tile as Tx
+
+
+class MOEAlignTile(Tile):
+    def __init__(self, num_experts, numel, block_size, pad_sorted_token_ids=False):
+        super().__init__()
+        self.num_experts = num_experts
+        self.scan_size = next_power_of_two(num_experts)
+        self.numel = numel  # numel = num_tokens * num_experts
+        self.block_size = block_size
+        self.pad_sorted_token_ids = pad_sorted_token_ids
+
+    def _alloc_buffer(self, smem_manager: SmemManager):
+        self.smem_manager = smem_manager
+        # alloc shared memory
+        self.shared_counts = smem_manager.alloc([self.num_experts], "int32")
+        self.prefix = smem_manager.alloc([self.num_experts + 1], "int32")
+        self.scan_buf = smem_manager.alloc([self.scan_size], "int32")
+        self.warp_sums = smem_manager.alloc(
+            [KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER], "int32"
+        )
+        self.s_total_tokens_post_pad = smem_manager.alloc([1], "int32")
+
+    def init(self, smem_manager: SmemManager):
+        self._alloc_buffer(smem_manager)
+
+    @T.inline
+    def warp_exclusive_scan(self, v, output, mask=0xFFFFFFFF):
+        # offset = T.alloc_scalar("int32")
+        # original = T.alloc_scalar("int32")
+        # Legacy warp-scoped version:
+        #     lane_id = T.lane_id(32)
+        #     offset = 1
+        #     original = v
+        #     while offset < 32:
+        #         n = T.tvm_warp_shuffle_up(mask, v, offset)
+        #         if lane_id >= offset:
+        #             v += n
+        #         offset = offset << 1
+        #     output = v - original
+        #     v = original
+        output[0] = T.cuda.func_call(
+            "warp_exclusive_scan",
+            v,
+            mask,
+            source_code="""
+            __device__ __forceinline__ int warp_exclusive_scan(int v, unsigned mask = 0xffffffffu) {
+            int original = v;
+            #pragma unroll
+            for (int offset = 1; offset < 32; offset <<= 1) {
+                int n = __shfl_up_sync(mask, v, offset);
+                if ((threadIdx.x & (32 - 1)) >= offset) v += n;
+            }
+            return v - original;
+            }
+                                  """,
+            return_type="int32",
+        )
+
+    @T.inline
+    def run(
+        self,
+        m_idx,
+        n_idx,
+        k_idx,
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        total_tokens_post_pad,
+        cumsum_buffer,
+        num_valid_tokens=None,
+    ):
+        idx = T.alloc_local([1], "int32")
+        pre = T.alloc_local([1], "int32")
+        sum_val = T.alloc_local([1], "int32")
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        self.smem_manager.wait_all("cta")
+        if tid < self.num_experts:
+            self.shared_counts[tid] = 0
+        T.tvm_storage_sync("shared")
+        idx[0] = tid
+        while idx[0] < self.numel:
+            expert_id: T.let = topk_ids[
+                idx[0]
+            ]  # TODO: the reference expert use topk_ids[idx[0]] + 1. Is it correct?
+            T.cuda.atomic_add(T.address_of(self.shared_counts[expert_id]), 1)
+            idx[0] += KernelConfig.NUM_THREADS
+        T.tvm_storage_sync("shared")
+        if tid < self.num_experts:
+            padded_count: T.let = (
+                ceildiv(self.shared_counts[tid], self.block_size) * self.block_size
+            )
+            self.scan_buf[tid] = padded_count
+        elif tid < self.scan_size:
+            self.scan_buf[tid] = 0
+        T.tvm_storage_sync("shared")
+        v: T.let = T.if_then_else(tid < self.num_experts, self.scan_buf[tid], 0)
+        self.warp_exclusive_scan(v, pre)
+        if lane_id == 31:
+            self.warp_sums[warp_id] = pre[0] + v
+        T.tvm_storage_sync("shared")
+        num_warps_for_scan = T.meta_var(ceildiv(self.scan_size, 32))
+        if warp_id == 0:
+            val: T.let = T.if_then_else(lane_id < num_warps_for_scan, self.warp_sums[lane_id], 0)
+            self.warp_exclusive_scan(val, sum_val)
+            if lane_id == num_warps_for_scan - 1:
+                self.prefix[self.num_experts] = sum_val[0] + val
+                self.s_total_tokens_post_pad[0] = sum_val[0] + val
+                total_tokens_post_pad[0] = self.s_total_tokens_post_pad[0]
+            self.warp_sums[lane_id] = sum_val[0]
+        T.tvm_storage_sync("shared")
+        if tid < self.scan_size:
+            self.scan_buf[tid] = pre[0] + self.warp_sums[warp_id]
+        if tid < self.num_experts:
+            self.prefix[tid] = self.scan_buf[tid]
+        if tid <= self.num_experts:
+            cumsum_buffer[tid] = self.prefix[tid]
+        T.tvm_storage_sync("shared")
+        num_blocks: T.let = self.s_total_tokens_post_pad[0] // self.block_size
+        idx[0] = tid
+        while idx[0] < num_blocks:
+            block_start: T.let = idx[0] * self.block_size
+            left = T.alloc_local([1], "int32")
+            right = T.alloc_local([1], "int32")
+            left[0] = 0
+            right[0] = self.num_experts
+            while left[0] < right[0]:
+                mid: T.let = (left[0] + right[0]) // 2
+                if self.prefix[mid] <= block_start:
+                    left[0] = mid + 1
+                else:
+                    right[0] = mid
+            expert_ids[idx[0]] = left[0] - 1  # TODO: the reference expert use left - 2
+            if num_valid_tokens is not None:
+                if idx[0] < cumsum_buffer[left[0]] // self.block_size - 1:
+                    num_valid_tokens[idx[0]] = self.block_size
+                else:
+                    num_valid_tokens[idx[0]] = (
+                        self.shared_counts[left[0] - 1] - 1
+                    ) % self.block_size + 1
+
+            idx[0] += KernelConfig.NUM_THREADS
+        if self.pad_sorted_token_ids:
+            VEC_SIZE: T.let = 4
+            idx[0] = tid * VEC_SIZE
+            out_ptr = sorted_token_ids.view(-1)
+            fill_vec = T.alloc_buffer([4], "int32", scope="local")
+            for vec in T.vectorized(VEC_SIZE):
+                fill_vec[vec] = self.numel
+            while idx[0] < self.s_total_tokens_post_pad[0]:
+                for vec in T.vectorized(VEC_SIZE):
+                    out_ptr[idx[0] + vec] = fill_vec[vec]
+                idx[0] += VEC_SIZE * KernelConfig.NUM_THREADS
+        self.smem_manager.arrive_all("cta")
+        self.smem_manager.advance()
+
+
+class CountAndSortExpertTokens(Tile):
+    VEC_SIZE = 16 // F16_BYTES
+    PIPE_DEPTH = 8
+
+    def __init__(self, numel, hidden_size, topk):
+        super().__init__()
+        self.numel = numel  # numel = num_tokens * num_experts
+        self.hidden_size = hidden_size
+        assert self.hidden_size <= KernelConfig.NUM_THREADS * self.VEC_SIZE
+        self.topk = topk
+
+    def _alloc_buffer(self, smem_manager: SmemManager):
+        self.smem_manager = smem_manager
+        self.s_rank_post_pad = smem_manager.alloc([KernelConfig.NUM_THREADS], "int64")
+        self.fetched_data = smem_manager.alloc(
+            [self.PIPE_DEPTH, KernelConfig.NUM_THREADS, self.VEC_SIZE], "float16"
+        )
+
+    def init(self, smem_manager: SmemManager):
+        self._alloc_buffer(smem_manager)
+
+    # fmt: off
+    @T.inline
+    def run(self, m_idx, n_idx, k_idx, topk_ids, sorted_token_ids, cumsum_buffer, data, reordered_data):
+        idx = T.alloc_local([1], "int32")
+        cnt = T.alloc_local([1], "int32")
+        col_idx = T.alloc_local([1], "int32")
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        reordered_data_flat = reordered_data.view(-1)
+        process_token_idx: T.let = m_idx + tid * KernelConfig.SM_NUMBER
+        self.smem_manager.wait_all("cta")
+        if process_token_idx < self.numel:
+            expert_id: T.let = topk_ids[process_token_idx]
+            rank_post_pad: T.let = T.cuda.atomic_add(T.address_of(cumsum_buffer[expert_id]), 1)
+            sorted_token_ids[rank_post_pad] = process_token_idx
+            self.s_rank_post_pad[tid] = rank_post_pad
+        idx[0] = m_idx
+        T.tvm_storage_sync("shared")
+        col_idx[0] = tid * self.VEC_SIZE
+        for i in T.unroll(self.PIPE_DEPTH - 1):
+            if idx[0] < self.numel and col_idx[0] < self.hidden_size:
+                Tx.thread.copy_async(
+                    self.fetched_data[i, tid, :],
+                    data[idx[0] // self.topk, col_idx[0] : col_idx[0] + self.VEC_SIZE],
+                    dispatch="ldgsts",
+                    direct=True,
+                )
+            T.ptx.cp_async.commit_group()
+            idx[0] += KernelConfig.SM_NUMBER
+        cnt[0] = 0
+        while idx[0] < self.numel + (self.PIPE_DEPTH - 1) * KernelConfig.SM_NUMBER:
+            if idx[0] < self.numel and col_idx[0] < self.hidden_size:
+                cp_pipe_idx = T.meta_var((idx[0] // KernelConfig.SM_NUMBER) % self.PIPE_DEPTH)
+                Tx.thread.copy_async(
+                    self.fetched_data[cp_pipe_idx, tid, :],
+                    data[idx[0] // self.topk, col_idx[0] : col_idx[0] + self.VEC_SIZE],
+                    dispatch="ldgsts",
+                    direct=True,
+                )
+            T.ptx.cp_async.commit_group()
+            T.ptx.cp_async.wait_group(self.PIPE_DEPTH - 1)
+            rank_post_pad: T.let = self.s_rank_post_pad[cnt[0]]
+            pipe_idx = T.meta_var(cnt[0] % self.PIPE_DEPTH)
+            if col_idx[0] < self.hidden_size:
+                for vec in T.vectorized(self.VEC_SIZE):
+                    reordered_data_flat[
+                        T.cast(rank_post_pad, "int32") * self.hidden_size + col_idx[0] + vec
+                    ] = self.fetched_data[pipe_idx, tid, vec]
+            idx[0] += KernelConfig.SM_NUMBER
+            cnt[0] += 1
+        self.smem_manager.arrive_all("cta")
+        self.smem_manager.advance()
+    # fmt: on

--- a/tirx_kernels/megakernel/kernels/topk_softmax.py
+++ b/tirx_kernels/megakernel/kernels/topk_softmax.py
@@ -1,0 +1,245 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tvm
+from tirx_kernels.megakernel.utils.base import SmemManager, Tile
+from tirx_kernels.megakernel.utils.config import KernelConfig
+from tirx_kernels.megakernel.utils.utils import find_power_of_two, is_power_of_two
+from tvm.script import tirx as T
+
+
+class TopkSoftmaxTile(Tile):
+    WARPS_PER_TB = 8
+    MAX_BYTES_PER_LDG = 16
+    TPB = 256
+    bdx = 32
+    bdy = KernelConfig.NUM_THREADS // bdx
+
+    def __init__(self, num_experts: T.int32, num_tokens: T.int32, topk: T.int32, dtype="float32"):
+        super().__init__()
+        T.Assert(
+            is_power_of_two(num_experts),
+            f"number of experts is {num_experts}, which is not a power of 2",
+        )
+        T.Assert(
+            tvm.tirx.all(1 <= num_experts, num_experts <= 256),
+            f"number of experts is {num_experts}, which is not within [1, 256]",
+        )
+        self.num_experts = num_experts
+        self.num_tokens = num_tokens
+        self.topk = topk
+        self.dtype = dtype
+        if dtype in ["float16", "bfloat16"]:
+            self.n_bytes = 2
+        elif dtype in ["float32"]:
+            self.n_bytes = 4
+        else:
+            raise ValueError(f"{dtype} is not supported in topk_softmax")
+        T.Assert(
+            self.n_bytes * self.num_experts >= self.MAX_BYTES_PER_LDG,
+            f"n_bytes * num_experts is {self.n_bytes * self.num_experts}, which is less than 16",
+        )
+        # self.BYTES_PER_LDG = T.min(self.MAX_BYTES_PER_LDG, self.n_bytes * self.num_experts)
+        self.BYTES_PER_LDG = self.MAX_BYTES_PER_LDG
+        T.Assert(
+            tvm.tirx.all(is_power_of_two(self.BYTES_PER_LDG), self.BYTES_PER_LDG <= 16),
+            f"BYTES_PER_LDG is {self.BYTES_PER_LDG}, which is not a power of 2 or is larger than 16",
+        )
+        self.ELTS_PER_LDG = self.BYTES_PER_LDG // self.n_bytes
+        T.Assert(
+            tvm.tirx.any(
+                num_experts // (self.ELTS_PER_LDG * 32) == 0,
+                num_experts % (self.ELTS_PER_LDG * 32) == 0,
+            ),
+            f"num_experts is {num_experts}, which is not multiple or less than {(self.ELTS_PER_LDG * 32)}",
+        )
+        self.ELTS_PER_ROW = num_experts
+        T.Assert(
+            num_experts // (self.ELTS_PER_LDG * 32) <= 1,
+            f"num_experts is {num_experts}, which is larger than {self.ELTS_PER_LDG * 32}",
+        )
+        # self.VECs_PER_THREAD = T.max(1, num_experts // (self.ELTS_PER_LDG * 32))
+        self.VECs_PER_THREAD = 1
+        self.VPT = self.VECs_PER_THREAD * self.ELTS_PER_LDG
+        T.Assert(is_power_of_two(self.VPT), f"VPT is {self.VPT}, which is not a power of 2")
+        self.LDG_PER_THREAD = self.VPT // self.ELTS_PER_LDG
+        T.Assert(
+            self.VPT % self.ELTS_PER_LDG == 0,
+            f"VPT is {self.VPT}, which is not a multiple of {self.ELTS_PER_LDG}",
+        )
+        self.THREADS_PER_ROW = num_experts // self.VPT
+        T.Assert(
+            32 % self.THREADS_PER_ROW == 0,
+            f"THREADS_PER_ROW is {self.THREADS_PER_ROW}, which is not divisible by 32",
+        )
+        T.Assert(
+            is_power_of_two(self.THREADS_PER_ROW),
+            f"THREADS_PER_ROW is {self.THREADS_PER_ROW}, which is not a power of 2",
+        )
+        T.Assert(
+            self.THREADS_PER_ROW <= 32,
+            f"THREADS_PER_ROW is {self.THREADS_PER_ROW}, which is not less or equal to 32",
+        )
+        self.COLS_PER_GROUP_LDG = self.ELTS_PER_LDG * self.THREADS_PER_ROW
+        self.ELTS_PER_WARP = self.VPT * 32
+        self.ROWS_PER_WARP = self.ELTS_PER_WARP // self.ELTS_PER_ROW
+        self.ROWS_PER_CTA = self.WARPS_PER_TB * self.ROWS_PER_WARP
+        T.Assert(
+            self.ELTS_PER_WARP % self.ELTS_PER_ROW == 0,
+            f"ELTS_PER_WARP is {self.ELTS_PER_WARP}, which is not a multiple of {self.ELTS_PER_ROW}",
+        )
+        self.num_warps = (num_tokens + self.ROWS_PER_WARP - 1) // self.ROWS_PER_WARP
+        self.num_blocks = (self.num_warps + self.WARPS_PER_TB - 1) // self.WARPS_PER_TB
+        self.MAX_OCCUPANCY = 8
+        self.PERSISTENT_SM_NUMBER = KernelConfig.SM_NUMBER * 1
+
+    def _alloc_local(self):
+        # alloc local memory
+        self.row_chunk_temp = T.alloc_local([self.VPT], self.dtype)
+        self.row_chunk = T.alloc_local([self.VPT], "float32")
+        self.thread_max = T.alloc_local([1], self.dtype)
+        self.row_sum = T.alloc_local([1], "float32")
+        self.reciprocal_row_sum = T.alloc_local([1], "float32")
+        self.row_sum_for_renormalize = T.alloc_local([1], "float32")
+        self.col = T.alloc_local([1], "int32")
+        self.max_val = T.alloc_local([1], "float32")
+        self.expert = T.alloc_local([1], "int32")
+        self.token_idx = T.alloc_local([1], "int32")
+
+    @T.inline
+    def init(self, smem_manager: SmemManager = None):
+        self._alloc_local()
+
+    # fmt: off
+    @T.inline
+    def run(self, m_idx, n_idx, k_idx, gating_output, topk_weights, topk_indices, renormalize=False):
+        gating_output_flat = gating_output.view(-1)
+        topk_weights_flat = topk_weights.view(-1)
+        topk_indices_flat = topk_indices.view(-1)
+        warp_id_in_cta = T.warp_id([KernelConfig.WG_NUMBER * KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([self.bdx])
+
+        self.token_idx[0] = m_idx * self.ROWS_PER_CTA
+
+        while self.token_idx[0] < self.num_tokens:
+            cta_base_row = T.meta_var(self.token_idx[0])
+            warp_base_row = T.meta_var(cta_base_row + warp_id_in_cta * self.ROWS_PER_WARP)
+            thread_row_in_warp = T.meta_var(lane_id // self.THREADS_PER_ROW)
+            thread_row = T.meta_var(warp_base_row + thread_row_in_warp)
+
+            thread_group_idx = T.meta_var(lane_id % self.THREADS_PER_ROW)
+            first_elt_read_by_thread = T.meta_var(thread_group_idx * self.ELTS_PER_LDG)
+            thread_read_ptr_offset = T.meta_var(thread_row * self.ELTS_PER_ROW + first_elt_read_by_thread)
+
+            if thread_row < self.num_tokens:
+                # copy global to reg
+                for ii in T.unroll(self.LDG_PER_THREAD):
+                    thread_read_ptr_offset1 = T.meta_var(thread_read_ptr_offset + ii * self.THREADS_PER_ROW * self.ELTS_PER_LDG)
+                    for vec in T.vectorized(self.ELTS_PER_LDG):
+                        thread_read_ptr_offset2 = T.meta_var(thread_read_ptr_offset1 + vec)
+                        self.row_chunk_temp[ii * self.ELTS_PER_LDG + vec] = gating_output_flat[thread_read_ptr_offset2]
+            else:
+                for ii in T.unroll(self.VPT):
+                    self.row_chunk_temp[ii] = 0.0
+
+            # max reduce within thread
+            self.thread_max[0] = self.row_chunk_temp[0]
+            for ii in T.unroll(1, self.VPT):
+                self.thread_max[0] = T.max(self.thread_max[0], self.row_chunk_temp[ii])
+
+            # max reduce within thread group
+            # now, thread_max in all threads have the max within the row
+            for kr in T.unroll(find_power_of_two(self.THREADS_PER_ROW // 2) + 1):
+                self.thread_max[0] = T.max(self.thread_max[0], T.tvm_warp_shuffle_xor(
+                    0xFFFFFFFF, self.thread_max[0], (self.THREADS_PER_ROW // 2) >> kr, self.THREADS_PER_ROW, 32
+                ))
+
+            # take exp and compute local sum
+            self.row_sum[0] = 0
+            for ii in T.unroll(self.VPT):
+                self.row_chunk[ii] = T.exp(T.Cast("float32", self.row_chunk_temp[ii]) - T.Cast("float32", self.thread_max[0]))
+                self.row_sum[0] += self.row_chunk[ii]
+
+            # sum reduce within thread group
+            # now, all threads have the sum within the row
+            for kr in T.unroll(find_power_of_two(self.THREADS_PER_ROW // 2) + 1):
+                self.row_sum[0] = self.row_sum[0] + T.tvm_warp_shuffle_xor(
+                    0xFFFFFFFF, self.row_sum[0], (self.THREADS_PER_ROW // 2) >> kr, self.THREADS_PER_ROW, 32
+                )
+
+            # scale the rows
+            self.reciprocal_row_sum[0] = 1.0 / self.row_sum[0]
+            for ii in T.unroll(self.VPT):
+                self.row_chunk[ii] = self.row_chunk[ii] * self.reciprocal_row_sum[0]
+
+            # now, start to find topk elements in each row
+            start_col = T.meta_var(first_elt_read_by_thread)
+            self.row_sum_for_renormalize[0] = 0
+
+            for k_idx in T.serial(self.topk):
+                # first step, each thread does local argmax
+                self.max_val[0] = self.row_chunk[0]
+                self.expert[0] = start_col
+                self.col[0] = start_col
+                for ldg in T.unroll(self.LDG_PER_THREAD):
+                    for ii in T.unroll(self.ELTS_PER_LDG):
+                        val = T.meta_var(self.row_chunk[ldg * self.ELTS_PER_LDG + ii])
+                        if val > self.max_val[0]:
+                            self.max_val[0] = val
+                            self.expert[0] = self.col[0] + ii
+                    self.col[0] = self.col[0] + self.COLS_PER_GROUP_LDG
+
+                # second step, perform argmax reduce among threads
+                for ki in T.unroll(find_power_of_two(self.THREADS_PER_ROW // 2) + 1):
+                    other_max = T.tvm_warp_shuffle_xor(
+                        0xFFFFFFFF, self.max_val[0], (self.THREADS_PER_ROW // 2) >> ki, self.THREADS_PER_ROW, 32
+                    )
+                    other_expert = T.tvm_warp_shuffle_xor(
+                        0xFFFFFFFF, self.expert[0], (self.THREADS_PER_ROW // 2) >> ki, self.THREADS_PER_ROW, 32
+                    )
+                    if (other_max > self.max_val[0]) or ((other_max == self.max_val[0]) and (other_expert < self.expert[0])):
+                        self.max_val[0] = other_max
+                        self.expert[0] = other_expert
+
+                # write max to global memory
+                if thread_group_idx == 0 and thread_row < self.num_tokens:
+                    start_expert = T.meta_var(0)
+                    end_expert = T.meta_var(self.num_experts)
+                    should_process_row = T.meta_var(T.bool((self.expert[0] >= start_expert) and (self.expert[0] < end_expert)))
+                    idx = T.meta_var(self.topk * thread_row + k_idx)
+                    topk_weights_flat[idx] = self.max_val[0]
+                    topk_indices_flat[idx] = T.if_then_else(should_process_row, self.expert[0] - start_expert, self.num_experts)
+                    self.row_sum_for_renormalize[0] = self.row_sum_for_renormalize[0] + self.max_val[0]
+
+                # clear value in thread
+                if k_idx + 1 < self.topk:
+                    ldg_group_for_expert = T.meta_var(self.expert[0] // self.COLS_PER_GROUP_LDG)
+                    thread_to_clear_in_group = T.meta_var((self.expert[0] // self.ELTS_PER_LDG) % self.THREADS_PER_ROW)
+                    if thread_group_idx == thread_to_clear_in_group:
+                        offset_for_expert = T.meta_var(self.expert[0] % self.ELTS_PER_LDG)
+                        idx = T.meta_var(ldg_group_for_expert * self.ELTS_PER_LDG + offset_for_expert)
+                        self.row_chunk[idx] = -10000.0
+
+            # handle renormalize of top k weights
+            if renormalize and thread_group_idx == 0 and thread_row < self.num_tokens:
+                row_sum_for_renormalize_inv = T.meta_var(1.0 / self.row_sum_for_renormalize[0])
+                for k_idx in T.unroll(self.topk):
+                    idx = T.meta_var(self.topk * thread_row + k_idx)
+                    topk_weights_flat[idx] = topk_weights_flat[idx] * row_sum_for_renormalize_inv
+
+            self.token_idx[0] += self.PERSISTENT_SM_NUMBER * self.ROWS_PER_CTA
+    # fmt: on

--- a/tirx_kernels/megakernel/moe.py
+++ b/tirx_kernels/megakernel/moe.py
@@ -1,0 +1,1622 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from __future__ import annotations
+
+import math
+from unittest import SkipTest
+
+import numpy as np
+import torch
+
+import tvm
+from tirx_kernels.megakernel.kernels import (
+    CountAndSortExpertTokens,
+    GemmTile,
+    GroupGEMMSiluTile,
+    GroupGEMMTileSM100,
+    MOEAlignTile,
+    TopkSoftmaxTile,
+)
+from tirx_kernels.megakernel.utils import dynamic_scheduler, static_scheduler
+from tirx_kernels.megakernel.utils.base import MegaKernelWrapper
+from tirx_kernels.megakernel.utils.config import (
+    MEGAKERNEL_MOE_BENCH_CONFIG,
+    JobType,
+    KernelConfig,
+    ProfileEventType,
+)
+from tirx_kernels.megakernel.utils.dynamic_scheduler import DynamicTileScheduler
+from tirx_kernels.megakernel.utils.static_scheduler import StaticTileScheduler
+from tirx_kernels.megakernel.utils.support import (
+    generate_exec_queue_moe,
+    get_max_blocks_padded_relaxed,
+    get_max_num_tokens_padded,
+)
+from tirx_kernels.megakernel.utils.utils import ceildiv, f_init_const, get_source
+from tvm.script import tirx as Tx
+
+# TODO: fix abnormal slowness of batch-attn on the first tile
+
+KERNEL_META = {"name": "megakernel_moe", "category": "megakernel", "compute_capability": 10}
+
+_SUPPORTED_SCHEDULERS = ("static", "dynamic", "unfused")
+_STATIC_QUEUE_SCHEDULERS = ("static", "unfused")
+_TEST_BATCH_SIZES = (1, 128)
+_BENCH_BATCH_SIZES = (1, 8, 32, 128, 512, 1024, 2048, 4096)
+_BENCH_LAUNCH_SLOT_HEADROOM = 1.25
+
+CONFIGS = [
+    {
+        "label": f"moe_a3b_bs{batch_size}_{scheduler}",
+        "batch_size": batch_size,
+        "scheduler": scheduler,
+        "world_size": 1,
+    }
+    for batch_size in _TEST_BATCH_SIZES
+    for scheduler in _SUPPORTED_SCHEDULERS
+]
+
+BENCH_CONFIGS = [
+    {"label": f"moe_a3b_bs{batch_size}_all", "batch_size": batch_size, "world_size": 1}
+    for batch_size in _BENCH_BATCH_SIZES
+]
+
+_COMPILE_CACHE = {}
+
+
+class MegaKernelMOE(MegaKernelWrapper):
+    MOE_M_PAD_SIZE = 128
+    GATING_BLK_M = 128
+
+    def __init__(self, config, world_size, profiler_on):
+        super().__init__(config, 1, profiler_on)
+        self.world_size = world_size
+        self.HIDDEN_SIZE = config.get("HIDDEN_SIZE", None)
+        self.INTERMEDIATE_SIZE = config.get("INTERMEDIATE_SIZE", None)
+        self.NUM_EXPERTS = config.get("NUM_EXPERTS", None)
+        self.NUM_EXPERTS_PER_TOK = config.get("NUM_EXPERTS_PER_TOK", None)
+        self.GATING_SPLIT_K_FACTOR = config.get("GATING_SPLIT_K_FACTOR", None)
+
+    def _set_tiles(self, batch_size, low_batch):
+        self.gate = self._add_tile(
+            GemmTile(
+                self.NUM_EXPERTS,
+                self.HIDDEN_SIZE,
+                "float16",
+                "float16",
+                self.GATING_SPLIT_K_FACTOR,
+                self.GATING_BLK_M,
+                self.GATING_BLK_M,
+                use_tma_reduce=True,
+            ),
+            ProfileEventType.MOE_GATING,
+        )
+        self.topk_softmax = self._add_tile(
+            TopkSoftmaxTile(
+                self.NUM_EXPERTS, batch_size, self.NUM_EXPERTS_PER_TOK, dtype="float32"
+            ),
+            ProfileEventType.TOPK_SOFTMAX,
+        )
+        numel = self.NUM_EXPERTS_PER_TOK * batch_size
+        self.align = self._add_tile(
+            MOEAlignTile(self.NUM_EXPERTS, numel, self.MOE_M_PAD_SIZE, pad_sorted_token_ids=True),
+            ProfileEventType.MOE_ALIGN,
+        )
+        self.count_and_sort_expert_tokens = self._add_tile(
+            CountAndSortExpertTokens(numel, self.HIDDEN_SIZE, self.NUM_EXPERTS_PER_TOK),
+            ProfileEventType.COUNT_AND_SORT,
+        )
+        self.group_gemm_gate_up_silu = self._add_tile(
+            GroupGEMMSiluTile(
+                self.INTERMEDIATE_SIZE * 2,
+                self.HIDDEN_SIZE,
+                self.NUM_EXPERTS,
+                self.NUM_EXPERTS_PER_TOK,
+                numel,
+                "float16",
+                "float16",
+                low_batch=low_batch,
+            ),
+            ProfileEventType.GROUP_GEMM_GATE_UP_SILU,
+        )
+        self.group_gemm_down = self._add_tile(
+            GroupGEMMTileSM100(
+                self.HIDDEN_SIZE,
+                self.INTERMEDIATE_SIZE,
+                self.NUM_EXPERTS,
+                self.NUM_EXPERTS_PER_TOK,
+                numel,
+                "float16",
+                "float16",
+                acc_output=True,
+                low_batch=low_batch,
+            ),
+            ProfileEventType.GROUP_GEMM_DOWN,
+        )
+
+    def set_tiles(self, batch_size, low_batch):
+        self.reset()
+        self._set_tiles(batch_size, low_batch)
+
+    def _set_events(
+        self,
+        batch_size,
+        Semaphore: type[static_scheduler.Semaphore | dynamic_scheduler.Semaphore],
+        etensor_workspace_global,
+        unfused=False,
+    ):
+        self.evt_gating = self.add_etensor(
+            Semaphore,
+            etensor_workspace_global,
+            shape=[1],
+            f_init=f_init_const(
+                self.GATING_SPLIT_K_FACTOR * ceildiv(batch_size, self.GATING_BLK_M)
+            ),
+        )
+        self.evt_topk_softmax = self.add_etensor(
+            Semaphore,
+            etensor_workspace_global,
+            shape=[1],
+            f_init=f_init_const(KernelConfig.SM_NUMBER),
+        )
+        self.evt_moe_align = self.add_etensor(
+            Semaphore, etensor_workspace_global, shape=[1], f_init=f_init_const(1)
+        )
+        self.evt_count_and_sort = self.add_etensor(
+            Semaphore,
+            etensor_workspace_global,
+            shape=[1],
+            f_init=f_init_const(KernelConfig.SM_NUMBER),
+        )
+        max_num_tokens_padded = get_max_num_tokens_padded(
+            batch_size, self.NUM_EXPERTS_PER_TOK, self.NUM_EXPERTS, self.MOE_M_PAD_SIZE
+        )
+        max_blocks_padded_relaxed = get_max_blocks_padded_relaxed(
+            batch_size, self.NUM_EXPERTS_PER_TOK, self.NUM_EXPERTS, self.MOE_M_PAD_SIZE
+        )
+        if unfused:
+            self.evt_group_gemm_gate_up = self.add_etensor(
+                Semaphore,
+                etensor_workspace_global,
+                shape=[1],
+                f_init=f_init_const(
+                    max_num_tokens_padded
+                    // self.MOE_M_PAD_SIZE
+                    * self.INTERMEDIATE_SIZE
+                    * 2
+                    // GroupGEMMTileSM100.BLK_N
+                ),
+            )
+        else:
+            self.evt_group_gemm_gate_up = self.add_etensor(
+                Semaphore,
+                etensor_workspace_global,
+                shape=[max_blocks_padded_relaxed],
+                f_init=f_init_const(self.INTERMEDIATE_SIZE * 2 // GroupGEMMTileSM100.BLK_N),
+            )
+        f_init_group_gemm_down = (
+            f_init_const(
+                max_num_tokens_padded
+                // self.MOE_M_PAD_SIZE
+                * self.HIDDEN_SIZE
+                // GroupGEMMTileSM100.BLK_N
+            )
+            if issubclass(Semaphore, static_scheduler.Semaphore)
+            else None
+        )
+        self.evt_group_gemm_down = self.add_etensor(
+            Semaphore, etensor_workspace_global, shape=[1], f_init=f_init_group_gemm_down
+        )
+
+    def set_events(
+        self,
+        is_dynamic_sch,
+        batch_size,
+        Semaphore: type[static_scheduler.Semaphore | dynamic_scheduler.Semaphore],
+        etensor_workspace_global,
+        unfused=False,
+    ):
+        self._set_events(batch_size, Semaphore, etensor_workspace_global, unfused=unfused)
+        self.set_events_complete(is_dynamic_sch, Semaphore, etensor_workspace_global)
+        self.num_etensors[is_dynamic_sch] = len(self.etensor_and_f_init_pairs)
+
+    def _add_tile(self, tile, profiler_event_type, predicate=True):
+        self.tile_attr[tile] = (profiler_event_type, predicate)
+        subclass = GroupGEMMTileSM100 if isinstance(tile, GemmTile) else tile.__class__
+        self.class_list.add(subclass)
+        return tile
+
+    @Tx.inline
+    def task_impl_moe_gating(self, A, B, output, is_dynamic_sch):
+        if is_dynamic_sch:
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_gating,
+                lambda notify_idx: (1, -1, 0),
+                lambda trigger_idx: (
+                    lambda push_idx: (
+                        JobType.MOE_TOPK_SOFTMAX.value,
+                        self.topk_softmax.PERSISTENT_SM_NUMBER,
+                        push_idx,
+                        0,
+                        0,
+                    )
+                ),
+                "warpgroup",
+                "warpgroup",
+                scope_id=0,
+            )
+        self.run_tile(
+            self.gate,
+            self.tile_scheduler.m_idx,
+            self.tile_scheduler.n_idx,
+            self.tile_scheduler.k_idx,
+            A,
+            B,
+            output,
+            self.profiler,
+        )
+        self.tile_scheduler.notify(
+            self.evt_gating, lambda notify_idx: (1, -1, 0), scope="warpgroup", scope_id=0
+        )
+
+    @Tx.inline
+    def task_impl_moe_topk_softmax(
+        self,
+        gating_output_global,
+        topk_weights_global,
+        topk_indices_global,
+        is_dynamic_sch,
+        renormalize=True,
+    ):
+        if is_dynamic_sch:
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_topk_softmax,
+                lambda notify_idx: (1, -1, 0),
+                lambda trigger_idx: lambda push_idx: (JobType.MOE_ALIGN.value, 1, 0, 0, 0),
+                "thread",
+                "thread",
+            )
+        self.tile_scheduler.wait(self.evt_gating, 0, wait_level="cta")
+        self.run_tile(
+            self.topk_softmax,
+            self.tile_scheduler.m_idx,
+            self.tile_scheduler.n_idx,
+            self.tile_scheduler.k_idx,
+            gating_output_global,
+            topk_weights_global,
+            topk_indices_global,
+            renormalize=renormalize,
+        )
+        self.tile_scheduler.notify(
+            self.evt_topk_softmax, lambda notify_idx: (1, -1, 0), scope="cta"
+        )
+
+    @Tx.inline
+    def task_impl_moe_align(
+        self,
+        topk_ids_flattened,
+        sorted_token_ids_global,
+        expert_ids_global,
+        num_tokens_post_pad_global,
+        cumsum_buffer_global,
+        num_valid_tokens_global,
+        down_proj_task_size,
+        is_dynamic_sch,
+    ):
+        tid = Tx.thread_id([KernelConfig.NUM_THREADS])
+        if is_dynamic_sch:
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_moe_align,
+                lambda notify_idx: (1, -1, 0),
+                lambda trigger_idx: (
+                    lambda push_idx: (
+                        JobType.MOE_COUNT_AND_SORT.value,
+                        KernelConfig.SM_NUMBER,
+                        push_idx,
+                        0,
+                        0,
+                    )
+                ),
+                "cta",
+                "cta",
+            )
+        self.tile_scheduler.wait(self.evt_topk_softmax, 0, wait_level="cta")
+        self.run_tile(
+            self.align,
+            self.tile_scheduler.m_idx,
+            self.tile_scheduler.n_idx,
+            self.tile_scheduler.k_idx,
+            topk_ids_flattened,
+            sorted_token_ids_global,
+            expert_ids_global,
+            num_tokens_post_pad_global,
+            cumsum_buffer_global,
+            num_valid_tokens_global,
+        )
+        Tx.cuda.cta_sync()
+        if tid == 0:
+            # TODO: make this etensor initialization a task
+            if is_dynamic_sch:
+                self.evt_group_gemm_down.sem[0] = (
+                    (self.evt_group_gemm_down.base + 1)
+                    * (num_tokens_post_pad_global[0] // self.MOE_M_PAD_SIZE)
+                    * (self.HIDDEN_SIZE // GroupGEMMTileSM100.BLK_N // down_proj_task_size)
+                )
+        self.tile_scheduler.notify(
+            self.evt_moe_align, lambda notify_idx: (1, -1, 0), scope="thread"
+        )
+
+    @Tx.inline
+    def task_impl_moe_count_and_sort(
+        self,
+        topk_ids_flattened,
+        sorted_token_ids_global,
+        cumsum_buffer_global,
+        hidden_state_global,
+        reordered_hidden_state_global,
+        num_tokens_post_pad_global,
+        is_dynamic_sch,
+    ):
+        if is_dynamic_sch:
+            n_axis_len = Tx.meta_var(self.INTERMEDIATE_SIZE * 2 // GroupGEMMTileSM100.BLK_N)
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_count_and_sort,
+                lambda notify_idx: (1, -1, 0),
+                lambda trigger_idx: (
+                    lambda push_idx: (
+                        JobType.MOE_GROUP_GEMM_GATE_UP_SILU.value,
+                        num_tokens_post_pad_global[0] // self.MOE_M_PAD_SIZE * n_axis_len,
+                        push_idx // n_axis_len,
+                        push_idx % n_axis_len,
+                        0,
+                    )
+                ),
+                "cta",
+                "cta",
+            )
+        self.tile_scheduler.wait(self.evt_moe_align, 0, wait_level="cta")
+        self.run_tile(
+            self.count_and_sort_expert_tokens,
+            self.tile_scheduler.m_idx,
+            self.tile_scheduler.n_idx,
+            self.tile_scheduler.k_idx,
+            topk_ids_flattened,
+            sorted_token_ids_global,
+            cumsum_buffer_global,
+            hidden_state_global,
+            reordered_hidden_state_global,
+        )
+        self.tile_scheduler.notify(
+            self.evt_count_and_sort, lambda notify_idx: (1, -1, 0), scope="cta"
+        )
+
+    @Tx.inline
+    def task_impl_moe_group_gemm_gate_up_silu(
+        self,
+        A,
+        B,
+        output,
+        topk_weights_flattened,
+        sorted_token_ids_global,
+        expert_ids_global,
+        num_valid_tokens_global,
+        num_tokens_post_pad_global,
+        unfused,
+        down_proj_task_size,
+        is_dynamic_sch,
+    ):
+        if is_dynamic_sch:
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_group_gemm_gate_up,
+                lambda notify_idx: (1, -1, self.tile_scheduler.m_idx),
+                lambda trigger_idx: (
+                    lambda push_idx: (
+                        JobType.MOE_GROUP_GEMM_DOWN.value,
+                        self.HIDDEN_SIZE // GroupGEMMTileSM100.BLK_N // down_proj_task_size,
+                        self.tile_scheduler.m_idx,
+                        push_idx,
+                        0,
+                    )
+                ),
+                "warp",
+                "warp",
+            )
+        self.tile_scheduler.wait(self.evt_count_and_sort, 0, wait_level="warp")
+        if (
+            is_dynamic_sch
+            or self.tile_scheduler.m_idx < num_tokens_post_pad_global[0] // self.MOE_M_PAD_SIZE
+        ):
+            self.run_tile(
+                self.group_gemm_gate_up_silu,
+                self.tile_scheduler.m_idx,
+                self.tile_scheduler.n_idx,
+                self.tile_scheduler.k_idx,
+                A,
+                B,
+                output,
+                expert_ids_global,
+                topk_weights_flattened,
+                sorted_token_ids_global,
+                num_valid_tokens_global,
+                self.profiler,
+            )
+        idx = Tx.meta_var(self.tile_scheduler.m_idx if not unfused else 0)
+        self.tile_scheduler.notify(
+            self.evt_group_gemm_gate_up,
+            lambda notify_idx: (1, -1, idx),
+            scope="warpgroup",
+            scope_id=0,
+        )
+
+    @Tx.inline
+    def task_impl_moe_group_gemm_down(
+        self,
+        A,
+        B,
+        output,
+        expert_ids_global,
+        topk_weights_flattened,
+        sorted_token_ids_global,
+        num_valid_tokens_global,
+        num_tokens_post_pad_global,
+        unfused,
+        down_proj_task_size,
+        is_dynamic_sch,
+    ):
+        if is_dynamic_sch:
+            self.tile_scheduler.pre_notify_and_push(
+                self.evt_group_gemm_down,
+                lambda notify_idx: (1, -1, 0),
+                lambda trigger_idx: (
+                    lambda push_idx: (JobType.END.value, KernelConfig.SM_NUMBER, 0, 0, 0)
+                ),
+                "warp",
+                "warp",
+            )
+        wait_idx = Tx.meta_var(self.tile_scheduler.m_idx if not unfused else 0)
+        self.tile_scheduler.wait(self.evt_group_gemm_gate_up, wait_idx, wait_level="warp")
+        if (
+            is_dynamic_sch
+            or self.tile_scheduler.m_idx < num_tokens_post_pad_global[0] // self.MOE_M_PAD_SIZE
+        ):
+            for i in range(down_proj_task_size):
+                self.run_tile(
+                    self.group_gemm_down,
+                    self.tile_scheduler.m_idx,
+                    self.tile_scheduler.n_idx * down_proj_task_size + i,
+                    self.tile_scheduler.k_idx,
+                    A,
+                    B,
+                    output,
+                    expert_ids_global,
+                    topk_weights_flattened,
+                    sorted_token_ids_global,
+                    num_valid_tokens_global,
+                    self.profiler,
+                )
+
+    # fmt: off
+    @Tx.inline
+    def fused_body(
+        self,
+        batch_size,
+        hidden_state_global,
+        residual_global,
+        output_global,
+        gate_weight_global,
+        grp_gate_up_weight_global,
+        grp_down_weight_global,
+        gating_output_global,
+        topk_weights_global,
+        topk_indices_global,
+        sorted_token_ids_global,
+        expert_ids_global,
+        num_valid_tokens_global,
+        num_tokens_post_pad_global,
+        cumsum_buffer_global,
+        reordered_hidden_state_global,
+        gate_up_output_global,
+        silu_mul_output_global,
+        topk_reduce_output_global,
+        etensor_workspace_global,
+        profiler_buffer,
+        exec_queue,
+        exec_task,
+        exec_head,
+        exec_tail,
+        down_proj_task_size, # to amortize dynamic scheduling overhead
+        low_batch,
+        unfused,
+        is_dynamic_sch,
+        Semaphore: type[static_scheduler.Semaphore | dynamic_scheduler.Semaphore],
+        Scheduler: type[static_scheduler.StaticTileScheduler | dynamic_scheduler.DynamicTileScheduler],
+    ):
+        # initialize tile
+        self.set_tiles(batch_size, low_batch)
+        self.host_init_all()
+
+        Tx.device_entry()
+        cta_id = Tx.cta_id([KernelConfig.SM_NUMBER])
+        warp_id = Tx.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        wg_id = Tx.warpgroup_id([KernelConfig.WG_NUMBER])
+        tid = Tx.thread_id([KernelConfig.NUM_THREADS])
+        tid_in_wg = Tx.thread_id_in_wg([128])
+        lane_id = Tx.lane_id([32])
+        Tx.alloc_buffer([1], "uint32", scope="local", align=8)
+        Tx.alloc_buffer([1], "uint64", scope="local", align=8)
+        self.init_profiler(profiler_buffer)
+        buf = Tx.alloc_buffer([KernelConfig.MAX_SMEM_SIZE], "uint8", scope="shared.dyn")
+        Tx.attr({"tirx.dyn_smem_bytes": KernelConfig.MAX_SMEM_SIZE})
+        # initialize smem manager
+        self.set_smem_manager(KernelConfig.MAX_SMEM_SIZE, 16384, buf.data)
+
+        # initialize device
+        self.device_init_all(self.smem_manager)
+        self.class_init_all(self.smem_manager)
+
+        # initialize event tensors
+        self.set_events(
+            is_dynamic_sch,
+            batch_size,
+            Semaphore,
+            etensor_workspace_global,
+            unfused,
+        )
+
+        # initialize tile scheduler and smem_manager
+        if not is_dynamic_sch:
+            self.init_tile_scheduler(False, Scheduler, "moe", exec_queue, self.smem_manager)
+        else:
+            self.init_tile_scheduler(True, Scheduler, exec_task, exec_head, exec_tail, self.smem_manager, self.profiler)
+        self.smem_manager.init()
+
+        topk_ids_flattened = topk_indices_global.view(-1)
+        topk_weights_flattened = topk_weights_global.view(-1)
+        while self.tile_scheduler.valid():
+            if self.tile_scheduler.task_type == JobType.MOE_GATING.value:
+                self.task_impl_moe_gating(hidden_state_global, gate_weight_global, gating_output_global, is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.MOE_TOPK_SOFTMAX.value:
+                self.task_impl_moe_topk_softmax(gating_output_global, topk_weights_global, topk_indices_global, is_dynamic_sch, renormalize=False)
+            elif self.tile_scheduler.task_type == JobType.MOE_ALIGN.value:
+                self.task_impl_moe_align(topk_ids_flattened, sorted_token_ids_global, expert_ids_global, num_tokens_post_pad_global, cumsum_buffer_global, num_valid_tokens_global, down_proj_task_size, is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.MOE_COUNT_AND_SORT.value:
+                self.task_impl_moe_count_and_sort(topk_ids_flattened, sorted_token_ids_global, cumsum_buffer_global, hidden_state_global, reordered_hidden_state_global, num_tokens_post_pad_global, is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.MOE_GROUP_GEMM_GATE_UP_SILU.value:
+                self.task_impl_moe_group_gemm_gate_up_silu(reordered_hidden_state_global, grp_gate_up_weight_global, silu_mul_output_global, topk_weights_flattened, sorted_token_ids_global, expert_ids_global, num_valid_tokens_global, num_tokens_post_pad_global, unfused, down_proj_task_size, is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.MOE_GROUP_GEMM_DOWN.value:
+                self.task_impl_moe_group_gemm_down(silu_mul_output_global, grp_down_weight_global, topk_reduce_output_global, expert_ids_global, topk_weights_flattened, sorted_token_ids_global, num_valid_tokens_global, num_tokens_post_pad_global, unfused, down_proj_task_size, is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.INIT_ETENSOR.value:
+                self.task_impl_init_etensor(is_dynamic_sch)
+            elif self.tile_scheduler.task_type == JobType.WAIT_ETENSOR_INIT.value:
+                self.task_impl_wait_etensor_init_complete(is_dynamic_sch)
+            else:
+                Tx.cuda.trap_when_assert_failed(False)
+            self.smem_manager.exit_tile_runtime()
+            self.tile_scheduler.next_tile()
+        if self.profiler_on:
+            self.profiler.finalize(lane_id == 0)
+        self.class_finalize_all()
+
+    # fmt: on
+
+    # FIXME: change offset_factor to 0 can make performance better
+    #       but it requires change on engine side
+    def get_func_static(self, unfused=False):
+        compile_batch_size = getattr(self, "_compile_batch_size", 1)
+
+        # fmt: off
+        @Tx.prim_func
+        def main(
+            # input and output
+            hidden_state_ptr: Tx.handle, # input: read-only
+            residual_ptr: Tx.handle, # input & output: inplace update
+            output_ptr: Tx.handle, # output
+
+            # weight
+            gate_weight_ptr: Tx.handle, # read-only
+            grp_gate_up_weight_ptr: Tx.handle, # read-only
+            grp_down_weight_ptr: Tx.handle, # read-only
+
+            # intermediate buffer
+            gating_output_ptr: Tx.handle, # intermediate
+            topk_weights_ptr: Tx.handle, # intermediate
+            topk_indices_ptr: Tx.handle, # intermediate
+            sorted_token_ids_ptr: Tx.handle, # intermediate
+            expert_ids_ptr: Tx.handle, # intermediate
+            num_valid_tokens_ptr: Tx.handle, # intermediate
+            num_tokens_post_pad_ptr: Tx.handle, # intermediate
+            cumsum_buffer_ptr: Tx.handle, # intermediate
+            reordered_hidden_state_ptr: Tx.handle, # intermediate
+            gate_up_output_ptr: Tx.handle, # intermediate
+            silu_mul_output_ptr: Tx.handle, # intermediate
+            topk_reduce_output_ptr: Tx.handle, # intermediate
+
+
+            # event tensor
+            etensor_workspace_ptr: Tx.handle, # not required to reset. Must be 0 before launch.
+
+            # execution queue
+            exec_queue_ptr: Tx.handle,
+            profiler_buffer: Tx.Buffer((self.PROFILER_BUFFER_SIZE,), "uint64")
+        ):
+            Tx.func_attr(
+                {"global_symbol": "main", "target": Tx.target("cuda")}
+            )
+
+            # match buffer
+            batch_size = Tx.meta_var(compile_batch_size)
+
+            # input and output
+            hidden_state_global = Tx.match_buffer(hidden_state_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+            residual_global = Tx.match_buffer(residual_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+            output_global = Tx.match_buffer(output_ptr, [batch_size, self.HIDDEN_SIZE], "float16")
+
+            # weight
+            gate_weight_global = Tx.match_buffer(gate_weight_ptr, [self.NUM_EXPERTS, self.HIDDEN_SIZE], "float16", scope="global")
+            grp_gate_up_weight_global = Tx.match_buffer(grp_gate_up_weight_ptr, [self.NUM_EXPERTS, self.INTERMEDIATE_SIZE * 2, self.HIDDEN_SIZE], "float16", scope="global")
+            grp_down_weight_global = Tx.match_buffer(grp_down_weight_ptr, [self.NUM_EXPERTS, self.HIDDEN_SIZE, self.INTERMEDIATE_SIZE], "float16", scope="global")
+
+            # intermediate buffer
+            gating_output_global = Tx.match_buffer(gating_output_ptr, [batch_size, self.NUM_EXPERTS], "float32", scope="global")
+            topk_weights_global = Tx.match_buffer(topk_weights_ptr, [batch_size, self.NUM_EXPERTS_PER_TOK], "float32", scope="global")
+            topk_indices_global = Tx.match_buffer(topk_indices_ptr, [batch_size, self.NUM_EXPERTS_PER_TOK], "int32", scope="global")
+            max_num_tokens_padded = Tx.int32()
+            sorted_token_ids_global = Tx.match_buffer(sorted_token_ids_ptr, [max_num_tokens_padded], "int32", scope="global")
+            expert_ids_global = Tx.match_buffer(expert_ids_ptr, [max_num_tokens_padded // self.MOE_M_PAD_SIZE], "int32", scope="global")
+            num_valid_tokens_global = Tx.match_buffer(num_valid_tokens_ptr, [max_num_tokens_padded // self.MOE_M_PAD_SIZE], "int32", scope="global")
+            num_tokens_post_pad_global = Tx.match_buffer(num_tokens_post_pad_ptr, [1], "int32", scope="global")
+            cumsum_buffer_global = Tx.match_buffer(cumsum_buffer_ptr, [self.NUM_EXPERTS + 1], "int32", scope="global")
+            reordered_hidden_state_global = Tx.match_buffer(reordered_hidden_state_ptr, [max_num_tokens_padded, self.HIDDEN_SIZE], "float16", scope="global")
+            gate_up_output_global = Tx.match_buffer(gate_up_output_ptr, [max_num_tokens_padded, self.INTERMEDIATE_SIZE * 2], "float16", scope="global")
+            silu_mul_output_global = Tx.match_buffer(silu_mul_output_ptr, [max_num_tokens_padded, self.INTERMEDIATE_SIZE], "float16", scope="global")
+            topk_reduce_output_global = Tx.match_buffer(topk_reduce_output_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+
+            # event tensor
+            etensor_workspace_size = Tx.int32()
+            etensor_workspace_global = Tx.match_buffer(etensor_workspace_ptr, [etensor_workspace_size], "int32", scope="global")
+
+            # exec queue
+            exec_queue = Tx.match_buffer(exec_queue_ptr, [KernelConfig.SM_NUMBER, StaticTileScheduler.MAX_TASKS], "int32", scope="global")
+
+            @Tx.inline
+            def run(low_batch, dynamic_gemm_size):
+                num_valid_tokens = Tx.meta_var(num_valid_tokens_global if dynamic_gemm_size else None)
+                self.fused_body(
+                    batch_size, hidden_state_global, residual_global, output_global, gate_weight_global, grp_gate_up_weight_global, grp_down_weight_global,
+                    gating_output_global, topk_weights_global, topk_indices_global, sorted_token_ids_global, expert_ids_global, num_valid_tokens, num_tokens_post_pad_global,
+                    cumsum_buffer_global, reordered_hidden_state_global, gate_up_output_global, silu_mul_output_global, topk_reduce_output_global,
+                    etensor_workspace_global,
+                    profiler_buffer, exec_queue, None, None, None, 1, low_batch, unfused,
+                    False, static_scheduler.Semaphore, static_scheduler.StaticTileScheduler
+                )
+
+            if compile_batch_size >= 2048:
+                run(low_batch=False, dynamic_gemm_size=True)
+            elif compile_batch_size >= 512:
+                run(low_batch=True, dynamic_gemm_size=True)
+            else:
+                run(low_batch=True, dynamic_gemm_size=False)
+            # fmt: on
+        return main
+
+    def get_func_dynamic(self):
+        compile_batch_size = getattr(self, "_compile_batch_size", 1)
+
+        # fmt: off
+        @Tx.prim_func
+        def main(
+            # input and output
+            hidden_state_ptr: Tx.handle, # input: read-only
+            residual_ptr: Tx.handle, # input & output: inplace update
+            output_ptr: Tx.handle, # output
+
+            # weight
+            gate_weight_ptr: Tx.handle, # read-only
+            grp_gate_up_weight_ptr: Tx.handle, # read-only
+            grp_down_weight_ptr: Tx.handle, # read-only
+
+            # intermediate buffer
+            gating_output_ptr: Tx.handle, # intermediate
+            topk_weights_ptr: Tx.handle, # intermediate
+            topk_indices_ptr: Tx.handle, # intermediate
+            sorted_token_ids_ptr: Tx.handle, # intermediate
+            expert_ids_ptr: Tx.handle, # intermediate
+            num_valid_tokens_ptr: Tx.handle, # intermediate
+            num_tokens_post_pad_ptr: Tx.handle, # intermediate
+            cumsum_buffer_ptr: Tx.handle, # intermediate
+            reordered_hidden_state_ptr: Tx.handle, # intermediate
+            gate_up_output_ptr: Tx.handle, # intermediate
+            silu_mul_output_ptr: Tx.handle, # intermediate
+            topk_reduce_output_ptr: Tx.handle, # intermediate
+
+
+            # event tensor
+            etensor_workspace_ptr: Tx.handle, # not required to reset. Must be 0 before launch.
+
+            # execution queue
+            queue_tasks_ptr: Tx.handle,
+            queue_head_ptr: Tx.handle,
+            queue_tail_ptr: Tx.handle,
+            profiler_buffer: Tx.Buffer((self.PROFILER_BUFFER_SIZE,), "uint64")
+        ):
+            Tx.func_attr(
+                {"global_symbol": "main", "target": Tx.target("cuda")}
+            )
+
+            # match buffer
+            batch_size = Tx.meta_var(compile_batch_size)
+
+            # input and output
+            hidden_state_global = Tx.match_buffer(hidden_state_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+            residual_global = Tx.match_buffer(residual_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+            output_global = Tx.match_buffer(output_ptr, [batch_size, self.HIDDEN_SIZE], "float16")
+
+            # weight
+            gate_weight_global = Tx.match_buffer(gate_weight_ptr, [self.NUM_EXPERTS, self.HIDDEN_SIZE], "float16", scope="global")
+            grp_gate_up_weight_global = Tx.match_buffer(grp_gate_up_weight_ptr, [self.NUM_EXPERTS, self.INTERMEDIATE_SIZE * 2, self.HIDDEN_SIZE], "float16", scope="global")
+            grp_down_weight_global = Tx.match_buffer(grp_down_weight_ptr, [self.NUM_EXPERTS, self.HIDDEN_SIZE, self.INTERMEDIATE_SIZE], "float16", scope="global")
+
+            # intermediate buffer
+            gating_output_global = Tx.match_buffer(gating_output_ptr, [batch_size, self.NUM_EXPERTS], "float32", scope="global")
+            topk_weights_global = Tx.match_buffer(topk_weights_ptr, [batch_size, self.NUM_EXPERTS_PER_TOK], "float32", scope="global")
+            topk_indices_global = Tx.match_buffer(topk_indices_ptr, [batch_size, self.NUM_EXPERTS_PER_TOK], "int32", scope="global")
+            max_num_tokens_padded = Tx.int32()
+            sorted_token_ids_global = Tx.match_buffer(sorted_token_ids_ptr, [max_num_tokens_padded], "int32", scope="global")
+            expert_ids_global = Tx.match_buffer(expert_ids_ptr, [max_num_tokens_padded // self.MOE_M_PAD_SIZE], "int32", scope="global")
+            num_valid_tokens_global = Tx.match_buffer(num_valid_tokens_ptr, [max_num_tokens_padded // self.MOE_M_PAD_SIZE], "int32", scope="global")
+            num_tokens_post_pad_global = Tx.match_buffer(num_tokens_post_pad_ptr, [1], "int32", scope="global")
+            cumsum_buffer_global = Tx.match_buffer(cumsum_buffer_ptr, [self.NUM_EXPERTS + 1], "int32", scope="global")
+            reordered_hidden_state_global = Tx.match_buffer(reordered_hidden_state_ptr, [max_num_tokens_padded, self.HIDDEN_SIZE], "float16", scope="global")
+            gate_up_output_global = Tx.match_buffer(gate_up_output_ptr, [max_num_tokens_padded, self.INTERMEDIATE_SIZE * 2], "float16", scope="global")
+            silu_mul_output_global = Tx.match_buffer(silu_mul_output_ptr, [max_num_tokens_padded, self.INTERMEDIATE_SIZE], "float16", scope="global")
+            topk_reduce_output_global = Tx.match_buffer(topk_reduce_output_ptr, [batch_size, self.HIDDEN_SIZE], "float16", scope="global")
+
+            # event tensor
+            etensor_workspace_size = Tx.int32()
+            etensor_workspace_global = Tx.match_buffer(etensor_workspace_ptr, [etensor_workspace_size], "int32", scope="global")
+
+            # exec queue
+            queue_tasks_global = Tx.match_buffer(queue_tasks_ptr, [DynamicTileScheduler.MAX_TASKS], "int32", scope="global", offset_factor=1)
+            queue_head_global = Tx.match_buffer(queue_head_ptr, [1], "int32", scope="global", offset_factor=1)
+            queue_tail_global = Tx.match_buffer(queue_tail_ptr, [1], "int32", scope="global", offset_factor=1)
+
+            @Tx.inline
+            def run(low_batch, dynamic_gemm_size, down_proj_task_size):
+                num_valid_tokens = Tx.meta_var(num_valid_tokens_global if dynamic_gemm_size else None)
+                self.fused_body(
+                    batch_size, hidden_state_global, residual_global, output_global, gate_weight_global, grp_gate_up_weight_global, grp_down_weight_global,
+                    gating_output_global, topk_weights_global, topk_indices_global, sorted_token_ids_global, expert_ids_global, num_valid_tokens, num_tokens_post_pad_global,
+                    cumsum_buffer_global, reordered_hidden_state_global, gate_up_output_global, silu_mul_output_global, topk_reduce_output_global,
+                    etensor_workspace_global,
+                    profiler_buffer, None, queue_tasks_global, queue_head_global, queue_tail_global, down_proj_task_size, low_batch, False,
+                    True, dynamic_scheduler.Semaphore, dynamic_scheduler.DynamicTileScheduler
+                )
+
+            if compile_batch_size >= 2048:
+                run(low_batch=False, dynamic_gemm_size=True, down_proj_task_size=4)
+            elif compile_batch_size >= 512:
+                run(low_batch=True, dynamic_gemm_size=True, down_proj_task_size=4)
+            elif compile_batch_size >= 4:
+                run(low_batch=True, dynamic_gemm_size=False, down_proj_task_size=4)
+            else:
+                run(low_batch=True, dynamic_gemm_size=False, down_proj_task_size=1)
+            # fmt: on
+        return main
+
+
+arg_dict = {}
+
+
+def prepare_data(batch_size, mk: MegaKernelMOE):
+    print("start prepare data", flush=True)
+    global arg_dict
+
+    def _correct_weight_tensor_view(tensor):
+        if mk.world_size == 1:
+            return tensor.view(*tensor.shape[1:])
+        return tensor
+
+    torch.manual_seed(42)
+
+    # input
+    arg_dict["hidden_state"] = torch.randn((batch_size, mk.HIDDEN_SIZE), dtype=torch.float16)
+    arg_dict["residual"] = torch.randn((batch_size, mk.HIDDEN_SIZE), dtype=torch.float16)
+    # intermediate buffer
+    arg_dict["gating_output"] = torch.zeros((batch_size, mk.NUM_EXPERTS), dtype=torch.float32)
+    arg_dict["topk_weights"] = torch.zeros(
+        (batch_size, mk.NUM_EXPERTS_PER_TOK), dtype=torch.float32
+    )
+    arg_dict["topk_indices"] = torch.zeros((batch_size, mk.NUM_EXPERTS_PER_TOK), dtype=torch.int32)
+    max_num_tokens_padded = get_max_num_tokens_padded(
+        batch_size, mk.NUM_EXPERTS_PER_TOK, mk.NUM_EXPERTS, mk.MOE_M_PAD_SIZE
+    )
+    arg_dict["sorted_token_ids"] = torch.zeros((max_num_tokens_padded,), dtype=torch.int32)
+    arg_dict["expert_ids"] = torch.zeros(
+        (max_num_tokens_padded // mk.MOE_M_PAD_SIZE,), dtype=torch.int32
+    )
+    arg_dict["num_valid_tokens"] = torch.zeros(
+        (max_num_tokens_padded // mk.MOE_M_PAD_SIZE,), dtype=torch.int32
+    )
+    arg_dict["num_tokens_post_pad"] = torch.zeros((1,), dtype=torch.int32)
+    arg_dict["cumsum_buffer"] = torch.zeros((mk.NUM_EXPERTS + 1,), dtype=torch.int32)
+    arg_dict["reordered_hidden_state"] = torch.zeros(
+        (max_num_tokens_padded, mk.HIDDEN_SIZE), dtype=torch.float16
+    )
+    arg_dict["gate_up_output"] = torch.zeros(
+        (max_num_tokens_padded, mk.INTERMEDIATE_SIZE * 2), dtype=torch.float16
+    )
+    arg_dict["silu_mul_output"] = torch.zeros(
+        (max_num_tokens_padded, mk.INTERMEDIATE_SIZE), dtype=torch.float16
+    )
+    arg_dict["topk_reduce_output"] = torch.zeros((batch_size, mk.HIDDEN_SIZE), dtype=torch.float16)
+
+    # weight initialization
+    if not hasattr(prepare_data, "weight_initialized"):
+        prepare_data.weight_initialized = True
+    else:
+        return arg_dict
+    arg_dict["gate_weight"] = _correct_weight_tensor_view(
+        torch.zeros((mk.world_size, mk.NUM_EXPERTS, mk.HIDDEN_SIZE), dtype=torch.float16).cuda()
+    )
+    torch.nn.init.xavier_normal_(arg_dict["gate_weight"], gain=1.0)
+    arg_dict["gate_weight"] = arg_dict["gate_weight"].cpu()
+    arg_dict["grp_gate_up_weight"] = _correct_weight_tensor_view(
+        torch.zeros(
+            (mk.world_size, mk.NUM_EXPERTS, mk.INTERMEDIATE_SIZE * 2, mk.HIDDEN_SIZE),
+            dtype=torch.float16,
+        ).cuda()
+    )
+    for i in range(mk.NUM_EXPERTS):
+        torch.nn.init.xavier_normal_(arg_dict["grp_gate_up_weight"][i], gain=1.0)
+    arg_dict["grp_gate_up_weight"] = arg_dict["grp_gate_up_weight"].cpu()
+    w1 = arg_dict["grp_gate_up_weight"]
+    arg_dict["grp_up_gate_weight"] = torch.cat(
+        (w1[:, mk.INTERMEDIATE_SIZE :, :], w1[:, : mk.INTERMEDIATE_SIZE, :]), dim=1
+    ).contiguous()
+    new_order_indices = np.stack(
+        (
+            np.arange(mk.INTERMEDIATE_SIZE).reshape(-1, 16),
+            np.arange(mk.INTERMEDIATE_SIZE, mk.INTERMEDIATE_SIZE * 2).reshape(-1, 16),
+        ),
+        axis=1,
+    ).reshape(-1)
+    arg_dict["shuffled_grp_gate_up_weight"] = arg_dict["grp_gate_up_weight"][
+        :, new_order_indices, :
+    ]
+
+    arg_dict["grp_down_weight"] = _correct_weight_tensor_view(
+        torch.zeros(
+            (mk.world_size, mk.NUM_EXPERTS, mk.HIDDEN_SIZE, mk.INTERMEDIATE_SIZE),
+            dtype=torch.float16,
+        ).cuda()
+    )
+    for i in range(mk.NUM_EXPERTS):
+        torch.nn.init.xavier_normal_(arg_dict["grp_down_weight"][i], gain=1.0)
+    arg_dict["grp_down_weight"] = arg_dict["grp_down_weight"].cpu()
+    print("end prepare data", flush=True)
+    return arg_dict
+
+
+def _require_cuda_sm100():
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA is required for MegaKernelMOE")
+    if torch.cuda.get_device_capability()[0] < 10:
+        raise SkipTest("MegaKernelMOE requires SM100 or newer")
+    if not tvm.cuda(0).exist:
+        raise SkipTest("TVM CUDA device 0 is not available")
+    return torch
+
+
+def _reset_prepare_data_cache():
+    arg_dict.clear()
+    if hasattr(prepare_data, "weight_initialized"):
+        delattr(prepare_data, "weight_initialized")
+
+
+def _check_scheduler(scheduler: str):
+    if scheduler not in _SUPPORTED_SCHEDULERS:
+        raise ValueError(
+            f"Unsupported scheduler {scheduler!r}; expected one of {_SUPPORTED_SCHEDULERS}"
+        )
+
+
+def _compile_moe_schedulers(
+    schedulers: tuple[str, ...], batch_size: int, world_size: int, profiler_on: bool
+) -> tuple[MegaKernelMOE, dict[str, tvm.runtime.Module]]:
+    if world_size != 1:
+        raise SkipTest("tirx-kernels MegaKernelMOE benchmark currently supports world_size=1")
+    for scheduler in schedulers:
+        _check_scheduler(scheduler)
+
+    key = (schedulers, batch_size, world_size, profiler_on)
+    cached = _COMPILE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    mk = MegaKernelMOE(
+        config=MEGAKERNEL_MOE_BENCH_CONFIG, world_size=world_size, profiler_on=profiler_on
+    )
+    mk._compile_batch_size = batch_size
+    libs = {}
+    for scheduler in schedulers:
+        _, libs[scheduler] = get_source(mk.get_module(scheduler))
+    _COMPILE_CACHE[key] = (mk, libs)
+    return mk, libs
+
+
+def _as_tvm_tensor(value, dev):
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().contiguous().numpy()
+    return tvm.runtime.tensor(value, dev)
+
+
+def _as_cuda_tensor(value):
+    if isinstance(value, torch.Tensor):
+        return value.detach().cuda()
+    return torch.from_numpy(np.asarray(value)).cuda()
+
+
+def _make_tir_case(
+    *,
+    batch_size: int,
+    mk: MegaKernelMOE,
+    lib: tvm.runtime.Module,
+    scheduler: str,
+    data: dict[str, torch.Tensor],
+    launch_slots: int,
+):
+    dev = tvm.cuda(0)
+    max_num_tokens_padded = get_max_num_tokens_padded(
+        batch_size, mk.NUM_EXPERTS_PER_TOK, mk.NUM_EXPERTS, mk.MOE_M_PAD_SIZE
+    )
+    case = {
+        "kernel": lib["main"],
+        "scheduler": scheduler,
+        "cursor": 0,
+        "launch_slots": launch_slots,
+        "hidden_state": _as_tvm_tensor(data["hidden_state"], dev),
+        "output": tvm.runtime.tensor(np.zeros((batch_size, mk.HIDDEN_SIZE), dtype=np.float16), dev),
+        "gate_weight": _as_tvm_tensor(data["gate_weight"], dev),
+        "shuffled_grp_gate_up_weight": _as_tvm_tensor(data["shuffled_grp_gate_up_weight"], dev),
+        "grp_down_weight": _as_tvm_tensor(data["grp_down_weight"], dev),
+        "topk_weights": _as_tvm_tensor(data["topk_weights"], dev),
+        "topk_indices": _as_tvm_tensor(data["topk_indices"], dev),
+        "sorted_token_ids": _as_tvm_tensor(data["sorted_token_ids"], dev),
+        "expert_ids": _as_tvm_tensor(data["expert_ids"], dev),
+        "num_valid_tokens": _as_tvm_tensor(data["num_valid_tokens"], dev),
+        "num_tokens_post_pad": _as_tvm_tensor(data["num_tokens_post_pad"], dev),
+        "cumsum_buffer": _as_tvm_tensor(data["cumsum_buffer"], dev),
+        "reordered_hidden_state": _as_tvm_tensor(data["reordered_hidden_state"], dev),
+        "gate_up_output": _as_tvm_tensor(data["gate_up_output"], dev),
+        "silu_mul_output": _as_tvm_tensor(data["silu_mul_output"], dev),
+        "etensor_workspace": tvm.runtime.tensor(
+            np.zeros([mk.ETENSOR_WORKSPACE_SIZE], dtype=np.int32), dev
+        ),
+        "profiler_buffer": tvm.runtime.tensor(
+            np.zeros([mk.PROFILER_BUFFER_SIZE], dtype=np.uint64), dev
+        ),
+        "residual": [],
+        "gating_output": [],
+        "topk_reduce_output": [],
+        "graph_reset": {
+            "residual_source": _as_cuda_tensor(data["residual"]),
+            "residual": [],
+            "gating_output": [],
+            "topk_reduce_output": [],
+        },
+    }
+    for name in (
+        "output",
+        "topk_weights",
+        "topk_indices",
+        "sorted_token_ids",
+        "expert_ids",
+        "num_valid_tokens",
+        "num_tokens_post_pad",
+        "cumsum_buffer",
+        "reordered_hidden_state",
+        "gate_up_output",
+        "silu_mul_output",
+        "etensor_workspace",
+        "profiler_buffer",
+    ):
+        case["graph_reset"].setdefault("zero", []).append(torch.from_dlpack(case[name]))
+
+    for _ in range(launch_slots):
+        residual = _as_tvm_tensor(data["residual"], dev)
+        gating_output = _as_tvm_tensor(data["gating_output"], dev)
+        topk_reduce_output = _as_tvm_tensor(data["topk_reduce_output"], dev)
+        case["residual"].append(residual)
+        case["gating_output"].append(gating_output)
+        case["topk_reduce_output"].append(topk_reduce_output)
+        case["graph_reset"]["residual"].append(torch.from_dlpack(residual))
+        case["graph_reset"]["gating_output"].append(torch.from_dlpack(gating_output))
+        case["graph_reset"]["topk_reduce_output"].append(torch.from_dlpack(topk_reduce_output))
+
+    if scheduler in _STATIC_QUEUE_SCHEDULERS:
+        exec_queue = generate_exec_queue_moe(
+            batch_size, mk.config, mk.num_etensors[False], "static"
+        )
+        case["exec_queue"] = tvm.runtime.tensor(exec_queue, dev)
+    else:
+        exec_queue = generate_exec_queue_moe(
+            batch_size, mk.config, mk.num_etensors[True], "dynamic"
+        )
+        case["queue_tasks"] = []
+        case["queue_head"] = []
+        case["queue_tail"] = []
+        case["graph_reset"].update(
+            {
+                "queue_tasks_source": _as_cuda_tensor(exec_queue.tasks.copy()),
+                "queue_head_source": _as_cuda_tensor(exec_queue.head.copy()),
+                "queue_tail_source": _as_cuda_tensor(exec_queue.tail.copy()),
+                "queue_tasks": [],
+                "queue_head": [],
+                "queue_tail": [],
+            }
+        )
+        for _ in range(launch_slots):
+            queue_tasks = tvm.runtime.tensor(exec_queue.tasks.copy(), dev)
+            queue_head = tvm.runtime.tensor(exec_queue.head.copy(), dev)
+            queue_tail = tvm.runtime.tensor(exec_queue.tail.copy(), dev)
+            case["queue_tasks"].append(queue_tasks)
+            case["queue_head"].append(queue_head)
+            case["queue_tail"].append(queue_tail)
+            case["graph_reset"]["queue_tasks"].append(torch.from_dlpack(queue_tasks))
+            case["graph_reset"]["queue_head"].append(torch.from_dlpack(queue_head))
+            case["graph_reset"]["queue_tail"].append(torch.from_dlpack(queue_tail))
+
+    byte_tensors = [
+        case["hidden_state"],
+        case["output"],
+        case["gate_weight"],
+        case["shuffled_grp_gate_up_weight"],
+        case["grp_down_weight"],
+        case["topk_weights"],
+        case["topk_indices"],
+        case["sorted_token_ids"],
+        case["expert_ids"],
+        case["num_valid_tokens"],
+        case["num_tokens_post_pad"],
+        case["cumsum_buffer"],
+        case["reordered_hidden_state"],
+        case["gate_up_output"],
+        case["silu_mul_output"],
+        case["etensor_workspace"],
+        case["profiler_buffer"],
+        case["residual"][0],
+        case["gating_output"][0],
+        case["topk_reduce_output"][0],
+    ]
+    if scheduler in _STATIC_QUEUE_SCHEDULERS:
+        byte_tensors.append(case["exec_queue"])
+    else:
+        byte_tensors.extend([case["queue_tasks"][0], case["queue_head"][0], case["queue_tail"][0]])
+    case["byte_tensors"] = byte_tensors
+    case["max_num_tokens_padded"] = max_num_tokens_padded
+    return case
+
+
+def _reset_tir_case_for_cuda_graph(case):
+    idx = case["cursor"]
+    if idx >= case["launch_slots"]:
+        raise RuntimeError(
+            f"MegaKernelMOE {case['scheduler']} benchmark exhausted launch slots "
+            f"({case['launch_slots']}); increase launch-slot capacity"
+        )
+
+    reset = case["graph_reset"]
+    for tensor in reset.get("zero", []):
+        tensor.zero_()
+    reset["residual"][idx].copy_(reset["residual_source"])
+    reset["gating_output"][idx].zero_()
+    reset["topk_reduce_output"][idx].zero_()
+    if case["scheduler"] not in _STATIC_QUEUE_SCHEDULERS:
+        reset["queue_tasks"][idx].copy_(reset["queue_tasks_source"])
+        reset["queue_head"][idx].copy_(reset["queue_head_source"])
+        reset["queue_tail"][idx].copy_(reset["queue_tail_source"])
+
+
+def _run_tir_case(case):
+    idx = case["cursor"]
+    if idx >= case["launch_slots"]:
+        raise RuntimeError(
+            f"MegaKernelMOE {case['scheduler']} benchmark exhausted launch slots "
+            f"({case['launch_slots']}); increase launch-slot capacity"
+        )
+    kernel = case["kernel"]
+    if case["scheduler"] in _STATIC_QUEUE_SCHEDULERS:
+        kernel(
+            case["hidden_state"],
+            case["residual"][idx],
+            case["output"],
+            case["gate_weight"],
+            case["shuffled_grp_gate_up_weight"],
+            case["grp_down_weight"],
+            case["gating_output"][idx],
+            case["topk_weights"],
+            case["topk_indices"],
+            case["sorted_token_ids"],
+            case["expert_ids"],
+            case["num_valid_tokens"],
+            case["num_tokens_post_pad"],
+            case["cumsum_buffer"],
+            case["reordered_hidden_state"],
+            case["gate_up_output"],
+            case["silu_mul_output"],
+            case["topk_reduce_output"][idx],
+            case["etensor_workspace"],
+            case["exec_queue"],
+            case["profiler_buffer"],
+        )
+    else:
+        kernel(
+            case["hidden_state"],
+            case["residual"][idx],
+            case["output"],
+            case["gate_weight"],
+            case["shuffled_grp_gate_up_weight"],
+            case["grp_down_weight"],
+            case["gating_output"][idx],
+            case["topk_weights"],
+            case["topk_indices"],
+            case["sorted_token_ids"],
+            case["expert_ids"],
+            case["num_valid_tokens"],
+            case["num_tokens_post_pad"],
+            case["cumsum_buffer"],
+            case["reordered_hidden_state"],
+            case["gate_up_output"],
+            case["silu_mul_output"],
+            case["topk_reduce_output"][idx],
+            case["etensor_workspace"],
+            case["queue_tasks"][idx],
+            case["queue_head"][idx],
+            case["queue_tail"][idx],
+            case["profiler_buffer"],
+        )
+    case["cursor"] += 1
+    case["last_output"] = case["topk_reduce_output"][idx]
+    return case["last_output"]
+
+
+def _ensure_reference_cuda_case(case, mk: MegaKernelMOE):
+    ref_case = case.get("reference_cuda")
+    if ref_case is not None:
+        return ref_case
+
+    cpu_data = case["cpu_data"]
+    ref_case = {
+        key: cpu_data[key].clone().cuda()
+        for key in (
+            "hidden_state",
+            "gate_weight",
+            "grp_gate_up_weight",
+            "grp_up_gate_weight",
+            "grp_down_weight",
+        )
+    }
+    ref_case["hidden_state_router"] = ref_case["hidden_state"].to(torch.float32)
+    ref_case["gate_weight_router"] = ref_case["gate_weight"].to(torch.float32)
+    ref_case["baseline_gating_output"] = torch.empty(
+        (case["batch_size"], mk.NUM_EXPERTS), dtype=torch.float32, device="cuda"
+    )
+    ref_case["baseline_topk_weights"] = torch.empty(
+        (case["batch_size"], mk.NUM_EXPERTS_PER_TOK), dtype=torch.float32, device="cuda"
+    )
+    ref_case["baseline_topk_indices_i64"] = torch.empty(
+        (case["batch_size"], mk.NUM_EXPERTS_PER_TOK), dtype=torch.int64, device="cuda"
+    )
+    ref_case["baseline_topk_indices"] = torch.empty(
+        (case["batch_size"], mk.NUM_EXPERTS_PER_TOK), dtype=torch.int32, device="cuda"
+    )
+    case["reference_cuda"] = ref_case
+    return ref_case
+
+
+def _compute_reference_routing(ref_case, mk: MegaKernelMOE):
+    torch.mm(
+        ref_case["hidden_state_router"],
+        ref_case["gate_weight_router"].T,
+        out=ref_case["baseline_gating_output"],
+    )
+    routing_weights = torch.softmax(ref_case["baseline_gating_output"], dim=-1, dtype=torch.float32)
+    torch.topk(
+        routing_weights,
+        mk.NUM_EXPERTS_PER_TOK,
+        dim=-1,
+        out=(ref_case["baseline_topk_weights"], ref_case["baseline_topk_indices_i64"]),
+    )
+    ref_case["baseline_topk_indices"].copy_(ref_case["baseline_topk_indices_i64"])
+    return (
+        ref_case["baseline_gating_output"],
+        ref_case["baseline_topk_weights"],
+        ref_case["baseline_topk_indices"],
+    )
+
+
+def _build_sglang_full_reference(mk: MegaKernelMOE):
+    try:
+        import importlib
+        import os
+
+        os.environ.setdefault(
+            "SGLANG_MOE_CONFIG_DIR", os.path.join(os.path.dirname(__file__), "sglang_moe_configs")
+        )
+
+        triton_compiler = importlib.import_module("triton.compiler.compiler")
+        if not hasattr(triton_compiler, "triton_key"):
+            triton_key = triton_compiler.get_cache_key.__globals__.get("triton_key")
+            if triton_key is not None:
+                triton_compiler.triton_key = triton_key
+
+        from sglang.srt.layers.moe import MoeRunnerConfig
+        from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import fused_moe
+        from sglang.srt.layers.moe.topk import StandardTopKOutput
+        from sglang.srt.runtime_context import get_server_args
+        from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+    except (ImportError, AttributeError) as err:
+        raise RuntimeError(f"sglang full MoE reference is unavailable: {err}") from err
+
+    try:
+        get_server_args()
+    except ValueError:
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    moe_config = MoeRunnerConfig(
+        num_experts=mk.NUM_EXPERTS,
+        num_local_experts=mk.NUM_EXPERTS,
+        hidden_size=mk.HIDDEN_SIZE,
+        intermediate_size_per_partition=mk.INTERMEDIATE_SIZE,
+        top_k=mk.NUM_EXPERTS_PER_TOK,
+        params_dtype=torch.float16,
+        inplace=False,
+    )
+
+    def run(case):
+        ref_case = _ensure_reference_cuda_case(case, mk)
+        gating_output, topk_weights, topk_indices = _compute_reference_routing(ref_case, mk)
+        topk_output = StandardTopKOutput(
+            topk_weights=topk_weights, topk_ids=topk_indices, router_logits=gating_output
+        )
+        out = fused_moe(
+            ref_case["hidden_state"],
+            ref_case["grp_gate_up_weight"],
+            ref_case["grp_down_weight"],
+            topk_output,
+            moe_config,
+        )
+        ref_case["sglang_full_output"] = out
+        return out
+
+    return run
+
+
+def _build_flashinfer_full_reference(
+    batch_size: int, mk: MegaKernelMOE, *, tune: bool | None = None
+):
+    try:
+        import os
+
+        import flashinfer.fused_moe as fused_moe_lib
+        from flashinfer.autotuner import autotune
+    except ImportError as err:
+        raise RuntimeError(f"flashinfer full MoE reference is unavailable: {err}") from err
+
+    tune_mode = (
+        os.environ.get("TIRX_MEGAKERNEL_MOE_FLASHINFER_AUTOTUNE", "1") != "0"
+        if tune is None
+        else tune
+    )
+    tune_cache = os.environ.get(
+        "TIRX_MEGAKERNEL_MOE_FLASHINFER_CACHE",
+        os.path.expanduser("~/.cache/tirx-kernels/megakernel_moe_flashinfer_cutlass.json"),
+    )
+    tune_cache_dir = os.path.dirname(tune_cache)
+    if tune_cache_dir:
+        os.makedirs(tune_cache_dir, exist_ok=True)
+
+    tuned = False
+
+    def run_cutlass(ref_case, topk_weights, topk_indices, out):
+        fused_moe_lib.cutlass_fused_moe(
+            ref_case["hidden_state"],
+            topk_indices,
+            topk_weights,
+            ref_case["grp_up_gate_weight"],
+            ref_case["grp_down_weight"],
+            ref_case["hidden_state"].dtype,
+            quant_scales=[],
+            output=out,
+            tune_max_num_tokens=batch_size,
+        )
+
+    def run(case):
+        nonlocal tuned
+        ref_case = _ensure_reference_cuda_case(case, mk)
+        _, topk_weights, topk_indices = _compute_reference_routing(ref_case, mk)
+        out = ref_case.get("flashinfer_full_output")
+        if out is None:
+            out = torch.zeros_like(ref_case["hidden_state"])
+            ref_case["flashinfer_full_output"] = out
+
+        if not tuned:
+            with (
+                torch.inference_mode(),
+                autotune(tune_mode, cache=tune_cache, tuning_buckets=(batch_size,), round_up=True),
+            ):
+                run_cutlass(ref_case, topk_weights, topk_indices, out)
+            tuned = True
+        else:
+            with torch.inference_mode():
+                run_cutlass(ref_case, topk_weights, topk_indices, out)
+        return out
+
+    return run
+
+
+def _run_tir_case_and_check_finite(case):
+    out = _run_tir_case(case["tir"]).numpy()
+    if not np.isfinite(out).all():
+        raise AssertionError("MegaKernelMOE TIR output contains non-finite values")
+    return out
+
+
+def _validate_tir_matches_reference(case, reference_output):
+    out = case["tir"].get("last_output")
+    if out is None:
+        out_np = _run_tir_case_and_check_finite(case)
+    else:
+        out_np = out.numpy()
+    ref_np = reference_output.detach().cpu().numpy()
+    np.testing.assert_allclose(out_np, ref_np, rtol=2e-2, atol=1e-2)
+    abs_diff = np.abs(out_np.astype(np.float32) - ref_np.astype(np.float32))
+    return {
+        "allclose_rtol": 2e-2,
+        "allclose_atol": 1e-2,
+        "max_abs": float(abs_diff.max(initial=0.0)),
+        "mean_abs": float(abs_diff.mean()),
+        "numel": int(abs_diff.size),
+    }
+
+
+def run_test(
+    batch_size: int, scheduler: str | None = None, world_size: int = 1, profiler_on: bool = False
+):
+    _require_cuda_sm100()
+    schedulers = (scheduler,) if scheduler is not None else _SUPPORTED_SCHEDULERS
+    for scheduler_name in schedulers:
+        _check_scheduler(scheduler_name)
+    mk, libs = _compile_moe_schedulers(tuple(schedulers), batch_size, world_size, profiler_on)
+
+    _reset_prepare_data_cache()
+    data = dict(prepare_data(batch_size, mk))
+    case = {"batch_size": batch_size, "cpu_data": data}
+    tir_cases = {
+        scheduler_name: _make_tir_case(
+            batch_size=batch_size,
+            mk=mk,
+            lib=libs[scheduler_name],
+            scheduler=scheduler_name,
+            data=data,
+            launch_slots=2,
+        )
+        for scheduler_name in schedulers
+    }
+
+    for scheduler_name in schedulers:
+        _run_tir_case_and_check_finite({**case, "tir": tir_cases[scheduler_name]})
+
+    flashinfer_output = _build_flashinfer_full_reference(batch_size, mk, tune=False)(case)
+    for scheduler_name in schedulers:
+        validation_case = {**case, "tir": tir_cases[scheduler_name]}
+        _validate_tir_matches_reference(validation_case, flashinfer_output)
+    torch.cuda.synchronize()
+
+
+def _estimate_tir_runtime_us(case) -> float:
+    _run_tir_case(case)
+    torch.cuda.synchronize()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(5):
+        _run_tir_case(case)
+    end_event.record()
+    torch.cuda.synchronize()
+    return max(start_event.elapsed_time(end_event) * 1000.0 / 5.0, 1.0)
+
+
+def _estimate_bench_launch_slots(
+    runtime_us: float, warmup: int | None, repeat: int | None, rounds: int, preflight_launches: int
+) -> int:
+    """Reserve enough pre-zeroed slots for the pure-launch bench loop.
+
+    The current MoE kernel uses reductions into output workspaces, so the timed
+    closure must not reuse a workspace slot unless it has been reset outside the
+    timed region.  The new Triton-style bench API takes warmup/repeat as
+    millisecond budgets, not fixed iteration counts.  This estimate is only for
+    workspace capacity; the actual benchmark protocol remains owned by
+    ``tvm.tirx.bench.bench``.
+    """
+    warmup_budget_ms = 25 if warmup is None else warmup
+    repeat_budget_ms = 100 if repeat is None else repeat
+    estimate_ms = max(runtime_us / 1000.0, 1e-6)
+    n_warmup = max(1, int(warmup_budget_ms / estimate_ms))
+    n_repeat = max(1, int(repeat_budget_ms / estimate_ms))
+    # bench() calls fn() once, then runs a five-call estimate before the warmup
+    # and timed loops.  Its independent runtime estimate can be faster than this
+    # allocation probe, so reserve proportional headroom for the budget-derived
+    # loop counts without changing the benchmark protocol itself.
+    budget_launches = math.ceil((n_warmup + n_repeat) * _BENCH_LAUNCH_SLOT_HEADROOM)
+    return preflight_launches + rounds * (1 + 5 + budget_launches) + 16
+
+
+def run_bench(
+    batch_size: int,
+    scheduler: str | None = None,
+    world_size: int = 1,
+    profiler_on: bool = False,
+    warmup: int | None = None,
+    repeat: int | None = None,
+    timer: str | None = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **kwargs,
+):
+    _require_cuda_sm100()
+    from tvm.tirx.bench import bench
+
+    schedulers = (scheduler,) if scheduler is not None else _SUPPORTED_SCHEDULERS
+    for scheduler_name in schedulers:
+        _check_scheduler(scheduler_name)
+    mk, libs = _compile_moe_schedulers(tuple(schedulers), batch_size, world_size, profiler_on)
+
+    _reset_prepare_data_cache()
+    data = dict(prepare_data(batch_size, mk))
+    case = {"batch_size": batch_size, "cpu_data": data}
+    launch_slots: dict[str, int] = {}
+    tir_runtime_estimate_us: dict[str, float] = {}
+
+    for scheduler_name in schedulers:
+        probe_case = _make_tir_case(
+            batch_size=batch_size,
+            mk=mk,
+            lib=libs[scheduler_name],
+            scheduler=scheduler_name,
+            data=data,
+            launch_slots=8,
+        )
+        tir_runtime_estimate_us[scheduler_name] = _estimate_tir_runtime_us(probe_case)
+        launch_slots[scheduler_name] = _estimate_bench_launch_slots(
+            tir_runtime_estimate_us[scheduler_name], warmup, repeat, rounds, preflight_launches=1
+        )
+        if timer == "cudagraph_proton":
+            launch_slots[scheduler_name] *= 4
+        del probe_case
+    torch.cuda.empty_cache()
+
+    tir_cases = {
+        scheduler_name: _make_tir_case(
+            batch_size=batch_size,
+            mk=mk,
+            lib=libs[scheduler_name],
+            scheduler=scheduler_name,
+            data=data,
+            launch_slots=launch_slots[scheduler_name],
+        )
+        for scheduler_name in schedulers
+    }
+    for scheduler_name in schedulers:
+        validation_case = {**case, "tir": tir_cases[scheduler_name]}
+        _run_tir_case_and_check_finite(validation_case)
+
+    sglang_runner = None
+    flashinfer_runner = None
+    validation = {}
+
+    def build_sglang_full():
+        nonlocal sglang_runner
+        if sglang_runner is None:
+            runner = _build_sglang_full_reference(mk)
+
+            def run():
+                return runner(case)
+
+            sglang_runner = run
+        return sglang_runner
+
+    def build_flashinfer_full():
+        nonlocal flashinfer_runner
+        if flashinfer_runner is None:
+            runner = _build_flashinfer_full_reference(batch_size, mk)
+
+            def run():
+                return runner(case)
+
+            flashinfer_runner = run
+        return flashinfer_runner
+
+    def make_tir_runner(tir_case):
+        def run_tir():
+            return _run_tir_case(tir_case)
+
+        run_tir.graph_reset = lambda: _reset_tir_case_for_cuda_graph(tir_case)
+        return run_tir
+
+    tir_impls = {
+        ("tir" if scheduler is not None else f"tir_{scheduler_name}"): make_tir_runner(
+            tir_cases[scheduler_name]
+        )
+        for scheduler_name in schedulers
+    }
+
+    result = bench(
+        tir_impls,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"sglang_full": build_sglang_full, "flashinfer_full": build_flashinfer_full},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+        **kwargs,
+    )
+
+    baseline_errors = result.get("errors") or {}
+    if baseline_errors:
+        details = "; ".join(f"{name}: {error}" for name, error in baseline_errors.items())
+        raise RuntimeError(f"MegaKernelMOE benchmark requires both full references: {details}")
+    if sglang_runner is None or flashinfer_runner is None:
+        raise RuntimeError("MegaKernelMOE benchmark requires both full references")
+
+    sglang_output = sglang_runner()
+    flashinfer_output = flashinfer_runner()
+    for scheduler_name in schedulers:
+        impl_name = "tir" if scheduler is not None else f"tir_{scheduler_name}"
+        validation_case = {**case, "tir": tir_cases[scheduler_name]}
+        validation[f"{impl_name}_vs_flashinfer_full"] = _validate_tir_matches_reference(
+            validation_case, flashinfer_output
+        )
+        validation[f"{impl_name}_vs_sglang_full"] = _validate_tir_matches_reference(
+            validation_case, sglang_output
+        )
+
+    result.setdefault("metadata", {})
+    result["metadata"].update(
+        {
+            "scheduler": scheduler if scheduler is not None else "all",
+            "schedulers": list(schedulers),
+            "our_impls": list(tir_impls),
+            "batch_size": batch_size,
+            "world_size": world_size,
+            "config": MEGAKERNEL_MOE_BENCH_CONFIG["CONFIG_NAME"],
+            "benchmark_scope": "full_moe_router_plus_expert",
+            "sglang_router": "torch_fp32_mm_softmax_topk",
+            "sglang_weight_layout": "grp_gate_up_weight",
+            "flashinfer_router": "torch_fp32_mm_softmax_topk",
+            "flashinfer_weight_layout": "grp_up_gate_weight",
+            "launch_slots": launch_slots if scheduler is None else launch_slots[scheduler],
+            "tir_runtime_estimate_us": (
+                tir_runtime_estimate_us if scheduler is None else tir_runtime_estimate_us[scheduler]
+            ),
+        }
+    )
+    if validation:
+        result["metadata"]["validation"] = validation
+    return result

--- a/tirx_kernels/megakernel/sglang_moe_configs/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_B200.json
+++ b/tirx_kernels/megakernel/sglang_moe_configs/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_B200.json
@@ -1,0 +1,66 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 4
+  },
+  "8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "128": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 8,
+    "num_stages": 3
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 5
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 4
+  },
+  "4096": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 4
+  }
+}

--- a/tirx_kernels/megakernel/sglang_moe_configs/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_B200_down.json
+++ b/tirx_kernels/megakernel/sglang_moe_configs/configs/triton_3_6_0/E=128,N=768,device_name=NVIDIA_B200_down.json
@@ -1,0 +1,74 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3,
+    "USE_TMA": true
+  },
+  "8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3,
+    "USE_TMA": true
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+    "USE_TMA": true
+  },
+  "128": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "USE_TMA": true
+  },
+  "512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+    "USE_TMA": true
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3,
+    "USE_TMA": true
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 4,
+    "USE_TMA": true
+  },
+  "4096": {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 2,
+    "USE_TMA": true
+  }
+}

--- a/tirx_kernels/megakernel/utils/__init__.py
+++ b/tirx_kernels/megakernel/utils/__init__.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Utility modules for megakernel."""
+
+from importlib import import_module
+from typing import Any
+
+_SUBMODULES = ("base", "config", "utils", "support", "static_scheduler", "dynamic_scheduler")
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SUBMODULES:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tirx_kernels/megakernel/utils/base.py
+++ b/tirx_kernels/megakernel/utils/base.py
@@ -1,0 +1,691 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Base abstract classes for megakernel."""
+
+import functools
+from typing import Literal
+
+import tvm
+from tvm.script import ir as I
+from tvm.script import tirx as T
+from tvm.tirx import Expr
+from tvm.tirx.bench import CudaProfiler
+from tvm.tirx.expr import Var
+
+from .config import KernelConfig, ProfileEventType
+from .utils import any_sync, f_init_const
+
+
+@T.meta_class
+class Tile:
+    """Abstract base class for megakernel tiles."""
+
+    need_init = True
+
+    @classmethod
+    def class_init(cls, smem_manager):
+        pass
+
+    @classmethod
+    def class_finalize(cls):
+        pass
+
+    def __init__(self):
+        self._instance_id = id(self)
+
+    def __str__(self):
+        class_name = self.__class__.__name__
+        return f"{class_name}-{self._instance_id:x}"
+
+    def init(self, smem_manager):
+        pass
+
+    def host_init(self):
+        pass
+
+    def run(self, m_idx, n_idx, k_idx):
+        raise NotImplementedError("run is not implemented")
+
+    def prefetch(self, m_idx, n_idx, k_idx):
+        raise NotImplementedError("prefetch is not implemented")
+
+
+@T.meta_class
+class Barriers:
+    """Mbarrier wrapper class"""
+
+    def __init__(self, smem_manager, pipe_depth, is_p2c, persistent=True):
+        self.smem_manager = smem_manager
+        self.init_phase = 0 if is_p2c else 1
+        self.pipe_depth = pipe_depth
+        self.persistent = persistent
+
+    def _alloc(self):
+        self.mbar = self.smem_manager.alloc(
+            (self.pipe_depth,), "uint64", method="persistent" if self.persistent else "shared"
+        )
+
+    @T.inline
+    def init(self, threads_num_wait):
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        self._alloc()
+        if self.pipe_depth == 1:
+            if tid == 0:
+                T.ptx.mbarrier.init(self.mbar.ptr_to([0]), threads_num_wait)
+        elif tid == 0:
+            for i in T.serial(self.pipe_depth):
+                T.ptx.mbarrier.init(self.mbar.ptr_to([i]), threads_num_wait)
+
+    @T.inline
+    def wait(self, idx, phase):
+        T.ptx.mbarrier.try_wait(self.mbar.ptr_to([idx]), self.init_phase ^ phase)
+
+
+@T.meta_class
+class SmemManager:
+    """Shared memory manager"""
+
+    def __init__(self, smem_max_bytes, chunk_size, ptr: Var, fusion_mode=False):
+        self.smem_max_bytes = smem_max_bytes
+        self.chunk_size = chunk_size
+        self.chunk_num = smem_max_bytes // chunk_size
+        assert self.chunk_num <= 32
+        self.ptr = ptr
+        self.reguler_pool_allocator = T.SMEMPool(ptr)
+        self.persistent_pool_allocator = T.SMEMPool(None if fusion_mode else ptr)
+        self.tiles = {}
+        self.runtime_tile_chunk_count = {}
+        self.bufs = {}
+        self.persistent_bufs = {}
+        self.cur_tile_name = ""
+        self.persistent_pool_allocator.move_base_to(self.chunk_size * self.chunk_num)
+        self.fusion_mode = fusion_mode
+        self._pool_allocators = {
+            "persistent": self.persistent_pool_allocator,
+            "shared": self.reguler_pool_allocator,
+            "exclusive": self.reguler_pool_allocator,
+        }
+
+    @property
+    def pool_allocator(self):
+        return self.reguler_pool_allocator
+
+    def _inner_alloc(self):
+        self.mbar = self.alloc((self.chunk_num,), "uint64", method="persistent")
+        self.shared_count = self.alloc((1,), "int32", method="persistent")
+        if self.fusion_mode:
+            self.cur_phase = T.alloc_local([1], "int32", scope="local.persistent")
+            self.reg_count = T.alloc_local([1], "int32", scope="local.persistent")
+        else:
+            self.cur_phase = T.alloc_local([1], "int32")
+            self.reg_count = T.alloc_local([1], "int32")
+
+    @T.inline
+    def init(self):
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        self.check_smem_well_formed(debug=False)
+        self._inner_alloc()
+        self.cur_phase[0] = 1
+        if tid == 0:
+            for i in T.serial(self.chunk_num):
+                T.ptx.mbarrier.init(self.mbar.ptr_to([i]), 1)
+            self.shared_count[0] = 0
+        T.tvm_storage_sync("shared")
+        T.ptx.fence.mbarrier_init()
+        T.ptx.fence.proxy_async("shared::cta")
+
+    def alloc(
+        self,
+        shape,
+        dtype="float32",
+        strides=None,
+        scope="shared.dyn",
+        align=1,
+        layout="default",
+        split=1,
+        method: Literal["shared", "exclusive", "persistent"] = "shared",
+    ):
+        assert "shared" in scope
+        pool_allocator = self._pool_allocators[method]
+        beg = pool_allocator.offset
+        if align > 0:
+            beg = (beg + align - 1) // align * align
+        if self.fusion_mode and method == "persistent":
+            scope = "shared.persistent"
+        buf = pool_allocator.alloc(shape, dtype, strides, scope, align, layout)
+        end = pool_allocator.offset
+        size = end - beg
+        assert size % split == 0
+        if method == "persistent":
+            self.persistent_bufs[buf] = (beg, end)
+        else:
+            if method == "shared":
+                assert len(self.tiles[self.cur_tile_name][1]["exclusive"]) == 0, (
+                    "Cannot use both shared and shared/exclusive methods at the same time"
+                )
+            elif method == "exclusive":
+                assert len(self.tiles[self.cur_tile_name][1]["shared"]) == 0, (
+                    "Cannot use both shared and shared/exclusive methods at the same time"
+                )
+            buf_info = (split, beg, size, method)
+            self.tiles[self.cur_tile_name][0] = max(
+                self.tiles[self.cur_tile_name][0], (end - 1) // self.chunk_size
+            )
+            self.tiles[self.cur_tile_name][1][method].append(buf_info)
+            self.bufs[buf] = buf_info
+            if method == "exclusive":
+                for split_idx in range(split):
+                    beg_chunk_id = (beg + size // split * split_idx) // self.chunk_size
+                    end_chunk_id = (beg + size // split * (split_idx + 1) - 1) // self.chunk_size
+                    for chunk_id in range(beg_chunk_id, end_chunk_id + 1):
+                        self.tiles[self.cur_tile_name][2][chunk_id] += 1
+        return buf
+
+    def check_smem_well_formed(self, debug=False):
+        for _, buf_info_dict, _ in self.tiles.values():
+            checked_exclusive = []
+            check_overlap = []
+            for method in ["shared", "exclusive"]:
+                for split, beg, size, _ in buf_info_dict[method]:
+                    end = beg + size
+                    assert end <= self.chunk_num * self.chunk_size
+                    for beg_other, end_other in check_overlap:
+                        assert beg >= end_other or beg_other >= end, (
+                            "Overlap detected in smem allocation"
+                        )
+                    check_overlap.append((beg, end))
+                    if method == "exclusive":
+                        for split_idx in range(split):
+                            beg_chunk_id = (beg + size // split * split_idx) // self.chunk_size
+                            end_chunk_id = (
+                                beg + size // split * (split_idx + 1) - 1
+                            ) // self.chunk_size
+                            for beg_id, end_id in checked_exclusive:
+                                assert beg_id > end_chunk_id or end_id < beg_chunk_id, (
+                                    "Exclusive chunk overlap detected"
+                                )
+                            checked_exclusive.append((beg_chunk_id, end_chunk_id))
+                    else:
+                        beg_chunk_id = beg // self.chunk_size
+                        end_chunk_id = (end - 1) // self.chunk_size
+                        checked_exclusive.append((beg_chunk_id, end_chunk_id))
+        for beg_persistent, end_persistent in self.persistent_bufs.values():
+            assert (
+                beg_persistent >= self.chunk_size * self.chunk_num
+                and end_persistent <= self.smem_max_bytes
+            )
+            for _, beg, size, _ in self.bufs.values():
+                assert beg >= end_persistent or beg_persistent >= beg + size
+        persistent_buf_list = list(self.persistent_bufs.values())
+        for i in range(len(persistent_buf_list)):
+            beg_i, end_i = persistent_buf_list[i]
+            for j in range(i + 1, len(persistent_buf_list)):
+                beg_j, end_j = persistent_buf_list[j]
+                assert beg_i >= end_j or beg_j >= end_i
+        if debug:
+            self._debug_print()
+
+    def _debug_print(self):
+        for k, v in self.tiles.items():
+            print(k, v)
+        for k, v in self.bufs.items():
+            print(k, v)
+        for k, v in self.persistent_bufs.items():
+            print(k, v)
+
+    def set_tile(self, cur_tile: Tile | None):
+        if cur_tile is None:
+            self.cur_tile_name = "default"
+        else:
+            self.cur_tile_name = str(cur_tile)
+        self.tiles[self.cur_tile_name] = [
+            -1,
+            {"exclusive": [], "shared": []},
+            [0 for _ in range(self.chunk_num)],
+        ]
+        self.runtime_tile_chunk_count[self.cur_tile_name] = [
+            [0 for _ in range(self.chunk_num)] for _ in range(2)
+        ]
+        self.reguler_pool_allocator.move_base_to(0)
+
+    def _assert_cond(self, cond):
+        assert cond
+
+    @T.inline
+    def advance(self):
+        self.cur_phase[0] = self.cur_phase[0] ^ 1
+
+    def enter_tile_runtime(self, cur_tile: Tile):
+        self.cur_tile_name = str(cur_tile)
+
+    def exit_tile_runtime(self):
+        self._check_runtime()
+        self.cur_tile_name = ""
+
+    def _check_runtime(self):
+        pass
+
+    @T.inline
+    def wait_all(self, level: Literal["cta", "warpgroup"] = "cta"):
+        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        if level == "cta":
+            if warp_id == 0:
+                if lane_id < self.chunk_num:
+                    T.ptx.mbarrier.try_wait(self.mbar.ptr_to([lane_id]), self.cur_phase[0])
+            T.tvm_storage_sync("shared")
+        elif level == "warpgroup":
+            if warp_id % KernelConfig.WARP_NUMBER == 0:
+                if lane_id < self.chunk_num:
+                    T.ptx.mbarrier.try_wait(self.mbar.ptr_to([lane_id]), self.cur_phase[0])
+            T.ptx.bar.sync(6 + wg_id, 128)
+
+    @T.inline
+    def wait_specific(self, lane_id, buffer, split_idx: int):
+        self._assert_cond(buffer in self.bufs and buffer not in self.persistent_bufs)
+        self._assert_cond(self.bufs[buffer][3] == "exclusive")
+        beg_chunk_id = (
+            self.bufs[buffer][1] + self.bufs[buffer][2] // self.bufs[buffer][0] * split_idx
+        ) // self.chunk_size
+        end_chunk_id = (
+            self.bufs[buffer][1]
+            + self.bufs[buffer][2] // self.bufs[buffer][0] * (split_idx + 1)
+            - 1
+        ) // self.chunk_size
+        if (lane_id >= beg_chunk_id) & (lane_id <= end_chunk_id):
+            T.ptx.mbarrier.try_wait(self.mbar.ptr_to([lane_id]), self.cur_phase[0])
+
+    @T.inline
+    def wait_unused(self, lane_id, cur_tile: Tile):
+        self._assert_cond(len(self.tiles[self.cur_tile_name][1]["shared"]) == 0)
+        if (lane_id < self.chunk_num) & (lane_id > self.tiles[str(cur_tile)][0]):
+            T.ptx.mbarrier.try_wait(self.mbar.ptr_to([lane_id]), self.cur_phase[0])
+
+    @T.inline
+    def wait_chunk(self, chunk_id):
+        T.ptx.mbarrier.try_wait(self.mbar.ptr_to([chunk_id]), self.cur_phase[0])
+
+    @T.inline
+    def wait_specific_one_thread(self, buffer, split_idx: int):
+        self._assert_cond(buffer in self.bufs and buffer not in self.persistent_bufs)
+        self._assert_cond(self.bufs[buffer][3] == "exclusive")
+        beg_chunk_id = (
+            self.bufs[buffer][1] + self.bufs[buffer][2] // self.bufs[buffer][0] * split_idx
+        ) // self.chunk_size
+        end_chunk_id = (
+            self.bufs[buffer][1]
+            + self.bufs[buffer][2] // self.bufs[buffer][0] * (split_idx + 1)
+            - 1
+        ) // self.chunk_size
+        for idx in T.serial(0, end_chunk_id - beg_chunk_id + 1):
+            T.ptx.mbarrier.try_wait(self.mbar.ptr_to([beg_chunk_id + idx]), self.cur_phase[0])
+
+    @T.inline
+    def arrive_all(self, level: Literal["cta", "warpgroup"] = "cta"):
+        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        if level == "cta":
+            T.tvm_storage_sync("shared")
+            if warp_id == 0:
+                if lane_id < self.chunk_num:
+                    T.ptx.mbarrier.arrive(self.mbar.ptr_to([lane_id]))
+        elif level == "warpgroup":
+            self.reg_count[0] = 0
+            T.ptx.bar.sync(6 + wg_id, 128)
+            if warp_id % KernelConfig.WARP_NUMBER == 0:
+                if lane_id == 0:
+                    self.reg_count[0] = T.cuda.atomic_add(T.address_of(self.shared_count[0]), 1) + 1
+                    if self.reg_count[0] == KernelConfig.WG_NUMBER:
+                        T.cuda.atomic_add(
+                            T.address_of(self.shared_count[0]), -KernelConfig.WG_NUMBER
+                        )
+                self.reg_count[0] = T.tvm_warp_shuffle(4294967295, self.reg_count[0], 0, 32, 32)
+                if self.reg_count[0] == KernelConfig.WG_NUMBER:
+                    if lane_id < self.chunk_num:
+                        T.ptx.mbarrier.arrive(self.mbar.ptr_to([lane_id]))
+
+    @T.inline
+    def arrive_specific(self, lane_id, buffer, split_idx: int):
+        self._assert_cond(buffer in self.bufs and buffer not in self.persistent_bufs)
+        self._assert_cond(self.bufs[buffer][3] == "exclusive")
+        beg_chunk_id = (
+            self.bufs[buffer][1] + self.bufs[buffer][2] // self.bufs[buffer][0] * split_idx
+        ) // self.chunk_size
+        end_chunk_id = (
+            self.bufs[buffer][1]
+            + self.bufs[buffer][2] // self.bufs[buffer][0] * (split_idx + 1)
+            - 1
+        ) // self.chunk_size
+        if (lane_id >= beg_chunk_id) & (lane_id <= end_chunk_id):
+            T.ptx.mbarrier.arrive(self.mbar.ptr_to([lane_id]))
+
+    @T.inline
+    def arrive_unused(self, lane_id, cur_tile: Tile):
+        self._assert_cond(len(self.tiles[self.cur_tile_name][1]["shared"]) == 0)
+        if (lane_id < self.chunk_num) & (lane_id > self.tiles[str(cur_tile)][0]):
+            T.ptx.mbarrier.arrive(self.mbar.ptr_to([lane_id]))
+
+    @T.inline
+    def arrive_chunk(self, chunk_id):
+        T.ptx.mbarrier.arrive(self.mbar.ptr_to([chunk_id]))
+
+
+@T.meta_class
+class SemaphoreBase:
+    """Abstract base class for semaphore."""
+
+    base = 1 << 16
+
+    def __init__(self):
+        pass
+
+    def semaphore_wait(self, *coord, level, mask):
+        raise NotImplementedError
+
+    def semaphore_notify(self, *coord, rank=-1):
+        raise NotImplementedError
+
+
+@T.meta_class
+class TileSchedulerBase:
+    """Abstract base class for tile schedulers."""
+
+    MAX_TASKS = 128
+
+    def __init__(self):
+        pass
+
+    def get_idx_and_task_type(self) -> tuple[list[Expr], Expr]:
+        raise NotImplementedError
+
+    @T.inline
+    def init(self):
+        raise NotImplementedError
+
+    @T.inline
+    def next_tile(self):
+        raise NotImplementedError
+
+    @T.inline
+    def wait(self, evt, *coord, wait_level, mask):
+        raise NotImplementedError
+
+    @T.inline
+    def notify(self, evt, func_notify, scope, scope_id, release):
+        raise NotImplementedError
+
+    @T.inline
+    def pre_notify_and_push(self, evt, func_notify, func_trigger_list, push_level, scope, scope_id):
+        pass
+
+    def valid(self):
+        raise NotImplementedError
+
+
+class InitETensorTile(Tile):
+    VEC_SIZE = 1
+
+    def __init__(self, etensor_and_f_init_pairs):
+        super().__init__()
+        self.etensor_and_f_init_pairs = etensor_and_f_init_pairs
+        self.total_num_etensors = len(etensor_and_f_init_pairs)
+
+    def convert_1d_index_to_nd(self, idx, shape):
+        nd_idx = []
+        for i in reversed(range(len(shape))):
+            nd_idx.append(idx % shape[i])
+            idx = idx // shape[i]
+        return list(reversed(nd_idx))
+
+    def run(self, m_idx, n_idx, k_idx):
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        if_frames = [T.If(m_idx == i) for i in range(self.total_num_etensors)]
+        then_frames = [T.Then() for i in range(self.total_num_etensors)]
+        else_frames = [T.Else() for i in range(self.total_num_etensors - 1)]
+        idx = T.alloc_local([1], "int32")
+        T.buffer_store(idx, tid * self.VEC_SIZE, [0])
+        for i in range(self.total_num_etensors):
+            if_frames[i].__enter__()
+            with then_frames[i]:
+                etensor, f_init = self.etensor_and_f_init_pairs[i]
+                if f_init is None:
+                    T.evaluate(0)
+                else:
+                    nelem = functools.reduce(lambda x, y: x * y, etensor.shape, 1)
+                    etensor_1d = etensor.view(-1)
+                    with T.While(idx[0] < nelem):
+                        with T.vectorized(self.VEC_SIZE) as v:
+                            T.buffer_store(
+                                etensor_1d,
+                                f_init(*self.convert_1d_index_to_nd(idx[0] + v, etensor.shape))
+                                * (SemaphoreBase.base + 1),
+                                idx[0] + v,
+                            )
+                        T.buffer_store(idx, idx[0] + KernelConfig.NUM_THREADS * self.VEC_SIZE, [0])
+            if i < self.total_num_etensors - 1:
+                else_frames[i].__enter__()
+        for i in range(self.total_num_etensors - 1, -1, -1):
+            if i < self.total_num_etensors - 1:
+                else_frames[i].__exit__(None, None, None)
+            if_frames[i].__exit__(None, None, None)
+
+
+class MegaKernelWrapper:
+    """Base class for megakernel wrappers."""
+
+    ETENSOR_WORKSPACE_SIZE = 1024 * 1024
+    NUM_GROUPS = KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER
+    PROFILER_BUFFER_SIZE = int(10000000.0)
+    PROFILER_WRITE_STRIDE = KernelConfig.SM_NUMBER * NUM_GROUPS
+
+    def __init__(self, config: dict = {}, tp_size: int = 1, profiler_on: bool = False):
+        self.tp_size = tp_size
+        self.config = config
+        self.profiler_on = profiler_on
+        self.tile_attr = {}
+        self.class_list = set()
+        self.etensor_and_f_init_pairs = []
+        self.num_etensors = {}
+        self.etensor_workspace_offset = 0
+
+    def _init_profiler(self, profiler_buffer):
+        if self.profiler_on:
+            self.profiler = CudaProfiler(
+                profiler_buffer, write_stride=self.PROFILER_WRITE_STRIDE, num_groups=self.NUM_GROUPS
+            )
+        else:
+            self.profiler = None
+
+    def _init_tile_scheduler(self, scheduler_class: type[TileSchedulerBase], *args):
+        self.tile_scheduler: TileSchedulerBase = scheduler_class(*args)
+
+    def _add_tile(self, tile, profiler_event_type, predicate=True):
+        self.tile_attr[tile] = (profiler_event_type, predicate)
+        self.class_list.add(tile.__class__)
+        return tile
+
+    @T.inline
+    def init_profiler(self, profiler_buffer):
+        self._init_profiler(profiler_buffer)
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        if self.profiler_on:
+            self.profiler.init(warp_id)
+
+    def set_smem_manager(self, smem_max_bytes, chunk_size, ptr: Var):
+        self.smem_manager = SmemManager(smem_max_bytes, chunk_size, ptr)
+
+    @T.inline
+    def init_tile_scheduler(self, is_dynamic_sch, scheduler_class, *args):
+        self._init_tile_scheduler(scheduler_class, *args)
+        self.tile_scheduler.init()
+        if is_dynamic_sch:
+            self.tile_scheduler.next_tile()
+
+    @T.inline
+    def run_tile(self, tile: Tile, *args, **kwargs):
+        event_type = T.meta_var(self.tile_attr[tile][0])
+        self.smem_manager.enter_tile_runtime(tile)
+        lane_id = T.lane_id([32])
+        if self.profiler_on:
+            self.profiler.start(event_type, lane_id == 0)
+        tile.run(*args, **kwargs)
+        if self.profiler_on:
+            self.profiler.end(event_type, lane_id == 0)
+
+    @T.inline
+    def run_tile_prefetch(self, tile: Tile, *args):
+        self.smem_manager.enter_tile_runtime(tile)
+        lane_id = T.lane_id([32])
+        if self.profiler_on:
+            self.profiler.start(ProfileEventType.PREFETCH, lane_id == 0)
+        tile.prefetch(*args)
+        if self.profiler_on:
+            self.profiler.end(ProfileEventType.PREFETCH, lane_id == 0)
+
+    def add_etensor(self, sem_class, etensor_workspace, shape, f_init):
+        size = functools.reduce(lambda x, y: x * y, shape, 1)
+        etensor_buffer = T.decl_buffer(
+            shape, "int32", etensor_workspace.data, elem_offset=self.etensor_workspace_offset
+        )
+        self.etensor_workspace_offset += size
+        etensor = sem_class(etensor_buffer)
+        self.etensor_and_f_init_pairs.append((etensor_buffer, f_init))
+        return etensor
+
+    def set_events_complete(
+        self, is_dynamic_sch, Semaphore: type[SemaphoreBase], etensor_workspace_global
+    ):
+        if not is_dynamic_sch:
+            num_evtensors = len(self.etensor_and_f_init_pairs)
+            self.evt_etensor_init_complete = self.add_etensor(
+                Semaphore,
+                etensor_workspace_global,
+                shape=[1],
+                f_init=f_init_const(num_evtensors + 1 + KernelConfig.SM_NUMBER),
+            )
+        else:
+            self.evt_etensor_init_complete = None
+        self.init_etensor_tile = self._add_tile(
+            InitETensorTile(self.etensor_and_f_init_pairs), ProfileEventType.INIT_ETENSOR
+        )
+
+    @T.inline
+    def task_impl_init_etensor(self, is_dynamic_sch):
+        self.run_tile(
+            self.init_etensor_tile,
+            self.tile_scheduler.m_idx,
+            self.tile_scheduler.n_idx,
+            self.tile_scheduler.k_idx,
+        )
+        if self.evt_etensor_init_complete is not None:
+            if self.tile_scheduler.m_idx < len(self.etensor_and_f_init_pairs):
+                self.tile_scheduler.notify(
+                    self.evt_etensor_init_complete,
+                    lambda notify_idx: (1, -1, 0),
+                    scope="cta",
+                    release=True,
+                )
+
+    @T.inline
+    def task_impl_wait_etensor_init_complete(self, is_dynamic_sch):
+        if not is_dynamic_sch:
+            warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+            lane_id = T.lane_id([32])
+            if self.profiler_on:
+                self.profiler.start(ProfileEventType.WAIT_ETENSOR_INIT, lane_id == 0)
+            state = T.alloc_local([1], "int32")
+            state[0] = -1
+            while 1:
+                if lane_id == 0:
+                    T.ptx.ld_global_acquire(
+                        state[0], self.evt_etensor_init_complete.sem.ptr_to([0])
+                    )
+                if any_sync(
+                    4294967295,
+                    state[0] <= KernelConfig.SM_NUMBER * (SemaphoreBase.base + 1) and state[0] > 0,
+                ):
+                    if (lane_id == 0) & (warp_id == 0):
+                        T.cuda.atomic_add(
+                            self.evt_etensor_init_complete.sem.ptr_to([0]),
+                            -(SemaphoreBase.base + 1),
+                        )
+                    break
+                T.cuda.nano_sleep(40)
+            if self.profiler_on:
+                self.profiler.end(ProfileEventType.WAIT_ETENSOR_INIT, lane_id == 0)
+
+    def reset(self):
+        self.tile_attr = {}
+        self.class_list = set()
+        self.etensor_and_f_init_pairs = []
+        self.etensor_workspace_offset = 0
+
+    def host_init_all(self):
+        for tile, (_, predicate) in self.tile_attr.items():
+            if predicate:
+                tile.host_init()
+
+    def class_init_all(self, smem_manager: SmemManager):
+        for cls in self.class_list:
+            if cls.need_init:
+                smem_manager.set_tile(cls)
+                cls.class_init(smem_manager)
+
+    def class_finalize_all(self):
+        for cls in self.class_list:
+            if cls.need_init:
+                cls.class_finalize()
+
+    def device_init_all(self, smem_manager: SmemManager):
+        for tile, (_, predicate) in self.tile_attr.items():
+            if predicate:
+                smem_manager.set_tile(tile)
+                tile.init(smem_manager)
+
+    def get_func_static(self, unfused=False):
+        raise NotImplementedError
+
+    def get_func_dynamic(self):
+        raise NotImplementedError
+
+    def get_func(self, scheduler: Literal["static", "dynamic", "unfused"]):
+        if scheduler == "static" or scheduler == "unfused":
+            return self.get_func_static(unfused=scheduler == "unfused")
+        elif scheduler == "dynamic":
+            return self.get_func_dynamic()
+        else:
+            raise ValueError(f"Unsupported scheduler: {scheduler}")
+
+    def get_module(self, scheduler: Literal["static", "dynamic", "unfused"]):
+        @I.ir_module
+        class Module:
+            @T.prim_func
+            def main():
+                pass
+
+        module: tvm.IRModule = Module
+        if scheduler == "static" or scheduler == "unfused":
+            module.update_func(
+                module.get_global_var("main"), self.get_func_static(unfused=scheduler == "unfused")
+            )
+        elif scheduler == "dynamic":
+            module.update_func(module.get_global_var("main"), self.get_func_dynamic())
+        else:
+            raise ValueError(f"Unsupported scheduler: {scheduler}")
+        return module

--- a/tirx_kernels/megakernel/utils/config.py
+++ b/tirx_kernels/megakernel/utils/config.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Configuration for megakernel."""
+
+from enum import Enum
+
+F16_BYTES = 2
+F32_BYTES = 4
+
+
+class KernelConfig:
+    # global constant
+    M_CLUSTER = 1
+    N_CLUSTER = 1
+    WG_NUMBER = 2
+    WARP_NUMBER = 4
+    NUM_THREADS = (32 * WARP_NUMBER) * WG_NUMBER
+    SM_NUMBER = 148
+    CTA_GROUP = M_CLUSTER
+    MAX_SMEM_SIZE = 232448
+
+
+class JobType(Enum):
+    MOE_GATING = 18
+    MOE_TOPK_SOFTMAX = 19
+    MOE_ALIGN = 20
+    MOE_COUNT_AND_SORT = 22
+    MOE_GROUP_GEMM_DOWN = 25
+    MOE_GROUP_GEMM_GATE_UP_SILU = 27
+    INIT_ETENSOR = 28
+    WAIT_ETENSOR_INIT = 29
+    END = 31
+
+
+class ProfileEventType(Enum):
+    FETCH = 5
+    PUSH = 20
+    PREFETCH = 26
+    TMA = 27
+    MMA = 28
+    MOE_GATING = 38
+    TOPK_SOFTMAX = 39
+    MOE_ALIGN = 40
+    COUNT_AND_SORT = 41
+    SILU_MUL = 43
+    GROUP_GEMM_DOWN = 44
+    GROUP_GEMM_GATE_UP_SILU = 51
+    INIT_ETENSOR = 52
+    WAIT_ETENSOR_INIT = 53
+    END = 54
+
+
+MEGAKERNEL_MOE_BENCH_CONFIG = {
+    "CONFIG_NAME": "moe_a3b",
+    "HIDDEN_SIZE": 2048,
+    "INTERMEDIATE_SIZE": 768,
+    "NUM_EXPERTS": 128,
+    "NUM_EXPERTS_PER_TOK": 8,
+    "GATING_SPLIT_K_FACTOR": 4,
+}

--- a/tirx_kernels/megakernel/utils/dynamic_scheduler.py
+++ b/tirx_kernels/megakernel/utils/dynamic_scheduler.py
@@ -1,0 +1,562 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Dynamic tile scheduler for megakernel."""
+
+from typing import Literal
+
+import numpy as np
+
+from tirx_kernels.megakernel.utils.base import Barriers, SemaphoreBase, TileSchedulerBase
+from tirx_kernels.megakernel.utils.config import JobType, KernelConfig, ProfileEventType
+from tirx_kernels.megakernel.utils.utils import (
+    any_sync,
+    atomic_add_int32,
+    gt,
+    pack_into_32bit,
+    stg,
+    sts,
+    unpack_from_32bit,
+    while_ld_global_acquire,
+)
+from tvm.script import tirx as T
+from tvm.tirx.bench import CudaProfiler
+
+# notes: The following applies to decrement=False. The logic for True is similar.
+#        For semaphore with expected count = expected_cnt, we set it actual count = expected_cnt * (base + 1).
+#        Here base >= expected_cnt is the power of 2 (for efficiency mod in the following and giving convenience for decrement=True).
+#        By default, the base will be set to 1 << 16.
+#        That means the semaphore will take in two args: Semaphore(expected_cnt, base). For decrement=True, we can set semaphore value in generation.
+#        In dynamic scheduling, the semaphore will be notified for two times.
+#        The first one happens after the prefetch of the tile but before the corresponding semaphore wait,
+#        which will atomic_add the semaphore value by 1.
+#        The second one happens after the tile running, which will atomic_add the semaphore value by base.
+#        The task pushing will happen after the first semaphore notify, which will be triggered by old_value % base == expected_cnt - 1.
+#        In this way, the tasks will be pre-push when the last tile has already been dispatched to the sm, which avoid the dead lock.
+#        For semaphore wait, we can still use the condition value == expected_cnt * (base + 1) to distinguish.
+
+
+class Semaphore(SemaphoreBase):
+    def __init__(self, buffer, debug=False):
+        self.sem = buffer
+        self.state = T.alloc_local([1], "int32")
+
+        # cta-level interface
+
+    @T.inline
+    def semaphore_wait(self, *coord, level: Literal["cta", "warp"] = "cta", mask=0xFFFFFFFF):
+        if level == "cta":
+            while 1:
+                T.ptx.ld_global_acquire(
+                    self.state[0], self.sem.access_ptr("r", offset=self.sem.elem_offset_of(coord))
+                )
+                if T.cuda.syncthreads_and(self.state[0] == 0):
+                    break
+                T.cuda.nano_sleep(40)
+        elif level == "warp":
+            warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+            lane_id = T.lane_id([32])
+            if (mask >> warp_id) & 1 == 1:
+                self.state[0] = -1
+                while 1:
+                    if lane_id == 0:
+                        T.ptx.ld_global_acquire(
+                            self.state[0],
+                            self.sem.access_ptr("r", offset=self.sem.elem_offset_of(coord)),
+                        )
+                    if any_sync(0xFFFFFFFF, self.state[0] == 0):
+                        break
+                    T.cuda.nano_sleep(40)
+        else:
+            assert False
+
+    @T.inline
+    def semaphore_notify(self, *coord, pre_notify=False, rank=-1, release=False):
+        number = T.meta_var(1 if pre_notify else self.base)
+        # the old value will be stored in self.state
+        self.state[0] = atomic_add_int32(self.sem.ptr_to(coord), -number, rank, release=release)
+        if self.state[0] <= 0:
+            while 1:
+                T.ptx.ld_global_acquire(self.state[0], self.sem.ptr_to(coord))
+                if gt(self.state[0], 0):
+                    self.state[0] = atomic_add_int32(
+                        self.sem.ptr_to(coord), -number, rank, release=release
+                    )
+                    break
+                sleep_time = T.meta_var(800 if pre_notify else 40)
+                T.cuda.nano_sleep(sleep_time)
+
+    def is_triggered(self):
+        return self.state[0] % self.base == 1
+
+
+class SchedulerBarrier(Barriers):
+    def __init__(self, smem_manager, is_p2c):
+        super().__init__(smem_manager, 1, is_p2c)
+
+    @T.inline
+    def arrive(self):
+        T.ptx.mbarrier.arrive(self.mbar.ptr_to([0]))
+
+
+@T.meta_class
+class MPMCQueue:
+    def __init__(
+        self,
+        capacity: int,
+        tasks: T.Buffer,
+        head: T.Buffer,
+        tail: T.Buffer,
+        smem_manager,
+        debug=False,
+    ):
+        # TODO: we currently assume that the queue is infinitely large.
+        if capacity & (capacity - 1):
+            raise ValueError("capacity must be a power-of-two")
+        self.capacity = capacity
+        self.mask = capacity - 1
+        self.tasks = tasks  # an array of (task_type, m_idx, n_idx, k_idx)
+        self.head = head
+        self.tail = tail
+        self.debug = debug
+        self.smem_manager = smem_manager
+
+    def _alloc(self):
+        self.head_r = T.local_scalar(dtype="int32")
+        self.tail_r = T.local_scalar(dtype="int32")
+        self.masked_pos = T.local_scalar(dtype="int32")
+        self.idx = T.local_scalar(dtype="int32")
+        self.tail_smem = self.smem_manager.alloc(
+            (KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER,), "int32", method="persistent"
+        )
+
+    @T.inline
+    def init(self):
+        self._alloc()
+
+    @T.inline
+    def enqueue(self, rank, func_push, level: Literal["thread", "warp", "warpgroup", "cta"]):
+        if level == "thread":
+            task_type, enqueue_num, m_idx, n_idx, k_idx = func_push(0)
+            if self.debug:
+                T.cuda.trap_when_assert_failed(enqueue_num == 1)  # notes: enqueue_num must be 1
+            self.tail_r = atomic_add_int32(
+                self.tail.access_ptr("rw", offset=self.tail.elem_offset_of([T.int32(0)])), 1, rank
+            )
+            self.masked_pos = self.tail_r & self.mask
+            task_info = T.meta_var(
+                pack_into_32bit(m_idx, n_idx, k_idx, task_type, host=False, debug=self.debug)
+            )
+            stg(
+                task_info,
+                self.tasks.access_ptr("rw", offset=self.tasks.elem_offset_of([self.masked_pos])),
+                rank,
+            )
+        else:
+            lane_id = T.lane_id([32])
+            tid_in_wg = T.thread_id_in_wg([KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER])
+            tid = T.thread_id([KernelConfig.NUM_THREADS])
+            wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+            warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+            idx_map = T.meta_var(
+                {
+                    "warp": (warp_id, lane_id, 32),
+                    "warpgroup": (
+                        wg_id,
+                        tid_in_wg,
+                        KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER,
+                    ),
+                    "cta": (0, tid, KernelConfig.NUM_THREADS),
+                }
+            )
+            scope_idx, tid_in_scope, tid_stride = idx_map[level]
+            enqueue_num = func_push(0)[1]
+            if level == "warp":
+                if tid_in_scope == 0:
+                    self.tail_r = atomic_add_int32(
+                        self.tail.access_ptr("rw", offset=self.tail.elem_offset_of([T.int32(0)])),
+                        enqueue_num,
+                        rank,
+                    )
+                self.tail_r = T.tvm_warp_shuffle(0xFFFFFFFF, self.tail_r, 0, 32, 32)
+            else:
+                if tid_in_scope == 0:
+                    self.tail_smem[scope_idx] = atomic_add_int32(
+                        self.tail.access_ptr("rw", offset=self.tail.elem_offset_of([T.int32(0)])),
+                        enqueue_num,
+                        rank,
+                    )
+                if level == "warpgroup":
+                    T.ptx.bar.sync(6 + wg_id, 128)
+                elif level == "cta":
+                    T.tvm_storage_sync("shared")
+                self.tail_r = self.tail_smem[scope_idx]
+
+            self.idx = tid_in_scope
+            while self.idx < enqueue_num:
+                self.masked_pos = (self.tail_r + self.idx) & self.mask
+                task_type, _, m_idx, n_idx, k_idx = func_push(self.idx)
+                task_info = T.meta_var(
+                    pack_into_32bit(m_idx, n_idx, k_idx, task_type, host=False, debug=self.debug)
+                )
+                stg(
+                    task_info,
+                    self.tasks.access_ptr(
+                        "rw", offset=self.tasks.elem_offset_of([self.masked_pos])
+                    ),
+                    rank,
+                )
+                self.idx += tid_stride
+
+    @T.inline
+    def dequeue(self, fetched_task_info):
+        self.head_r = T.cuda.atomic_add(
+            self.head.access_ptr("rw", offset=self.head.elem_offset_of([T.int32(0)])), 1
+        )
+        self.masked_pos = self.head_r & self.mask
+        while_ld_global_acquire(
+            self.tasks.access_ptr("r", offset=self.tasks.elem_offset_of([self.masked_pos])),
+            T.address_of(fetched_task_info),
+        )
+        # FIXME: enable this when we consider capacity issue
+        # self.tasks[self.masked_pos, 0] = -1
+
+
+class DynamicTileScheduler(TileSchedulerBase):
+    MAX_TASKS = 32768
+    scheduler_warp = 7
+
+    def __init__(
+        self,
+        tasks: T.Buffer,
+        head: T.Buffer,
+        tail: T.Buffer,
+        smem_manager,
+        profiler: CudaProfiler = None,
+        debug=False,
+    ):
+        self.queue = MPMCQueue(
+            capacity=self.MAX_TASKS, tasks=tasks, head=head, tail=tail, smem_manager=smem_manager
+        )
+        self.profiler_on = profiler is not None
+        self.profiler = profiler
+        self.debug = debug
+        self.smem_manager = smem_manager
+
+    def _alloc(self):
+        self.task_info = T.local_scalar(dtype="int32")
+        self.task_type = T.local_scalar(dtype="int32")
+        self.m_idx = T.local_scalar(dtype="int32")
+        self.n_idx = T.local_scalar(dtype="int32")
+        self.k_idx = T.local_scalar(dtype="int32")
+        self.idx = T.local_scalar(dtype="int32")
+        self.dequeue_phase = T.local_scalar(dtype="int32")
+        self.p2c_dequeue_barrier = SchedulerBarrier(self.smem_manager, is_p2c=True)
+        self.c2p_dequeue_barrier = SchedulerBarrier(self.smem_manager, is_p2c=False)
+        self.packed_value = self.smem_manager.alloc((1,), "int32", align=16, method="persistent")
+        self.semaphore_state = self.smem_manager.alloc(
+            (KernelConfig.NUM_THREADS,), "int32", method="persistent"
+        )
+
+    @T.inline
+    def _dequeue_and_store_packed(self):
+        self.queue.dequeue(self.task_info)
+        sts(self.task_info, self.packed_value.ptr_to([0]))
+
+    @T.inline
+    def _fetch_from_queue(self):
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        # fetch from GEMM queue
+        if warp_id == self.scheduler_warp:
+            if T.ptx.elect_sync():
+                self.c2p_dequeue_barrier.wait(0, self.dequeue_phase)
+                self._dequeue_and_store_packed()
+                self.p2c_dequeue_barrier.arrive()
+        self.p2c_dequeue_barrier.wait(0, self.dequeue_phase)
+        unpack_from_32bit(
+            self.packed_value[0],
+            T.address_of(self.task_type),
+            T.address_of(self.m_idx),
+            T.address_of(self.n_idx),
+            T.address_of(self.k_idx),
+        )
+        self.c2p_dequeue_barrier.arrive()
+        self.dequeue_phase = self.dequeue_phase ^ 1
+
+    @T.inline
+    def init(self):
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        self._alloc()
+        self.queue.init()
+        self.dequeue_phase = 0
+        if tid == 0:
+            self.p2c_dequeue_barrier.init(1)
+            self.c2p_dequeue_barrier.init(KernelConfig.NUM_THREADS)
+        T.tvm_storage_sync("shared")
+        T.ptx.fence.proxy_async("shared::cta")
+        T.ptx.fence.mbarrier_init()
+
+    @T.inline
+    def next_tile(self):
+        lane_id = T.lane_id([32])
+        if self.profiler_on:
+            self.profiler.start(ProfileEventType.FETCH, lane_id == 0)
+        self._fetch_from_queue()
+        if self.profiler_on:
+            self.profiler.end(ProfileEventType.FETCH, lane_id == 0)
+
+    def get_idx_and_task_type(self):
+        return [self.m_idx, self.n_idx, self.k_idx], self.task_type
+
+    @T.inline
+    def wait(
+        self, evt: Semaphore, *coord, wait_level: Literal["cta", "warp"] = "cta", mask=0xFFFFFFFF
+    ):
+        evt.semaphore_wait(*coord, level=wait_level, mask=mask)
+
+    @T.inline
+    def notify(
+        self,
+        evt: Semaphore,
+        func_notify,
+        scope: Literal["thread", "warp", "warpgroup", "cta"] = "thread",
+        scope_id=0,
+        pre_notify=False,
+    ):
+        # Notes: Here each thread will notify only at most one time,
+        #        and the tids of the threads involved among scope in the notification process start from 0 and increment sequentially.
+        # Notes: (notify_num, rank, coord) = func_notify(notify_idx), rank=-1 for the local rank
+        # Notes: scope_id = -1 represents that each scope will separately notify
+
+        max_notify_num_map = T.meta_var(
+            {
+                "thread": 1,
+                "warp": 32,
+                "warpgroup": KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER,
+                "cta": KernelConfig.NUM_THREADS,
+            }
+        )
+        max_scope_id_map = T.meta_var(
+            {
+                "thread": KernelConfig.NUM_THREADS,
+                "warp": KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER,
+                "warpgroup": KernelConfig.WG_NUMBER,
+                "cta": 1,
+            }
+        )
+
+        @T.inline
+        def sync(scope: Literal["thread", "warp", "warpgroup", "cta"], scope_id=0):
+            if scope == "thread":
+                pass
+            elif scope == "warp":
+                T.cuda.warp_sync()
+            elif scope == "warpgroup":
+                T.ptx.bar.sync(6 + scope_id, 128)
+            elif scope == "cta":
+                T.tvm_storage_sync("shared")
+
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        tid_in_wg = T.thread_id_in_wg([KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER])
+        lane_id = T.lane_id([32])
+        idx_map = T.meta_var(
+            {
+                "thread": (tid, 0),
+                "warp": (warp_id, lane_id),
+                "warpgroup": (wg_id, tid_in_wg),
+                "cta": (0, tid),
+            }
+        )
+        idx = T.meta_var(idx_map[scope])
+        if self.debug:
+            T.cuda.trap_when_assert_failed(scope_id == -1 or scope_id < max_scope_id_map[scope])
+        if scope_id == -1 or idx[0] == scope_id:
+            if not pre_notify:
+                sync(scope, scope_id)
+            notify_num = T.meta_var(func_notify(idx[1])[0])
+            rank = T.meta_var(func_notify(idx[1])[1])
+            coord = T.meta_var(func_notify(idx[1])[2:])
+            if self.debug:
+                T.cuda.trap_when_assert_failed(notify_num <= max_notify_num_map[scope])
+            if idx[1] < notify_num:
+                evt.semaphore_notify(*coord, pre_notify=pre_notify, rank=rank)
+
+    def _enqueue(self, idx, func_trigger_list, push_level):
+        if not isinstance(func_trigger_list, list):
+            func_trigger_list = [func_trigger_list]
+        for func_trigger in func_trigger_list:
+            self.queue.enqueue(-1, func_trigger(idx), push_level)
+
+    @T.inline
+    def pre_notify_and_push(
+        self,
+        evt: Semaphore,
+        func_notify,
+        func_trigger_list,
+        push_level: Literal["thread", "warp", "warpgroup", "cta"],
+        scope: Literal["thread", "warp", "warpgroup", "cta"],
+        scope_id=0,
+    ):
+        max_notify_num_map = T.meta_var(
+            {
+                "thread": 1,
+                "warp": 32,
+                "warpgroup": KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER,
+                "cta": KernelConfig.NUM_THREADS,
+            }
+        )
+        max_scope_id_map = T.meta_var(
+            {
+                "thread": KernelConfig.NUM_THREADS,
+                "warp": KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER,
+                "warpgroup": KernelConfig.WG_NUMBER,
+                "cta": 1,
+            }
+        )
+
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        tid_in_wg = T.thread_id_in_wg([KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER])
+        warp_id_in_wg = T.warp_id_in_wg([KernelConfig.WARP_NUMBER])
+        lane_id = T.lane_id([32])
+        idx_map = T.meta_var(
+            {
+                "thread": (tid, 0),
+                "warp": (warp_id, lane_id),
+                "warpgroup": (wg_id, tid_in_wg),
+                "cta": (0, tid),
+            }
+        )
+        idx_in_scope_map = T.meta_var(
+            {
+                "thread": {"thread": 0},
+                "warp": {"thread": lane_id, "warp": 0},
+                "warpgroup": {"thread": tid_in_wg, "warp": warp_id_in_wg, "warpgroup": 0},
+                "cta": {"thread": tid, "warp": warp_id, "warpgroup": wg_id, "cta": 0},
+            }
+        )
+        stride_in_scope_map = T.meta_var(
+            {
+                "warp": {"warp": 1},
+                "warpgroup": {"warp": KernelConfig.WARP_NUMBER, "warpgroup": 1},
+                "cta": {
+                    "warp": KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER,
+                    "warpgroup": KernelConfig.WG_NUMBER,
+                    "cta": 1,
+                },
+            }
+        )
+        scope_id_map = T.meta_var({"thread": tid, "warp": warp_id, "warpgroup": wg_id, "cta": 0})
+        new_scope_id = T.if_then_else(scope_id == -1, scope_id_map[scope], scope_id)
+        idx = T.meta_var(idx_map[scope])
+        if self.debug:
+            T.cuda.trap_when_assert_failed(scope_id == -1 or scope_id < max_scope_id_map[scope])
+        if idx[0] == new_scope_id:
+            notify_num = T.meta_var(func_notify(idx[1])[0])
+            rank = T.meta_var(func_notify(idx[1])[1])
+            coord_notify = T.meta_var(func_notify(idx[1])[2:])
+            if self.debug:
+                T.cuda.trap_when_assert_failed(notify_num <= max_notify_num_map[scope])
+            if idx[1] < notify_num:
+                evt.semaphore_notify(*coord_notify, pre_notify=True, rank=rank)
+            if self.profiler_on:
+                self.profiler.start(ProfileEventType.PUSH, lane_id == 0)
+            if scope == "thread":
+                if tid == new_scope_id:
+                    if push_level == "thread":
+                        if evt.is_triggered():
+                            self._enqueue(0, func_trigger_list, push_level)
+                    else:
+                        assert False
+            elif scope == "warp":
+                if warp_id == new_scope_id:
+                    if push_level == "thread":
+                        if lane_id < notify_num:
+                            if evt.is_triggered():
+                                self._enqueue(lane_id, func_trigger_list, push_level)
+                    elif push_level == "warp":
+                        self.semaphore_state[tid] = evt.state[0]
+                        T.cuda.warp_sync()
+                        self.idx = idx_in_scope_map[scope][push_level]
+                        while self.idx < notify_num:
+                            evt.state[0] = self.semaphore_state[new_scope_id * 32 + self.idx]
+                            if evt.is_triggered():
+                                self._enqueue(self.idx, func_trigger_list, push_level)
+                            self.idx += stride_in_scope_map[scope][push_level]
+                    else:
+                        assert False
+            elif scope == "warpgroup":
+                if wg_id == new_scope_id:
+                    if push_level == "thread":
+                        if tid_in_wg < notify_num:
+                            if evt.is_triggered():
+                                self._enqueue(tid_in_wg, func_trigger_list, push_level)
+                    elif push_level == "warp" or push_level == "warpgroup":
+                        self.semaphore_state[tid] = evt.state[0]
+                        T.cuda.warpgroup_sync(6 + wg_id)
+                        self.idx = idx_in_scope_map[scope][push_level]
+                        while self.idx < notify_num:
+                            evt.state[0] = self.semaphore_state[
+                                new_scope_id * KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER
+                                + self.idx
+                            ]
+                            if evt.is_triggered():
+                                self._enqueue(self.idx, func_trigger_list, push_level)
+                            self.idx += stride_in_scope_map[scope][push_level]
+                    else:
+                        assert False
+            elif scope == "cta":
+                if push_level == "thread":
+                    if tid < notify_num:
+                        if evt.is_triggered():
+                            self._enqueue(tid, func_trigger_list, push_level)
+                elif push_level == "warp" or push_level == "warpgroup" or push_level == "cta":
+                    self.semaphore_state[tid] = evt.state[0]
+                    T.tvm_storage_sync("shared")
+                    self.idx = idx_in_scope_map[scope][push_level]
+                    while self.idx < notify_num:
+                        evt.state[0] = self.semaphore_state[self.idx]
+                        if evt.is_triggered():
+                            self._enqueue(self.idx, func_trigger_list, push_level)
+                        self.idx += stride_in_scope_map[scope][push_level]
+                else:
+                    assert False
+            else:
+                assert False
+            if self.profiler_on:
+                self.profiler.end(ProfileEventType.PUSH, lane_id == 0)
+
+    def valid(self):
+        return self.task_type != JobType.END.value
+
+
+class MPMCQueueHost:
+    def __init__(self, capacity: int):
+        self.capacity = capacity
+        self.tasks = np.full((capacity,), -1, dtype=np.int32)
+        self.head = np.zeros((1,), dtype=np.int32)
+        self.tail = np.zeros((1,), dtype=np.int32)
+        self.head[0] = 0
+        self.tail[0] = 0
+
+    def enqueue(self, task_type, m_idx, n_idx, k_idx):
+        pos = self.tail[0] & (self.capacity - 1)
+        self.tasks[pos] = pack_into_32bit(m_idx, n_idx, k_idx, task_type)
+        self.tail[0] = self.tail[0] + 1

--- a/tirx_kernels/megakernel/utils/static_scheduler.py
+++ b/tirx_kernels/megakernel/utils/static_scheduler.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Static tile scheduler for megakernel."""
+
+from typing import Literal
+
+import tvm
+from tirx_kernels.megakernel.utils.base import SemaphoreBase, TileSchedulerBase
+from tirx_kernels.megakernel.utils.config import JobType, KernelConfig
+from tirx_kernels.megakernel.utils.utils import any_sync, atomic_add_int32, gt, unpack_from_32bit
+from tvm.script import tirx as T
+
+
+class Semaphore(SemaphoreBase):
+    def __init__(self, buffer):
+        self.sem = buffer
+        self.state = T.alloc_buffer([1], "int32", scope="local", align=4)
+
+    @T.inline
+    def semaphore_wait(self, *coord, level: Literal["cta", "warp"] = "cta", mask=0xFFFFFFFF):
+        if level == "cta":
+            while 1:
+                T.ptx.ld_global_acquire(
+                    self.state[0], self.sem.access_ptr("r", offset=self.sem.elem_offset_of(coord))
+                )
+                if T.cuda.syncthreads_and(self.state[0] == 0):
+                    break
+                T.cuda.nano_sleep(40)
+        elif level == "warp":
+            warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+            lane_id = T.lane_id([32])
+            if (mask >> warp_id) & 1 == 1:
+                self.state[0] = -1
+                while 1:
+                    if lane_id == 0:
+                        T.ptx.ld_global_acquire(
+                            self.state[0],
+                            self.sem.access_ptr("r", offset=self.sem.elem_offset_of(coord)),
+                        )
+                    if any_sync(0xFFFFFFFF, self.state[0] == 0):
+                        break
+                    T.cuda.nano_sleep(40)
+        else:
+            assert False
+
+    @T.inline
+    def semaphore_notify(self, *coord, rank=-1, release=False):
+        # wg is synced
+        self.state[0] = atomic_add_int32(
+            self.sem.ptr_to(coord), -(self.base + 1), rank, release=release
+        )
+        if self.state[0] <= 0:
+            while 1:
+                T.ptx.ld_global_acquire(self.state[0], self.sem.ptr_to(coord))
+                if gt(self.state[0], 0):
+                    atomic_add_int32(
+                        self.sem.ptr_to(coord), -(self.base + 1), rank, release=release
+                    )
+                    break
+                T.cuda.nano_sleep(40)
+
+
+class StaticTileScheduler(TileSchedulerBase):
+    MAX_TASKS = 128
+
+    def __init__(self, prefix: str, exec_queue, smem_manager, debug=False):
+        super().__init__()
+        self.exec_queue = exec_queue
+        self.debug = debug
+        self.prefix = prefix
+        self.smem_manager = smem_manager
+
+    @T.inline
+    def _update_current_m_n_idx(self):
+        unpack_from_32bit(
+            self.queue_smem[self.tile_idx],
+            T.address_of(self.task_type),
+            T.address_of(self.m_idx),
+            T.address_of(self.n_idx),
+            T.address_of(self.k_idx),
+        )
+
+    def _alloc(self):
+        self.m_idx = T.local_scalar("int32")
+        self.n_idx = T.local_scalar("int32")
+        self.k_idx = T.local_scalar("int32")
+        self.task_type = T.local_scalar("int32")
+        self.tile_idx = T.local_scalar("int32")
+        self.queue_smem = self.smem_manager.alloc(
+            (self.MAX_TASKS,), "int32", align=16, method="persistent"
+        )
+
+    @T.inline
+    def init(self):
+        self._alloc()
+        bx = T.cta_id([KernelConfig.SM_NUMBER])
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        self.tile_idx = 0
+        for k in T.serial(T.ceildiv(self.MAX_TASKS, KernelConfig.NUM_THREADS)):
+            idx = T.meta_var(k * KernelConfig.NUM_THREADS + tid)
+            if idx < self.MAX_TASKS:
+                self.queue_smem[idx] = self.exec_queue[bx, idx]
+        T.tvm_storage_sync("shared")
+        self._update_current_m_n_idx()
+
+    def get_idx_and_task_type(self):
+        return [self.m_idx, self.n_idx, self.k_idx], self.task_type
+
+    @T.inline
+    def next_tile(self):
+        self.tile_idx += 1
+        self._update_current_m_n_idx()
+
+    @T.inline
+    def wait(
+        self, evt: Semaphore, *coord, wait_level: Literal["cta", "warp"] = "cta", mask=0xFFFFFFFF
+    ):
+        evt.semaphore_wait(*coord, level=wait_level, mask=mask)
+
+    @T.inline
+    def notify(
+        self,
+        evt: Semaphore,
+        func_notify,
+        scope: Literal["thread", "warp", "warpgroup", "cta"] = "thread",
+        scope_id=0,
+        release=False,
+    ):
+        # Notes: Here each thread will notify only at most one time,
+        #        and the tids of the threads involved among scope in the notification process start from 0 and increment sequentially.
+        # Notes: (num, rank, coord) = func_notify(notify_idx), rank=-1 for the local rank
+        # Notes: scope_id = -1 represents that each scope will separately notify
+
+        max_notify_num_map = T.meta_var(
+            {
+                "thread": 1,
+                "warp": 32,
+                "warpgroup": KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER,
+                "cta": KernelConfig.NUM_THREADS,
+            }
+        )
+        max_scope_id_map = T.meta_var(
+            {
+                "thread": KernelConfig.NUM_THREADS,
+                "warp": KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER,
+                "warpgroup": KernelConfig.WG_NUMBER,
+                "cta": 1,
+            }
+        )
+
+        @T.inline
+        def sync(scope: Literal["thread", "warp", "warpgroup", "cta"], scope_id=0):
+            if scope == "thread":
+                pass
+            elif scope == "warp":
+                T.cuda.warp_sync()
+            elif scope == "warpgroup":
+                T.ptx.bar.sync(6 + scope_id, 128)
+            elif scope == "cta":
+                T.tvm_storage_sync("shared")
+
+        wg_id = T.warpgroup_id([KernelConfig.WG_NUMBER])
+        warp_id = T.warp_id([KernelConfig.WARP_NUMBER * KernelConfig.WG_NUMBER])
+        tid = T.thread_id([KernelConfig.NUM_THREADS])
+        tid_in_wg = T.thread_id_in_wg([KernelConfig.NUM_THREADS // KernelConfig.WG_NUMBER])
+        lane_id = T.lane_id([32])
+        idx_map = T.meta_var(
+            {
+                "thread": (tid, 0),
+                "warp": (warp_id, lane_id),
+                "warpgroup": (wg_id, tid_in_wg),
+                "cta": (0, tid),
+            }
+        )
+        idx = T.meta_var(idx_map[scope])
+        if self.debug:
+            T.cuda.trap_when_assert_failed(scope_id == -1 or scope_id < max_scope_id_map[scope])
+        if scope_id == -1 or idx[0] == scope_id:
+            sync(scope, scope_id)
+            # `func_notify` can emit side effects while constructing dependency exprs.
+            # Evaluate it once and then unpack to avoid duplicated rewrites.
+            notify_info = T.meta_var(func_notify(idx[1]))
+            notify_num = T.meta_var(notify_info[0])
+            rank = T.meta_var(notify_info[1])
+            coord = T.meta_var(notify_info[2:])
+            if self.debug:
+                T.cuda.trap_when_assert_failed(notify_num <= max_notify_num_map[scope])
+            if idx[1] < notify_num:
+                evt.semaphore_notify(*coord, rank=rank, release=release)
+
+    def valid(self):
+        return tvm.tirx.all(self.tile_idx < self.MAX_TASKS, self.task_type != JobType.END.value)

--- a/tirx_kernels/megakernel/utils/support.py
+++ b/tirx_kernels/megakernel/utils/support.py
@@ -1,0 +1,117 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""MOE-only support helpers for the event-dependency megakernel benchmark."""
+
+from typing import Literal
+
+import numpy as np
+import tvm_ffi
+
+import tvm
+from tirx_kernels.megakernel.kernels import GroupGEMMTileSM100
+from tirx_kernels.megakernel.utils.config import JobType, KernelConfig
+from tirx_kernels.megakernel.utils.dynamic_scheduler import DynamicTileScheduler, MPMCQueueHost
+from tirx_kernels.megakernel.utils.static_scheduler import StaticTileScheduler
+from tirx_kernels.megakernel.utils.utils import ceildiv, pack_into_32bit
+from tvm.script import tirx as T
+
+
+def push_moe_tasks(
+    central_queue: list[tuple[int, int, int, int]],
+    batch_size: int,
+    config: dict,
+    insert_wait_etensor_init: bool = False,
+):
+    """Append the static task sequence for the fused MOE megakernel."""
+    moe_blk_m = 128
+    gating_blk_m = 128
+    for m_idx in range(ceildiv(batch_size, gating_blk_m)):
+        for k_idx in range(config["GATING_SPLIT_K_FACTOR"]):
+            central_queue.append((m_idx, 0, k_idx, JobType.MOE_GATING.value))
+    if insert_wait_etensor_init:
+        for i in range(KernelConfig.SM_NUMBER):
+            central_queue.append((i, 0, 0, JobType.WAIT_ETENSOR_INIT.value))
+    for m_idx in range(KernelConfig.SM_NUMBER):
+        central_queue.append((m_idx, 0, 0, JobType.MOE_TOPK_SOFTMAX.value))
+    central_queue.append((0, 0, 0, JobType.MOE_ALIGN.value))
+    for m_idx in range(KernelConfig.SM_NUMBER):
+        central_queue.append((m_idx, 0, 0, JobType.MOE_COUNT_AND_SORT.value))
+
+    max_num_tokens_padded = get_max_num_tokens_padded(
+        batch_size, config["NUM_EXPERTS_PER_TOK"], config["NUM_EXPERTS"], moe_blk_m
+    )
+    for m_idx in range(max_num_tokens_padded // moe_blk_m):
+        for n_idx in range(config["INTERMEDIATE_SIZE"] * 2 // GroupGEMMTileSM100.BLK_N):
+            central_queue.append((m_idx, n_idx, 0, JobType.MOE_GROUP_GEMM_GATE_UP_SILU.value))
+    for m_idx in range(max_num_tokens_padded // moe_blk_m):
+        for n_idx in range(config["HIDDEN_SIZE"] // GroupGEMMTileSM100.BLK_N):
+            central_queue.append((m_idx, n_idx, 0, JobType.MOE_GROUP_GEMM_DOWN.value))
+
+
+@tvm_ffi.register_global_func("tirx.megakernel.get_max_num_tokens_padded")
+def get_max_num_tokens_padded(batch_size, topk, num_experts, moe_blk_m):
+    if isinstance(batch_size, int):
+        if batch_size * topk < num_experts:
+            return batch_size * topk * moe_blk_m
+        return (num_experts + ceildiv(batch_size * topk - num_experts, moe_blk_m)) * moe_blk_m
+    return T.if_then_else(
+        batch_size * topk < num_experts,
+        batch_size * topk * moe_blk_m,
+        (num_experts + ceildiv(batch_size * topk - num_experts, moe_blk_m)) * moe_blk_m,
+    )
+
+
+def get_max_blocks_padded_relaxed(batch_size, topk, num_experts, moe_blk_m):
+    return batch_size * topk // moe_blk_m + (num_experts + 1)
+
+
+def generate_exec_queue_moe(
+    batch_size: int, config: dict, etensor_num: int, scheduler: Literal["static", "dynamic"]
+):
+    if scheduler == "static":
+        exec_queue = np.zeros(
+            (KernelConfig.SM_NUMBER, StaticTileScheduler.MAX_TASKS), dtype=np.int32
+        )
+        central_queue = []
+        for i in range(etensor_num):
+            central_queue.append((i, 0, 0, JobType.INIT_ETENSOR.value))
+        push_moe_tasks(central_queue, batch_size, config, insert_wait_etensor_init=True)
+
+        tile_idx = 0
+        while central_queue:
+            for bx in range(KernelConfig.SM_NUMBER):
+                if central_queue:
+                    exec_queue[bx, tile_idx] = pack_into_32bit(*central_queue.pop(0))
+                else:
+                    exec_queue[bx, tile_idx] = pack_into_32bit(-1, -1, -1, JobType.END.value)
+            tile_idx += 1
+        for bx in range(KernelConfig.SM_NUMBER):
+            exec_queue[bx, tile_idx] = pack_into_32bit(-1, -1, -1, JobType.END.value)
+        return tvm.runtime.tensor(exec_queue, device=tvm.cuda(0))
+
+    if scheduler == "dynamic":
+        exec_queue = MPMCQueueHost(DynamicTileScheduler.MAX_TASKS)
+        gating_blk_m = 128
+        for i in range(etensor_num):
+            exec_queue.enqueue(JobType.INIT_ETENSOR.value, i, 0, 0)
+        for m in range(ceildiv(batch_size, gating_blk_m)):
+            for k in range(config["GATING_SPLIT_K_FACTOR"]):
+                exec_queue.enqueue(JobType.MOE_GATING.value, m, 0, k)
+        return exec_queue
+
+    raise ValueError(f"Unsupported scheduler: {scheduler}")

--- a/tirx_kernels/megakernel/utils/utils.py
+++ b/tirx_kernels/megakernel/utils/utils.py
@@ -1,0 +1,369 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Utility functions for megakernel."""
+
+import numpy as np
+
+import tvm
+from tvm.script import tirx as T
+from tvm.tirx import Expr
+
+
+def ceildiv(a, b):
+    if isinstance(a, Expr) or isinstance(b, Expr):
+        return T.truncdiv(a + b - 1, b)
+    return (a + b - 1) // b
+
+
+# task_type: [0:5], m_idx: [5:18], n_idx: [18:28], k_idx: [28:32]
+MAX_TASK_TYPE = 1 << 5
+MAX_M_IDX = 1 << 13
+MAX_N_IDX = 1 << 10
+MAX_K_IDX = 1 << 4
+
+
+def pack_into_32bit(m_idx, n_idx, k_idx, task_type, host=True, debug=False):
+    if host:
+        if debug:
+            assert (
+                task_type < MAX_TASK_TYPE
+                and m_idx < MAX_M_IDX
+                and n_idx < MAX_N_IDX
+                and k_idx < MAX_K_IDX
+            )
+        return (
+            np.int64([task_type | (m_idx << 5) | (n_idx << 18) | (k_idx << 28)])
+            .astype(np.int32)
+            .item()
+        )
+    else:
+        if debug:
+            T.cuda.trap_when_assert_failed(task_type < MAX_TASK_TYPE)
+            T.cuda.trap_when_assert_failed(m_idx < MAX_M_IDX)
+            T.cuda.trap_when_assert_failed(n_idx < MAX_N_IDX)
+            T.cuda.trap_when_assert_failed(k_idx < MAX_K_IDX)
+        return task_type | (m_idx << 5) | (n_idx << 18) | (k_idx << 28)
+
+
+unpack_from_32bit_code = """
+__forceinline__ __device__ void unpack_from_32bit(int32_t task_info, int32_t* task_type_ptr, int32_t* m_idx_ptr, int32_t* n_idx_ptr, int32_t* k_idx_ptr) {
+    *task_type_ptr = task_info & 0b11111;
+    *m_idx_ptr = (task_info >> 5) & 0b1111111111111;
+    *n_idx_ptr = (task_info >> 18) & 0b1111111111;
+    *k_idx_ptr = (task_info >> 28) & 0b1111;
+}
+"""
+
+
+@T.inline
+def unpack_from_32bit(task_info, task_type_ptr, m_idx_ptr, n_idx_ptr, k_idx_ptr):
+    T.cuda.func_call(
+        "unpack_from_32bit",
+        task_info,
+        task_type_ptr,
+        m_idx_ptr,
+        n_idx_ptr,
+        k_idx_ptr,
+        source_code=unpack_from_32bit_code,
+    )
+
+
+def is_power_of_two(n: T.int32):
+    return tvm.tirx.all(n > 0, T.bitwise_and(n, n - 1) == 0)
+
+
+def next_power_of_two(x):
+    return 1 << (x - 1).bit_length()
+
+
+def find_power_of_two(n):
+    assert n > 0 and (n & (n - 1)) == 0
+    return n.bit_length() - 1
+
+
+def rsqrt(x):
+    return T.cuda.func_call(
+        "_rsqrt",
+        x,
+        source_code="""
+__forceinline__ __device__ float _rsqrt(float x) {
+  float y;
+  asm volatile("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+""",
+        return_type="float32",
+    )
+
+
+def exp2(x):
+    return T.cuda.func_call(
+        "ptx_exp2",
+        x,
+        source_code="""
+    __forceinline__ __device__ float ptx_exp2(float x) {
+  float y;
+  asm volatile("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+  return y;
+}
+""",
+        return_type="float32",
+    )
+
+
+def silu(x):
+    return T.cuda.func_call(
+        "silu",
+        x,
+        source_code="""
+    __forceinline__ __device__ float silu(float x) {
+  return x / (1.0f + __expf(-x));
+}
+""",
+        return_type="float32",
+    )
+
+
+def threadfence_block():
+    return T.cuda.func_call(
+        "threadfence_block",
+        source_code="""
+__forceinline__ __device__ void threadfence_block() {
+  __threadfence_block();
+}
+""",
+    )
+
+
+def any_sync(mask, pred):
+    return T.cuda.func_call(
+        "any_sync",
+        mask,
+        pred,
+        source_code="""
+__forceinline__ __device__ int any_sync(unsigned mask, int pred) {
+  return __any_sync(mask, pred);
+}
+""",
+        return_type="int32",
+    )
+
+
+def gt(lhs, rhs):
+    return T.cuda.func_call(
+        "gt",
+        lhs,
+        rhs,
+        source_code="""
+__forceinline__ __device__ bool gt(int32_t a, int32_t b) {
+    return a > b;
+}
+""",
+        return_type="bool",
+    )
+
+
+def mbarrier_try_wait(mbarrier, phase):
+    return T.cuda.func_call(
+        "tvm_builtin_ptx_mbarrier_try_wait_check",
+        mbarrier,
+        phase,
+        source_code="""
+__forceinline__ __device__ bool tvm_builtin_ptx_mbarrier_try_wait_check(void* barrier, int phase) {
+    uint32_t smem_int_ptr = __cvta_generic_to_shared(barrier);
+  uint32_t waitComplete;
+
+  asm volatile(
+      "{\\n\\t"
+      ".reg .pred P1; \\n\\t"
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%1], %2; \\n\\t"
+      "selp.b32 %0, 1, 0, P1; \\n\\t"
+      "}"
+      : "=r"(waitComplete)
+      : "r"(smem_int_ptr), "r"(phase));
+
+  return static_cast<bool>(waitComplete);
+}
+""",
+        return_type="bool",
+    )
+
+
+def atomic_add_int32_remote(addr, value, pe):
+    func = """
+__forceinline__ __device__ int32_t atomic_add_int32_remote(int32_t* addr, int32_t value, int32_t pe) {
+    if (pe >= 0) {
+        int32_t* ptr = (int32_t*)(nvshmem_ptr(addr, pe));
+        int32_t old_value;
+        asm volatile ("atom.release.gpu.global.add.u32 %0, [%1], %2;"
+                        : "=r"(old_value)
+                        : "l"(ptr), "r"(value)
+                        : "memory");
+        return old_value;
+    } else {
+        return atomicAdd(addr, value);
+    }
+}
+"""
+    return T.cuda.func_call(
+        "atomic_add_int32_remote", addr, value, pe, source_code=func, return_type="int32"
+    )
+
+
+def atomic_add_int32_local_release(addr, value):
+    func = """
+__forceinline__ __device__ int32_t atomic_add_int32_release(int32_t* addr, int32_t value) {
+    int32_t old_value;
+    asm volatile ("atom.release.gpu.global.add.s32 %0, [%1], %2;"
+                  : "=r"(old_value)
+                  : "l"(addr), "r"(value)
+                  : "memory");
+    return old_value;
+}
+"""
+    return T.cuda.func_call(
+        "atomic_add_int32_release", addr, value, source_code=func, return_type="int32"
+    )
+
+
+def atomic_add_int32_local(addr, value):
+    func = """
+__forceinline__ __device__ int32_t atomic_add_int32(int32_t* addr, int32_t value) {
+    return atomicAdd(addr, value);
+}
+"""
+    return T.cuda.func_call("atomic_add_int32", addr, value, source_code=func, return_type="int32")
+
+
+def is_const_minus_one(value):
+    return (isinstance(value, int) and value == -1) or (
+        isinstance(value, tvm.tirx.IntImm) and value.value == -1
+    )
+
+
+def atomic_add_int32(addr, value, pe, release=False):
+    if is_const_minus_one(pe):
+        if release:
+            return atomic_add_int32_local_release(addr, value)
+        else:
+            return atomic_add_int32_local(addr, value)
+    else:
+        print(f"pe is not -1: {pe}, {type(pe)}")
+        return atomic_add_int32_remote(addr, value, pe)
+
+
+def stg_remote(v, dst_addr, pe):
+    func = """
+__forceinline__ __device__ void stg_remote(int32_t v, void* dst_addr, int32_t pe) {
+    if (pe >= 0) {
+        void* ptr = nvshmem_ptr(dst_addr, pe);
+        asm volatile("st.global.release.sys.b32 [%0], %1;"
+                     :
+                     : "l"(ptr), "r"(v)
+                     : "memory");
+    } else {
+        asm volatile("st.global.release.gpu.b32 [%0], %1;"
+                     :
+                     : "l"(dst_addr), "r"(v)
+                     : "memory");
+    }
+}
+"""
+    return T.cuda.func_call("stg_remote", v, dst_addr, pe, source_code=func)
+
+
+def stg_local(v, dst_addr, pe):
+    func = """
+    __forceinline__ __device__ void stg_local(int32_t v, void* dst_addr, int32_t pe) {
+        asm volatile("st.global.release.gpu.b32 [%0], %1;"
+                    :
+                    : "l"(dst_addr), "r"(v)
+                    : "memory");
+    }
+    """
+    return T.cuda.func_call("stg_local", v, dst_addr, pe, source_code=func)
+
+
+def stg(v, dst_addr, pe):
+    if is_const_minus_one(pe):
+        return stg_local(v, dst_addr, pe)
+    else:
+        return stg_remote(v, dst_addr, pe)
+
+
+@T.inline
+def while_ld_global_acquire(addr, task_info):
+    T.cuda.func_call(
+        "while_ld_global_acquire",
+        addr,
+        task_info,
+        source_code="""
+__forceinline__ __device__ void while_ld_global_acquire(int32_t* addr, int32_t* task_info) {
+  asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\\n" : "=r"(*task_info) : "l"(addr) : "memory");
+  while (*task_info == -1) {
+    __nanosleep(800);
+    asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\\n" : "=r"(*task_info) : "l"(addr) : "memory");
+  }
+}
+""",
+    )
+
+
+@T.inline
+def sts(value, dst_addr):
+    T.cuda.func_call(
+        "sts",
+        value,
+        dst_addr,
+        source_code="""
+__forceinline__ __device__ void sts(int32_t v, void* dst_addr) {
+    asm volatile("st.shared.b32 [%0], %1;"
+                 :
+                 : "l"(dst_addr), "r"(v)
+                 : "memory");
+}
+""",
+    )
+
+
+def f_init_const(c):
+    return lambda *args: c
+
+
+def f_init_unmatched_dim(dim_len, in_par_size, out_par_size):
+    def f_init(i):
+        start_out_par = i * out_par_size
+        end_out_par = T.min(dim_len, (i + 1) * out_par_size)
+        return (end_out_par - 1) // in_par_size - start_out_par // in_par_size + 1
+
+    return f_init
+
+
+def get_source(module: "tvm.ir.IRModule"):
+    target = tvm.target.Target("cuda")
+    lib = tvm.compile(module, target, tir_pipeline="tirx")
+    src = lib.mod.imports[0].inspect_source()
+    return src, lib
+
+
+def get_source_func(func: "tvm.tirx.PrimFunc"):
+    target = tvm.target.Target("cuda")
+    mod = tvm.IRModule({"main": func})
+    mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
+    src = mod.mod.imports[0].inspect_source()
+    return src, mod


### PR DESCRIPTION
## What

Ports the FlashInfer frozen `flashkda_bf16_fused_m128` kernel (recurrent KDA prefill, M128 schedule) to TIRx, aligned 1:1 with the CUDA implementation (`csrc/kda/flashkda_bf16_fused_m128.cu`), including the same inline address-expression style at every smem use site — nvcc recovers the common subexpressions, so no manual CSE is needed.

- `tirx_kernels/flashkda/bf16_fused_m128.py`: kernel + configs + prepare_data
- `tirx_kernels/bench_suite/workloads_flashkda_bf16_fused_m128.yaml`: 5-config bench sweep
- README: FlashKDA ports table

## Validation

- Numeric regression: 6/6 pass (`python -m tirx_kernels.test --kernel flashkda_bf16_fused_m128`)
- bench_suite vs `flashinfer_frozen_m128` (run 41, ratio = frozen/tirx, higher = ours faster):

| config | tirx | frozen | ratio |
|---|---|---|---|
| h96_fixed8192 | 506.17µs | 508.26µs | 1.004 |
| h96_mixed | 385.15µs | 392.29µs | 1.019 |
| h96_uniform | 434.34µs | 437.86µs | 1.008 |
| h64_mixed | 271.20µs | 272.16µs | 1.004 |
| h64_uniform | 293.38µs | 294.48µs | 1.004 |

- Generated PTX/SASS: 64 registers, 0 spills, ldmatrix/stmatrix multiset matches the frozen kernel's instruction mix.