### PR TITLE
fix(kernels): use unaligned barriers across split roles

### DIFF
--- a/tirx_kernels/attention/flash_attention_backward.py
+++ b/tirx_kernels/attention/flash_attention_backward.py
@@ -871,7 +871,7 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                 T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_addr), T.uint32(512)
                 )
-                T.ptx.bar.sync(T.uint32(5), 416)
+                T.ptx.barrier.sync(T.uint32(5), 416)
             if warp_id == 1:
                 # ---- TMA warp: 2 loads per M-tile (Q, dO) ----
                 if T.cuda.elect_sync():
@@ -1377,7 +1377,7 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
         # ==============================================================
         elif (wg_id >= 1) & (wg_id <= 2):
             T.ptx.setmaxnreg.inc.sync.aligned.u32(136)
-            T.ptx.bar.sync(T.uint32(5), 416)
+            T.ptx.barrier.sync(T.uint32(5), 416)
             compute_wg = T.meta_var(wg_id - 1)
             gemm_s_ph = PipelineState(1)
             gemm_s_ph.init(0)
@@ -1771,7 +1771,7 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
         # ==============================================================
         else:
             T.ptx.setmaxnreg.inc.sync.aligned.u32(136)
-            T.ptx.bar.sync(T.uint32(5), 416)
+            T.ptx.barrier.sync(T.uint32(5), 416)
             gemm_dq_ph_wg3 = PipelineState(1)
             gemm_dq_ph_wg3.init(0)
 

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1735,7 +1735,7 @@ def get_kernel(
         )
 
     def sync_unaligned(barrier_idx, num_threads):
-        return T.ptx.bar.sync(T.uint32(barrier_idx), T.uint32(num_threads))
+        return T.ptx.barrier.sync(T.uint32(barrier_idx), T.uint32(num_threads))
 
     def prefetch_tensormap(tensor_map):
         return T.ptx.prefetch.tensormap(T.address_of(tensor_map))
@@ -2962,7 +2962,7 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
 
         @T.inline
         def workspace_grid_sync(counter_idx, sync_num_threads, sync_barrier_idx, sync_thread_idx):
-            T.ptx.bar.sync(T.uint32(sync_barrier_idx), T.uint32(sync_num_threads))
+            T.ptx.barrier.sync(T.uint32(sync_barrier_idx), T.uint32(sync_num_threads))
             if sync_thread_idx == 0:
                 if sm_idx == 0:
                     atomic_add_rel_u32(
@@ -2981,7 +2981,7 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     load_acq_u32(
                         grid_sync_new_value, workspace_grid_sync_count.ptr_to([counter_idx])
                     )
-            T.ptx.bar.sync(T.uint32(sync_barrier_idx), T.uint32(sync_num_threads))
+            T.ptx.barrier.sync(T.uint32(sync_barrier_idx), T.uint32(sync_num_threads))
 
         @T.inline
         def nvlink_barrier(

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -1475,7 +1475,7 @@ def get_kernel(**kwargs: Any):
                 T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                     T.address_of(tmem_ptr_in_smem[0]), T.uint32(num_tmem_cols)
                 )
-            T.ptx.bar.sync(9, T.uint32(num_math_threads + 2 * 32))
+            T.ptx.barrier.sync(9, T.uint32(num_math_threads + 2 * 32))
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
             current_num_kv: T.uint32 = start_num_kv
@@ -1608,7 +1608,7 @@ def get_kernel(**kwargs: Any):
             T.ptx.setmaxnreg.inc.sync.aligned.u32(num_math_registers)
             # Math warps consume TMEM: wait on named barrier 9 for the UMMA
             # warp's tcgen05.alloc (see the UMMA branch).
-            T.ptx.bar.sync(9, T.uint32(num_math_threads + 2 * 32))
+            T.ptx.barrier.sync(9, T.uint32(num_math_threads + 2 * 32))
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
             current_num_kv: T.uint32 = start_num_kv


### PR DESCRIPTION
## Summary

Use unaligned `barrier.sync` for named-barrier generations whose participating warps reach the barrier from distinct static role branches.

This fixes divergent-barrier errors in:

- SM100 FlashAttention backward
- SM100 FP8 paged MQA logits
- DeepGEMM FP8/FP4 Mega MoE

## Problem

`bar.sync` is the aligned form of a PTX named barrier. It promises that the blocking participants in one barrier generation execute the same static barrier instruction.

These kernels instead divide participating warps across specialized role branches. The branches use the same barrier ID and arrival count, but execute different static `bar.sync` instructions.

Compute Sanitizer therefore reports divergent barriers:

- FlashAttention backward: 160 errors
- FP8 paged MQA logits: 320 errors
- Mega MoE: 384 errors

## Changes

### FlashAttention backward

Barrier 5 synchronizes 416 threads from three static role branches:

- one 32-thread MMA warp
- 256 compute threads
- 128 dQ-reduction threads

Change the three participating sites from `bar.sync(5, 416)` to `barrier.sync(5, 416)`.

The later legal `bar.arrive` plus single blocking `bar.sync` generation is unchanged.

### FP8 paged MQA logits

Barrier 9 synchronizes:

- 64 UMMA threads
- 256 math threads

The two groups arrive from separate static branches. Change both sites to unaligned `barrier.sync`.

### Mega MoE

Correct the implementation of `sync_unaligned`, which previously emitted aligned `bar.sync`.

Also change the entry and exit barriers in `workspace_grid_sync` to unaligned form. That helper is inlined into separate dispatch and load-A role branches, so each rendezvous is completed from distinct static sites.

All other aligned barriers remain unchanged.

## Validation

B200 Compute Sanitizer, using freshly generated and compiled CUDA:

- FlashAttention backward: 160 → 0 errors
- FP8 paged MQA logits: 320 → 0 errors
- Mega MoE: 384 → 0 errors

Additional validation:

- canonical Synccheck: 3/3 passed
- canonical Racecheck: 3/3 passed
- independent numerical oracles: 3/3 passed
- FlashAttention backward wiki/persistent cases: 2/2 passed
- full correctness suite: 2496 passed, 122 skipped
- the sole sandbox-network-blocked PyO3 probe passed when rerun with dependency access
- `ruff check`, `git diff --check`, and the tirx-wiki validator passed
