### PR TITLE
fix(gdn): order state-input reuse and TMEM deallocation

### DIFF
--- a/tirx_kernels/attention/gdn_prefill_sm100.py
+++ b/tirx_kernels/attention/gdn_prefill_sm100.py
@@ -151,6 +151,7 @@ TMEM_SHARED_INPUT_COL = 448
 
 TMEM_ALLOC_BARRIER = 1
 INVERSE_BARRIER = 2
+CG1_TMEM_DEALLOC_BARRIER = 3
 INITIAL_STATE_BARRIER = 4
 
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
@@ -1828,6 +1829,7 @@ def _kernel(
                     _consumer_wait(smem_addr_cg1, 320, kv_previous_count_cg1, 1)
                     kv_consumer_count_cg1 = kv_consumer_count_cg1 + 1
                     state_input_count_cg1: T.int32 = state_input_producer_count_cg1
+                    _producer_acquire(smem_addr_cg1, 472, state_input_count_cg1, 1)
                     state_input_producer_count_cg1 = state_input_producer_count_cg1 + 1
                     state_values_cg1: T.float32[128]
                     state_input_words_cg1: T.uint32[64]
@@ -2086,6 +2088,7 @@ def _kernel(
                 # Retained runtime empty-sequence branch from CK:L1422-L1432.
                 _copy_empty_state(initial_state, final_state, batch_cg1, head_cg1, thread, HV=HV)
             work_linear_cg1 = work_linear_cg1 + grid_x
+        T.cuda.warpgroup_sync(CG1_TMEM_DEALLOC_BARRIER)
         if warp == 4:
             T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
             T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(


### PR DESCRIPTION
## Summary

- wait for the state-input empty generation before CG1 rewrites its single-stage TMEM slot
- synchronize CG1 warps 4-7 before warp 4 relinquishes and deallocates TMEM
- keep the fix kernel-only; there are no tirx-tools engine or checker changes

## Why

The state-input producer advanced its generation and overwrote the TMEM slot without first consuming the empty token returned by the MMA issuer. Separately, warp 4 could reach `tcgen05.dealloc` after its own work loop while another CG1 warp still had TMEM accesses in flight. The deallocation instruction synchronizes its issuing warp, so the four CG1 warps need an explicit named-barrier rendezvous first.

## Validation

- Synccheck, smallest HQ=2/HV=8 single-token case: `clean`, 0 findings
- Racecheck, same case: `review`, 31 `alias_stale_read` advisories and 3 same-warp register-dependency `read_write` advisories; no `error` or `incomplete`
- NumSim, same case against the independent NumPy oracle: `clean`, 0 mismatches and 0 diagnostics
- B200 device correctness, HQ=2/HV=8 and `seq_lens=(1,)`: PASS; max abs error `9.765625e-4` for output and `3.604591e-4` for final state
- `python -m pytest -q -n 1 tests/test_gdn_prefill_sm100.py`: 4 passed
- Ruff and `git diff --check`: passed

The full canonical suite produced 102 passed, 2 skipped, and 16 failures, all in `test_sparse_decode_optional_specialization.py`. The same 16 failures reproduce on untouched `origin/main` with TVM `4b5598a74f`; the tests expect legacy parameter names such as `q_h`, while the current TVM exposes `q`.

The stock GDN `run_test` launched the kernel but refused the installed FlashInfer package as an oracle because its source SHA differs from the frozen canonical SHA. The B200 result above therefore uses the independent NumPy oracle from the tirx-tools corpus.