### PR TITLE
refactor(attention): express FA4 descriptor offsets in TIR

### DIFF
--- a/tirx_kernels/attention/flash_attention4.py
+++ b/tirx_kernels/attention/flash_attention4.py
@@ -68,28 +68,14 @@ _MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
 _TMEM_LD_16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
 _TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
 _TMEM_ST_16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
-_SMEM_DESC_ADD_16B_SOURCE = r"""
-__forceinline__ __device__ uint64_t fa4_smem_desc_add_16B_offset(
-    uint64_t desc_base, int32_t offset) {
-  SmemDescriptor desc;
-  desc.desc_ = desc_base;
-  desc.lo += static_cast<uint32_t>(offset);
-  return desc.desc_;
-}
-"""
 
 
 def _smem_desc_add_16B_offset(desc_base, offset):
-    # Keep the descriptor update as one C++ expression.  Separate mov/add/mov
-    # T.ptx calls preserve low-32-bit wrap semantics, but perturb nvcc's PTX
-    # around this MMA hot path enough to regress long-sequence attention.
-    return T.cuda.func_call(
-        "fa4_smem_desc_add_16B_offset",
-        desc_base,
-        offset,
-        source_code=_SMEM_DESC_ADD_16B_SOURCE,
-        return_type="uint64",
-    )
+    # Update the address lane with uint32 wraparound without carrying into the descriptor bits.
+    desc_halves = T.reinterpret("uint32x2", desc_base)
+    desc_lo = T.Shuffle([desc_halves], [0]) + T.cast(offset, "uint32")
+    desc_hi = T.Shuffle([desc_halves], [1])
+    return T.reinterpret("uint64", T.Shuffle([desc_lo, desc_hi], [0, 1]))
 
 
 def _cast_f32x2_f16x2(dst, src, offset):


### PR DESCRIPTION
## Summary

- remove the remaining FA4 CUDA descriptor-offset wrapper
- rebuild the descriptor from its `uint32` lanes so the low 32-bit address wraps without carrying into descriptor bits
- leave FlashAttention-4 with no `T.cuda.func_call`

## Codegen

- causal GQA wrapper/new SASS is byte-for-byte identical (`fb1bc58fda84fc2b5b657b54f934d49f6f4f37d584d8968ad2b12e0924778120`)
- both variants use 128 registers, zero stack, 2,784 instructions, and no `LDL`/`STL`

## Validation

- final FA4 targeted tests: 36 passed, 1 skipped
- full low-level registry sweep: 657 passed, 1 skipped
- `bench_suite` completed all 32 FA4 configs over 5 rounds; the only noisy apparent outlier was rerun cleanly over 9 rounds at 58.740 us vs 59.756 us, normalized ratio delta +0.7%
- Ruff and `git diff --check` pass