### PR TITLE
feat(kernels): land the low-level TIRx kernel stack

### DIFF
--- a/tests/test_bench_suite.py
+++ b/tests/test_bench_suite.py
@@ -309,25 +309,30 @@ def test_gpu_pool_prioritizes_larger_waiting_claims(monkeypatch: pytest.MonkeyPa
     single_thread.join()
 
 
-def test_resident_strangers_include_idle_compute_contexts(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        run,
-        "_compute_pids_by_gpu_uuid",
-        lambda: {"GPU-0": {101, 999}, "GPU-1": {202}, "GPU-unassigned": {303}},
-    )
-
-    assert run._resident_strangers_on_gpu_uuids(("GPU-0", "GPU-1"), {999}) == {101, 202}
-
-
-def test_monitored_subprocess_requeues_resident_context_before_spawn(
+def test_monitored_subprocess_allows_idle_foreign_context(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(run, "_gpu_uuid_of", lambda gpu_index: f"GPU-{gpu_index}")
-    monkeypatch.setattr(
-        run,
-        "_resident_strangers_on_gpu_uuids",
-        lambda gpu_uuids, our_pids: {123} if gpu_uuids == ("GPU-4",) else set(),
+    monkeypatch.setattr(run, "_pid_sm_on_gpus", lambda gpu_indices: {123: 0.0})
+    log_path = tmp_path / "subprocess.log"
+
+    result = run._run_subprocess_monitored(
+        [sys.executable, "-c", "print('spawned')"],
+        os.environ.copy(),
+        str(tmp_path),
+        log_path,
+        ("4",),
+        0.01,
+        5.0,
     )
+
+    assert result == (0, False, [], False)
+    assert "spawned" in log_path.read_text()
+
+
+def test_monitored_subprocess_requeues_active_foreign_process_before_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(run, "_pid_sm_on_gpus", lambda gpu_indices: {123: 6.0})
     log_path = tmp_path / "subprocess.log"
 
     result = run._run_subprocess_monitored(
@@ -337,17 +342,17 @@ def test_monitored_subprocess_requeues_resident_context_before_spawn(
         log_path,
         ("4",),
         0.01,
-        0.0,
+        5.0,
     )
 
     assert result == (-1, True, [123], False)
-    assert "foreign compute contexts" in log_path.read_text()
+    assert "active foreign processes" in log_path.read_text()
 
 
-def test_monitored_subprocess_requeues_when_gpu_uuid_lookup_fails(
+def test_monitored_subprocess_requeues_when_utilization_sampling_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(run, "_gpu_uuid_of", lambda gpu_index: None)
+    monkeypatch.setattr(run, "_pid_sm_on_gpus", lambda gpu_indices: None)
     log_path = tmp_path / "subprocess.log"
 
     result = run._run_subprocess_monitored(
@@ -357,11 +362,11 @@ def test_monitored_subprocess_requeues_when_gpu_uuid_lookup_fails(
         log_path,
         ("4",),
         0.01,
-        0.0,
+        5.0,
     )
 
     assert result == (-1, True, [], False)
-    assert "could not resolve every assigned GPU UUID" in log_path.read_text()
+    assert "could not sample assigned GPU utilization" in log_path.read_text()
 
 
 def test_run_one_passes_multigpu_assignment_to_megamoe(

--- a/tests/test_fp8_blockwise_gemm.py
+++ b/tests/test_fp8_blockwise_gemm.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from tirx_kernels.gemm import fp8_blockwise_gemm
+
+
+def test_fp8_blockwise_gemm_rejects_unpacked_scale_tail() -> None:
+    with pytest.raises(ValueError):
+        fp8_blockwise_gemm.get_kernel(M=4096, N=2112, K=2176)

--- a/tests/test_gdn_prefill_sm100.py
+++ b/tests/test_gdn_prefill_sm100.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pathlib import Path
-
 from tirx_kernels.attention import gdn_prefill_sm100
 from tirx_kernels.bench_suite import run as bench_suite_run
 
@@ -80,30 +78,3 @@ def test_gdn_prefill_sm100_covers_frozen_cartesian_matrix() -> None:
     assert observed == {
         (hq, hv, seq_lens) for hq, hv in expected_heads for seq_lens in expected_sequences
     }
-
-
-def test_gdn_prefill_sm100_rejects_tile_primitive_execution_apis() -> None:
-    source = Path(gdn_prefill_sm100.__file__).read_text()
-    forbidden = (
-        "Tx.copy(",
-        "Tx.copy_async(",
-        "Tx.gemm(",
-        "Tx.gemm_async(",
-        "tvm.backend.cuda.tile_primitive",
-        "T.Kernel(",
-        "T.Parallel(",
-        "T.Pipelined(",
-        "T.alloc_fragment(",
-        "@T.prim_func",
-        "/home/",
-        ".porting/",
-    )
-
-    assert "T.device_entry()" in source
-    assert not {needle for needle in forbidden if needle in source}
-    assert '"evict_normal"' not in source
-    # The five TMA copies pass their zero cache policy as the ptx chain's
-    # trailing positional operand (the legacy kwarg spelling is retired).
-    assert source.count("T.uint64(0),") == 5
-    assert source.count("_descriptor_copy_payload(o_map, descriptor_o)") == 1
-    assert "% num_sequences" not in source

--- a/tests/test_low_level_ir_contract.py
+++ b/tests/test_low_level_ir_contract.py
@@ -1,0 +1,218 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+import tvm
+from tirx_kernels.low_level_ir import (
+    LowLevelIRContractError,
+    check_low_level_ir,
+    inspect_low_level_ir,
+)
+from tvm.script import tirx as T
+from tvm.script.tirx import tile as Tx
+
+
+@T.prim_func
+def _local_accesses_are_legal():
+    values = T.alloc_local((2,), "float32")
+    tmem_value = T.alloc_buffer((1,), "float32", scope="tmem")
+    values[0] = T.float32(1)
+    values[1] = values[0]
+    tmem_value[0] = values[1]
+
+
+@T.prim_func
+def _ptx_global_and_shared_accesses_are_legal(
+    source: T.Buffer((1,), "float32"), destination: T.Buffer((1,), "float32")
+):
+    scratch = T.alloc_buffer((1,), "float32", scope="shared")
+    value = T.alloc_local((1,), "float32")
+    T.ptx.ld.global_.f32(value[0], source.ptr_to([0]))
+    T.ptx.st.shared.f32(scratch.ptr_to([0]), value[0])
+    T.ptx.ld.shared.f32(value[0], scratch.ptr_to([0]))
+    T.ptx.st.global_.f32(destination.ptr_to([0]), value[0])
+
+
+def test_local_and_explicit_ptx_memory_accesses_pass() -> None:
+    report = check_low_level_ir(
+        [_local_accesses_are_legal, _ptx_global_and_shared_accesses_are_legal]
+    )
+
+    assert report.ok
+    assert len(report.checked_functions) == 2
+
+
+@T.prim_func
+def _address_only_accesses_are_legal(global_buffer: T.Buffer((2,), "float32")):
+    shared_buffer = T.alloc_buffer((2,), "float32", scope="shared.dyn")
+    local_buffer = T.alloc_local((1,), "float32")
+    T.evaluate(T.address_of(global_buffer[1]))
+    T.evaluate(T.address_of(shared_buffer[1]))
+    T.evaluate(T.address_of(local_buffer[0]))
+
+
+def test_direct_address_operands_are_reported_without_being_rejected() -> None:
+    report = check_low_level_ir(_address_only_accesses_are_legal)
+
+    assert report.ok
+    assert {finding.scope for finding in report.address_only_loads} == {"global", "shared.dyn"}
+    assert {finding.kind for finding in report.address_only_loads} == {"address_only_buffer_load"}
+
+
+def test_supported_function_containers_are_checked_recursively() -> None:
+    module = tvm.IRModule({"module_entry": _local_accesses_are_legal})
+    nested = {
+        "direct": _local_accesses_are_legal,
+        "module": module,
+        "sequence": [_local_accesses_are_legal, (_local_accesses_are_legal,)],
+    }
+
+    report = check_low_level_ir(nested)
+
+    assert report.ok
+    assert len(report.checked_functions) == 4
+    assert any("module_entry" in path for path in report.checked_functions)
+
+
+@T.prim_func
+def _tile_operation_is_forbidden(
+    source: T.Buffer((1,), "float32"), destination: T.Buffer((1,), "float32")
+):
+    Tx.copy(destination[:], source[:])
+
+
+def test_tile_operation_is_rejected() -> None:
+    with pytest.raises(LowLevelIRContractError) as caught:
+        check_low_level_ir(_tile_operation_is_forbidden)
+
+    assert {finding.kind for finding in caught.value.report.violations} == {"tile_primitive"}
+
+
+def _real_load(scope: str):
+    @T.prim_func
+    def kernel(source_ptr: T.handle):
+        source = T.match_buffer(source_ptr, (1,), "float32", scope=scope)
+        value = T.alloc_local((1,), "float32")
+        value[0] = source[0]
+
+    return kernel
+
+
+@pytest.mark.parametrize("scope", ["global", "global.texture", "shared", "shared.dyn"])
+def test_real_loads_from_forbidden_scopes_are_rejected(scope: str) -> None:
+    report = inspect_low_level_ir(_real_load(scope))
+
+    assert not report.ok
+    assert [(finding.kind, finding.scope) for finding in report.violations] == [
+        ("buffer_load", scope)
+    ]
+
+
+def _store(scope: str):
+    @T.prim_func
+    def kernel(destination_ptr: T.handle):
+        destination = T.match_buffer(destination_ptr, (1,), "float32", scope=scope)
+        destination[0] = T.float32(1)
+
+    return kernel
+
+
+@pytest.mark.parametrize("scope", ["global", "global.texture", "shared", "shared.dyn"])
+def test_stores_to_forbidden_scopes_are_rejected(scope: str) -> None:
+    report = inspect_low_level_ir(_store(scope))
+
+    assert not report.ok
+    assert [(finding.kind, finding.scope) for finding in report.violations] == [
+        ("buffer_store", scope)
+    ]
+
+
+@T.prim_func
+def _ordinary_call_argument_is_a_real_load(source: T.Buffer((1,), "float32")):
+    T.evaluate(T.call_extern("consume", source[0], dtype="float32"))
+
+
+def test_only_a_direct_address_operand_receives_the_exemption() -> None:
+    report = inspect_low_level_ir(_ordinary_call_argument_is_a_real_load)
+
+    assert not report.ok
+    assert len(report.address_only_loads) == 0
+    assert [finding.kind for finding in report.violations] == ["buffer_load"]
+
+
+@T.prim_func
+def _nested_index_load_remains_a_real_access(
+    data: T.Buffer((2,), "float32"), index: T.Buffer((1,), "int32")
+):
+    T.evaluate(T.address_of(data[index[0]]))
+
+
+def test_load_inside_an_address_index_is_not_exempt() -> None:
+    report = inspect_low_level_ir(_nested_index_load_remains_a_real_access)
+
+    assert not report.ok
+    assert [finding.scope for finding in report.address_only_loads] == ["global"]
+    assert [(finding.kind, finding.scope) for finding in report.violations] == [
+        ("buffer_load", "global")
+    ]
+
+
+@T.prim_func
+def _forbidden_load_in_buffer_load_predicate(guard: T.Buffer((1,), "bool")):
+    local = T.alloc_local((1,), "float32")
+    T.evaluate(local.vload([0], predicate=guard[0]))
+
+
+def test_forbidden_load_in_buffer_load_predicate_is_rejected() -> None:
+    report = inspect_low_level_ir(_forbidden_load_in_buffer_load_predicate)
+
+    assert not report.ok
+    assert [(finding.kind, finding.scope) for finding in report.violations] == [
+        ("buffer_load", "global")
+    ]
+
+
+def test_one_invalid_function_rejects_the_whole_nested_result() -> None:
+    result = {
+        "legal": _local_accesses_are_legal,
+        "nested": (_local_accesses_are_legal, [_real_load("shared.cluster")]),
+    }
+
+    with pytest.raises(LowLevelIRContractError) as caught:
+        check_low_level_ir(result)
+
+    finding = caught.value.report.violations[0]
+    assert finding.scope == "shared.cluster"
+    assert finding.node_type == "BufferLoad"
+    assert "nested" in finding.function
+    assert finding.span is not None
+    assert not caught.value.report.ok
+
+
+@pytest.mark.parametrize("scope", ["globalish", "shared_memory", "local", "tmem"])
+def test_unrelated_or_allowed_scope_names_are_not_rejected(scope: str) -> None:
+    report = check_low_level_ir(_real_load(scope))
+
+    assert report.ok
+
+
+@pytest.mark.parametrize("empty", [[], (), {}, tvm.IRModule({})])
+def test_empty_function_collections_are_rejected(empty) -> None:
+    with pytest.raises(TypeError, match="at least one TIRx PrimFunc"):
+        check_low_level_ir(empty)

--- a/tests/test_low_level_registry_contract.py
+++ b/tests/test_low_level_registry_contract.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from tirx_kernels.low_level_ir import check_low_level_ir
+from tirx_kernels.registry import discover_kernels
+
+
+def _registry_cases() -> list:
+    registry = discover_kernels(strict=True)
+    assert registry, "no registered kernels discovered"
+
+    cases = []
+    for kernel_name, module in sorted(registry.items()):
+        assert callable(getattr(module, "get_kernel", None)), (
+            f"{kernel_name}: get_kernel must be callable"
+        )
+        configs = getattr(module, "CONFIGS", None)
+        assert isinstance(configs, list) and configs, (
+            f"{kernel_name}: CONFIGS must be a non-empty list"
+        )
+
+        labels = []
+        for config in configs:
+            assert isinstance(config, dict), f"{kernel_name}: config must be a dict"
+            assert all(isinstance(key, str) for key in config), (
+                f"{kernel_name}: config keys must be strings"
+            )
+            label = config.get("label")
+            assert isinstance(label, str) and label, f"{kernel_name}: config label must be set"
+            labels.append(label)
+            parameters = {key: value for key, value in config.items() if key != "label"}
+            cases.append(
+                pytest.param(kernel_name, module, parameters, id=f"{kernel_name}[{label}]")
+            )
+
+        assert len(labels) == len(set(labels)), f"{kernel_name}: duplicate config labels"
+    return cases
+
+
+@pytest.mark.parametrize(("kernel_name", "module", "parameters"), _registry_cases())
+def test_registered_public_configs_satisfy_low_level_ir_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    kernel_name: str,
+    module: ModuleType,
+    parameters: dict[str, object],
+) -> None:
+    # Kernel construction is target-specific but must not require allocating a
+    # CUDA tensor.  Pin the two factories that derive compile-time scheduling
+    # constants from the target GPU to the repository's SM100 reference target.
+    monkeypatch.setenv("TIRX_DEEPGEMM_NUM_SMS_OVERRIDE", "148")
+    if kernel_name == "sparse_flashmla_decode_head64":
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+        monkeypatch.setattr(
+            torch.cuda,
+            "get_device_properties",
+            lambda _device: SimpleNamespace(multi_processor_count=148),
+        )
+        parameters = {**parameters, "device": "cuda:0"}
+
+    report = check_low_level_ir(module.get_kernel(**parameters))
+
+    assert report.ok

--- a/tests/test_mega_moe_helpers.py
+++ b/tests/test_mega_moe_helpers.py
@@ -31,7 +31,6 @@ from tirx_kernels.deepgemm.mega_moe import (
     _get_mega_moe_cuda_compile_mode,
     _get_num_bytes_per_pull,
     _make_symm_buffer_offsets,
-    _run_worker,
     get_deepgemm_launch_config,
     get_deepgemm_workspace_layout,
     run_bench,
@@ -257,12 +256,11 @@ def test_cuda_compile_mode_context_restores_environment(monkeypatch: pytest.Monk
     assert os.environ["TVM_CUDA_COMPILE_MODE"] == "nvrtc"
 
 
-def test_mega_moe_bench_inherits_shared_defaults() -> None:
+def test_mega_moe_bench_public_defaults() -> None:
     parameters = inspect.signature(run_bench).parameters
     assert parameters["warmup"].default is None
     assert parameters["repeat"].default is None
     assert parameters["timer"].default is None
-    assert "bench_tk" not in inspect.getsource(_run_worker)
 
 
 def test_megamoe_timer_wraps_deepgemm_bench_kineto(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_registry_discover.py
+++ b/tests/test_registry_discover.py
@@ -16,9 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-from tvm import tirx
+import importlib
+import sys
 
+import pytest
+
+import tirx_kernels
 from tirx_kernels.registry import discover_categories, discover_kernels, load_kernel
+from tvm import tirx
 
 
 def test_discover_categories_includes_kernel_dirs() -> None:
@@ -57,3 +62,45 @@ def test_load_kernel_finds_flash_attention_backward() -> None:
     assert {config["is_causal"] for config in mod.CONFIGS} == {False, True}
     kernel = mod.get_kernel(batch_size=1, seq_len=256, num_heads=1, head_dim=128, is_causal=False)
     assert sum(tirx.is_buffer_var(param) for param in kernel.params) == 9
+
+
+def _use_temporary_kernel_package(monkeypatch, root) -> None:
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(tirx_kernels, "__file__", str(root / "__init__.py"))
+    monkeypatch.setattr(tirx_kernels, "__path__", [str(root)])
+    importlib.invalidate_caches()
+
+
+def test_strict_discovery_rejects_malformed_declared_metadata(monkeypatch, tmp_path) -> None:
+    category = tmp_path / "fixturecat"
+    category.mkdir()
+    (category / "__init__.py").write_text("", encoding="utf-8")
+    (category / "broken.py").write_text("KERNEL_META = {'name': 'broken'}\n", encoding="utf-8")
+    _use_temporary_kernel_package(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="invalid KERNEL_META"):
+        discover_kernels(strict=True)
+
+    sys.modules.pop("tirx_kernels.fixturecat.broken", None)
+    sys.modules.pop("tirx_kernels.fixturecat", None)
+
+
+def test_discovery_rejects_duplicate_public_kernel_names(monkeypatch, tmp_path) -> None:
+    category = tmp_path / "fixturecat"
+    category.mkdir()
+    (category / "__init__.py").write_text("", encoding="utf-8")
+    metadata = (
+        "KERNEL_META = {'name': 'duplicate', 'category': 'fixturecat', 'compute_capability': 10}\n"
+    )
+    (category / "first.py").write_text(metadata, encoding="utf-8")
+    (category / "second.py").write_text(metadata, encoding="utf-8")
+    _use_temporary_kernel_package(monkeypatch, tmp_path)
+
+    with pytest.raises(ValueError, match="duplicate kernel registry name 'duplicate'"):
+        discover_kernels(strict=True)
+    with pytest.raises(ValueError, match="duplicate kernel registry name 'duplicate'"):
+        load_kernel("duplicate", strict=True)
+
+    sys.modules.pop("tirx_kernels.fixturecat.first", None)
+    sys.modules.pop("tirx_kernels.fixturecat.second", None)
+    sys.modules.pop("tirx_kernels.fixturecat", None)

--- a/tests/test_sparse_decode_optional_specialization.py
+++ b/tests/test_sparse_decode_optional_specialization.py
@@ -1,149 +1,52 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 
-from tirx_kernels.flashmla.sparse_decode_head64 import (
-    COMBINE_OPTIONAL_BUFFER_PARAMS,
-    MAIN_OPTIONAL_BUFFER_PARAMS,
-    ModelType,
-    _present_runtime_args,
-    _specialized_combine_kernel,
-    _specialized_decode_kernels,
-    _specialized_main_kernel,
-)
-
-MAIN_PARAMETER_NAMES = (
-    "q_h",
-    "kv_h",
-    "indices_h",
-    "topk_length_h",
-    "attn_sink_h",
-    "lse_h",
-    "out_h",
-    "lse_accum_h",
-    "o_accum_h",
-    "tile_scheduler_metadata_h",
-    "num_splits_h",
-    "extra_kv_h",
-    "extra_indices_h",
-    "extra_topk_length_h",
-    "sm_scale_div_log2",
-    "stride_q_b",
-    "stride_q_s_q",
-    "stride_q_h_q",
-    "stride_kv_block",
-    "stride_kv_row",
-    "stride_indices_b",
-    "stride_indices_s_q",
-    "stride_lse_b",
-    "stride_lse_s_q",
-    "stride_o_b",
-    "stride_o_s_q",
-    "stride_o_h_q",
-    "stride_extra_kv_block",
-    "stride_extra_kv_row",
-    "stride_extra_indices_b",
-    "stride_extra_indices_s_q",
-    "stride_lse_accum_split",
-    "stride_lse_accum_s_q",
-    "stride_o_accum_split",
-    "stride_o_accum_s_q",
-    "stride_o_accum_h_q",
-    "b",
-    "s_q",
-    "topk",
-    "extra_topk",
-    "num_blocks",
-    "extra_num_blocks",
-    "page_block_size",
-    "extra_page_block_size",
-    "num_sm_parts",
-)
-COMBINE_PARAMETER_NAMES = (
-    "lse_h",
-    "out_h",
-    "lse_accum_h",
-    "o_accum_h",
-    "num_splits_h",
-    "attn_sink_h",
-    "stride_lse_b",
-    "stride_lse_s_q",
-    "stride_o_b",
-    "stride_o_s_q",
-    "stride_o_h_q",
-    "stride_lse_accum_split",
-    "stride_lse_accum_s_q",
-    "stride_o_accum_split",
-    "stride_o_accum_s_q",
-    "stride_o_accum_h_q",
-    "b",
-    "s_q",
-    "h_q",
-    "d_v",
-    "num_sm_parts",
-)
-MAIN_PRESENCE_MASKS = (
-    (False, False, False, False, False),
-    (True, False, False, False, False),
-    (False, True, False, False, False),
-    (True, True, False, False, False),
-    (False, False, True, True, False),
-    (False, False, True, True, True),
-    (True, True, True, True, True),
-)
+from tirx_kernels.flashmla.sparse_decode_head64 import CONFIGS, get_kernel
+from tvm import tirx
 
 
-def _expected_params(
-    parameter_names: tuple[str, ...], optional_names: tuple[str, ...], presence: tuple[bool, ...]
-) -> list[str]:
-    optional_presence = dict(zip(optional_names, presence, strict=True))
-    return [name for name in parameter_names if optional_presence.get(name, True)]
+def _assert_static_parameter_protocol(kernel, *, total: int, buffers: int) -> None:
+    buffer_parameters = [tirx.is_buffer_var(parameter) for parameter in kernel.params]
+
+    assert len(kernel.params) == total
+    assert buffer_parameters == [True] * buffers + [False] * (total - buffers)
 
 
-@pytest.mark.parametrize("model_type", (ModelType.MODEL1, ModelType.V32))
-@pytest.mark.parametrize("presence", MAIN_PRESENCE_MASKS)
-def test_main_optional_specializations_have_static_abi(model_type, presence) -> None:
-    kernel = _specialized_main_kernel(model_type, presence)
-    expected_params = _expected_params(MAIN_PARAMETER_NAMES, MAIN_OPTIONAL_BUFFER_PARAMS, presence)
-
-    assert [param.name for param in kernel.params] == expected_params
-    assert len(kernel.params) == 40 + sum(presence)
-    optional_buffers = {
-        param.name for param in kernel.buffer_map if param.name in MAIN_OPTIONAL_BUFFER_PARAMS
-    }
-    assert optional_buffers == {
-        name
-        for name, is_present in zip(MAIN_OPTIONAL_BUFFER_PARAMS, presence, strict=True)
-        if is_present
-    }
-
-
-@pytest.mark.parametrize("have_attn_sink", (False, True))
-def test_combine_optional_specialization_has_static_abi(have_attn_sink: bool) -> None:
-    kernel = _specialized_combine_kernel(8, have_attn_sink)
-    presence = (have_attn_sink,)
-
-    assert [param.name for param in kernel.params] == _expected_params(
-        COMBINE_PARAMETER_NAMES, COMBINE_OPTIONAL_BUFFER_PARAMS, presence
-    )
-    assert len(kernel.params) == 20 + have_attn_sink
-    assert {param.name for param in kernel.buffer_map} & set(COMBINE_OPTIONAL_BUFFER_PARAMS) == (
-        {"attn_sink_h"} if have_attn_sink else set()
+@pytest.fixture(autouse=True)
+def _sm100_compile_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(multi_processor_count=148),
     )
 
 
-def test_main_and_combine_specialization_caches_are_independent() -> None:
-    presence = (True, True, False, False, False)
-    main_model1, combine_model1 = _specialized_decode_kernels(ModelType.MODEL1, 8, presence)
-    main_v32, combine_v32 = _specialized_decode_kernels(ModelType.V32, 8, presence)
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda config: config["label"])
+def test_public_configs_expose_the_documented_static_argument_protocol(config) -> None:
+    parameters = {key: value for key, value in config.items() if key != "label"}
 
-    assert main_model1 is _specialized_main_kernel(ModelType.MODEL1, presence)
-    assert main_v32 is _specialized_main_kernel(ModelType.V32, presence)
-    assert main_model1 is not main_v32
-    assert combine_model1 is combine_v32
-    assert combine_model1 is _specialized_combine_kernel(8, True)
+    main, combine = get_kernel(**parameters)
 
-
-def test_runtime_argument_filter_drops_absent_optionals() -> None:
-    assert _present_runtime_args(("a", None, "c", None), (1, 3), (False, False)) == ("a", "c")
-    assert _present_runtime_args(("a", "b", "c", "d"), (1, 3), (True, False)) == ("a", "b", "c")
+    have_extra_cache = bool(config.get("extra_topk", 0))
+    main_optional_buffers = sum(
+        (
+            bool(config.get("have_topk_length", False)),
+            bool(config.get("have_attn_sink", False)),
+            have_extra_cache,
+            have_extra_cache,
+            bool(config.get("have_extra_topk_length", False)),
+        )
+    )
+    combine_optional_buffers = int(bool(config.get("have_attn_sink", False)))
+    _assert_static_parameter_protocol(
+        main, total=40 + main_optional_buffers, buffers=9 + main_optional_buffers
+    )
+    _assert_static_parameter_protocol(
+        combine, total=20 + combine_optional_buffers, buffers=5 + combine_optional_buffers
+    )

--- a/tirx_kernels/_protocol.py
+++ b/tirx_kernels/_protocol.py
@@ -34,9 +34,10 @@ CONFIGS : list[dict]
 
 Functions
 ---------
-get_kernel(**cfg) -> tvm.tirx.PrimFunc | list[tvm.tirx.PrimFunc]
-    Return the TIR PrimFunc(s) for this kernel.  Multi-kernel workloads
-    (e.g. split-k GEMM with a separate reduce kernel) return a list.
+get_kernel(**cfg) -> PrimFunc | IRModule | nested function collection
+    Return the pre-lowering TIRx function or functions for this kernel.
+    Multi-kernel workloads may return an ``IRModule`` or a nested list,
+    tuple, or mapping containing ``tvm.tirx.PrimFunc`` objects.
 
 prepare_data(**cfg) -> dict[str, Any]
     Prepare input/output tensors.  Returns a dict mapping argument names

--- a/tirx_kernels/attention/flash_attention4.py
+++ b/tirx_kernels/attention/flash_attention4.py
@@ -18,13 +18,12 @@ import torch
 import tvm
 import tvm.testing
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench
 from tvm.tirx.cuda import iket
 from tvm.tirx.cuda.iket import IketProfiler
 from tvm.tirx.lang.pipeline import MBarrier, Pipeline, PipelineState, TCGen05Bar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.lang.tile_scheduler import FlashAttentionLinearScheduler, FlashAttentionLPTScheduler
-from tvm.tirx.layout import wg_local_layout
 
 M_CLUSTER = 1
 N_CLUSTER = 1
@@ -56,6 +55,56 @@ EMU_PAIRS_CAUSAL = 2
 EMU_START_CAUSAL = 0
 EMU_PAIRS_NC = 2
 EMU_START_NC = 1
+
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.cta_group::1"
+)
+_TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes.cta_group::1"
+)
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TMEM_LD_16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_ST_16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+_SMEM_DESC_ADD_16B_SOURCE = r"""
+__forceinline__ __device__ uint64_t fa4_smem_desc_add_16B_offset(
+    uint64_t desc_base, int32_t offset) {
+  SmemDescriptor desc;
+  desc.desc_ = desc_base;
+  desc.lo += static_cast<uint32_t>(offset);
+  return desc.desc_;
+}
+"""
+def _smem_desc_add_16B_offset(desc_base, offset):
+    # The fixed TVM PTX table intentionally does not register integer add.
+    # Keep the helper so only the descriptor's uint32 low half wraps; a uint64
+    # TIR addition could carry into the descriptor's layout bits.
+    return T.cuda.func_call(
+        "fa4_smem_desc_add_16B_offset",
+        desc_base,
+        offset,
+        source_code=_SMEM_DESC_ADD_16B_SOURCE,
+        return_type="uint64",
+    )
+
+
+def _cast_f32x2_f16x2(dst, src, offset):
+    dst_words = dst.view("uint32")
+    return T.ptx.cvt.rn.f16x2.f32(
+        dst_words[offset // 2], src[offset + 1], src[offset]
+    )
+
+
+def _tmem_load(dst, dst_offset, tmem_col, width):
+    chain = _TMEM_LD_16 if width == 16 else _TMEM_LD_32
+    return T.ptx[chain](*[dst[dst_offset + i] for i in range(width)], tmem_col)
+
+
+def _tmem_store(src, src_offset, tmem_col, width=16):
+    assert width == 16
+    return T.ptx[_TMEM_ST_16](tmem_col, *[src[src_offset + i] for i in range(width)])
 
 
 def ceildiv(a, b):
@@ -110,20 +159,121 @@ def ex2_emulation_2(out, idx, x, y):
     xy_clamped: T.f32[2]
     xy_clamped[0] = T.max(x, -127.0)
     xy_clamped[1] = T.max(y, -127.0)
+    packed: T.uint64
+    rhs: T.uint64
+    addend: T.uint64
     xy_rounded: T.f32[2]
-    Tx.add(xy_rounded, xy_clamped, fp32_round_int, rounding_mode="rm")
+    T.ptx.mov.b64(packed, xy_clamped[0], xy_clamped[1])
+    T.ptx.mov.b64(rhs, T.float32(fp32_round_int), T.float32(fp32_round_int))
+    T.ptx.add.rm.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(xy_rounded[0], xy_rounded[1], packed)
     xy_rounded_back: T.f32[2]
-    Tx.sub(xy_rounded_back, xy_rounded, fp32_round_int, rounding_mode="rn")
+    T.ptx.mov.b64(packed, xy_rounded[0], xy_rounded[1])
+    T.ptx.mov.b64(rhs, T.float32(fp32_round_int), T.float32(fp32_round_int))
+    T.ptx.sub.rn.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(xy_rounded_back[0], xy_rounded_back[1], packed)
     xy_frac: T.f32[2]
-    Tx.sub(xy_frac, xy_clamped, xy_rounded_back, rounding_mode="rn")
+    T.ptx.mov.b64(packed, xy_clamped[0], xy_clamped[1])
+    T.ptx.mov.b64(rhs, xy_rounded_back[0], xy_rounded_back[1])
+    T.ptx.sub.rn.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(xy_frac[0], xy_frac[1], packed)
     xy_frac_ex2: T.f32[2]
     xy_frac_ex2[0] = poly_ex2_deg3[3]
     xy_frac_ex2[1] = poly_ex2_deg3[3]
-    Tx.fma(xy_frac_ex2, xy_frac_ex2, xy_frac, poly_ex2_deg3[2])
-    Tx.fma(xy_frac_ex2, xy_frac_ex2, xy_frac, poly_ex2_deg3[1])
-    Tx.fma(xy_frac_ex2, xy_frac_ex2, xy_frac, poly_ex2_deg3[0])
+    T.ptx.mov.b64(rhs, xy_frac[0], xy_frac[1])
+    T.ptx.mov.b64(packed, xy_frac_ex2[0], xy_frac_ex2[1])
+    T.ptx.mov.b64(addend, T.float32(poly_ex2_deg3[2]), T.float32(poly_ex2_deg3[2]))
+    T.ptx.fma.rz.ftz.f32x2(packed, packed, rhs, addend)
+    T.ptx.mov.b64(xy_frac_ex2[0], xy_frac_ex2[1], packed)
+    T.ptx.mov.b64(packed, xy_frac_ex2[0], xy_frac_ex2[1])
+    T.ptx.mov.b64(rhs, xy_frac[0], xy_frac[1])
+    T.ptx.mov.b64(addend, T.float32(poly_ex2_deg3[1]), T.float32(poly_ex2_deg3[1]))
+    T.ptx.fma.rz.ftz.f32x2(packed, packed, rhs, addend)
+    T.ptx.mov.b64(xy_frac_ex2[0], xy_frac_ex2[1], packed)
+    T.ptx.mov.b64(packed, xy_frac_ex2[0], xy_frac_ex2[1])
+    T.ptx.mov.b64(rhs, xy_frac[0], xy_frac[1])
+    T.ptx.mov.b64(addend, T.float32(poly_ex2_deg3[0]), T.float32(poly_ex2_deg3[0]))
+    T.ptx.fma.rz.ftz.f32x2(packed, packed, rhs, addend)
+    T.ptx.mov.b64(xy_frac_ex2[0], xy_frac_ex2[1], packed)
     out[idx] = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0])
     out[idx + 1] = combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1])
+
+
+@T.inline
+def fma_f32x2(values, idx, multiplier, addend_value):
+    """Apply the packed f32x2 FMA emitted by the former tile primitive."""
+    packed: T.uint64
+    rhs: T.uint64
+    addend: T.uint64
+    T.ptx.mov.b64(packed, values[idx], values[idx + 1])
+    T.ptx.mov.b64(rhs, multiplier, multiplier)
+    T.ptx.mov.b64(addend, addend_value, addend_value)
+    T.ptx.fma.rz.ftz.f32x2(packed, packed, rhs, addend)
+    T.ptx.mov.b64(values[idx], values[idx + 1], packed)
+
+
+@T.inline
+def mul_f32x2(values, idx, multiplier):
+    """Apply the packed f32x2 multiply emitted by the former tile primitive."""
+    packed: T.uint64
+    rhs: T.uint64
+    T.ptx.mov.b64(packed, values[idx], values[idx + 1])
+    T.ptx.mov.b64(rhs, multiplier, multiplier)
+    T.ptx.mul.rz.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(values[idx], values[idx + 1], packed)
+
+
+@T.inline
+def reduce_max_128(out, values, accum=False):
+    """SM100 three-input max tree used by the former tile reduction."""
+    temp: T.f32[4]
+    for i in T.unroll(4):
+        if accum and i == 0:
+            T.ptx["max.f32"](temp[i], values[2 * i], values[2 * i + 1], out[0])
+        else:
+            temp[i] = T.max(values[2 * i], values[2 * i + 1])
+    for outer in T.serial(15):
+        for i in T.unroll(4):
+            T.ptx["max.f32"](
+                temp[i],
+                temp[i],
+                values[8 * (outer + 1) + 2 * i],
+                values[8 * (outer + 1) + 2 * i + 1],
+            )
+    out[0] = T.max(temp[0], temp[1])
+    T.ptx["max.f32"](out[0], out[0], temp[2], temp[3])
+
+
+@T.inline
+def reduce_sum_128(out, values, accum=False):
+    """Preserve the packed add tree and accumulator insertion order."""
+    local_sum: T.f32[8]
+    packed: T.uint64
+    rhs: T.uint64
+    for i in T.unroll(8):
+        if accum and i == 0:
+            local_sum[i] = values[i] + out[0]
+        else:
+            local_sum[i] = values[i]
+    for outer in T.serial(15):
+        for i in T.unroll(4):
+            T.ptx.mov.b64(packed, local_sum[2 * i], local_sum[2 * i + 1])
+            T.ptx.mov.b64(rhs, values[8 * (outer + 1) + 2 * i], values[8 * (outer + 1) + 2 * i + 1])
+            T.ptx.add.rn.ftz.f32x2(packed, packed, rhs)
+            T.ptx.mov.b64(local_sum[2 * i], local_sum[2 * i + 1], packed)
+    T.ptx.mov.b64(packed, local_sum[0], local_sum[1])
+    T.ptx.mov.b64(rhs, local_sum[2], local_sum[3])
+    T.ptx.add.rn.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(local_sum[0], local_sum[1], packed)
+    T.ptx.mov.b64(packed, local_sum[4], local_sum[5])
+    T.ptx.mov.b64(rhs, local_sum[6], local_sum[7])
+    T.ptx.add.rn.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(local_sum[4], local_sum[5], packed)
+    T.ptx.mov.b64(packed, local_sum[0], local_sum[1])
+    T.ptx.mov.b64(rhs, local_sum[4], local_sum[5])
+    T.ptx.add.rn.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(local_sum[0], local_sum[1], packed)
+    out[0] = local_sum[0] + local_sum[1]
 
 
 WG_NUMBER = 4
@@ -207,6 +357,247 @@ def _kernel(
     num_q_blocks_total = T.meta_var(ceildiv(SEQ_LEN_Q, SEQ_Q_PER_TILE))
     num_q_blocks = T.meta_var(ceildiv(num_q_blocks_total, SMEM_PIPE_DEPTH_Q))
     num_total_tasks = T.meta_var(BATCH_SIZE * NUM_KV_HEADS * num_q_blocks)
+    Q_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    Q_tensor_map_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    K_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    K_tensor_map_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    V_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    V_tensor_map_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    O_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if GQA_RATIO == 1:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            Q_tensor_map,
+            "float16",
+            3,
+            Q.data,
+            HEAD_DIM // 2,
+            SEQ_LEN_Q,
+            BATCH_SIZE * NUM_QO_HEADS * 2,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            Q_tensor_map_1,
+            "float16",
+            3,
+            Q.data,
+            HEAD_DIM // 2,
+            SEQ_LEN_Q,
+            BATCH_SIZE * NUM_QO_HEADS * 2,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            O_tensor_map,
+            "float16",
+            3,
+            O.data,
+            HEAD_DIM // 2,
+            SEQ_LEN_Q,
+            BATCH_SIZE * NUM_QO_HEADS * 2,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            Q_tensor_map,
+            "float16",
+            4,
+            Q.data,
+            HEAD_DIM // 2,
+            NUM_QO_HEADS,
+            SEQ_LEN_Q,
+            BATCH_SIZE * 2,
+            HEAD_DIM * F16_BYTES,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            GQA_RATIO,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            Q_tensor_map_1,
+            "float16",
+            4,
+            Q.data,
+            HEAD_DIM // 2,
+            NUM_QO_HEADS,
+            SEQ_LEN_Q,
+            BATCH_SIZE * 2,
+            HEAD_DIM * F16_BYTES,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            GQA_RATIO,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            O_tensor_map,
+            "float16",
+            4,
+            O.data,
+            HEAD_DIM // 2,
+            NUM_QO_HEADS,
+            SEQ_LEN_Q,
+            BATCH_SIZE * 2,
+            HEAD_DIM * F16_BYTES,
+            NUM_QO_HEADS * HEAD_DIM * F16_BYTES,
+            HEAD_DIM,
+            HEAD_DIM // 2,
+            GQA_RATIO,
+            SEQ_Q_PER_TILE,
+            2,
+            1,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        K_tensor_map,
+        "float16",
+        3,
+        K.data,
+        HEAD_DIM // 2,
+        SEQ_LEN_KV,
+        BATCH_SIZE * NUM_KV_HEADS * 2,
+        NUM_KV_HEADS * HEAD_DIM * F16_BYTES,
+        HEAD_DIM,
+        HEAD_DIM // 2,
+        BLK_N,
+        2,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        K_tensor_map_1,
+        "float16",
+        3,
+        K.data,
+        HEAD_DIM // 2,
+        SEQ_LEN_KV,
+        BATCH_SIZE * NUM_KV_HEADS * 2,
+        NUM_KV_HEADS * HEAD_DIM * F16_BYTES,
+        HEAD_DIM,
+        HEAD_DIM // 2,
+        BLK_N,
+        2,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        V_tensor_map,
+        "float16",
+        3,
+        V.data,
+        HEAD_DIM // 2,
+        SEQ_LEN_KV,
+        BATCH_SIZE * NUM_KV_HEADS * 2,
+        NUM_KV_HEADS * HEAD_DIM * F16_BYTES,
+        HEAD_DIM,
+        HEAD_DIM // 2,
+        BLK_N,
+        2,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        V_tensor_map_1,
+        "float16",
+        3,
+        V.data,
+        HEAD_DIM // 2,
+        SEQ_LEN_KV,
+        BATCH_SIZE * NUM_KV_HEADS * 2,
+        NUM_KV_HEADS * HEAD_DIM * F16_BYTES,
+        HEAD_DIM,
+        HEAD_DIM // 2,
+        BLK_N,
+        2,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
     # When every CTA runs exactly ONE task (causal always launches
     # cta_count == num_total_tasks; non-causal whenever tasks <= 148), the
     # task tail is fully exposed on the critical path — there is no next
@@ -240,6 +631,31 @@ def _kernel(
     K_smem = pool.alloc_tcgen05_mma_AB((SMEM_PIPE_DEPTH_KV, BLK_N, HEAD_DIM), "float16")
     V_smem = K_smem.view(SMEM_PIPE_DEPTH_KV, BLK_N, HEAD_DIM)
     O_smem = pool.alloc_tcgen05_mma_AB((TMEM_PIPE_DEPTH, BLK_M, HEAD_DIM), "float16")
+    q_desc = SmemDescriptor()
+    q_desc.init(Q_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+    q_desc.make_lo_uniform()
+    k_desc = SmemDescriptor()
+    k_desc.init(K_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+    k_desc.make_lo_uniform()
+    v_desc = SmemDescriptor()
+    v_desc.init(V_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+    v_desc.make_lo_uniform()
+    q_desc_steady = SmemDescriptor()
+    k_desc_steady = SmemDescriptor()
+    v_desc_steady_hi = SmemDescriptor()
+    v_desc_tail_lo = SmemDescriptor()
+    v_desc_tail_hi = SmemDescriptor()
+    if is_causal and GQA_RATIO > 1:
+        q_desc_steady.init(Q_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+        q_desc_steady.make_lo_uniform()
+        k_desc_steady.init(K_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+        k_desc_steady.make_lo_uniform()
+        v_desc_steady_hi.init(V_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+        v_desc_steady_hi.make_lo_uniform()
+        v_desc_tail_lo.init(V_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+        v_desc_tail_lo.make_lo_uniform()
+        v_desc_tail_hi.init(V_smem.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+        v_desc_tail_hi.make_lo_uniform()
     sScale = pool.alloc((SSCALE_TOTAL_SIZE,), "float32", align=1024)
     tmem_addr = pool.alloc([1], "uint32")
     ACC_SCALE_BASE: T.let = 0
@@ -297,21 +713,15 @@ def _kernel(
         alloc_warp=12,
         dealloc_warp=0,
     )
-    tmem = tmem_pool.alloc((128, N_COLS_TMEM), "float32")
+    _tmem_f32 = tmem_pool.alloc((128, N_COLS_TMEM), "float32")
     tmem_pool.move_base_to(0)
-    tmem_as_f16 = tmem_pool.alloc((128, N_COLS_TMEM * 2), "float16")
+    _tmem_f16 = tmem_pool.alloc((128, N_COLS_TMEM * 2), "float16")
     T.ptx.fence.proxy.async_.shared__cta()
     T.ptx.fence.mbarrier_init.release.cluster()
     T.cuda.cta_sync()
-    # S and O share the (128, N_COLS_TMEM) f32 tmem as 2*SMEM_PIPE_DEPTH_Q
-    # MMA_N-wide stages: S in the low SMEM_PIPE_DEPTH_Q, O in the high ones
-    # (indexed SMEM_PIPE_DEPTH_Q + stage). Indexing a constant stage at the use
-    # site keeps the column offset in the region so allocated_addr stays 0.
-    S_region = T.meta_var(tmem.rearrange("m (s n) -> s m n", n=MMA_N))
-    O_region = S_region
-    # P overlays the f16 view of the S stages: the high MMA_N-wide half (two=1)
-    # of each stage's 2*MMA_N f16 columns, indexed [stage, 1, :, cols].
-    P_region = T.meta_var(tmem_as_f16.rearrange("m (s two n) -> s two m n", two=2, n=MMA_N))
+    # Direct tcgen05 addresses preserve the same overlay: S occupies columns
+    # [0, 256), O occupies [256, 512), and packed-f16 P aliases the high half
+    # of each S stage.
     scheduler = (
         FlashAttentionLPTScheduler(
             "fa_scheduler",
@@ -340,7 +750,9 @@ def _kernel(
     phase_q_load = 0
     tmem_pool.commit()
     if (wg_id == 3) & (warp_id == 0):
-        T.cuda.trap_when_assert_failed(tmem_addr[0] == T.uint32(0))
+        allocated_tmem_addr: T.uint32
+        T.ptx.ld.shared.u32(allocated_tmem_addr, tmem_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(allocated_tmem_addr == T.uint32(0))
     if wg_id == 2:
         for i_q in T.unroll(2):
             p_o_rescale.arrive(i_q)
@@ -355,69 +767,73 @@ def _kernel(
             if warp_id == 1:
 
                 @T.inline
-                def load_q(i_q):
+                def load_q(i_q, tensor_map):
                     q_load.empty.wait(i_q, phase_q_load)
-                    tma_copy_q = T.meta_var(
-                        {
-                            "dispatch": "tma_auto",
-                            "mbar": q_load.full.buf.ptr_to([i_q]),
-                            "cta_group": CTA_GROUP,
-                        }
-                    )
                     tma_q_token = iket.range_start("issue-tma-q")
-                    Q_smem_4d = Q_smem.view(SMEM_PIPE_DEPTH_Q, SEQ_Q_PER_TILE, GQA_RATIO, HEAD_DIM)
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            Q_smem_4d[i_q, :, :, :],
-                            Q[
-                                batch_idx,
-                                m_start + i_q * SEQ_Q_PER_TILE : m_start
-                                + (i_q + 1) * SEQ_Q_PER_TILE,
-                                kv_head_idx * GQA_RATIO : (kv_head_idx + 1) * GQA_RATIO,
-                                :,
-                            ],
-                            **tma_copy_q,
-                        )
+                        if GQA_RATIO == 1:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_3D](
+                                    Q_smem.ptr_to([i_q, 0, 0]),
+                                    T.address_of(tensor_map),
+                                    T.int32(0),
+                                    T.cast(m_start + i_q * SEQ_Q_PER_TILE, "int32"),
+                                    T.cast((batch_idx * NUM_QO_HEADS + kv_head_idx) * 2, "int32"),
+                                    T.cuda.cvta_generic_to_shared(q_load.full.buf.ptr_to([i_q])),
+                                )
+                            )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_4D](
+                                    Q_smem.ptr_to([i_q, 0, 0]),
+                                    T.address_of(tensor_map),
+                                    T.int32(0),
+                                    T.cast(kv_head_idx * GQA_RATIO, "int32"),
+                                    T.cast(m_start + i_q * SEQ_Q_PER_TILE, "int32"),
+                                    T.cast(batch_idx * 2, "int32"),
+                                    T.cuda.cvta_generic_to_shared(q_load.full.buf.ptr_to([i_q])),
+                                )
+                            )
                         q_load.full.arrive(i_q, CTA_GROUP * BLK_M * HEAD_DIM * F16_BYTES)
                     iket.range_end(tma_q_token)
 
                 @T.inline
-                def load_k(i_kv):
+                def load_k(i_kv, tensor_map):
                     kv_load.empty.wait(kv_pipe.stage, kv_pipe.phase)
-                    tma_copy_k = T.meta_var(
-                        {
-                            "dispatch": "tma_auto",
-                            "mbar": kv_load.full.buf.ptr_to([kv_pipe.stage]),
-                            "cta_group": CTA_GROUP,
-                        }
-                    )
                     tma_k_token = iket.range_start("issue-tma-k")
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            K_smem[kv_pipe.stage, :, :],
-                            K[batch_idx, i_kv * BLK_N : (i_kv + 1) * BLK_N, kv_head_idx, :],
-                            **tma_copy_k,
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_3D](
+                                K_smem.ptr_to([kv_pipe.stage, 0, 0]),
+                                T.address_of(tensor_map),
+                                T.int32(0),
+                                T.cast(i_kv * BLK_N, "int32"),
+                                T.cast((batch_idx * NUM_KV_HEADS + kv_head_idx) * 2, "int32"),
+                                T.cuda.cvta_generic_to_shared(
+                                    kv_load.full.buf.ptr_to([kv_pipe.stage])
+                                ),
+                            )
                         )
                         kv_load.full.arrive(kv_pipe.stage, CTA_GROUP * BLK_N * HEAD_DIM * F16_BYTES)
                     iket.range_end(tma_k_token)
                     kv_pipe.advance()
 
                 @T.inline
-                def load_v(i_kv):
+                def load_v(i_kv, tensor_map):
                     kv_load.empty.wait(kv_pipe.stage, kv_pipe.phase)
-                    tma_copy_v = T.meta_var(
-                        {
-                            "dispatch": "tma_auto",
-                            "mbar": kv_load.full.buf.ptr_to([kv_pipe.stage]),
-                            "cta_group": CTA_GROUP,
-                        }
-                    )
                     tma_v_token = iket.range_start("issue-tma-v")
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            V_smem[kv_pipe.stage, :, :],
-                            V[batch_idx, i_kv * BLK_N : (i_kv + 1) * BLK_N, kv_head_idx, :],
-                            **tma_copy_v,
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_3D](
+                                V_smem.ptr_to([kv_pipe.stage, 0, 0]),
+                                T.address_of(tensor_map),
+                                T.int32(0),
+                                T.cast(i_kv * BLK_N, "int32"),
+                                T.cast((batch_idx * NUM_KV_HEADS + kv_head_idx) * 2, "int32"),
+                                T.cuda.cvta_generic_to_shared(
+                                    kv_load.full.buf.ptr_to([kv_pipe.stage])
+                                ),
+                            )
                         )
                         kv_load.full.arrive(kv_pipe.stage, CTA_GROUP * BLK_N * HEAD_DIM * F16_BYTES)
                     iket.range_end(tma_v_token)
@@ -429,15 +845,15 @@ def _kernel(
                     if is_causal
                     else num_kv_blocks
                 )
-                load_q(0)
-                load_k(load_trip_count - 1)
-                load_q(1)
+                load_q(0, Q_tensor_map)
+                load_k(load_trip_count - 1, K_tensor_map)
+                load_q(1, Q_tensor_map_1)
                 phase_q_load ^= 1
-                load_v(load_trip_count - 1)
+                load_v(load_trip_count - 1, V_tensor_map)
                 for _i in T.serial(load_trip_count - 1, unroll=False):
                     i_kv: T.let = load_trip_count - 2 - _i
-                    load_k(i_kv)
-                    load_v(i_kv)
+                    load_k(i_kv, K_tensor_map_1)
+                    load_v(i_kv, V_tensor_map_1)
             if warp_id == 2:
                 corr_epi.full.wait(0, phase_tmem)
                 tma_store_token = iket.range_start("tma-store")
@@ -445,18 +861,28 @@ def _kernel(
                     if i_q != 0:
                         corr_epi.full.wait(i_q, phase_tmem)
                     m_start_global = T.meta_var(m_start + i_q * SEQ_Q_PER_TILE)
-                    O_smem_4d = O_smem.view(TMEM_PIPE_DEPTH, SEQ_Q_PER_TILE, GQA_RATIO, HEAD_DIM)
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            O[
-                                batch_idx,
-                                m_start_global : m_start_global + SEQ_Q_PER_TILE,
-                                kv_head_idx * GQA_RATIO : (kv_head_idx + 1) * GQA_RATIO,
-                                :,
-                            ],
-                            O_smem_4d[i_q, :, :, :],
-                            dispatch="tma_auto",
-                        )
+                        if GQA_RATIO == 1:
+                            T.evaluate(
+                                T.ptx[_TMA_S2G_3D](
+                                    T.address_of(O_tensor_map),
+                                    T.int32(0),
+                                    T.cast(m_start_global, "int32"),
+                                    T.cast((batch_idx * NUM_QO_HEADS + kv_head_idx) * 2, "int32"),
+                                    O_smem.ptr_to([i_q, 0, 0]),
+                                )
+                            )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_S2G_4D](
+                                    T.address_of(O_tensor_map),
+                                    T.int32(0),
+                                    T.cast(kv_head_idx * GQA_RATIO, "int32"),
+                                    T.cast(m_start_global, "int32"),
+                                    T.cast(batch_idx * 2, "int32"),
+                                    O_smem.ptr_to([i_q, 0, 0]),
+                                )
+                            )
                     T.ptx.cp.async_.bulk.commit_group()
                 # Drain the stores stage by stage. The wait count lives in the
                 # instruction text, so it has to be a literal rather than a loop
@@ -472,14 +898,24 @@ def _kernel(
                 acc = 0
 
                 @T.inline
-                def gemm_qk(q_stage, kv_stage):
-                    Tx.warp.gemm_async(
-                        S_region[q_stage, :, :],
-                        Q_smem[q_stage, 0:BLK_M, 0:HEAD_DIM],
-                        K_smem[kv_stage, 0:BLK_N, 0:HEAD_DIM],
-                        dispatch="tcgen05",
-                        cta_group=CTA_GROUP,
-                    )
+                def gemm_qk(q_stage, kv_stage, q_desc_value, k_desc_value):
+                    for ki in T.unroll(HEAD_DIM // MMA_K):
+                        if T.cuda.elect_sync():
+                            T.ptx[_MMA_F16](
+                                T.cast(q_stage * MMA_N, "uint32"),
+                                _smem_desc_add_16B_offset(
+                                    q_desc_value, q_stage * 2048 + ki // 4 * 1024 + ki % 4 * 2
+                                ),
+                                _smem_desc_add_16B_offset(
+                                    k_desc_value, kv_stage * 2048 + ki // 4 * 1024 + ki % 4 * 2
+                                ),
+                                T.uint32(136314896),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                ki != 0,
+                            )
                     if T.cuda.elect_sync():
                         s_ready.arrive(q_stage)
 
@@ -494,40 +930,53 @@ def _kernel(
                 K_SPLIT = T.meta_var((4 if is_causal else 6) * MMA_K)
 
                 @T.inline
-                def gemm_pv_part1(i_q, kv_stage, should_accumulate):
-                    Tx.warp.gemm_async(
-                        O_region[SMEM_PIPE_DEPTH_Q + i_q, :, :],
-                        P_region[i_q, 1, :, 0:K_SPLIT],
-                        V_smem[kv_stage, 0:K_SPLIT, 0:HEAD_DIM],
-                        transB=True,
-                        accum=should_accumulate,
-                        dispatch="tcgen05",
-                        cta_group=CTA_GROUP,
-                    )
+                def gemm_pv_part1(i_q, kv_stage, should_accumulate, v_desc_value):
+                    for ki in T.unroll(K_SPLIT // MMA_K):
+                        if T.cuda.elect_sync():
+                            T.ptx[_MMA_F16](
+                                T.cast((SMEM_PIPE_DEPTH_Q + i_q) * MMA_N, "uint32"),
+                                T.cast(i_q * MMA_N + MMA_N // 2 + ki * (MMA_K // 2), "uint32"),
+                                _smem_desc_add_16B_offset(v_desc_value, kv_stage * 2048 + ki * 128),
+                                T.uint32(136380432),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                tvm.tirx.any(ki != 0, T.cast(should_accumulate, "bool")),
+                            )
 
                 @T.inline
-                def gemm_pv_part2(i_q, kv_stage):
+                def gemm_pv_part2(i_q, kv_stage, v_desc_value):
                     p_ready_2.wait(i_q, phase_tmem)
-                    Tx.warp.gemm_async(
-                        O_region[SMEM_PIPE_DEPTH_Q + i_q, :, :],
-                        P_region[i_q, 1, :, K_SPLIT:BLK_N],
-                        V_smem[kv_stage, K_SPLIT:BLK_N, 0:HEAD_DIM],
-                        transB=True,
-                        accum=True,
-                        dispatch="tcgen05",
-                        cta_group=CTA_GROUP,
-                    )
+                    for ki in T.unroll((BLK_N - K_SPLIT) // MMA_K):
+                        if T.cuda.elect_sync():
+                            T.ptx[_MMA_F16](
+                                T.cast((SMEM_PIPE_DEPTH_Q + i_q) * MMA_N, "uint32"),
+                                T.cast(
+                                    i_q * MMA_N + MMA_N // 2 + K_SPLIT // 2 + ki * (MMA_K // 2),
+                                    "uint32",
+                                ),
+                                _smem_desc_add_16B_offset(
+                                    v_desc_value, kv_stage * 2048 + K_SPLIT * 8 + ki * 128
+                                ),
+                                T.uint32(136380432),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.bool(True),
+                            )
 
                 @T.inline
-                def gemm_pv(i_q, kv_stage, should_accumulate):
-                    gemm_pv_part1(i_q, kv_stage, should_accumulate)
-                    gemm_pv_part2(i_q, kv_stage)
+                def gemm_pv(i_q, kv_stage, should_accumulate, v_desc_lo, v_desc_hi):
+                    gemm_pv_part1(i_q, kv_stage, should_accumulate, v_desc_lo)
+                    gemm_pv_part2(i_q, kv_stage, v_desc_hi)
 
                 for i_q in T.unroll(SMEM_PIPE_DEPTH_Q):
                     q_load.full.wait(i_q, phase_q_load)
                     if i_q == 0:
                         kv_load.full.wait(kv_pipe.stage, kv_pipe.phase)
-                    gemm_qk(i_q, kv_pipe.stage)
+                    gemm_qk(i_q, kv_pipe.stage, q_desc.desc, k_desc.desc)
                     if i_q == 1:
                         if T.cuda.elect_sync():
                             kv_load.empty.arrive(kv_pipe.stage)
@@ -548,13 +997,24 @@ def _kernel(
                         if i_q == 0:
                             kv_load.full.wait(stage_v, phase_v)
                         p_o_rescale.wait(i_q, phase_tmem)
-                        gemm_pv(i_q, stage_v, acc)
+                        gemm_pv(
+                            i_q,
+                            stage_v,
+                            acc,
+                            v_desc.desc,
+                            v_desc_steady_hi.desc if is_causal and GQA_RATIO > 1 else v_desc.desc,
+                        )
                         if i_q == 1:
                             if T.cuda.elect_sync():
                                 kv_load.empty.arrive(stage_v)
                         if i_q == 0:
                             kv_load.full.wait(stage_k, phase_k)
-                        gemm_qk(i_q, stage_k)
+                        gemm_qk(
+                            i_q,
+                            stage_k,
+                            q_desc_steady.desc if is_causal and GQA_RATIO > 1 else q_desc.desc,
+                            k_desc_steady.desc if is_causal and GQA_RATIO > 1 else k_desc.desc,
+                        )
                         # Early Q release (non-causal / multi-task CTAs):
                         # Q[i_q]'s LAST reader is this final QK — committing
                         # here fires when it completes, ~2 tail-PV gemms
@@ -578,7 +1038,13 @@ def _kernel(
                     if i_q == 0:
                         kv_load.full.wait(kv_pipe.stage, kv_pipe.phase)
                     p_o_rescale.wait(i_q, phase_tmem)
-                    gemm_pv(i_q, kv_pipe.stage, acc)
+                    gemm_pv(
+                        i_q,
+                        kv_pipe.stage,
+                        acc,
+                        v_desc_tail_lo.desc if is_causal and GQA_RATIO > 1 else v_desc.desc,
+                        v_desc_tail_hi.desc if is_causal and GQA_RATIO > 1 else v_desc.desc,
+                    )
                     if i_q == 1:
                         if T.cuda.elect_sync():
                             kv_load.empty.arrive(kv_pipe.stage)
@@ -665,10 +1131,9 @@ def _kernel(
             @T.inline
             def softmax_step(i_kv, apply_mask=False, is_first=False):
                 s_chunk_buf: T.f32[BLK_N]
-                s_chunk = s_chunk_buf.view(128, BLK_N, layout=wg_local_layout(BLK_N))
                 p_chunk_buf_f32: T.f32[BLK_N // 2]
                 p_chunk_buf = T.decl_buffer((BLK_N,), dtype="float16", data=p_chunk_buf_f32.data)
-                p_chunk = p_chunk_buf.view(128, BLK_N, layout=wg_local_layout(BLK_N))
+                p_chunk_u32 = p_chunk_buf.view("uint32")
                 s_ready.wait(wg_id, phase_s_full)
                 if warp_id == 0:
                     iket.mark("softmax-phase-0")
@@ -677,21 +1142,21 @@ def _kernel(
                     softmax_max_token = iket.range_start("softmax-max")
                 tile_max: T.f32[1]
                 for chunk_idx in T.unroll(BLK_N // SOFTMAX_LD_CHUNK):
-                    Tx.wg.copy_async(
-                        s_chunk[
-                            :, chunk_idx * SOFTMAX_LD_CHUNK : (chunk_idx + 1) * SOFTMAX_LD_CHUNK
-                        ],
-                        S_region[
-                            wg_id,
-                            :,
-                            chunk_idx * SOFTMAX_LD_CHUNK : (chunk_idx + 1) * SOFTMAX_LD_CHUNK,
-                        ],
+                    T.evaluate(
+                        _tmem_load(
+                            s_chunk_buf,
+                            chunk_idx * SOFTMAX_LD_CHUNK,
+                            T.cuda.get_tmem_addr(
+                                T.uint32(0), 0, wg_id * MMA_N + chunk_idx * SOFTMAX_LD_CHUNK
+                            ),
+                            SOFTMAX_LD_CHUNK,
+                        )
                     )
                 if apply_mask:
                     apply_causal_mask(s_chunk_buf, m_block_idx, i_kv)
                 row_max_old: T.f32
                 if is_first:
-                    Tx.max(tile_max, s_chunk_buf)
+                    reduce_max_128(tile_max, s_chunk_buf)
                 else:
                     # row_max is initialized by the first softmax step.  Keep
                     # its load inside the non-first specialization so the
@@ -699,7 +1164,7 @@ def _kernel(
                     # whose result is dead on that path.
                     row_max_old = row_max[0]
                     tile_max[0] = row_max_old
-                    Tx.max(tile_max, s_chunk_buf, accum=True)
+                    reduce_max_128(tile_max, s_chunk_buf, accum=True)
                 row_max_new: T.f32
                 acc_scale: T.f32
                 acc_scale_: T.f32
@@ -723,7 +1188,7 @@ def _kernel(
                 iket.range_end(softmax_max_token)
                 if tid_in_wg < BLK_M and (not is_first):
                     sScale_idx: T.let = ACC_SCALE_BASE + tid_in_wg + wg_id * BLK_M
-                    sScale[sScale_idx] = acc_scale
+                    T.ptx.st.shared.f32(sScale.ptr_to([sScale_idx]), acc_scale)
                 # Stats-ready handshake to the correction wg via HW named
                 # barrier (FA4 CuTeDSL sm_stats_barrier): softmax warp w of
                 # stage wg_id pairs with correction warp w on barrier
@@ -739,7 +1204,8 @@ def _kernel(
                 softmax_fma_token = iket.sentinel_token("softmax-fma")
                 if warp_id == 0:
                     softmax_fma_token = iket.range_start("softmax-fma")
-                Tx.wg.fma(s_chunk, s_chunk, scale_log2, -row_max_scaled)
+                for i in T.unroll(BLK_N // 2):
+                    fma_f32x2(s_chunk_buf, 2 * i, T.float32(scale_log2), -row_max_scaled)
                 iket.range_end(softmax_fma_token)
                 if USE_S0_S1_BARRIER:
                     bar_s0_s1_sequence.wait(wg_id * 4 + warp_id, phase_s0_s1)
@@ -767,10 +1233,9 @@ def _kernel(
                             ex2_emulation_2(
                                 s_chunk_local, idx, s_chunk_local[idx], s_chunk_local[idx + 1]
                             )
-                    Tx.wg.cast(
-                        p_chunk[:, frag_idx * BLK_N // 4 : (frag_idx + 1) * BLK_N // 4],
-                        s_chunk[:, frag_idx * BLK_N // 4 : (frag_idx + 1) * BLK_N // 4],
-                    )
+                    for i in T.unroll(BLK_N // 4 // 2):
+                        idx = T.meta_var(frag_idx * BLK_N // 4 + 2 * i)
+                        T.evaluate(_cast_f32x2_f16x2(p_chunk_buf, s_chunk_buf, idx))
                 if USE_S0_S1_BARRIER:
                     bar_s0_s1_sequence.arrive((1 - wg_id) * 4 + warp_id)
                 iket.range_end(softmax_exp2_token)
@@ -779,21 +1244,28 @@ def _kernel(
                     softmax_tmem_st_token = iket.range_start("softmax-tmem-st")
                 P_SPLIT_Q = T.meta_var(2 if is_causal else 3)
                 for i in T.unroll(P_SPLIT_Q):
-                    Tx.wg.copy_async(
-                        P_region[wg_id, 1, :, i * BLK_N // 4 : (i + 1) * BLK_N // 4],
-                        p_chunk[:, i * BLK_N // 4 : (i + 1) * BLK_N // 4],
+                    T.evaluate(
+                        _tmem_store(
+                            p_chunk_u32,
+                            i * BLK_N // 4 // 2,
+                            T.cuda.get_tmem_addr(
+                                T.uint32(0), 0, (wg_id * 2 * MMA_N + MMA_N + i * BLK_N // 4) // 2
+                            ),
+                        )
                     )
                 T.ptx.tcgen05.wait__st.sync.aligned()
                 p_o_rescale.arrive(wg_id)
                 for i in T.unroll(4 - P_SPLIT_Q):
-                    Tx.wg.copy_async(
-                        P_region[
-                            wg_id,
-                            1,
-                            :,
-                            (P_SPLIT_Q + i) * BLK_N // 4 : (P_SPLIT_Q + 1 + i) * BLK_N // 4,
-                        ],
-                        p_chunk[:, (P_SPLIT_Q + i) * BLK_N // 4 : (P_SPLIT_Q + 1 + i) * BLK_N // 4],
+                    T.evaluate(
+                        _tmem_store(
+                            p_chunk_u32,
+                            (P_SPLIT_Q + i) * BLK_N // 4 // 2,
+                            T.cuda.get_tmem_addr(
+                                T.uint32(0),
+                                0,
+                                (wg_id * 2 * MMA_N + MMA_N + (P_SPLIT_Q + i) * BLK_N // 4) // 2,
+                            ),
+                        )
                     )
                 if warp_id == 0:
                     iket.mark("softmax-phase-2")
@@ -811,10 +1283,10 @@ def _kernel(
                 phase_s_full ^= 1
                 phase_q ^= 1
                 if is_first:
-                    Tx.sum(row_sum, s_chunk_buf)
+                    reduce_sum_128(row_sum, s_chunk_buf)
                 else:
                     row_sum[0] = row_sum[0] * acc_scale
-                    Tx.sum(row_sum, s_chunk_buf, accum=True)
+                    reduce_sum_128(row_sum, s_chunk_buf, accum=True)
                 if warp_id == 0:
                     iket.mark("softmax-phase-5")
                 iket.range_end(softmax_sum_token)
@@ -874,28 +1346,39 @@ def _kernel(
                 T.ptx.rcp.approx.ftz.f32(
                     norm_scale_sm, T.Select(acc_O_row_is_zero_or_nan, T.float32(1.0), row_sum[0])
                 )
-                o_row_f32_sm = T.wg_reg_tile(EPI_LD_SM)
-                o_row_f16_sm = T.wg_reg_tile(EPI_LD_SM, "float16")
+                o_row_f32_sm: T.f32[EPI_LD_SM]
+                o_row_f16_sm: T.f16[EPI_LD_SM]
+                o_row_f16_sm_u32 = T.decl_buffer(
+                    (EPI_LD_SM // 2,), "uint32", data=o_row_f16_sm.data
+                )
                 for epi_q in T.unroll(2):
                     if wg_id == epi_q:
                         for d_tile in T.unroll(ceildiv(HEAD_DIM, EPI_LD_SM)):
-                            Tx.wg.copy_async(
-                                o_row_f32_sm,
-                                O_region[
-                                    SMEM_PIPE_DEPTH_Q + epi_q,
-                                    :,
-                                    d_tile * EPI_LD_SM : (d_tile + 1) * EPI_LD_SM,
-                                ],
+                            d_start: T.let = d_tile * EPI_LD_SM
+                            T.evaluate(
+                                _tmem_load(
+                                    o_row_f32_sm,
+                                    0,
+                                    T.cuda.get_tmem_addr(
+                                        T.uint32(0),
+                                        0,
+                                        (SMEM_PIPE_DEPTH_Q + epi_q) * MMA_N + d_start,
+                                    ),
+                                    EPI_LD_SM,
+                                )
                             )
-                            Tx.wg.mul(o_row_f32_sm, o_row_f32_sm, norm_scale_sm)
-                            Tx.wg.cast(o_row_f16_sm, o_row_f32_sm)
-                            Tx.wg.copy(
-                                O_smem[
-                                    epi_q, 0:BLK_M, d_tile * EPI_LD_SM : (d_tile + 1) * EPI_LD_SM
-                                ],
-                                o_row_f16_sm,
-                                vec_len=8,
-                            )
+                            for i in T.unroll(EPI_LD_SM // 2):
+                                mul_f32x2(o_row_f32_sm, 2 * i, norm_scale_sm)
+                            for i in T.unroll(EPI_LD_SM // 2):
+                                T.evaluate(_cast_f32x2_f16x2(o_row_f16_sm, o_row_f32_sm, 2 * i))
+                            for i in T.unroll(EPI_LD_SM // 8):
+                                T.ptx.st.shared.v4.u32(
+                                    O_smem.ptr_to([epi_q, tid_in_wg, d_start + i * 8]),
+                                    o_row_f16_sm_u32[i * 4],
+                                    o_row_f16_sm_u32[i * 4 + 1],
+                                    o_row_f16_sm_u32[i * 4 + 2],
+                                    o_row_f16_sm_u32[i * 4 + 3],
+                                )
                 iket.range_end(epi_ld_tmem_token)
                 T.ptx.fence.proxy.async_.shared__cta()
                 corr_epi.full.arrive(wg_id)
@@ -903,7 +1386,9 @@ def _kernel(
                 phase_oepi ^= 1
             else:
                 if tid_in_wg < BLK_M:
-                    sScale[ROW_SUM_BASE + tid_in_wg + wg_id * BLK_M] = row_sum[0]
+                    T.ptx.st.shared.f32(
+                        sScale.ptr_to([ROW_SUM_BASE + tid_in_wg + wg_id * BLK_M]), row_sum[0]
+                    )
                 if STATS_BAR_PAIRWISE:
                     T.ptx.bar.arrive(T.uint32(1 + wg_id * 4 + warp_id), 64)
                 else:
@@ -937,7 +1422,9 @@ def _kernel(
                     acc_scale: T.f32
                     should_rescale: T.i32
                     if tid_in_wg < BLK_M:
-                        acc_scale = sScale[ACC_SCALE_BASE + tid_in_wg + i_q * BLK_M]
+                        T.ptx.ld.shared.f32(
+                            acc_scale, sScale.ptr_to([ACC_SCALE_BASE + tid_in_wg + i_q * BLK_M])
+                        )
                         should_rescale = T.Select(acc_scale < T.float32(1.0), 1, 0)
                     else:
                         should_rescale = 0
@@ -945,26 +1432,34 @@ def _kernel(
                     if any_needs_rescale != 0:
                         if tid_in_wg < BLK_M:
                             RESCALE_TILE = T.meta_var(16)
-                            o_row = T.wg_reg_tile(RESCALE_TILE)
+                            o_row: T.f32[RESCALE_TILE]
                             for d_tile in T.unroll(ceildiv(HEAD_DIM, RESCALE_TILE)):
                                 d_start: T.let = d_tile * RESCALE_TILE
                                 if d_start < HEAD_DIM:
-                                    Tx.wg.copy_async(
-                                        o_row,
-                                        O_region[
-                                            SMEM_PIPE_DEPTH_Q + i_q,
-                                            :,
-                                            d_start : d_start + RESCALE_TILE,
-                                        ],
+                                    T.evaluate(
+                                        _tmem_load(
+                                            o_row,
+                                            0,
+                                            T.cuda.get_tmem_addr(
+                                                T.uint32(0),
+                                                0,
+                                                (SMEM_PIPE_DEPTH_Q + i_q) * MMA_N + d_start,
+                                            ),
+                                            RESCALE_TILE,
+                                        )
                                     )
-                                    Tx.wg.mul(o_row, o_row, acc_scale)
-                                    Tx.wg.copy_async(
-                                        O_region[
-                                            SMEM_PIPE_DEPTH_Q + i_q,
-                                            :,
-                                            d_start : d_start + RESCALE_TILE,
-                                        ],
-                                        o_row,
+                                    for i in T.unroll(RESCALE_TILE // 2):
+                                        mul_f32x2(o_row, 2 * i, acc_scale)
+                                    T.evaluate(
+                                        _tmem_store(
+                                            o_row,
+                                            0,
+                                            T.cuda.get_tmem_addr(
+                                                T.uint32(0),
+                                                0,
+                                                (SMEM_PIPE_DEPTH_Q + i_q) * MMA_N + d_start,
+                                            ),
+                                        )
                                     )
                             T.ptx.tcgen05.wait__st.sync.aligned()
                     p_o_rescale.arrive(i_q)
@@ -978,7 +1473,10 @@ def _kernel(
                         T.ptx.bar.sync(T.uint32(1 + i_q * 4 + warp_id), 64)
                     else:
                         T.ptx.bar.sync(T.uint32(1 + i_q), 256)
-                    row_sum: T.let = sScale[ROW_SUM_BASE + tid_in_wg + i_q * BLK_M]
+                    row_sum: T.f32
+                    T.ptx.ld.shared.f32(
+                        row_sum, sScale.ptr_to([ROW_SUM_BASE + tid_in_wg + i_q * BLK_M])
+                    )
                     softmax_corr.empty.arrive(i_q)
                     o_ready.wait(i_q, phase_tmem)
                     corr_epi.empty.wait(i_q, phase_tmem)
@@ -992,29 +1490,36 @@ def _kernel(
                     T.ptx.rcp.approx.ftz.f32(
                         norm_scale, T.Select(acc_O_mn_row_is_zero_or_nan, T.float32(1.0), row_sum)
                     )
-                    o_row_f32 = T.wg_reg_tile(TMEM_EPI_LD_SIZE)
-                    o_row_f16 = T.wg_reg_tile(TMEM_EPI_LD_SIZE, "float16")
+                    o_row_f32: T.f32[TMEM_EPI_LD_SIZE]
+                    o_row_f16: T.f16[TMEM_EPI_LD_SIZE]
+                    o_row_f16_u32 = T.decl_buffer(
+                        (TMEM_EPI_LD_SIZE // 2,), "uint32", data=o_row_f16.data
+                    )
                     for d_tile in T.unroll(ceildiv(HEAD_DIM, TMEM_EPI_LD_SIZE)):
                         d_start: T.let = d_tile * TMEM_EPI_LD_SIZE
                         if d_start < HEAD_DIM:
-                            Tx.wg.copy_async(
-                                o_row_f32,
-                                O_region[
-                                    SMEM_PIPE_DEPTH_Q + i_q, :, d_start : d_start + TMEM_EPI_LD_SIZE
-                                ],
+                            T.evaluate(
+                                _tmem_load(
+                                    o_row_f32,
+                                    0,
+                                    T.cuda.get_tmem_addr(
+                                        T.uint32(0), 0, (SMEM_PIPE_DEPTH_Q + i_q) * MMA_N + d_start
+                                    ),
+                                    TMEM_EPI_LD_SIZE,
+                                )
                             )
-                            Tx.wg.mul(o_row_f32, o_row_f32, norm_scale)
-                            Tx.wg.cast(o_row_f16, o_row_f32)
-                            Tx.wg.copy(
-                                O_smem[
-                                    i_q,
-                                    0:BLK_M,
-                                    d_tile * TMEM_EPI_LD_SIZE : d_tile * TMEM_EPI_LD_SIZE
-                                    + TMEM_EPI_LD_SIZE,
-                                ],
-                                o_row_f16,
-                                vec_len=8,
-                            )
+                            for i in T.unroll(TMEM_EPI_LD_SIZE // 2):
+                                mul_f32x2(o_row_f32, 2 * i, norm_scale)
+                            for i in T.unroll(TMEM_EPI_LD_SIZE // 2):
+                                T.evaluate(_cast_f32x2_f16x2(o_row_f16, o_row_f32, 2 * i))
+                            for i in T.unroll(TMEM_EPI_LD_SIZE // 8):
+                                T.ptx.st.shared.v4.u32(
+                                    O_smem.ptr_to([i_q, tid_in_wg, d_start + i * 8]),
+                                    o_row_f16_u32[i * 4],
+                                    o_row_f16_u32[i * 4 + 1],
+                                    o_row_f16_u32[i * 4 + 2],
+                                    o_row_f16_u32[i * 4 + 3],
+                                )
                     iket.range_end(epi_ld_tmem_token)
                     T.ptx.fence.proxy.async_.shared__cta()
                     corr_epi.full.arrive(i_q)
@@ -1022,7 +1527,13 @@ def _kernel(
                 phase_tmem ^= 1
             phase_q ^= 1
         scheduler.next_tile()
-    tmem_pool.dealloc()
+    if (wg_id == 0) & (warp_id == 0):
+        dealloc_tmem_addr: T.uint32
+        T.ptx.ld.shared.u32(dealloc_tmem_addr, tmem_addr.ptr_to([0]))
+        T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
+        T.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](
+            dealloc_tmem_addr, T.uint32(N_COLS_TMEM)
+        )
     # No final cta_sync: warps exit independently after the dealloc. On the
     # single-task causal shapes the kernel-end barrier is fully exposed (~11%
     # of stall samples on the tail); dropping it is safe (50x reused-module
@@ -1042,14 +1553,31 @@ def get_flash_attention4_kernel(
     # per regime (swept 3..8; >=6 re-spills): multi-wave s2048/s4096_h32kv32_c
     # want 5 (0.967->0.992, 0.974->0.993); the single-wave s1024_h32kv32_c
     # wants 4 (0.954->0.962, won all 3 rounds, s2048/s4096 unaffected ~tie).
-    # GQA=2 (s1024kv16_c) and throughput-bound non-causal keep 10's ILP. Read
-    # by tir support/nvcc.py via the env var; set per-shape here because each
-    # bench config compiles in its own process. FA4_REG_LEVEL overrides (tuning).
+    # After shortening the descriptor live ranges, the two benchmarked short
+    # causal GQA paths (kv4/kv8) are spill-free again at level 10. A paired
+    # same-process A/B selected level 10 for both; the other short causal
+    # regimes keep their previously validated level. Throughput-bound
+    # non-causal variants retain level 10. Read by tir support/nvcc.py via the
+    # env var; set per-shape here because each bench config compiles in its own
+    # process.
+    # FA4_REG_LEVEL overrides (tuning).
     _reg_override = os.environ.get("FA4_REG_LEVEL", "")
     if _reg_override:
         _reg_level = _reg_override
+    elif (
+        is_causal
+        and batch_size == 1
+        and seq_len_q == 1024
+        and seq_len_kv == 1024
+        and num_qo_heads == 32
+        and num_kv_heads in (4, 8)
+        and head_dim == 128
+    ):
+        _reg_level = "10"
     elif is_causal and num_qo_heads == num_kv_heads:
         _reg_level = "4" if seq_len_q <= 1024 else "5"
+    elif is_causal and seq_len_q <= 1024:
+        _reg_level = "5"
     else:
         _reg_level = "10"
     os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _reg_level

--- a/tirx_kernels/attention/flash_attention4.py
+++ b/tirx_kernels/attention/flash_attention4.py
@@ -68,28 +68,14 @@ _MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
 _TMEM_LD_16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
 _TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
 _TMEM_ST_16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
-_SMEM_DESC_ADD_16B_SOURCE = r"""
-__forceinline__ __device__ uint64_t fa4_smem_desc_add_16B_offset(
-    uint64_t desc_base, int32_t offset) {
-  SmemDescriptor desc;
-  desc.desc_ = desc_base;
-  desc.lo += static_cast<uint32_t>(offset);
-  return desc.desc_;
-}
-"""
 
 
 def _smem_desc_add_16B_offset(desc_base, offset):
-    # Keep the descriptor update as one C++ expression.  Separate mov/add/mov
-    # T.ptx calls preserve low-32-bit wrap semantics, but perturb nvcc's PTX
-    # around this MMA hot path enough to regress long-sequence attention.
-    return T.cuda.func_call(
-        "fa4_smem_desc_add_16B_offset",
-        desc_base,
-        offset,
-        source_code=_SMEM_DESC_ADD_16B_SOURCE,
-        return_type="uint64",
-    )
+    # Update the address lane with uint32 wraparound without carrying into the descriptor bits.
+    desc_halves = T.reinterpret("uint32x2", desc_base)
+    desc_lo = T.Shuffle([desc_halves], [0]) + T.cast(offset, "uint32")
+    desc_hi = T.Shuffle([desc_halves], [1])
+    return T.reinterpret("uint64", T.Shuffle([desc_lo, desc_hi], [0, 1]))
 
 
 def _cast_f32x2_f16x2(dst, src, offset):

--- a/tirx_kernels/attention/flash_attention4.py
+++ b/tirx_kernels/attention/flash_attention4.py
@@ -77,10 +77,12 @@ __forceinline__ __device__ uint64_t fa4_smem_desc_add_16B_offset(
   return desc.desc_;
 }
 """
+
+
 def _smem_desc_add_16B_offset(desc_base, offset):
-    # The fixed TVM PTX table intentionally does not register integer add.
-    # Keep the helper so only the descriptor's uint32 low half wraps; a uint64
-    # TIR addition could carry into the descriptor's layout bits.
+    # Keep the descriptor update as one C++ expression.  Separate mov/add/mov
+    # T.ptx calls preserve low-32-bit wrap semantics, but perturb nvcc's PTX
+    # around this MMA hot path enough to regress long-sequence attention.
     return T.cuda.func_call(
         "fa4_smem_desc_add_16B_offset",
         desc_base,
@@ -92,9 +94,7 @@ def _smem_desc_add_16B_offset(desc_base, offset):
 
 def _cast_f32x2_f16x2(dst, src, offset):
     dst_words = dst.view("uint32")
-    return T.ptx.cvt.rn.f16x2.f32(
-        dst_words[offset // 2], src[offset + 1], src[offset]
-    )
+    return T.ptx.cvt.rn.f16x2.f32(dst_words[offset // 2], src[offset + 1], src[offset])
 
 
 def _tmem_load(dst, dst_offset, tmem_col, width):
@@ -116,23 +116,23 @@ def shl_u32_clamp(val, shift):
     the fused ``max(col_limit - s*CHUNK, 0)`` (one VIADDMNMX, like cutedsl) and
     drop the ``min(.,CHUNK)`` clamp (which adds a VIMNMX above cutedsl's count):
     ``~shl_clamp(0xFFFFFFFF, k)`` is the low-k-bits mask for any k, no min."""
-    func_name = "shl_u32_clamp"
-    source_code = (
-        f"\n__device__ __forceinline__ unsigned int {func_name}"
-        "(unsigned int val, unsigned int shift) {\n"
-        "  unsigned int r;\n"
-        '  asm("shl.b32 %0, %1, %2;" : "=r"(r) : "r"(val), "r"(shift));\n'
-        "  return r;\n}\n"
-    )
-    return T.cuda.func_call(func_name, val, shift, source_code=source_code, return_type="uint32")
+    result = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.shl.b32(result[0], val, shift))
+    return result[0]
 
 
 def combine_int_frac_ex2(x_rounded, frac_ex2):
-    func_name = "combine_int_frac_ex2"
-    source_code = f'\n__device__ __forceinline__ float {func_name}(float x_rounded, float frac_ex2) {{\n  float out;\n  asm volatile(\n    "{{\\n\\t"\n    ".reg .s32 x_rounded_i, frac_ex_i, x_rounded_e, out_i;\\n\\t"\n    "mov.b32 x_rounded_i, %1;\\n\\t"\n    "mov.b32 frac_ex_i, %2;\\n\\t"\n    "shl.b32 x_rounded_e, x_rounded_i, 23;\\n\\t"\n    "add.s32 out_i, x_rounded_e, frac_ex_i;\\n\\t"\n    "mov.b32 %0, out_i;\\n\\t"\n    "}}\\n"\n    : "=f"(out) : "f"(x_rounded), "f"(frac_ex2));\n  return out;\n}}\n'
-    return T.cuda.func_call(
-        func_name, x_rounded, frac_ex2, source_code=source_code, return_type="float32"
-    )
+    x_rounded_i = T.alloc_local((1,), "int32")
+    frac_ex_i = T.alloc_local((1,), "int32")
+    x_rounded_e = T.alloc_local((1,), "int32")
+    out_i = T.alloc_local((1,), "int32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.mov.b32(x_rounded_i[0], x_rounded))
+    T.evaluate(T.ptx.mov.b32(frac_ex_i[0], frac_ex2))
+    T.evaluate(T.ptx.shl.b32(x_rounded_e[0], x_rounded_i[0], T.uint32(23)))
+    T.evaluate(T.ptx.add.s32(out_i[0], x_rounded_e[0], frac_ex_i[0]))
+    T.evaluate(T.ptx.mov.b32(out[0], out_i[0]))
+    return out[0]
 
 
 def get_n_block_max(m_block_idx, causal, SEQ_LEN_KV, SEQ_LEN_Q, SEQ_Q_PER_TILE):

--- a/tirx_kernels/attention/flash_attention_backward.py
+++ b/tirx_kernels/attention/flash_attention_backward.py
@@ -1107,9 +1107,10 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                     q_row_start,
                     (K_smem.elem_offset - Q_row.elem_offset) * DTYPE_SIZE,
                 )
-                desc_q_row = matrix_desc_from_anchor(
-                    MATRIX_DESC_F16_SS_LDO_512, q_row_start, 0
-                )
+                if not causal:
+                    desc_q_row = matrix_desc_from_anchor(
+                        MATRIX_DESC_F16_SS_LDO_512, q_row_start, 0
+                    )
                 desc_v_row = matrix_desc_from_anchor(
                     MATRIX_DESC_F16_SS_LDO_1024,
                     q_row_start,
@@ -1177,7 +1178,23 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                     q_ph.advance()
                     accum_var = 0
                     if T.cuda.elect_sync():
-                        mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row)
+                        if causal:
+                            # Keep the causal Q-row descriptor issue-local.
+                            # Its address encoding is cheap to rebuild, while
+                            # carrying it across the whole 2-CTA MMA loop
+                            # creates avoidable uniform-register pressure.
+                            q_row_issue_addr: T.uint32 = T.cuda.cvta_generic_to_shared(
+                                Q_row.ptr_to([0, 0, 0])
+                            )
+                            q_row_issue_start: T.uint64 = T.cast(
+                                T.shift_right(q_row_issue_addr, T.uint32(4)), "uint64"
+                            )
+                            desc_q_row_issue: T.uint64 = matrix_desc_from_anchor(
+                                MATRIX_DESC_F16_SS_LDO_512, q_row_issue_start, 0
+                            )
+                            mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row_issue)
+                        else:
+                            mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row)
                     if T.cuda.elect_sync():
                         mma2wg0_s.arrive(0, cta_group=CTA_GROUP, cta_mask=pair_mask)
                         tcgen05_commit(
@@ -1222,7 +1239,19 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                         dq_tmem_free_ph.advance()
                         accum_var = 0
                         if T.cuda.elect_sync():
-                            mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row)
+                            if causal:
+                                q_row_issue_addr: T.uint32 = T.cuda.cvta_generic_to_shared(
+                                    Q_row.ptr_to([0, 0, 0])
+                                )
+                                q_row_issue_start: T.uint64 = T.cast(
+                                    T.shift_right(q_row_issue_addr, T.uint32(4)), "uint64"
+                                )
+                                desc_q_row_issue: T.uint64 = matrix_desc_from_anchor(
+                                    MATRIX_DESC_F16_SS_LDO_512, q_row_issue_start, 0
+                                )
+                                mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row_issue)
+                            else:
+                                mma_s(TMEM_OFF_A, accum_var, desc_k_row, desc_q_row)
                         if T.cuda.elect_sync():
                             mma2wg0_s.arrive(0, cta_group=CTA_GROUP, cta_mask=pair_mask)
                             tcgen05_commit(
@@ -1368,8 +1397,10 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                     0, remote=1 - id_in_pair, pred=True
                 )
                 tmem_dealloc_mbar.wait(0, 0)
+                tmem_dealloc_addr: T.uint32
+                T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_addr.ptr_to([0]))
                 T.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](
-                    tmem_addr[0], T.uint32(512)
+                    tmem_dealloc_addr, T.uint32(512)
                 )
 
         # ==============================================================
@@ -1447,13 +1478,17 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
                     for stage in T.unroll(STRIP_SIZE // 32):
                         for j_inner in T.unroll(32 // 2):
                             j = T.meta_var(stage * (32 // 2) + j_inner)
+                            lse_pair_0: T.float32
+                            lse_pair_1: T.float32
+                            T.ptx.ld.shared.v2.f32(
+                                lse_pair_0,
+                                lse_pair_1,
+                                sLSE.ptr_to([0, strip_off + 2 * j]),
+                            )
                             scaled_pair: T.let = fma_scale_sub_f32x2(
                                 T.cuda.make_float2(S_strip[2 * j], S_strip[2 * j + 1]),
                                 T.cuda.make_float2(T.float32(scale_log2), T.float32(scale_log2)),
-                                T.cuda.make_float2(
-                                    sLSE[0, strip_off + 2 * j],
-                                    sLSE[0, strip_off + 2 * j + 1],
-                                ),
+                                T.cuda.make_float2(lse_pair_0, lse_pair_1),
                             )
                             S_strip[2 * j] = T.cuda.float2_x(scaled_pair)
                             S_strip[2 * j + 1] = T.cuda.float2_y(scaled_pair)
@@ -1535,13 +1570,17 @@ __forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
 
                     # dS^T[n,m] = P^T[n,j] * (dP^T[n,j] - dpsum[m]).
                     for j in T.unroll(STRIP_SIZE // 2):
+                        dpsum_pair_0: T.float32
+                        dpsum_pair_1: T.float32
+                        T.ptx.ld.shared.v2.f32(
+                            dpsum_pair_0,
+                            dpsum_pair_1,
+                            sDPsum.ptr_to([strip_off + 2 * j]),
+                        )
                         T.ptx.sub.rn.ftz.f32x2(
                             dP_pairs[j],
                             T.cuda.make_float2(dP_strip[2 * j], dP_strip[2 * j + 1]),
-                            T.cuda.make_float2(
-                                sDPsum[strip_off + 2 * j],
-                                sDPsum[strip_off + 2 * j + 1],
-                            ),
+                            T.cuda.make_float2(dpsum_pair_0, dpsum_pair_1),
                         )
                         T.ptx.mul.rn.ftz.f32x2(
                             dP_pairs[j],

--- a/tirx_kernels/attention/flash_attention_backward.py
+++ b/tirx_kernels/attention/flash_attention_backward.py
@@ -110,29 +110,42 @@ def build_preprocess(B, S, H, D):
     NBLK = S // ROWS_PER_BLOCK
     LOG2_E = math.log2(math.e)
 
-    dot_f16x8_source_code = R"""
-__forceinline__ __device__ float tvm_builtin_dot_f16x8(
-    const half* lhs, const half* rhs) {
-    uint4 lhs_bits = *reinterpret_cast<const uint4*>(lhs);
-    uint4 rhs_bits = *reinterpret_cast<const uint4*>(rhs);
-    const half2* lhs2 = reinterpret_cast<const half2*>(&lhs_bits);
-    const half2* rhs2 = reinterpret_cast<const half2*>(&rhs_bits);
-    float sum = 0.0f;
-#pragma unroll
-    for (int i = 0; i < 4; ++i) {
-        float2 l = __half22float2(lhs2[i]);
-        float2 r = __half22float2(rhs2[i]);
-        sum = fmaf(l.x, r.x, sum);
-        sum = fmaf(l.y, r.y, sum);
-    }
-    return sum;
-}
-"""
-
     try:
         from tvm.script import tir as T
     except ImportError:
         from tvm.script import tirx as T
+
+    def dot_f16x8(lhs, rhs):
+        lhs_words = T.alloc_local((4,), "uint32")
+        rhs_words = T.alloc_local((4,), "uint32")
+        lhs_halves = T.alloc_local((2,), "uint16")
+        rhs_halves = T.alloc_local((2,), "uint16")
+        lhs_value = T.alloc_local((2,), "float32")
+        rhs_value = T.alloc_local((2,), "float32")
+        result = T.alloc_local((1,), "float32")
+        T.evaluate(
+            T.ptx.ld.global_.nc.v4.b32(lhs_words[0], lhs_words[1], lhs_words[2], lhs_words[3], lhs)
+        )
+        T.evaluate(
+            T.ptx.ld.global_.nc.v4.b32(rhs_words[0], rhs_words[1], rhs_words[2], rhs_words[3], rhs)
+        )
+        T.buffer_store(result, T.float32(0), 0)
+        for pair in range(4):
+            T.evaluate(T.ptx.mov.b32(lhs_halves[0], lhs_halves[1], lhs_words[pair]))
+            for element in range(2):
+                T.evaluate(T.ptx.cvt.f32.f16(lhs_value[element], lhs_halves[element]))
+            T.evaluate(T.ptx.mov.b32(rhs_halves[0], rhs_halves[1], rhs_words[pair]))
+            for element in range(2):
+                T.evaluate(T.ptx.cvt.f32.f16(rhs_value[element], rhs_halves[element]))
+            for element in range(2):
+                # CUDA's default fast-math path lowers the original fmaf chain
+                # with FTZ; spelling it here preserves the final instruction schedule.
+                T.evaluate(
+                    T.ptx.fma.rn.ftz.f32(
+                        result[0], lhs_value[element], rhs_value[element], result[0]
+                    )
+                )
+        return result[0]
 
     @T.prim_func
     def preprocess_kernel(
@@ -166,12 +179,9 @@ __forceinline__ __device__ float tvm_builtin_dot_f16x8(
                             s: T.int32 = (
                                 bx * ROWS_PER_BLOCK + row_iter * ROWS_PER_WAVE + row_in_wave
                             )
-                            acc: T.float32 = T.cuda.func_call(
-                                "tvm_builtin_dot_f16x8",
+                            acc: T.float32 = dot_f16x8(
                                 T.address_of(dO_buf[bz, s, by, d_start]),
                                 T.address_of(O_buf[bz, s, by, d_start]),
-                                source_code=dot_f16x8_source_code,
-                                return_type="float32",
                             )
                             for chunk in T.unroll(ELEMS_PER_THREAD // 4):
                                 for d in T.vectorized(4):
@@ -221,18 +231,16 @@ def build_cast_f32_to_f16(B, S, H, D, scale):
     num_groups = B * S * H * (D // GROUP_WIDTH)
     NBLK = (num_groups + GROUPS_PER_BLOCK - 1) // GROUPS_PER_BLOCK
 
-    scale_cast_f32x4_f16x4_source_code = R"""
-__forceinline__ __device__ void tvm_builtin_scale_cast_f32x4_f16x4(
-    half* dst, const float* src, float scale) {
-    float4 value = *reinterpret_cast<const float4*>(src);
-    half2 lo = __floats2half2_rn(value.x * scale, value.y * scale);
-    half2 hi = __floats2half2_rn(value.z * scale, value.w * scale);
-    uint2 packed;
-    packed.x = *reinterpret_cast<const uint32_t*>(&lo);
-    packed.y = *reinterpret_cast<const uint32_t*>(&hi);
-    *reinterpret_cast<uint2*>(dst) = packed;
-}
-"""
+    def scale_cast_f32x4_f16x4(dst_ptr, src_ptr, scale_value):
+        source = T.alloc_local((4,), "float32")
+        scaled = T.alloc_local((4,), "float32")
+        packed = T.alloc_local((2,), "uint32")
+        T.evaluate(T.ptx.ld.global_.v4.f32(source[0], source[1], source[2], source[3], src_ptr))
+        for element in range(4):
+            T.evaluate(T.ptx.mul.rn.f32(scaled[element], source[element], scale_value))
+        T.evaluate(T.ptx.cvt.rn.f16x2.f32(packed[0], scaled[1], scaled[0]))
+        T.evaluate(T.ptx.cvt.rn.f16x2.f32(packed[1], scaled[3], scaled[2]))
+        return T.ptx.st.global_.v2.b32(dst_ptr, packed[0], packed[1])
 
     @T.prim_func
     def cast_kernel(src: T.Buffer((B, H, S, D), "float32"), dst: T.Buffer((B, S, H, D), "float16")):
@@ -259,13 +267,10 @@ __forceinline__ __device__ void tvm_builtin_scale_cast_f32x4_f16x4(
                             + (((s_in_block >> 6) & 1) << 6)
                         )
                         src_d: T.int32 = (s_in_block & 31) << 2
-                        T.cuda.func_call(
-                            "tvm_builtin_scale_cast_f32x4_f16x4",
+                        scale_cast_f32x4_f16x4(
                             T.address_of(dst[b, s, h, d]),
                             T.address_of(src[b, h, src_s, src_d]),
                             T.float32(scale),
-                            source_code=scale_cast_f32x4_f16x4_source_code,
-                            return_type="void",
                         )
 
     mod = tvm.IRModule({"main": cast_kernel})
@@ -413,30 +418,15 @@ def build_kernel(
     def cast_f32x2_to_f16x2(dst, src):
         T.cuda.float22half2(dst, src)
 
-    fma_scale_sub_f32x2_source_code = R"""
-__forceinline__ __device__ unsigned long long tvm_builtin_fma_scale_sub_f32x2(
-    unsigned long long scores,
-    unsigned long long scale,
-    unsigned long long lse) {
-    float2 score_pair = *reinterpret_cast<float2*>(&scores);
-    float2 scale_pair = *reinterpret_cast<float2*>(&scale);
-    float2 lse_pair = *reinterpret_cast<float2*>(&lse);
-    float2 result = make_float2(
-        fmaf(score_pair.x, scale_pair.x, -lse_pair.x),
-        fmaf(score_pair.y, scale_pair.y, -lse_pair.y));
-    return *reinterpret_cast<unsigned long long*>(&result);
-}
-"""
-
     def fma_scale_sub_f32x2(scores, scale, lse):
-        return T.cuda.func_call(
-            "tvm_builtin_fma_scale_sub_f32x2",
-            scores,
-            scale,
-            lse,
-            source_code=fma_scale_sub_f32x2_source_code,
-            return_type="uint64",
+        neg_lse = T.alloc_local((1,), "uint64")
+        result = T.alloc_local((1,), "uint64")
+        sign_mask = T.bitwise_or(
+            T.shift_left(T.uint64(0x80000000), T.uint64(32)), T.uint64(0x80000000)
         )
+        T.evaluate(T.ptx.xor.b64(neg_lse[0], lse, sign_mask))
+        T.evaluate(T.ptx.fma.rn.f32x2(result[0], scores, scale, neg_lse[0]))
+        return result[0]
 
     # The dialect takes one composed TMEM address instead of a base plus
     # row/col; get_tmem_addr packs them the same way the old operands did.

--- a/tirx_kernels/attention/gdn_prefill_sm100.py
+++ b/tirx_kernels/attention/gdn_prefill_sm100.py
@@ -234,6 +234,13 @@ def _byte_ptr(ptr, byte_offset):
     return T.reinterpret("handle", T.reinterpret("uint64", ptr) + T.cast(byte_offset, "uint64"))
 
 
+@T.inline
+def _load_sequence_bounds(cu_seqlens, batch, bounds):
+    # Keep these scalar: an odd batch index is only four-byte aligned.
+    T.ptx.ld.global_.s32(bounds[0], cu_seqlens.ptr_to([batch]))
+    T.ptx.ld.global_.s32(bounds[1], cu_seqlens.ptr_to([batch + 1]))
+
+
 def _pipe_stage(count, stages):
     return T.cast(T.cast(count, "uint32") % T.uint32(stages), "int32")
 
@@ -329,11 +336,15 @@ def _producer_tail_state(smem_base_addr, empty_off, index, phase, stages):
 
 @T.inline
 def _descriptor_copy_payload(src_map, dst_ptr):
-    payload = T.decl_buffer(
-        (8,), "uint64", data=_byte_ptr(T.address_of(src_map), 0), scope="param", align=16
+    payload: T.uint64[4]
+    T.ptx.ld.global_.v4.b64(
+        payload[0], payload[1], payload[2], payload[3], _byte_ptr(T.address_of(src_map), 0)
     )
     T.ptx.st.global_.v4.b64(dst_ptr, payload[0], payload[1], payload[2], payload[3])
-    T.ptx.st.global_.v4.b64(_byte_ptr(dst_ptr, 32), payload[4], payload[5], payload[6], payload[7])
+    T.ptx.ld.global_.v4.b64(
+        payload[0], payload[1], payload[2], payload[3], _byte_ptr(T.address_of(src_map), 32)
+    )
+    T.ptx.st.global_.v4.b64(_byte_ptr(dst_ptr, 32), payload[0], payload[1], payload[2], payload[3])
 
 
 def _replace_global_address(desc, address):
@@ -909,7 +920,9 @@ def _copy_empty_state(initial_state, final_state, batch, output_head, thread, *,
         T.cast(batch, "int64") * T.cast(HV, "int64") + T.cast(output_head, "int64")
     ) * T.int64(D_HEAD * D_HEAD) + cg1_thread * T.int64(D_HEAD)
     for key in T.serial(0, D_HEAD):
-        final_state[state_base + key] = initial_state[state_base + key]
+        state_value: T.float32
+        T.ptx.ld.global_.f32(state_value, initial_state.ptr_to([state_base + key]))
+        T.ptx.st.global_.f32(final_state.ptr_to([state_base + key]), state_value)
 
 
 @T.inline
@@ -1190,12 +1203,20 @@ def _load_gate_beta_chunk(
         valid0 = T.cast(pos0 < batch_end, "int32")
         valid1 = T.cast(pos1 < batch_end, "int32")
         if valid0 != 0:
-            gate0 = gate[pos0 * T.cast(HV, "int64") + T.cast(output_head, "int64")]
+            T.ptx.ld.global_.f32(
+                gate0, gate.ptr_to([pos0 * T.cast(HV, "int64") + T.cast(output_head, "int64")])
+            )
         if valid1 != 0:
-            gate1 = gate[pos1 * T.cast(HV, "int64") + T.cast(output_head, "int64")]
+            T.ptx.ld.global_.f32(
+                gate1, gate.ptr_to([pos1 * T.cast(HV, "int64") + T.cast(output_head, "int64")])
+            )
     else:
-        gate0 = gate[pos0 * T.cast(HV, "int64") + T.cast(output_head, "int64")]
-        gate1 = gate[pos1 * T.cast(HV, "int64") + T.cast(output_head, "int64")]
+        T.ptx.ld.global_.f32(
+            gate0, gate.ptr_to([pos0 * T.cast(HV, "int64") + T.cast(output_head, "int64")])
+        )
+        T.ptx.ld.global_.f32(
+            gate1, gate.ptr_to([pos1 * T.cast(HV, "int64") + T.cast(output_head, "int64")])
+        )
 
     gate0 = _lg2_approx_ftz(gate0 + T.float32(1.0e-10))
     gate1 = _lg2_approx_ftz(gate1 + T.float32(1.0e-10))
@@ -1215,10 +1236,10 @@ def _load_gate_beta_chunk(
     # The register scan precedes stage acquisition in the frozen source.
     _producer_acquire_state(smem_base_addr, 184, gate_count, gate_phase)
     gate_stage: T.int32 = gate_count
-    s_cumsumlog[gate_stage * 64 + lane] = gate0
-    s_cumsumlog[gate_stage * 64 + lane + 32] = gate1
-    s_cumprod[gate_stage * 64 + lane] = cumprod0
-    s_cumprod[gate_stage * 64 + lane + 32] = cumprod1
+    T.ptx.st.shared.f32(s_cumsumlog.ptr_to([gate_stage * 64 + lane]), gate0)
+    T.ptx.st.shared.f32(s_cumsumlog.ptr_to([gate_stage * 64 + lane + 32]), gate1)
+    T.ptx.st.shared.f32(s_cumprod.ptr_to([gate_stage * 64 + lane]), cumprod0)
+    T.ptx.st.shared.f32(s_cumprod.ptr_to([gate_stage * 64 + lane + 32]), cumprod1)
     _software_commit_state(smem_base_addr, 144, gate_count)
 
     _producer_acquire_state(smem_base_addr, 264, beta_count, beta_phase)
@@ -1228,8 +1249,8 @@ def _load_gate_beta_chunk(
         smem_base_addr, SMEM_BETA_OFF + (beta_stage * 64 + lane + 32) * 4
     )
     if is_last_tile:
-        s_beta[beta_stage * 64 + lane] = T.float32(0.0)
-        s_beta[beta_stage * 64 + lane + 32] = T.float32(0.0)
+        T.ptx.st.shared.f32(s_beta.ptr_to([beta_stage * 64 + lane]), T.float32(0.0))
+        T.ptx.st.shared.f32(s_beta.ptr_to([beta_stage * 64 + lane + 32]), T.float32(0.0))
         T.ptx["cp.async.ca.shared.global"](
             beta_dst0,
             beta.ptr_to([pos0 * T.cast(HV, "int64") + T.cast(output_head, "int64")]),
@@ -1496,8 +1517,10 @@ def _kernel(
             # spelling another runtime modulus makes NVRTC emit rem.s32,
             # which is absent from the frozen PTX.
             batch_cg0: T.int32 = remain_cg0
-            batch_start_cg0: T.int64 = T.cast(cu_seqlens[batch_cg0], "int64")
-            batch_end_cg0: T.int64 = T.cast(cu_seqlens[batch_cg0 + 1], "int64")
+            sequence_bounds_cg0: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_cg0, sequence_bounds_cg0)
+            batch_start_cg0: T.int64 = T.cast(sequence_bounds_cg0[0], "int64")
+            batch_end_cg0: T.int64 = T.cast(sequence_bounds_cg0[1], "int64")
             seqlen_cg0: T.int32 = T.cast(batch_end_cg0 - batch_start_cg0, "int32")
             num_pairs_cg0: T.int32 = (seqlen_cg0 + PAIR_TOKENS - 1) // PAIR_TOKENS
 
@@ -1523,8 +1546,14 @@ def _kernel(
                 gate_consumer_phase_cg0 = _pipe_next_phase(gate1_count_cg0, gate1_phase_cg0, 5)
                 gate0_stage_cg0: T.int32 = gate0_count_cg0
                 gate1_stage_cg0: T.int32 = gate1_count_cg0
-                row_log0_cg0: T.float32 = s_cumsumlog[gate0_stage_cg0 * 64 + row_cg0]
-                row_log1_cg0: T.float32 = s_cumsumlog[gate1_stage_cg0 * 64 + row_cg0]
+                row_log0_cg0: T.float32
+                row_log1_cg0: T.float32
+                T.ptx.ld.shared.f32(
+                    row_log0_cg0, s_cumsumlog.ptr_to([gate0_stage_cg0 * 64 + row_cg0])
+                )
+                T.ptx.ld.shared.f32(
+                    row_log1_cg0, s_cumsumlog.ptr_to([gate1_stage_cg0 * 64 + row_cg0])
+                )
                 for frag_idx_cg0 in T.unroll(32):
                     col_cg0: T.int32 = col_base_cg0 + frag_idx_cg0
                     if frag_idx_cg0 >= 16:
@@ -1535,14 +1564,16 @@ def _kernel(
                     transfer_exp0_cg0: T.float32 = T.float32(0.0)
                     transfer_exp1_cg0: T.float32 = T.float32(0.0)
                     if row_cg0 >= col_cg0:
-                        T.ptx.ex2.approx.ftz.f32(
-                            transfer_exp0_cg0,
-                            row_log0_cg0 - s_cumsumlog[gate0_stage_cg0 * 64 + col_cg0],
+                        col_log0_cg0: T.float32
+                        col_log1_cg0: T.float32
+                        T.ptx.ld.shared.f32(
+                            col_log0_cg0, s_cumsumlog.ptr_to([gate0_stage_cg0 * 64 + col_cg0])
                         )
-                        T.ptx.ex2.approx.ftz.f32(
-                            transfer_exp1_cg0,
-                            row_log1_cg0 - s_cumsumlog[gate1_stage_cg0 * 64 + col_cg0],
+                        T.ptx.ld.shared.f32(
+                            col_log1_cg0, s_cumsumlog.ptr_to([gate1_stage_cg0 * 64 + col_cg0])
                         )
+                        T.ptx.ex2.approx.ftz.f32(transfer_exp0_cg0, row_log0_cg0 - col_log0_cg0)
+                        T.ptx.ex2.approx.ftz.f32(transfer_exp1_cg0, row_log1_cg0 - col_log1_cg0)
                     transfer0_cg0[frag_idx_cg0] = transfer_exp0_cg0
                     transfer1_cg0[frag_idx_cg0] = transfer_exp1_cg0
                 _consumer_release_state(smem_addr_cg0, 184, gate0_count_cg0)
@@ -1558,8 +1589,10 @@ def _kernel(
                 _consumer_wait_state(smem_addr_cg0, 224, beta1_count_cg0, beta1_phase_cg0)
                 beta_consumer_index_cg0 = _pipe_next_index(beta1_count_cg0, 5)
                 beta_consumer_phase_cg0 = _pipe_next_phase(beta1_count_cg0, beta1_phase_cg0, 5)
-                beta0_cg0: T.float32 = s_beta[beta0_count_cg0 * 64 + row_cg0]
-                beta1_cg0: T.float32 = s_beta[beta1_count_cg0 * 64 + row_cg0]
+                beta0_cg0: T.float32
+                beta1_cg0: T.float32
+                T.ptx.ld.shared.f32(beta0_cg0, s_beta.ptr_to([beta0_count_cg0 * 64 + row_cg0]))
+                T.ptx.ld.shared.f32(beta1_cg0, s_beta.ptr_to([beta1_count_cg0 * 64 + row_cg0]))
 
                 # KK0 seed: acquire Ainv, consume accumulator, then multiply
                 # packed f32x2 by transfer and the beta ROW before narrowing.
@@ -1654,16 +1687,17 @@ def _kernel(
                     inv_col0_cg0: T.int32 = col_base_cg0 + pair_frag_cg0 * 2
                     if pair_frag_cg0 >= 8:
                         inv_col0_cg0 = inv_col0_cg0 + 16
+                    beta_col0_cg0: T.uint64
+                    T.ptx.ld.shared.u64(
+                        beta_col0_cg0, s_beta.ptr_to([beta0_count_cg0 * 64 + inv_col0_cg0])
+                    )
                     inv_mul_cg0: T.uint64
                     T.ptx.mul.rn.f32x2(
                         inv_mul_cg0,
                         T.cuda.make_float2(
                             inv_values_cg0[pair_frag_cg0 * 2], inv_values_cg0[pair_frag_cg0 * 2 + 1]
                         ),
-                        T.cuda.make_float2(
-                            s_beta[beta0_count_cg0 * 64 + inv_col0_cg0],
-                            s_beta[beta0_count_cg0 * 64 + inv_col0_cg0 + 1],
-                        ),
+                        beta_col0_cg0,
                     )
                     inv_values_cg0[pair_frag_cg0 * 2] = T.cuda.float2_x(inv_mul_cg0)
                     inv_values_cg0[pair_frag_cg0 * 2 + 1] = T.cuda.float2_y(inv_mul_cg0)
@@ -1681,16 +1715,17 @@ def _kernel(
                     inv_col1_cg0: T.int32 = col_base_cg0 + pair_frag_cg0 * 2
                     if pair_frag_cg0 >= 8:
                         inv_col1_cg0 = inv_col1_cg0 + 16
+                    beta_col1_cg0: T.uint64
+                    T.ptx.ld.shared.u64(
+                        beta_col1_cg0, s_beta.ptr_to([beta1_count_cg0 * 64 + inv_col1_cg0])
+                    )
                     inv_mul_cg0: T.uint64
                     T.ptx.mul.rn.f32x2(
                         inv_mul_cg0,
                         T.cuda.make_float2(
                             inv_values_cg0[pair_frag_cg0 * 2], inv_values_cg0[pair_frag_cg0 * 2 + 1]
                         ),
-                        T.cuda.make_float2(
-                            s_beta[beta1_count_cg0 * 64 + inv_col1_cg0],
-                            s_beta[beta1_count_cg0 * 64 + inv_col1_cg0 + 1],
-                        ),
+                        beta_col1_cg0,
                     )
                     inv_values_cg0[pair_frag_cg0 * 2] = T.cuda.float2_x(inv_mul_cg0)
                     inv_values_cg0[pair_frag_cg0 * 2 + 1] = T.cuda.float2_y(inv_mul_cg0)
@@ -1784,8 +1819,10 @@ def _kernel(
             )
             remain_cg1: T.int32 = T.cast(remain_u32_cg1, "int32")
             batch_cg1: T.int32 = remain_cg1
-            batch_start_cg1: T.int64 = T.cast(cu_seqlens[batch_cg1], "int64")
-            batch_end_cg1: T.int64 = T.cast(cu_seqlens[batch_cg1 + 1], "int64")
+            sequence_bounds_cg1: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_cg1, sequence_bounds_cg1)
+            batch_start_cg1: T.int64 = T.cast(sequence_bounds_cg1[0], "int64")
+            batch_end_cg1: T.int64 = T.cast(sequence_bounds_cg1[1], "int64")
             seqlen_cg1: T.int32 = T.cast(batch_end_cg1 - batch_start_cg1, "int32")
             num_valid_chunks_cg1: T.int32 = (seqlen_cg1 + CHUNK - 1) // CHUNK
             num_pairs_cg1: T.int32 = (seqlen_cg1 + PAIR_TOKENS - 1) // PAIR_TOKENS
@@ -1821,7 +1858,10 @@ def _kernel(
                     gate_consumer_index_cg1 = _pipe_next_index(gate_count_cg1, 5)
                     gate_consumer_phase_cg1 = _pipe_next_phase(gate_count_cg1, gate_phase_cg1, 5)
                     gate_stage_cg1: T.int32 = gate_count_cg1
-                    cumprod_total_cg1: T.float32 = s_cumprod[gate_stage_cg1 * 64 + 63]
+                    cumprod_total_cg1: T.float32
+                    T.ptx.ld.shared.f32(
+                        cumprod_total_cg1, s_cumprod.ptr_to([gate_stage_cg1 * 64 + 63])
+                    )
 
                     # Previous recurrent state -> f16 state-input TMEM, then
                     # the same f32 fragment is decayed in place and restored.
@@ -1881,28 +1921,33 @@ def _kernel(
                     cumprod_factor_cg1: T.float32[16]
                     decay_factor_cg1: T.float32[16]
                     factor_col_base_cg1: T.int32 = T.bitwise_and(thread << 1, T.int32(6))
-                    last_log_cg1: T.float32 = s_cumsumlog[gate_stage_cg1 * 64 + 63]
+                    last_log_cg1: T.float32
+                    T.ptx.ld.shared.f32(
+                        last_log_cg1, s_cumsumlog.ptr_to([gate_stage_cg1 * 64 + 63])
+                    )
                     for factor_group_cg1 in T.unroll(8):
                         factor_col_cg1: T.int32 = factor_col_base_cg1 + factor_group_cg1 * 8
-                        cumprod_factor_cg1[factor_group_cg1 * 2] = s_cumprod[
-                            gate_stage_cg1 * 64 + factor_col_cg1
-                        ]
-                        cumprod_factor_cg1[factor_group_cg1 * 2 + 1] = s_cumprod[
-                            gate_stage_cg1 * 64 + factor_col_cg1 + 1
-                        ]
+                        T.ptx.ld.shared.v2.f32(
+                            cumprod_factor_cg1[factor_group_cg1 * 2],
+                            cumprod_factor_cg1[factor_group_cg1 * 2 + 1],
+                            s_cumprod.ptr_to([gate_stage_cg1 * 64 + factor_col_cg1]),
+                        )
                         # Frozen PTX spells this as scalar negations feeding
                         # add.rn.f32x2; ptxas folds those negations into the
                         # packed subtraction.  Express the resulting native
                         # operation directly so the CUDA C++ bridge does not
                         # materialize two standalone FADD negations.
                         decay_diff_cg1: T.uint64[1]
+                        cumsumlog_factor_cg1: T.float32[2]
+                        T.ptx.ld.shared.v2.f32(
+                            cumsumlog_factor_cg1[0],
+                            cumsumlog_factor_cg1[1],
+                            s_cumsumlog.ptr_to([gate_stage_cg1 * 64 + factor_col_cg1]),
+                        )
                         T.ptx.sub.rn.f32x2(
                             decay_diff_cg1[0],
                             T.cuda.make_float2(last_log_cg1, last_log_cg1),
-                            T.cuda.make_float2(
-                                s_cumsumlog[gate_stage_cg1 * 64 + factor_col_cg1],
-                                s_cumsumlog[gate_stage_cg1 * 64 + factor_col_cg1 + 1],
-                            ),
+                            T.cuda.make_float2(cumsumlog_factor_cg1[0], cumsumlog_factor_cg1[1]),
                         )
                         T.ptx.ex2.approx.ftz.f32(
                             decay_factor_cg1[factor_group_cg1 * 2],
@@ -2114,8 +2159,10 @@ def _kernel(
                 _udiv_u32_const(T.cast(work_linear_issuer0, "uint32"), HV), "int32"
             )
             batch_issuer0: T.int32 = remain_issuer0
-            batch_start_issuer0: T.int64 = T.cast(cu_seqlens[batch_issuer0], "int64")
-            batch_end_issuer0: T.int64 = T.cast(cu_seqlens[batch_issuer0 + 1], "int64")
+            sequence_bounds_issuer0: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_issuer0, sequence_bounds_issuer0)
+            batch_start_issuer0: T.int64 = T.cast(sequence_bounds_issuer0[0], "int64")
+            batch_end_issuer0: T.int64 = T.cast(sequence_bounds_issuer0[1], "int64")
             seqlen_issuer0: T.int32 = T.cast(batch_end_issuer0 - batch_start_issuer0, "int32")
             num_pairs_issuer0: T.int32 = (seqlen_issuer0 + PAIR_TOKENS - 1) // PAIR_TOKENS
 
@@ -2238,8 +2285,10 @@ def _kernel(
                 _udiv_u32_const(T.cast(work_linear_issuer1, "uint32"), HV), "int32"
             )
             batch_issuer1: T.int32 = remain_issuer1
-            batch_start_issuer1: T.int64 = T.cast(cu_seqlens[batch_issuer1], "int64")
-            batch_end_issuer1: T.int64 = T.cast(cu_seqlens[batch_issuer1 + 1], "int64")
+            sequence_bounds_issuer1: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_issuer1, sequence_bounds_issuer1)
+            batch_start_issuer1: T.int64 = T.cast(sequence_bounds_issuer1[0], "int64")
+            batch_end_issuer1: T.int64 = T.cast(sequence_bounds_issuer1[1], "int64")
             seqlen_issuer1: T.int32 = T.cast(batch_end_issuer1 - batch_start_issuer1, "int32")
             num_pairs_issuer1: T.int32 = (seqlen_issuer1 + PAIR_TOKENS - 1) // PAIR_TOKENS
             padded_chunks_issuer1: T.int32 = num_pairs_issuer1 * 2
@@ -2391,8 +2440,10 @@ def _kernel(
                 value_subhead_tma = head_tma - qk_head_tma * (HV // HQ)
             remain_tma: T.int32 = T.cast(remain_u32_tma, "int32")
             batch_tma: T.int32 = remain_tma
-            batch_start_tma: T.int64 = T.cast(cu_seqlens[batch_tma], "int64")
-            batch_end_tma: T.int64 = T.cast(cu_seqlens[batch_tma + 1], "int64")
+            sequence_bounds_tma: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_tma, sequence_bounds_tma)
+            batch_start_tma: T.int64 = T.cast(sequence_bounds_tma[0], "int64")
+            batch_end_tma: T.int64 = T.cast(sequence_bounds_tma[1], "int64")
             seqlen_tma: T.int32 = T.cast(batch_end_tma - batch_start_tma, "int32")
             num_valid_chunks_tma: T.int32 = (seqlen_tma + CHUNK - 1) // CHUNK
             num_pairs_tma: T.int32 = (seqlen_tma + PAIR_TOKENS - 1) // PAIR_TOKENS
@@ -2572,8 +2623,10 @@ def _kernel(
                 value_subhead_epi = head_epi - qk_head_epi * (HV // HQ)
             remain_epi: T.int32 = T.cast(remain_u32_epi, "int32")
             batch_epi: T.int32 = remain_epi
-            batch_start_epi: T.int64 = T.cast(cu_seqlens[batch_epi], "int64")
-            batch_end_epi: T.int64 = T.cast(cu_seqlens[batch_epi + 1], "int64")
+            sequence_bounds_epi: T.int32[2]
+            _load_sequence_bounds(cu_seqlens, batch_epi, sequence_bounds_epi)
+            batch_start_epi: T.int64 = T.cast(sequence_bounds_epi[0], "int64")
+            batch_end_epi: T.int64 = T.cast(sequence_bounds_epi[1], "int64")
             seqlen_epi: T.int32 = T.cast(batch_end_epi - batch_start_epi, "int32")
             num_valid_chunks_epi: T.int32 = (seqlen_epi + CHUNK - 1) // CHUNK
             num_pairs_epi: T.int32 = (seqlen_epi + PAIR_TOKENS - 1) // PAIR_TOKENS

--- a/tirx_kernels/attention/gdn_prefill_sm100.py
+++ b/tirx_kernels/attention/gdn_prefill_sm100.py
@@ -156,47 +156,6 @@ INITIAL_STATE_BARRIER = 4
 
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
 
-# Only source operations unavailable as exact native TIRx calls live here.
-_GDN_SRCS = {
-    "replace_global_address": r"""__device__ __forceinline__ void gdn_tensormap_replace_global_address(void *desc, const void *addr) {
-    asm volatile("tensormap.replace.tile.global_address.global.b1024.b64 [%0], %1;"
-                 :: "l"(desc), "l"(addr) : "memory");
-}
-""",
-    **{
-        f"replace_global_dim_{dim}": f"""__device__ __forceinline__ void gdn_tensormap_replace_global_dim_{dim}(void *desc, unsigned int value) {{
-    asm volatile("tensormap.replace.tile.global_dim.global.b1024.b32 [%0], {dim}, %1;"
-                 :: "l"(desc), "r"(value) : "memory");
-}}
-"""
-        for dim in range(5)
-    },
-    **{
-        f"replace_global_stride_{dim}": f"""__device__ __forceinline__ void gdn_tensormap_replace_global_stride_{dim}(void *desc, unsigned long long value) {{
-    asm volatile("tensormap.replace.tile.global_stride.global.b1024.b64 [%0], {dim}, %1;"
-                 :: "l"(desc), "l"(value) : "memory");
-}}
-"""
-        for dim in range(4)
-    },
-    "tensormap_release": r"""__device__ __forceinline__ void gdn_tensormap_release() {
-    asm volatile("fence.proxy.tensormap::generic.release.gpu;" ::: "memory");
-}
-""",
-    "tensormap_acquire": r"""__device__ __forceinline__ void gdn_tensormap_acquire(const void *desc) {
-    asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;"
-                 :: "l"(desc) : "memory");
-}
-""",
-    "lg2_approx_ftz": r"""__device__ __forceinline__ float gdn_lg2_approx_ftz(float value) {
-    float out;
-    asm volatile("lg2.approx.ftz.f32 %0, %1;" : "=f"(out) : "f"(value));
-    return out;
-}
-""",
-}
-
-
 @T.inline
 def _init_pipeline(smem_raw, full_off, empty_off, stages, producers, consumers):
     for stage in range(stages):
@@ -348,33 +307,17 @@ def _descriptor_copy_payload(src_map, dst_ptr):
 
 
 def _replace_global_address(desc, address):
-    return T.cuda.func_call(
-        "gdn_tensormap_replace_global_address",
-        desc,
-        address,
-        source_code=_GDN_SRCS["replace_global_address"],
-        return_type="void",
+    return T.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, T.reinterpret("uint64", address)
     )
 
 
 def _replace_global_dim(desc, dim, value):
-    return T.cuda.func_call(
-        f"gdn_tensormap_replace_global_dim_{dim}",
-        desc,
-        value,
-        source_code=_GDN_SRCS[f"replace_global_dim_{dim}"],
-        return_type="void",
-    )
+    return T.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(desc, dim, value)
 
 
 def _replace_global_stride(desc, dim, value):
-    return T.cuda.func_call(
-        f"gdn_tensormap_replace_global_stride_{dim}",
-        desc,
-        value,
-        source_code=_GDN_SRCS[f"replace_global_stride_{dim}"],
-        return_type="void",
-    )
+    return T.ptx.tensormap_replace.tile.global_stride.global_.b1024.b64(desc, dim, value)
 
 
 @T.inline
@@ -394,24 +337,17 @@ def _replace_descriptor(desc, address, dim1, dim2, dim3, stride0, stride1, strid
 
 
 def _tensormap_release():
-    return T.cuda.func_call(
-        "gdn_tensormap_release", source_code=_GDN_SRCS["tensormap_release"], return_type="void"
-    )
+    return T.ptx.fence.proxy.tensormap__generic.release.gpu()
 
 
 def _tensormap_acquire(desc):
-    return T.cuda.func_call(
-        "gdn_tensormap_acquire",
-        desc,
-        source_code=_GDN_SRCS["tensormap_acquire"],
-        return_type="void",
-    )
+    return T.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
 
 
 def _lg2_approx_ftz(value):
-    return T.cuda.func_call(
-        "gdn_lg2_approx_ftz", value, source_code=_GDN_SRCS["lg2_approx_ftz"], return_type="float32"
-    )
+    result = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.lg2.approx.ftz.f32(result[0], value))
+    return result[0]
 
 
 def _smem_desc_b128(smem_addr):

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -205,7 +205,7 @@ defaults to FlashInfer's `auto` backend; set
 |------|---------|---------|
 | `--rounds N` | `5` | Complete standard-timer calls per implementation/workload |
 | `--cooldown` | `1.0` | Seconds before every implementation in every round |
-| `--util-threshold` | `0` | Skip GPUs with SM utilization above this percent |
+| `--util-threshold` | `0` | Skip GPUs above this utilization; requeue if a foreign process exceeds it during a run |
 | `--mem-threshold` | `0` | Skip GPUs with compute-app memory-used percent above this percent |
 
 Round aggregation is always the arithmetic mean. The raw five-element sample arrays

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -468,63 +468,50 @@ def _visible_gpu_rows(rows: list[tuple[str, str]]) -> list[tuple[str, str]]:
     return [(index, uuid) for index, uuid in rows if index in visible or uuid in visible]
 
 
-def _gpu_uuid_of(idx: str) -> str | None:
-    """Look up the UUID for a GPU index via nvidia-smi."""
-    try:
-        out = subprocess.run(
-            ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        ).stdout
-    except Exception:
-        return None
-    for line in out.splitlines():
-        parts = [p.strip() for p in line.split(",")]
-        if len(parts) >= 2 and parts[0] == idx:
-            return parts[1]
-    return None
+def _pid_sm_on_gpus(gpu_indices: tuple[str, ...]) -> dict[int, float] | None:
+    """Return the maximum per-process SM utilization on assigned GPUs.
 
-
-def _compute_pids_by_gpu_uuid() -> dict[str, set[int]]:
-    """Return every compute-app PID grouped by physical GPU UUID.
-
-    Unlike ``pmon`` SM utilization, a compute context remains visible between
-    short kernel bursts.  The authoritative benchmark gate already rejects
-    resident compute-app memory before assignment, so the runtime monitor must
-    apply the same isolation rule when a context appears after assignment.
+    ``None`` means the utilization snapshot failed and the caller must fail
+    closed.  Inactive rows use ``-`` for SM utilization and are equivalent to
+    zero, so a process that only keeps a CUDA context resident is shareable.
     """
+    if not gpu_indices:
+        return {}
     try:
-        out = subprocess.run(
-            ["nvidia-smi", "--query-compute-apps=pid,gpu_uuid", "--format=csv,noheader"],
+        completed = subprocess.run(
+            ["nvidia-smi", "pmon", "-i", ",".join(gpu_indices), "-c", "1", "-s", "u"],
             capture_output=True,
             text=True,
-            timeout=5,
-        ).stdout
-    except Exception:
-        return {}
-    result: dict[str, set[int]] = {}
-    for line in out.splitlines():
-        parts = [part.strip() for part in line.split(",")]
-        if len(parts) < 2:
+            timeout=8,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if completed.returncode != 0:
+        return None
+
+    result: dict[int, float] = {}
+    assigned = set(gpu_indices)
+    for line in completed.stdout.splitlines():
+        fields = line.split()
+        if len(fields) < 4 or fields[0] not in assigned:
             continue
         try:
-            pid = int(parts[0])
+            pid = int(fields[1])
+            sm = float(fields[3])
         except ValueError:
             continue
-        result.setdefault(parts[1], set()).add(pid)
+        result[pid] = max(result.get(pid, 0.0), sm)
     return result
 
 
-def _resident_strangers_on_gpu_uuids(gpu_uuids: tuple[str, ...], our_pids: set[int]) -> set[int]:
-    """Foreign compute contexts resident on any assigned physical GPU."""
-    pids_by_uuid = _compute_pids_by_gpu_uuid()
-    return {
-        pid
-        for gpu_uuid in gpu_uuids
-        for pid in pids_by_uuid.get(gpu_uuid, ())
-        if pid not in our_pids
-    }
+def _active_strangers(
+    gpu_indices: tuple[str, ...], our_pids: set[int], sm_threshold: float
+) -> dict[int, float] | None:
+    """Foreign PIDs whose sampled SM utilization exceeds the threshold."""
+    snapshot = _pid_sm_on_gpus(gpu_indices)
+    if snapshot is None:
+        return None
+    return {pid: sm for pid, sm in snapshot.items() if pid not in our_pids and sm > sm_threshold}
 
 
 class _BenchPidRegistry:
@@ -633,11 +620,10 @@ def _run_subprocess_monitored(
 
     Returns (returncode, interfered, intruder_pids, cancelled).
 
-    Interference means any foreign CUDA compute context is resident on an
-    assigned card.  The acquisition gate already rejects compute-app memory at
-    the default zero threshold.  Applying the same rule while a workload runs
-    closes the sampling hole where a resident process launches only short
-    kernels between `pmon` SM-utilization snapshots.
+    Interference means a foreign CUDA process exceeds ``sm_threshold`` on an
+    assigned card.  Per-process ``pmon`` utilization stays meaningful while
+    the benchmark itself drives aggregate device utilization to 100%, and it
+    permits idle resident contexts when a nonzero threshold is requested.
 
     Protection is applied immediately before spawn and after every process wait
     poll.  Registered bench subprocesses and their descendants (for example
@@ -646,20 +632,19 @@ def _run_subprocess_monitored(
     proc: subprocess.Popen | None = None
     registered_pid: int | None = None
     intruders: list[int] = []
+    interfered = False
     cancelled = False
     if cancel_event is not None and cancel_event.is_set():
         return -1, False, [], True
-    resolved_gpu_uuids = [_gpu_uuid_of(gpu_index) for gpu_index in gpu_indices]
-    if any(gpu_uuid is None for gpu_uuid in resolved_gpu_uuids):
-        with open(log_path, "w") as lf:
-            lf.write("RACE_LOST: could not resolve every assigned GPU UUID for monitoring\n")
-        return -1, True, [], False
-    gpu_uuids = tuple(gpu_uuid for gpu_uuid in resolved_gpu_uuids if gpu_uuid is not None)
-    if gpu_uuids:
-        pre = _resident_strangers_on_gpu_uuids(gpu_uuids, _our_pids())
+    if gpu_indices:
+        pre = _active_strangers(gpu_indices, _our_pids(), sm_threshold)
+        if pre is None:
+            with open(log_path, "w") as lf:
+                lf.write("RACE_LOST: could not sample assigned GPU utilization\n")
+            return -1, True, [], False
         if pre:
             with open(log_path, "w") as lf:
-                lf.write(f"RACE_LOST: pre-spawn check — foreign compute contexts {pre}\n")
+                lf.write(f"RACE_LOST: pre-spawn check — active foreign processes {pre}\n")
             return -1, True, sorted(pre), False
     with open(log_path, "w") as lf:
         proc = subprocess.Popen(
@@ -678,11 +663,16 @@ def _run_subprocess_monitored(
                 break  # subprocess exited normally
             except subprocess.TimeoutExpired:
                 pass
-            if not gpu_uuids:
+            if not gpu_indices:
                 continue
-            resident = _resident_strangers_on_gpu_uuids(gpu_uuids, _our_pids())
-            if resident:
-                intruders = sorted(resident)
+            active = _active_strangers(gpu_indices, _our_pids(), sm_threshold)
+            if active is None:
+                interfered = True
+                _terminate_subprocess(proc)
+                break
+            if active:
+                interfered = True
+                intruders = sorted(active)
                 _terminate_subprocess(proc)
                 break
     except KeyboardInterrupt:
@@ -693,7 +683,7 @@ def _run_subprocess_monitored(
             _BenchPidRegistry.unregister(registered_pid)
         if proc is not None:
             _reap_subprocess(proc)
-    return proc.returncode, bool(intruders), intruders, cancelled
+    return proc.returncode, interfered, intruders, cancelled
 
 
 def run_one(
@@ -1508,8 +1498,8 @@ def main() -> None:
         "--util-threshold",
         type=float,
         default=DEFAULT_UTIL_THRESHOLD,
-        help="%% GPU utilization above which assignment skips a card. "
-        "Once assigned, any foreign CUDA compute context requeues the workload "
+        help="%% GPU utilization above which assignment skips a card; during a run, "
+        "a foreign process above this per-PID SM utilization requeues the workload "
         f"(default {DEFAULT_UTIL_THRESHOLD:g})",
     )
     ap.add_argument(

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1637,6 +1637,27 @@ def get_kernel(
     def load_volatile_u64(dst, address):
         return T.ptx.ld.volatile.global_.u64(dst, address)
 
+    def load_global_s64(dst, address):
+        return T.ptx.ld.global_.s64(dst, address)
+
+    def load_global_u64(dst, address):
+        return T.ptx.ld.global_.u64(dst, address)
+
+    def load_global_u32(dst, address):
+        return T.ptx.ld.global_.u32(dst, address)
+
+    def store_global_u64(address, value):
+        return T.ptx.st.global_.u64(address, value)
+
+    def store_global_u32(address, value):
+        return T.ptx.st.global_.u32(address, value)
+
+    def store_global_u8(address, value):
+        return T.ptx.st.global_.u8(address, value)
+
+    def store_global_f32(address, value):
+        return T.ptx.st.global_.f32(address, value)
+
     # Destination-first, mirroring the PTX these wrap: the caller declares the
     # register and passes it in.
     def load_acq_sys_s32(dst, address):
@@ -1658,6 +1679,12 @@ def get_kernel(
         # ptx destinations are declared registers, so the helper writes into
         # one the caller owns rather than returning a value.
         return T.ptx.ld.global_.f32(dst, address)
+
+    def load_shared_u64(dst, address):
+        return T.ptx.ld.shared.u64(dst, address)
+
+    def load_shared_u32(dst, address):
+        return T.ptx.ld.shared.u32(dst, address)
 
     def uint32_bits_to_float(bits):
         return T.cuda.uint_as_float(bits)
@@ -1854,6 +1881,9 @@ def get_kernel(
 
     def st_shared_u32(ptr, value):
         return T.ptx.st.shared.u32(ptr, value)
+
+    def st_shared_u64(ptr, value):
+        return T.ptx.st.shared.u64(ptr, value)
 
     def st_shared_bulk(ptr, num_bytes):
         return T.ptx.st_bulk.weak.shared__cta(ptr, T.cast(num_bytes, "uint64"))
@@ -2066,12 +2096,11 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
             )
         return rank_offset
 
-    def symm_rank_base_expr(
-        sym_buffer_base, symm_rank_offsets, smem_symm_rank_bases, mapped_rank_idx
-    ):
+    def load_symm_rank_base(dst, smem_symm_rank_bases, mapped_rank_idx):
         if num_processes > 1:
-            return smem_symm_rank_bases[T.cast(mapped_rank_idx, "int32")]
-        return sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+            return load_shared_u64(
+                dst, smem_symm_rank_bases.ptr_to([T.cast(mapped_rank_idx, "int32")])
+            )
 
     sm100_smem_capacity = 232448
     shared_alignment = 1024
@@ -2891,6 +2920,16 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
         expected_ring_count: T.int32
         scheduler_num_m_blocks: T.int32
         scheduler_cached_status: T.uint64
+        ordinary_global_u64: T.uint64
+        ordinary_global_u32: T.uint32
+        ordinary_global_s64: T.int64
+        symm_rank_base: T.uint64
+        nvl_counter_value: T.uint32
+        smem_expert_count_value: T.uint32
+        tmem_allocated: T.uint32
+        dst_rank_idx_u32: T.uint32
+        dst_token_idx_u32: T.uint32
+        dst_topk_idx_u32: T.uint32
         sched_stage_idx: T.int32
         sched_phase: T.int32
         sched_num_total_m_blocks: T.int32
@@ -3003,22 +3042,18 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         counter_idx, sync_num_threads, sync_barrier_idx, sync_thread_idx
                     )
                 if sm_idx == 0:
-                    barrier_status = T.cast(
-                        T.bitwise_and(workspace_nvl_barrier_counter[0], T.uint32(3)), "int32"
-                    )
+                    load_global_u32(nvl_counter_value, workspace_nvl_barrier_counter.ptr_to([0]))
+                    barrier_status = T.cast(T.bitwise_and(nvl_counter_value, T.uint32(3)), "int32")
                     barrier_signal_phase = T.bitwise_and(barrier_status, T.int32(1))
                     barrier_signal_sign = T.shift_right(barrier_status, T.int32(1))
                     if sync_thread_idx < T.int32(num_processes):
                         barrier_target = T.int32(1)
                         if barrier_signal_sign != 0:
                             barrier_target = T.int32(-1)
+                        symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                        load_symm_rank_base(symm_rank_base, smem_symm_rank_bases, sync_thread_idx)
                         peer_red_add_rel_sys_s32(
-                            symm_rank_base_expr(
-                                sym_buffer_base,
-                                symm_rank_offsets,
-                                smem_symm_rank_bases,
-                                sync_thread_idx,
-                            ),
+                            symm_rank_base,
                             T.uint64(workspace_layout.barrier_offset + 20)
                             + T.cast(barrier_signal_phase * 4, "uint64"),
                             barrier_target,
@@ -3043,13 +3078,16 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                                         barrier_status_printf,
                                         workspace_nvl_barrier_signal.ptr_to([barrier_signal_phase]),
                                     )
+                                    load_global_u32(
+                                        nvl_counter_value, workspace_nvl_barrier_counter.ptr_to([0])
+                                    )
                                     T.cuda.printf(
                                         f"DeepGEMM NVLink barrier timeout "
                                         f"({nvlink_barrier_timeout_seconds}s): "
                                         "rank=%d, counter=%d, signal=%d, target=%d, "
                                         "phase=%d, sign=%d, tag=%d\n",
                                         rank_idx,
-                                        T.cast(workspace_nvl_barrier_counter[0], "int32"),
+                                        T.cast(nvl_counter_value, "int32"),
                                         barrier_status_printf,
                                         barrier_target,
                                         barrier_signal_phase,
@@ -3499,9 +3537,18 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
 
         @T.inline
         def store_token_src_metadata(pool_token_idx, src_rank_idx, src_token_idx, src_topk_idx):
-            workspace_token_src_metadata[pool_token_idx, 0] = T.cast(src_rank_idx, "uint32")
-            workspace_token_src_metadata[pool_token_idx, 1] = T.cast(src_token_idx, "uint32")
-            workspace_token_src_metadata[pool_token_idx, 2] = T.cast(src_topk_idx, "uint32")
+            store_global_u32(
+                workspace_token_src_metadata.ptr_to([pool_token_idx, 0]),
+                T.cast(src_rank_idx, "uint32"),
+            )
+            store_global_u32(
+                workspace_token_src_metadata.ptr_to([pool_token_idx, 1]),
+                T.cast(src_token_idx, "uint32"),
+            )
+            store_global_u32(
+                workspace_token_src_metadata.ptr_to([pool_token_idx, 2]),
+                T.cast(src_topk_idx, "uint32"),
+            )
 
         # Relaxed arrive — no prior memory effect needs to be released to peers
         # before TMEM alloc + mbarrier init below. Wait still .acquire (default).
@@ -3515,8 +3562,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
         if flat_warp_idx == 0:
             if num_processes > 1:
                 if lane_idx < num_processes:
-                    smem_symm_rank_bases[lane_idx] = sym_buffer_base + T.cast(
-                        symm_rank_offset_arg_expr(symm_rank_offsets, lane_idx), "uint64"
+                    st_shared_u64(
+                        smem_symm_rank_bases.ptr_to([lane_idx]),
+                        sym_buffer_base
+                        + T.cast(symm_rank_offset_arg_expr(symm_rank_offsets, lane_idx), "uint64"),
                     )
             if T.cuda.elect_sync():
                 T.evaluate(st_shared_bulk(smem_expert_count.ptr_to([0]), T.uint32(num_experts * 4)))
@@ -3593,7 +3642,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     )
                     if T.cast(token_idx, "uint32") < T.cast(num_tokens, "uint32"):
                         topk_idx = T.cast(lane_idx_u32 % T.uint32(num_topk), "int32")
-                        dispatch_expert_idx = T.cast(input_topk_idx[token_idx, topk_idx], "int32")
+                        load_global_s64(
+                            ordinary_global_s64, input_topk_idx.ptr_to([token_idx, topk_idx])
+                        )
+                        dispatch_expert_idx = T.cast(ordinary_global_s64, "int32")
                         if dispatch_expert_idx >= 0:
                             T.evaluate(
                                 T.cuda.atomic_add(
@@ -3613,8 +3665,11 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
             )
             dispatch_expert_idx = flat_warp_idx * 32 + lane_idx
             while T.cast(dispatch_expert_idx, "uint32") < T.uint32(num_experts):
+                load_shared_u32(
+                    smem_expert_count_value, smem_expert_count.ptr_to([dispatch_expert_idx])
+                )
                 send_value = T.bitwise_or(
-                    T.uint64(1 << 32), T.cast(smem_expert_count[dispatch_expert_idx], "uint64")
+                    T.uint64(1 << 32), T.cast(smem_expert_count_value, "uint64")
                 )
                 prev_send_count: T.uint64
                 T.ptx.atom.global_.add.u64(
@@ -3622,7 +3677,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     workspace_expert_send_count.ptr_to([dispatch_expert_idx]),
                     send_value,
                 )
-                smem_expert_count[dispatch_expert_idx] = T.cast(prev_send_count, "int32")
+                st_shared_u32(
+                    smem_expert_count.ptr_to([dispatch_expert_idx]),
+                    T.cast(prev_send_count, "uint32"),
+                )
                 dispatch_expert_idx = dispatch_expert_idx + kernel_config.num_dispatch_threads
             T.ptx.bar.sync(
                 T.uint32(dispatch_sync_barrier_idx), T.uint32(kernel_config.num_dispatch_threads)
@@ -3641,7 +3699,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     if T.cast(token_idx, "uint32") < T.cast(num_tokens, "uint32"):
                         topk_idx = T.cast(lane_idx_u32 % T.uint32(num_topk), "int32")
                         dispatch_token_topk_idx = token_idx * num_topk + topk_idx
-                        dispatch_expert_idx = T.cast(input_topk_idx[token_idx, topk_idx], "int32")
+                        load_global_s64(
+                            ordinary_global_s64, input_topk_idx.ptr_to([token_idx, topk_idx])
+                        )
+                        dispatch_expert_idx = T.cast(ordinary_global_s64, "int32")
                         if dispatch_expert_idx >= 0:
                             dispatch_expert_idx_u32 = T.cast(dispatch_expert_idx, "uint32")
                             dispatch_dst_rank_idx = T.cast(
@@ -3653,13 +3714,14 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                             dispatch_dst_slot_idx = T.cuda.atomic_add(
                                 smem_expert_count.ptr_to([dispatch_expert_idx]), 1
                             )
+                            symm_rank_base = sym_buffer_base + T.cast(
+                                symm_rank_offsets[0], "uint64"
+                            )
+                            load_symm_rank_base(
+                                symm_rank_base, smem_symm_rank_bases, dispatch_dst_rank_idx
+                            )
                             peer_store_u32(
-                                symm_rank_base_expr(
-                                    sym_buffer_base,
-                                    symm_rank_offsets,
-                                    smem_symm_rank_bases,
-                                    dispatch_dst_rank_idx,
-                                ),
+                                symm_rank_base,
                                 T.uint64(
                                     workspace_layout.src_token_topk_idx_offset
                                     + (
@@ -3697,14 +3759,14 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                 dispatch_dst_local_expert_idx = T.cast(
                     dispatch_expert_idx_u32 % T.uint32(num_experts_per_rank), "int32"
                 )
-                scheduler_cached_status = workspace_expert_send_count[dispatch_expert_idx]
+                load_global_u64(
+                    scheduler_cached_status,
+                    workspace_expert_send_count.ptr_to([dispatch_expert_idx]),
+                )
+                symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                load_symm_rank_base(symm_rank_base, smem_symm_rank_bases, dispatch_dst_rank_idx)
                 peer_store_u64(
-                    symm_rank_base_expr(
-                        sym_buffer_base,
-                        symm_rank_offsets,
-                        smem_symm_rank_bases,
-                        dispatch_dst_rank_idx,
-                    ),
+                    symm_rank_base,
                     T.uint64(
                         workspace_layout.expert_recv_count_offset
                         + (rank_idx * num_experts_per_rank + dispatch_dst_local_expert_idx) * 8
@@ -3712,14 +3774,11 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     T.bitwise_and(scheduler_cached_status, T.uint64(0xFFFFFFFF)),
                 )
                 peer_recv_count_sum_prev: T.uint64  # atom returns the old value; unused here
+                symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                load_symm_rank_base(symm_rank_base, smem_symm_rank_bases, dispatch_dst_rank_idx)
                 peer_atomic_add_u64(
                     peer_recv_count_sum_prev,
-                    symm_rank_base_expr(
-                        sym_buffer_base,
-                        symm_rank_offsets,
-                        smem_symm_rank_bases,
-                        dispatch_dst_rank_idx,
-                    ),
+                    symm_rank_base,
                     T.uint64(
                         workspace_layout.expert_recv_count_sum_offset
                         + dispatch_dst_local_expert_idx * 8
@@ -3776,16 +3835,17 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                     old_expert_idx = current_expert_idx
                     for rank_lane_idx in T.unroll(0, num_ranks_per_lane):
                         dispatch_dst_rank_idx = rank_lane_idx * 32 + lane_idx
-                        stored_rank_counts[rank_lane_idx] = T.Select(
-                            T.cast(dispatch_dst_rank_idx, "uint32") < T.uint32(num_processes),
-                            T.cast(
-                                workspace_expert_recv_count[
-                                    dispatch_dst_rank_idx, current_expert_idx
-                                ],
-                                "uint32",
-                            ),
-                            T.uint32(0),
-                        )
+                        stored_rank_counts[rank_lane_idx] = T.uint32(0)
+                        if T.cast(dispatch_dst_rank_idx, "uint32") < T.uint32(num_processes):
+                            load_global_u64(
+                                ordinary_global_u64,
+                                workspace_expert_recv_count.ptr_to(
+                                    [dispatch_dst_rank_idx, current_expert_idx]
+                                ),
+                            )
+                            stored_rank_counts[rank_lane_idx] = T.cast(
+                                ordinary_global_u64, "uint32"
+                            )
                 token_idx_in_expert = dispatch_token_iter - expert_start_idx
                 dispatch_dst_slot_idx = token_idx_in_expert
                 round_offset = T.int32(0)
@@ -3852,12 +3912,13 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         ] - T.min(
                             remaining_rank_counts[rank_lane_idx], T.cast(min_active_count, "uint32")
                         )
-                pull_src_token_topk_idx = T.cast(
-                    workspace_src_token_topk_idx[
-                        current_expert_idx, current_rank_in_expert_idx, token_idx_in_rank
-                    ],
-                    "int32",
+                load_global_u32(
+                    ordinary_global_u32,
+                    workspace_src_token_topk_idx.ptr_to(
+                        [current_expert_idx, current_rank_in_expert_idx, token_idx_in_rank]
+                    ),
                 )
+                pull_src_token_topk_idx = T.cast(ordinary_global_u32, "int32")
                 pull_src_token_topk_idx_u32 = T.cast(pull_src_token_topk_idx, "uint32")
                 pull_src_token_idx = T.cast(
                     pull_src_token_topk_idx_u32 // T.uint32(num_topk), "int32"
@@ -3883,14 +3944,13 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         )
                 if T.cuda.elect_sync():
                     for pull_chunk_idx in T.unroll(0, num_pull_chunks):
+                        symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                        load_symm_rank_base(
+                            symm_rank_base, smem_symm_rank_bases, current_rank_in_expert_idx
+                        )
                         tma_load_1d_symm(
                             smem_send_buffers.ptr_to([flat_warp_idx, 0]),
-                            symm_rank_base_expr(
-                                sym_buffer_base,
-                                symm_rank_offsets,
-                                smem_symm_rank_bases,
-                                current_rank_in_expert_idx,
-                            ),
+                            symm_rank_base,
                             T.uint64(
                                 symm_buffer_layout.input_token_offset
                                 + pull_src_token_idx * hidden
@@ -3929,38 +3989,38 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                 dispatch_dst_rank_idx = lane_idx
                 while dispatch_dst_rank_idx < hidden // 128:
                     pulled_sf: T.uint32
+                    symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                    load_symm_rank_base(
+                        symm_rank_base, smem_symm_rank_bases, current_rank_in_expert_idx
+                    )
                     peer_load_u32(
                         pulled_sf,
-                        symm_rank_base_expr(
-                            sym_buffer_base,
-                            symm_rank_offsets,
-                            smem_symm_rank_bases,
-                            current_rank_in_expert_idx,
-                        ),
+                        symm_rank_base,
                         T.uint64(
                             symm_buffer_layout.input_sf_offset
                             + (pull_src_token_idx * (hidden // 128) + dispatch_dst_rank_idx) * 4
                         ),
                     )
-                    l1_acts_sf[dispatch_dst_rank_idx, sf_row_idx] = T.cast(pulled_sf, "int32")
+                    store_global_u32(
+                        l1_acts_sf.ptr_to([dispatch_dst_rank_idx, sf_row_idx]), pulled_sf
+                    )
                     dispatch_dst_rank_idx = dispatch_dst_rank_idx + 32
                 T.cuda.warp_sync()
                 if T.cuda.elect_sync():
                     pulled_weight: T.float32
+                    symm_rank_base = sym_buffer_base + T.cast(symm_rank_offsets[0], "uint64")
+                    load_symm_rank_base(
+                        symm_rank_base, smem_symm_rank_bases, current_rank_in_expert_idx
+                    )
                     peer_load_f32(
                         pulled_weight,
-                        symm_rank_base_expr(
-                            sym_buffer_base,
-                            symm_rank_offsets,
-                            smem_symm_rank_bases,
-                            current_rank_in_expert_idx,
-                        ),
+                        symm_rank_base,
                         T.uint64(
                             symm_buffer_layout.input_topk_weights_offset
                             + pull_src_token_topk_idx * 4
                         ),
                     )
-                    l1_topk_weights[pull_ring_token_idx] = pulled_weight
+                    store_global_f32(l1_topk_weights.ptr_to([pull_ring_token_idx]), pulled_weight)
                     store_token_src_metadata(
                         pull_pool_token_idx,
                         current_rank_in_expert_idx,
@@ -4016,17 +4076,21 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                 # SM 0: clear expert send count and schedule task counters
                 dispatch_expert_idx = thread_idx
                 while dispatch_expert_idx < num_experts:
-                    workspace_expert_send_count[dispatch_expert_idx] = T.uint64(0)
+                    store_global_u64(
+                        workspace_expert_send_count.ptr_to([dispatch_expert_idx]), T.uint64(0)
+                    )
                     dispatch_expert_idx = dispatch_expert_idx + kernel_config.num_dispatch_threads
                 if (flat_warp_idx == 0) & T.cuda.elect_sync() != 0:
-                    workspace_l1_task_count[0] = T.uint32(0)
-                    workspace_l2_task_count[0] = T.uint32(0)
-                    workspace_shared_l1_task_count[0] = T.uint32(0)
-                    workspace_shared_l2_task_count[0] = T.uint32(0)
+                    store_global_u32(workspace_l1_task_count.ptr_to([0]), T.uint32(0))
+                    store_global_u32(workspace_l2_task_count.ptr_to([0]), T.uint32(0))
+                    store_global_u32(workspace_shared_l1_task_count.ptr_to([0]), T.uint32(0))
+                    store_global_u32(workspace_shared_l2_task_count.ptr_to([0]), T.uint32(0))
                 T.cuda.warp_sync()
                 dispatch_expert_idx = thread_idx
                 while dispatch_expert_idx < workspace_layout.num_shared_l2_pool_blocks:
-                    workspace_shared_l2_full_count[dispatch_expert_idx] = T.uint32(0)
+                    store_global_u32(
+                        workspace_shared_l2_full_count.ptr_to([dispatch_expert_idx]), T.uint32(0)
+                    )
                     dispatch_expert_idx = dispatch_expert_idx + kernel_config.num_dispatch_threads
                 T.cuda.warp_sync()
             else:
@@ -4057,7 +4121,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         T.uint32(kernel_config.num_dispatch_threads),
                     )
                     if thread_idx == 0:
-                        workspace_expert_recv_count_sum[pull_local_expert_idx] = T.uint64(0)
+                        store_global_u64(
+                            workspace_expert_recv_count_sum.ptr_to([pull_local_expert_idx]),
+                            T.uint64(0),
+                        )
                     if kernel_collect_stats and flat_warp_idx == 1 and lane_idx == 0:
                         T.evaluate(
                             red_add_gpu_s32(
@@ -4067,9 +4134,12 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         )
                     dispatch_dst_rank_idx = thread_idx
                     while dispatch_dst_rank_idx < T.int32(num_processes):
-                        workspace_expert_recv_count[
-                            dispatch_dst_rank_idx, pull_local_expert_idx
-                        ] = T.uint64(0)
+                        store_global_u64(
+                            workspace_expert_recv_count.ptr_to(
+                                [dispatch_dst_rank_idx, pull_local_expert_idx]
+                            ),
+                            T.uint64(0),
+                        )
                         dispatch_dst_rank_idx = (
                             dispatch_dst_rank_idx + kernel_config.num_dispatch_threads
                         )
@@ -4078,10 +4148,18 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                         pull_ring_block_idx = (
                             pull_pool_block_offset + dispatch_dst_slot_idx
                         ) % num_ring_blocks
-                        workspace_l1_full_count[pull_ring_block_idx] = T.uint32(0)
-                        workspace_l1_empty_count[pull_ring_block_idx] = T.uint32(0)
-                        workspace_l2_full_count[pull_ring_block_idx] = T.uint32(0)
-                        workspace_l2_empty_count[pull_ring_block_idx] = T.uint32(0)
+                        store_global_u32(
+                            workspace_l1_full_count.ptr_to([pull_ring_block_idx]), T.uint32(0)
+                        )
+                        store_global_u32(
+                            workspace_l1_empty_count.ptr_to([pull_ring_block_idx]), T.uint32(0)
+                        )
+                        store_global_u32(
+                            workspace_l2_full_count.ptr_to([pull_ring_block_idx]), T.uint32(0)
+                        )
+                        store_global_u32(
+                            workspace_l2_empty_count.ptr_to([pull_ring_block_idx]), T.uint32(0)
+                        )
                         dispatch_dst_slot_idx = (
                             dispatch_dst_slot_idx + kernel_config.num_dispatch_threads
                         )
@@ -4493,7 +4571,8 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
             epilogue_bf16_packed = T.alloc_local((4,), "uint32")
             tmem_addr = T.alloc_local((1,), "uint32")
             reduced = T.alloc_local((num_uint4_per_lane * num_elems_per_uint4, 2), "float32")
-            T.cuda.trap_when_assert_failed(tmem_ptr_in_smem[0] == T.uint32(0))
+            load_shared_u32(tmem_allocated, tmem_ptr_in_smem.ptr_to([0]))
+            T.cuda.trap_when_assert_failed(tmem_allocated == T.uint32(0))
             epilogue_warp_idx = flat_warp_idx - kernel_config.epilogue_warp_start_idx
             epilogue_warp_idx_u32 = T.cast(epilogue_warp_idx, "uint32")
             epilogue_wg_idx = T.cast(epilogue_warp_idx_u32 // T.uint32(4), "int32")
@@ -4665,8 +4744,11 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                                     + i * (atom_m // 2)
                                     + lane_idx
                                 ) * 2
-                                smem_amax_reduction[amax_reduction_idx] = amax_values[i, 0]
-                                smem_amax_reduction[amax_reduction_idx + 1] = amax_values[i, 1]
+                                T.ptx.st.shared.v2.f32(
+                                    smem_amax_reduction.ptr_to([amax_reduction_idx]),
+                                    amax_values[i, 0],
+                                    amax_values[i, 1],
+                                )
                             T.cuda.warp_sync()
                         tma_stage_idx = s % num_tma_store_stages
                         T.evaluate(tma_store_wait(1))
@@ -4680,8 +4762,11 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                                 + i * (atom_m // 2)
                                 + (lane_idx % 4)
                             ) * 2
-                            wp_amax[0] = smem_amax_reduction[amax_reduction_idx]
-                            wp_amax[1] = smem_amax_reduction[amax_reduction_idx + 1]
+                            T.ptx.ld.shared.v2.f32(
+                                wp_amax[0],
+                                wp_amax[1],
+                                smem_amax_reduction.ptr_to([amax_reduction_idx]),
+                            )
                             amax_values[i, 0] = T.max(amax_values[i, 0], wp_amax[0])
                             amax_values[i, 1] = T.max(amax_values[i, 1], wp_amax[1])
                             get_e4m3_sf_and_sf_inv(
@@ -4746,11 +4831,13 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                                 )
                                 sf_bits = float_bits(sf[0])
                                 sf_bits_hi = float_bits(sf[1])
-                                l2_sf_buffer[sf_addr] = T.cast(
-                                    T.shift_right(sf_bits, T.uint32(23)), "int8"
+                                store_global_u8(
+                                    l2_sf_buffer.ptr_to([sf_addr]),
+                                    T.cast(T.shift_right(sf_bits, T.uint32(23)), "uint8"),
                                 )
-                                l2_sf_buffer[sf_addr + T.uint64(16)] = T.cast(
-                                    T.shift_right(sf_bits_hi, T.uint32(23)), "int8"
+                                store_global_u8(
+                                    l2_sf_buffer.ptr_to([sf_addr + T.uint64(16)]),
+                                    T.cast(T.shift_right(sf_bits_hi, T.uint32(23)), "uint8"),
                                 )
                         T.cuda.warp_sync()
                         T.ptx.bar.sync(
@@ -4878,11 +4965,18 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                             )
                             if T.cast(m_idx_in_block, "uint32") < T.cast(valid_m, "uint32"):
                                 src_metadata_idx = pool_m_idx + m_idx_in_block
-                                dst_rank_idx_u32 = workspace_token_src_metadata[src_metadata_idx, 0]
-                                dst_token_idx_u32 = workspace_token_src_metadata[
-                                    src_metadata_idx, 1
-                                ]
-                                dst_topk_idx_u32 = workspace_token_src_metadata[src_metadata_idx, 2]
+                                load_global_u32(
+                                    dst_rank_idx_u32,
+                                    workspace_token_src_metadata.ptr_to([src_metadata_idx, 0]),
+                                )
+                                load_global_u32(
+                                    dst_token_idx_u32,
+                                    workspace_token_src_metadata.ptr_to([src_metadata_idx, 1]),
+                                )
+                                load_global_u32(
+                                    dst_topk_idx_u32,
+                                    workspace_token_src_metadata.ptr_to([src_metadata_idx, 2]),
+                                )
                                 dst_rank_idx = T.cast(dst_rank_idx_u32, "int32")
                                 dst_token_base_offset = T.cast(
                                     dst_topk_idx_u32, "uint64"
@@ -4909,18 +5003,18 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
                                     ]
                                 )
                                 lds128(smem_ptr, epilogue_bf16_packed)
-                                dst_peer_base = symm_rank_base_expr(
-                                    sym_buffer_base,
-                                    symm_rank_offsets,
-                                    smem_symm_rank_bases,
-                                    dst_rank_idx,
+                                symm_rank_base = sym_buffer_base + T.cast(
+                                    symm_rank_offsets[0], "uint64"
+                                )
+                                load_symm_rank_base(
+                                    symm_rank_base, smem_symm_rank_bases, dst_rank_idx
                                 )
                                 dst_ptr = (
                                     T.cast(symm_buffer_layout.combine_token_offset, "uint64")
                                     + dst_ptr
                                 )
                                 stg128_symm(
-                                    dst_peer_base,
+                                    symm_rank_base,
                                     dst_ptr,
                                     epilogue_bf16_packed[0],
                                     epilogue_bf16_packed[1],
@@ -4955,7 +5049,10 @@ __forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
             while T.cast(token_idx, "uint32") < T.cast(num_tokens, "uint32"):
                 stored_topk_slot_idx = T.int32(-1)
                 if lane_idx < num_topk:
-                    stored_topk_slot_idx = T.cast(input_topk_idx[token_idx, lane_idx], "int32")
+                    load_global_s64(
+                        ordinary_global_s64, input_topk_idx.ptr_to([token_idx, lane_idx])
+                    )
+                    stored_topk_slot_idx = T.cast(ordinary_global_s64, "int32")
                 total_mask = ballot_sync(T.uint32(0xFFFFFFFF), stored_topk_slot_idx >= T.int32(0))
                 for chunk in T.unroll(0, num_chunks):
                     mask = total_mask

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1526,7 +1526,6 @@ def get_kernel(
     collect_stats: bool = False,
     emit_nvl_barrier_timeout_printf: bool = True,
 ):
-    from tvm.backend.cuda.op import cuda_func_call
     from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
     from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
@@ -2034,49 +2033,39 @@ def get_kernel(
             "int32",
         )
 
-    # `ptx::st_async_cluster` (deep_gemm/include/deep_gemm/ptx/ld_st.cuh): map the
-    # destination smem + mbarrier into the peer CTA with `mapa`, then push the
-    # 32-byte TaskInfo as two `st.async...v4` transactions that complete the
-    # published-task mbarrier's tx count. No TIRx wrapper exists for
-    # `st.async.shared::cluster.mbarrier::complete_tx::bytes`; see
-    # `.porting/mega_moe/tirx_dsl_improve.md`.
-    _st_async_cluster_task_info_src = r"""
-__forceinline__ __device__ void tvm_builtin_st_async_cluster_task_info(
-    void* dst, void* bar, uint32_t dst_cta_idx,
-    uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3,
-    uint32_t v4, uint32_t v5, uint32_t v6, uint32_t v7) {
-    const uint32_t bar_addr = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
-    const uint32_t dst_addr = static_cast<uint32_t>(__cvta_generic_to_shared(dst));
-    uint32_t mapped_bar, mapped_dst;
-    asm volatile("mapa.shared::cluster.u32 %0, %1, %2;"
-                 : "=r"(mapped_bar) : "r"(bar_addr), "r"(dst_cta_idx));
-    asm volatile("mapa.shared::cluster.u32 %0, %1, %2;"
-                 : "=r"(mapped_dst) : "r"(dst_addr), "r"(dst_cta_idx));
-    asm volatile(
-        "st.async.shared::cluster.mbarrier::complete_tx::bytes.u32.v4 [%0], {%1, %2, %3, %4}, [%5];" ::
-        "r"(mapped_dst), "r"(v0), "r"(v1), "r"(v2), "r"(v3), "r"(mapped_bar));
-    asm volatile(
-        "st.async.shared::cluster.mbarrier::complete_tx::bytes.u32.v4 [%0], {%1, %2, %3, %4}, [%5];" ::
-        "r"(mapped_dst + 16), "r"(v4), "r"(v5), "r"(v6), "r"(v7), "r"(mapped_bar));
-}
-"""
-
     def st_async_cluster_task_info(dst_ptr, bar_ptr, dst_cta_idx, task_info_regs):
-        return cuda_func_call(
-            "tvm_builtin_st_async_cluster_task_info",
-            dst_ptr,
-            bar_ptr,
-            T.cast(dst_cta_idx, "uint32"),
-            task_info_regs[0],
-            task_info_regs[1],
-            task_info_regs[2],
-            task_info_regs[3],
+        mapped_bar = T.alloc_local((1,), "uint32")
+        mapped_dst = T.alloc_local((1,), "uint32")
+        mapped_dst_hi = T.alloc_local((1,), "uint32")
+        cta = T.cast(dst_cta_idx, "uint32")
+        T.evaluate(
+            T.ptx.mapa.shared__cluster.u32(
+                mapped_bar[0], T.cuda.cvta_generic_to_shared(bar_ptr), cta
+            )
+        )
+        T.evaluate(
+            T.ptx.mapa.shared__cluster.u32(
+                mapped_dst[0], T.cuda.cvta_generic_to_shared(dst_ptr), cta
+            )
+        )
+        T.evaluate(
+            T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.v4.u32(
+                mapped_dst[0],
+                task_info_regs[0],
+                task_info_regs[1],
+                task_info_regs[2],
+                task_info_regs[3],
+                mapped_bar[0],
+            )
+        )
+        T.evaluate(T.ptx.add.u32(mapped_dst_hi[0], mapped_dst[0], T.uint32(16)))
+        return T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.v4.u32(
+            mapped_dst_hi[0],
             task_info_regs[4],
             task_info_regs[5],
             task_info_regs[6],
             task_info_regs[7],
-            source_code=_st_async_cluster_task_info_src,
-            return_type="void",
+            mapped_bar[0],
         )
 
     def atomic_add_u32(dst, address, value):

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -282,8 +282,15 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 def _mqa_fp4_wrelu_reduce_src(num_heads: int) -> str:
-    """DeepGEMM f32 wrelu epilogue (sm100_mqa_logits.cuh): relu as x+|x| packed into
-    FADD2+FFMA2, tail /2; emitted as a kernel-local helper via T.cuda_func_call."""
+    """DeepGEMM's packed weighted-ReLU reduction.
+
+    The individual PTX operations are registered, and ptxas produces the same
+    FADD2/FFMA2 reduction from them.  However, expanding the reduction into
+    separate inline-asm wrappers prevents NVRTC from hoisting and uniform-
+    lowering surrounding runtime address calculations in the compressed BF16
+    kernel.  Keep this hot composite so those calculations stay on the uniform
+    datapath; the expanded form regresses its paired bench_suite result.
+    """
     return (
         f"__forceinline__ __device__ float tvm_builtin_mqa_fp4_wrelu_reduce_{num_heads}("
         "const float* __restrict__ accum, const float* __restrict__ weights) {\n"
@@ -1037,7 +1044,6 @@ def get_kernel(**kwargs: Any):
                             T.ptx.tcgen05.wait__ld.sync.aligned()
                             if q_inner_i == block_q - 1:
                                 tmem_pipe.empty.arrive(tmem_stage_idx)
-                            # Weighted-ReLU reduce via inline CUDA (see _mqa_fp4_wrelu_reduce_src).
                             result_f32: T.float32 = cuda_func_call(
                                 f"tvm_builtin_mqa_fp4_wrelu_reduce_{num_heads}",
                                 T.address_of(accum[0]),

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -307,12 +307,11 @@ def _mqa_fp4_wrelu_reduce_src(num_heads: int) -> str:
 
 
 def get_kernel(**kwargs: Any):
-    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_smem_layout, sf_tmem_layout
+    from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_tmem_layout
     from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
-    from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import MBarrier, Pipeline
-    from tvm.tirx.layout import S, TCol, TileLayout, TLane, wg_local_layout
+    from tvm.tirx.layout import S, TCol, TileLayout, TLane
 
     config = _make_config(**kwargs)
     num_heads = config.num_heads
@@ -359,17 +358,36 @@ def get_kernel(**kwargs: Any):
     # cp deposit dst: sf_per_mma is the cp atom (<= epc=4 so t_col stays a single
     # iter); SF_K//4 K-outer groups absorb the num_sfkv/128 row chunks.
     sf_tmem_kv_layout = sf_tmem_layout(128, SF_K=num_sfkv // 32, sf_per_mma=head_dim // 32)
-    # cp (SMEM->TMEM UTCCP) SMEM-side layouts: post-transpose bytes ARE the canonical
-    # sf_smem_layout, with sf_per_mma = cp atom = head_dim/sf_vec.
-    sf_cp_K = head_dim // 32
-    sf_smem_q_cp_layout = sf_smem_layout(
-        128, SF_K=num_sfq // 32, sf_per_mma=sf_cp_K, pipe_depth=num_q_stages
-    )
-    sf_smem_kv_cp_layout = sf_smem_layout(
-        128, SF_K=num_sfkv // 32, sf_per_mma=sf_cp_K, pipe_depth=num_kv_stages
-    )
     tmem_layout = TileLayout(S[(128, num_tmem_cols) : (1 @ TLane, 1 @ TCol)])
     logits_tir_dtype = "float32" if config.logits_dtype == "float32" else "bfloat16"
+    cache_policy_evict_normal = T.uint64(0x1000000000000000)
+    tma_g2s_1d = (
+        "cp.async.bulk.tensor.1d.shared::cluster.global"
+        ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+    )
+    tma_g2s_2d = (
+        "cp.async.bulk.tensor.2d.shared::cluster.global"
+        ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+    )
+    tcgen05_cp = "tcgen05.cp.cta_group::1.32x128b.warpx4"
+    tcgen05_mma = "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X"
+    tcgen05_ld_x32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+
+    def replace_smem_desc_addr(desc, smem_ptr):
+        shared_addr = T.cuda.cvta_generic_to_shared(smem_ptr)
+        start_addr = T.cast(
+            T.bitwise_and(T.shift_right(shared_addr, T.uint32(4)), T.uint32(0x3FFF)), "uint64"
+        )
+        return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
+
+    def recompute_fp4_smem_desc(smem_ptr):
+        # ldo=0, sdo=32, 64B swizzle.  This is the exact uniform descriptor
+        # form produced by the former ``smem_desc="recompute"`` dispatch.
+        shared_addr = T.cuda.cvta_generic_to_shared(smem_ptr)
+        start_addr = T.cast(
+            T.bitwise_and(T.shift_right(shared_addr, T.uint32(4)), T.uint32(0x3FFF)), "uint64"
+        )
+        return T.bitwise_or(T.shift_left(T.uint64(0x80004020), T.uint64(32)), start_addr)
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())
@@ -423,10 +441,106 @@ def get_kernel(**kwargs: Any):
         q_gmem = T.match_buffer(q_gmem_h, (seq_len * num_heads, head_dim // 2), "uint8")
         sf_q_gmem = T.match_buffer(sf_q_gmem_h, (seq_len, num_heads), "uint32")
         kv_gmem = T.match_buffer(kv_gmem_h, (seq_len_kv, head_dim // 2), "uint8")
-        # 2D (1, seq_len_kv) view so copy_async(tma) builds a 2D descriptor
-        # (UTMALDG.2D) like upstream's make_tma_2d_desc for sf_kv.
+        # Preserve the public physical (1, seq_len_kv) buffer view; the unit
+        # outer dimension canonicalizes to the rank-1 SFKV tensor map below.
         sf_kv_gmem = T.match_buffer(sf_kv_gmem_h, (1, seq_len_kv), "uint32")
         weights_gmem = T.match_buffer(weights_gmem_h, (seq_len, num_heads), "float32")
+
+        # Runtime tensor maps are part of the public runtime-length contract:
+        # packed Q/KV use the original 64-byte swizzle, while scales and
+        # weights remain unswizzled.  The rank-1 SFKV map is the canonical
+        # lowering of the physical (1, seq_len_kv) view above.
+        sf_kv_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            sf_kv_gmem_tensormap,
+            "uint32",
+            1,
+            sf_kv_gmem.data,
+            seq_len_kv,
+            block_kv,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        kv_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            kv_gmem_tensormap,
+            "uint8",
+            2,
+            kv_gmem.data,
+            head_dim // 2,
+            seq_len_kv,
+            head_dim // 2,
+            head_dim // 2,
+            block_kv,
+            1,
+            1,
+            0,
+            SwizzleMode.SWIZZLE_64B_ATOM.value,
+            2,
+            0,
+        )
+        weights_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            weights_gmem_tensormap,
+            "float32",
+            2,
+            weights_gmem.data,
+            num_heads,
+            seq_len,
+            num_heads * 4,
+            num_heads,
+            block_q,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        sf_q_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            sf_q_gmem_tensormap,
+            "uint32",
+            2,
+            sf_q_gmem.data,
+            num_heads,
+            seq_len,
+            num_heads * 4,
+            num_heads,
+            block_q,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        q_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            q_gmem_tensormap,
+            "uint8",
+            2,
+            q_gmem.data,
+            head_dim // 2,
+            seq_len * num_heads,
+            head_dim // 2,
+            head_dim // 2,
+            block_q * num_heads,
+            1,
+            1,
+            0,
+            SwizzleMode.SWIZZLE_64B_ATOM.value,
+            2,
+            0,
+        )
         T.device_entry()
         if config.logits_dtype == "float32":
             # __launch_bounds__(kNumThreads, 1): without .minnctapersm ptxas ignores
@@ -447,6 +561,23 @@ def get_kernel(**kwargs: Any):
         warp_idx = T.warp_id([num_warps])
         warpgroup_idx = T.warpgroup_id([num_warps // 4])
         lane_idx = T.lane_id([32])
+        # Keep the former dispatcher placement: one warp-elected prefetch for
+        # each map, issued before any pipeline work.
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(sf_q_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(weights_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(sf_kv_gmem_tensormap)))
         # SMEMPool owns the smem offsets; q/kv carry a 64B-atom swizzle (head_dim//2
         # B/row). Under the pool .data is the arena base — use .ptr_to([0,...])/.view.
         pool = T.SMEMPool()
@@ -532,7 +663,7 @@ def get_kernel(**kwargs: Any):
             if config.logits_dtype == "float32":
                 T.ptx.st.global_.f32(logits_flat.ptr_to([flat_offset]), value)
             else:
-                logits_flat[flat_offset] = value
+                T.ptx.st.global_.b16(logits_flat.ptr_to([flat_offset]), value)
 
         @T.inline
         def load_schedule(q_idx):
@@ -542,12 +673,14 @@ def get_kernel(**kwargs: Any):
                 row_idx: T.uint32 = T.min(
                     q_idx * T.uint32(block_q) + T.uint32(schedule_i), seq_len - T.uint32(1)
                 )
-                seq_k_start[schedule_i] = T.min(
-                    T.cast(cu_seq_len_k_start[row_idx], "uint32"), seq_len_kv
+                row_start: T.int32
+                row_end: T.int32
+                T.ptx.ld.global_.s32(
+                    row_start, cu_seq_len_k_start.ptr_to([T.cast(row_idx, "int32")])
                 )
-                seq_k_end[schedule_i] = T.min(
-                    T.cast(cu_seq_len_k_end[row_idx], "uint32"), seq_len_kv
-                )
+                T.ptx.ld.global_.s32(row_end, cu_seq_len_k_end.ptr_to([T.cast(row_idx, "int32")]))
+                seq_k_start[schedule_i] = T.min(T.cast(row_start, "uint32"), seq_len_kv)
+                seq_k_end[schedule_i] = T.min(T.cast(row_end, "uint32"), seq_len_kv)
                 schedule_start = T.min(schedule_start, seq_k_start[schedule_i])
                 schedule_end = T.max(schedule_end, seq_k_end[schedule_i])
             schedule_start = schedule_start // T.uint32(4) * T.uint32(4)
@@ -582,33 +715,36 @@ def get_kernel(**kwargs: Any):
                     # u32 row base — the copy_async(tma) gmem-layout grouping now
                     # handles unsigned shape extents (no int32 cast needed).
                     q_row0: T.uint32 = q_idx * T.uint32(block_q * num_heads)
-                    Tx.copy_async(
-                        smem_q[q_stage_idx],
-                        q_gmem[q_row0 : q_row0 + block_q * num_heads, :],
-                        dispatch="tma_auto",
-                        mbar=q_pipe.full.ptr_to([q_stage_idx]),
-                        cta_group=1,
-                        cache_hint="evict_normal",
-                        prefetch_tensormap=True,
+                    T.evaluate(
+                        T.ptx[tma_g2s_2d](
+                            smem_q.ptr_to([q_stage_idx, 0, 0]),
+                            T.address_of(q_gmem_tensormap),
+                            T.int32(0),
+                            T.cast(q_row0, "int32"),
+                            q_pipe.full.ptr_to([q_stage_idx]),
+                            cache_policy_evict_normal,
+                        )
                     )
                     q_blk0: T.uint32 = q_idx * T.uint32(block_q)
-                    Tx.copy_async(
-                        smem_sf_q_2d[q_stage_idx],
-                        sf_q_gmem[q_blk0 : q_blk0 + block_q, :],
-                        dispatch="tma_auto",
-                        mbar=q_pipe.full.ptr_to([q_stage_idx]),
-                        cta_group=1,
-                        cache_hint="evict_normal",
-                        prefetch_tensormap=True,
+                    T.evaluate(
+                        T.ptx[tma_g2s_2d](
+                            smem_sf_q_2d.ptr_to([q_stage_idx, 0, 0]),
+                            T.address_of(sf_q_gmem_tensormap),
+                            T.int32(0),
+                            T.cast(q_blk0, "int32"),
+                            q_pipe.full.ptr_to([q_stage_idx]),
+                            cache_policy_evict_normal,
+                        )
                     )
-                    Tx.copy_async(
-                        smem_weights[q_stage_idx],
-                        weights_gmem[q_blk0 : q_blk0 + block_q, :],
-                        dispatch="tma_auto",
-                        mbar=q_pipe.full.ptr_to([q_stage_idx]),
-                        cta_group=1,
-                        cache_hint="evict_normal",
-                        prefetch_tensormap=True,
+                    T.evaluate(
+                        T.ptx[tma_g2s_2d](
+                            smem_weights.ptr_to([q_stage_idx, 0, 0]),
+                            T.address_of(weights_gmem_tensormap),
+                            T.int32(0),
+                            T.cast(q_blk0, "int32"),
+                            q_pipe.full.ptr_to([q_stage_idx]),
+                            cache_policy_evict_normal,
+                        )
                     )
                     q_pipe.full.arrive(
                         q_stage_idx,
@@ -636,23 +772,24 @@ def get_kernel(**kwargs: Any):
                     while kv_idx < num_kv_blocks:
                         kv_pipe.empty.wait(kv_stage_idx, kv_phase ^ T.uint32(1))
                         kv_row0: T.uint32 = kv_start + kv_idx * T.uint32(block_kv)
-                        Tx.copy_async(
-                            smem_kv[kv_stage_idx],
-                            kv_gmem[kv_row0 : kv_row0 + block_kv, :],
-                            dispatch="tma_auto",
-                            mbar=kv_pipe.full.ptr_to([kv_stage_idx]),
-                            cta_group=1,
-                            cache_hint="evict_normal",
-                            prefetch_tensormap=True,
+                        T.evaluate(
+                            T.ptx[tma_g2s_2d](
+                                smem_kv.ptr_to([kv_stage_idx, 0, 0]),
+                                T.address_of(kv_gmem_tensormap),
+                                T.int32(0),
+                                T.cast(kv_row0, "int32"),
+                                kv_pipe.full.ptr_to([kv_stage_idx]),
+                                cache_policy_evict_normal,
+                            )
                         )
-                        Tx.copy_async(
-                            smem_sf_kv[kv_stage_idx : kv_stage_idx + 1, 0:block_kv],
-                            sf_kv_gmem[0:1, kv_row0 : kv_row0 + block_kv],
-                            dispatch="tma_auto",
-                            mbar=kv_pipe.full.ptr_to([kv_stage_idx]),
-                            cta_group=1,
-                            cache_hint="evict_normal",
-                            prefetch_tensormap=True,
+                        T.evaluate(
+                            T.ptx[tma_g2s_1d](
+                                smem_sf_kv.ptr_to([kv_stage_idx, 0]),
+                                T.address_of(sf_kv_gmem_tensormap),
+                                T.cast(kv_row0, "int32"),
+                                kv_pipe.full.ptr_to([kv_stage_idx]),
+                                cache_policy_evict_normal,
+                            )
                         )
                         kv_pipe.full.arrive(
                             kv_stage_idx,
@@ -666,10 +803,12 @@ def get_kernel(**kwargs: Any):
                     q_idx = q_idx + T.uint32(config.num_sms)
         elif warp_idx == spec_warp_start + 2:
             T.ptx.setmaxnreg.dec.sync.aligned.u32(56)
-            T.cuda.trap_when_assert_failed(tmem_ptr_in_smem[0] == T.uint32(0))
+            tmem_allocated: T.uint32
+            T.ptx.ld.shared.u32(tmem_allocated, tmem_ptr_in_smem.ptr_to([0]))
+            T.cuda.trap_when_assert_failed(tmem_allocated == T.uint32(0))
             desc_i: T.uint32
-            # GAP 1: encode the block-scaled instruction descriptor ONCE here; the
-            # gemm_async path rotates the per-ki SF id from this single desc_i.
+            # Encode the block-scaled instruction descriptor once; each K phase
+            # rotates its SF id from this same base descriptor below.
             T.cuda.tcgen05.encode_instr_descriptor_block_scaled(
                 T.address_of(desc_i),
                 d_dtype="float32",
@@ -690,30 +829,9 @@ def get_kernel(**kwargs: Any):
             # carries elem_offset, giving the true buffer start under the pool.
             smem_kv_fp4 = smem_kv.view("float4_e2m1fn")
             smem_q_fp4 = smem_q.view("float4_e2m1fn")
-            # e8m0 views of the SF SMEM under the cp (sf_smem) layout, declared at the
-            # (rows=128, SF_K) footprint matching the SF TMEM tile.
-            smem_sf_q_cp = smem_sf_q_t.view("float8_e8m0fnu").view(
-                num_q_stages, 128, num_sfq // 32, layout=sf_smem_q_cp_layout
-            )
-            smem_sf_kv_cp = smem_sf_kv_t.view("float8_e8m0fnu").view(
-                num_kv_stages, 128, num_sfkv // 32, layout=sf_smem_kv_cp_layout
-            )
-            # SFA/SFB TMEM views in the dispatcher-canonical sf_tmem_layout (sf_per_mma
-            # == 2 for fp4+e8m0); same TMEM columns as the SF cp deposits.
-            sf_mma_k_dispatch = T.meta_var(umma_k // 32)  # fp4 SF_VEC=32 -> 2 SFs/MMA-K
-            sf_K_dispatch = T.meta_var((umma_k // 32) * (head_dim // umma_k))
-            sf_tmem_q_mma_layout = T.meta_var(
-                sf_tmem_layout(128, SF_K=sf_K_dispatch, sf_per_mma=sf_mma_k_dispatch)
-            )
-            sf_tmem_kv_mma_layout = T.meta_var(
-                sf_tmem_layout(128, SF_K=sf_K_dispatch, sf_per_mma=sf_mma_k_dispatch)
-            )
-            sfq_tmem_mma = T.decl_buffer(
-                (128, sf_K_dispatch),
-                "float8_e8m0fnu",
-                scope="tmem",
-                allocated_addr=tmem_start_col_of_sfq,
-                layout=sf_tmem_q_mma_layout,
+            desc_sf: T.uint64
+            T.cuda.tcgen05.encode_matrix_descriptor(
+                T.address_of(desc_sf), T.reinterpret("handle", T.uint64(0)), ldo=0, sdo=8, swizzle=0
             )
             q_stage_idx: T.uint32 = T.uint32(0)
             q_phase: T.uint32 = T.uint32(0)
@@ -743,7 +861,10 @@ def get_kernel(**kwargs: Any):
                         (previous_tmem_iter // T.uint32(num_tmem_stages)) & T.uint32(1),
                     )
                 if T.cuda.elect_sync():
-                    Tx.copy_async(sfq_tmem, smem_sf_q_cp[T.cast(q_stage_idx, "int32")], cta_group=1)
+                    T.ptx[tcgen05_cp](
+                        T.uint32(tmem_start_col_of_sfq),
+                        replace_smem_desc_addr(desc_sf, smem_sf_q_t.ptr_to([q_stage_idx, 0])),
+                    )
                 T.cuda.warp_sync()
                 kv_idx: T.uint32 = T.uint32(0)
                 while kv_idx < num_kv_blocks:
@@ -754,42 +875,51 @@ def get_kernel(**kwargs: Any):
                     # cp + MMA share ONE elect scope: drops a redundant elect.sync per
                     # kv-iter and lets the cp overlap the MMA setup.
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            sfkv_tmem, smem_sf_kv_cp[T.cast(kv_stage_idx, "int32")], cta_group=1
-                        )
+                        for sfkv_i in T.unroll(0, num_sfkv // num_utccp_aligned_elems):
+                            T.ptx[tcgen05_cp](
+                                T.uint32(tmem_start_col_of_sfkv + sfkv_i * 4),
+                                replace_smem_desc_addr(
+                                    desc_sf,
+                                    smem_sf_kv_t.ptr_to(
+                                        [kv_stage_idx, sfkv_i * num_utccp_aligned_elems]
+                                    ),
+                                ),
+                            )
                         for math_wg_i in T.unroll(0, num_math_warpgroups):
                             tmem_addr: T.uint32 = tmem_stage_idx * T.uint32(umma_n)
-                            # int32 column base: a uint32 base would promote the slice
-                            # extent and fail the gemm dispatch's StructuralEqual check.
-                            tmem_col_start: T.int32 = T.cast(tmem_addr, "int32")
                             tmem_pipe.empty.wait(tmem_stage_idx, tmem_phase ^ T.uint32(1))
-                            # REGION D: block-scaled fp4 UMMA (KV @ Qᵀ) via gemm_async;
-                            # operand order (D, A=KV, B=Q) with SFA=KV / SFB=Q scales in TMEM.
-                            sfkv_tmem_mma = T.decl_buffer(
-                                (128, sf_K_dispatch),
-                                "float8_e8m0fnu",
-                                scope="tmem",
-                                allocated_addr=tmem_start_col_of_sfkv + math_wg_i * 4,
-                                layout=sf_tmem_kv_mma_layout,
-                            )
-                            Tx.gemm_async(
-                                tmem[:, tmem_col_start : tmem_col_start + umma_n],
-                                smem_kv_fp4[
-                                    kv_stage_idx,
-                                    math_wg_i * umma_m : math_wg_i * umma_m + umma_m,
-                                    :,
-                                ],
-                                smem_q_fp4[q_stage_idx, :, :],
-                                SFA=sfkv_tmem_mma,
-                                SFB=sfq_tmem_mma,
-                                accum=False,
-                                descI=desc_i,
-                                dispatch="tcgen05",
-                                cta_group=1,
-                                # Recompute the SMEM descriptor per MMA (cvta on the
-                                # uniform datapath); "hoist" costs an R2UR per MMA here.
-                                smem_desc="recompute",
-                            )
+                            # REGION D: block-scaled FP4 UMMA, D = KV @ Qᵀ.  The
+                            # first K=64 phase overwrites and the second accumulates;
+                            # scale ids 0/2 select the two block-32 factors.
+                            desc_i_local: T.uint32 = desc_i
+                            for ki in T.unroll(0, head_dim // umma_k):
+                                sf_linear: T.int32 = ki * (umma_k // 32)
+                                T.cuda.runtime_instr_desc(
+                                    T.address_of(desc_i_local), sf_linear % (umma_k // 16)
+                                )
+                                T.ptx[tcgen05_mma](
+                                    tmem_addr,
+                                    recompute_fp4_smem_desc(
+                                        smem_kv_fp4.ptr_to(
+                                            [kv_stage_idx, math_wg_i * umma_m, ki * umma_k]
+                                        )
+                                    ),
+                                    recompute_fp4_smem_desc(
+                                        smem_q_fp4.ptr_to([q_stage_idx, 0, ki * umma_k])
+                                    ),
+                                    desc_i_local,
+                                    T.cuda.get_tmem_addr(
+                                        tmem_start_col_of_sfkv + math_wg_i * 4,
+                                        sf_linear % 128 // 4,
+                                        sf_linear // 128,
+                                    ),
+                                    T.cuda.get_tmem_addr(
+                                        tmem_start_col_of_sfq,
+                                        sf_linear % 128 // 4,
+                                        sf_linear // 128,
+                                    ),
+                                    T.ptx.pred(ki != 0),
+                                )
                             tmem_pipe.full.arrive(tmem_stage_idx)
                             tmem_issued = tmem_issued + T.uint32(1)
                             tmem_stage_idx = tmem_stage_idx + T.uint32(1)
@@ -859,7 +989,16 @@ def get_kernel(**kwargs: Any):
                 num_kv_blocks: T.uint32 = schedule_result[1]
                 q_pipe.full.wait(q_stage_idx, q_phase)
                 if num_kv_blocks > T.uint32(0):
-                    Tx.warpgroup.copy(cached_weights, smem_weights[q_stage_idx])
+                    for weight_i in T.unroll(0, block_q):
+                        for weight_j in T.unroll(0, num_heads // 4):
+                            weight_col = weight_j * 4
+                            T.ptx.ld.shared.v4.f32(
+                                cached_weights[weight_i, weight_col],
+                                cached_weights[weight_i, weight_col + 1],
+                                cached_weights[weight_i, weight_col + 2],
+                                cached_weights[weight_i, weight_col + 3],
+                                smem_weights.ptr_to([q_stage_idx, weight_i, weight_col]),
+                            )
                     # Publish the generic-proxy weight reads before this
                     # consumer releases the Q stage for a later TMA overwrite.
                     T.ptx.fence.proxy.async_.shared__cta()
@@ -882,16 +1021,18 @@ def get_kernel(**kwargs: Any):
                             )
                             # REGION E: TMEM->register read as 2x tcgen05.ld.32x32b.x32
                             # (DeepGEMM's 64-head shape); accum stays flat for the reduce.
-                            accum_2d = accum.view(128, num_heads, layout=wg_local_layout(num_heads))
-                            Tx.warpgroup.copy_async(
-                                accum_2d[:, 0 : num_heads // 2],
-                                tmem[:, tmem_addr : tmem_addr + num_heads // 2],
+                            T.ptx[tcgen05_ld_x32](
+                                *[accum[head_i] for head_i in range(num_heads // 2)],
+                                T.cuda.get_tmem_addr(T.uint32(0), 0, tmem_addr),
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
                             tmem_addr_hi: T.uint32 = tmem_addr + T.uint32(num_heads // 2)
-                            Tx.warpgroup.copy_async(
-                                accum_2d[:, num_heads // 2 : num_heads],
-                                tmem[:, tmem_addr_hi : tmem_addr_hi + num_heads // 2],
+                            T.ptx[tcgen05_ld_x32](
+                                *[
+                                    accum[num_heads // 2 + head_i]
+                                    for head_i in range(num_heads // 2)
+                                ],
+                                T.cuda.get_tmem_addr(T.uint32(0), 0, tmem_addr_hi),
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
                             if q_inner_i == block_q - 1:

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -23,8 +23,6 @@ from unittest import SkipTest
 
 import torch
 
-from tvm.backend.cuda.op import cuda_func_call
-
 _DEEP_GEMM_MODULE_NAME = "deep_gemm"
 _SM100_SMEM_CAPACITY = 232448
 _TEST_DIFF_THRESHOLD = 5e-6
@@ -279,31 +277,6 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
     }
 
 
-def _mqa_fp8_wrelu_reduce_src(num_heads: int) -> str:
-    """DeepGEMM f32 wrelu epilogue (sm100_mqa_logits.cuh): relu as x+|x| packed into
-    FADD2+FFMA2, tail /2; emitted as a kernel-local helper via T.cuda_func_call."""
-    return (
-        f"__forceinline__ __device__ float tvm_builtin_mqa_fp8_wrelu_reduce_{num_heads}("
-        "const float* __restrict__ accum, const float* __restrict__ weights) {\n"
-        "    float2 sum_0 = make_float2(0.0f, 0.0f);\n"
-        "    float2 sum_1 = make_float2(0.0f, 0.0f);\n"
-        "    #pragma unroll\n"
-        f"    for (int j = 0; j < {num_heads}; j += 4) {{\n"
-        "        float2 a_0 = make_float2(accum[j], accum[j + 1]);\n"
-        "        float2 a_1 = make_float2(fabsf(accum[j]), fabsf(accum[j + 1]));\n"
-        "        sum_0 = __ffma2_rn(__fadd2_rn(a_0, a_1),"
-        " make_float2(weights[j], weights[j + 1]), sum_0);\n"
-        "        float2 a_2 = make_float2(accum[j + 2], accum[j + 3]);\n"
-        "        float2 a_3 = make_float2(fabsf(accum[j + 2]), fabsf(accum[j + 3]));\n"
-        "        sum_1 = __ffma2_rn(__fadd2_rn(a_2, a_3),"
-        " make_float2(weights[j + 2], weights[j + 3]), sum_1);\n"
-        "    }\n"
-        "    float2 sum = __fadd2_rn(sum_0, sum_1);\n"
-        "    return (sum.x + sum.y) / 2.0f;\n"
-        "}"
-    )
-
-
 def get_kernel(**kwargs: Any):
     from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
@@ -369,6 +342,45 @@ def get_kernel(**kwargs: Any):
     tcgen05_ld = f"tcgen05.ld.sync.aligned.32x32b.x{num_heads // 2}.b32"
     desc_sdo = head_dim // 2
     desc_swizzle = {32: 1, 64: 2, 128: 3}[head_dim]
+
+    def wrelu_reduce(accum, weights, row):
+        sum_0 = T.alloc_local((1,), "uint64")
+        sum_1 = T.alloc_local((1,), "uint64")
+        accum_pair = T.alloc_local((1,), "uint64")
+        abs_pair = T.alloc_local((1,), "uint64")
+        relu_pair = T.alloc_local((1,), "uint64")
+        weight_pair = T.alloc_local((1,), "uint64")
+        abs_lo = T.alloc_local((1,), "float32")
+        abs_hi = T.alloc_local((1,), "float32")
+        total = T.alloc_local((1,), "uint64")
+        total_lo = T.alloc_local((1,), "float32")
+        total_hi = T.alloc_local((1,), "float32")
+        result = T.alloc_local((1,), "float32")
+        T.evaluate(T.ptx.mov.b64(sum_0[0], T.float32(0), T.float32(0)))
+        T.evaluate(T.ptx.mov.b64(sum_1[0], T.float32(0), T.float32(0)))
+        for head in range(0, num_heads, 4):
+            T.evaluate(T.ptx.mov.b64(accum_pair[0], accum[head], accum[head + 1]))
+            T.evaluate(T.ptx.abs.f32(abs_lo[0], accum[head]))
+            T.evaluate(T.ptx.abs.f32(abs_hi[0], accum[head + 1]))
+            T.evaluate(T.ptx.mov.b64(abs_pair[0], abs_lo[0], abs_hi[0]))
+            T.evaluate(T.ptx.add.rn.f32x2(relu_pair[0], accum_pair[0], abs_pair[0]))
+            T.evaluate(T.ptx.mov.b64(weight_pair[0], weights[row, head], weights[row, head + 1]))
+            T.evaluate(T.ptx.fma.rn.f32x2(sum_0[0], relu_pair[0], weight_pair[0], sum_0[0]))
+
+            T.evaluate(T.ptx.mov.b64(accum_pair[0], accum[head + 2], accum[head + 3]))
+            T.evaluate(T.ptx.abs.f32(abs_lo[0], accum[head + 2]))
+            T.evaluate(T.ptx.abs.f32(abs_hi[0], accum[head + 3]))
+            T.evaluate(T.ptx.mov.b64(abs_pair[0], abs_lo[0], abs_hi[0]))
+            T.evaluate(T.ptx.add.rn.f32x2(relu_pair[0], accum_pair[0], abs_pair[0]))
+            T.evaluate(
+                T.ptx.mov.b64(weight_pair[0], weights[row, head + 2], weights[row, head + 3])
+            )
+            T.evaluate(T.ptx.fma.rn.f32x2(sum_1[0], relu_pair[0], weight_pair[0], sum_1[0]))
+        T.evaluate(T.ptx.add.rn.f32x2(total[0], sum_0[0], sum_1[0]))
+        T.evaluate(T.ptx.mov.b64(total_lo[0], total_hi[0], total[0]))
+        T.evaluate(T.ptx.add.rn.f32(result[0], total_lo[0], total_hi[0]))
+        T.evaluate(T.ptx.mul.rn.f32(result[0], result[0], T.float32(0.5)))
+        return result[0]
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())
@@ -862,13 +874,8 @@ def get_kernel(**kwargs: Any):
                                 T.cuda.get_tmem_addr(T.uint32(0), 0, tmem_addr_hi),
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
-                            # Weighted-ReLU reduce via inline CUDA (see _mqa_fp8_wrelu_reduce_src).
-                            reduced: T.float32 = cuda_func_call(
-                                f"tvm_builtin_mqa_fp8_wrelu_reduce_{num_heads}",
-                                T.address_of(accum[0]),
-                                T.address_of(cached_weights[q_inner_i, 0]),
-                                source_code=_mqa_fp8_wrelu_reduce_src(num_heads),
-                                return_type="float32",
+                            reduced: T.float32 = wrelu_reduce(
+                                accum, cached_weights, q_inner_i
                             )
                             result = T.cast(scale_kv * reduced, logits_tir_dtype)
                             q_offset: T.uint64 = q_row_off_base[0] + T.cast(

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -307,9 +307,8 @@ def _mqa_fp8_wrelu_reduce_src(num_heads: int) -> str:
 def get_kernel(**kwargs: Any):
     from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
-    from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline
-    from tvm.tirx.layout import S, TCol, TileLayout, TLane, wg_local_layout
+    from tvm.tirx.layout import S, TCol, TileLayout, TLane
 
     config = _make_config(**kwargs)
     num_heads = config.num_heads
@@ -357,9 +356,19 @@ def get_kernel(**kwargs: Any):
         raise ValueError(f"tensor memory columns {num_tmem_cols} exceeds SM100 single-CTA limit")
     tmem_layout = TileLayout(S[(128, num_tmem_cols) : (1 @ TLane, 1 @ TCol)])
     logits_tir_dtype = "float32" if config.logits_dtype == "float32" else "bfloat16"
-
-    def lane_id_u32():
-        return T.cast(T.cuda.mov_sreg(32, "laneid"), "uint32")
+    cache_policy_evict_normal = T.uint64(0x1000000000000000)
+    tma_g2s_1d = (
+        "cp.async.bulk.tensor.1d.shared::cluster.global"
+        ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+    )
+    tma_g2s_2d = (
+        "cp.async.bulk.tensor.2d.shared::cluster.global"
+        ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+    )
+    tcgen05_mma = "tcgen05.mma.cta_group::1.kind::f8f6f4"
+    tcgen05_ld = f"tcgen05.ld.sync.aligned.32x32b.x{num_heads // 2}.b32"
+    desc_sdo = head_dim // 2
+    desc_swizzle = {32: 1, 64: 2, 128: 3}[head_dim]
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())
@@ -399,6 +408,83 @@ def get_kernel(**kwargs: Any):
         kv_gmem = T.match_buffer(kv_gmem_h, (seq_len_kv, head_dim), "uint8")
         kv_scales_gmem = T.match_buffer(kv_scales_gmem_h, (seq_len_kv,), "float32")
         weights_gmem = T.match_buffer(weights_gmem_h, (seq_len, num_heads), "float32")
+
+        # Runtime lengths remain part of the public kernel ABI, so construct
+        # the four tensor maps in the host prologue instead of specializing
+        # sequence lengths into the PrimFunc.  Q/KV retain the dispatcher's
+        # head-dimension swizzle; weights and per-token KV scales are linear.
+        kv_scales_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            kv_scales_gmem_tensormap,
+            "float32",
+            1,
+            kv_scales_gmem.data,
+            seq_len_kv,
+            block_kv,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        kv_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            kv_gmem_tensormap,
+            "uint8",
+            2,
+            kv_gmem.data,
+            head_dim,
+            seq_len_kv,
+            head_dim,
+            head_dim,
+            block_kv,
+            1,
+            1,
+            0,
+            _SWZ.value,
+            2,
+            0,
+        )
+        weights_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            weights_gmem_tensormap,
+            "float32",
+            2,
+            weights_gmem.data,
+            num_heads,
+            seq_len,
+            num_heads * 4,
+            num_heads,
+            block_q,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        q_gmem_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            q_gmem_tensormap,
+            "uint8",
+            2,
+            q_gmem.data,
+            head_dim,
+            seq_len * num_heads,
+            head_dim,
+            head_dim,
+            block_q * num_heads,
+            1,
+            1,
+            0,
+            _SWZ.value,
+            2,
+            0,
+        )
         T.device_entry()
         T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
         # TIRX_TRANSCRIBE_START sm100_fp8_mqa_logits
@@ -418,7 +504,22 @@ def get_kernel(**kwargs: Any):
         warp_idx_u32: T.let = T.cast(warp_idx, "uint32")
         warpgroup_idx = T.warpgroup_id([num_warps // 4])
         lane_idx = T.lane_id([32])
-        lane_idx_u32: T.let = lane_id_u32()
+        lane_idx_u32: T.let = T.cast(lane_idx, "uint32")
+
+        # Match the former dispatcher placement: one elected lane of warp 0
+        # prefetches every descriptor before pipeline traffic begins.
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(weights_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_gmem_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_scales_gmem_tensormap)))
 
         # SMEMPool owns the smem offsets; q/kv carry the 128B MMA swizzle layout. Under
         # the pool .data is the arena base — use .ptr_to([0,...]) for a buffer's start.
@@ -472,11 +573,11 @@ def get_kernel(**kwargs: Any):
         @T.inline
         def store_logits(flat_offset, value):
             # Scalar predicated store: per-thread non-contiguous output, so TMA/bulk
-            # does not apply; bf16 stays a plain buffer store (predicated @P STG.E.U16).
+            # does not apply.  Both dtypes use explicit PTX global stores.
             if config.logits_dtype == "float32":
                 T.ptx.st.global_.f32(logits_flat.ptr_to([flat_offset]), value)
             else:
-                logits_flat[flat_offset] = value
+                T.ptx.st.global_.b16(logits_flat.ptr_to([flat_offset]), value)
 
         @T.inline
         def load_schedule(q_idx):
@@ -486,12 +587,14 @@ def get_kernel(**kwargs: Any):
                 row_idx: T.uint32 = T.min(
                     q_idx * T.uint32(block_q) + T.uint32(schedule_i), seq_len - T.uint32(1)
                 )
-                seq_k_start[schedule_i] = T.min(
-                    T.cast(cu_seq_len_k_start[row_idx], "uint32"), seq_len_kv
+                row_start: T.int32
+                row_end: T.int32
+                T.ptx.ld.global_.s32(
+                    row_start, cu_seq_len_k_start.ptr_to([T.cast(row_idx, "int32")])
                 )
-                seq_k_end[schedule_i] = T.min(
-                    T.cast(cu_seq_len_k_end[row_idx], "uint32"), seq_len_kv
-                )
+                seq_k_start[schedule_i] = T.min(T.cast(row_start, "uint32"), seq_len_kv)
+                T.ptx.ld.global_.s32(row_end, cu_seq_len_k_end.ptr_to([T.cast(row_idx, "int32")]))
+                seq_k_end[schedule_i] = T.min(T.cast(row_end, "uint32"), seq_len_kv)
                 schedule_start = T.min(schedule_start, seq_k_start[schedule_i])
                 schedule_end = T.max(schedule_end, seq_k_end[schedule_i])
             schedule_start = schedule_start // T.uint32(4) * T.uint32(4)
@@ -521,27 +624,25 @@ def get_kernel(**kwargs: Any):
                 q_idx: T.uint32 = sm_idx_u32
                 while q_idx < num_q_blocks:
                     q_pipe.empty.wait(q_stage_idx, q_phase ^ T.uint32(1))
-                    # u32 row bases — the copy_async(tma) gmem-layout grouping now
-                    # handles unsigned shape extents (no int32 cast needed).
+                    # Keep scheduler row bases in u32; cast only the TensorMap
+                    # coordinates consumed by the explicit TMA instruction.
                     q_row0: T.uint32 = q_idx * T.uint32(block_q * num_heads)
-                    Tx.copy_async(
-                        smem_q[q_stage_idx],
-                        q_gmem[q_row0 : q_row0 + block_q * num_heads, :],
-                        dispatch="tma_auto",
-                        mbar=q_pipe.full.ptr_to([q_stage_idx]),
-                        cta_group=1,
-                        cache_hint="evict_normal",
-                        prefetch_tensormap=True,
+                    T.ptx[tma_g2s_2d](
+                        smem_q.ptr_to([q_stage_idx, 0, 0]),
+                        T.address_of(q_gmem_tensormap),
+                        T.int32(0),
+                        T.cast(q_row0, "int32"),
+                        q_pipe.full.ptr_to([q_stage_idx]),
+                        cache_policy_evict_normal,
                     )
                     q_blk0: T.uint32 = q_idx * T.uint32(block_q)
-                    Tx.copy_async(
-                        smem_weights[q_stage_idx],
-                        weights_gmem[q_blk0 : q_blk0 + block_q, :],
-                        dispatch="tma_auto",
-                        mbar=q_pipe.full.ptr_to([q_stage_idx]),
-                        cta_group=1,
-                        cache_hint="evict_normal",
-                        prefetch_tensormap=True,
+                    T.ptx[tma_g2s_2d](
+                        smem_weights.ptr_to([q_stage_idx, 0, 0]),
+                        T.address_of(weights_gmem_tensormap),
+                        T.int32(0),
+                        T.cast(q_blk0, "int32"),
+                        q_pipe.full.ptr_to([q_stage_idx]),
+                        cache_policy_evict_normal,
                     )
                     q_pipe.full.arrive(
                         q_stage_idx, tx_count=smem_q_size_per_stage + smem_weight_size_per_stage
@@ -566,23 +667,20 @@ def get_kernel(**kwargs: Any):
                     while kv_idx < num_kv_blocks:
                         kv_pipe.empty.wait(kv_stage_idx, kv_phase ^ T.uint32(1))
                         kv_row0: T.uint32 = kv_start + kv_idx * T.uint32(block_kv)
-                        Tx.copy_async(
-                            smem_kv[kv_stage_idx],
-                            kv_gmem[kv_row0 : kv_row0 + block_kv, :],
-                            dispatch="tma_auto",
-                            mbar=kv_pipe.full.ptr_to([kv_stage_idx]),
-                            cta_group=1,
-                            cache_hint="evict_normal",
-                            prefetch_tensormap=True,
+                        T.ptx[tma_g2s_2d](
+                            smem_kv.ptr_to([kv_stage_idx, 0, 0]),
+                            T.address_of(kv_gmem_tensormap),
+                            T.int32(0),
+                            T.cast(kv_row0, "int32"),
+                            kv_pipe.full.ptr_to([kv_stage_idx]),
+                            cache_policy_evict_normal,
                         )
-                        Tx.copy_async(
-                            smem_kv_scales[kv_stage_idx, 0:block_kv],
-                            kv_scales_gmem[kv_row0 : kv_row0 + block_kv],
-                            dispatch="tma_auto",
-                            mbar=kv_pipe.full.ptr_to([kv_stage_idx]),
-                            cta_group=1,
-                            cache_hint="evict_normal",
-                            prefetch_tensormap=True,
+                        T.ptx[tma_g2s_1d](
+                            smem_kv_scales.ptr_to([kv_stage_idx, 0]),
+                            T.address_of(kv_scales_gmem_tensormap),
+                            T.cast(kv_row0, "int32"),
+                            kv_pipe.full.ptr_to([kv_stage_idx]),
+                            cache_policy_evict_normal,
                         )
                         kv_pipe.full.arrive(
                             kv_stage_idx,
@@ -596,9 +694,32 @@ def get_kernel(**kwargs: Any):
                     q_idx = q_idx + T.uint32(config.num_sms)
         elif warp_idx == spec_warp_start + 2:
             T.ptx.setmaxnreg.dec.sync.aligned.u32(56)
-            T.cuda.trap_when_assert_failed(tmem_ptr_in_smem[0] == T.uint32(0))
-            # fp8 (e4m3) views over the 128B-swizzled uint8 SMEM; with descI omitted the
-            # tcgen05 dispatch constant-folds the dense instruction descriptor.
+            tmem_allocated: T.uint32
+            T.ptx.ld.shared.u32(tmem_allocated, tmem_ptr_in_smem.ptr_to([0]))
+            T.cuda.trap_when_assert_failed(tmem_allocated == T.uint32(0))
+            # Dense E4M3 UMMA metadata is invariant across the persistent loop.
+            # Keep the runtime descriptor encoding that the former dispatcher
+            # produced, then update only the per-stage matrix descriptors.
+            desc_i: T.uint32
+            T.cuda.tcgen05.encode_instr_descriptor(
+                T.address_of(desc_i),
+                d_dtype="float32",
+                a_dtype="float8_e4m3fn",
+                b_dtype="float8_e4m3fn",
+                M=umma_m,
+                N=umma_n,
+                K=umma_k,
+                trans_a=False,
+                trans_b=False,
+                n_cta_groups=1,
+            )
+            runtime_instr_desc: T.uint64 = T.shift_left(T.cast(desc_i, "uint64"), T.uint64(32))
+            runtime_instr_desc_hi: T.uint32 = T.cast(
+                T.shift_right(runtime_instr_desc, T.uint64(32)), "uint32"
+            )
+            desc_a: T.uint64
+            desc_b: T.uint64
+            # FP8 (E4M3) views over the head-dimension-swizzled uint8 SMEM.
             smem_q_fp8 = smem_q.view("float8_e4m3fn")
             smem_kv_fp8 = smem_kv.view("float8_e4m3fn")
             # Whole MMA-warp loop in one elect scope: ring cursors stay elect-lane
@@ -620,27 +741,37 @@ def get_kernel(**kwargs: Any):
                         kv_pipe.full.wait(kv_stage_idx, kv_phase)
                         for math_wg_i in T.unroll(0, num_math_warpgroups):
                             tmem_addr: T.uint32 = tmem_stage_idx * T.uint32(umma_n)
-                            # int32 column base: a uint32 base would promote the slice
-                            # extent and fail the gemm dispatch's StructuralEqual check.
-                            tmem_col_start: T.int32 = T.cast(tmem_addr, "int32")
                             tmem_pipe.empty.wait(tmem_stage_idx, tmem_phase ^ T.uint32(1))
-                            # D = KV @ Q^T over full head_dim in one issue; the tcgen05
-                            # dispatch unrolls the umma_k tiling and accumulates internally.
-                            Tx.gemm_async(
-                                tmem[:, tmem_col_start : tmem_col_start + umma_n],
-                                smem_kv_fp8[
-                                    kv_stage_idx,
-                                    math_wg_i * umma_m : math_wg_i * umma_m + umma_m,
-                                    :,
-                                ],
-                                smem_q_fp8[q_stage_idx, :, :],
-                                accum=False,
-                                dispatch="tcgen05",
-                                cta_group=1,
-                                # SMEM descriptor handling: see the gemm_async tcgen05
-                                # dispatch for the hoist-vs-recompute rationale.
-                                smem_desc="hoist",
-                            )
+                            # D = KV @ Q^T.  Issue K=32 phases in increasing order;
+                            # phase zero overwrites and later phases accumulate.
+                            for ki in T.unroll(0, head_dim // umma_k):
+                                T.cuda.tcgen05.encode_matrix_descriptor(
+                                    T.address_of(desc_a),
+                                    smem_kv_fp8.ptr_to(
+                                        [kv_stage_idx, math_wg_i * umma_m, ki * umma_k]
+                                    ),
+                                    ldo=0,
+                                    sdo=desc_sdo,
+                                    swizzle=desc_swizzle,
+                                )
+                                T.cuda.tcgen05.encode_matrix_descriptor(
+                                    T.address_of(desc_b),
+                                    smem_q_fp8.ptr_to([q_stage_idx, 0, ki * umma_k]),
+                                    ldo=0,
+                                    sdo=desc_sdo,
+                                    swizzle=desc_swizzle,
+                                )
+                                T.ptx[tcgen05_mma](
+                                    tmem_addr,
+                                    desc_a,
+                                    desc_b,
+                                    runtime_instr_desc_hi,
+                                    T.uint32(0),
+                                    T.uint32(0),
+                                    T.uint32(0),
+                                    T.uint32(0),
+                                    T.ptx.pred(ki != 0),
+                                )
                             tmem_pipe.full.arrive(tmem_stage_idx)
                             tmem_stage_idx = tmem_stage_idx + T.uint32(1)
                             if tmem_stage_idx >= T.uint32(num_tmem_stages):
@@ -683,7 +814,16 @@ def get_kernel(**kwargs: Any):
                 num_kv_blocks: T.uint32 = schedule_result[1]
                 q_pipe.full.wait(q_stage_idx, q_phase)
                 if num_kv_blocks > T.uint32(0):
-                    Tx.warpgroup.copy(cached_weights, smem_weights[q_stage_idx])
+                    for weight_i in T.unroll(0, block_q):
+                        for weight_j in T.unroll(0, num_heads // 4):
+                            weight_col = weight_j * 4
+                            T.ptx.ld.shared.v4.f32(
+                                cached_weights[weight_i, weight_col],
+                                cached_weights[weight_i, weight_col + 1],
+                                cached_weights[weight_i, weight_col + 2],
+                                cached_weights[weight_i, weight_col + 3],
+                                smem_weights.ptr_to([q_stage_idx, weight_i, weight_col]),
+                            )
                     q_row_off_base[0] = T.cast(q_idx * T.uint32(block_q), "uint64") * T.cast(
                         logits_stride, "uint64"
                     )
@@ -706,18 +846,20 @@ def get_kernel(**kwargs: Any):
                         tmem_stage_base: T.uint32 = tmem_stage_idx * T.uint32(umma_n)
                         for q_inner_i in T.unroll(0, block_q):
                             tmem_addr: T.uint32 = tmem_stage_base + T.uint32(q_inner_i * num_heads)
-                            # TMEM->register read as 2x tcgen05.ld.32x32b.x32 with a
-                            # fence between (DeepGEMM tmem_load_no_fence shape for 64 heads).
-                            accum_2d = accum.view(128, num_heads, layout=wg_local_layout(num_heads))
+                            # TMEM->register read as two 32x32b chunks (x16 for 32 heads,
+                            # x32 for 64), with a tcgen05.wait.ld after each issue.
                             tmem_addr_hi: T.uint32 = tmem_addr + T.uint32(num_heads // 2)
-                            Tx.warpgroup.copy_async(
-                                accum_2d[:, 0 : num_heads // 2],
-                                tmem[:, tmem_addr : tmem_addr + num_heads // 2],
+                            T.ptx[tcgen05_ld](
+                                *[accum[head_i] for head_i in range(num_heads // 2)],
+                                T.cuda.get_tmem_addr(T.uint32(0), 0, tmem_addr),
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
-                            Tx.warpgroup.copy_async(
-                                accum_2d[:, num_heads // 2 : num_heads],
-                                tmem[:, tmem_addr_hi : tmem_addr_hi + num_heads // 2],
+                            T.ptx[tcgen05_ld](
+                                *[
+                                    accum[num_heads // 2 + head_i]
+                                    for head_i in range(num_heads // 2)
+                                ],
+                                T.cuda.get_tmem_addr(T.uint32(0), 0, tmem_addr_hi),
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
                             # Weighted-ReLU reduce via inline CUDA (see _mqa_fp8_wrelu_reduce_src).
@@ -874,8 +1016,8 @@ def _run_tirx_invocation(data: dict[str, Any], invocation: dict[str, Any]) -> to
     config: MQALogitsFP8Config = data["config"]
     executable = invocation["executable"]
     logits = invocation["logits"]
-    # Raw GMEM buffers: the in-kernel copy_async(tma) builds the descriptors; Q/KV move
-    # as uint8 (fp8 e4m3 bytes), KV-scales and weights stay float32.
+    # Raw GMEM buffers: the host prologue builds runtime TensorMaps, then explicit TMA
+    # moves Q/KV as uint8 (fp8 e4m3 bytes); KV scales and weights stay float32.
     kv_fp8, kv_scales = data["kv_in"]
     q_gmem = (
         data["q_in"].view(torch.uint8).reshape(config.seq_len * config.num_heads, config.head_dim)

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
@@ -631,45 +631,6 @@ def get_kernel(**kwargs: Any):
             return q_atom_idx
         return q_atom_idx // T.uint32(num_next_n_atoms)
 
-    def get_num_kv_expr(q_atom_idx, runtime_batch_size, context_lens_flat, indices):
-        # Local one-page specialization: CUDA get_num_kv still loads context_lens,
-        # but this config family can only have one positive BLOCK_KV page.
-        if not config.varlen and config.max_num_pages == 1:
-            return T.uint32(1)
-        if config.varlen:
-            is_paired = T.And(
-                q_atom_idx + T.uint32(1) < runtime_batch_size,
-                indices[T.cast(q_atom_idx, "int32")]
-                == indices[T.cast(q_atom_idx + T.uint32(1), "int32")],
-            )
-            ctx_len: T.uint32 = T.if_then_else(
-                is_paired,
-                T.cast(context_lens_flat[T.cast(q_atom_idx + T.uint32(1), "int32")], "uint32"),
-                T.cast(context_lens_flat[T.cast(q_atom_idx, "int32")], "uint32"),
-            )
-            return (ctx_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
-        else:
-            if num_next_n_atoms == 1:
-                q_idx: T.uint32 = q_atom_idx
-            else:
-                q_idx: T.uint32 = q_atom_idx // T.uint32(num_next_n_atoms)
-            lens_idx: T.uint32 = q_idx * T.uint32(config.next_n) + T.uint32(config.next_n - 1)
-            ctx_len: T.uint32 = T.cast(context_lens_flat[T.cast(lens_idx, "int32")], "uint32")
-            return (ctx_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
-
-    def get_atom_advance_expr(q_atom_idx, bound, indices):
-        if config.varlen:
-            return T.if_then_else(
-                T.And(
-                    q_atom_idx + T.uint32(1) < bound,
-                    indices[T.cast(q_atom_idx, "int32")]
-                    == indices[T.cast(q_atom_idx + T.uint32(1), "int32")],
-                ),
-                T.uint32(2),
-                T.uint32(1),
-            )
-        return T.uint32(1)
-
     def should_refresh_num_kv_expr(q_atom_idx):
         if config.varlen:
             return T.bool(True)
@@ -965,6 +926,8 @@ def get_kernel(**kwargs: Any):
         )
         fetch_result = T.alloc_local((4,), "uint32")
         scheduler_result = T.alloc_local((7,), "uint32")
+        num_kv_result = T.alloc_local((1,), "uint32")
+        atom_advance_result = T.alloc_local((1,), "uint32")
 
         @T.inline
         def mbarrier_wait_phase(barrier_ptr, phase):
@@ -987,6 +950,54 @@ def get_kernel(**kwargs: Any):
         def get_kv_pipeline(kv_iter_idx):
             fetch_result[2] = kv_iter_idx % T.uint32(num_kv_stages)
             fetch_result[3] = (kv_iter_idx // T.uint32(num_kv_stages)) & T.uint32(1)
+
+        @T.inline
+        def load_num_kv(q_atom_idx_arg, runtime_batch_size_arg):
+            # The one-page specialization has exactly one positive BLOCK_KV
+            # page, so it intentionally performs no metadata read.
+            if not config.varlen and config.max_num_pages == 1:
+                num_kv_result[0] = T.uint32(1)
+            elif config.varlen:
+                context_idx: T.uint32 = q_atom_idx_arg
+                if q_atom_idx_arg + T.uint32(1) < runtime_batch_size_arg:
+                    index_0 = T.local_scalar("int32")
+                    index_1 = T.local_scalar("int32")
+                    T.ptx.ld.global_.s32(index_0, indices.ptr_to([T.cast(q_atom_idx_arg, "int32")]))
+                    T.ptx.ld.global_.s32(
+                        index_1, indices.ptr_to([T.cast(q_atom_idx_arg + T.uint32(1), "int32")])
+                    )
+                    if index_0 == index_1:
+                        context_idx = q_atom_idx_arg + T.uint32(1)
+                context_len = T.local_scalar("uint32")
+                T.ptx.ld.global_.u32(
+                    context_len, context_lens_flat.ptr_to([T.cast(context_idx, "int32")])
+                )
+                num_kv_result[0] = (context_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
+            else:
+                if num_next_n_atoms == 1:
+                    q_idx: T.uint32 = q_atom_idx_arg
+                else:
+                    q_idx: T.uint32 = q_atom_idx_arg // T.uint32(num_next_n_atoms)
+                lens_idx: T.uint32 = q_idx * T.uint32(config.next_n) + T.uint32(config.next_n - 1)
+                context_len = T.local_scalar("uint32")
+                T.ptx.ld.global_.u32(
+                    context_len, context_lens_flat.ptr_to([T.cast(lens_idx, "int32")])
+                )
+                num_kv_result[0] = (context_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
+
+        @T.inline
+        def load_atom_advance(q_atom_idx_arg, bound_arg):
+            atom_advance_result[0] = T.uint32(1)
+            if config.varlen:
+                if q_atom_idx_arg + T.uint32(1) < bound_arg:
+                    index_0 = T.local_scalar("int32")
+                    index_1 = T.local_scalar("int32")
+                    T.ptx.ld.global_.s32(index_0, indices.ptr_to([T.cast(q_atom_idx_arg, "int32")]))
+                    T.ptx.ld.global_.s32(
+                        index_1, indices.ptr_to([T.cast(q_atom_idx_arg + T.uint32(1), "int32")])
+                    )
+                    if index_0 == index_1:
+                        atom_advance_result[0] = T.uint32(2)
 
         @T.inline
         def utccp_required_smem_warp_transpose(buf1d, base_offset):
@@ -1123,18 +1134,16 @@ def get_kernel(**kwargs: Any):
                 scheduler_result[5] = current_kv_idx_arg + T.uint32(num_tiles_per_split)
                 if scheduler_result[5] >= current_num_kv_arg:
                     scheduler_result[5] = T.uint32(0)
-                    scheduler_result[4] = current_q_atom_idx_arg + get_atom_advance_expr(
-                        current_q_atom_idx_arg, end_q_atom_idx_arg, indices
-                    )
+                    load_atom_advance(current_q_atom_idx_arg, end_q_atom_idx_arg)
+                    scheduler_result[4] = current_q_atom_idx_arg + atom_advance_result[0]
                     if T.And(
                         should_refresh_num_kv_expr(scheduler_result[4]),
                         exist_q_atom_idx_expr(
                             scheduler_result[4], end_q_atom_idx_arg, end_kv_idx_arg
                         ),
                     ):
-                        scheduler_result[6] = get_num_kv_expr(
-                            scheduler_result[4], batch_size, context_lens_flat, indices
-                        )
+                        load_num_kv(scheduler_result[4], batch_size)
+                        scheduler_result[6] = num_kv_result[0]
                 scheduler_result[3] = T.uint32(1)
 
         @T.inline
@@ -1177,31 +1186,40 @@ def get_kernel(**kwargs: Any):
         # Early schedule-metadata load: issue the global loads before the
         # pipeline/barrier prologue so the ~200-cycle L2 latency overlaps with
         # the setup below (same early-load structure as the aligned fp8 kernel).
-        start_q_atom_idx: T.let = T.cast(
-            schedule_meta_u32_flat[T.cast(sm_idx_u32 * T.uint32(2), "int32")], "uint32"
+        start_q_atom_idx = T.local_scalar("uint32")
+        start_kv_tile_idx = T.local_scalar("uint32")
+        end_q_atom_idx = T.local_scalar("uint32")
+        end_kv_tile_idx = T.local_scalar("uint32")
+        T.ptx.ld.global_.u32(
+            start_q_atom_idx,
+            schedule_meta_u32_flat.ptr_to([T.cast(sm_idx_u32 * T.uint32(2), "int32")]),
         )
-        start_kv_idx: T.let = T.cast(
-            schedule_meta_u32_flat[T.cast(sm_idx_u32 * T.uint32(2) + T.uint32(1), "int32")],
-            "uint32",
-        ) * T.uint32(num_tiles_per_split)
-        end_q_atom_idx: T.let = T.cast(
-            schedule_meta_u32_flat[T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2), "int32")],
-            "uint32",
+        T.ptx.ld.global_.u32(
+            start_kv_tile_idx,
+            schedule_meta_u32_flat.ptr_to(
+                [T.cast(sm_idx_u32 * T.uint32(2) + T.uint32(1), "int32")]
+            ),
         )
-        end_kv_idx: T.let = T.cast(
-            schedule_meta_u32_flat[
-                T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2) + T.uint32(1), "int32")
-            ],
-            "uint32",
-        ) * T.uint32(num_tiles_per_split)
+        T.ptx.ld.global_.u32(
+            end_q_atom_idx,
+            schedule_meta_u32_flat.ptr_to(
+                [T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2), "int32")]
+            ),
+        )
+        T.ptx.ld.global_.u32(
+            end_kv_tile_idx,
+            schedule_meta_u32_flat.ptr_to(
+                [T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2) + T.uint32(1), "int32")]
+            ),
+        )
+        start_kv_idx: T.let = start_kv_tile_idx * T.uint32(num_tiles_per_split)
         # Clamp the context-length read for zero-work CTAs (start == total q
         # atoms); the value is stale but never used because has_work is false.
-        start_num_kv: T.let = get_num_kv_expr(
+        load_num_kv(
             T.min(start_q_atom_idx, batch_size * T.uint32(num_next_n_atoms) - T.uint32(1)),
             batch_size,
-            context_lens_flat,
-            indices,
         )
+        start_num_kv: T.let = num_kv_result[0]
 
         # Warm the block table into L2 as early as possible. Race-safe: a stale
         # prefetched line is invalidated by any later producer write, so the
@@ -1279,6 +1297,9 @@ def get_kernel(**kwargs: Any):
         if warp_idx == tma_warp_0:
             # TMA warp 0: loads Q + SFQ + weights (shared) and KV/SFKV for group 0.
             T.ptx.setmaxnreg.dec.sync.aligned.u32(num_specialized_registers)
+            # Keep the scheduler endpoint role-local.  Extending the scaled
+            # value across the full warp-role dispatch makes ptxas spill it.
+            tma0_end_kv_idx: T.let = end_kv_tile_idx * T.uint32(num_tiles_per_split)
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
             current_num_kv: T.uint32 = start_num_kv
@@ -1293,7 +1314,11 @@ def get_kernel(**kwargs: Any):
             next_kv_idx: T.uint32 = current_kv_idx
             next_num_kv: T.uint32 = current_num_kv
             fetch_next_task(
-                current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                current_q_atom_idx,
+                current_kv_idx,
+                current_num_kv,
+                end_q_atom_idx,
+                tma0_end_kv_idx,
             )
             next_q_atom_idx = scheduler_result[0]
             next_kv_idx = scheduler_result[1]
@@ -1310,11 +1335,14 @@ def get_kernel(**kwargs: Any):
             cached_kv_blocks = T.alloc_local((num_pages_per_tile,), "uint32")
 
             while fetched_next_task:
-                next_advance: T.uint32 = get_atom_advance_expr(next_q_atom_idx, batch_size, indices)
+                load_atom_advance(next_q_atom_idx, batch_size)
+                next_advance: T.uint32 = atom_advance_result[0]
                 prefetch_q: T.bool = T.And(
                     q_atom_idx != next_q_atom_idx,
                     exist_q_atom_idx_expr(
-                        next_q_atom_idx + next_advance, end_q_atom_idx, end_kv_idx
+                        next_q_atom_idx + next_advance,
+                        end_q_atom_idx,
+                        tma0_end_kv_idx,
                     ),
                 )
                 if q_atom_idx != next_q_atom_idx:
@@ -1350,20 +1378,19 @@ def get_kernel(**kwargs: Any):
                         # may still exceed the block table's row length, and an
                         # out-of-range garbage page id would send TMA out of
                         # bounds (page 0 is used as the masked-dumpster tile).
-                        cached_kv_blocks[block_i] = T.if_then_else(
-                            T.And(
-                                prefetch_tile_idx < num_kv,
-                                prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
-                                < T.uint32(config.max_num_pages),
-                            ),
-                            T.cast(
-                                block_table_flat[
-                                    T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")
-                                ],
-                                "uint32",
-                            ),
-                            T.uint32(0),
-                        )
+                        if T.And(
+                            prefetch_tile_idx < num_kv,
+                            prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
+                            < T.uint32(config.max_num_pages),
+                        ):
+                            T.ptx.ld.global_.u32(
+                                cached_kv_blocks[block_i],
+                                block_table_flat.ptr_to(
+                                    [T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")]
+                                ),
+                            )
+                        else:
+                            cached_kv_blocks[block_i] = T.uint32(0)
                 T.cuda.warp_sync()
 
                 kv_block_idx = T.alloc_local((num_pages_per_tile,), "uint32")
@@ -1408,7 +1435,11 @@ def get_kernel(**kwargs: Any):
                 next_kv_idx = current_kv_idx
                 next_num_kv = current_num_kv
                 fetch_next_task(
-                    current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                    current_q_atom_idx,
+                    current_kv_idx,
+                    current_num_kv,
+                    end_q_atom_idx,
+                    tma0_end_kv_idx,
                 )
                 next_q_atom_idx = scheduler_result[0]
                 next_kv_idx = scheduler_result[1]
@@ -1420,6 +1451,7 @@ def get_kernel(**kwargs: Any):
         elif warp_idx == tma_warp_1:
             # TMA warp 1: loads KV/SFKV for group 1 only.
             T.ptx.setmaxnreg.dec.sync.aligned.u32(num_specialized_registers)
+            tma1_end_kv_idx: T.let = end_kv_tile_idx * T.uint32(num_tiles_per_split)
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
             current_num_kv: T.uint32 = start_num_kv
@@ -1431,7 +1463,11 @@ def get_kernel(**kwargs: Any):
             next_kv_idx: T.uint32 = current_kv_idx
             next_num_kv: T.uint32 = current_num_kv
             fetch_next_task(
-                current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                current_q_atom_idx,
+                current_kv_idx,
+                current_num_kv,
+                end_q_atom_idx,
+                tma1_end_kv_idx,
             )
             next_q_atom_idx = scheduler_result[0]
             next_kv_idx = scheduler_result[1]
@@ -1467,20 +1503,19 @@ def get_kernel(**kwargs: Any):
                         # may still exceed the block table's row length, and an
                         # out-of-range garbage page id would send TMA out of
                         # bounds (page 0 is used as the masked-dumpster tile).
-                        cached_kv_blocks[block_i] = T.if_then_else(
-                            T.And(
-                                prefetch_tile_idx < num_kv,
-                                prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
-                                < T.uint32(config.max_num_pages),
-                            ),
-                            T.cast(
-                                block_table_flat[
-                                    T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")
-                                ],
-                                "uint32",
-                            ),
-                            T.uint32(0),
-                        )
+                        if T.And(
+                            prefetch_tile_idx < num_kv,
+                            prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
+                            < T.uint32(config.max_num_pages),
+                        ):
+                            T.ptx.ld.global_.u32(
+                                cached_kv_blocks[block_i],
+                                block_table_flat.ptr_to(
+                                    [T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")]
+                                ),
+                            )
+                        else:
+                            cached_kv_blocks[block_i] = T.uint32(0)
                 T.cuda.warp_sync()
 
                 kv_block_idx = T.alloc_local((num_pages_per_tile,), "uint32")
@@ -1533,7 +1568,11 @@ def get_kernel(**kwargs: Any):
                 next_kv_idx = current_kv_idx
                 next_num_kv = current_num_kv
                 fetch_next_task(
-                    current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                    current_q_atom_idx,
+                    current_kv_idx,
+                    current_num_kv,
+                    end_q_atom_idx,
+                    tma1_end_kv_idx,
                 )
                 next_q_atom_idx = scheduler_result[0]
                 next_kv_idx = scheduler_result[1]
@@ -1547,6 +1586,7 @@ def get_kernel(**kwargs: Any):
             # stage, copies the scale factors into TMEM, then issues the 2
             # block-scaled tcgen05 MMAs (K=64 each) for its group.
             T.ptx.setmaxnreg.dec.sync.aligned.u32(num_specialized_registers)
+            umma_end_kv_idx: T.let = end_kv_tile_idx * T.uint32(num_tiles_per_split)
             umma_group_idx: T.let = warp_idx_u32 - T.uint32(umma_warp_0)
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
@@ -1586,7 +1626,11 @@ def get_kernel(**kwargs: Any):
             next_kv_idx: T.uint32 = current_kv_idx
             next_num_kv: T.uint32 = current_num_kv
             fetch_next_task(
-                current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                current_q_atom_idx,
+                current_kv_idx,
+                current_num_kv,
+                end_q_atom_idx,
+                umma_end_kv_idx,
             )
             next_q_atom_idx = scheduler_result[0]
             next_kv_idx = scheduler_result[1]
@@ -1747,7 +1791,11 @@ def get_kernel(**kwargs: Any):
                 next_kv_idx = current_kv_idx
                 next_num_kv = current_num_kv
                 fetch_next_task(
-                    current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                    current_q_atom_idx,
+                    current_kv_idx,
+                    current_num_kv,
+                    end_q_atom_idx,
+                    umma_end_kv_idx,
                 )
                 next_q_atom_idx = scheduler_result[0]
                 next_kv_idx = scheduler_result[1]
@@ -1758,6 +1806,7 @@ def get_kernel(**kwargs: Any):
                 current_num_kv = scheduler_result[6]
         elif warp_idx < spec_warp_start:
             T.ptx.setmaxnreg.inc.sync.aligned.u32(num_math_registers)
+            math_end_kv_idx: T.let = end_kv_tile_idx * T.uint32(num_tiles_per_split)
             current_q_atom_idx: T.uint32 = start_q_atom_idx
             current_kv_idx: T.uint32 = start_kv_idx
             current_num_kv: T.uint32 = start_num_kv
@@ -1775,7 +1824,11 @@ def get_kernel(**kwargs: Any):
             next_kv_idx: T.uint32 = current_kv_idx
             next_num_kv: T.uint32 = current_num_kv
             fetch_next_task(
-                current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                current_q_atom_idx,
+                current_kv_idx,
+                current_num_kv,
+                end_q_atom_idx,
+                math_end_kv_idx,
             )
             next_q_atom_idx = scheduler_result[0]
             next_kv_idx = scheduler_result[1]
@@ -1943,10 +1996,13 @@ def get_kernel(**kwargs: Any):
                         fadd_rn_noftz(T.cuda.float2_x(sum_v), T.cuda.float2_y(sum_v)),
                     )
                     result = T.cast(result_f32, logits_tir_dtype)
-                    logits_flat[
-                        T.cast(kv_offset_arg, "uint64")
-                        + T.cast(q_inner_i, "uint64") * T.cast(logits_stride, "uint64")
-                    ] = result
+                    logits_offset: T.uint64 = T.cast(kv_offset_arg, "uint64") + T.cast(
+                        q_inner_i, "uint64"
+                    ) * T.cast(logits_stride, "uint64")
+                    if config.logits_dtype == "float32":
+                        T.ptx.st.global_.f32(logits_flat.ptr_to([logits_offset]), result)
+                    else:
+                        T.ptx.st.global_.b16(logits_flat.ptr_to([logits_offset]), result)
 
             while fetched_next_task:
                 if q_atom_idx != next_q_atom_idx:
@@ -1969,17 +2025,16 @@ def get_kernel(**kwargs: Any):
                     for weight_i in T.unroll(0, next_n_atom):
                         for weight_j in T.unroll(0, num_heads // 4):
                             weight_col = weight_j * 4
-                            raw = smem_weights.vload(
-                                [q_stage_idx, weight_i, weight_col], dtype="float32x4"
+                            T.ptx.ld.shared.v4.f32(
+                                cached_weights[weight_i, weight_col],
+                                cached_weights[weight_i, weight_col + 1],
+                                cached_weights[weight_i, weight_col + 2],
+                                cached_weights[weight_i, weight_col + 3],
+                                smem_weights.ptr_to([q_stage_idx, weight_i, weight_col]),
                             )
-                            cached_weights[weight_i, weight_col] = T.Shuffle([raw], [0])
-                            cached_weights[weight_i, weight_col + 1] = T.Shuffle([raw], [1])
-                            cached_weights[weight_i, weight_col + 2] = T.Shuffle([raw], [2])
-                            cached_weights[weight_i, weight_col + 3] = T.Shuffle([raw], [3])
                     if config.varlen:
-                        is_paired_atom = get_atom_advance_expr(
-                            next_q_atom_idx, batch_size, indices
-                        ) == T.uint32(2)
+                        load_atom_advance(next_q_atom_idx, batch_size)
+                        is_paired_atom = atom_advance_result[0] == T.uint32(2)
                 q_atom_idx = next_q_atom_idx
                 kv_idx: T.uint32 = next_kv_idx
                 kv_offset: T.uint64 = (
@@ -2018,7 +2073,11 @@ def get_kernel(**kwargs: Any):
                 next_kv_idx = current_kv_idx
                 next_num_kv = current_num_kv
                 fetch_next_task(
-                    current_q_atom_idx, current_kv_idx, current_num_kv, end_q_atom_idx, end_kv_idx
+                    current_q_atom_idx,
+                    current_kv_idx,
+                    current_num_kv,
+                    end_q_atom_idx,
+                    math_end_kv_idx,
                 )
                 next_q_atom_idx = scheduler_result[0]
                 next_kv_idx = scheduler_result[1]

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
@@ -647,38 +647,20 @@ def get_kernel(**kwargs: Any):
     def lane_id_u32():
         return T.cast(T.cuda.mov_sreg(32, "laneid"), "uint32")
 
-    # relu-weighted-accumulate of a packed f32x2 pair:
-    #   d = fma(a + |a|, w, c)
-    # Same asm-block form as the aligned fp8 kernel: non-ftz ``abs.f32`` so
-    # ptxas folds the abs into the FADD2 source modifier (``FADD2 d, a, |a|``)
-    # instead of materializing standalone FADD abs instructions; keeps the
-    # ReLU on the FMA pipe instead of scalar FMNMX on the ALU pipe.
-    _RELU2_FMA_F32X2_SRC = (
-        "__forceinline__ __device__ void tirx_relu2_fma_f32x2("
-        "uint64_t* d, unsigned long long a, unsigned long long w, unsigned long long c) {\n"
-        "    asm volatile(\n"
-        '        "{\\n"\n'
-        '        ".reg .f32 al, ah, rl, rh;\\n"\n'
-        '        ".reg .b64 rp;\\n"\n'
-        '        "mov.b64 {al, ah}, %1;\\n"\n'
-        '        "abs.f32 rl, al;\\n"\n'
-        '        "abs.f32 rh, ah;\\n"\n'
-        '        "mov.b64 rp, {rl, rh};\\n"\n'
-        '        "add.rn.f32x2 rp, %1, rp;\\n"\n'
-        '        "fma.rn.f32x2 %0, rp, %2, %3;\\n"\n'
-        '        "}\\n"\n'
-        '        : "=l"(*reinterpret_cast<uint64_t*>(d))\n'
-        '        : "l"(a), "l"(w), "l"(c));\n'
-        "}\n"
-    )
-
     def relu2_fma_f32x2(a, w, c):
+        a_lo = T.alloc_local((1,), "float32")
+        a_hi = T.alloc_local((1,), "float32")
+        abs_lo = T.alloc_local((1,), "float32")
+        abs_hi = T.alloc_local((1,), "float32")
+        abs_pair = T.alloc_local((1,), "uint64")
+        relu_pair = T.alloc_local((1,), "uint64")
         out = T.alloc_local((1,), "uint64")
-        T.evaluate(
-            T.cuda.func_call(
-                "tirx_relu2_fma_f32x2", out.ptr_to([0]), a, w, c, source_code=_RELU2_FMA_F32X2_SRC
-            )
-        )
+        T.evaluate(T.ptx.mov.b64(a_lo[0], a_hi[0], a))
+        T.evaluate(T.ptx.abs.f32(abs_lo[0], a_lo[0]))
+        T.evaluate(T.ptx.abs.f32(abs_hi[0], a_hi[0]))
+        T.evaluate(T.ptx.mov.b64(abs_pair[0], abs_lo[0], abs_hi[0]))
+        T.evaluate(T.ptx.add.rn.f32x2(relu_pair[0], a, abs_pair[0]))
+        T.evaluate(T.ptx.fma.rn.f32x2(out[0], relu_pair[0], w, c))
         return out[0]
 
     def fadd2_rn_noftz(a, b):
@@ -695,14 +677,6 @@ def get_kernel(**kwargs: Any):
         out = T.alloc_local((1,), "float32")
         T.evaluate(T.ptx.mul.rn.f32(out[0], a, b))
         return out[0]
-
-    # Race-safe early L2 warm-up helper (see the block-table prefetch in the
-    # kernel prologue; mirrors the aligned fp8 kernel).
-    _PREFETCH_L2_SRC = (
-        "__forceinline__ __device__ void tirx_prefetch_l2(const void* p) {\n"
-        '    asm volatile("prefetch.global.L2 [%0];" :: "l"(p));\n'
-        "}\n"
-    )
 
     # Block-table L2 warm-up coverage (plain Python ints, evaluated at trace
     # time): prefetch the whole table, capped at 512 lines (64 KB).
@@ -1232,12 +1206,8 @@ def get_kernel(**kwargs: Any):
                     + T.uint32(pf_i * 64)
                 )
                 if line_idx < T.uint32(num_prefetch_lines):
-                    T.evaluate(
-                        T.cuda.func_call(
-                            "tirx_prefetch_l2",
-                            block_table_flat.ptr_to([T.cast(line_idx * T.uint32(32), "int64")]),
-                            source_code=_PREFETCH_L2_SRC,
-                        )
+                    T.ptx.prefetch.global_.L2(
+                        block_table_flat.ptr_to([T.cast(line_idx * T.uint32(32), "int64")])
                     )
 
         if warp_idx_presync == tma_warp_0:

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -681,37 +681,6 @@ def get_kernel(**kwargs: Any):
             return q_atom_idx
         return q_atom_idx // T.uint32(num_next_n_atoms)
 
-    def get_num_kv_expr(q_atom_idx, runtime_batch_size, context_lens_flat, indices):
-        if config.varlen:
-            is_paired = T.And(
-                q_atom_idx + T.uint32(1) < runtime_batch_size,
-                indices[T.cast(q_atom_idx, "int32")]
-                == indices[T.cast(q_atom_idx + T.uint32(1), "int32")],
-            )
-            ctx_len: T.uint32 = T.if_then_else(
-                is_paired,
-                T.cast(context_lens_flat[T.cast(q_atom_idx + T.uint32(1), "int32")], "uint32"),
-                T.cast(context_lens_flat[T.cast(q_atom_idx, "int32")], "uint32"),
-            )
-            return (ctx_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
-        q_idx: T.uint32 = q_atom_idx // T.uint32(num_next_n_atoms)
-        lens_idx: T.uint32 = q_idx * T.uint32(config.next_n) + T.uint32(config.next_n - 1)
-        ctx_len: T.uint32 = T.cast(context_lens_flat[T.cast(lens_idx, "int32")], "uint32")
-        return (ctx_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
-
-    def get_atom_advance_expr(q_atom_idx, bound, indices):
-        if config.varlen:
-            return T.if_then_else(
-                T.And(
-                    q_atom_idx + T.uint32(1) < bound,
-                    indices[T.cast(q_atom_idx, "int32")]
-                    == indices[T.cast(q_atom_idx + T.uint32(1), "int32")],
-                ),
-                T.uint32(2),
-                T.uint32(1),
-            )
-        return T.uint32(1)
-
     def should_refresh_num_kv_expr(q_atom_idx):
         if config.varlen:
             return T.bool(True)
@@ -937,6 +906,8 @@ def get_kernel(**kwargs: Any):
         )
         fetch_result = T.alloc_local((4,), "uint32")
         scheduler_result = T.alloc_local((7,), "uint32")
+        num_kv_result = T.alloc_local((1,), "uint32")
+        atom_advance_result = T.alloc_local((1,), "uint32")
 
         @T.inline
         def mbarrier_wait_phase(barrier_ptr, phase):
@@ -959,6 +930,46 @@ def get_kernel(**kwargs: Any):
         def get_kv_pipeline(kv_iter_idx):
             fetch_result[2] = kv_iter_idx % T.uint32(num_kv_stages)
             fetch_result[3] = (kv_iter_idx // T.uint32(num_kv_stages)) & T.uint32(1)
+
+        @T.inline
+        def load_num_kv(q_atom_idx_arg, runtime_batch_size_arg):
+            if config.varlen:
+                context_idx: T.uint32 = q_atom_idx_arg
+                if q_atom_idx_arg + T.uint32(1) < runtime_batch_size_arg:
+                    index_0 = T.local_scalar("int32")
+                    index_1 = T.local_scalar("int32")
+                    T.ptx.ld.global_.s32(index_0, indices.ptr_to([T.cast(q_atom_idx_arg, "int32")]))
+                    T.ptx.ld.global_.s32(
+                        index_1, indices.ptr_to([T.cast(q_atom_idx_arg + T.uint32(1), "int32")])
+                    )
+                    if index_0 == index_1:
+                        context_idx = q_atom_idx_arg + T.uint32(1)
+                context_len = T.local_scalar("uint32")
+                T.ptx.ld.global_.u32(
+                    context_len, context_lens_flat.ptr_to([T.cast(context_idx, "int32")])
+                )
+            else:
+                q_idx: T.uint32 = q_atom_idx_arg // T.uint32(num_next_n_atoms)
+                lens_idx: T.uint32 = q_idx * T.uint32(config.next_n) + T.uint32(config.next_n - 1)
+                context_len = T.local_scalar("uint32")
+                T.ptx.ld.global_.u32(
+                    context_len, context_lens_flat.ptr_to([T.cast(lens_idx, "int32")])
+                )
+            num_kv_result[0] = (context_len + T.uint32(umma_m - 1)) // T.uint32(umma_m)
+
+        @T.inline
+        def load_atom_advance(q_atom_idx_arg, bound_arg):
+            atom_advance_result[0] = T.uint32(1)
+            if config.varlen:
+                if q_atom_idx_arg + T.uint32(1) < bound_arg:
+                    index_0 = T.local_scalar("int32")
+                    index_1 = T.local_scalar("int32")
+                    T.ptx.ld.global_.s32(index_0, indices.ptr_to([T.cast(q_atom_idx_arg, "int32")]))
+                    T.ptx.ld.global_.s32(
+                        index_1, indices.ptr_to([T.cast(q_atom_idx_arg + T.uint32(1), "int32")])
+                    )
+                    if index_0 == index_1:
+                        atom_advance_result[0] = T.uint32(2)
 
         @T.inline
         def tma_load_2d_q(dst, barrier_ptr, tensor_map, coord0, coord1):
@@ -1080,47 +1091,52 @@ def get_kernel(**kwargs: Any):
                 scheduler_result[5] = current_kv_idx_arg + T.uint32(num_tiles_per_split)
                 if scheduler_result[5] >= current_num_kv_arg:
                     scheduler_result[5] = T.uint32(0)
-                    scheduler_result[4] = current_q_atom_idx_arg + get_atom_advance_expr(
-                        current_q_atom_idx_arg, end_q_atom_idx_arg, indices
-                    )
+                    load_atom_advance(current_q_atom_idx_arg, end_q_atom_idx_arg)
+                    scheduler_result[4] = current_q_atom_idx_arg + atom_advance_result[0]
                     if T.And(
                         should_refresh_num_kv_expr(scheduler_result[4]),
                         exist_q_atom_idx_expr(
                             scheduler_result[4], end_q_atom_idx_arg, end_kv_idx_arg
                         ),
                     ):
-                        scheduler_result[6] = get_num_kv_expr(
-                            scheduler_result[4], batch_size, context_lens_flat, indices
-                        )
+                        load_num_kv(scheduler_result[4], batch_size)
+                        scheduler_result[6] = num_kv_result[0]
                 scheduler_result[3] = T.uint32(1)
 
         # Early schedule-metadata load: issue the global loads before the
         # pipeline/barrier prologue so the ~200-cycle L2 latency overlaps with
         # the setup below (matches the CuTeDSL baseline).
-        start_q_atom_idx: T.let = T.cast(
-            schedule_meta_flat[T.cast(sm_idx_u32 * T.uint32(2), "int32")], "uint32"
+        start_q_atom_idx = T.local_scalar("uint32")
+        start_kv_tile_idx = T.local_scalar("uint32")
+        end_q_atom_idx = T.local_scalar("uint32")
+        end_kv_tile_idx = T.local_scalar("uint32")
+        T.ptx.ld.global_.u32(
+            start_q_atom_idx, schedule_meta_flat.ptr_to([T.cast(sm_idx_u32 * T.uint32(2), "int32")])
         )
-        start_kv_idx: T.let = T.cast(
-            schedule_meta_flat[T.cast(sm_idx_u32 * T.uint32(2) + T.uint32(1), "int32")], "uint32"
-        ) * T.uint32(num_tiles_per_split)
-        end_q_atom_idx: T.let = T.cast(
-            schedule_meta_flat[T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2), "int32")], "uint32"
+        T.ptx.ld.global_.u32(
+            start_kv_tile_idx,
+            schedule_meta_flat.ptr_to([T.cast(sm_idx_u32 * T.uint32(2) + T.uint32(1), "int32")]),
         )
-        end_kv_idx: T.let = T.cast(
-            schedule_meta_flat[
-                T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2) + T.uint32(1), "int32")
-            ],
-            "uint32",
-        ) * T.uint32(num_tiles_per_split)
+        T.ptx.ld.global_.u32(
+            end_q_atom_idx,
+            schedule_meta_flat.ptr_to([T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2), "int32")]),
+        )
+        T.ptx.ld.global_.u32(
+            end_kv_tile_idx,
+            schedule_meta_flat.ptr_to(
+                [T.cast((sm_idx_u32 + T.uint32(1)) * T.uint32(2) + T.uint32(1), "int32")]
+            ),
+        )
+        start_kv_idx: T.let = start_kv_tile_idx * T.uint32(num_tiles_per_split)
+        end_kv_idx: T.let = end_kv_tile_idx * T.uint32(num_tiles_per_split)
         # Clamp the context-length read for zero-work CTAs (start == total q
         # atoms); the value is stale but never used because has_work is false
         # (same clamp as the CuTeDSL baseline).
-        start_num_kv: T.let = get_num_kv_expr(
+        load_num_kv(
             T.min(start_q_atom_idx, batch_size * T.uint32(num_next_n_atoms) - T.uint32(1)),
             batch_size,
-            context_lens_flat,
-            indices,
         )
+        start_num_kv: T.let = num_kv_result[0]
 
         # Warm the block table into L2 as early as possible. Race-safe: a stale
         # prefetched line is invalidated by any later producer write, so the
@@ -1227,7 +1243,8 @@ def get_kernel(**kwargs: Any):
             cached_kv_blocks = T.alloc_local((num_pages_per_tile,), "uint32")
 
             while fetched_next_task:
-                next_advance: T.uint32 = get_atom_advance_expr(next_q_atom_idx, batch_size, indices)
+                load_atom_advance(next_q_atom_idx, batch_size)
+                next_advance: T.uint32 = atom_advance_result[0]
                 prefetch_q: T.bool = T.And(
                     q_atom_idx != next_q_atom_idx,
                     exist_q_atom_idx_expr(
@@ -1269,20 +1286,19 @@ def get_kernel(**kwargs: Any):
                         # may still exceed the block table's row length, and an
                         # out-of-range garbage page id would send TMA out of
                         # bounds (page 0 is used as the masked-dumpster tile).
-                        cached_kv_blocks[block_i] = T.if_then_else(
-                            T.And(
-                                prefetch_tile_idx < num_kv,
-                                prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
-                                < T.uint32(config.max_num_pages),
-                            ),
-                            T.cast(
-                                block_table_flat[
-                                    T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")
-                                ],
-                                "uint32",
-                            ),
-                            T.uint32(0),
-                        )
+                        if T.And(
+                            prefetch_tile_idx < num_kv,
+                            prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
+                            < T.uint32(config.max_num_pages),
+                        ):
+                            T.ptx.ld.global_.u32(
+                                cached_kv_blocks[block_i],
+                                block_table_flat.ptr_to(
+                                    [T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")]
+                                ),
+                            )
+                        else:
+                            cached_kv_blocks[block_i] = T.uint32(0)
                 T.cuda.warp_sync()
 
                 kv_block_idx = T.alloc_local((num_pages_per_tile,), "uint32")
@@ -1386,20 +1402,19 @@ def get_kernel(**kwargs: Any):
                         # may still exceed the block table's row length, and an
                         # out-of-range garbage page id would send TMA out of
                         # bounds (page 0 is used as the masked-dumpster tile).
-                        cached_kv_blocks[block_i] = T.if_then_else(
-                            T.And(
-                                prefetch_tile_idx < num_kv,
-                                prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
-                                < T.uint32(config.max_num_pages),
-                            ),
-                            T.cast(
-                                block_table_flat[
-                                    T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")
-                                ],
-                                "uint32",
-                            ),
-                            T.uint32(0),
-                        )
+                        if T.And(
+                            prefetch_tile_idx < num_kv,
+                            prefetch_tile_idx * T.uint32(num_pages_per_tile) + T.uint32(block_i)
+                            < T.uint32(config.max_num_pages),
+                        ):
+                            T.ptx.ld.global_.u32(
+                                cached_kv_blocks[block_i],
+                                block_table_flat.ptr_to(
+                                    [T.cast(block_table_index + T.cast(block_i, "uint64"), "int64")]
+                                ),
+                            )
+                        else:
+                            cached_kv_blocks[block_i] = T.uint32(0)
                 T.cuda.warp_sync()
 
                 kv_block_idx = T.alloc_local((num_pages_per_tile,), "uint32")
@@ -1803,11 +1818,15 @@ def get_kernel(**kwargs: Any):
                         scale_kv_half, fadd_rn_noftz(T.cuda.float2_x(sum_v), T.cuda.float2_y(sum_v))
                     )
                     result = T.cast(result_f32, logits_tir_dtype)
-                    logits_flat[
+                    logits_offset: T.uint64 = (
                         T.cast(kv_offset_arg, "uint64")
                         + T.cast(q_inner_i, "uint64") * T.cast(logits_stride, "uint64")
                         + T.cast(math_thread_idx, "uint64")
-                    ] = result
+                    )
+                    if config.logits_dtype == "float32":
+                        T.ptx.st.global_.f32(logits_flat.ptr_to([logits_offset]), result)
+                    else:
+                        T.ptx.st.global_.b16(logits_flat.ptr_to([logits_offset]), result)
 
             while fetched_next_task:
                 if q_atom_idx != next_q_atom_idx:
@@ -1833,17 +1852,16 @@ def get_kernel(**kwargs: Any):
                     for weight_i in T.unroll(0, next_n_atom):
                         for weight_j in T.unroll(0, num_heads // 4):
                             weight_col = weight_j * 4
-                            raw = smem_weights.vload(
-                                [q_stage_idx, weight_i, weight_col], dtype="float32x4"
+                            T.ptx.ld.shared.v4.f32(
+                                cached_weights[weight_i, weight_col],
+                                cached_weights[weight_i, weight_col + 1],
+                                cached_weights[weight_i, weight_col + 2],
+                                cached_weights[weight_i, weight_col + 3],
+                                smem_weights.ptr_to([q_stage_idx, weight_i, weight_col]),
                             )
-                            cached_weights[weight_i, weight_col] = T.Shuffle([raw], [0])
-                            cached_weights[weight_i, weight_col + 1] = T.Shuffle([raw], [1])
-                            cached_weights[weight_i, weight_col + 2] = T.Shuffle([raw], [2])
-                            cached_weights[weight_i, weight_col + 3] = T.Shuffle([raw], [3])
                     if config.varlen:
-                        is_paired_atom = get_atom_advance_expr(
-                            next_q_atom_idx, batch_size, indices
-                        ) == T.uint32(2)
+                        load_atom_advance(next_q_atom_idx, batch_size)
+                        is_paired_atom = atom_advance_result[0] == T.uint32(2)
                 q_atom_idx = next_q_atom_idx
                 kv_idx: T.uint32 = next_kv_idx
                 kv_offset: T.uint64 = T.cast(atom_to_token_idx_expr(q_atom_idx), "uint64") * T.cast(

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -695,41 +695,20 @@ def get_kernel(**kwargs: Any):
     def lane_id_u32():
         return T.cast(T.cuda.mov_sreg(32, "laneid"), "uint32")
 
-    # relu-weighted-accumulate of a packed f32x2 pair:
-    #   d = fma(a + |a|, w, c)
-    # Emitted as one asm block with non-ftz ``abs.f32`` so that ptxas folds the
-    # abs into the FADD2 source modifier (``FADD2 d, a, |a|``) instead of
-    # materializing standalone FADD abs instructions (which is what the
-    # ``fabsf`` -> ``abs.ftz.f32`` path produces, since an ftz abs cannot fold
-    # into a non-ftz add.rn.f32x2). This is the DeepGEMM/CuTeDSL SM100 epilogue
-    # pattern: it keeps the ReLU on the FMA pipe instead of scalar FMNMX on the
-    # ALU pipe.
-    _RELU2_FMA_F32X2_SRC = (
-        "__forceinline__ __device__ void tirx_relu2_fma_f32x2("
-        "uint64_t* d, unsigned long long a, unsigned long long w, unsigned long long c) {\n"
-        "    asm volatile(\n"
-        '        "{\\n"\n'
-        '        ".reg .f32 al, ah, rl, rh;\\n"\n'
-        '        ".reg .b64 rp;\\n"\n'
-        '        "mov.b64 {al, ah}, %1;\\n"\n'
-        '        "abs.f32 rl, al;\\n"\n'
-        '        "abs.f32 rh, ah;\\n"\n'
-        '        "mov.b64 rp, {rl, rh};\\n"\n'
-        '        "add.rn.f32x2 rp, %1, rp;\\n"\n'
-        '        "fma.rn.f32x2 %0, rp, %2, %3;\\n"\n'
-        '        "}\\n"\n'
-        '        : "=l"(*reinterpret_cast<uint64_t*>(d))\n'
-        '        : "l"(a), "l"(w), "l"(c));\n'
-        "}\n"
-    )
-
     def relu2_fma_f32x2(a, w, c):
+        a_lo = T.alloc_local((1,), "float32")
+        a_hi = T.alloc_local((1,), "float32")
+        abs_lo = T.alloc_local((1,), "float32")
+        abs_hi = T.alloc_local((1,), "float32")
+        abs_pair = T.alloc_local((1,), "uint64")
+        relu_pair = T.alloc_local((1,), "uint64")
         out = T.alloc_local((1,), "uint64")
-        T.evaluate(
-            T.cuda.func_call(
-                "tirx_relu2_fma_f32x2", out.ptr_to([0]), a, w, c, source_code=_RELU2_FMA_F32X2_SRC
-            )
-        )
+        T.evaluate(T.ptx.mov.b64(a_lo[0], a_hi[0], a))
+        T.evaluate(T.ptx.abs.f32(abs_lo[0], a_lo[0]))
+        T.evaluate(T.ptx.abs.f32(abs_hi[0], a_hi[0]))
+        T.evaluate(T.ptx.mov.b64(abs_pair[0], abs_lo[0], abs_hi[0]))
+        T.evaluate(T.ptx.add.rn.f32x2(relu_pair[0], a, abs_pair[0]))
+        T.evaluate(T.ptx.fma.rn.f32x2(out[0], relu_pair[0], w, c))
         return out[0]
 
     def fadd2_rn_noftz(a, b):
@@ -749,14 +728,6 @@ def get_kernel(**kwargs: Any):
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())
-
-    # Race-safe early L2 warm-up helper (see the block-table prefetch in the
-    # kernel prologue).
-    _PREFETCH_L2_SRC = (
-        "__forceinline__ __device__ void tirx_prefetch_l2(const void* p) {\n"
-        '    asm volatile("prefetch.global.L2 [%0];" :: "l"(p));\n'
-        "}\n"
-    )
 
     # Block-table L2 warm-up coverage (plain Python ints, evaluated at trace
     # time): prefetch the whole table, capped at 512 lines (64 KB).
@@ -1151,12 +1122,8 @@ def get_kernel(**kwargs: Any):
                     + T.uint32(pf_i * 64)
                 )
                 if line_idx < T.uint32(num_prefetch_lines):
-                    T.evaluate(
-                        T.cuda.func_call(
-                            "tirx_prefetch_l2",
-                            block_table_flat.ptr_to([T.cast(line_idx * T.uint32(32), "int64")]),
-                            source_code=_PREFETCH_L2_SRC,
-                        )
+                    T.ptx.prefetch.global_.L2(
+                        block_table_flat.ptr_to([T.cast(line_idx * T.uint32(32), "int64")])
                     )
 
         if warp_idx == tma_warp_0:

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -401,27 +401,16 @@ def get_kernel(**kwargs: Any):
     cache_policy_evict_first = T.uint64(0x12F0000000000000)
     cache_policy_evict_last = T.uint64(0x14F0000000000000)
     tf32_instr_desc = T.uint32(67635472)
-    # The fixed TVM PTX table intentionally omits integer add. This helper
-    # performs uint32 wraparound in the descriptor's low half without a carry
-    # into the encoded layout fields.
-    smem_desc_add_source = r"""
-__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(
-    uint64_t desc_base, int32_t offset) {
-    SmemDescriptor desc;
-    desc.desc_ = desc_base;
-    desc.lo += static_cast<uint32_t>(offset);
-    return desc.desc_;
-}
-"""
-
     def add_smem_desc_offset(desc, offset):
-        return T.cuda.func_call(
-            "tvm_builtin_smem_desc_add_16B_offset",
-            desc,
-            offset,
-            source_code=smem_desc_add_source,
-            return_type="uint64",
-        )
+        # Descriptor offsets wrap in the low 32 bits without carrying into the
+        # encoded layout fields in the high half.
+        desc_lo = T.alloc_local((1,), "uint32")
+        desc_hi = T.alloc_local((1,), "uint32")
+        result = T.alloc_local((1,), "uint64")
+        T.evaluate(T.ptx.mov.b64(desc_lo[0], desc_hi[0], desc))
+        T.evaluate(T.ptx.add.u32(desc_lo[0], desc_lo[0], T.cast(offset, "uint32")))
+        T.evaluate(T.ptx.mov.b64(result[0], desc_lo[0], desc_hi[0]))
+        return result[0]
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -354,9 +354,8 @@ class TF32HCBenchCase:
 def get_kernel(**kwargs: Any):
     from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode, mma_shared_layout
     from tvm.script import tirx as T
-    from tvm.script.tirx import tile as Tx
     from tvm.tirx.lang.pipeline import Pipeline, TCGen05Bar
-    from tvm.tirx.layout import S, TCol, TileLayout, TLane, laneid, tcgen05_atom_layout
+    from tvm.tirx.layout import S, TCol, TileLayout, TLane, tcgen05_atom_layout
 
     config = _make_config(**kwargs)
     block_m = config.block_m
@@ -392,27 +391,40 @@ def get_kernel(**kwargs: Any):
     num_k_blocks = config.num_k_blocks
     num_k_blocks_per_split = num_k_blocks // num_splits
     remain_k_blocks = num_k_blocks % num_splits
+    tma_g2s_2d = (
+        "cp.async.bulk.tensor.2d.shared::cluster.global"
+        ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+    )
+    tma_s2g_2d = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+    tma_s2g_3d = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+    tcgen05_mma_tf32 = "tcgen05.mma.cta_group::1.kind::tf32"
+    cache_policy_evict_first = T.uint64(0x12F0000000000000)
+    cache_policy_evict_last = T.uint64(0x14F0000000000000)
+    tf32_instr_desc = T.uint32(67635472)
+    # The fixed TVM PTX table intentionally omits integer add. This helper
+    # performs uint32 wraparound in the descriptor's low half without a carry
+    # into the encoded layout fields.
+    smem_desc_add_source = r"""
+__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(
+    uint64_t desc_base, int32_t offset) {
+    SmemDescriptor desc;
+    desc.desc_ = desc_base;
+    desc.lo += static_cast<uint32_t>(offset);
+    return desc.desc_;
+}
+"""
+
+    def add_smem_desc_offset(desc, offset):
+        return T.cuda.func_call(
+            "tvm_builtin_smem_desc_add_16B_offset",
+            desc,
+            offset,
+            source_code=smem_desc_add_source,
+            return_type="uint64",
+        )
 
     def cuda_grid_dependency_synchronize():
         T.evaluate(T.ptx.griddepcontrol.wait())
-
-    def fma_sum_of_squares(acc0, acc1, a_flat, npairs, sc):
-        # Plain (non-@T.inline) Python helper: the parser executes this call's
-        # Python ``for`` at parse time, unrolling it so each 2-wide pair slice
-        # stays a compile-time-static rank-1 region (a TIR loop var or a
-        # middle-dim scalar index would make the fma reg path reject the op —
-        # non-static extent / "op rank 3 > anchor rank 2"). Fused packed
-        # fma.f32x2 accumulate (acc += pair*pair) into the two per-row dual
-        # accumulators, structurally mirroring the hand ffma2 sum0/sum1 float2
-        # pair (the T.fma f32x2 path emits fma.rz.ftz vs the hand's rn/non-ftz
-        # — a sub-ULP sqr difference, well within the kernel's 1e-8 gate). The
-        # flat A view exposes the .16x256b physical register order
-        # ``reg = v0p + 2*va + 4*vb``: each group of four registers contains a
-        # packed row-0 pair followed by the matching packed row-1 pair.
-        for p in range(npairs):
-            lo0, lo1 = 4 * p, 4 * p + 2
-            sc.fma(acc0, a_flat[lo0 : lo0 + 2], a_flat[lo0 : lo0 + 2], acc0)
-            sc.fma(acc1, a_flat[lo1 : lo1 + 2], a_flat[lo1 : lo1 + 2], acc1)
 
     @T.prim_func
     def sm100_tf32_hc_prenorm_gemm(
@@ -422,12 +434,106 @@ def get_kernel(**kwargs: Any):
         d: T.Buffer(config.d_shape, "float32"),
         sqr_sum: T.Buffer((config.num_splits * config.m,), "float32"),
     ):
+        # Build the same host-side tensor maps that copy_async previously
+        # synthesized, but make them part of the public pre-lowering IR.
+        d_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        if num_splits == 1:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                d_tensormap,
+                "float32",
+                2,
+                T.handle_add_byte_offset(d.data, 0),
+                config.n,
+                config.m,
+                T.uint32(config.n * 4),
+                T.uint32(block_n),
+                T.uint32(block_m),
+                1,
+                1,
+                0,
+                3,
+                2,
+                0,
+            )
+        else:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                d_tensormap,
+                "float32",
+                3,
+                T.handle_add_byte_offset(d.data, 0),
+                config.n,
+                config.m,
+                num_splits,
+                T.uint32(config.n * 4),
+                config.m * config.n * 4,
+                T.uint32(block_n),
+                T.uint32(block_m),
+                1,
+                1,
+                1,
+                1,
+                0,
+                3,
+                2,
+                0,
+            )
+        b_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            b_tensormap,
+            "float32",
+            2,
+            T.handle_add_byte_offset(b.data, 0),
+            config.k,
+            config.n,
+            config.k * 4,
+            T.uint32(block_swizzled_bk),
+            block_n,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+            11,
+        )
+        a_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            a_tensormap,
+            "bfloat16",
+            2,
+            T.handle_add_byte_offset(a.data, 0),
+            config.k,
+            config.m,
+            config.k * 2,
+            T.uint32(block_k),
+            T.uint32(block_m),
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
         T.device_entry()
         T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
         # TIRX_TRANSCRIBE_START sm100_tf32_hc_prenorm_gemm_impl
         warp_idx = T.warp_id([num_warps])
         T.warpgroup_id([num_warps // 4])
         lane_idx = T.lane_id([32])
+
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(a_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(b_tensormap)))
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(d_tensormap)))
         lane_u32: T.uint32 = T.cast(lane_idx, "uint32")
 
         # SMEMPool bump-allocates a 1024-aligned uint8 arena, reproducing the hand
@@ -528,29 +634,34 @@ def get_kernel(**kwargs: Any):
                         smem_pipe.empty.wait(stage_idx, tma_ph)
                         m_idx0: T.uint32 = m_block_idx * T.uint32(block_m)
                         k_idx0: T.uint32 = k_offset + s * T.uint32(block_k)
-                        # A as bf16 (exact in tf32); B as TFLOAT32 so TMA RN-truncates
-                        # on load, matching the tf32 MMA (else ~1 ULP divergence).
-                        Tx.copy_async(
-                            smem_a_mma[stage_idx],
-                            a[m_idx0 : m_idx0 + block_m, k_idx0 : k_idx0 + block_k],
-                            dispatch="tma_explicit",
-                            mbar=smem_pipe.full.ptr_to([stage_idx]),
-                            cta_group=1,
-                            cache_hint="evict_first",
-                            oob="zero",
-                            prefetch_tensormap=True,
+                        # A remains bf16 (exact in tf32); B's tensor map uses
+                        # TFLOAT32 OOB-fill mode 11 so the load RN-truncates as
+                        # before.  Coordinates are tensor-map order: K, then M/N.
+                        T.ptx[tma_g2s_2d](
+                            T.ptr_byte_offset(
+                                smem_a_mma.ptr_to([0, 0, 0]),
+                                stage_idx * T.uint32(block_m * block_k * 2),
+                                "bfloat16",
+                            ),
+                            T.address_of(a_tensormap),
+                            T.cast(k_idx0, "int32"),
+                            T.cast(m_idx0, "int32"),
+                            smem_pipe.full.ptr_to([stage_idx]),
+                            cache_policy_evict_first,
                         )
-                        for b_atom in T.unroll(block_k // 32):
-                            Tx.copy_async(
-                                smem_b_mma[stage_idx, :, b_atom * 32 : b_atom * 32 + 32],
-                                b[0:block_n, k_idx0 + b_atom * 32 : k_idx0 + b_atom * 32 + 32],
-                                dispatch="tma_explicit",
-                                mbar=smem_pipe.full.ptr_to([stage_idx]),
-                                cta_group=1,
-                                cache_hint="evict_last",
-                                oob="zero",
-                                tma_dtype="tf32",
-                                prefetch_tensormap=True,
+                        for b_atom in T.unroll(num_b_tma_atoms):
+                            T.ptx[tma_g2s_2d](
+                                T.ptr_byte_offset(
+                                    smem_b_mma.ptr_to([0, 0, 0]),
+                                    stage_idx * T.uint32(block_n * block_k * 4)
+                                    + T.uint32(b_atom * block_n * block_swizzled_bk * 4),
+                                    "float32",
+                                ),
+                                T.address_of(b_tensormap),
+                                T.cast(k_idx0 + T.uint32(b_atom * block_swizzled_bk), "int32"),
+                                T.int32(0),
+                                smem_pipe.full.ptr_to([stage_idx]),
+                                cache_policy_evict_last,
                             )
                         smem_pipe.full.arrive(
                             stage_idx,
@@ -569,21 +680,37 @@ def get_kernel(**kwargs: Any):
                     stage_idx: T.uint32 = mma_st
                     cast_stage_idx: T.uint32 = mma_cs
                     cast_pipe.full.wait(cast_stage_idx, mma_ph)
-                    # int32 col base (a uint32 extent fails gemm_async's layout check).
+                    # TMEM A columns and the swizzled B matrix descriptor match
+                    # the former tcgen05 tile dispatch exactly.
                     a_col: T.int32 = T.cast(cast_stage_idx * T.uint32(block_k), "int32")
-                    # D += A(tmem tf32) @ B^T(smem); accum=(s != 0) mirrors the hand scale_c.
-                    Tx.warp.gemm_async(
-                        _tmem[0:block_m, d_tmem_start_col : d_tmem_start_col + block_n],
-                        _tmem[0:block_m, a_col : a_col + block_k],
-                        smem_b_mma[stage_idx],
-                        accum=(s != T.uint32(0)),
-                        is_AB_tf32=True,
-                        dispatch="tcgen05",
-                        cta_group=1,
-                        # "local_hoist": one encode per stage + one add per MMA,
-                        # mirroring the hand's shuffle + IADD descriptor pattern.
-                        smem_desc="local_hoist",
+                    desc_b: T.uint64
+                    T.cuda.tcgen05.encode_matrix_descriptor(
+                        T.address_of(desc_b),
+                        smem_b_mma.ptr_to([0, 0, 0]),
+                        ldo=256,
+                        sdo=64,
+                        swizzle=3,
                     )
+                    for ki in T.unroll(block_k // umma_k):
+                        if T.cuda.elect_sync():
+                            T.ptx[tcgen05_mma_tf32](
+                                T.uint32(d_tmem_start_col),
+                                T.cast(a_col + T.int32(ki * umma_k), "uint32"),
+                                add_smem_desc_offset(
+                                    desc_b,
+                                    (
+                                        T.uint32((ki // 4) * 1024 + (ki % 4) * 8)
+                                        + stage_idx * T.uint32(block_n * block_k)
+                                    )
+                                    // T.uint32(4),
+                                ),
+                                tf32_instr_desc,
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.uint32(0),
+                                T.ptx.pred((s != T.uint32(0)) if ki == 0 else T.bool(True)),
+                            )
                     if T.cuda.elect_sync():
                         cast_pipe.empty.arrive(cast_stage_idx)
                         smem_pipe.empty.arrive(stage_idx)
@@ -600,6 +727,7 @@ def get_kernel(**kwargs: Any):
             # D epilogue, hand-aligned: 8 x [tcgen05.ld.32x32b.x4 + wait.ld +
             # st.shared.v4 (lane<16) + syncwarp] into the 128B-swizzled smem_cd.
             d_frag = T.alloc_local((4,), "float32")
+            d_words = d_frag.view("uint32")
             for i in T.unroll(block_n // 4):
                 taddr_d: T.uint32 = T.uint32(d_tmem_start_col + i * 4)
                 T.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](
@@ -607,10 +735,25 @@ def get_kernel(**kwargs: Any):
                 )
                 T.ptx.tcgen05.wait__ld.sync.aligned()
                 if lane_u32 < T.uint32(16):
-                    # Per-thread 4-col slice store; the swizzled layout of
-                    # smem_cd_mma computes the address, the 16B chunk emits v4.
+                    # Per-thread 4-col slice store; ptr_to applies the same
+                    # 128B-swizzled layout that the former tile copy selected.
                     m_row: T.uint32 = T.cast(warp_idx, "uint32") * T.uint32(16) + lane_u32
-                    Tx.copy(smem_cd_mma[m_row, i * 4 : (i + 1) * 4], d_frag[:])
+                    compose_m: T.uint32 = m_row * T.uint32(block_n) + T.uint32(i * 4)
+                    compose_q: T.uint32 = compose_m // T.uint32(4)
+                    smem_cd_offset: T.uint32 = (
+                        (compose_q ^ ((compose_q & T.uint32(56)) >> T.uint32(3))) << T.uint32(2)
+                    ) + compose_m % T.uint32(4)
+                    T.ptx.st.shared.v4.u32(
+                        T.ptr_byte_offset(
+                            smem_cd_mma.ptr_to([0, 0]),
+                            smem_cd_offset * T.uint32(4),
+                            "float32",
+                        ),
+                        d_words[0],
+                        d_words[1],
+                        d_words[2],
+                        d_words[3],
+                    )
                 T.cuda.warp_sync()
 
             T.ptx.fence.proxy.async_.shared__cta()
@@ -620,24 +763,34 @@ def get_kernel(**kwargs: Any):
                     # D store via TMA (writes only the valid region of boundary tiles).
                     m0: T.uint32 = m_block_idx * T.uint32(block_m)
                     if num_splits == 1:
-                        Tx.copy_async(
-                            d[m0 : m0 + block_m, 0:block_n],
-                            smem_cd_mma,
-                            dispatch="tma_auto",
-                            prefetch_tensormap=True,
-                            cache_hint="evict_first",
+                        T.ptx[tma_s2g_2d](
+                            T.address_of(d_tensormap),
+                            T.int32(0),
+                            T.cast(m0, "int32"),
+                            smem_cd_mma.ptr_to([0, 0]),
+                            cache_policy_evict_first,
                         )
                     else:
                         ks: T.uint32 = k_split_idx
-                        Tx.copy_async(
-                            d[ks, m0 : m0 + block_m, 0:block_n],
-                            smem_cd_mma,
-                            dispatch="tma_auto",
-                            prefetch_tensormap=True,
-                            cache_hint="evict_first",
+                        T.ptx[tma_s2g_3d](
+                            T.address_of(d_tensormap),
+                            T.int32(0),
+                            T.cast(m0, "int32"),
+                            T.cast(ks, "int32"),
+                            smem_cd_mma.ptr_to([0, 0]),
+                            cache_policy_evict_first,
                         )
                     T.ptx.cp.async_.bulk.commit_group()
-            tmem_pool.dealloc()  # warp-1-guarded relinquish + tcgen05.dealloc
+            # Keep the TMEM teardown on warp 1, but spell the allocator-slot read
+            # explicitly so the public pre-lowering IR contains a real PTX shared
+            # load rather than a shared BufferLoad.
+            if warp_idx == 1:
+                T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+                tmem_dealloc_addr: T.uint32
+                T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_ptr_in_smem.ptr_to([0]))
+                T.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](
+                    tmem_dealloc_addr, T.uint32(num_tmem_cols)
+                )
         else:
             sub_warp_idx: T.uint32 = T.cast(
                 T.cast(warp_idx, "int32") - T.int32(num_mma_warps), "uint32"
@@ -658,7 +811,7 @@ def get_kernel(**kwargs: Any):
             # structurally incompatible with the wid_in_wg+split-laneid atom) and
             # falls to a 16x-scalar-LDS reg path that costs +25% on the latency-
             # bound tail. The square/accumulate runs on the flat ``.local()`` view
-            # (per-thread private regs via ``Tx.fill`` / ``Tx.fma``). Its physical
+            # (per-thread private regs via explicit PTX). Its physical
             # register order interleaves the two Layout-F rows in packed pairs:
             # regs [4*p:4*p+2] feed row m_idx0 and regs [4*p+2:4*p+4] feed row
             # m_idx1 (+8).
@@ -674,10 +827,14 @@ def get_kernel(**kwargs: Any):
             sqr0 = T.alloc_local((2,), "float32")
             sqr1 = T.alloc_local((2,), "float32")
             a_flat = a_fp32.local()  # 1D physical-register view, 32 fp32 values per thread
-            # Per-thread private regs: use thread-scope fill/fma (not Tx.warp — warp
-            # scope requires a laneid-distributed layout; see elementwise reg dispatch).
-            Tx.fill(sqr0, T.float32(0))
-            Tx.fill(sqr1, T.float32(0))
+            a_words = a_flat.view("uint32")
+            a_bf16_flat = a_bf16.local()
+            a_bf16_u16 = a_bf16_flat.view("uint16")
+            a_bf16_words = a_bf16_flat.view("uint32")
+            sqr0[0] = T.float32(0)
+            sqr0[1] = T.float32(0)
+            sqr1[0] = T.float32(0)
+            sqr1[1] = T.float32(0)
             cast_st: T.uint32 = T.uint32(0)
             cast_ph: T.uint32 = T.uint32(0)
             cast_cs: T.uint32 = T.uint32(0)
@@ -687,29 +844,110 @@ def get_kernel(**kwargs: Any):
                 cast_stage_idx: T.uint32 = cast_cs
                 a_col: T.int32 = T.cast(cast_stage_idx * T.uint32(block_k), "int32")
                 smem_pipe.full.wait(stage_idx, cast_ph)
-                # SMEM->reg A load via ldmatrix.x4 (T.copy dispatch).
-                Tx.warpgroup.copy(a_bf16, smem_a_mma[stage_idx])
+                # Four x4 ldmatrix instructions reproduce the warpgroup copy's
+                # physical register order.  Keep the dispatcher's explicit
+                # swizzled element offset so ptxas sees the same address DAG.
+                for mm in T.unroll(4):
+                    smem_off: T.uint32 = (
+                        T.cast(
+                            T.cast(sub_warp_idx, "int32") * T.int32(1024)
+                            + T.int32((mm // 2) * 512),
+                            "uint32",
+                        )
+                        + stage_idx * T.uint32(block_m * block_k)
+                        + T.cast(lane_idx % T.int32(8) * T.int32(block_k), "uint32")
+                        + (
+                            T.cast(
+                                T.int32((mm % 2) * 32) + lane_idx // T.int32(8) * T.int32(8),
+                                "uint32",
+                            )
+                            ^ (
+                                (
+                                    T.cast(
+                                        T.cast(sub_warp_idx, "int32") * T.int32(16)
+                                        + T.int32((mm // 2) * 8),
+                                        "uint32",
+                                    )
+                                    + stage_idx * T.uint32(block_k)
+                                    + T.cast(lane_idx % T.int32(8) * T.int32(block_k), "uint32")
+                                    // T.uint32(block_k)
+                                )
+                                & T.uint32(7)
+                            )
+                            << T.uint32(3)
+                        )
+                    )
+                    reg_base = (mm % 2) * 8 + mm // 2
+                    T.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        a_bf16_words[reg_base],
+                        a_bf16_words[reg_base + 2],
+                        a_bf16_words[reg_base + 4],
+                        a_bf16_words[reg_base + 6],
+                        T.ptr_byte_offset(
+                            smem_a_mma.ptr_to([0, 0, 0]), smem_off * 2, "bfloat16"
+                        ),
+                    )
                 cast_pipe.empty.wait(cast_stage_idx, cast_cph)
                 # bf16->tf32 + sqr-fma + TMEM deposit: interleaved per 8-col atom on
                 # short mainloops (hand structure); single wide STTM.x8 on deep pipelines.
                 if num_k_blocks_per_split <= 16:
                     for p in range(block_k // 8):
-                        Tx.warpgroup.cast(
-                            a_fp32[:, p * 8 : (p + 1) * 8], a_bf16[:, p * 8 : (p + 1) * 8]
-                        )
+                        for f in range(2):
+                            T.ptx.cvt.f32.bf16(
+                                a_flat[p * 4 + f * 2], a_bf16_u16[p * 4 + f * 2]
+                            )
+                            T.ptx.cvt.f32.bf16(
+                                a_flat[p * 4 + f * 2 + 1], a_bf16_u16[p * 4 + f * 2 + 1]
+                            )
                         # sqr{0,1} += a*a for this atom's packed pair per row.
-                        Tx.fma(sqr0, a_flat[4 * p : 4 * p + 2], a_flat[4 * p : 4 * p + 2], sqr0)
-                        Tx.fma(
-                            sqr1, a_flat[4 * p + 2 : 4 * p + 4], a_flat[4 * p + 2 : 4 * p + 4], sqr1
-                        )
-                        Tx.warpgroup.copy_async(
-                            _tmem[0:block_m, a_col + p * 8 : a_col + (p + 1) * 8],
-                            a_fp32[:, p * 8 : (p + 1) * 8],
+                        pair0_lhs: T.uint64
+                        pair0_rhs: T.uint64
+                        pair0_acc: T.uint64
+                        T.ptx.mov.b64(pair0_lhs, a_flat[p * 4], a_flat[p * 4 + 1])
+                        T.ptx.mov.b64(pair0_rhs, a_flat[p * 4], a_flat[p * 4 + 1])
+                        T.ptx.mov.b64(pair0_acc, sqr0[0], sqr0[1])
+                        T.ptx.fma.rz.ftz.f32x2(pair0_lhs, pair0_lhs, pair0_rhs, pair0_acc)
+                        T.ptx.mov.b64(sqr0[0], sqr0[1], pair0_lhs)
+                        pair1_lhs: T.uint64
+                        pair1_rhs: T.uint64
+                        pair1_acc: T.uint64
+                        T.ptx.mov.b64(pair1_lhs, a_flat[p * 4 + 2], a_flat[p * 4 + 3])
+                        T.ptx.mov.b64(pair1_rhs, a_flat[p * 4 + 2], a_flat[p * 4 + 3])
+                        T.ptx.mov.b64(pair1_acc, sqr1[0], sqr1[1])
+                        T.ptx.fma.rz.ftz.f32x2(pair1_lhs, pair1_lhs, pair1_rhs, pair1_acc)
+                        T.ptx.mov.b64(sqr1[0], sqr1[1], pair1_lhs)
+                        T.ptx["tcgen05.st.sync.aligned.16x256b.x1.b32"](
+                            T.cuda.get_tmem_addr(T.uint32(0), 0, a_col + p * 8),
+                            a_words[p * 4],
+                            a_words[p * 4 + 1],
+                            a_words[p * 4 + 2],
+                            a_words[p * 4 + 3],
                         )
                 else:
-                    Tx.warpgroup.cast(a_fp32, a_bf16)
-                    fma_sum_of_squares(sqr0, sqr1, a_flat, cast_pairs, Tx)
-                    Tx.warpgroup.copy_async(_tmem[0:block_m, a_col : a_col + block_k], a_fp32)
+                    for f in range(cast_per_thread // 2):
+                        T.ptx.cvt.f32.bf16(a_flat[f * 2], a_bf16_u16[f * 2])
+                        T.ptx.cvt.f32.bf16(a_flat[f * 2 + 1], a_bf16_u16[f * 2 + 1])
+                    for p in T.unroll(cast_pairs):
+                        pair0_lhs: T.uint64
+                        pair0_rhs: T.uint64
+                        pair0_acc: T.uint64
+                        T.ptx.mov.b64(pair0_lhs, a_flat[p * 4], a_flat[p * 4 + 1])
+                        T.ptx.mov.b64(pair0_rhs, a_flat[p * 4], a_flat[p * 4 + 1])
+                        T.ptx.mov.b64(pair0_acc, sqr0[0], sqr0[1])
+                        T.ptx.fma.rz.ftz.f32x2(pair0_lhs, pair0_lhs, pair0_rhs, pair0_acc)
+                        T.ptx.mov.b64(sqr0[0], sqr0[1], pair0_lhs)
+                        pair1_lhs: T.uint64
+                        pair1_rhs: T.uint64
+                        pair1_acc: T.uint64
+                        T.ptx.mov.b64(pair1_lhs, a_flat[p * 4 + 2], a_flat[p * 4 + 3])
+                        T.ptx.mov.b64(pair1_rhs, a_flat[p * 4 + 2], a_flat[p * 4 + 3])
+                        T.ptx.mov.b64(pair1_acc, sqr1[0], sqr1[1])
+                        T.ptx.fma.rz.ftz.f32x2(pair1_lhs, pair1_lhs, pair1_rhs, pair1_acc)
+                        T.ptx.mov.b64(sqr1[0], sqr1[1], pair1_lhs)
+                    T.ptx["tcgen05.st.sync.aligned.16x256b.x8.b32"](
+                        T.cuda.get_tmem_addr(T.uint32(0), 0, a_col),
+                        *[a_words[i] for i in range(cast_per_thread)],
+                    )
                 T.ptx.tcgen05.wait__st.sync.aligned()
                 cast_pipe.full.arrive(cast_stage_idx)
                 cast_st = stage_idx + T.uint32(1)
@@ -722,19 +960,17 @@ def get_kernel(**kwargs: Any):
 
             # Cross-lane sum-of-squares reduce over the 4 K-lanes (the hand's
             # shfl_xor 2,1), then store the two per-row results.
-            sqr_part = T.alloc_buffer(
-                [2], "float32", scope="local", layout=TileLayout(S[(2,) : (1,)])
-            )
+            sqr_part = T.alloc_local((2,), "float32")
             sqr_part[0] = sqr0[0] + sqr0[1]
             sqr_part[1] = sqr1[0] + sqr1[1]
-            sqr_warp = sqr_part.view(
-                16,
-                4,
-                layout=TileLayout(S[(1, 1) : (1, 1)])
-                .tile(TileLayout(S[(8, 4) : (4 @ laneid, 1 @ laneid)]), (8, 4), (1, 1))
-                .tile(TileLayout(S[(2, 1) : (1, 1)]), (2, 1), (8, 4)),
-            )
-            Tx.warp.sum(sqr_warp, sqr_warp, thread_reduce=True)
+            for spa in range(2):
+                reduce_mask: T.uint32 = T.tvm_warp_activemask()
+                sqr_part[spa] = sqr_part[spa] + T.tvm_warp_shuffle_xor(
+                    reduce_mask, sqr_part[spa], 1, 32, 32
+                )
+                sqr_part[spa] = sqr_part[spa] + T.tvm_warp_shuffle_xor(
+                    reduce_mask, sqr_part[spa], 2, 32, 32
+                )
             reduced0: T.float32 = sqr_part[0]
             reduced1: T.float32 = sqr_part[1]
             m_idx0: T.uint32 = (
@@ -745,9 +981,13 @@ def get_kernel(**kwargs: Any):
             m_idx1: T.uint32 = m_idx0 + T.uint32(8)
             if (lane_u32 % T.uint32(4)) == T.uint32(0):
                 if m_idx0 < shape_m:
-                    sqr_sum[T.cast(m_offset + m_idx0, "int32")] = reduced0
+                    T.ptx.st.global_.f32(
+                        sqr_sum.ptr_to([T.cast(m_offset + m_idx0, "int32")]), reduced0
+                    )
                 if m_idx1 < shape_m:
-                    sqr_sum[T.cast(m_offset + m_idx1, "int32")] = reduced1
+                    T.ptx.st.global_.f32(
+                        sqr_sum.ptr_to([T.cast(m_offset + m_idx1, "int32")]), reduced1
+                    )
 
     return sm100_tf32_hc_prenorm_gemm.with_attr(
         "tirx.kernel_launch_params",

--- a/tirx_kernels/flashkda/bf16_fused_m128.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128.py
@@ -235,6 +235,60 @@ def _ld_global_v4_u32(dst, ptr):
     return T.ptx.ld.global_.v4.b32(dst[0], dst[1], dst[2], dst[3], ptr)
 
 
+def _ld_global_s32(buffer, index):
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.s32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _ld_global_s64(buffer, index):
+    out = T.alloc_local((1,), "int64")
+    T.evaluate(T.ptx.ld.global_.s64(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _ld_global_f32(buffer, index):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.global_.f32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _ld_global_bf16(buffer, index):
+    bits = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(bits[0], buffer.ptr_to([index])))
+    return T.reinterpret("bfloat16", bits[0])
+
+
+def _st_global_bf16(buffer, index, value):
+    return T.ptx.st.global_.b16(buffer.ptr_to([index]), T.reinterpret("uint16", value))
+
+
+def _ld_shared_f32(buffer, index):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.shared.f32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _ld_shared_v4_f32(dst, dst_offset, buffer, index):
+    return T.ptx.ld.shared.v4.f32(
+        dst[dst_offset],
+        dst[dst_offset + 1],
+        dst[dst_offset + 2],
+        dst[dst_offset + 3],
+        buffer.ptr_to([index]),
+    )
+
+
+def _ld_shared_bf16(buffer, index):
+    bits = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.shared.b16(bits[0], buffer.ptr_to([index])))
+    return T.reinterpret("bfloat16", bits[0])
+
+
+def _st_shared_f32(buffer, index, value):
+    return T.ptx.st.shared.f32(buffer.ptr_to([index]), value)
+
+
 def _tanh_approx(x):
     # tanh.approx.f32 (prep-role sigmoid)
     return T.cuda.func_call(
@@ -1264,10 +1318,10 @@ def _kernel(
         T.ptx.setmaxnreg.inc.sync.aligned.u32(168)  # .cu:731
         # .cu:732 compute_main
         task_idx: T.int32 = bid  # .cu:733
-        seq_idx: T.int32 = seq_order[task_idx // h]  # .cu:734
+        seq_idx: T.int32 = _ld_global_s32(seq_order, task_idx // h)  # .cu:734
         head_idx: T.int32 = task_idx % h  # .cu:735
-        bos: T.int64 = cu_seqlens[seq_idx]  # .cu:736
-        eos: T.int64 = cu_seqlens[seq_idx + 1]  # .cu:737
+        bos: T.int64 = _ld_global_s64(cu_seqlens, seq_idx)  # .cu:736
+        eos: T.int64 = _ld_global_s64(cu_seqlens, seq_idx + 1)  # .cu:737
         seq_len: T.int32 = T.cast(eos - bos, "int32")  # .cu:738
         num_chunks: T.int32 = (seq_len + 32 - 1) // 32  # .cu:739
         warp_in_wg: T.int32 = warp % 4  # .cu:740
@@ -1355,13 +1409,16 @@ def _kernel(
                 )
                 state_scale: T.f32[16]
                 for state_half in T.unroll(2):  # .cu:850-859
-                    for state_col in T.unroll(16):
-                        state_scale[state_col] = smem_gt_all[
+                    for state_vec in T.unroll(4):
+                        _ld_shared_v4_f32(
+                            state_scale,
+                            state_vec * 4,
+                            smem_gt_all,
                             compute_stage * 10496
                             + state_col_block_1 * 32
                             + state_half * 16
-                            + state_col
-                        ]  # .cu:854
+                            + state_vec * 4,
+                        )  # .cu:854
                     for _ls in T.unroll(8):  # .cu:857-858
                         _pk = _mul_f32x2_inplace(
                             T.cuda.make_float2(
@@ -1400,11 +1457,13 @@ def _kernel(
                 for residual_col in T.unroll(16):  # .cu:874-881
                     token_col: T.int32 = residual_half * 16 + residual_col  # .cu:876
                     residual_v[residual_col] = T.cuda.bfloat162float(
-                        smem_v_all[compute_stage * 20992 + token_col * 128 + state_row]
+                        _ld_shared_bf16(
+                            smem_v_all, compute_stage * 20992 + token_col * 128 + state_row
+                        )
                     )  # .cu:877-879
-                    residual_beta[residual_col] = smem_prep_beta_all[
-                        compute_stage * 10496 + token_col
-                    ]  # .cu:880
+                    residual_beta[residual_col] = _ld_shared_f32(
+                        smem_prep_beta_all, compute_stage * 10496 + token_col
+                    )  # .cu:880
                 for _ls in T.unroll(8):  # .cu:882-884
                     _pk = _sub_f32x2_inplace(
                         T.cuda.make_float2(residual_v[_ls * 2], residual_v[_ls * 2 + 1]),
@@ -1521,10 +1580,10 @@ def _kernel(
         T.ptx.setmaxnreg.dec.sync.aligned.u32(48)  # .cu:965
         # .cu:966 epilogue_main
         task_idx_1: T.int32 = bid  # .cu:967
-        seq_idx_1: T.int32 = seq_order[task_idx_1 // h]  # .cu:968
+        seq_idx_1: T.int32 = _ld_global_s32(seq_order, task_idx_1 // h)  # .cu:968
         head_idx_1: T.int32 = task_idx_1 % h  # .cu:969
-        bos_1: T.int64 = cu_seqlens[seq_idx_1]  # .cu:970
-        eos_1: T.int64 = cu_seqlens[seq_idx_1 + 1]  # .cu:971
+        bos_1: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_1)  # .cu:970
+        eos_1: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_1 + 1)  # .cu:971
         seq_len_1: T.int32 = T.cast(eos_1 - bos_1, "int32")  # .cu:972
         num_chunks_1: T.int32 = (seq_len_1 + 32 - 1) // 32  # .cu:973
         warp_id_in_role_1: T.int32 = warp - 4  # .cu:974
@@ -1644,7 +1703,9 @@ def _kernel(
                         out_idx: T.int64 = (
                             out_token * T.cast(h, "int64") + T.cast(head_idx_1, "int64")
                         ) * 128 + T.cast(state_row_1, "int64")  # .cu:1073
-                        out[out_idx] = T.cast(_tmem_load_6[token_col_1], "bfloat16")  # .cu:1074
+                        _st_global_bf16(
+                            out, out_idx, T.cast(_tmem_load_6[token_col_1], "bfloat16")
+                        )  # .cu:1074
             epilogue_stage += 1  # .cu:1078
             if epilogue_stage == 5:  # .cu:1079
                 epilogue_stage = T.uint32(0)
@@ -1661,9 +1722,9 @@ def _kernel(
         # ---- Role: mma (.cu:1092-1247) ----
         # .cu:1093 mma_main
         task_idx_2: T.int32 = bid  # .cu:1094
-        seq_idx_2: T.int32 = seq_order[task_idx_2 // h]  # .cu:1095
-        bos_2: T.int64 = cu_seqlens[seq_idx_2]  # .cu:1096
-        eos_2: T.int64 = cu_seqlens[seq_idx_2 + 1]  # .cu:1097
+        seq_idx_2: T.int32 = _ld_global_s32(seq_order, task_idx_2 // h)  # .cu:1095
+        bos_2: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_2)  # .cu:1096
+        eos_2: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_2 + 1)  # .cu:1097
         seq_len_2: T.int32 = T.cast(eos_2 - bos_2, "int32")  # .cu:1098
         num_chunks_2: T.int32 = (seq_len_2 + 32 - 1) // 32  # .cu:1099
         mma_stage: T.uint32 = 0  # .cu:1100
@@ -1789,10 +1850,10 @@ def _kernel(
         # ---- Role: load (.cu:1248-1296) ----
         # .cu:1249 load_main
         task_idx_3: T.int32 = bid  # .cu:1250
-        seq_idx_3: T.int32 = seq_order[task_idx_3 // h]  # .cu:1251
+        seq_idx_3: T.int32 = _ld_global_s32(seq_order, task_idx_3 // h)  # .cu:1251
         head_idx_2: T.int32 = task_idx_3 % h  # .cu:1252
-        bos_3: T.int64 = cu_seqlens[seq_idx_3]  # .cu:1253
-        eos_3: T.int64 = cu_seqlens[seq_idx_3 + 1]  # .cu:1254
+        bos_3: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_3)  # .cu:1253
+        eos_3: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_3 + 1)  # .cu:1254
         seq_len_3: T.int32 = T.cast(eos_3 - bos_3, "int32")  # .cu:1255
         num_chunks_3: T.int32 = (seq_len_3 + 32 - 1) // 32  # .cu:1256
         load_stage: T.uint32 = 0  # .cu:1257
@@ -1869,10 +1930,10 @@ def _kernel(
         T.ptx.setmaxnreg.dec.sync.aligned.u32(48)  # .cu:1299
         # .cu:1300 prep_main
         task_idx_4: T.int32 = bid  # .cu:1301
-        seq_idx_4: T.int32 = seq_order[task_idx_4 // h]  # .cu:1302
+        seq_idx_4: T.int32 = _ld_global_s32(seq_order, task_idx_4 // h)  # .cu:1302
         head_idx_3: T.int32 = task_idx_4 % h  # .cu:1303
-        bos_4: T.int64 = cu_seqlens[seq_idx_4]  # .cu:1304
-        eos_4: T.int64 = cu_seqlens[seq_idx_4 + 1]  # .cu:1305
+        bos_4: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_4)  # .cu:1304
+        eos_4: T.int64 = _ld_global_s64(cu_seqlens, seq_idx_4 + 1)  # .cu:1305
         seq_len_4: T.int32 = T.cast(eos_4 - bos_4, "int32")  # .cu:1306
         num_chunks_4: T.int32 = (seq_len_4 + 32 - 1) // 32  # .cu:1307
         instance_id: T.int32 = (warp - 12) // 4  # .cu:1308
@@ -1884,7 +1945,8 @@ def _kernel(
         prep_stage: T.uint32 = T.cast(prep_instance, "uint32")  # .cu:1314
         gate_rate_stage_f32: T.int32 = prep_instance * 10496  # .cu:1315
         if prep_tid == 0:  # .cu:1316-1319
-            smem_gate_rate_all[gate_rate_stage_f32] = _expf(A_log[head_idx_3])
+            a_log_value: T.f32 = _ld_global_f32(A_log, head_idx_3)
+            _st_shared_f32(smem_gate_rate_all, gate_rate_stage_f32, _expf(a_log_value))
         if prep_instance == 0:  # .cu:1320-1332
             T.ptx.bar.sync(T.uint32(11), T.uint32(128))
         elif prep_instance == 1:
@@ -1986,10 +2048,14 @@ def _kernel(
                         0.5
                     ) + T.float32(0.5)  # .cu:1377-1379
                 if prep_tid < 128:  # .cu:1381-1391
-                    early_gate_rate: T.f32 = smem_gate_rate_all[stage_f32]  # .cu:1382
-                    early_gate_bias: T.f32 = dt_bias[head_idx_3 * 128 + prep_tid]  # .cu:1383
+                    early_gate_rate: T.f32 = _ld_shared_f32(
+                        smem_gate_rate_all, stage_f32
+                    )  # .cu:1382
+                    early_gate_bias: T.f32 = _ld_global_f32(
+                        dt_bias, head_idx_3 * 128 + prep_tid
+                    )  # .cu:1383
                     early_gate_raw: T.f32 = T.cuda.bfloat162float(
-                        smem_g_raw_all[stage_bf16 + prep_tid]
+                        _ld_shared_bf16(smem_g_raw_all, stage_bf16 + prep_tid)
                     )  # .cu:1384-1385
                     early_gate_arg: T.f32 = early_gate_rate * (
                         early_gate_raw + early_gate_bias
@@ -2056,18 +2122,19 @@ def _kernel(
                 if chunk_is_full_2 == 0:  # .cu:1432-1440
                     beta_token: T.int64 = bos_4 + T.cast(chunk_idx_3 * 32 + lane, "int64")
                     if beta_token < eos_4:
-                        beta_logit_1: T.f32 = T.cast(
-                            beta[beta_token * T.cast(h, "int64") + T.cast(head_idx_3, "int64")],
-                            "float32",
+                        beta_logit_1: T.f32 = T.cuda.bfloat162float(
+                            _ld_global_bf16(
+                                beta, beta_token * T.cast(h, "int64") + T.cast(head_idx_3, "int64")
+                            )
                         )  # .cu:1435
                         beta_value = _tanh_approx(beta_logit_1 * T.float32(0.5)) * T.float32(
                             0.5
                         ) + T.float32(0.5)  # .cu:1436-1438
-                smem_prep_beta_all[stage_f32 + lane] = beta_value  # .cu:1441
+                _st_shared_f32(smem_prep_beta_all, stage_f32 + lane, beta_value)  # .cu:1441
             if prep_tid < 128:  # .cu:1443-1472
                 gate_col: T.int32 = prep_tid  # .cu:1444
-                gate_rate: T.f32 = smem_gate_rate_all[stage_f32]  # .cu:1445
-                gate_bias: T.f32 = dt_bias[head_idx_3 * 128 + gate_col]  # .cu:1446
+                gate_rate: T.f32 = _ld_shared_f32(smem_gate_rate_all, stage_f32)  # .cu:1445
+                gate_bias: T.f32 = _ld_global_f32(dt_bias, head_idx_3 * 128 + gate_col)  # .cu:1446
                 prefix_log2: T.f32 = T.float32(0.0)  # .cu:1447
                 for gate_row in T.serial(0, 32):  # .cu:1448-1471
                     gate_token: T.int64 = bos_4 + T.cast(
@@ -2082,7 +2149,9 @@ def _kernel(
                     if gate_needs_compute != 0:  # .cu:1458-1468
                         if gate_token < eos_4:
                             gate_raw: T.f32 = T.cuda.bfloat162float(
-                                smem_g_raw_all[stage_bf16 + gate_row * 128 + gate_col]
+                                _ld_shared_bf16(
+                                    smem_g_raw_all, stage_bf16 + gate_row * 128 + gate_col
+                                )
                             )  # .cu:1460-1461
                             gate_arg: T.f32 = gate_rate * (gate_raw + gate_bias)  # .cu:1462
                             gate_sigmoid: T.f32 = _tanh_approx(
@@ -2094,7 +2163,9 @@ def _kernel(
                                 * gate_sigmoid
                             )  # .cu:1466
                     prefix_log2 += gate_log2  # .cu:1469
-                    smem_gate_all[stage_f32 + gate_row * 128 + gate_col] = prefix_log2  # .cu:1470
+                    _st_shared_f32(
+                        smem_gate_all, stage_f32 + gate_row * 128 + gate_col, prefix_log2
+                    )  # .cu:1470
             if prep_instance == 0:  # .cu:1473-1485
                 T.ptx.bar.sync(T.uint32(11), T.uint32(128))
             elif prep_instance == 1:
@@ -2114,14 +2185,24 @@ def _kernel(
                     _phase_qk_raw_full,
                 )
             if prep_tid < 128:  # .cu:1489-1493
-                total_log2: T.f32 = smem_gt_prefix_all[stage_f32 + prep_tid]  # .cu:1490
-                smem_restore_factor_all[stage_f32 + prep_tid] = _approx_exp2(
-                    total_log2
-                    - T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                total_log2: T.f32 = _ld_shared_f32(
+                    smem_gt_prefix_all, stage_f32 + prep_tid
+                )  # .cu:1490
+                _st_shared_f32(
+                    smem_restore_factor_all,
+                    stage_f32 + prep_tid,
+                    _approx_exp2(
+                        total_log2
+                        - T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                    ),
                 )  # .cu:1491-1492
             if prep_tid == 0:  # .cu:1494-1497
-                smem_restore_factor_all[stage_f32 + 128] = _approx_exp2(
-                    T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                _st_shared_f32(
+                    smem_restore_factor_all,
+                    stage_f32 + 128,
+                    _approx_exp2(
+                        T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
+                    ),
                 )
             q_u32 = T.decl_buffer((total_tokens * h * D_HEAD // 2,), "uint32", data=q.data)
             k_u32 = T.decl_buffer((total_tokens * h * D_HEAD // 2,), "uint32", data=k.data)
@@ -2233,9 +2314,17 @@ def _kernel(
                 qd_vec: T.f32[8]  # .cu:1641
                 kd_vec: T.f32[8]  # .cu:1642
                 ki_vec: T.f32[8]  # .cu:1643
+                prefix_vec: T.f32[8]
+                for prefix_vec_idx in T.unroll(2):
+                    _ld_shared_v4_f32(
+                        prefix_vec,
+                        prefix_vec_idx * 4,
+                        smem_gate_all,
+                        stage_f32 + row_1 * 128 + segment_1 * 8 + prefix_vec_idx * 4,
+                    )
                 for elem_in_segment_1 in T.serial(0, 8):  # .cu:1644-1653
                     col: T.int32 = segment_1 * 8 + elem_in_segment_1  # .cu:1645
-                    prefix: T.f32 = smem_gate_all[stage_f32 + row_1 * 128 + col]  # .cu:1646
+                    prefix: T.f32 = prefix_vec[elem_in_segment_1]  # .cu:1646
                     common_log2: T.f32 = (
                         T.float32(lower_bound) * T.float32(1.4426950408889634) * T.float32(16.0)
                     )  # .cu:1647
@@ -2458,8 +2547,8 @@ def _kernel(
                 row0: T.int32 = pair_row_base + lane // 4  # .cu:1826
                 row1: T.int32 = row0 + 8  # .cu:1827
                 col0: T.int32 = pair_col_base + lane % 4 * 2  # .cu:1828
-                beta0: T.f32 = smem_prep_beta_all[stage_f32 + row0]  # .cu:1829
-                beta1: T.f32 = smem_prep_beta_all[stage_f32 + row1]  # .cu:1830
+                beta0: T.f32 = _ld_shared_f32(smem_prep_beta_all, stage_f32 + row0)  # .cu:1829
+                beta1: T.f32 = _ld_shared_f32(smem_prep_beta_all, stage_f32 + row1)  # .cu:1830
                 seed: T.f32[8]  # .cu:1831
                 for _zi in T.unroll(8):  # .cu:1832-1839
                     seed[_zi] = T.float32(0.0)
@@ -2687,18 +2776,26 @@ def _kernel(
                 else:
                     T.ptx.bar.sync(T.uint32(15), T.uint32(128))
             if prep_tid < 128:  # .cu:2065-2069
-                total_log2_1: T.f32 = smem_gt_prefix_all[stage_f32 + prep_tid]  # .cu:2066
-                smem_gt_all[stage_f32 + prep_tid] = _approx_exp2(total_log2_1)  # .cu:2067-2068
+                total_log2_1: T.f32 = _ld_shared_f32(
+                    smem_gt_prefix_all, stage_f32 + prep_tid
+                )  # .cu:2066
+                _st_shared_f32(
+                    smem_gt_all, stage_f32 + prep_tid, _approx_exp2(total_log2_1)
+                )  # .cu:2067-2068
             if prep_local_warp >= 2:  # .cu:2070-2187
                 stage_f32_0: T.int32 = T.cast(prep_stage, "int32") * 10496  # .cu:2071
-                restore_scale: T.f32 = smem_restore_factor_all[stage_f32_0 + 128]  # .cu:2072
+                restore_scale: T.f32 = _ld_shared_f32(
+                    smem_restore_factor_all, stage_f32_0 + 128
+                )  # .cu:2072
                 restore_factor: T.f32[8]  # .cu:2073
                 restore_segment: T.int32 = lane & 15  # .cu:2074
-                for restore_elem in T.unroll(8):  # .cu:2075-2079
-                    restore_col: T.int32 = restore_segment * 8 + restore_elem  # .cu:2077
-                    restore_factor[restore_elem] = smem_restore_factor_all[
-                        stage_f32_0 + restore_col
-                    ]  # .cu:2078
+                for restore_vec in T.unroll(2):  # .cu:2075-2079
+                    _ld_shared_v4_f32(
+                        restore_factor,
+                        restore_vec * 4,
+                        smem_restore_factor_all,
+                        stage_f32_0 + restore_segment * 8 + restore_vec * 4,
+                    )  # .cu:2078
                 for restore_pass in T.serial(
                     0, 6, unroll=False
                 ):  # .cu:2080-2081 (#pragma unroll 1)
@@ -3245,14 +3342,18 @@ def _kernel(
                 )
             elif prep_local_warp == 1:  # .cu:2405-2522
                 stage_f32_0_1: T.int32 = T.cast(prep_stage, "int32") * 10496  # .cu:2406
-                restore_scale_1: T.f32 = smem_restore_factor_all[stage_f32_0_1 + 128]  # .cu:2407
+                restore_scale_1: T.f32 = _ld_shared_f32(
+                    smem_restore_factor_all, stage_f32_0_1 + 128
+                )  # .cu:2407
                 restore_factor_1: T.f32[8]  # .cu:2408
                 restore_segment_1: T.int32 = lane & 15  # .cu:2409
-                for restore_elem_2 in T.unroll(8):  # .cu:2410-2414
-                    restore_col_1: T.int32 = restore_segment_1 * 8 + restore_elem_2  # .cu:2412
-                    restore_factor_1[restore_elem_2] = smem_restore_factor_all[
-                        stage_f32_0_1 + restore_col_1
-                    ]  # .cu:2413
+                for restore_vec_1 in T.unroll(2):  # .cu:2410-2414
+                    _ld_shared_v4_f32(
+                        restore_factor_1,
+                        restore_vec_1 * 4,
+                        smem_restore_factor_all,
+                        stage_f32_0_1 + restore_segment_1 * 8 + restore_vec_1 * 4,
+                    )  # .cu:2413
                 for restore_pass_1 in T.serial(0, 4, unroll=False):  # .cu:2415-2416
                     restore_row_1: T.int32 = restore_pass_1 * 2 + (lane >> 4)  # .cu:2417
                     restore_qd_values_1: T.f32[8]  # .cu:2418

--- a/tirx_kernels/flashkda/bf16_fused_m128.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128.py
@@ -116,38 +116,8 @@ LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
 # CUDA device helpers, transcribed in source order from
 # csrc/kda/flashkda_bf16_fused_m128.cu:110-496.
 #
-# Helpers whose PTX instruction form has an exact T.ptx/T.cuda wrapper use that
-# wrapper.  Helpers with no exact wrapper (token-returning waits, ticks waits,
-# raw-descriptor MMA, raw tensor-map TMA) keep the verbatim CUDA body behind a
-# target-local T.cuda.func_call inline fallback (see tirx_dsl_improve.md).
+# Helpers use the exact T.ptx/T.cuda wrappers available in the target TVM.
 # ---------------------------------------------------------------------------
-
-_FLASHKDA_SRCS = {
-    "flashkda_tensormap_acquire": r"""__device__ __forceinline__ void flashkda_tensormap_acquire(const void *tmap_ptr) {
-    asm volatile(
-        "fence.proxy.tensormap::generic.acquire.gpu [%0], 128;\n"
-        :: "l"(tmap_ptr) : "memory");
-}
-""",
-    "flashkda_tanh_approx": r"""// tanh.approx.f32 (sigmoid via tanh; used throughout the prep role)
-__device__ __forceinline__ float flashkda_tanh_approx(float x) {
-    float y;
-    asm volatile("tanh.approx.f32 %0, %1;" : "=f"(y) : "f"(x));
-    return y;
-}
-""",
-    "flashkda_fmaf_rn": r"""// __fmaf_rn (value form of fma.rn.f32)
-__device__ __forceinline__ float flashkda_fmaf_rn(float a, float b, float c) {
-    return __fmaf_rn(a, b, c);
-}
-""",
-    "flashkda_rsqrtf": r"""// rsqrtf
-__device__ __forceinline__ float flashkda_rsqrtf(float x) {
-    return rsqrtf(x);
-}
-""",
-}
-
 
 # tcgen05.mma spelling: kind::f16 from the (float32, bfloat16, bfloat16) dtypes; the A
 # operand is a uint32 TMEM address (use_a_tmem), which selects the ts form.
@@ -291,12 +261,9 @@ def _st_shared_f32(buffer, index, value):
 
 def _tanh_approx(x):
     # tanh.approx.f32 (prep-role sigmoid)
-    return T.cuda.func_call(
-        "flashkda_tanh_approx",
-        x,
-        source_code=_FLASHKDA_SRCS["flashkda_tanh_approx"],
-        return_type="float32",
-    )
+    result = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.tanh.approx.f32(result[0], x))
+    return result[0]
 
 
 def _expf(x):
@@ -307,22 +274,20 @@ def _expf(x):
 
 
 def _rsqrtf(x):
-    # rsqrtf verbatim
-    return T.cuda.func_call(
-        "flashkda_rsqrtf", x, source_code=_FLASHKDA_SRCS["flashkda_rsqrtf"], return_type="float32"
-    )
+    # CUDA's fast-math rsqrtf lowers to this exact PTX form.
+    result = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.rsqrt.approx.ftz.f32(result[0], x))
+    return result[0]
 
 
 def _fmaf_rn(a, b, c):
-    # __fmaf_rn verbatim (value form)
-    return T.cuda.func_call(
-        "flashkda_fmaf_rn",
-        a,
-        b,
-        c,
-        source_code=_FLASHKDA_SRCS["flashkda_fmaf_rn"],
-        return_type="float32",
-    )
+    result = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.fma.rn.f32(result[0], a, b, c))
+    return result[0]
+
+
+def _tensormap_acquire(tmap):
+    return T.ptx.fence.proxy.tensormap__generic.acquire.gpu(tmap)
 
 
 def _ld_shared_b32(smem_raw, smem, addr):
@@ -1113,42 +1078,12 @@ def _kernel(
 
     # .cu:504-521 (FLASHINFER INTEGRATION: acquire global tensor maps).
     if thread_idx == 0:
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            q_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            k_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            v_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            g_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            beta_tma_tmap,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            out_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
+        _tensormap_acquire(q_tma)
+        _tensormap_acquire(k_tma)
+        _tensormap_acquire(v_tma)
+        _tensormap_acquire(g_tma)
+        _tensormap_acquire(beta_tma_tmap)
+        _tensormap_acquire(out_tma)
     T.cuda.cta_sync()  # .cu:520 __syncthreads()
 
     # .cu:522-524

--- a/tirx_kernels/flashkda/bf16_fused_m128_tx_tile.py
+++ b/tirx_kernels/flashkda/bf16_fused_m128_tx_tile.py
@@ -22,7 +22,6 @@ import math
 from typing import Any
 
 from tirx_kernels.flashkda.bf16_fused_m128 import (
-    _FLASHKDA_SRCS,
     D_HEAD,
     LAUNCH_TAGS,
     MBAR_FINAL_READY_OFF,
@@ -115,6 +114,7 @@ from tirx_kernels.flashkda.bf16_fused_m128 import (
     _st_shared_b32,
     _sub_f32x2_inplace,
     _tanh_approx,
+    _tensormap_acquire,
     _tma_2d_gmem2smem,
     _tma_3d_gmem2smem,
     _tma_4d_gmem2smem,
@@ -271,42 +271,12 @@ def _kernel_tx_tile(
 
     # .cu:504-521 (FLASHINFER INTEGRATION: acquire global tensor maps).
     if thread_idx == 0:
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            q_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            k_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            v_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            g_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            beta_tma_tmap,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
-        T.cuda.func_call(
-            "flashkda_tensormap_acquire",
-            out_tma,
-            source_code=_FLASHKDA_SRCS["flashkda_tensormap_acquire"],
-            return_type="void",
-        )
+        _tensormap_acquire(q_tma)
+        _tensormap_acquire(k_tma)
+        _tensormap_acquire(v_tma)
+        _tensormap_acquire(g_tma)
+        _tensormap_acquire(beta_tma_tmap)
+        _tensormap_acquire(out_tma)
     T.cuda.cta_sync()  # .cu:520 __syncthreads()
 
     # .cu:522-524

--- a/tirx_kernels/flashmla/sparse_decode_head64.py
+++ b/tirx_kernels/flashmla/sparse_decode_head64.py
@@ -4,19 +4,17 @@ import math
 import random
 from dataclasses import dataclass, fields
 from enum import Enum
-from functools import lru_cache, partial
+from functools import lru_cache
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
-from tirx_kernels.flashmla._gemm import tcgen05_config
-from tirx_kernels.flashmla._tma import tma_config
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.ir import PointerType, PrimType
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.lang.pipeline import MBarrier, PipelineState, TCGen05Bar, TMABar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.layout import S, TileLayout, laneid, wid_in_wg
 
 B_H = 64
@@ -65,15 +63,51 @@ MainPresenceMask = tuple[bool, bool, bool, bool, bool]
 MAIN_OPTIONAL_ARG_INDICES = (3, 4, 11, 12, 13)
 COMBINE_OPTIONAL_ARG_INDICES = (5,)
 
-_mma_config = partial(tcgen05_config, cta_group=1)
-_kv_gather_tma = partial(
-    tma_config,
-    dispatch="tma_explicit",
-    cta_group=1,
-    cache_hint=T.uint64(0x14F0000000000000),
-    mbarrier_addr=True,
-    tensormap_l2_promotion="L2::128B",
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_TMEM_ST_64 = "tcgen05.st.sync.aligned.32x32b.x64.b32"
+_TMA_G2S_4D_CACHE = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
 )
+_TMA_G2S_5D_CACHE = (
+    "cp.async.bulk.tensor.5d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_GATHER4_2D_CACHE = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+_TCGEN_CP_128X256 = "tcgen05.cp.cta_group::1.128x256b"
+_MMA_WS_F16 = "tcgen05.mma.ws.cta_group::1.kind::f16"
+_Q_TMA_CACHE_HINT = T.uint64(0x12F0000000000000)
+_KV_TMA_CACHE_HINT = T.uint64(0x14F0000000000000)
+def _tmem_load(dst, tmem_col, width):
+    chain = _TMEM_LD_32 if width == 32 else _TMEM_LD_64
+    return T.ptx[chain](*[dst[i] for i in range(width)], tmem_col)
+
+
+def _tmem_store(src, tmem_col, width=64):
+    assert width == 64
+    return T.ptx[_TMEM_ST_64](tmem_col, *[src[i] for i in range(width)])
+
+
+def _cast_f32x2_bf16x2(dst, src, offset):
+    dst_words = dst.view("uint32")
+    return T.ptx.cvt.rn.bf16x2.f32(
+        dst_words[offset // 2], src[offset + 1], src[offset]
+    )
+
+
+def _replace_smem_desc_addr(desc, smem_ptr):
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
 
 
 class ModelType(str, Enum):
@@ -521,6 +555,175 @@ def _kernel(
         extra_kv_nope_tma = extra_kv.view("int64").sub[:, : d_nope // 8]
         extra_kv_rope_tma = extra_kv.sub[:, kv_rope_start : kv_rope_start + 64]
 
+    # The former tile lowering synthesized these host-side TensorMaps.
+    # Keep their exact rank, byte strides, boxes, swizzles, and L2 promotion
+    # in the public PrimFunc so construction no longer requires a lowering
+    # pass.  Alternate extra-cache maps deliberately are not prefetched,
+    # matching the source selector path emitted by the former dispatcher.
+    kv_rope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_rope_tensormap,
+        "bfloat16",
+        2,
+        T.handle_add_byte_offset(kv.data, kv_rope_start * BF16_BYTES),
+        64,
+        num_blocks * (stride_kv_block // tma_k_stride),
+        tma_k_stride,
+        rope_tile,
+        1,
+        1,
+        1,
+        0,
+        2 if is_v32 else 3,
+        2,
+        0,
+    )
+    kv_nope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_nope_tensormap,
+        "int64",
+        2,
+        kv.data,
+        d_nope // 8,
+        num_blocks * (stride_kv_block // tma_k_stride),
+        tma_k_stride,
+        d_nope // 8,
+        1,
+        1,
+        1,
+        0,
+        0,
+        2,
+        0,
+    )
+    if extra_kv_h is not None:
+        extra_kv_rope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            extra_kv_rope_tensormap,
+            "bfloat16",
+            2,
+            T.handle_add_byte_offset(extra_kv.data, kv_rope_start * BF16_BYTES),
+            64,
+            extra_num_blocks * (stride_extra_kv_block // tma_k_stride),
+            tma_k_stride,
+            rope_tile,
+            1,
+            1,
+            1,
+            0,
+            2 if is_v32 else 3,
+            2,
+            0,
+        )
+        extra_kv_nope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            extra_kv_nope_tensormap,
+            "int64",
+            2,
+            extra_kv.data,
+            d_nope // 8,
+            extra_num_blocks * (stride_extra_kv_block // tma_k_stride),
+            tma_k_stride,
+            d_nope // 8,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+    q_strided_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        q_strided_tensormap,
+        "bfloat16",
+        4,
+        q.data,
+        d_qk,
+        B_H,
+        s_q,
+        b,
+        stride_q_h_q * BF16_BYTES,
+        stride_q_s_q * BF16_BYTES,
+        stride_q_b * BF16_BYTES,
+        64,
+        B_H,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    if is_v32:
+        q_tail_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            q_tail_tensormap,
+            "bfloat16",
+            5,
+            q.data,
+            32,
+            B_H,
+            d_qk // 32,
+            s_q,
+            b,
+            stride_q_h_q * BF16_BYTES,
+            32 * BF16_BYTES,
+            stride_q_s_q * BF16_BYTES,
+            stride_q_b * BF16_BYTES,
+            32,
+            B_H,
+            2,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            2,
+            2,
+            0,
+        )
+    out_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        out_tensormap,
+        "bfloat16",
+        4,
+        out.data,
+        D_V,
+        B_H,
+        s_q,
+        b,
+        stride_o_h_q * BF16_BYTES,
+        stride_o_s_q * BF16_BYTES,
+        stride_o_b * BF16_BYTES,
+        64,
+        B_H,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+
     T.device_entry()
     T.attr(
         {"tirx.launch_bounds_min_blocks_per_sm": 1, "tirx.launch_bounds_max_blocks_per_cluster": 1}
@@ -530,11 +733,6 @@ def _kernel(
     # Python values; binding either as an ordinary scalar would turn it
     # into a TIR expression and destroy the C++ if-constexpr structure.
     source_smem_size = T.meta_var(232192 if is_v32 else 218848)
-    q_strided = q.sub[:, :s_q, :B_H, :d_qk]
-    if is_v32:
-        q_tail_tma = q_strided.view(b, s_q, B_H, d_qk // 32, 32).permute(0, 1, 3, 2, 4)
-    out_strided = out.sub[:, :s_q, :B_H, :D_V]
-
     # kernel.cuh:25-33.  Grid is exactly (s_q, num_sm_parts, 1), with
     # three 128-thread warpgroups and the same canonical role indices.
     s_q_idx, partition_idx, _ = T.cta_id([s_q, num_sm_parts, 1])
@@ -544,6 +742,19 @@ def _kernel(
     lane_idx = T.lane_id([32])
     idx_in_warpgroup = T.thread_id_in_wg([128])
     warp_idx: T.let = warpgroup_idx * 4 + warp_idx_in_wg
+
+    if warp_idx == 0:
+        if T.cuda.elect_sync() != T.uint32(0):
+            # The former dispatcher emitted one descriptor per syntactic
+            # output TMA site.  Eight prefetches preserve that PTX protocol
+            # while the explicit kernel safely reuses the identical map.
+            for _prefetch_i in T.unroll(8):
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(out_tensormap)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_strided_tensormap)))
+            if is_v32:
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_tail_tensormap)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_nope_tensormap)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_rope_tensormap)))
 
     # config.h:159-193.  Recreate SharedMemoryPlan's two unions.  V32 stores
     # each NoPE/RoPE stage contiguously as a 576-column SW128 allocation.
@@ -601,6 +812,27 @@ def _kernel(
     )
     pool.move_base_to(sp_union_end)
 
+    # Dispatcher-equivalent SMEM descriptors for the two SxV N-halves.
+    # Their bases are identical; separate values keep the two instruction
+    # streams and descriptor lifetimes aligned with the CUDA template.
+    pv_b_lo_desc = SmemDescriptor()
+    pv_b_lo_desc.init(k_full.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3)
+    pv_b_hi_desc = SmemDescriptor()
+    pv_b_hi_desc.init(k_full.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3)
+    pv_a_lo_desc = SmemDescriptor()
+    pv_a_lo_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+    pv_a_hi_desc = SmemDescriptor()
+    pv_a_hi_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+    q_main_cp_desc: T.uint64
+    T.cuda.tcgen05.encode_matrix_descriptor(
+        T.address_of(q_main_cp_desc), T.reinterpret(T.handle().ty, T.uint64(0)), 1, 64, 3
+    )
+    if is_v32:
+        q_tail_cp_desc: T.uint64
+        T.cuda.tcgen05.encode_matrix_descriptor(
+            T.address_of(q_tail_cp_desc), T.reinterpret(T.handle().ty, T.uint64(0)), 1, 32, 2
+        )
+
     rowwise_buf = pool.alloc((128,), "float32", align=16)
     is_token_valid = pool.alloc((NUM_INDEX_BUFS, B_TOPK // 8), "int8", align=16)
     tma_coord = pool.alloc((NUM_INDEX_BUFS, B_TOPK), "int32", align=16)
@@ -632,7 +864,6 @@ def _kernel(
     o_tmem = tmem_pool.alloc_tcgen05_mma_D(
         (B_H, D_V), "float32", M=64, cta_group=1, ws=True, group=(2, 2, 128)
     )
-    o_win = o_tmem.rearrange("h (a b c) -> (b h) (a c)", a=2, b=2, c=128)
     tmem_pool.move_base_to(256)
     q_tmem = tmem_pool.alloc_tcgen05_mma_A(
         (2, B_H, d_qk // 2), "bfloat16", M=64, cta_group=1, ws=True
@@ -692,7 +923,9 @@ def _kernel(
         T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
             T.address_of(tmem_start_addr[0]), T.uint32(512)
         )
-        T.cuda.trap_when_assert_failed(tmem_start_addr[0] == T.uint32(0))
+        allocated_tmem_start: T.uint32
+        T.ptx.ld.shared.u32(allocated_tmem_start, tmem_start_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(allocated_tmem_start == T.uint32(0))
         T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
     T.cuda.cta_sync()
 
@@ -703,7 +936,6 @@ def _kernel(
         T.ptx.setmaxnreg.inc.sync.aligned.u32(224)
         rs_buf = PipelineState(NUM_BUFS, phase=0)
         rs_index = PipelineState(NUM_INDEX_BUFS, phase=0)
-        p_tmem_win = p_tmem.rearrange("b h t -> (b h) t")
         s_frag_layout = TileLayout(
             S[(2, 32, 2, 32) : (1 @ wid_in_wg, 1 @ laneid, 2 @ wid_in_wg, 1)]
         )
@@ -794,20 +1026,34 @@ def _kernel(
                     p = p_frag.local()
                     p_peer = p_peer_frag.local()
                     if warp_idx < 2:
-                        Tx.wg.copy_async(p_frag[:, :], p_tmem_win.chunk((None, 2))[:, 0])
-                        Tx.wg.copy_async(p_peer_frag[:, :], p_tmem_win.chunk((None, 2))[:, 1])
+                        T.evaluate(_tmem_load(p, T.uint32(400), B_TOPK // 2))
+                        T.evaluate(
+                            _tmem_load(
+                                p_peer,
+                                T.cuda.get_tmem_addr(T.uint32(400), 0, B_TOPK // 2),
+                                B_TOPK // 2,
+                            )
+                        )
                     else:
-                        Tx.wg.copy_async(p_peer_frag[:, :], p_tmem_win.chunk((None, 2))[:, 0])
-                        Tx.wg.copy_async(p_frag[:, :], p_tmem_win.chunk((None, 2))[:, 1])
+                        T.evaluate(_tmem_load(p_peer, T.uint32(400), B_TOPK // 2))
+                        T.evaluate(
+                            _tmem_load(
+                                p, T.cuda.get_tmem_addr(T.uint32(400), 0, B_TOPK // 2), B_TOPK // 2
+                            )
+                        )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
                     T.ptx.tcgen05.fence__before_thread_sync()
 
                     for exchange_i in T.unroll((B_TOPK // 2) // 4):
                         exchange_offset: T.let = exchange_i * 32 * 4 + lane_idx * 4
-                        Tx.copy(
-                            p_exchange[warp_idx ^ 2, exchange_offset : exchange_offset + 4],
-                            p_peer[exchange_i * 4 : exchange_i * 4 + 4],
-                            dispatch="vec_128b",
+                        p_peer_words = p_peer.view("uint32")
+                        peer_word: T.let = exchange_i * 4
+                        T.ptx.st.shared.v4.u32(
+                            p_exchange.view("uint32").ptr_to([warp_idx ^ 2, exchange_offset]),
+                            p_peer_words[peer_word],
+                            p_peer_words[peer_word + 1],
+                            p_peer_words[peer_word + 2],
+                            p_peer_words[peer_word + 3],
                         )
                     T.ptx.bar.sync(
                         T.uint32(BAR_WG0_WARP02 + T.bitwise_and(warp_idx, T.int32(1))), 64
@@ -815,10 +1061,13 @@ def _kernel(
                     for exchange_i in T.unroll((B_TOPK // 2) // 4):
                         exchange_offset: T.let = exchange_i * 32 * 4 + lane_idx * 4
                         peer_tmp = T.alloc_local((4,), "float32")
-                        Tx.copy(
-                            peer_tmp[0:4],
-                            p_exchange[warp_idx, exchange_offset : exchange_offset + 4],
-                            dispatch="vec_128b",
+                        peer_tmp_words = peer_tmp.view("uint32")
+                        T.ptx.ld.shared.v4.u32(
+                            peer_tmp_words[0],
+                            peer_tmp_words[1],
+                            peer_tmp_words[2],
+                            peer_tmp_words[3],
+                            p_exchange.view("uint32").ptr_to([warp_idx, exchange_offset]),
                         )
                         pair0: T.uint64
                         pair1: T.uint64
@@ -837,9 +1086,13 @@ def _kernel(
                         p[exchange_i * 4 + 2] = T.cuda.float2_x(pair1)
                         p[exchange_i * 4 + 3] = T.cuda.float2_y(pair1)
 
-                    valid_word: T.let = is_token_valid.view("uint32")[
-                        rs_index.stage, T.if_then_else(idx_in_warpgroup >= 64, 1, 0)
-                    ]
+                    valid_word: T.uint32
+                    T.ptx.ld.shared.u32(
+                        valid_word,
+                        is_token_valid.view("uint32").ptr_to(
+                            [rs_index.stage, T.if_then_else(idx_in_warpgroup >= 64, 1, 0)]
+                        ),
+                    )
                     for p_i in T.unroll(B_TOPK // 2):
                         if T.bitwise_and(
                             T.shift_right(valid_word, T.cast(p_i, "uint32")), T.uint32(1)
@@ -850,10 +1103,12 @@ def _kernel(
                     for p_i in T.unroll(B_TOPK // 2):
                         cur_pi_max = T.max(cur_pi_max, p[p_i])
                     cur_pi_max = cur_pi_max * sm_scale_div_log2
-                    rowwise_buf[idx_in_warpgroup] = cur_pi_max
+                    T.ptx.st.shared.f32(rowwise_buf.ptr_to([idx_in_warpgroup]), cur_pi_max)
                     T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
                     bar_valid_free.arrive(rs_index.stage)
-                    cur_pi_max = T.max(cur_pi_max, rowwise_buf[idx_in_warpgroup ^ 64])
+                    peer_pi_max: T.float32
+                    T.ptx.ld.shared.f32(peer_pi_max, rowwise_buf.ptr_to([idx_in_warpgroup ^ 64]))
+                    cur_pi_max = T.max(cur_pi_max, peer_pi_max)
                     real_mi = T.max(real_mi, cur_pi_max)
                     should_scale_o: T.let = (
                         T.cuda.any_sync(T.uint32(0xFFFFFFFF), cur_pi_max - mi > 6.0) != 0
@@ -889,16 +1144,34 @@ def _kernel(
                     T.ptx.fma.rn.f32(li_next, li, scale_for_old, cur_sum)
                     li = li_next
 
-                    Tx.wg.copy(s_smem_gemm[:, :], s_frag[:, :])
+                    s_base: T.let = idx_in_warpgroup // 64 * 2048 + idx_in_warpgroup % 64 * 8
+                    s_words = s_frag.local().view("uint32")
+                    for s_store_i in T.unroll(4):
+                        s_ptr: T.let = T.ptr_byte_offset(
+                            s_smem_gemm.ptr_to([0, 0]),
+                            (s_base + s_store_i * 512) * BF16_BYTES,
+                            "bfloat16",
+                        )
+                        s_word: T.let = s_store_i * 4
+                        T.ptx.st.shared.v4.u32(
+                            s_ptr,
+                            s_words[s_word],
+                            s_words[s_word + 1],
+                            s_words[s_word + 2],
+                            s_words[s_word + 3],
+                        )
                     if T.And(block_idx != start_block, should_scale_o):
                         scale_for_old_pair: T.let = T.cuda.make_float2(scale_for_old, scale_for_old)
                         T.ptx.tcgen05.fence__after_thread_sync()
                         o_rescale_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 64), "float32")
                         o_rescale = o_rescale_frag.local()
                         for o_chunk in T.unroll((D_V // 2) // 64):
-                            Tx.wg.copy_async(
-                                o_rescale_frag[:, :],
-                                o_win.chunk((None, (D_V // 2) // 64))[:, o_chunk],
+                            T.evaluate(
+                                _tmem_load(
+                                    o_rescale,
+                                    T.cuda.get_tmem_addr(T.uint32(0), 0, o_chunk * 64),
+                                    64,
+                                )
                             )
                             T.ptx.tcgen05.wait__ld.sync.aligned()
                             scaled_pair: T.uint64
@@ -912,9 +1185,10 @@ def _kernel(
                                 )
                                 o_rescale[scale_i * 2] = T.cuda.float2_x(scaled_pair)
                                 o_rescale[scale_i * 2 + 1] = T.cuda.float2_y(scaled_pair)
-                            Tx.wg.copy_async(
-                                o_win.chunk((None, (D_V // 2) // 64))[:, o_chunk],
-                                o_rescale_frag[:, :],
+                            T.evaluate(
+                                _tmem_store(
+                                    o_rescale, T.cuda.get_tmem_addr(T.uint32(0), 0, o_chunk * 64)
+                                )
                             )
                             T.ptx.tcgen05.wait__st.sync.aligned()
                         T.ptx.tcgen05.fence__before_thread_sync()
@@ -934,24 +1208,40 @@ def _kernel(
                 # allocation above.  Do not let a faster warp reuse the same
                 # locations for ``li`` until all of those reads have retired.
                 T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-                rowwise_buf[idx_in_warpgroup] = li
+                T.ptx.st.shared.f32(rowwise_buf.ptr_to([idx_in_warpgroup]), li)
                 T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-                li = li + rowwise_buf[idx_in_warpgroup ^ 64]
+                peer_li: T.float32
+                T.ptx.ld.shared.f32(peer_li, rowwise_buf.ptr_to([idx_in_warpgroup ^ 64]))
+                li = li + peer_li
                 if idx_in_warpgroup < B_H:
                     if is_no_split:
                         cur_lse: T.float32
                         T.ptx.fma.rn.f32(cur_lse, mi, T.float32(LN_2), T.log(li))
-                        lse[
-                            batch_idx * stride_lse_b + s_q_idx * stride_lse_s_q + idx_in_warpgroup
-                        ] = T.if_then_else(
-                            cur_lse == T.float32(-float("inf")), T.float32(float("inf")), cur_lse
+                        T.ptx.st.global_.f32(
+                            lse.ptr_to(
+                                [
+                                    batch_idx * stride_lse_b
+                                    + s_q_idx * stride_lse_s_q
+                                    + idx_in_warpgroup
+                                ]
+                            ),
+                            T.if_then_else(
+                                cur_lse == T.float32(-float("inf")),
+                                T.float32(float("inf")),
+                                cur_lse,
+                            ),
                         )
                     else:
-                        lse_accum[
-                            n_split_idx * stride_lse_accum_split
-                            + s_q_idx * stride_lse_accum_s_q
-                            + idx_in_warpgroup
-                        ] = T.log2(li) + mi
+                        T.ptx.st.global_.f32(
+                            lse_accum.ptr_to(
+                                [
+                                    n_split_idx * stride_lse_accum_split
+                                    + s_q_idx * stride_lse_accum_s_q
+                                    + idx_in_warpgroup
+                                ]
+                            ),
+                            T.log2(li) + mi,
+                        )
                 bar_sv_done.wait(rs_buf.stage, rs_buf.phase)
                 rs_buf.advance()
                 rs_index.advance()
@@ -976,8 +1266,8 @@ def _kernel(
 
                     @T.inline
                     def emit_no_split_epilogue(epi_i: T.constexpr):
-                        Tx.wg.copy_async(
-                            o_epi_frag[:, :], o_win.chunk((None, (D_V // 2) // 64))[:, epi_i]
+                        T.evaluate(
+                            _tmem_load(o_epi, T.cuda.get_tmem_addr(T.uint32(0), 0, epi_i * 64), 64)
                         )
                         T.ptx.tcgen05.wait__ld.sync.aligned()
                         scaled_pair: T.uint64
@@ -989,36 +1279,77 @@ def _kernel(
                             )
                             o_epi[scale_i * 2] = T.cuda.float2_x(scaled_pair)
                             o_epi[scale_i * 2 + 1] = T.cuda.float2_y(scaled_pair)
-                        Tx.wg.cast(o_epi_bf16_frag[:, :], o_epi_frag[:, :])
+                        o_epi_bf16 = o_epi_bf16_frag.local()
+                        for cast_i in T.unroll(64 // 2):
+                            T.evaluate(_cast_f32x2_bf16x2(o_epi_bf16, o_epi, cast_i * 2))
                         col_base = T.meta_var(
                             (D_V // 2 if epi_i * 64 >= D_V // 4 else 0) + (epi_i * 64) % (D_V // 4)
                         )
-                        Tx.wg.copy(
-                            o_smem_win.chunk((None, (D_V // 2) // 64))[:, epi_i],
-                            o_epi_bf16_frag[:, :],
-                        )
+                        o_epi_words = o_epi_bf16.view("uint32")
+                        for o_store_i in T.unroll(8):
+                            o_smem_offset: T.let = (
+                                col_base * B_H
+                                + idx_in_warpgroup // 64 * 8192
+                                + idx_in_warpgroup % 64 * 64
+                                + T.bitwise_xor(
+                                    o_store_i * 8,
+                                    T.shift_left(
+                                        T.bitwise_and(
+                                            idx_in_warpgroup // 64 * 128 + idx_in_warpgroup % 64, 7
+                                        ),
+                                        3,
+                                    ),
+                                )
+                            )
+                            o_smem_ptr: T.let = T.ptr_byte_offset(
+                                o_smem_win.ptr_to([0, 0]), o_smem_offset * BF16_BYTES, "bfloat16"
+                            )
+                            o_word: T.let = o_store_i * 4
+                            T.ptx.st.shared.v4.u32(
+                                o_smem_ptr,
+                                o_epi_words[o_word],
+                                o_epi_words[o_word + 1],
+                                o_epi_words[o_word + 2],
+                                o_epi_words[o_word + 3],
+                            )
                         T.ptx.fence.proxy.async_.shared__cta()
                         T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
                         if warp_idx == 0:
                             if T.cuda.elect_sync() != T.uint32(0):
-                                Tx.copy_async(
-                                    out_strided[batch_idx, s_q_idx, :, col_base : col_base + 64],
-                                    o_smem[:, col_base : col_base + 64],
-                                    **tma_config(
-                                        dispatch="tma_explicit", tensormap_l2_promotion="L2::128B"
-                                    ),
+                                T.evaluate(
+                                    T.ptx[_TMA_S2G_4D](
+                                        T.address_of(out_tensormap),
+                                        T.int32(col_base),
+                                        T.int32(0),
+                                        T.cast(s_q_idx, "int32"),
+                                        T.cast(batch_idx, "int32"),
+                                        T.cuda.cvta_generic_to_shared(
+                                            T.ptr_byte_offset(
+                                                o_smem.ptr_to([0, 0]),
+                                                col_base * B_H * BF16_BYTES,
+                                                "bfloat16",
+                                            )
+                                        ),
+                                    )
                                 )
                         warp1_col_base = T.meta_var(col_base + D_V // 4)
                         if warp_idx == 1:
                             if T.cuda.elect_sync() != T.uint32(0):
-                                Tx.copy_async(
-                                    out_strided[
-                                        batch_idx, s_q_idx, :, warp1_col_base : warp1_col_base + 64
-                                    ],
-                                    o_smem[:, warp1_col_base : warp1_col_base + 64],
-                                    **tma_config(
-                                        dispatch="tma_explicit", tensormap_l2_promotion="L2::128B"
-                                    ),
+                                T.evaluate(
+                                    T.ptx[_TMA_S2G_4D](
+                                        T.address_of(out_tensormap),
+                                        T.int32(warp1_col_base),
+                                        T.int32(0),
+                                        T.cast(s_q_idx, "int32"),
+                                        T.cast(batch_idx, "int32"),
+                                        T.cuda.cvta_generic_to_shared(
+                                            T.ptr_byte_offset(
+                                                o_smem.ptr_to([0, 0]),
+                                                warp1_col_base * B_H * BF16_BYTES,
+                                                "bfloat16",
+                                            )
+                                        ),
+                                    )
                                 )
 
                     emit_no_split_epilogue(0)
@@ -1032,8 +1363,10 @@ def _kernel(
                     split_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 64), "float32")
                     split_local = split_frag.local()
                     for epi_i in T.unroll((D_V // 2) // 64):
-                        Tx.wg.copy_async(
-                            split_frag[:, :], o_win.chunk((None, (D_V // 2) // 64))[:, epi_i]
+                        T.evaluate(
+                            _tmem_load(
+                                split_local, T.cuda.get_tmem_addr(T.uint32(0), 0, epi_i * 64), 64
+                            )
                         )
                         T.ptx.tcgen05.wait__ld.sync.aligned()
                         scaled_pair: T.uint64
@@ -1052,13 +1385,17 @@ def _kernel(
                             + T.if_then_else(epi_i * 64 >= D_V // 4, D_V // 2, 0)
                             + (epi_i * 64) % (D_V // 4)
                         )
+                        split_words = split_local.view("uint32")
                         for j in T.unroll(64 // 4):
-                            Tx.copy(
-                                o_accum_smem[
-                                    idx_in_warpgroup % 64, col_base + j * 4 : col_base + j * 4 + 4
-                                ],
-                                split_local[j * 4 : j * 4 + 4],
-                                dispatch="vec_128b",
+                            split_word: T.let = j * 4
+                            T.ptx.st.shared.v4.u32(
+                                o_accum_smem.view("uint32").ptr_to(
+                                    [idx_in_warpgroup % 64, col_base + j * 4]
+                                ),
+                                split_words[split_word],
+                                split_words[split_word + 1],
+                                split_words[split_word + 2],
+                                split_words[split_word + 3],
                             )
                     T.ptx.fence.proxy.async_.shared__cta()
                     T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
@@ -1104,11 +1441,16 @@ def _kernel(
             rs_buf = PipelineState(NUM_BUFS, phase=0)
             rs_index = PipelineState(NUM_INDEX_BUFS, phase=0)
             q_sw128_tmem = q_tmem.sub[:, :, 0:256]
-            q_sw128_tmem_cp = q_sw128_tmem.rearrange("b h (dc di) -> h dc b di", di=64)
             k_full_tiled = k_full.rearrange("b r (dc h ci) -> b (h r) (dc ci)", dc=4, h=2, ci=64)
             q_tail_tmem = q_tmem.sub[:, :, q_tail_start : q_tail_start + 32]
-            q_tail_tmem_cp = q_tail_tmem.rearrange("b h k -> h (b k)")
             k_rope_tiled = k_rope.rearrange("b r (h ci) -> b (h r) ci", h=2, ci=32)
+
+            qk_nope_desc = SmemDescriptor()
+            qk_rope_desc = SmemDescriptor()
+            if role == 4:
+                qk_nope_desc.init(k_full_tiled.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+                if is_v32:
+                    qk_rope_desc.init(k_rope_tiled.ptr_to([0, 0, 0]), ldo=0, sdo=32, swizzle=2)
 
             # kernel.cuh:657-667.  These warp-7 invariants are deliberately
             # materialized before the scheduler traversal.  Pointer bases are
@@ -1197,40 +1539,66 @@ def _kernel(
                         # copy into eight source-order TMA boxes instead of
                         # issuing one monolithic 64 KiB transaction.
                         for q_tile in T.unroll(512 // 64):
-                            Tx.copy_async(
-                                q_sw128[:, q_tile * 64 : (q_tile + 1) * 64],
-                                q_strided[batch_idx, s_q_idx, :, q_tile * 64 : (q_tile + 1) * 64],
-                                **tma_config(
-                                    dispatch="tma_explicit",
-                                    mbar=bar_q_tma.ptr_to([0]),
-                                    cta_group=1,
-                                    cache_hint="evict_first",
-                                    tensormap_l2_promotion="L2::128B",
-                                ),
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_4D_CACHE](
+                                    T.ptr_byte_offset(
+                                        q_sw128.ptr_to([0, 0]),
+                                        q_tile * B_H * 64 * BF16_BYTES,
+                                        "bfloat16",
+                                    ),
+                                    T.address_of(q_strided_tensormap),
+                                    T.cast(q_tile * 64, "int32"),
+                                    T.int32(0),
+                                    T.cast(s_q_idx, "int32"),
+                                    T.cast(batch_idx, "int32"),
+                                    T.cuda.cvta_generic_to_shared(bar_q_tma.ptr_to([0])),
+                                    _Q_TMA_CACHE_HINT,
+                                )
                             )
                         if is_v32:
-                            Tx.copy_async(
-                                q_sw64.rearrange("h (a c) -> a h c", a=2, c=32)[:, :, :],
-                                q_tail_tma[batch_idx, s_q_idx, 16:18, :, :],
-                                **tma_config(
-                                    dispatch="tma_explicit",
-                                    mbar=bar_q_tma.ptr_to([0]),
-                                    cta_group=1,
-                                    cache_hint="evict_first",
-                                    tensormap_l2_promotion="L2::128B",
-                                ),
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_5D_CACHE](
+                                    q_sw64.ptr_to([0, 0]),
+                                    T.address_of(q_tail_tensormap),
+                                    T.int32(0),
+                                    T.int32(0),
+                                    T.int32(16),
+                                    T.cast(s_q_idx, "int32"),
+                                    T.cast(batch_idx, "int32"),
+                                    T.cuda.cvta_generic_to_shared(bar_q_tma.ptr_to([0])),
+                                    _Q_TMA_CACHE_HINT,
+                                )
                             )
                         bar_q_tma.arrive(0, tx_count=B_H * d_qk * BF16_BYTES)
                         bar_q_tma.wait(0, batch_bar_phase)
                         T.ptx.tcgen05.fence__after_thread_sync()
-                        Tx.copy_async(
-                            q_sw128_tmem_cp[:, :, :, :],
-                            q_sw128.view(B_H, 4, 2, 64)[:, :, :, :],
-                            shape="128x256b",
-                            cta_group=1,
-                        )
+                        q_main_cp_view = q_sw128.view(B_H, 4, 2, 64)
+                        for q_main_flat in T.unroll(16):
+                            q_main_src: T.let = T.ptr_byte_offset(
+                                q_main_cp_view.ptr_to([0, 0, 0, 0]),
+                                (q_main_flat % 4 * 1024 + q_main_flat // 4 % 4 * 2) * 16,
+                                "bfloat16",
+                            )
+                            T.evaluate(
+                                T.ptx[_TCGEN_CP_128X256](
+                                    T.cast(
+                                        256 + q_main_flat % 4 * 32 + q_main_flat // 4 % 4 * 8,
+                                        "uint32",
+                                    ),
+                                    _replace_smem_desc_addr(q_main_cp_desc, q_main_src),
+                                )
+                            )
                         if is_v32:
-                            Tx.copy_async(q_tail_tmem_cp[:, :], q_sw64[:, :])
+                            for q_tail_flat in T.unroll(2):
+                                q_tail_src: T.let = T.ptr_byte_offset(
+                                    q_sw64.ptr_to([0, 0]), q_tail_flat % 2 * 2 * 16, "bfloat16"
+                                )
+                                T.evaluate(
+                                    T.ptx[_TCGEN_CP_128X256](
+                                        T.cast(384 + q_tail_flat % 2 * 8, "uint32"),
+                                        _replace_smem_desc_addr(q_tail_cp_desc, q_tail_src),
+                                    )
+                                )
                         bar_q_utccp.arrive(0)
                         bar_q_utccp.wait(0, batch_bar_phase)
                         T.ptx.tcgen05.fence__after_thread_sync()
@@ -1239,32 +1607,53 @@ def _kernel(
                         # shared K latent is interpreted; both instances issue
                         # the same dual-head P and SxV pipelines.
                         for block_idx in T.serial(start_block, end_block, unroll=False):
+                            k_stage_elems = T.meta_var(
+                                B_TOPK * (D_V + 64) if is_v32 else B_TOPK * D_V
+                            )
                             if is_v32:
                                 bar_rope_ready.wait(rs_buf.stage, rs_buf.phase)
                                 T.ptx.tcgen05.fence__after_thread_sync()
-                                Tx.gemm_async(
-                                    p_tmem[:, :, :],
-                                    q_tail_tmem[:, :, :],
-                                    k_rope_tiled[rs_buf.stage, :, :],
-                                    **_mma_config(accum=T.uint32(0)),
-                                )
+                                for qk_rope_ki in T.unroll(2):
+                                    qk_rope_offset: T.let = (
+                                        rs_buf.stage * k_stage_elems + qk_rope_ki * 16
+                                    ) // 8
+                                    T.evaluate(
+                                        T.ptx[_MMA_WS_F16](
+                                            T.uint32(400),
+                                            T.cast(384 + qk_rope_ki * 8, "uint32"),
+                                            qk_rope_desc.add_16B_offset(qk_rope_offset),
+                                            T.uint32(69207184),
+                                            qk_rope_ki != 0,
+                                            T.uint64(0),
+                                        )
+                                    )
                                 bar_nope_ready.wait(rs_buf.stage, rs_buf.phase)
                                 T.ptx.tcgen05.fence__after_thread_sync()
-                                Tx.gemm_async(
-                                    p_tmem[:, :, :],
-                                    q_sw128_tmem[:, :, :],
-                                    k_full_tiled[rs_buf.stage, :, :],
-                                    **_mma_config(accum=T.uint32(1)),
-                                )
                             else:
                                 bar_rope_ready.wait(rs_buf.stage, rs_buf.phase)
                                 bar_nope_ready.wait(rs_buf.stage, rs_buf.phase)
                                 T.ptx.tcgen05.fence__after_thread_sync()
-                                Tx.gemm_async(
-                                    p_tmem[:, :, :],
-                                    q_sw128_tmem[:, :, :],
-                                    k_full_tiled[rs_buf.stage, :, :],
-                                    **_mma_config(accum=T.uint32(0)),
+
+                            for qk_nope_ki in T.unroll(16):
+                                qk_nope_offset: T.let = (
+                                    qk_nope_ki // 2048 * k_stage_elems
+                                    + rs_buf.stage * k_stage_elems
+                                    + qk_nope_ki % 16 // 4 * 8192
+                                    + qk_nope_ki % 2048 // 16 * 64
+                                    + qk_nope_ki % 4 * 16
+                                ) // 8
+                                T.evaluate(
+                                    T.ptx[_MMA_WS_F16](
+                                        T.uint32(400),
+                                        T.cast(256 + qk_nope_ki * 8, "uint32"),
+                                        qk_nope_desc.add_16B_offset(qk_nope_offset),
+                                        T.uint32(69207184),
+                                        T.Or(
+                                            qk_nope_ki != 0,
+                                            T.cast(T.uint32(1 if is_v32 else 0), "bool"),
+                                        ),
+                                        T.uint64(0),
+                                    )
                                 )
                             bar_qk_done.arrive(rs_buf.stage)
 
@@ -1273,20 +1662,41 @@ def _kernel(
                             mma_o_accum: T.let = T.if_then_else(
                                 block_idx == start_block, T.uint32(0), T.uint32(1)
                             )
-                            Tx.gemm_async(
-                                o_tmem.sub[:, 0 : D_V // 2],
-                                s_smem_gemm[:, :],
-                                k_full[rs_buf.stage, :, 0 : D_V // 2],
-                                transB=True,
-                                **_mma_config(accum=mma_o_accum),
-                            )
-                            Tx.gemm_async(
-                                o_tmem.sub[:, D_V // 2 : D_V],
-                                s_smem_gemm[:, :],
-                                k_full[rs_buf.stage, :, D_V // 2 : D_V],
-                                transB=True,
-                                **_mma_config(accum=mma_o_accum),
-                            )
+                            for pv_ki in T.unroll(4):
+                                pv_a_offset: T.let = (pv_ki % 4 * 1024 + pv_ki // 4 * 8) // 8
+                                pv_b_lo_offset: T.let = (
+                                    (pv_ki * 16) // 64 * k_stage_elems
+                                    + rs_buf.stage * k_stage_elems
+                                    + (pv_ki * 16) % 64 * 64
+                                ) // 8
+                                T.evaluate(
+                                    T.ptx[_MMA_WS_F16](
+                                        T.uint32(0),
+                                        pv_a_lo_desc.add_16B_offset(pv_a_offset),
+                                        pv_b_lo_desc.add_16B_offset(pv_b_lo_offset),
+                                        T.uint32(71369872),
+                                        T.Or(pv_ki != 0, T.cast(mma_o_accum, "bool")),
+                                        T.uint64(0),
+                                    )
+                                )
+                            for pv_ki in T.unroll(4):
+                                pv_a_offset: T.let = (pv_ki % 4 * 1024 + pv_ki // 4 * 8) // 8
+                                pv_b_hi_offset: T.let = (
+                                    (pv_ki * 16) // 64 * k_stage_elems
+                                    + rs_buf.stage * k_stage_elems
+                                    + (pv_ki * 16) % 64 * 64
+                                    + 16384
+                                ) // 8
+                                T.evaluate(
+                                    T.ptx[_MMA_WS_F16](
+                                        T.uint32(128),
+                                        pv_a_hi_desc.add_16B_offset(pv_a_offset),
+                                        pv_b_hi_desc.add_16B_offset(pv_b_hi_offset),
+                                        T.uint32(71369872),
+                                        T.Or(pv_ki != 0, T.cast(mma_o_accum, "bool")),
+                                        T.uint64(0),
+                                    )
+                                )
                             bar_sv_done.arrive(rs_buf.stage)
                             rs_buf.advance()
                             rs_index.advance()
@@ -1301,31 +1711,50 @@ def _kernel(
                             bar_raw_free.wait(rs_buf.stage, rs_buf.phase ^ 1)
                             cur_indices = T.alloc_local((4,), "int32")
                             next_indices = T.alloc_local((4,), "int32")
-                            Tx.copy(
-                                cur_indices[0:4],
-                                tma_coord[rs_index.stage, 0:4],
-                                dispatch="vec_128b",
+                            cur_index_words = cur_indices.view("uint32")
+                            T.ptx.ld.shared.v4.u32(
+                                cur_index_words[0],
+                                cur_index_words[1],
+                                cur_index_words[2],
+                                cur_index_words[3],
+                                tma_coord.view("uint32").ptr_to([rs_index.stage, 0]),
                             )
                             for row4 in T.unroll(B_TOPK // 4):
                                 row: T.let = row4 * 4
                                 if row + 4 < B_TOPK:
-                                    Tx.copy(
-                                        next_indices[0:4],
-                                        tma_coord[rs_index.stage, row + 4 : row + 8],
-                                        dispatch="vec_128b",
+                                    next_index_words = next_indices.view("uint32")
+                                    T.ptx.ld.shared.v4.u32(
+                                        next_index_words[0],
+                                        next_index_words[1],
+                                        next_index_words[2],
+                                        next_index_words[3],
+                                        tma_coord.view("uint32").ptr_to([rs_index.stage, row + 4]),
                                     )
-                                Tx.copy_async(
-                                    raw_nope.sub[rs_buf.stage, :, :][row : row + 4, :],
-                                    kv_nope_tma[0:1, :],
-                                    **_kv_gather_tma(
-                                        mbar=bar_raw_ready.ptr_to([rs_buf.stage]),
-                                        gather4=[cur_indices[j] for j in range(4)],
-                                        src_selector=(
-                                            [(block_idx >= num_orig_blocks, extra_kv_nope_tma)]
-                                            if extra_kv_h is not None
-                                            else None
+                                selected_nope_tensormap: T.uint64 = T.reinterpret(
+                                    "uint64", T.address_of(kv_nope_tensormap)
+                                )
+                                if extra_kv_h is not None:
+                                    selected_nope_tensormap = T.if_then_else(
+                                        block_idx >= num_orig_blocks,
+                                        T.reinterpret(
+                                            "uint64", T.address_of(extra_kv_nope_tensormap)
                                         ),
-                                    ),
+                                        T.reinterpret("uint64", T.address_of(kv_nope_tensormap)),
+                                    )
+                                T.evaluate(
+                                    T.ptx[_TMA_GATHER4_2D_CACHE](
+                                        raw_nope.ptr_to([rs_buf.stage, row, 0]),
+                                        T.reinterpret(T.handle().ty, selected_nope_tensormap),
+                                        T.int32(0),
+                                        cur_indices[0],
+                                        cur_indices[1],
+                                        cur_indices[2],
+                                        cur_indices[3],
+                                        T.cuda.cvta_generic_to_shared(
+                                            bar_raw_ready.ptr_to([rs_buf.stage])
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
                                 )
                                 cur_indices[0] = next_indices[0]
                                 cur_indices[1] = next_indices[1]
@@ -1350,37 +1779,75 @@ def _kernel(
                                 bar_sv_done.wait(rs_buf.stage, rs_buf.phase ^ 1)
                             cur_indices = T.alloc_local((4,), "int32")
                             next_indices = T.alloc_local((4,), "int32")
-                            Tx.copy(
-                                cur_indices[0:4],
-                                tma_coord[rs_index.stage, 0:4],
-                                dispatch="vec_128b",
+                            cur_index_words = cur_indices.view("uint32")
+                            T.ptx.ld.shared.v4.u32(
+                                cur_index_words[0],
+                                cur_index_words[1],
+                                cur_index_words[2],
+                                cur_index_words[3],
+                                tma_coord.view("uint32").ptr_to([rs_index.stage, 0]),
                             )
                             for row4 in T.unroll(B_TOPK // 4):
                                 row: T.let = row4 * 4
                                 if row + 4 < B_TOPK:
-                                    Tx.copy(
-                                        next_indices[0:4],
-                                        tma_coord[rs_index.stage, row + 4 : row + 8],
-                                        dispatch="vec_128b",
+                                    next_index_words = next_indices.view("uint32")
+                                    T.ptx.ld.shared.v4.u32(
+                                        next_index_words[0],
+                                        next_index_words[1],
+                                        next_index_words[2],
+                                        next_index_words[3],
+                                        tma_coord.view("uint32").ptr_to([rs_index.stage, row + 4]),
                                     )
                                 for rope_part in T.unroll(64 // rope_tile):
-                                    Tx.copy_async(
-                                        k_rope_tma.sub[rs_buf.stage, :, :][
-                                            row : row + 4,
-                                            rope_part * rope_tile : (rope_part + 1) * rope_tile,
-                                        ],
-                                        kv_rope_tma[
-                                            0:1, rope_part * rope_tile : (rope_part + 1) * rope_tile
-                                        ],
-                                        **_kv_gather_tma(
-                                            mbar=bar_rope_ready.ptr_to([rs_buf.stage]),
-                                            gather4=[cur_indices[j] for j in range(4)],
-                                            src_selector=(
-                                                [(block_idx >= num_orig_blocks, extra_kv_rope_tma)]
-                                                if extra_kv_h is not None
-                                                else None
+                                    if is_v32:
+                                        rope_tma_dst: T.let = T.ptr_byte_offset(
+                                            k_union.ptr_to([0, 0, 0]),
+                                            (
+                                                rs_buf.stage * B_TOPK * (D_V + 64)
+                                                + (D_V + rope_part * rope_tile) * B_TOPK
+                                                + row * rope_tile
+                                            )
+                                            * BF16_BYTES,
+                                            "bfloat16",
+                                        )
+                                    else:
+                                        rope_tma_dst: T.let = T.ptr_byte_offset(
+                                            k_full.ptr_to([0, 0, 0]),
+                                            (
+                                                rs_buf.stage * B_TOPK * D_V
+                                                + d_nope * B_TOPK
+                                                + row * 64
+                                            )
+                                            * BF16_BYTES,
+                                            "bfloat16",
+                                        )
+                                    selected_rope_tensormap: T.uint64 = T.reinterpret(
+                                        "uint64", T.address_of(kv_rope_tensormap)
+                                    )
+                                    if extra_kv_h is not None:
+                                        selected_rope_tensormap = T.if_then_else(
+                                            block_idx >= num_orig_blocks,
+                                            T.reinterpret(
+                                                "uint64", T.address_of(extra_kv_rope_tensormap)
                                             ),
-                                        ),
+                                            T.reinterpret(
+                                                "uint64", T.address_of(kv_rope_tensormap)
+                                            ),
+                                        )
+                                    T.evaluate(
+                                        T.ptx[_TMA_GATHER4_2D_CACHE](
+                                            rope_tma_dst,
+                                            T.reinterpret(T.handle().ty, selected_rope_tensormap),
+                                            T.cast(rope_part * rope_tile, "int32"),
+                                            cur_indices[0],
+                                            cur_indices[1],
+                                            cur_indices[2],
+                                            cur_indices[3],
+                                            T.cuda.cvta_generic_to_shared(
+                                                bar_rope_ready.ptr_to([rs_buf.stage])
+                                            ),
+                                            _KV_TMA_CACHE_HINT,
+                                        )
                                     )
                                 cur_indices[0] = next_indices[0]
                                 cur_indices[1] = next_indices[1]
@@ -1427,23 +1894,20 @@ def _kernel(
                             )
 
                             pair_indices = T.alloc_local((2,), "int32")
+                            pair_index_words = pair_indices.view("uint32")
                             if is_extra:
-                                Tx.copy(
-                                    pair_indices[0:2],
-                                    extra_indices[
-                                        extra_indices_base + abs_pos : extra_indices_base
-                                        + abs_pos
-                                        + 2
-                                    ],
-                                    dispatch="vec_64b",
-                                    cache="nc",
+                                T.ptx.ld.global_.nc.v2.u32(
+                                    pair_index_words[0],
+                                    pair_index_words[1],
+                                    extra_indices.view("uint32").ptr_to(
+                                        [extra_indices_base + abs_pos]
+                                    ),
                                 )
                             else:
-                                Tx.copy(
-                                    pair_indices[0:2],
-                                    indices[indices_base + abs_pos : indices_base + abs_pos + 2],
-                                    dispatch="vec_64b",
-                                    cache="nc",
+                                T.ptx.ld.global_.nc.v2.u32(
+                                    pair_index_words[0],
+                                    pair_index_words[1],
+                                    indices.view("uint32").ptr_to([indices_base + abs_pos]),
                                 )
                             bar_valid_free.wait(rs_index.stage, rs_index.phase ^ 1)
                             coords = T.alloc_local((2,), "int32")
@@ -1598,24 +2062,34 @@ def _kernel(
                                 "int8",
                             )
                             if is_v32:
-                                scales_e8m0.view("uint64")[rs_index.stage, lane_idx] = T.bitwise_or(
-                                    scale_words[0], T.shift_left(scale_words[1], T.uint64(32))
+                                T.ptx.st.shared.u64(
+                                    scales_e8m0.view("uint64").ptr_to([rs_index.stage, lane_idx]),
+                                    T.bitwise_or(
+                                        scale_words[0], T.shift_left(scale_words[1], T.uint64(32))
+                                    ),
                                 )
                             else:
-                                Tx.copy(
-                                    scales_e8m0.view("uint64")[
-                                        rs_index.stage, lane_idx * 2 : lane_idx * 2 + 2
-                                    ],
-                                    scale_words[0:2],
-                                    dispatch="vec_128b",
+                                scale_word_bits = scale_words.view("uint32")
+                                T.ptx.st.shared.v4.u32(
+                                    scales_e8m0.view("uint32").ptr_to(
+                                        [rs_index.stage, lane_idx * 4]
+                                    ),
+                                    scale_word_bits[0],
+                                    scale_word_bits[1],
+                                    scale_word_bits[2],
+                                    scale_word_bits[3],
                                 )
-                            Tx.copy(
-                                tma_coord[rs_index.stage, lane_idx * 2 : lane_idx * 2 + 2],
-                                coords[0:2],
-                                dispatch="vec_64b",
+                            coord_words = coords.view("uint32")
+                            T.ptx.st.shared.v2.u32(
+                                tma_coord.view("uint32").ptr_to([rs_index.stage, lane_idx * 2]),
+                                coord_words[0],
+                                coord_words[1],
                             )
                             if lane_idx % 4 == 0:
-                                is_token_valid[rs_index.stage, lane_idx // 4] = valid_mask
+                                T.ptx.st.shared.b8(
+                                    is_token_valid.ptr_to([rs_index.stage, lane_idx // 4]),
+                                    T.reinterpret("uint8", valid_mask),
+                                )
                             bar_valid_ready.arrive(rs_index.stage)
                             rs_buf.advance()
                             rs_index.advance()
@@ -1767,9 +2241,11 @@ def _kernel(
                         row_idx: T.let = local_row * (128 // 8) + group_idx
                         scales_bf16_bits = T.alloc_local((num_scales,), "uint16")
                         if is_v32:
-                            packed_scales: T.let = scales_e8m0.view("uint32")[
-                                rs_index.stage, row_idx
-                            ]
+                            packed_scales: T.uint32
+                            T.ptx.ld.shared.u32(
+                                packed_scales,
+                                scales_e8m0.view("uint32").ptr_to([rs_index.stage, row_idx]),
+                            )
                             for scale_pair_idx in T.unroll(2):
                                 converted_pair = T.local_scalar("uint32")
                                 T.ptx.cvt.rn.bf16x2.ue8m0x2(
@@ -1788,9 +2264,11 @@ def _kernel(
                                     T.shift_right(converted_pair, T.uint32(16)), "uint16"
                                 )
                         else:
-                            packed_scales: T.let = scales_e8m0.view("uint64")[
-                                rs_index.stage, row_idx
-                            ]
+                            packed_scales: T.uint64
+                            T.ptx.ld.shared.u64(
+                                packed_scales,
+                                scales_e8m0.view("uint64").ptr_to([rs_index.stage, row_idx]),
+                            )
                             for scale_pair_idx in T.unroll(4):
                                 converted_pair = T.local_scalar("uint32")
                                 T.ptx.cvt.rn.bf16x2.ue8m0x2(
@@ -1953,11 +2431,14 @@ def _sparse_decode_head64_combine_kernel(
         elem_offset=oaccum_offset,
     )
     datas = T.alloc_local((D_V // (32 * 4), 4), "float32")
+    data_words = datas.view("uint32")
     for elem_i in T.unroll(D_V // (32 * 4)):
-        Tx.copy(
-            datas[elem_i, 0:4],
-            oaccum_ptr[lane_idx * 4 + elem_i * 128 : lane_idx * 4 + elem_i * 128 + 4],
-            dispatch="vec_128b",
+        T.ptx.ld.global_.v4.u32(
+            data_words[elem_i, 0],
+            data_words[elem_i, 1],
+            data_words[elem_i, 2],
+            data_words[elem_i, 3],
+            oaccum_ptr.view("uint32").ptr_to([lane_idx * 4 + elem_i * 128]),
         )
 
     # combine.cu:71-119.  Gather log2 LSE, warp-reduce max/sum, store the
@@ -1965,9 +2446,9 @@ def _sparse_decode_head64_combine_kernel(
     local_lse = T.alloc_local(((max_splits + 31) // 32,), "float32")
     for lse_i in T.unroll((max_splits + 31) // 32):
         split_idx: T.let = lse_i * 32 + lane_idx
-        local_lse[lse_i] = T.if_then_else(
-            split_idx < my_num_splits, g_lse_accum[split_idx, warp_idx], T.float32(-float("inf"))
-        )
+        local_lse[lse_i] = T.float32(-float("inf"))
+        if split_idx < my_num_splits:
+            T.ptx.ld.global_.f32(local_lse[lse_i], g_lse_accum.ptr_to([split_idx, warp_idx]))
     max_lse: T.float32 = T.float32(-float("inf"))
     for lse_i in T.unroll((max_splits + 31) // 32):
         max_lse = T.max(max_lse, local_lse[lse_i])
@@ -1991,7 +2472,7 @@ def _sparse_decode_head64_combine_kernel(
         T.log2(sum_lse) + max_lse,
     )
     if lane_idx == 0:
-        g_lse[warp_idx] = global_lse / T.float32(LOG_2_E)
+        T.ptx.st.global_.f32(g_lse.ptr_to([warp_idx]), global_lse / T.float32(LOG_2_E))
 
     if attn_sink_h is not None:
         sink: T.let = T.cuda.ldg(attn_sink.ptr_to([head_idx]), "float32")
@@ -2005,7 +2486,9 @@ def _sparse_decode_head64_combine_kernel(
             )
     for lse_i in T.unroll((max_splits + 31) // 32):
         split_idx: T.let = lse_i * 32 + lane_idx
-        T.ptx.ex2.approx.ftz.f32(lse_scales[warp_idx, split_idx], local_lse[lse_i] - global_lse)
+        lse_scale_value: T.float32
+        T.ptx.ex2.approx.ftz.f32(lse_scale_value, local_lse[lse_i] - global_lse)
+        T.ptx.st.shared.f32(lse_scales.ptr_to([warp_idx, split_idx]), lse_scale_value)
     T.cuda.warp_sync()
 
     # combine.cu:123-160.  Keep the unroll-1 split traversal and the
@@ -2015,23 +2498,20 @@ def _sparse_decode_head64_combine_kernel(
         for vec_i in T.unroll(4):
             result[elem_i, vec_i] = 0.0
     for split_idx in T.serial(0, my_num_splits, unroll=False):
-        lse_scale: T.let = lse_scales[warp_idx, split_idx]
+        lse_scale: T.float32
+        T.ptx.ld.shared.f32(lse_scale, lse_scales.ptr_to([warp_idx, split_idx]))
         for elem_i in T.unroll(D_V // (32 * 4)):
             for vec_i in T.unroll(4):
                 result[elem_i, vec_i] = result[elem_i, vec_i] + lse_scale * datas[elem_i, vec_i]
             if split_idx != my_num_splits - 1:
-                Tx.copy(
-                    datas[elem_i, 0:4],
-                    oaccum_ptr[
-                        (split_idx + 1) * stride_o_accum_split + lane_idx * 4 + elem_i * 128 : (
-                            split_idx + 1
-                        )
-                        * stride_o_accum_split
-                        + lane_idx * 4
-                        + elem_i * 128
-                        + 4
-                    ],
-                    dispatch="vec_128b",
+                T.ptx.ld.global_.v4.u32(
+                    data_words[elem_i, 0],
+                    data_words[elem_i, 1],
+                    data_words[elem_i, 2],
+                    data_words[elem_i, 3],
+                    oaccum_ptr.view("uint32").ptr_to(
+                        [(split_idx + 1) * stride_o_accum_split + lane_idx * 4 + elem_i * 128]
+                    ),
                 )
 
     out_offset: T.int32 = (
@@ -2044,7 +2524,10 @@ def _sparse_decode_head64_combine_kernel(
         data_converted[1] = result[elem_i, 1]
         data_converted[2] = result[elem_i, 2]
         data_converted[3] = result[elem_i, 3]
-        o_ptr.view("uint64")[(lane_idx * 4 + elem_i * 128) // 4] = data_converted.view("uint64")[0]
+        T.ptx.st.global_.u64(
+            o_ptr.view("uint64").ptr_to([(lane_idx * 4 + elem_i * 128) // 4]),
+            data_converted.view("uint64")[0],
+        )
 
 
 def _kernel_shape_params(

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -2,20 +2,18 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, fields
-from functools import partial
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
-from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
-from tirx_kernels.flashmla._tma import leader_mbar, tma_config
+from tirx_kernels.flashmla._tma import leader_mbar
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler
 from tvm.tirx.lang.pipeline import MBarrier, TCGen05Bar, TMABar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.layout import S, TileLayout, laneid, wid_in_wg
 
 B_H = 128
@@ -52,15 +50,111 @@ WG1_ROWS_PER_WARP = (B_TOPK // 2) // 4 // WG1_NUM_WARPS
 WG2_NUM_WARPS = 4
 WG2_ROWS_PER_PART = (B_TOPK // 2) // 4 // WG2_NUM_WARPS
 
-# KV gather4 TMA knobs shared by the gather call sites.
-_mma_config = partial(tcgen05_config, cta_group=2)
-_kv_gather_tma = partial(
-    tma_config,
-    dispatch="tma_explicit",
-    cta_group=2,
-    cta_mask=T.uint16(1),
-    cache_hint=T.uint64(0x14F0000000000000),
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_TMEM_ST_32 = "tcgen05.st.sync.aligned.32x32b.x32.b32"
+_TMA_G2S_4D_CACHE = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::2.L2::cache_hint"
 )
+_TMA_GATHER4_2D_CACHE = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4"
+    ".mbarrier::complete_tx::bytes.cta_group::2.L2::cache_hint"
+)
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TCGEN_CP_64X128 = "tcgen05.cp.cta_group::2.64x128b.warpx2::02_13"
+_TCGEN_COMMIT = (
+    "tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64"
+)
+_MMA_F16 = "tcgen05.mma.cta_group::2.kind::f16"
+_Q_TMA_CACHE_HINT = T.uint64(0x12F0000000000000)
+_KV_TMA_CACHE_HINT = T.uint64(0x14F0000000000000)
+_SMEM_DESC_ADD_SOURCE = r"""
+__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(uint64_t desc_base, int32_t offset) {
+    SmemDescriptor desc;
+    desc.desc_ = desc_base;
+    desc.lo += static_cast<uint32_t>(offset);
+    return desc.desc_;
+}
+"""
+
+
+def _tmem_load(dst, tmem_col, width):
+    chain = _TMEM_LD_32 if width == 32 else _TMEM_LD_64
+    return T.ptx[chain](*[dst[i] for i in range(width)], tmem_col)
+
+
+def _tmem_store(src, tmem_col, width=32):
+    assert width == 32
+    return T.ptx[_TMEM_ST_32](tmem_col, *[src[i] for i in range(width)])
+
+
+def _cast_f32x2_bf16x2(dst, src, offset):
+    dst_words = dst.view("uint32")
+    return T.ptx.cvt.rn.bf16x2.f32(
+        dst_words[offset // 2], src[offset + 1], src[offset]
+    )
+
+
+def _replace_smem_desc_addr(desc, smem_ptr):
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
+
+
+def _recompute_smem_desc(smem_ptr, upper, matrix_start):
+    start_addr = T.bitwise_and(
+        T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+    )
+    return T.bitwise_or(
+        T.shift_left(T.uint64(upper), T.uint64(32)),
+        T.cast(T.bitwise_or(T.uint32(matrix_start), start_addr), "uint64"),
+    )
+
+
+def _add_smem_desc_offset(desc, offset):
+    # The fixed TVM PTX table intentionally does not register integer add.
+    # Keep the helper so uint32 descriptor address arithmetic cannot carry
+    # into the encoded layout fields in the upper half.
+    return T.cuda.func_call(
+        "tvm_builtin_smem_desc_add_16B_offset",
+        desc,
+        offset,
+        source_code=_SMEM_DESC_ADD_SOURCE,
+        return_type="uint64",
+    )
+
+
+def _mma_f16(d_tmem, a_operand, b_desc, idesc, enable_input_d):
+    return T.ptx[_MMA_F16](
+        d_tmem,
+        a_operand,
+        b_desc,
+        idesc,
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        T.uint32(0),
+        enable_input_d,
+    )
+
+
+@T.inline
+def mul_f32x2(values, idx, multiplier):
+    packed: T.uint64
+    rhs: T.uint64
+    T.ptx.mov.b64(packed, values[idx], values[idx + 1])
+    T.ptx.mov.b64(rhs, multiplier, multiplier)
+    T.ptx.mul.rz.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(values[idx], values[idx + 1], packed)
 
 
 @dataclass(frozen=True)
@@ -266,6 +360,155 @@ def _kernel(
     have_topk_length: T.constexpr,
     sm_scale_div_log2: T.constexpr,
 ):
+    kv_v_part1_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_v_part1_tensormap,
+        "bfloat16",
+        2,
+        kv.data,
+        d_qk,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    kv_v_part0_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_v_part0_tensormap,
+        "bfloat16",
+        2,
+        kv.data,
+        d_qk,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    kv_k_part1_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_k_part1_tensormap,
+        "bfloat16",
+        2,
+        kv.data,
+        d_qk,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    kv_k_part0_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_k_part0_tensormap,
+        "bfloat16",
+        2,
+        kv.data,
+        d_qk,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    out_part1_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        out_part1_tensormap,
+        "bfloat16",
+        3,
+        out.data,
+        D_V,
+        h_q,
+        s_q,
+        D_V * BF16_BYTES,
+        h_q * D_V * BF16_BYTES,
+        B_EPI,
+        B_H // 2,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    out_part0_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        out_part0_tensormap,
+        "bfloat16",
+        3,
+        out.data,
+        D_V,
+        h_q,
+        s_q,
+        D_V * BF16_BYTES,
+        h_q * D_V * BF16_BYTES,
+        B_EPI,
+        B_H // 2,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    q_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        q_tensormap,
+        "bfloat16",
+        4,
+        q.data,
+        64,
+        h_q,
+        d_qk // 64,
+        s_q,
+        d_qk * BF16_BYTES,
+        64 * BF16_BYTES,
+        h_q * d_qk * BF16_BYTES,
+        64,
+        B_H // 2,
+        d_qk // 64,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
     T.device_entry()
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
     iket = IketProfiler()
@@ -288,6 +531,27 @@ def _kernel(
     num_k_blocks: T.let = T.max((topk_len + B_TOPK - 1) // B_TOPK, 1)
     warpgroup_idx: T.let = T.cuda.__shfl_sync(T.uint32(0xFFFFFFFF), thread_idx // 128, 0, 32)
     idx_in_warpgroup: T.let = thread_idx % 128
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(out_part0_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(out_part1_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_k_part0_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_k_part1_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_v_part0_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_v_part1_tensormap)))
     d_sq = T.meta_var(d_qk - D_TQ)
     num_sq_tiles = T.meta_var((d_qk - D_TQ) // 64)
     num_qk_tiles = T.meta_var(d_qk // 64)
@@ -306,6 +570,10 @@ def _kernel(
     pool = T.SMEMPool()
     u_base = T.meta_var(pool.offset)
     q_full = pool.alloc_tcgen05_mma_AB((B_H // 2, d_qk), "bfloat16")
+    q_cp_desc: T.uint64
+    T.cuda.tcgen05.encode_matrix_descriptor(
+        T.address_of(q_cp_desc), T.reinterpret(T.handle().ty, T.uint64(0)), 0, 64, 3
+    )
     # sQ stays live as q_full's first d_sq cols (a contiguous prefix under the
     # 64-col swizzle chunks); v/k reuse the D_TQ tail once Q has moved to TMEM.
     pool.move_base_to(u_base + (B_H // 2) * d_sq * BF16_BYTES)
@@ -369,20 +637,25 @@ def _kernel(
     if warp_idx == 0:
         prologue_token = iket.range_start("h128-q-load")
         if T.cuda.elect_sync():
-            Tx.copy_async(
-                q_full[:, :],
-                q.chunk((None, 2, None))[s_q_idx, cta_idx, :],
-                **tma_config(
-                    mbar=leader_mbar(bar_prologue_q.ptr_to([0])),
-                    cta_group=2,
-                    cache_hint=T.uint64(0x12F0000000000000),
-                ),
+            T.evaluate(
+                T.ptx[_TMA_G2S_4D_CACHE](
+                    q_full.ptr_to([0, 0]),
+                    T.address_of(q_tensormap),
+                    T.int32(0),
+                    T.cast(cta_idx * (B_H // 2), "int32"),
+                    T.int32(0),
+                    T.cast(s_q_idx, "int32"),
+                    T.cuda.cvta_generic_to_shared(leader_mbar(bar_prologue_q.ptr_to([0]))),
+                    _Q_TMA_CACHE_HINT,
+                )
             )
 
         T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
             T.address_of(tmem_start_addr[0]), T.uint32(512)
         )
-        T.cuda.trap_when_assert_failed(tmem_start_addr[0] == T.uint32(0))
+        allocated_tmem_start: T.uint32
+        T.ptx.ld.shared.u32(allocated_tmem_start, tmem_start_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(allocated_tmem_start == T.uint32(0))
         T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
         iket.range_end(prologue_token)
 
@@ -391,17 +664,123 @@ def _kernel(
     tmem_pool = T.TMEMPool(pool, total_cols=512, cta_group=2, tmem_addr=tmem_start_addr)
     # O accumulator: one alloc; logical col halves are the B lo/hi gemm outputs,
     # read back as a (128, D_V//2) datapath-D tile via permute+reshape.
+    o_tmem_col = T.meta_var(tmem_pool.offset)
     o_tmem = tmem_pool.alloc_tcgen05_mma_D(
         (B_H // 2, D_V), "float32", M=128, cta_group=2, group=(2, 2, 128)
     )
     tmem_o_lo = o_tmem.sub[:, 0 : D_V // 2]
     tmem_o_hi = o_tmem.sub[:, D_V // 2 : D_V]
     o_win = o_tmem.rearrange("h (a b c) -> (b h) (a c)", a=2, b=2, c=128)
+    tmem_p_col = T.meta_var(tmem_pool.offset)
     tmem_p = tmem_pool.alloc_tcgen05_mma_D((B_H // 2, B_TOPK), "float32", M=128, cta_group=2)
     # Qt TMEM at real 128-lane footprint: the 64x128b.warpx2::02_13 copy mirrors rows 0-63 to
     # lane +64, so the alloc declares that replica (R[2:64@TLane]); MMA validates it at the anchor.
+    q_tmem_col = T.meta_var(tmem_pool.offset)
     q_tmem = tmem_pool.alloc_tcgen05_mma_A((B_H // 2, D_TQ), "bfloat16", M=128, cta_group=2)
     v_smem_gemm = v_smem.rearrange("(x r) (z kl) -> r (z x kl)", x=2, z=2, kl=64)
+
+    if mma_smem_desc == "hoist":
+        qk_k_part0_desc = SmemDescriptor()
+        qk_k_part0_desc.init(k_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3)
+        qk_k_part1_desc = SmemDescriptor()
+        qk_k_part1_desc.init(k_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3)
+
+        pv_a_part0_lo_desc = SmemDescriptor()
+        pv_a_part0_lo_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+        pv_a_part0_hi_desc = SmemDescriptor()
+        pv_a_part0_hi_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+        pv_a_part1_lo_desc = SmemDescriptor()
+        pv_a_part1_lo_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+        pv_a_part1_hi_desc = SmemDescriptor()
+        pv_a_part1_hi_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+
+        pv_b_part0_lo_desc = SmemDescriptor()
+        pv_b_part0_lo_desc.init(v_smem_gemm.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+        pv_b_part0_hi_desc = SmemDescriptor()
+        pv_b_part0_hi_desc.init(v_smem_gemm.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+        pv_b_part1_lo_desc = SmemDescriptor()
+        pv_b_part1_lo_desc.init(v_smem_gemm.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+        pv_b_part1_hi_desc = SmemDescriptor()
+        pv_b_part1_hi_desc.init(v_smem_gemm.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+
+    @T.inline
+    def issue_pv_mma(dest_offset, s_offset, v_offset, hoisted_a, hoisted_b):
+        if mma_smem_desc == "local_hoist":
+            pv_a_local = SmemDescriptor()
+            pv_a_local.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+            pv_b_local = SmemDescriptor()
+            pv_b_local.init(v_smem_gemm.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+        for mma_mi in T.unroll(1):
+            for mma_ni in T.unroll(1):
+                for mma_ki in T.unroll(4):
+                    pv_a_offset: T.let = (
+                        mma_ki % 4 * 1024 + mma_mi * 512 + mma_ki // 4 * 8 + s_offset
+                    )
+                    pv_b_offset: T.let = mma_ki * 1024 + mma_ni * 64 + v_offset
+                    if mma_smem_desc == "recompute":
+                        pv_a_ptr: T.let = T.ptr_byte_offset(
+                            s_smem_gemm.ptr_to([0, 0]), pv_a_offset // 8 * 16, "bfloat16"
+                        )
+                        pv_b_ptr: T.let = T.ptr_byte_offset(
+                            v_smem_gemm.ptr_to([0, 0]), pv_b_offset // 8 * 16, "bfloat16"
+                        )
+                        T.evaluate(
+                            _mma_f16(
+                                T.cast(o_tmem_col + dest_offset + mma_ni * 128, "uint32"),
+                                _recompute_smem_desc(pv_a_ptr, 0x00004008, 0x00400000),
+                                _recompute_smem_desc(pv_b_ptr, 0x40004040, 0x04000000),
+                                T.uint32(0x08410490),
+                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                            )
+                        )
+                    elif mma_smem_desc == "encode":
+                        pv_a_encode = SmemDescriptor()
+                        pv_a_encode.init(
+                            T.ptr_byte_offset(
+                                s_smem_gemm.ptr_to([0, 0]), pv_a_offset // 8 * 16, "bfloat16"
+                            ),
+                            ldo=64,
+                            sdo=8,
+                            swizzle=0,
+                        )
+                        pv_b_encode = SmemDescriptor()
+                        pv_b_encode.init(
+                            T.ptr_byte_offset(
+                                v_smem_gemm.ptr_to([0, 0]), pv_b_offset // 8 * 16, "bfloat16"
+                            ),
+                            ldo=1024,
+                            sdo=64,
+                            swizzle=3,
+                        )
+                        T.evaluate(
+                            _mma_f16(
+                                T.cast(o_tmem_col + dest_offset + mma_ni * 128, "uint32"),
+                                pv_a_encode.desc,
+                                pv_b_encode.desc,
+                                T.uint32(0x08410490),
+                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                            )
+                        )
+                    elif mma_smem_desc == "local_hoist":
+                        T.evaluate(
+                            _mma_f16(
+                                T.cast(o_tmem_col + dest_offset + mma_ni * 128, "uint32"),
+                                pv_a_local.add_16B_offset(pv_a_offset // 8),
+                                pv_b_local.add_16B_offset(pv_b_offset // 8),
+                                T.uint32(0x08410490),
+                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                            )
+                        )
+                    else:
+                        T.evaluate(
+                            _mma_f16(
+                                T.cast(o_tmem_col + dest_offset + mma_ni * 128, "uint32"),
+                                _add_smem_desc_offset(hoisted_a, pv_a_offset // 8),
+                                _add_smem_desc_offset(hoisted_b, pv_b_offset // 8),
+                                T.uint32(0x08410490),
+                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                            )
+                        )
 
     if warpgroup_idx == 0:
         # CUDA phase1.cuh:150-386.  Scale/exp warpgroup and epilogue.
@@ -421,10 +800,8 @@ def _kernel(
             T.ptx.tcgen05.fence__after_thread_sync()
 
             p_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, P_TMEM_COLS), "uint32")
-            Tx.wg.copy_async(
-                p_frag[:, :], tmem_p.rearrange("h (b t) -> (b h) t", b=2).with_dtype("uint32")[:, :]
-            )
             p = p_frag.local()
+            T.evaluate(_tmem_load(p, T.uint32(tmem_p_col), P_TMEM_COLS))
             T.ptx.tcgen05.wait__ld.sync.aligned()
             T.ptx.tcgen05.fence__before_thread_sync()
             bar_p_free.arrive(cur_buf, remote=T.uint32(0))
@@ -433,8 +810,14 @@ def _kernel(
             valid_word_offset: T.let = T.if_then_else(
                 idx_in_warpgroup >= 64, B_TOPK // 8 // 2 // 4, 0
             )
-            is_k_valid_lo: T.let = is_k_valid.view("uint32")[cur_buf, valid_word_offset]
-            is_k_valid_hi: T.let = is_k_valid.view("uint32")[cur_buf, valid_word_offset + 1]
+            is_k_valid_lo: T.uint32
+            is_k_valid_hi: T.uint32
+            T.ptx.ld.shared.u32(
+                is_k_valid_lo, is_k_valid.view("uint32").ptr_to([cur_buf, valid_word_offset])
+            )
+            T.ptx.ld.shared.u32(
+                is_k_valid_hi, is_k_valid.view("uint32").ptr_to([cur_buf, valid_word_offset + 1])
+            )
 
             @T.inline
             def mask_p_half(valid_word, base):
@@ -456,9 +839,11 @@ def _kernel(
             bar_k_valid_free.arrive(cur_buf)
 
             T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-            rowwise_max_buf[idx_in_warpgroup] = cur_pi_max
+            T.ptx.st.shared.f32(rowwise_max_buf.ptr_to([idx_in_warpgroup]), cur_pi_max)
             T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-            cur_pi_max = T.max(cur_pi_max, rowwise_max_buf[idx_in_warpgroup ^ 64])
+            peer_pi_max: T.float32
+            T.ptx.ld.shared.f32(peer_pi_max, rowwise_max_buf.ptr_to([idx_in_warpgroup ^ 64]))
+            cur_pi_max = T.max(cur_pi_max, peer_pi_max)
             real_mi = T.max(real_mi, cur_pi_max)
             should_scale_o: T.bool = (
                 T.cuda.any_sync(T.uint32(0xFFFFFFFF), cur_pi_max - mi > 6.0) != 0
@@ -508,19 +893,40 @@ def _kernel(
                 T.ptx.fence.proxy.async_.shared__cta()
                 iket.range_end(pv_wait_token)
 
-            Tx.wg.copy(s_smem_gemm[:, :], s_frag[:, :])
+            s_base: T.let = idx_in_warpgroup // 64 * 4096 + idx_in_warpgroup % 64 * 8
+            s_words = s_frag.local().view("uint32")
+            for s_store_i in T.unroll(8):
+                s_ptr: T.let = T.ptr_byte_offset(
+                    s_smem_gemm.ptr_to([0, 0]), (s_base + s_store_i * 512) * BF16_BYTES, "bfloat16"
+                )
+                s_word: T.let = s_store_i * 4
+                T.ptx.st.shared.v4.u32(
+                    s_ptr,
+                    s_words[s_word],
+                    s_words[s_word + 1],
+                    s_words[s_word + 2],
+                    s_words[s_word + 3],
+                )
 
             if (k > 0) & should_scale_o:
                 T.ptx.tcgen05.fence__after_thread_sync()
                 o_rescale_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 32), "float32")
+                o_rescale = o_rescale_frag.local()
                 for chunk_idx in T.unroll((D_V // 2) // 32):
-                    Tx.wg.copy_async(
-                        o_rescale_frag[:, :], o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx]
+                    T.evaluate(
+                        _tmem_load(
+                            o_rescale,
+                            T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, chunk_idx * 32),
+                            32,
+                        )
                     )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
-                    Tx.wg.mul(o_rescale_frag[:, :], o_rescale_frag[:, :], scale_for_old)
-                    Tx.wg.copy_async(
-                        o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx], o_rescale_frag[:, :]
+                    for scale_i in T.unroll(32 // 2):
+                        mul_f32x2(o_rescale, scale_i * 2, scale_for_old)
+                    T.evaluate(
+                        _tmem_store(
+                            o_rescale, T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, chunk_idx * 32)
+                        )
                     )
                     T.ptx.tcgen05.wait__st.sync.aligned()
                 T.ptx.tcgen05.fence__before_thread_sync()
@@ -534,9 +940,11 @@ def _kernel(
             li = 0.0
             mi = T.float32(-float("inf"))
 
-        rowwise_li_buf[idx_in_warpgroup] = li
+        T.ptx.st.shared.f32(rowwise_li_buf.ptr_to([idx_in_warpgroup]), li)
         T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-        li = li + rowwise_li_buf[idx_in_warpgroup ^ 64]
+        peer_li: T.float32
+        T.ptx.ld.shared.f32(peer_li, rowwise_li_buf.ptr_to([idx_in_warpgroup ^ 64]))
+        li = li + peer_li
 
         if idx_in_warpgroup < B_H // 2:
             global_head: T.let = cta_idx * (B_H // 2) + idx_in_warpgroup
@@ -546,8 +954,8 @@ def _kernel(
             cur_lse = T.if_then_else(
                 cur_lse == T.float32(-float("inf")), T.float32(float("inf")), cur_lse
             )
-            max_logits[s_q_idx, global_head] = real_mi * LN_2
-            lse[s_q_idx, global_head] = cur_lse
+            T.ptx.st.global_.f32(max_logits.ptr_to([s_q_idx, global_head]), real_mi * LN_2)
+            T.ptx.st.global_.f32(lse.ptr_to([s_q_idx, global_head]), cur_lse)
 
         last_k: T.let = num_k_blocks - 1
         last_buf: T.let = last_k % NUM_BUFS
@@ -575,35 +983,75 @@ def _kernel(
                 o_epi[o_zero_i] = 0.0
             output_scale = 1.0
         o_epi_bf16_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, B_EPI), "bfloat16")
+        o_epi_bf16 = o_epi_bf16_frag.local()
         o_smem_win = o_smem.rearrange("h (b r) -> (b h) r", b=2)
         for epi_k in T.unroll((D_V // 2) // B_EPI):
             if have_valid_indices:
-                Tx.wg.copy_async(
-                    o_epi_frag[:, :], o_win.chunk((None, (D_V // 2) // B_EPI))[:, epi_k]
+                T.evaluate(
+                    _tmem_load(
+                        o_epi, T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, epi_k * B_EPI), B_EPI
+                    )
                 )
                 T.ptx.tcgen05.wait__ld.sync.aligned()
-            Tx.wg.mul(o_epi_frag[:, :], o_epi_frag[:, :], output_scale)
-            Tx.wg.cast(o_epi_bf16_frag[:, :], o_epi_frag[:, :])
-            Tx.wg.copy(
-                o_smem_win.chunk((None, (D_V // 2) // B_EPI))[:, epi_k], o_epi_bf16_frag[:, :]
-            )
+            for scale_i in T.unroll(B_EPI // 2):
+                mul_f32x2(o_epi, scale_i * 2, output_scale)
+            for cast_i in T.unroll(B_EPI // 2):
+                T.evaluate(_cast_f32x2_bf16x2(o_epi_bf16, o_epi, cast_i * 2))
+            o_epi_words = o_epi_bf16.view("uint32")
+            for o_store_i in T.unroll(8):
+                s_off: T.let = (
+                    idx_in_warpgroup // 64 * 16384
+                    + epi_k * 4096
+                    + idx_in_warpgroup % 64 * 64
+                    + T.bitwise_xor(
+                        o_store_i * 8,
+                        T.shift_left(
+                            T.bitwise_and(
+                                idx_in_warpgroup // 64 * 256 + epi_k * 64 + idx_in_warpgroup % 64, 7
+                            ),
+                            3,
+                        ),
+                    )
+                )
+                s_ptr: T.let = T.ptr_byte_offset(
+                    o_smem_win.ptr_to([0, 0]), s_off * BF16_BYTES, "bfloat16"
+                )
+                o_word: T.let = o_store_i * 4
+                T.ptx.st.shared.v4.u32(
+                    s_ptr,
+                    o_epi_words[o_word],
+                    o_epi_words[o_word + 1],
+                    o_epi_words[o_word + 2],
+                    o_epi_words[o_word + 3],
+                )
 
             T.ptx.fence.proxy.async_.shared__cta()
             T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
             if warp_idx == 0:
                 if T.cuda.elect_sync():
-                    Tx.copy_async(
-                        out.chunk((None, 2, D_V // B_EPI))[s_q_idx, cta_idx, epi_k],
-                        o_smem.chunk((None, D_V // B_EPI))[:, epi_k],
-                        **tma_config(),
+                    o_part0_offset: T.let = epi_k * B_EPI * (B_H // 2) * BF16_BYTES
+                    T.evaluate(
+                        T.ptx[_TMA_S2G_3D](
+                            T.address_of(out_part0_tensormap),
+                            T.cast(epi_k * B_EPI, "int32"),
+                            T.cast(cta_idx * (B_H // 2), "int32"),
+                            T.cast(s_q_idx, "int32"),
+                            T.ptr_byte_offset(o_smem.ptr_to([0, 0]), o_part0_offset, "bfloat16"),
+                        )
                     )
             if warp_idx == 1:
                 if T.cuda.elect_sync():
                     epi_k2: T.let = epi_k + (D_V // B_EPI // 2)
-                    Tx.copy_async(
-                        out.chunk((None, 2, D_V // B_EPI))[s_q_idx, cta_idx, epi_k2],
-                        o_smem.chunk((None, D_V // B_EPI))[:, epi_k2],
-                        **tma_config(),
+                    T.evaluate(epi_k2)
+                    o_part1_offset: T.let = (epi_k * B_EPI + D_V // 2) * (B_H // 2) * BF16_BYTES
+                    T.evaluate(
+                        T.ptx[_TMA_S2G_3D](
+                            T.address_of(out_part1_tensormap),
+                            T.cast(epi_k * B_EPI + D_V // 2, "int32"),
+                            T.cast(cta_idx * (B_H // 2), "int32"),
+                            T.cast(s_q_idx, "int32"),
+                            T.ptr_byte_offset(o_smem.ptr_to([0, 0]), o_part1_offset, "bfloat16"),
+                        )
                     )
 
         if warp_idx == 0:
@@ -626,7 +1074,24 @@ def _kernel(
                 idx_block = indices.view(
                     s_q, stride_indices_s_q // B_TOPK, 2, WG1_ROWS_PER_WARP, WG1_NUM_WARPS, 4
                 ).sub[s_q_idx, k, cta_idx, :, wg1_warp_idx, :]
-                Tx.copy(indices_int4[:, :], idx_block[:, :], cache="nc")
+                indices_words = indices_int4.view(16).view("uint32")
+                for indices_load_i in T.unroll(4):
+                    indices_word: T.let = indices_load_i * 4
+                    T.ptx.ld.global_.nc.v4.u32(
+                        indices_words[indices_word],
+                        indices_words[indices_word + 1],
+                        indices_words[indices_word + 2],
+                        indices_words[indices_word + 3],
+                        indices.ptr_to(
+                            [
+                                g_indices_base
+                                + k * B_TOPK
+                                + cta_idx * (B_TOPK // 2)
+                                + wg1_warp_idx * 4
+                                + indices_load_i * 16
+                            ]
+                        ),
+                    )
                 for local_row in T.unroll(WG1_ROWS_PER_WARP):
                     for j in T.unroll(4):
                         idx: T.let = indices_int4[local_row, j]
@@ -639,26 +1104,33 @@ def _kernel(
                 cur_phase: T.let = (k // NUM_BUFS) & 1
 
                 @T.inline
-                def gather_k_part(col_start, col_count, tx_dim, bar):
+                def gather_k_part(col_start, col_count, tx_dim, bar, tensormap):
                     if not should_skip_tma:
                         k_gather_tile = k_smem.sub[
                             :, col_start * 64 : col_start * 64 + col_count * 64
                         ].tile(0, (-1, WG1_NUM_WARPS, 4))[:, wg1_warp_idx, :]
                         for row_group in T.unroll(WG1_ROWS_PER_WARP):
                             for col_atom in T.unroll(col_count):
-                                col = T.meta_var((col_start + col_atom) * 64)
-                                Tx.copy_async(
-                                    k_gather_tile[
-                                        row_group * 4 : row_group * 4 + 4,
-                                        col_atom * 64 : col_atom * 64 + 64,
-                                    ],
-                                    kv_tma[0:1, col : col + 64],
-                                    **_kv_gather_tma(
-                                        mbar=leader_mbar(bar.ptr_to([cur_buf])),
-                                        gather4=[
-                                            indices_int4[row_group, lane] for lane in range(4)
-                                        ],
-                                    ),
+                                k_gather_offset: T.let = (
+                                    (col_start + col_atom) * 64 * (B_TOPK // 2)
+                                    + (wg1_warp_idx * 4 + row_group * 16) * 64
+                                ) * BF16_BYTES
+                                T.evaluate(
+                                    T.ptx[_TMA_GATHER4_2D_CACHE](
+                                        T.ptr_byte_offset(
+                                            k_smem.ptr_to([0, 0]), k_gather_offset, "bfloat16"
+                                        ),
+                                        T.address_of(tensormap),
+                                        T.cast((col_start + col_atom) * 64, "int32"),
+                                        indices_int4[row_group, 0],
+                                        indices_int4[row_group, 1],
+                                        indices_int4[row_group, 2],
+                                        indices_int4[row_group, 3],
+                                        T.cuda.cvta_generic_to_shared(
+                                            leader_mbar(bar.ptr_to([cur_buf]))
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
                                 )
                     else:
                         _rem1 = T.alloc_local([1], "uint64")
@@ -673,13 +1145,19 @@ def _kernel(
                     prev_buf: T.let = (k - 1) % NUM_BUFS
                     prev_phase: T.let = ((k - 1) // NUM_BUFS) & 1
                     bar_qk_part_done.wait(prev_buf, prev_phase)
-                gather_k_part(0, num_sq_tiles, d_sq, bar_k_part0_ready)
+                gather_k_part(0, num_sq_tiles, d_sq, bar_k_part0_ready, kv_k_part0_tensormap)
 
                 if k > 0:
                     prev_buf: T.let = (k - 1) % NUM_BUFS
                     prev_phase: T.let = ((k - 1) // NUM_BUFS) & 1
                     bar_qk_done.wait(prev_buf, prev_phase)
-                gather_k_part(num_sq_tiles, num_qk_tiles - num_sq_tiles, D_TQ, bar_k_part1_ready)
+                gather_k_part(
+                    num_sq_tiles,
+                    num_qk_tiles - num_sq_tiles,
+                    D_TQ,
+                    bar_k_part1_ready,
+                    kv_k_part1_tensormap,
+                )
         iket.range_end(k_gather_token)
 
     elif warpgroup_idx == 2:
@@ -698,41 +1176,70 @@ def _kernel(
                     bar_sv_part_done.wait(prev_buf, prev_phase)
 
                 @T.inline
-                def gather_v_part(row_offset, part, token_buf, bar):
+                def gather_v_part(row_offset, part, token_buf, bar, tensormap):
                     # V loads all 128 tokens; the two parts map to an extent-2
                     # axis indexed by part. One strided nc copy, like head64.
                     idx_block = indices.view(
                         s_q, stride_indices_s_q // B_TOPK, 2, WG2_ROWS_PER_PART, WG2_NUM_WARPS, 4
                     ).sub[s_q_idx, k, part, :, wg2_warp_idx, :]
-                    Tx.copy(token_buf[:, :], idx_block[:, :], cache="nc")
+                    token_words = token_buf.view(16).view("uint32")
+                    for token_load_i in T.unroll(4):
+                        token_word: T.let = token_load_i * 4
+                        T.ptx.ld.global_.nc.v4.u32(
+                            token_words[token_word],
+                            token_words[token_word + 1],
+                            token_words[token_word + 2],
+                            token_words[token_word + 3],
+                            indices.ptr_to(
+                                [
+                                    g_indices_base
+                                    + k * B_TOPK
+                                    + part * (B_TOPK // 2)
+                                    + wg2_warp_idx * 4
+                                    + token_load_i * 16
+                                ]
+                            ),
+                        )
                     src0: T.let = cta_idx * 256
                     v_gather_tile = v_smem_gemm.tile(0, (2, -1, WG2_NUM_WARPS, 4))[
                         part, :, wg2_warp_idx, :
                     ]
                     for row_group in T.unroll(WG2_ROWS_PER_PART):
                         for col_atom in T.unroll((D_V // 2) // 64):
-                            col = T.meta_var(src0 + col_atom * 64)
-                            Tx.copy_async(
-                                v_gather_tile[
-                                    row_group * 4 : row_group * 4 + 4,
-                                    col_atom * 64 : col_atom * 64 + 64,
-                                ],
-                                kv_tma[0:1, col : col + 64],
-                                **_kv_gather_tma(
-                                    mbar=leader_mbar(bar.ptr_to([cur_buf])),
-                                    gather4=[token_buf[row_group, lane] for lane in range(4)],
-                                ),
+                            v_gather_offset: T.let = (
+                                part * (B_TOPK // 2) * 64
+                                + col_atom * 64 * B_TOPK
+                                + (wg2_warp_idx * 4 + row_group * 16) * 64
+                            ) * BF16_BYTES
+                            T.evaluate(
+                                T.ptx[_TMA_GATHER4_2D_CACHE](
+                                    T.ptr_byte_offset(
+                                        v_smem.ptr_to([0, 0]), v_gather_offset, "bfloat16"
+                                    ),
+                                    T.address_of(tensormap),
+                                    T.cast(src0 + col_atom * 64, "int32"),
+                                    token_buf[row_group, 0],
+                                    token_buf[row_group, 1],
+                                    token_buf[row_group, 2],
+                                    token_buf[row_group, 3],
+                                    T.cuda.cvta_generic_to_shared(
+                                        leader_mbar(bar.ptr_to([cur_buf]))
+                                    ),
+                                    _KV_TMA_CACHE_HINT,
+                                )
                             )
 
                 token_idxs_part0 = T.alloc_local((WG2_ROWS_PER_PART, 4), "int32")
-                gather_v_part(0, 0, token_idxs_part0, bar_v_part0_ready)
+                gather_v_part(0, 0, token_idxs_part0, bar_v_part0_ready, kv_v_part0_tensormap)
 
                 if k > 0:
                     prev_buf: T.let = (k - 1) % NUM_BUFS
                     prev_phase: T.let = ((k - 1) // NUM_BUFS) & 1
                     bar_sv_done.wait(prev_buf, prev_phase)
                 token_idxs_part1 = T.alloc_local((WG2_ROWS_PER_PART, 4), "int32")
-                gather_v_part(WG2_ROWS_PER_PART, 1, token_idxs_part1, bar_v_part1_ready)
+                gather_v_part(
+                    WG2_ROWS_PER_PART, 1, token_idxs_part1, bar_v_part1_ready, kv_v_part1_tensormap
+                )
         iket.range_end(v_gather_token)
 
     else:
@@ -744,14 +1251,26 @@ def _kernel(
                 bar_prologue_q.arrive(0, tx_count=B_H * d_qk * BF16_BYTES)
                 bar_prologue_q.wait(0, 0)
                 T.ptx.tcgen05.fence__after_thread_sync()
-                Tx.copy_async(
-                    q_tmem[:, :],
-                    q_full[:, d_sq : d_sq + D_TQ],
-                    shape="64x128b",
-                    cta_group=2,
-                    multicast="warpx2::02_13",
+                for q_copy_flat in T.unroll(48):
+                    q_copy_src: T.let = T.ptr_byte_offset(
+                        q_full.ptr_to([0, 0]),
+                        (d_sq * 8 + q_copy_flat % 6 * 512 + q_copy_flat // 6 % 8) * 16,
+                        "bfloat16",
+                    )
+                    T.evaluate(
+                        T.ptx[_TCGEN_CP_64X128](
+                            T.cast(
+                                q_tmem_col + q_copy_flat % 6 * 32 + q_copy_flat // 6 % 8 * 4,
+                                "uint32",
+                            ),
+                            _replace_smem_desc_addr(q_cp_desc, q_copy_src),
+                        )
+                    )
+                T.evaluate(
+                    T.ptx[_TCGEN_COMMIT](
+                        T.cuda.cvta_generic_to_shared(bar_prologue_utccp.ptr_to([0])), T.uint16(3)
+                    )
                 )
-                bar_prologue_utccp.arrive(0, cta_group=2, cta_mask=3)
 
                 for k in T.serial(0, num_k_blocks + 1, unroll=False):
                     if k < num_k_blocks:
@@ -769,12 +1288,125 @@ def _kernel(
                         mma_p_accumulate = T.uint32(0)
                         if d_sq > 0:
                             sq_smem = q_full.sub[:, :d_sq]
-                            Tx.gemm_async(
-                                tmem_p[:, :],
-                                sq_smem[:, :d_sq],
-                                k_smem[:, :d_sq],
-                                **_mma_config(accum=mma_p_accumulate, smem_desc=mma_smem_desc),
-                            )
+                            if mma_smem_desc == "local_hoist":
+                                qk_part0_a_local = SmemDescriptor()
+                                qk_part0_a_local.init(
+                                    sq_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3
+                                )
+                                qk_part0_b_local = SmemDescriptor()
+                                qk_part0_b_local.init(
+                                    k_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3
+                                )
+                            if mma_smem_desc == "hoist":
+                                qk_part0_a_hoist = SmemDescriptor()
+                                qk_part0_a_hoist.init(
+                                    sq_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3
+                                )
+                            for mma_mi in T.unroll(1):
+                                for mma_ni in T.unroll(1):
+                                    for mma_ki in T.unroll(d_sq // 16):
+                                        qk_part0_offset: T.let = (
+                                            mma_ki % (d_sq // 16) // 4 * 4096
+                                            + mma_mi * 4096
+                                            + mma_ki // (d_sq // 16) * 64
+                                            + mma_ki % 4 * 16
+                                        )
+                                        if mma_smem_desc == "recompute":
+                                            qk_part0_a_ptr: T.let = T.ptr_byte_offset(
+                                                sq_smem.ptr_to([0, 0]),
+                                                qk_part0_offset // 8 * 16,
+                                                "bfloat16",
+                                            )
+                                            qk_part0_b_ptr: T.let = T.ptr_byte_offset(
+                                                k_smem.ptr_to([0, 0]),
+                                                qk_part0_offset // 8 * 16,
+                                                "bfloat16",
+                                            )
+                                            T.evaluate(
+                                                _mma_f16(
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    _recompute_smem_desc(
+                                                        qk_part0_a_ptr, 0x40004040, 0x02000000
+                                                    ),
+                                                    _recompute_smem_desc(
+                                                        qk_part0_b_ptr, 0x40004040, 0x02000000
+                                                    ),
+                                                    T.uint32(0x08200490),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                )
+                                            )
+                                        elif mma_smem_desc == "encode":
+                                            qk_part0_a_encode = SmemDescriptor()
+                                            qk_part0_a_encode.init(
+                                                T.ptr_byte_offset(
+                                                    sq_smem.ptr_to([0, 0]),
+                                                    qk_part0_offset // 8 * 16,
+                                                    "bfloat16",
+                                                ),
+                                                ldo=512,
+                                                sdo=64,
+                                                swizzle=3,
+                                            )
+                                            qk_part0_b_encode = SmemDescriptor()
+                                            qk_part0_b_encode.init(
+                                                T.ptr_byte_offset(
+                                                    k_smem.ptr_to([0, 0]),
+                                                    qk_part0_offset // 8 * 16,
+                                                    "bfloat16",
+                                                ),
+                                                ldo=512,
+                                                sdo=64,
+                                                swizzle=3,
+                                            )
+                                            T.evaluate(
+                                                _mma_f16(
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    qk_part0_a_encode.desc,
+                                                    qk_part0_b_encode.desc,
+                                                    T.uint32(0x08200490),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                )
+                                            )
+                                        elif mma_smem_desc == "local_hoist":
+                                            T.evaluate(
+                                                _mma_f16(
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    qk_part0_a_local.add_16B_offset(
+                                                        qk_part0_offset // 8
+                                                    ),
+                                                    qk_part0_b_local.add_16B_offset(
+                                                        qk_part0_offset // 8
+                                                    ),
+                                                    T.uint32(0x08200490),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                )
+                                            )
+                                        else:
+                                            T.evaluate(
+                                                _mma_f16(
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    qk_part0_a_hoist.add_16B_offset(
+                                                        qk_part0_offset // 8
+                                                    ),
+                                                    qk_k_part0_desc.add_16B_offset(
+                                                        qk_part0_offset // 8
+                                                    ),
+                                                    T.uint32(0x08200490),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                )
+                                            )
                             mma_p_accumulate = T.uint32(1)
                         bar_qk_part_done.arrive(cur_buf, cta_group=2, cta_mask=3)
 
@@ -784,12 +1416,81 @@ def _kernel(
                         bar_k_part1_ready.wait(cur_buf, cur_phase)
                         T.ptx.tcgen05.fence__after_thread_sync()
 
-                        Tx.gemm_async(
-                            tmem_p[:, :],
-                            q_tmem[:, :D_TQ],
-                            k_smem[:, d_sq : d_sq + D_TQ],
-                            **_mma_config(accum=mma_p_accumulate, smem_desc=mma_smem_desc),
-                        )
+                        if mma_smem_desc == "local_hoist":
+                            qk_part1_b_local = SmemDescriptor()
+                            qk_part1_b_local.init(k_smem.ptr_to([0, 0]), ldo=512, sdo=64, swizzle=3)
+                        for mma_mi in T.unroll(1):
+                            for mma_ni in T.unroll(1):
+                                for mma_ki in T.unroll(D_TQ // 16):
+                                    qk_part1_offset: T.let = (
+                                        mma_ki % (D_TQ // 16) // 4 * 4096
+                                        + mma_ni * 4096
+                                        + mma_ki // (D_TQ // 16) * 64
+                                        + mma_ki % 4 * 16
+                                        + d_sq // 64 * 4096
+                                    )
+                                    if mma_smem_desc == "recompute":
+                                        qk_part1_b_ptr: T.let = T.ptr_byte_offset(
+                                            k_smem.ptr_to([0, 0]),
+                                            qk_part1_offset // 8 * 16,
+                                            "bfloat16",
+                                        )
+                                        T.evaluate(
+                                            _mma_f16(
+                                                T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                T.cast(q_tmem_col + mma_ki * 8, "uint32"),
+                                                _recompute_smem_desc(
+                                                    qk_part1_b_ptr, 0x40004040, 0x02000000
+                                                ),
+                                                T.uint32(0x08200490),
+                                                T.Or(mma_ki != 0, T.cast(mma_p_accumulate, "bool")),
+                                            )
+                                        )
+                                    elif mma_smem_desc == "encode":
+                                        qk_part1_b_encode = SmemDescriptor()
+                                        qk_part1_b_encode.init(
+                                            T.ptr_byte_offset(
+                                                k_smem.ptr_to([0, 0]),
+                                                qk_part1_offset // 8 * 16,
+                                                "bfloat16",
+                                            ),
+                                            ldo=512,
+                                            sdo=64,
+                                            swizzle=3,
+                                        )
+                                        T.evaluate(
+                                            _mma_f16(
+                                                T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                T.cast(q_tmem_col + mma_ki * 8, "uint32"),
+                                                qk_part1_b_encode.desc,
+                                                T.uint32(0x08200490),
+                                                T.Or(mma_ki != 0, T.cast(mma_p_accumulate, "bool")),
+                                            )
+                                        )
+                                    elif mma_smem_desc == "local_hoist":
+                                        T.evaluate(
+                                            _mma_f16(
+                                                T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                T.cast(q_tmem_col + mma_ki * 8, "uint32"),
+                                                qk_part1_b_local.add_16B_offset(
+                                                    qk_part1_offset // 8
+                                                ),
+                                                T.uint32(0x08200490),
+                                                T.Or(mma_ki != 0, T.cast(mma_p_accumulate, "bool")),
+                                            )
+                                        )
+                                    else:
+                                        T.evaluate(
+                                            _mma_f16(
+                                                T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                T.cast(q_tmem_col + mma_ki * 8, "uint32"),
+                                                qk_k_part1_desc.add_16B_offset(
+                                                    qk_part1_offset // 8
+                                                ),
+                                                T.uint32(0x08200490),
+                                                T.Or(mma_ki != 0, T.cast(mma_p_accumulate, "bool")),
+                                            )
+                                        )
                         mma_p_accumulate = T.uint32(1)
                         bar_qk_done.arrive(cur_buf, cta_group=2, cta_mask=3)
 
@@ -804,20 +1505,14 @@ def _kernel(
                         bar_v_part0_ready.wait(cur_buf_prev, cur_phase_prev)
                         T.ptx.tcgen05.fence__after_thread_sync()
                         mma_o_accumulate = T.if_then_else(k == 1, T.uint32(0), T.uint32(1))
-                        Tx.gemm_async(
-                            tmem_o_lo[:, :],
-                            s_smem_gemm[:, 0 : B_TOPK // 2],
-                            v_smem_gemm[0 : B_TOPK // 2, 0 : D_V // 4],
-                            transB=True,
-                            **_mma_config(accum=mma_o_accumulate, smem_desc=mma_smem_desc),
-                        )
-                        Tx.gemm_async(
-                            tmem_o_hi[:, :],
-                            s_smem_gemm[:, 0 : B_TOPK // 2],
-                            v_smem_gemm[0 : B_TOPK // 2, D_V // 4 : D_V // 2],
-                            transB=True,
-                            **_mma_config(accum=mma_o_accumulate, smem_desc=mma_smem_desc),
-                        )
+                        if mma_smem_desc == "hoist":
+                            issue_pv_mma(0, 0, 0, pv_a_part0_lo_desc.desc, pv_b_part0_lo_desc.desc)
+                            issue_pv_mma(
+                                128, 0, 16384, pv_a_part0_hi_desc.desc, pv_b_part0_hi_desc.desc
+                            )
+                        else:
+                            issue_pv_mma(0, 0, 0, T.uint64(0), T.uint64(0))
+                            issue_pv_mma(128, 0, 16384, T.uint64(0), T.uint64(0))
                         mma_o_accumulate = T.uint32(1)
                         bar_sv_part_done.arrive(cur_buf_prev, cta_group=2, cta_mask=3)
 
@@ -826,20 +1521,16 @@ def _kernel(
                         )
                         bar_v_part1_ready.wait(cur_buf_prev, cur_phase_prev)
                         T.ptx.tcgen05.fence__after_thread_sync()
-                        Tx.gemm_async(
-                            tmem_o_lo[:, :],
-                            s_smem_gemm[:, B_TOPK // 2 : B_TOPK],
-                            v_smem_gemm[B_TOPK // 2 : B_TOPK, 0 : D_V // 4],
-                            transB=True,
-                            **_mma_config(accum=mma_o_accumulate, smem_desc=mma_smem_desc),
-                        )
-                        Tx.gemm_async(
-                            tmem_o_hi[:, :],
-                            s_smem_gemm[:, B_TOPK // 2 : B_TOPK],
-                            v_smem_gemm[B_TOPK // 2 : B_TOPK, D_V // 4 : D_V // 2],
-                            transB=True,
-                            **_mma_config(accum=mma_o_accumulate, smem_desc=mma_smem_desc),
-                        )
+                        if mma_smem_desc == "hoist":
+                            issue_pv_mma(
+                                0, 4096, 4096, pv_a_part1_lo_desc.desc, pv_b_part1_lo_desc.desc
+                            )
+                            issue_pv_mma(
+                                128, 4096, 20480, pv_a_part1_hi_desc.desc, pv_b_part1_hi_desc.desc
+                            )
+                        else:
+                            issue_pv_mma(0, 4096, 4096, T.uint64(0), T.uint64(0))
+                            issue_pv_mma(128, 4096, 20480, T.uint64(0), T.uint64(0))
                         mma_o_accumulate = T.uint32(1)
                         bar_sv_done.arrive(cur_buf_prev, cta_group=2, cta_mask=3)
             iket.range_end(mma_token)
@@ -850,14 +1541,19 @@ def _kernel(
                 lane_indices = T.alloc_local((8,), "int32")
                 for k in T.serial(0, num_k_blocks, unroll=False):
                     row_base: T.let = g_indices_base + k * B_TOPK + lane_idx * 8
-                    Tx.copy(
-                        lane_indices[0:8],
-                        indices[row_base : row_base + 8],
-                        dispatch="vec_256b",
-                        cache="nc",
-                        l1_evict="L1::evict_normal",
-                        l2_evict="L2::evict_normal",
-                        prefetch_size="L2::256B",
+                    lane_index_words = lane_indices.view("uint32")
+                    T.evaluate(
+                        T.ptx["ld.global.nc.L1::evict_normal.L2::evict_normal.L2::256B.v8.u32"](
+                            lane_index_words[0],
+                            lane_index_words[1],
+                            lane_index_words[2],
+                            lane_index_words[3],
+                            lane_index_words[4],
+                            lane_index_words[5],
+                            lane_index_words[6],
+                            lane_index_words[7],
+                            indices.ptr_to([row_base]),
+                        )
                     )
                     abs_pos_start: T.let = k * B_TOPK
                     is_ks_valid_mask: T.let = pack_valid_mask8(
@@ -866,7 +1562,10 @@ def _kernel(
                     cur_buf: T.let = k % NUM_BUFS
                     cur_phase: T.let = (k // NUM_BUFS) & 1
                     bar_k_valid_free.wait(cur_buf, cur_phase ^ 1)
-                    is_k_valid[cur_buf, lane_idx] = is_ks_valid_mask
+                    T.ptx.st.shared.b8(
+                        is_k_valid.ptr_to([cur_buf, lane_idx]),
+                        T.reinterpret("uint8", is_ks_valid_mask),
+                    )
                     bar_k_valid_ready.arrive(cur_buf)
             iket.range_end(valid_mask_token)
 
@@ -887,7 +1586,8 @@ def get_kernel(**kwargs: Any):
         have_topk_length=cfg.have_topk_length,
         sm_scale_div_log2=(1.0 / math.sqrt(cfg.d_qk)) * LOG_2_E,
     )
-    return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+    kernel = kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+    return kernel
 
 
 def run_test(**kwargs: Any) -> None:

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -69,16 +69,6 @@ _TCGEN_COMMIT = (
 _MMA_F16 = "tcgen05.mma.cta_group::2.kind::f16"
 _Q_TMA_CACHE_HINT = T.uint64(0x12F0000000000000)
 _KV_TMA_CACHE_HINT = T.uint64(0x14F0000000000000)
-_SMEM_DESC_ADD_SOURCE = r"""
-__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(uint64_t desc_base, int32_t offset) {
-    SmemDescriptor desc;
-    desc.desc_ = desc_base;
-    desc.lo += static_cast<uint32_t>(offset);
-    return desc.desc_;
-}
-"""
-
-
 def _tmem_load(dst, tmem_col, width):
     chain = _TMEM_LD_32 if width == 32 else _TMEM_LD_64
     return T.ptx[chain](*[dst[i] for i in range(width)], tmem_col)
@@ -117,16 +107,15 @@ def _recompute_smem_desc(smem_ptr, upper, matrix_start):
 
 
 def _add_smem_desc_offset(desc, offset):
-    # The fixed TVM PTX table intentionally does not register integer add.
-    # Keep the helper so uint32 descriptor address arithmetic cannot carry
-    # into the encoded layout fields in the upper half.
-    return T.cuda.func_call(
-        "tvm_builtin_smem_desc_add_16B_offset",
-        desc,
-        offset,
-        source_code=_SMEM_DESC_ADD_SOURCE,
-        return_type="uint64",
-    )
+    # Descriptor offsets wrap in the low 32 bits without carrying into the
+    # encoded layout fields in the high half.
+    desc_lo = T.alloc_local((1,), "uint32")
+    desc_hi = T.alloc_local((1,), "uint32")
+    result = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.mov.b64(desc_lo[0], desc_hi[0], desc))
+    T.evaluate(T.ptx.add.u32(desc_lo[0], desc_lo[0], T.cast(offset, "uint32")))
+    T.evaluate(T.ptx.mov.b64(result[0], desc_lo[0], desc_hi[0]))
+    return result[0]
 
 
 def _mma_f16(d_tmem, a_operand, b_desc, idesc, enable_input_d):

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -20,28 +20,17 @@ LOG_2_E = math.log2(math.e)
 
 BF16_BYTES = 2
 
-_SMEM_DESC_ADD_SOURCE = r"""
-__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(
-    uint64_t desc_base, int32_t offset) {
-    SmemDescriptor desc;
-    desc.desc_ = desc_base;
-    desc.lo += static_cast<uint32_t>(offset);
-    return desc.desc_;
-}
-"""
-
-
 def _add_smem_desc_offset(desc, offset):
-    # The fixed TVM PTX table intentionally does not register integer add.
-    # Keep the helper so uint32 descriptor address arithmetic cannot carry
-    # into the encoded layout fields in the upper half.
-    return T.cuda.func_call(
-        "tvm_builtin_smem_desc_add_16B_offset",
-        desc,
-        offset,
-        source_code=_SMEM_DESC_ADD_SOURCE,
-        return_type="uint64",
-    )
+    # Descriptor offsets wrap in the low 32 bits without carrying into the
+    # encoded layout fields in the high half.
+    desc_lo = T.alloc_local((1,), "uint32")
+    desc_hi = T.alloc_local((1,), "uint32")
+    result = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.mov.b64(desc_lo[0], desc_hi[0], desc))
+    T.evaluate(T.ptx.add.u32(desc_lo[0], desc_lo[0], T.cast(offset, "uint32")))
+    T.evaluate(T.ptx.mov.b64(result[0], desc_lo[0], desc_hi[0]))
+    return result[0]
+
 
 @dataclass(frozen=True)
 class SparseFlashMLAPrefillHead128SmallTopKConfig:

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -2,72 +2,46 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, fields
-from functools import partial
+from functools import cache
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
-from tirx_kernels.flashmla._gemm import tcgen05_config
-from tirx_kernels.flashmla._mask import pack_valid_mask8
-from tirx_kernels.flashmla._tma import leader_mbar, tma_config
 from tvm.backend.cuda.lang.clc import query_cancel_first_ctaid_x
-from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
-from tvm.tirx.cuda.iket import IketProfiler
-from tvm.tirx.lang.pipeline import MBarrier, TCGen05Bar, TMABar
-from tvm.tirx.layout import S, TileLayout, laneid, wid_in_wg
+from tvm.tirx.layout import Axis
 
 B_H = 128
 B_TOPK = 64
 D_QK = 512
 D_V = 512
-NUM_THREADS = 512
-NUM_K_BUFS = 4
-NUM_INDEX_BUFS = 4
-NUM_WORKER_THREADS = (128 + 4 + (B_TOPK // 8) + 1 + 128) * 2 + 1
-MAX_INIT_VAL = -1.0e30
 LOG_2_E = math.log2(math.e)
-LN_2 = math.log(2.0)
-
-IKET_EVENT_NAMES = (
-    "h128-small-q-load-output",
-    "h128-small-kv-load",
-    "h128-small-qk-pv-issue",
-    "h128-small-valid-mask",
-    "h128-small-clc",
-    "h128-small-softmax",
-)
-
-LAUNCH_TAGS = (
-    "blockIdx.x",
-    "clusterCtaIdx.x",
-    "threadIdx.x",
-    "tirx.use_programtic_dependent_launch",
-    "tirx.use_dyn_shared_memory",
-)
 
 BF16_BYTES = 2
-B_EPI = 64
 
-BAR_WG0_SYNC = 0
-BAR_WG2_SYNC = 1
-BAR_WG2_WARP02 = 2
+_SMEM_DESC_ADD_SOURCE = r"""
+__forceinline__ __device__ uint64_t tvm_builtin_smem_desc_add_16B_offset(
+    uint64_t desc_base, int32_t offset) {
+    SmemDescriptor desc;
+    desc.desc_ = desc_base;
+    desc.lo += static_cast<uint32_t>(offset);
+    return desc.desc_;
+}
+"""
 
-WG1_ROWS_PER_WARP = B_TOPK // 4
-WG3_ELEMS_PER_THREAD = B_TOPK // 2
 
-# KV gather4 TMA knobs shared by the gather call sites.
-_mma_config = partial(tcgen05_config, cta_group=2, smem_desc="local_hoist")
-_kv_gather_tma = partial(
-    tma_config,
-    dispatch="tma_explicit",
-    cta_group=2,
-    cta_mask=T.uint16(1),
-    cache_hint=T.uint64(0x14F0000000000000),
-)
-
+def _add_smem_desc_offset(desc, offset):
+    # The fixed TVM PTX table intentionally does not register integer add.
+    # Keep the helper so uint32 descriptor address arithmetic cannot carry
+    # into the encoded layout fields in the upper half.
+    return T.cuda.func_call(
+        "tvm_builtin_smem_desc_add_16B_offset",
+        desc,
+        offset,
+        source_code=_SMEM_DESC_ADD_SOURCE,
+        return_type="uint64",
+    )
 
 @dataclass(frozen=True)
 class SparseFlashMLAPrefillHead128SmallTopKConfig:
@@ -256,759 +230,776 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-@T.jit
-def _kernel(
-    q: T.Buffer((s_q, h_q, d_qk), "bfloat16"),
-    kv: T.Buffer((s_kv * stride_kv_s_kv,), "bfloat16"),
-    indices: T.Buffer((s_q * stride_indices_s_q,), "int32"),
-    attn_sink: T.Buffer((h_q,), "float32"),
-    topk_length: T.Buffer((s_q,), "int32"),
-    out: T.Buffer((s_q, h_q, D_V), "bfloat16"),
-    max_logits: T.Buffer((s_q, h_q), "float32"),
-    lse: T.Buffer((s_q, h_q), "float32"),
-    *,
-    s_q: T.constexpr,
-    s_kv: T.constexpr,
-    topk: T.constexpr,
-    d_qk: T.constexpr,
-    h_q: T.constexpr,
-    stride_kv_s_kv: T.constexpr,
-    stride_indices_s_q: T.constexpr,
-    have_attn_sink: T.constexpr,
-    have_topk_length: T.constexpr,
-    sm_scale_div_log2: T.constexpr,
+# The dispatcher-selected SM100 form is frozen below as explicit TMA,
+# tcgen05, TMEM, packed-register, and PTX memory operations.
+# fmt: off
+@cache
+def _make_low_level_kernel(
+    s_q: int,
+    s_kv: int,
+    topk: int,
+    stride_kv_s_kv: int,
+    stride_indices_s_q: int,
+    have_attn_sink: bool,
+    have_topk_length: bool,
+    sm_scale_div_log2: float,
 ):
-    T.device_entry()
-    T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
-    iket = IketProfiler()
-    # CUDA_TRANSCRIBE_START: phase1.cuh:24, scoped to KernelTemplate<Prefill, 512>.
-    block_idx = T.cta_id([2 * s_q])
-    T.cta_id_in_cluster([2])
-    cta_idx: T.let = block_idx % 2
-    thread_idx = T.thread_id([NUM_THREADS])
-    T.warpgroup_id([NUM_THREADS // 128])
-    T.warp_id_in_wg([4])
-    T.lane_id([32])
-    T.thread_id_in_wg([128])
-    warp_idx: T.let = T.cuda.__shfl_sync(T.uint32(0xFFFFFFFF), thread_idx // 32, 0, 32)
-    lane_idx: T.let = thread_idx % 32
-    warpgroup_idx: T.let = T.cuda.__shfl_sync(T.uint32(0xFFFFFFFF), thread_idx // 128, 0, 32)
-    idx_in_warpgroup: T.let = thread_idx % 128
-
-    pool = T.SMEMPool()
-    q_smem = pool.alloc_tcgen05_mma_AB((B_H // 2, D_QK), "bfloat16")
-    k_smem = pool.alloc_tcgen05_mma_AB((NUM_K_BUFS * B_TOPK, D_QK // 2), "bfloat16")
-    s_smem_gemm = pool.alloc_tcgen05_mma_AB(
-        (B_H // 2, B_TOPK), "bfloat16", swizzle_mode=SwizzleMode.SWIZZLE_NONE
-    )
-    p_exchange = pool.alloc((4, (B_H // 2 // 2) * (B_TOPK // 2)), "uint32")
-    rowwise_max_buf = pool.alloc((128,), "float32")
-    rowwise_li_buf = pool.alloc((128,), "float32")
-    is_k_valid = pool.alloc((NUM_INDEX_BUFS, B_TOPK // 8), "int8", align=16)
-
-    bar_sQ_full = TMABar(pool, 1, leader=True)
-    bar_tQ_empty = TCGen05Bar(pool, 1, leader=True)
-    bar_tQ_full = TCGen05Bar(pool, 1, leader=True)
-    bar_tOut_full = TCGen05Bar(pool, 1, leader=True)
-    bar_tOut_empty = MBarrier(pool, 1, leader=True)
-    bar_KV_full = TMABar(pool, NUM_K_BUFS, leader=True)
-    bar_KV_empty = TCGen05Bar(pool, NUM_K_BUFS, leader=True)
-    bar_P_empty = MBarrier(pool, 1, leader=True)
-    bar_QK_done = TCGen05Bar(pool, 1, leader=True)
-    bar_SV_done = TCGen05Bar(pool, 1, leader=True)
-    bar_S_O_full = MBarrier(pool, 1, leader=True)
-    bar_li_full = MBarrier(pool, 1, leader=True)
-    bar_li_empty = MBarrier(pool, 1, leader=True)
-    bar_valid_coord_scales_full = MBarrier(pool, NUM_INDEX_BUFS, leader=True)
-    bar_valid_coord_scales_empty = MBarrier(pool, NUM_INDEX_BUFS, leader=True)
-    bar_clc_full = TMABar(pool, 1, leader=True)
-    bar_clc_empty = MBarrier(pool, 1, leader=True)
-    clc_response = pool.alloc((4,), "uint32", align=16)
-    tmem_start_addr = pool.alloc((1,), "uint32", align=4)
-    pool.commit()
-    tmem_pool = T.TMEMPool(pool, total_cols=512, cta_group=2, tmem_addr=tmem_start_addr)
-    # O accumulator: one alloc; col halves = B lo/hi gemm outputs (physical col 0-127/128-255),
-    # read back as a (128, D_V//2) datapath-D tile via permute+reshape.
-    o_tmem = tmem_pool.alloc_tcgen05_mma_D(
-        (B_H // 2, D_V), "float32", M=128, cta_group=2, group=(2, 2, 128)
-    )
-    o_win = o_tmem.rearrange("h (a b c) -> (b h) (a c)", a=2, b=2, c=128)
-    # Q TMEM: one alloc at real 128-lane footprint, batched [2,M,K] head-dim fold (batch==lane-half);
-    # q_tmem_fold[b,h,k]=Q[h,256b+k], lane-half b = contiguous D half [256b,+256) matching K gather.
-    q_tmem_fold = tmem_pool.alloc_tcgen05_mma_A(
-        (2, B_H // 2, D_QK // 2), "bfloat16", M=128, cta_group=2
-    )
-    tmem_p_col = T.meta_var(tmem_pool.offset)
-    tmem_p = tmem_pool.alloc_tcgen05_mma_D((B_H // 2, B_TOPK * 2), "float32", M=128, cta_group=2)
-    k_smem_gemm = k_smem.rearrange(
-        "(kh row) (buf kl) -> buf row (kh kl)", kh=(D_QK // 2) // 64, buf=NUM_K_BUFS, kl=64
-    )
-
-    if warp_idx == 1:
-        if T.cuda.elect_sync():
-            bar_sQ_full.init(1)
-            bar_tQ_empty.init(1)
-            bar_tQ_full.init(1)
-            bar_tOut_full.init(1)
-            bar_tOut_empty.init(256)
-            bar_P_empty.init(256)
-            bar_QK_done.init(1)
-            bar_SV_done.init(1)
-            bar_S_O_full.init(256)
-            bar_li_full.init(B_H // 2)
-            bar_li_empty.init(128)
-            bar_clc_full.init(1)
-            bar_clc_empty.init(NUM_WORKER_THREADS)
-            T.ptx.fence.mbarrier_init.release.cluster()
-    elif warp_idx == 2:
-        T.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
-            T.address_of(tmem_start_addr[0]), T.uint32(512)
-        )
-        T.cuda.trap_when_assert_failed(tmem_start_addr[0] == T.uint32(0))
-        T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
-    elif warp_idx == 3:
-        if T.cuda.elect_sync():
-            for init_stage in T.unroll(NUM_K_BUFS):
-                T.ptx.mbarrier.init.shared.b64(bar_KV_full.ptr_to([init_stage]), T.uint32(1))
-                T.ptx.mbarrier.init.shared.b64(bar_KV_empty.ptr_to([init_stage]), T.uint32(1))
-            for init_stage in T.unroll(NUM_INDEX_BUFS):
-                T.ptx.mbarrier.init.shared.b64(
-                    bar_valid_coord_scales_full.ptr_to([init_stage]), T.uint32(B_TOPK // 8)
-                )
-                T.ptx.mbarrier.init.shared.b64(
-                    bar_valid_coord_scales_empty.ptr_to([init_stage]), T.uint32(128)
-                )
-            T.ptx.fence.mbarrier_init.release.cluster()
-
-    T.cuda.cluster_sync()
-
-    if warpgroup_idx == 0:
-        # CUDA phase1.cuh:192-396. Q fetching and O write-back warpgroup.
-        q_o_token = iket.range_start("h128-small-q-load-output")
-        T.ptx.setmaxnreg.inc.sync.aligned.u32(160)
-
-        @T.inline
-        def issue_q_copy(q_s_q_idx, q_outer_loop_phase):
-            if warp_idx == 0:
-                if T.cuda.elect_sync():
-                    T.ptx.cp.async_.bulk.wait_group(0)
-                    # Q's head-dim halves interleave per 64-elem chunk, matching the cp fold.
-                    q_tma = q.rearrange(
-                        "s h (half chunk inner) -> inner h half chunk s",
-                        half=2,
-                        chunk=D_QK // 64 // 2,
-                        inner=64,
-                    )
-                    q_smem_tma = q_smem.rearrange(
-                        "m (chunk c d0) -> d0 m c chunk", chunk=D_QK // 64 // 2, c=2
-                    )
-                    Tx.copy_async(
-                        q_smem_tma[:, :, :, :],
-                        q_tma.chunk((None, 2, None, None, None))[:, cta_idx, :, :, q_s_q_idx],
-                        **tma_config(
-                            mbar=leader_mbar(bar_sQ_full.ptr_to([0])),
-                            cta_group=2,
-                            cache_hint=T.uint64(0x12F0000000000000),
-                        ),
-                    )
-                    if cta_idx == 0:
-                        bar_sQ_full.arrive(0, tx_count=B_H * D_QK * BF16_BYTES)
-                        bar_sQ_full.wait(0, q_outer_loop_phase)
-                        bar_tQ_empty.wait(0, q_outer_loop_phase ^ 1)
-                        T.ptx.tcgen05.fence__after_thread_sync()
-                        q_tmem_cp = q_tmem_fold.rearrange("b h (dc di) -> h dc b di", di=64)
-                        Tx.copy_async(
-                            q_tmem_cp[:, :, :, :],
-                            q_smem.view(B_H // 2, D_QK // 128, 2, 64)[:, :, :, :],
-                            shape="128x256b",
-                            cta_group=2,
-                        )
-                        bar_tQ_full.arrive(0, cta_group=2, cta_mask=3)
-
-        @T.inline
-        def perform_o_copy_out(o_s_q_idx, o_outer_loop_phase, is_last_o: T.constexpr):
-            bar_li_full.wait(0, o_outer_loop_phase)
-            output_scale: T.let = rowwise_li_buf[idx_in_warpgroup % 64]
-            bar_li_empty.arrive(0)
-
-            bar_tOut_full.wait(0, o_outer_loop_phase)
-            if is_last_o:
-                if T.cuda.elect_sync():
-                    T.ptx.griddepcontrol.launch_dependents()
-
-            o_epi_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, B_EPI), "float32")
-            o_epi = o_epi_frag.local()
-            o_epi_bf16_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, B_EPI), "bfloat16")
-            q_smem_win = q_smem.rearrange("h (b r) -> (b h) r", b=2)
-            for epi_k in T.unroll((D_V // 2) // B_EPI):
-                Tx.wg.copy_async(
-                    o_epi_frag[:, :], o_win.chunk((None, (D_V // 2) // B_EPI))[:, epi_k]
-                )
-                T.ptx.tcgen05.wait__ld.sync.aligned()
-                if epi_k == 0:
-                    if is_last_o:
-                        bar_tQ_full.wait(0, o_outer_loop_phase)
-                    else:
-                        bar_tQ_full.wait(0, o_outer_loop_phase ^ 1)
-                    T.ptx.fence.proxy.async_.shared__cta()
-                if epi_k == ((D_V // 2) // B_EPI) - 1:
-                    bar_tOut_empty.arrive(0, remote=T.uint32(0))
-                Tx.wg.mul(o_epi_frag[:, :], o_epi_frag[:, :], output_scale)
-                Tx.wg.cast(o_epi_bf16_frag[:, :], o_epi_frag[:, :])
-                Tx.wg.copy(
-                    q_smem_win.chunk((None, (D_V // 2) // B_EPI))[:, epi_k], o_epi_bf16_frag[:, :]
-                )
-
-            T.ptx.fence.proxy.async_.shared__cta()
-            T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-            if warp_idx == 0:
-                if T.cuda.elect_sync():
-                    Tx.copy_async(
-                        out.chunk((None, 2, None))[o_s_q_idx, cta_idx, :],
-                        q_smem[:, :],
-                        **tma_config(),
-                    )
-                    T.ptx.cp.async_.bulk.commit_group()
-
-        wg0_job_valid: T.int32 = 1
-        wg0_job_block_idx: T.int32 = block_idx
-        wg0_outer_loop_phase: T.int32 = 0
-        last_valid: T.int32 = 0
-        last_s_q_idx: T.int32 = 0
-        last_outer_loop_phase: T.int32 = 0
-
-        while wg0_job_valid != 0:
-            wg0_s_q_idx: T.let = wg0_job_block_idx // 2
-            issue_q_copy(wg0_s_q_idx, wg0_outer_loop_phase)
-
-            if last_valid != 0:
-                perform_o_copy_out(last_s_q_idx, last_outer_loop_phase, False)
-            else:
-                bar_tQ_full.wait(0, wg0_outer_loop_phase)
-            last_valid = 1
-            last_s_q_idx = wg0_s_q_idx
-            last_outer_loop_phase = wg0_outer_loop_phase
-
-            bar_clc_full.wait(0, wg0_outer_loop_phase)
-            wg0_next_job = T.local_scalar("uint32")
-            query_cancel_first_ctaid_x(wg0_next_job, T.address_of(clc_response[0]))
-            _rem1 = T.alloc_local([1], "uint64")
-            T.ptx.mapa.shared__cluster.u64(_rem1[0], bar_clc_empty.ptr_to([0]), T.uint32(0))
-            T.ptx.mbarrier.arrive.b64(_rem1[0], T.uint32(1), pred=T.bool(True))
-            if wg0_next_job == T.uint32(0xFFFFFFFF):
-                wg0_job_valid = 0
-            else:
-                wg0_job_block_idx = T.cast(wg0_next_job, "int32")
-            wg0_outer_loop_phase = wg0_outer_loop_phase ^ 1
-
-        if last_valid != 0:
-            if warp_idx == 0:
-                if T.cuda.elect_sync():
-                    T.ptx.cp.async_.bulk.wait_group(0)
-            T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-            perform_o_copy_out(last_s_q_idx, last_outer_loop_phase, True)
-
-        if warp_idx == 0:
-            T.ptx.tcgen05.dealloc.cta_group__2.sync.aligned.b32(T.uint32(0), T.uint32(512))
-        iket.range_end(q_o_token)
-
-    elif warpgroup_idx == 1:
-        # CUDA phase1.cuh:397-451. Prefill KV gather producer.
-        kv_gather_token = iket.range_start("h128-small-kv-load")
-        T.ptx.setmaxnreg.dec.sync.aligned.u32(80)
-        # Source uses canonical_warp_idx() here, not canonical_warp_idx_sync().
-        wg1_warp_idx: T.let = thread_idx // 32 - 4
-        if T.cuda.elect_sync():
-            wg1_job_valid: T.int32 = 1
-            wg1_job_block_idx: T.int32 = block_idx
-            wg1_outer_loop_phase: T.int32 = 0
-            wg1_rs: T.int32 = 0
-            while wg1_job_valid != 0:
-                wg1_s_q_idx: T.let = wg1_job_block_idx // 2
-                wg1_topk_len: T.let = (
-                    T.cuda.ldg(topk_length.ptr_to([wg1_s_q_idx]), "int32")
-                    if have_topk_length
-                    else topk
-                )
-                wg1_num_k_blocks: T.let = T.max((wg1_topk_len + B_TOPK - 1) // B_TOPK, 1)
-                wg1_g_indices_base: T.let = wg1_s_q_idx * stride_indices_s_q
-
-                for k in T.serial(0, wg1_num_k_blocks, unroll=False):
-                    k_buf_idx: T.let = wg1_rs % NUM_K_BUFS
-                    k_bar_phase: T.let = (wg1_rs // NUM_K_BUFS) & 1
-                    cur_indices = T.alloc_local((WG1_ROWS_PER_WARP,), "int32")
-                    for local_row in T.unroll(WG1_ROWS_PER_WARP // 8):
-                        row: T.let = local_row * (4 * 8) + wg1_warp_idx * 8
-                        row_base: T.let = wg1_g_indices_base + k * B_TOPK + row
-                        Tx.copy(
-                            cur_indices[local_row * 8 : local_row * 8 + 8],
-                            indices[row_base : row_base + 8],
-                            dispatch="vec_256b",
-                            cache="nc",
-                            l1_evict="L1::no_allocate",
-                            l2_evict="L2::evict_first",
-                            prefetch_size="L2::256B",
-                        )
-                    bar_KV_empty.wait(k_buf_idx, k_bar_phase ^ 1)
-                    k_smem_gemm_cur = k_smem_gemm.sub[k_buf_idx]
-                    src_col: T.let = cta_idx * (D_QK // 2)
-                    # Rows interleave (row_group, warp, pair, lane4): this warp's 8-row stripes of each
-                    # 64-col chunk. Col reshaped to (chunk,64); row picks this warp's rows via rank-preserving tile.
-                    k_gather_tile = (
-                        k_smem_gemm_cur.view(B_TOPK, (D_QK // 2) // 64, 64).tile(0, (-1, 4, 2, 4))
-                    )[:, wg1_warp_idx, :, :]
-                    kv_tma = kv.view(
-                        s_kv, D_QK, layout=TileLayout(S[(s_kv, D_QK) : (stride_kv_s_kv, 1)])
-                    )
-                    k_gather_tile_2d = k_gather_tile.view(WG1_ROWS_PER_WARP, D_QK // 2)
-                    for row_group in T.unroll(WG1_ROWS_PER_WARP // 4):
-                        for col_atom in T.unroll((D_QK // 2) // 64):
-                            col = T.meta_var(src_col + col_atom * 64)
-                            Tx.copy_async(
-                                k_gather_tile_2d[
-                                    row_group * 4 : row_group * 4 + 4,
-                                    col_atom * 64 : col_atom * 64 + 64,
-                                ],
-                                kv_tma[0:1, col : col + 64],
-                                **_kv_gather_tma(
-                                    mbar=leader_mbar(bar_KV_full.ptr_to([k_buf_idx])),
-                                    gather4=[
-                                        cur_indices[row_group * 4 + lane] for lane in range(4)
-                                    ],
-                                ),
-                            )
-                    wg1_rs = wg1_rs + 1
-
-                bar_clc_full.wait(0, wg1_outer_loop_phase)
-                wg1_next_job = T.local_scalar("uint32")
-                query_cancel_first_ctaid_x(wg1_next_job, T.address_of(clc_response[0]))
-                _rem2 = T.alloc_local([1], "uint64")
-                T.ptx.mapa.shared__cluster.u64(_rem2[0], bar_clc_empty.ptr_to([0]), T.uint32(0))
-                T.ptx.mbarrier.arrive.b64(_rem2[0], T.uint32(1), pred=T.bool(True))
-                if wg1_next_job == T.uint32(0xFFFFFFFF):
-                    wg1_job_valid = 0
+    @T.prim_func
+    def _kernel(q: T.Buffer((s_q, 128, 512), "bfloat16"), kv: T.Buffer((s_kv * stride_kv_s_kv,), "bfloat16"), indices: T.Buffer((s_q * stride_indices_s_q,), "int32"), attn_sink: T.Buffer((128,), "float32"), topk_length: T.Buffer((s_q,), "int32"), out: T.Buffer((s_q, 128, 512), "bfloat16"), max_logits: T.Buffer((s_q, 128), "float32"), lse: T.Buffer((s_q, 128), "float32")):
+        T.func_attr({"tirx.kernel_launch_params": ["blockIdx.x", "clusterCtaIdx.x", "threadIdx.x", "tirx.use_programtic_dependent_launch", "tirx.use_dyn_shared_memory"]})
+        kv_tma_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed("runtime.cuTensorMapEncodeTiled", kv_tma_tensormap, "bfloat16", 2, T.handle_add_byte_offset(kv.data, 0), 512, s_kv, stride_kv_s_kv * 2, 64, 1, 1, 1, 0, 3, 3, 0)
+        out_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed("runtime.cuTensorMapEncodeTiled", out_tensormap, "bfloat16", 4, T.handle_add_byte_offset(out.data, 0), 64, 128, 8, s_q, 1024, 128, 131072, 64, 64, 8, 1, 1, 1, 1, 1, 0, 3, 3, 0)
+        out_tensormap_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed("runtime.cuTensorMapEncodeTiled", out_tensormap_1, "bfloat16", 4, T.handle_add_byte_offset(out.data, 0), 64, 128, 8, s_q, 1024, 128, 131072, 64, 64, 8, 1, 1, 1, 1, 1, 0, 3, 3, 0)
+        q_tma_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed("runtime.cuTensorMapEncodeTiled", q_tma_tensormap, "bfloat16", 5, T.handle_add_byte_offset(q.data, 0), 64, 128, 2, 4, s_q, 1024, 512, 128, 131072, 64, 64, 2, 4, 1, 1, 1, 1, 1, 1, 0, 3, 3, 0)
+        with T.launch_thread("clusterCtaIdx.x", 2) as clusterCtaIdx_x:
+            blockIdx_x = T.launch_thread("blockIdx.x", 2 * s_q)
+            threadIdx_x = T.launch_thread("threadIdx.x", 512)
+            warp_id_in_cta: T.let[T.int32] = T.tvm_warp_shuffle(T.uint32(4294967295), threadIdx_x // 32, 0, 32, 32)
+            block_idx: T.let[T.int32] = blockIdx_x
+            v: T.let[T.int32] = clusterCtaIdx_x
+            thread_idx: T.let[T.int32] = threadIdx_x
+            v_1: T.let[T.int32] = warp_id_in_cta // 4
+            v_2: T.let[T.int32] = warp_id_in_cta % 4
+            v_3: T.let[T.int32] = threadIdx_x % 32
+            v_4: T.let[T.int32] = threadIdx_x % 128
+            v_5: T.let[T.int32] = threadIdx_x % 128
+            v_6: T.let[T.int32] = threadIdx_x % 128
+            v_7: T.let[T.int32] = threadIdx_x % 128
+            T.evaluate(v)
+            T.evaluate(v_1)
+            T.evaluate(v_2)
+            T.evaluate(v_3)
+            T.evaluate(v_4)
+            T.evaluate(v_5)
+            T.evaluate(v_6)
+            T.evaluate(v_7)
+            if warp_id_in_cta == 0:
+                if T.cuda.elect_sync() != T.uint32(0):
+                    T.ptx.prefetch(T.reinterpret(T.handle().ty, T.address_of(q_tma_tensormap)), "", "", "", "tensormap", "")
+            if warp_id_in_cta == 0:
+                if T.cuda.elect_sync() != T.uint32(0):
+                    T.ptx.prefetch(T.reinterpret(T.handle().ty, T.address_of(out_tensormap_1)), "", "", "", "tensormap", "")
+            if warp_id_in_cta == 0:
+                if T.cuda.elect_sync() != T.uint32(0):
+                    T.ptx.prefetch(T.reinterpret(T.handle().ty, T.address_of(out_tensormap)), "", "", "", "tensormap", "")
+            if warp_id_in_cta == 0:
+                if T.cuda.elect_sync() != T.uint32(0):
+                    T.ptx.prefetch(T.reinterpret(T.handle().ty, T.address_of(kv_tma_tensormap)), "", "", "", "tensormap", "")
+            with T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1}):
+                cta_idx: T.let[T.int32] = block_idx % 2
+                warp_idx: T.let[T.int32] = T.cuda.__shfl_sync(T.uint32(4294967295), thread_idx // 32, 0, 32)
+                lane_idx: T.let[T.int32] = thread_idx % 32
+                warpgroup_idx: T.let[T.int32] = T.cuda.__shfl_sync(T.uint32(4294967295), thread_idx // 128, 0, 32)
+                idx_in_warpgroup: T.let[T.int32] = thread_idx % 128
+                pool_buf = T.alloc_buffer((0,), "uint8", scope="shared.dyn")
+                q_smem = T.decl_buffer((64, 512), "bfloat16", data=pool_buf.data, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(64, 8, 64):(64, 4096, 1)])))
+                k_smem = T.decl_buffer((256, 256), "bfloat16", data=pool_buf.data, elem_offset=32768, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(256, 4, 64):(64, 16384, 1)])))
+                s_smem_gemm = T.decl_buffer((64, 64), "bfloat16", data=pool_buf.data, elem_offset=98304, scope="shared.dyn", align=1024, layout=T.TileLayout(T.S[(64, 8, 8):(8, 512, 1)]))
+                p_exchange = T.decl_buffer((4, 1024), "uint32", data=pool_buf.data, elem_offset=51200, scope="shared.dyn")
+                rowwise_max_buf = T.decl_buffer((128,), data=pool_buf.data, elem_offset=55296, scope="shared.dyn")
+                rowwise_li_buf = T.decl_buffer((128,), data=pool_buf.data, elem_offset=55424, scope="shared.dyn")
+                is_k_valid = T.decl_buffer((4, 8), "int8", data=pool_buf.data, elem_offset=222208, scope="shared.dyn", align=16)
+                buffer = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27780, scope="shared.dyn", align=8)
+                buffer_1 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27781, scope="shared.dyn", align=8)
+                buffer_2 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27782, scope="shared.dyn", align=8)
+                buffer_3 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27783, scope="shared.dyn", align=8)
+                bar_tOut_empty_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27784, scope="shared.dyn", align=8)
+                buffer_4 = T.decl_buffer((4,), "uint64", data=pool_buf.data, elem_offset=27785, scope="shared.dyn", align=8)
+                buffer_5 = T.decl_buffer((4,), "uint64", data=pool_buf.data, elem_offset=27789, scope="shared.dyn", align=8)
+                bar_P_empty_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27793, scope="shared.dyn", align=8)
+                buffer_6 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27794, scope="shared.dyn", align=8)
+                buffer_7 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27795, scope="shared.dyn", align=8)
+                bar_S_O_full_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27796, scope="shared.dyn", align=8)
+                bar_li_full_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27797, scope="shared.dyn", align=8)
+                bar_li_empty_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27798, scope="shared.dyn", align=8)
+                bar_valid_coord_scales_full_buf = T.decl_buffer((4,), "uint64", data=pool_buf.data, elem_offset=27799, scope="shared.dyn", align=8)
+                bar_valid_coord_scales_empty_buf = T.decl_buffer((4,), "uint64", data=pool_buf.data, elem_offset=27803, scope="shared.dyn", align=8)
+                buffer_8 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27807, scope="shared.dyn", align=8)
+                bar_clc_empty_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27808, scope="shared.dyn", align=8)
+                clc_response = T.decl_buffer((4,), "uint32", data=pool_buf.data, elem_offset=55620, scope="shared.dyn", align=16)
+                tmem_start_addr = T.decl_buffer((1,), "uint32", data=pool_buf.data, elem_offset=55624, scope="shared.dyn", align=4)
+                with T.attr({"tirx.dyn_smem_bytes": T.int64(222500)}):
+                    T.evaluate(0)
+                o_tmem = T.decl_buffer((64, 512), scope="tmem", layout=T.TileLayout(T.S[(64, 2, 2, 128):(1 @ Axis.TLane, 128 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=0)
+                buffer_9 = T.decl_buffer((64, 2, 2, 128), scope="tmem", layout=T.TileLayout(T.S[(64, 2, 2, 128):(1 @ Axis.TLane, 128 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=0)
+                buffer_10 = T.decl_buffer((2, 64, 2, 128), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 2, 128):(64 @ Axis.TLane, 1 @ Axis.TLane, 128 @ Axis.TCol, 1 @ Axis.TCol)]), allocated_addr=0)
+                o_win = T.decl_buffer((128, 256), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 2, 128):(64 @ Axis.TLane, 1 @ Axis.TLane, 128 @ Axis.TCol, 1 @ Axis.TCol)]), allocated_addr=0)
+                q_tmem_fold = T.decl_buffer((2, 64, 256), "bfloat16", scope="tmem", layout=T.TileLayout(T.S[(128, 256):(1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=256)
+                tmem_p = T.decl_buffer((64, 128), scope="tmem", layout=T.TileLayout(T.S[(64, 2, 64):(1 @ Axis.TLane, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                buffer_11 = k_smem.view(4, 64, 4, 64)
+                buffer_12 = T.decl_buffer((4, 64, 4, 64), "bfloat16", data=buffer_11.data, elem_offset=32768, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(4, 64, 4, 64):(16384, 64, 4096, 1)])))
+                k_smem_gemm = buffer_12.view(4, 64, 256)
+                if warp_idx == 1:
+                    if T.cuda.elect_sync():
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_1[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_2[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_3[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_tOut_empty_buf[i])), T.uint32(256), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_P_empty_buf[i])), T.uint32(256), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_6[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_7[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_S_O_full_buf[i])), T.uint32(256), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_li_full_buf[i])), T.uint32(64), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_li_empty_buf[i])), T.uint32(128), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_8[i])), T.uint32(1), "init", "shared", "b64", "")
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_clc_empty_buf[i])), T.uint32(539), "init", "shared", "b64", "")
+                        T.ptx.fence("mbarrier_init", "release", "cluster", "")
                 else:
-                    wg1_job_block_idx = T.cast(wg1_next_job, "int32")
-                wg1_outer_loop_phase = wg1_outer_loop_phase ^ 1
-        iket.range_end(kv_gather_token)
-
-    elif warpgroup_idx == 2:
-        # CUDA phase1.cuh:533-787. UMMA, valid-mask loading, and CLC producer.
-        T.ptx.setmaxnreg.dec.sync.aligned.u32(80)
-
-        if (warp_idx == 8) & (cta_idx == 0):
-            mma_token = iket.range_start("h128-small-qk-pv-issue")
-            if T.cuda.elect_sync():
-                umma_job_valid: T.int32 = 1
-                umma_job_block_idx: T.int32 = block_idx
-                umma_outer_loop_phase: T.int32 = 0
-                umma_rs: T.int32 = 0
-                while umma_job_valid != 0:
-                    umma_s_q_idx: T.let = umma_job_block_idx // 2
-                    umma_topk_len: T.let = (
-                        T.cuda.ldg(topk_length.ptr_to([umma_s_q_idx]), "int32")
-                        if have_topk_length
-                        else topk
-                    )
-                    umma_num_k_blocks: T.let = T.max((umma_topk_len + B_TOPK - 1) // B_TOPK, 1)
-                    bar_tQ_full.wait(0, umma_outer_loop_phase)
-
-                    for k in T.serial(0, umma_num_k_blocks + 1, unroll=False):
-                        if k < umma_num_k_blocks:
-                            k_buf_idx: T.let = umma_rs % NUM_K_BUFS
-                            k_bar_phase: T.let = (umma_rs // NUM_K_BUFS) & 1
-                            p_bar_phase: T.let = umma_rs & 1
-                            bar_P_empty.wait(0, p_bar_phase ^ 1)
-                            bar_KV_full.arrive(k_buf_idx, tx_count=B_TOPK * D_QK * BF16_BYTES)
-                            bar_KV_full.wait(k_buf_idx, k_bar_phase)
-                            T.ptx.tcgen05.fence__after_thread_sync()
-                            qk_accumulate: T.uint32 = 0
-                            Tx.gemm_async(
-                                tmem_p[:, :],
-                                q_tmem_fold[:, :, :],
-                                k_smem_gemm[k_buf_idx, :, :],
-                                **_mma_config(accum=qk_accumulate),
-                            )
-                            qk_accumulate = T.uint32(1)
-                            bar_QK_done.arrive(0, cta_group=2, cta_mask=3)
-                            if k == umma_num_k_blocks - 1:
-                                T.ptx.tcgen05.commit.cta_group__2.mbarrier__arrive__one.shared__cluster.b64(
-                                    bar_tQ_empty.ptr_to([0])
+                    if warp_idx == 2:
+                        T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(tmem_start_addr[0])), T.uint32(512), "alloc", "cta_group::2", "sync", "aligned", "shared::cta", "b32", "")
+                        allocated_tmem_addr: T.uint32
+                        T.ptx.ld.shared.u32(allocated_tmem_addr, tmem_start_addr.ptr_to([0]))
+                        T.cuda.trap_when_assert_failed(allocated_tmem_addr == T.uint32(0))
+                        T.ptx.tcgen05("relinquish_alloc_permit", "cta_group::2", "sync", "aligned", "")
+                    else:
+                        if warp_idx == 3:
+                            if T.cuda.elect_sync():
+                                for init_stage in T.unroll(4):
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_4[init_stage])), T.uint32(1), "init", "shared", "b64", "")
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_5[init_stage])), T.uint32(1), "init", "shared", "b64", "")
+                                for init_stage in T.unroll(4):
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_valid_coord_scales_full_buf[init_stage])), T.uint32(8), "init", "shared", "b64", "")
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_valid_coord_scales_empty_buf[init_stage])), T.uint32(128), "init", "shared", "b64", "")
+                                T.ptx.fence("mbarrier_init", "release", "cluster", "")
+                T.cuda.cluster_sync()
+                if warpgroup_idx == 0:
+                    q_o_token: T.uint32 = T.cuda.iket.range_start("h128-small-q-load-output")
+                    T.ptx.setmaxnreg(160, "inc", "sync", "aligned", "u32", "")
+                    wg0_job_valid: T.int32 = 1
+                    wg0_job_block_idx: T.int32 = block_idx
+                    wg0_outer_loop_phase: T.int32 = 0
+                    last_valid: T.int32 = 0
+                    last_s_q_idx: T.int32 = 0
+                    last_outer_loop_phase: T.int32 = 0
+                    while wg0_job_valid != 0:
+                        wg0_s_q_idx: T.let[T.int32] = wg0_job_block_idx // 2
+                        if warp_idx == 0:
+                            if T.cuda.elect_sync():
+                                T.ptx.cp(0, "async", "bulk", "wait_group", "", "")
+                                buffer_13 = q.view(s_q, 128, 2, 4, 64)
+                                buffer_14 = buffer_13.view(64, 128, 2, 4, s_q, layout=T.TileLayout(T.S[(64, 128, 2, 4, s_q):(1, 512, 256, 64, 65536)]))
+                                q_tma = T.decl_buffer((64, 128, 2, 4, s_q), "bfloat16", data=buffer_14.data, layout=T.TileLayout(T.S[(64, 128, 2, 4, s_q):(1, 512, 256, 64, 65536)]))
+                                buffer_15 = q_smem.view(64, 4, 2, 64)
+                                buffer_16 = buffer_15.view(64, 64, 2, 4, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(64, 64, 2, 4):(1, 64, 4096, 8192)])))
+                                q_smem_tma = T.decl_buffer((64, 64, 2, 4), "bfloat16", data=buffer_16.data, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(64, 64, 2, 4):(1, 64, 4096, 8192)])))
+                                buffer_17: T.uint64
+                                T.ptx.mapa(buffer_17, T.address_of(buffer[0]), T.uint32(0), "", "u64", "")
+                                buffer_18 = T.decl_scalar(T.bfloat16, data=q_smem_tma.data, elem_offset=0, scope="shared.dyn")
+                                T.ptx.cp(T.cuda.cvta_generic_to_shared(T.address_of(buffer_18)), T.reinterpret(T.handle().ty, T.address_of(q_tma_tensormap)), 0, block_idx % 2 * 64, 0, 0, wg0_job_block_idx // 2, T.cuda.cvta_generic_to_shared(T.reinterpret(T.handle().ty, buffer_17)), T.uint64(1364590687093260288), "async", "bulk", "tensor", "5d", "shared::cluster", "global", "", "mbarrier::complete_tx::bytes", "", "cta_group::2", "L2::cache_hint", "")
+                                if cta_idx == 0:
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer[0])), T.uint32(131072), "arrive", "expect_tx", "", "", "shared", "b64", "")
+                                    T.cuda.mbarrier_wait(T.address_of(buffer[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
+                                    T.cuda.mbarrier_wait(T.address_of(buffer_1[0]), T.bitwise_xor(T.bitwise_xor(wg0_outer_loop_phase, 1), 0))
+                                    T.ptx.tcgen05("fence::after_thread_sync", "")
+                                    buffer_19 = T.decl_buffer((2, 64, 4, 64), "bfloat16", scope="tmem", layout=T.TileLayout(T.S[(128, 256):(1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=256)
+                                    buffer_20 = T.decl_buffer((64, 4, 2, 64), "bfloat16", scope="tmem", layout=T.TileLayout(T.S[(64, 4, 2, 64):(1 @ Axis.TLane, 64 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=256)
+                                    q_tmem_cp = T.decl_buffer((64, 4, 2, 64), "bfloat16", scope="tmem", layout=T.TileLayout(T.S[(64, 4, 2, 64):(1 @ Axis.TLane, 64 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=256)
+                                    buffer_21 = q_smem.view(64, 4, 2, 64)
+                                    cp_desc: T.uint64
+                                    T.cuda.tcgen05.encode_matrix_descriptor(cp_desc.buffer.data, T.reinterpret(T.handle().ty, T.uint64(0)), 1, 64, 3)
+                                    for flat in T.unroll(16):
+                                        T.ptx.tcgen05(T.Cast("uint32", 256 + (flat % 4 * 32 + flat // 4 % 4 * 8)), T.bitwise_or(T.bitwise_and(cp_desc, T.bitwise_not(T.uint64(16383))), T.Cast("uint64", T.bitwise_and(T.shift_right(T.cuda.cvta_generic_to_shared(T.ptr_byte_offset(T.address_of(buffer_21[0, 0, 0, 0]), (flat % 4 * 1024 + flat // 4 % 4 * 2) * 16, T.type_annotation("bfloat16"))), T.uint32(4)), T.uint32(16383)))), "cp", "cta_group::2", "128x256b", "", "", "", "")
+                                    T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_2[0])), T.Cast("uint16", 3), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "multicast::cluster", "b64", "")
+                        if last_valid != 0:
+                            T.cuda.mbarrier_wait(T.address_of(bar_li_full_buf[0]), T.bitwise_xor(last_outer_loop_phase, 0))
+                            output_scale: T.float32
+                            T.ptx.ld.shared.f32(output_scale, rowwise_li_buf.ptr_to([idx_in_warpgroup % 64]))
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_li_empty_buf[0])), T.uint32(1), "arrive", "", "", "shared", "b64", "")
+                            T.cuda.mbarrier_wait(T.address_of(buffer_3[0]), T.bitwise_xor(last_outer_loop_phase, 0))
+                            buffer_13 = T.alloc_local((64,))
+                            o_epi_frag = buffer_13.view(128, 64, layout=T.TileLayout(T.S[(128, 64):(1 @ Axis.tid_in_wg, 1)]))
+                            o_epi = o_epi_frag.local()
+                            buffer_14 = T.alloc_local((64,), "bfloat16")
+                            o_epi_bf16_frag = buffer_14.view(128, 64, layout=T.TileLayout(T.S[(128, 64):(1 @ Axis.tid_in_wg, 1)]))
+                            buffer_15 = q_smem.view(64, 2, 256)
+                            buffer_16 = buffer_15.view(2, 64, 256, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(2, 64, 4, 64):(16384, 64, 4096, 1)])))
+                            q_smem_win = buffer_16.view(128, 256)
+                            for epi_k in T.unroll(4):
+                                local_storage = o_epi_frag.local()
+                                T.ptx.tcgen05(local_storage[0], local_storage[1], local_storage[2], local_storage[3], local_storage[4], local_storage[5], local_storage[6], local_storage[7], local_storage[8], local_storage[9], local_storage[10], local_storage[11], local_storage[12], local_storage[13], local_storage[14], local_storage[15], local_storage[16], local_storage[17], local_storage[18], local_storage[19], local_storage[20], local_storage[21], local_storage[22], local_storage[23], local_storage[24], local_storage[25], local_storage[26], local_storage[27], local_storage[28], local_storage[29], local_storage[30], local_storage[31], local_storage[32], local_storage[33], local_storage[34], local_storage[35], local_storage[36], local_storage[37], local_storage[38], local_storage[39], local_storage[40], local_storage[41], local_storage[42], local_storage[43], local_storage[44], local_storage[45], local_storage[46], local_storage[47], local_storage[48], local_storage[49], local_storage[50], local_storage[51], local_storage[52], local_storage[53], local_storage[54], local_storage[55], local_storage[56], local_storage[57], local_storage[58], local_storage[59], local_storage[60], local_storage[61], local_storage[62], local_storage[63], T.cuda.get_tmem_addr(T.uint32(0), 0, epi_k * 64), "ld", "sync", "aligned", "32x32b", "x64", "", "b32", "")
+                                T.ptx.tcgen05("wait::ld", "sync", "aligned", "")
+                                if epi_k == 0:
+                                    T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(T.bitwise_xor(last_outer_loop_phase, 1), 0))
+                                    T.ptx.fence("proxy", "async", "shared::cta", "")
+                                if epi_k == 3:
+                                    buffer_17: T.uint32
+                                    T.ptx.mapa(buffer_17, T.cuda.cvta_generic_to_shared(T.address_of(bar_tOut_empty_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                    T.ptx.mbarrier(buffer_17, "arrive", "", "", "shared::cluster", "b64", "")
+                                buffer_17 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                                buffer_18 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                                for f in range(32):
+                                    dst_lane_indices_0_0: T.int32 = f * 2
+                                    dst_lane_indices_1_0: T.int32 = f * 2 + 1
+                                    buffer_19: T.uint64
+                                    buffer_20: T.uint64
+                                    T.ptx.mov(buffer_19, buffer_18[f * 2], buffer_18[f * 2 + 1], "b64", "")
+                                    T.ptx.mov(buffer_20, output_scale, output_scale, "b64", "")
+                                    T.ptx.mul(buffer_19, buffer_19, buffer_20, "rz", "ftz", "", "f32x2", "")
+                                    T.ptx.mov(buffer_17[f * 2], buffer_17[f * 2 + 1], buffer_19, "b64", "")
+                                buffer_19 = o_epi_bf16_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                                buffer_19_words = buffer_19.view("uint32")
+                                buffer_20 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                                for f in range(32):
+                                    dst_lane_indices_0_0: T.int32 = f * 2
+                                    dst_lane_indices_1_0: T.int32 = f * 2 + 1
+                                    T.ptx.cvt.rn.bf16x2.f32(
+                                        buffer_19_words[f], buffer_20[f * 2 + 1], buffer_20[f * 2]
+                                    )
+                                r_local = o_epi_bf16_frag.local()
+                                r_words = r_local.view("uint32")
+                                for f in range(8):
+                                    ds: T.int32 = f % 8 * 8
+                                    dr: T.int32 = f % 8 * 8
+                                    s_off: T.int32 = v_5 // 64 * 16384 + epi_k % 4 * 4096 + v_5 % 64 * 64 + T.bitwise_xor(f * 8, T.shift_left(T.bitwise_and(v_5 // 64 * 256 + epi_k % 4 * 64 + v_5 % 64, 7), 3))
+                                    s_ptr: T.let = T.ptr_byte_offset(
+                                        T.address_of(q_smem_win[0, 0]), s_off * BF16_BYTES, "bfloat16"
+                                    )
+                                    r_w: T.int32 = dr // 2
+                                    T.ptx.st(T.cuda.cvta_generic_to_shared(s_ptr), r_words[r_w], r_words[r_w + 1], r_words[r_w + 2], r_words[r_w + 3], "", "", "shared", "", "", "", "v4", "u32", "")
+                            T.ptx.fence("proxy", "async", "shared::cta", "")
+                            T.ptx.bar(T.uint32(0), T.uint32(128), "", "sync", "")
+                            if warp_idx == 0:
+                                if T.cuda.elect_sync():
+                                    buffer_17 = T.decl_scalar(T.bfloat16, data=q_smem.data, elem_offset=0, scope="shared.dyn")
+                                    T.ptx.cp(T.reinterpret(T.handle().ty, T.address_of(out_tensormap_1)), 0, block_idx % 2 * 64, 0, last_s_q_idx, T.cuda.cvta_generic_to_shared(T.address_of(buffer_17)), "async", "bulk", "tensor", "4d", "global", "shared::cta", "tile", "bulk_group", "", "")
+                                    T.ptx.cp("async", "bulk", "commit_group", "")
+                        else:
+                            T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
+                        last_valid = 1
+                        last_s_q_idx = wg0_s_q_idx
+                        last_outer_loop_phase = wg0_outer_loop_phase
+                        T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
+                        wg0_next_job: T.uint32
+                        query_cancel_first_ctaid_x(wg0_next_job, T.address_of(clc_response[0]))
+                        _rem1: T.uint64
+                        T.ptx.mapa(_rem1, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                        T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem1), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                        if wg0_next_job == T.uint32(4294967295):
+                            wg0_job_valid = 0
+                        else:
+                            wg0_job_block_idx = T.Cast("int32", wg0_next_job)
+                        wg0_outer_loop_phase = T.bitwise_xor(wg0_outer_loop_phase, 1)
+                    if last_valid != 0:
+                        if warp_idx == 0:
+                            if T.cuda.elect_sync():
+                                T.ptx.cp(0, "async", "bulk", "wait_group", "", "")
+                        T.ptx.bar(T.uint32(0), T.uint32(128), "", "sync", "")
+                        T.cuda.mbarrier_wait(T.address_of(bar_li_full_buf[0]), T.bitwise_xor(last_outer_loop_phase, 0))
+                        output_scale: T.float32
+                        T.ptx.ld.shared.f32(output_scale, rowwise_li_buf.ptr_to([idx_in_warpgroup % 64]))
+                        T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_li_empty_buf[0])), T.uint32(1), "arrive", "", "", "shared", "b64", "")
+                        T.cuda.mbarrier_wait(T.address_of(buffer_3[0]), T.bitwise_xor(last_outer_loop_phase, 0))
+                        if T.cuda.elect_sync():
+                            T.ptx.griddepcontrol("launch_dependents", "")
+                        buffer_13 = T.alloc_local((64,))
+                        o_epi_frag = buffer_13.view(128, 64, layout=T.TileLayout(T.S[(128, 64):(1 @ Axis.tid_in_wg, 1)]))
+                        o_epi = o_epi_frag.local()
+                        buffer_14 = T.alloc_local((64,), "bfloat16")
+                        o_epi_bf16_frag = buffer_14.view(128, 64, layout=T.TileLayout(T.S[(128, 64):(1 @ Axis.tid_in_wg, 1)]))
+                        buffer_15 = q_smem.view(64, 2, 256)
+                        buffer_16 = buffer_15.view(2, 64, 256, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(2, 64, 4, 64):(16384, 64, 4096, 1)])))
+                        q_smem_win = buffer_16.view(128, 256)
+                        for epi_k in T.unroll(4):
+                            local_storage = o_epi_frag.local()
+                            T.ptx.tcgen05(local_storage[0], local_storage[1], local_storage[2], local_storage[3], local_storage[4], local_storage[5], local_storage[6], local_storage[7], local_storage[8], local_storage[9], local_storage[10], local_storage[11], local_storage[12], local_storage[13], local_storage[14], local_storage[15], local_storage[16], local_storage[17], local_storage[18], local_storage[19], local_storage[20], local_storage[21], local_storage[22], local_storage[23], local_storage[24], local_storage[25], local_storage[26], local_storage[27], local_storage[28], local_storage[29], local_storage[30], local_storage[31], local_storage[32], local_storage[33], local_storage[34], local_storage[35], local_storage[36], local_storage[37], local_storage[38], local_storage[39], local_storage[40], local_storage[41], local_storage[42], local_storage[43], local_storage[44], local_storage[45], local_storage[46], local_storage[47], local_storage[48], local_storage[49], local_storage[50], local_storage[51], local_storage[52], local_storage[53], local_storage[54], local_storage[55], local_storage[56], local_storage[57], local_storage[58], local_storage[59], local_storage[60], local_storage[61], local_storage[62], local_storage[63], T.cuda.get_tmem_addr(T.uint32(0), 0, epi_k * 64), "ld", "sync", "aligned", "32x32b", "x64", "", "b32", "")
+                            T.ptx.tcgen05("wait::ld", "sync", "aligned", "")
+                            if epi_k == 0:
+                                T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(last_outer_loop_phase, 0))
+                                T.ptx.fence("proxy", "async", "shared::cta", "")
+                            if epi_k == 3:
+                                buffer_17: T.uint32
+                                T.ptx.mapa(buffer_17, T.cuda.cvta_generic_to_shared(T.address_of(bar_tOut_empty_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                T.ptx.mbarrier(buffer_17, "arrive", "", "", "shared::cluster", "b64", "")
+                            buffer_17 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                            buffer_18 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                            for f in range(32):
+                                dst_lane_indices_0_0: T.int32 = f * 2
+                                dst_lane_indices_1_0: T.int32 = f * 2 + 1
+                                buffer_19: T.uint64
+                                buffer_20: T.uint64
+                                T.ptx.mov(buffer_19, buffer_18[f * 2], buffer_18[f * 2 + 1], "b64", "")
+                                T.ptx.mov(buffer_20, output_scale, output_scale, "b64", "")
+                                T.ptx.mul(buffer_19, buffer_19, buffer_20, "rz", "ftz", "", "f32x2", "")
+                                T.ptx.mov(buffer_17[f * 2], buffer_17[f * 2 + 1], buffer_19, "b64", "")
+                            buffer_19 = o_epi_bf16_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                            buffer_19_words = buffer_19.view("uint32")
+                            buffer_20 = o_epi_frag.local(layout=T.TileLayout(T.S[(32, 2):(2, 1)]))
+                            for f in range(32):
+                                dst_lane_indices_0_0: T.int32 = f * 2
+                                dst_lane_indices_1_0: T.int32 = f * 2 + 1
+                                T.ptx.cvt.rn.bf16x2.f32(
+                                    buffer_19_words[f], buffer_20[f * 2 + 1], buffer_20[f * 2]
                                 )
-
-                        if k > 0:
-                            prev_k: T.let = k - 1
-                            prev_rs: T.let = umma_rs - 1
-                            prev_buf: T.let = prev_rs % NUM_K_BUFS
-                            prev_s_o_phase: T.let = prev_rs & 1
-                            bar_S_O_full.wait(0, prev_s_o_phase)
-                            if prev_k == 0:
-                                bar_tOut_empty.wait(0, umma_outer_loop_phase ^ 1)
-                            T.ptx.tcgen05.fence__after_thread_sync()
-                            o_accumulate: T.uint32 = T.if_then_else(
-                                prev_k == 0, T.uint32(0), T.uint32(1)
-                            )
-
-                            @T.inline
-                            def gemm_o(dst, col_lo, col_hi):
-                                Tx.gemm_async(
-                                    dst[:, :],
-                                    s_smem_gemm[:, :],
-                                    k_smem_gemm[prev_buf, :, col_lo:col_hi],
-                                    transB=True,
-                                    **_mma_config(accum=o_accumulate),
+                            r_local = o_epi_bf16_frag.local()
+                            r_words = r_local.view("uint32")
+                            for f in range(8):
+                                ds: T.int32 = f % 8 * 8
+                                dr: T.int32 = f % 8 * 8
+                                s_off: T.int32 = v_6 // 64 * 16384 + epi_k % 4 * 4096 + v_6 % 64 * 64 + T.bitwise_xor(f * 8, T.shift_left(T.bitwise_and(v_6 // 64 * 256 + epi_k % 4 * 64 + v_6 % 64, 7), 3))
+                                s_ptr: T.let = T.ptr_byte_offset(
+                                    T.address_of(q_smem_win[0, 0]), s_off * BF16_BYTES, "bfloat16"
                                 )
-
-                            gemm_o(o_tmem.sub[:, 0 : D_V // 2], 0, D_V // 4)
-                            gemm_o(o_tmem.sub[:, D_V // 2 : D_V], D_V // 4, D_V // 2)
-                            o_accumulate = T.uint32(1)
-                            bar_SV_done.arrive(0, cta_group=2, cta_mask=3)
-                            bar_KV_empty.arrive(prev_buf, cta_group=2, cta_mask=3)
-
-                        if k != umma_num_k_blocks:
-                            umma_rs = umma_rs + 1
-
-                    T.ptx.tcgen05.fence__before_thread_sync()
-                    bar_tOut_full.arrive(0, cta_group=2, cta_mask=3)
-
-                    bar_clc_full.wait(0, umma_outer_loop_phase)
-                    umma_next_job = T.local_scalar("uint32")
-                    query_cancel_first_ctaid_x(umma_next_job, T.address_of(clc_response[0]))
-                    _rem3 = T.alloc_local([1], "uint64")
-                    T.ptx.mapa.shared__cluster.u64(_rem3[0], bar_clc_empty.ptr_to([0]), T.uint32(0))
-                    T.ptx.mbarrier.arrive.b64(_rem3[0], T.uint32(1), pred=T.bool(True))
-                    if umma_next_job == T.uint32(0xFFFFFFFF):
-                        umma_job_valid = 0
-                    else:
-                        umma_job_block_idx = T.cast(umma_next_job, "int32")
-                    umma_outer_loop_phase = umma_outer_loop_phase ^ 1
-            iket.range_end(mma_token)
-
-        elif warp_idx == 9:
-            valid_mask_token = iket.range_start("h128-small-valid-mask")
-            if lane_idx < B_TOPK // 8:
-                lane_indices = T.alloc_local((8,), "int32")
-                valid_job_valid: T.int32 = 1
-                valid_job_block_idx: T.int32 = block_idx
-                valid_outer_loop_phase: T.int32 = 0
-                valid_rs: T.int32 = 0
-                while valid_job_valid != 0:
-                    valid_s_q_idx: T.let = valid_job_block_idx // 2
-                    valid_topk_len: T.let = (
-                        T.cuda.ldg(topk_length.ptr_to([valid_s_q_idx]), "int32")
-                        if have_topk_length
-                        else topk
-                    )
-                    valid_num_k_blocks: T.let = T.max((valid_topk_len + B_TOPK - 1) // B_TOPK, 1)
-                    valid_g_indices_base: T.let = valid_s_q_idx * stride_indices_s_q
-                    for k in T.serial(0, valid_num_k_blocks, unroll=False):
-                        row_base: T.let = valid_g_indices_base + k * B_TOPK + lane_idx * 8
-                        Tx.copy(
-                            lane_indices[0:8],
-                            indices[row_base : row_base + 8],
-                            dispatch="vec_256b",
-                            cache="nc",
-                            l1_evict="L1::no_allocate",
-                            l2_evict="L2::evict_normal",
-                            prefetch_size="L2::256B",
-                        )
-                        abs_pos_start: T.let = k * B_TOPK
-                        mask: T.let = pack_valid_mask8(
-                            lane_indices, abs_pos_start, lane_idx, valid_topk_len, s_kv
-                        )
-                        index_buf_idx: T.let = valid_rs % NUM_INDEX_BUFS
-                        index_bar_phase: T.let = (valid_rs // NUM_INDEX_BUFS) & 1
-                        bar_valid_coord_scales_empty.wait(index_buf_idx, index_bar_phase ^ 1)
-                        is_k_valid[index_buf_idx, lane_idx] = mask
-                        bar_valid_coord_scales_full.arrive(index_buf_idx)
-                        valid_rs = valid_rs + 1
-
-                    bar_clc_full.wait(0, valid_outer_loop_phase)
-                    valid_next_job = T.local_scalar("uint32")
-                    query_cancel_first_ctaid_x(valid_next_job, T.address_of(clc_response[0]))
-                    _rem4 = T.alloc_local([1], "uint64")
-                    T.ptx.mapa.shared__cluster.u64(_rem4[0], bar_clc_empty.ptr_to([0]), T.uint32(0))
-                    T.ptx.mbarrier.arrive.b64(_rem4[0], T.uint32(1), pred=T.bool(True))
-                    if valid_next_job == T.uint32(0xFFFFFFFF):
-                        valid_job_valid = 0
-                    else:
-                        valid_job_block_idx = T.cast(valid_next_job, "int32")
-                    valid_outer_loop_phase = valid_outer_loop_phase ^ 1
-            iket.range_end(valid_mask_token)
-
-        elif warp_idx >= 10:
-            clc_token = iket.sentinel_token("h128-small-clc")
-            if warp_idx == 10:
-                clc_token = iket.range_start("h128-small-clc")
-            if T.cuda.elect_sync():
-                if warp_idx == 10:
-                    clc_job_valid: T.int32 = 1
-                    clc_outer_loop_phase: T.int32 = 0
-                    while clc_job_valid != 0:
-                        if cta_idx == 0:
-                            bar_clc_empty.wait(0, clc_outer_loop_phase ^ 1)
-                            T.ptx[
-                                "clusterlaunchcontrol.try_cancel.async.shared::cta"
-                                ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128"
-                            ](T.address_of(clc_response[0]), bar_clc_full.ptr_to([0]))
-                        bar_clc_full.arrive(0, tx_count=16)
-
-                        bar_clc_full.wait(0, clc_outer_loop_phase)
-                        clc_next_job = T.local_scalar("uint32")
-                        query_cancel_first_ctaid_x(clc_next_job, T.address_of(clc_response[0]))
-                        _rem5 = T.alloc_local([1], "uint64")
-                        T.ptx.mapa.shared__cluster.u64(
-                            _rem5[0], bar_clc_empty.ptr_to([0]), T.uint32(0)
-                        )
-                        T.ptx.mbarrier.arrive.b64(_rem5[0], T.uint32(1), pred=T.bool(True))
-                        if clc_next_job == T.uint32(0xFFFFFFFF):
-                            clc_job_valid = 0
-                        clc_outer_loop_phase = clc_outer_loop_phase ^ 1
-            iket.range_end(clc_token)
-
-    else:
-        # CUDA phase1.cuh:788-921. Scale/exp warpgroup.
-        softmax_token = iket.range_start("h128-small-softmax")
-        T.ptx.setmaxnreg.inc.sync.aligned.u32(160)
-        local_warp_idx: T.let = warp_idx - 12
-        wg3_job_valid: T.int32 = 1
-        wg3_job_block_idx: T.int32 = block_idx
-        wg3_outer_loop_phase: T.int32 = 0
-        wg3_rs: T.int32 = 0
-        while wg3_job_valid != 0:
-            wg3_s_q_idx: T.let = wg3_job_block_idx // 2
-            wg3_topk_len: T.let = (
-                T.cuda.ldg(topk_length.ptr_to([wg3_s_q_idx]), "int32") if have_topk_length else topk
-            )
-            wg3_num_k_blocks: T.let = T.max((wg3_topk_len + B_TOPK - 1) // B_TOPK, 1)
-            mi: T.float32 = MAX_INIT_VAL
-            li: T.float32 = 0.0
-            real_mi: T.float32 = T.float32(-float("inf"))
-            scale_pair: T.let = T.cuda.make_float2(sm_scale_div_log2, sm_scale_div_log2)
-
-            for k in T.serial(0, wg3_num_k_blocks, unroll=False):
-                k_buf_idx: T.let = wg3_rs % NUM_K_BUFS
-                k_bar_phase: T.let = (wg3_rs // NUM_K_BUFS) & 1
-                index_buf_idx: T.let = wg3_rs % NUM_INDEX_BUFS
-                index_bar_phase: T.let = (wg3_rs // NUM_INDEX_BUFS) & 1
-                bar_valid_coord_scales_full.wait(index_buf_idx, index_bar_phase)
-                p_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, WG3_ELEMS_PER_THREAD), "float32")
-                p_peer_frag = T.alloc_tcgen05_ldst_frag(
-                    "32x32b", (128, WG3_ELEMS_PER_THREAD), "float32"
-                )
-                p = p_frag.local().view("uint32")
-                p_peer = p_peer_frag.local().view("uint32")
-                bar_QK_done.wait(0, wg3_rs & 1)
-                T.ptx.tcgen05.fence__after_thread_sync()
-
-                @T.inline
-                def load_p(lo_dst, hi_dst):
-                    # datapath-B P read back as (128, B_TOPK) identity: merge the
-                    # two lane-halves into 128 rows.
-                    p_win = tmem_p.rearrange("h (b t) -> (b h) t", b=2)
-                    Tx.wg.copy_async(lo_dst[:, :], p_win.chunk((None, 2))[:, 0])
-                    Tx.wg.copy_async(hi_dst[:, :], p_win.chunk((None, 2))[:, 1])
-
-                if local_warp_idx < 2:
-                    load_p(p_frag, p_peer_frag)
+                                r_w: T.int32 = dr // 2
+                                T.ptx.st(T.cuda.cvta_generic_to_shared(s_ptr), r_words[r_w], r_words[r_w + 1], r_words[r_w + 2], r_words[r_w + 3], "", "", "shared", "", "", "", "v4", "u32", "")
+                        T.ptx.fence("proxy", "async", "shared::cta", "")
+                        T.ptx.bar(T.uint32(0), T.uint32(128), "", "sync", "")
+                        if warp_idx == 0:
+                            if T.cuda.elect_sync():
+                                buffer_17 = T.decl_scalar(T.bfloat16, data=q_smem.data, elem_offset=0, scope="shared.dyn")
+                                T.ptx.cp(T.reinterpret(T.handle().ty, T.address_of(out_tensormap)), 0, block_idx % 2 * 64, 0, last_s_q_idx, T.cuda.cvta_generic_to_shared(T.address_of(buffer_17)), "async", "bulk", "tensor", "4d", "global", "shared::cta", "tile", "bulk_group", "", "")
+                                T.ptx.cp("async", "bulk", "commit_group", "")
+                    if warp_idx == 0:
+                        T.ptx.tcgen05(T.uint32(0), T.uint32(512), "dealloc", "cta_group::2", "sync", "aligned", "b32", "")
+                    T.cuda.iket.range_end(q_o_token)
                 else:
-                    load_p(p_peer_frag, p_frag)
-                T.ptx.tcgen05.wait__ld.sync.aligned()
-                T.ptx.tcgen05.fence__before_thread_sync()
-                bar_P_empty.arrive(0, remote=T.uint32(0))
-
-                valid_word_offset: T.let = T.if_then_else(
-                    local_warp_idx >= 2, WG3_ELEMS_PER_THREAD // 32, 0
-                )
-                is_k_valid_u32: T.let = is_k_valid.view("uint32")[index_buf_idx, valid_word_offset]
-                for p_i in T.unroll(WG3_ELEMS_PER_THREAD):
-                    invalid_p_predicate: T.let = T.bitwise_and(
-                        T.shift_right(is_k_valid_u32, T.uint32(p_i)), T.uint32(1)
-                    ) == T.uint32(0)
-                    p[p_i] = T.if_then_else(invalid_p_predicate, T.uint32(0xFF800000), p[p_i])
-
-                sum_pair0: T.uint64
-                sum_pair1: T.uint64
-                for exchange_i in T.unroll(WG3_ELEMS_PER_THREAD // 4):
-                    exchange_offset = exchange_i * 32 * 4 + lane_idx * 4
-                    p_peer_offset: T.let = exchange_i * 4
-                    Tx.copy(
-                        p_exchange[local_warp_idx ^ 2, exchange_offset : exchange_offset + 4],
-                        p_peer[p_peer_offset : p_peer_offset + 4],
-                        dispatch="vec_128b",
-                    )
-                T.ptx.bar.sync(T.uint32(BAR_WG2_WARP02 + (local_warp_idx & 1)), 64)
-                for exchange_i in T.unroll(WG3_ELEMS_PER_THREAD // 4):
-                    exchange_offset = exchange_i * 32 * 4 + lane_idx * 4
-                    p_exchange_tmp = T.alloc_local((4,), "uint32")
-                    Tx.copy(
-                        p_exchange_tmp[0:4],
-                        p_exchange[local_warp_idx, exchange_offset : exchange_offset + 4],
-                        dispatch="vec_128b",
-                    )
-                    p_pair0: T.let = T.cuda.make_float2(
-                        T.cuda.uint_as_float(p[exchange_i * 4]),
-                        T.cuda.uint_as_float(p[exchange_i * 4 + 1]),
-                    )
-                    peer_pair0: T.let = T.cuda.make_float2(
-                        T.cuda.uint_as_float(p_exchange_tmp[0]),
-                        T.cuda.uint_as_float(p_exchange_tmp[1]),
-                    )
-                    T.ptx.add.rn.f32x2(sum_pair0, p_pair0, peer_pair0)
-                    p[exchange_i * 4] = T.cuda.float_as_uint(T.cuda.float2_x(sum_pair0))
-                    p[exchange_i * 4 + 1] = T.cuda.float_as_uint(T.cuda.float2_y(sum_pair0))
-                    p_pair1: T.let = T.cuda.make_float2(
-                        T.cuda.uint_as_float(p[exchange_i * 4 + 2]),
-                        T.cuda.uint_as_float(p[exchange_i * 4 + 3]),
-                    )
-                    peer_pair1: T.let = T.cuda.make_float2(
-                        T.cuda.uint_as_float(p_exchange_tmp[2]),
-                        T.cuda.uint_as_float(p_exchange_tmp[3]),
-                    )
-                    T.ptx.add.rn.f32x2(sum_pair1, p_pair1, peer_pair1)
-                    p[exchange_i * 4 + 2] = T.cuda.float_as_uint(T.cuda.float2_x(sum_pair1))
-                    p[exchange_i * 4 + 3] = T.cuda.float_as_uint(T.cuda.float2_y(sum_pair1))
-
-                cur_pi_max: T.float32 = T.float32(-float("inf"))
-                for p_i in T.unroll(WG3_ELEMS_PER_THREAD):
-                    cur_pi_max = T.max(cur_pi_max, T.cuda.uint_as_float(p[p_i]))
-                cur_pi_max = cur_pi_max * sm_scale_div_log2
-                rowwise_max_buf[idx_in_warpgroup] = cur_pi_max
-                T.ptx.bar.sync(T.uint32(BAR_WG2_WARP02 + (local_warp_idx & 1)), 64)
-                cur_pi_max = T.max(cur_pi_max, rowwise_max_buf[idx_in_warpgroup ^ 64])
-                real_mi = T.max(real_mi, cur_pi_max)
-                should_scale_o: T.let = (
-                    T.cuda.any_sync(T.uint32(0xFFFFFFFF), cur_pi_max - mi > 6.0) != 0
-                )
-                new_max: T.float32
-                scale_for_old: T.float32
-                if not should_scale_o:
-                    scale_for_old = 1.0
-                    new_max = mi
-                else:
-                    new_max = T.max(cur_pi_max, mi)
-                    T.ptx.ex2.approx.ftz.f32(scale_for_old, mi - new_max)
-                mi = new_max
-
-                # S frag: warpgroup-distributed (B_H//2, B_TOPK) tile. Thread idx owns row h = idx%64
-                # and k half [32*(idx//64), +32) in 8-elem chunks (from the packing loop below).
-                s_frag = T.alloc_buffer(
-                    (B_H // 2, B_TOPK),
-                    "bfloat16",
-                    scope="local",
-                    layout=TileLayout(
-                        S[(2, 32, 2, B_TOPK // 2) : (1 @ wid_in_wg, 1 @ laneid, 2 @ wid_in_wg, 1)]
-                    ),
-                )
-                s_pack = s_frag.local().view("uint32")
-                cur_sum_pair: T.uint64 = T.cuda.make_float2(T.float32(0.0), T.float32(0.0))
-                neg_new_max_pair: T.let = T.cuda.make_float2(-new_max, -new_max)
-                fma_pair: T.uint64
-                for s_i in T.unroll(WG3_ELEMS_PER_THREAD // 2):
-                    p_pair: T.let = T.cuda.make_float2(
-                        T.cuda.uint_as_float(p[s_i * 2]), T.cuda.uint_as_float(p[s_i * 2 + 1])
-                    )
-                    T.ptx.fma.rn.f32x2(fma_pair, p_pair, scale_pair, neg_new_max_pair)
-                    s_x: T.float32
-                    s_y: T.float32
-                    T.ptx.ex2.approx.ftz.f32(s_x, T.cuda.float2_x(fma_pair))
-                    T.ptx.ex2.approx.ftz.f32(s_y, T.cuda.float2_y(fma_pair))
-                    s_pair: T.let = T.cuda.make_float2(s_x, s_y)
-                    T.ptx.add.rn.f32x2(cur_sum_pair, cur_sum_pair, s_pair)
-                    s_pack[s_i] = T.cuda.float22bfloat162_rn(s_x, s_y)
-                cur_sum: T.let = T.cuda.float2_x(cur_sum_pair) + T.cuda.float2_y(cur_sum_pair)
-                li_tmp: T.float32
-                T.ptx.fma.rn.f32(li_tmp, li, scale_for_old, cur_sum)
-                li = li_tmp
-
-                bar_SV_done.wait(0, (wg3_rs & 1) ^ 1)
-                T.ptx.fence.proxy.async_.shared__cta()
-                Tx.wg.copy(s_smem_gemm[:, :], s_frag[:, :])
-
-                if (k > 0) & should_scale_o:
-                    T.ptx.tcgen05.fence__after_thread_sync()
-                    o_rescale_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 32), "float32")
-                    for chunk_idx in T.unroll((D_V // 2) // 32):
-                        Tx.wg.copy_async(
-                            o_rescale_frag[:, :],
-                            o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx],
-                        )
-                        T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Tx.wg.mul(o_rescale_frag[:, :], o_rescale_frag[:, :], scale_for_old)
-                        Tx.wg.copy_async(
-                            o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx],
-                            o_rescale_frag[:, :],
-                        )
-                        T.ptx.tcgen05.wait__st.sync.aligned()
-                    T.ptx.tcgen05.fence__before_thread_sync()
-
-                T.ptx.fence.proxy.async_.shared__cta()
-                bar_S_O_full.arrive(0, remote=T.uint32(0))
-                bar_valid_coord_scales_empty.arrive(index_buf_idx)
-                wg3_rs = wg3_rs + 1
-
-            if real_mi == T.float32(-float("inf")):
-                li = 0.0
-                mi = T.float32(-float("inf"))
-
-            bar_li_empty.wait(0, wg3_outer_loop_phase ^ 1)
-            rowwise_li_buf[idx_in_warpgroup ^ 64] = li
-            T.ptx.bar.sync(T.uint32(BAR_WG2_SYNC), 128)
-            li = li + rowwise_li_buf[idx_in_warpgroup]
-
-            if idx_in_warpgroup < B_H // 2:
-                head_idx: T.let = cta_idx * (B_H // 2) + idx_in_warpgroup
-                attn_sink_log2: T.let = (
-                    T.cuda.ldg(attn_sink.ptr_to([head_idx]), "float32") * LOG_2_E
-                    if have_attn_sink
-                    else T.float32(-float("inf"))
-                )
-                sink_exp: T.float32
-                T.ptx.ex2.approx.ftz.f32(sink_exp, attn_sink_log2 - mi)
-                output_scale: T.let = T.cuda.fdividef(T.float32(1.0), li + sink_exp)
-                rowwise_li_buf[idx_in_warpgroup] = T.if_then_else(li == 0.0, 0.0, output_scale)
-                bar_li_full.arrive(0)
-                cur_lse: T.float32
-                T.ptx.fma.rn.f32(cur_lse, mi, LN_2, T.log(li))
-                cur_lse = T.if_then_else(
-                    cur_lse == T.float32(-float("inf")), T.float32(float("inf")), cur_lse
-                )
-                max_logits[wg3_s_q_idx, head_idx] = real_mi * LN_2
-                lse[wg3_s_q_idx, head_idx] = cur_lse
-
-            bar_clc_full.wait(0, wg3_outer_loop_phase)
-            wg3_next_job = T.local_scalar("uint32")
-            query_cancel_first_ctaid_x(wg3_next_job, T.address_of(clc_response[0]))
-            _rem6 = T.alloc_local([1], "uint64")
-            T.ptx.mapa.shared__cluster.u64(_rem6[0], bar_clc_empty.ptr_to([0]), T.uint32(0))
-            T.ptx.mbarrier.arrive.b64(_rem6[0], T.uint32(1), pred=T.bool(True))
-            if wg3_next_job == T.uint32(0xFFFFFFFF):
-                wg3_job_valid = 0
-            else:
-                wg3_job_block_idx = T.cast(wg3_next_job, "int32")
-            wg3_outer_loop_phase = wg3_outer_loop_phase ^ 1
-        iket.range_end(softmax_token)
-
-    T.cuda.cluster_sync()
+                    if warpgroup_idx == 1:
+                        kv_gather_token: T.uint32 = T.cuda.iket.range_start("h128-small-kv-load")
+                        T.ptx.setmaxnreg(80, "dec", "sync", "aligned", "u32", "")
+                        wg1_warp_idx: T.let[T.int32] = thread_idx // 32 - 4
+                        if T.cuda.elect_sync():
+                            wg1_job_valid: T.int32 = 1
+                            wg1_job_block_idx: T.int32 = block_idx
+                            wg1_outer_loop_phase: T.int32 = 0
+                            wg1_rs: T.int32 = 0
+                            while wg1_job_valid != 0:
+                                wg1_s_q_idx: T.let[T.int32] = wg1_job_block_idx // 2
+                                wg1_topk_len: T.int32 = topk
+                                if have_topk_length:
+                                    T.ptx.ld.global_.s32(wg1_topk_len, topk_length.ptr_to([wg1_s_q_idx]))
+                                wg1_num_k_blocks: T.let[T.int32] = T.max((wg1_topk_len + 64 - 1) // 64, 1)
+                                wg1_g_indices_base: T.let[T.int32] = wg1_s_q_idx * stride_indices_s_q
+                                for k in T.serial(wg1_num_k_blocks, unroll=False):
+                                    k_buf_idx: T.let[T.int32] = wg1_rs % 4
+                                    k_bar_phase: T.let[T.int32] = T.bitwise_and(wg1_rs // 4, 1)
+                                    cur_indices = T.alloc_local((16,), "int32")
+                                    for local_row in T.unroll(2):
+                                        row: T.let[T.int32] = local_row * 32 + wg1_warp_idx * 8
+                                        row_base: T.let[T.int32] = wg1_g_indices_base + k * 64 + row
+                                        buffer_13 = T.decl_buffer((16,), "int32", data=cur_indices.data, scope="local")
+                                        buffer_14 = buffer_13.view("uint32")
+                                        T.ptx.ld(buffer_14[local_row * 8], buffer_14[local_row * 8 + 1], buffer_14[local_row * 8 + 2], buffer_14[local_row * 8 + 3], buffer_14[local_row * 8 + 4], buffer_14[local_row * 8 + 5], buffer_14[local_row * 8 + 6], buffer_14[local_row * 8 + 7], T.address_of(indices[row_base]), "", "", "global", "", "nc", "L1::no_allocate", "L2::evict_first", "L2::256B", "v8", "u32", "")
+                                    T.cuda.mbarrier_wait(T.address_of(buffer_5[k_buf_idx]), T.bitwise_xor(T.bitwise_xor(k_bar_phase, 1), 0))
+                                    k_smem_gemm_cur = T.decl_buffer((64, 256), "bfloat16", data=k_smem_gemm.data, elem_offset=32768 + k_buf_idx * 16384, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(64, 4, 64):(64, 4096, 1)])))
+                                    src_col: T.let[T.int32] = cta_idx * 256
+                                    buffer_13 = k_smem_gemm_cur.view(64, 4, 64)
+                                    buffer_14 = buffer_13.view(2, 4, 2, 4, 4, 64)
+                                    buffer_15 = T.decl_buffer((2, 2, 4, 4, 64), "bfloat16", data=buffer_14.data, elem_offset=32768 + k_buf_idx * 16384 + wg1_warp_idx * 512, scope="shared.dyn", align=1024, layout=T.ComposeLayout(3, 3, 3, T.TileLayout(T.S[(2, 2, 4, 4, 64):(2048, 256, 64, 4096, 1)])))
+                                    k_gather_tile = buffer_15.view(16, 4, 64)
+                                    kv_tma = kv.view(s_kv, 512, layout=T.TileLayout(T.S[(s_kv, 512):(stride_kv_s_kv, 1)]))
+                                    k_gather_tile_2d = k_gather_tile.view(16, 256)
+                                    for row_group in T.unroll(4):
+                                        for col_atom in T.unroll(4):
+                                            buffer_16: T.uint64
+                                            T.ptx.mapa(buffer_16, T.address_of(buffer_4[k_buf_idx]), T.uint32(0), "", "u64", "")
+                                            kv_dst_offset: T.let[T.int32] = (k_buf_idx * 16384 + wg1_warp_idx * 512 + row_group // 2 * 2048 + row_group % 2 * 256 + col_atom * 4096) * BF16_BYTES
+                                            T.ptx.cp(T.cuda.cvta_generic_to_shared(T.ptr_byte_offset(T.address_of(k_smem[0, 0]), kv_dst_offset, T.type_annotation("bfloat16"))), T.reinterpret(T.handle().ty, T.address_of(kv_tma_tensormap)), src_col + col_atom * 64, cur_indices[row_group * 4], cur_indices[row_group * 4 + 1], cur_indices[row_group * 4 + 2], cur_indices[row_group * 4 + 3], T.cuda.cvta_generic_to_shared(T.reinterpret(T.handle().ty, buffer_16)), T.uint64(1508705875169116160), "async", "bulk", "tensor", "2d", "shared::cluster", "global", "tile::gather4", "mbarrier::complete_tx::bytes", "", "cta_group::2", "L2::cache_hint", "")
+                                    wg1_rs = wg1_rs + 1
+                                T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(wg1_outer_loop_phase, 0))
+                                wg1_next_job: T.uint32
+                                query_cancel_first_ctaid_x(wg1_next_job, T.address_of(clc_response[0]))
+                                _rem2: T.uint64
+                                T.ptx.mapa(_rem2, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                                T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem2), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                                if wg1_next_job == T.uint32(4294967295):
+                                    wg1_job_valid = 0
+                                else:
+                                    wg1_job_block_idx = T.Cast("int32", wg1_next_job)
+                                wg1_outer_loop_phase = T.bitwise_xor(wg1_outer_loop_phase, 1)
+                        T.cuda.iket.range_end(kv_gather_token)
+                    else:
+                        if warpgroup_idx == 2:
+                            T.ptx.setmaxnreg(80, "dec", "sync", "aligned", "u32", "")
+                            if T.bitwise_and(warp_idx == 8, cta_idx == 0):
+                                mma_token: T.uint32 = T.cuda.iket.range_start("h128-small-qk-pv-issue")
+                                if T.cuda.elect_sync():
+                                    umma_job_valid: T.int32 = 1
+                                    umma_job_block_idx: T.int32 = block_idx
+                                    umma_outer_loop_phase: T.int32 = 0
+                                    umma_rs: T.int32 = 0
+                                    while umma_job_valid != 0:
+                                        umma_s_q_idx: T.let[T.int32] = umma_job_block_idx // 2
+                                        umma_topk_len: T.int32 = topk
+                                        if have_topk_length:
+                                            T.ptx.ld.global_.s32(umma_topk_len, topk_length.ptr_to([umma_s_q_idx]))
+                                        umma_num_k_blocks: T.let[T.int32] = T.max((umma_topk_len + 64 - 1) // 64, 1)
+                                        T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(umma_outer_loop_phase, 0))
+                                        for k in T.serial(umma_num_k_blocks + 1, unroll=False):
+                                            if k < umma_num_k_blocks:
+                                                k_buf_idx: T.let[T.int32] = umma_rs % 4
+                                                k_bar_phase: T.let[T.int32] = T.bitwise_and(umma_rs // 4, 1)
+                                                p_bar_phase: T.let[T.int32] = T.bitwise_and(umma_rs, 1)
+                                                T.cuda.mbarrier_wait(T.address_of(bar_P_empty_buf[0]), T.bitwise_xor(T.bitwise_xor(p_bar_phase, 1), 0))
+                                                T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_4[k_buf_idx])), T.uint32(65536), "arrive", "expect_tx", "", "", "shared", "b64", "")
+                                                T.cuda.mbarrier_wait(T.address_of(buffer_4[k_buf_idx]), T.bitwise_xor(k_bar_phase, 0))
+                                                T.ptx.tcgen05("fence::after_thread_sync", "")
+                                                qk_accumulate: T.uint32 = T.uint32(0)
+                                                descB_local: T.uint64
+                                                T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descB_local), T.address_of(k_smem_gemm[0, 0, 0]), 512, 64, 3)
+                                                for mi in T.unroll(1):
+                                                    for ni in T.unroll(1):
+                                                        for ki in T.unroll(16):
+                                                            T.ptx.tcgen05(T.Cast("uint32", ni * 64 + 384), T.Cast("uint32", ki * 8 + 256), _add_smem_desc_offset(descB_local, (ki // 1024 * 16384 + ni * 16384 + k_buf_idx * 16384 + ki % 16 // 4 * 4096 + ki % 1024 // 16 * 64 + ki % 4 * 16) // 8), T.uint32(136316048), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), ki != 0 or T.Cast("bool", qk_accumulate), "mma", "cta_group::2", "kind::f16", "p12")
+                                                qk_accumulate = T.uint32(1)
+                                                T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_6[0])), T.Cast("uint16", 3), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "multicast::cluster", "b64", "")
+                                                if k == umma_num_k_blocks - 1:
+                                                    T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_1[0])), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "b64", "")
+                                            if k > 0:
+                                                prev_k: T.let[T.int32] = k - 1
+                                                prev_rs: T.let[T.int32] = umma_rs - 1
+                                                prev_buf: T.let[T.int32] = prev_rs % 4
+                                                prev_s_o_phase: T.let[T.int32] = T.bitwise_and(prev_rs, 1)
+                                                T.cuda.mbarrier_wait(T.address_of(bar_S_O_full_buf[0]), T.bitwise_xor(prev_s_o_phase, 0))
+                                                if prev_k == 0:
+                                                    T.cuda.mbarrier_wait(T.address_of(bar_tOut_empty_buf[0]), T.bitwise_xor(T.bitwise_xor(umma_outer_loop_phase, 1), 0))
+                                                T.ptx.tcgen05("fence::after_thread_sync", "")
+                                                o_accumulate: T.uint32 = T.if_then_else(prev_k == 0, T.uint32(0), T.uint32(1))
+                                                buffer_13 = T.decl_buffer((64, 256), scope="tmem", layout=T.TileLayout(T.S[(64, 1, 2, 128):(1 @ Axis.TLane, 128 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=0)
+                                                descB_local: T.uint64
+                                                T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descB_local), T.address_of(k_smem_gemm[0, 0, 0]), 512, 64, 3)
+                                                descA_local: T.uint64
+                                                T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descA_local), T.address_of(s_smem_gemm[0, 0]), 64, 8, 0)
+                                                for mi in T.unroll(1):
+                                                    for ni in T.unroll(1):
+                                                        for ki in T.unroll(4):
+                                                            T.ptx.tcgen05(T.Cast("uint32", ni * 128), _add_smem_desc_offset(descA_local, (ki % 4 * 1024 + mi * 512 + ki // 4 * 8) // 8), _add_smem_desc_offset(descB_local, ((ki * 16 + ni) // 64 * 16384 + prev_buf * 16384 + (ki * 16 + ni) % 64 * 64) // 8), T.uint32(138478736), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), ki != 0 or T.Cast("bool", o_accumulate), "mma", "cta_group::2", "kind::f16", "p12")
+                                                buffer_14 = T.decl_buffer((64, 256), scope="tmem", layout=T.TileLayout(T.S[(64, 1, 2, 128):(1 @ Axis.TLane, 128 @ Axis.TCol, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=128)
+                                                descB_local_1: T.uint64
+                                                T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descB_local_1), T.address_of(k_smem_gemm[0, 0, 0]), 512, 64, 3)
+                                                descA_local_1: T.uint64
+                                                T.cuda.tcgen05.encode_matrix_descriptor(T.address_of(descA_local_1), T.address_of(s_smem_gemm[0, 0]), 64, 8, 0)
+                                                for mi in T.unroll(1):
+                                                    for ni in T.unroll(1):
+                                                        for ki in T.unroll(4):
+                                                            T.ptx.tcgen05(T.Cast("uint32", ni * 128 + 128), _add_smem_desc_offset(descA_local_1, (ki % 4 * 1024 + mi * 512 + ki // 4 * 8) // 8), _add_smem_desc_offset(descB_local_1, ((ki * 16 + ni) // 64 * 16384 + prev_buf * 16384 + (ki * 16 + ni) % 64 * 64 + 8192) // 8), T.uint32(138478736), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), T.uint32(0), ki != 0 or T.Cast("bool", o_accumulate), "mma", "cta_group::2", "kind::f16", "p12")
+                                                o_accumulate = T.uint32(1)
+                                                T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_7[0])), T.Cast("uint16", 3), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "multicast::cluster", "b64", "")
+                                                T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_5[prev_buf])), T.Cast("uint16", 3), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "multicast::cluster", "b64", "")
+                                            if k != umma_num_k_blocks:
+                                                umma_rs = umma_rs + 1
+                                        T.ptx.tcgen05("fence::before_thread_sync", "")
+                                        T.ptx.tcgen05(T.cuda.cvta_generic_to_shared(T.address_of(buffer_3[0])), T.Cast("uint16", 3), "commit", "cta_group::2", "mbarrier::arrive::one", "shared::cluster", "multicast::cluster", "b64", "")
+                                        T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(umma_outer_loop_phase, 0))
+                                        umma_next_job: T.uint32
+                                        query_cancel_first_ctaid_x(umma_next_job, T.address_of(clc_response[0]))
+                                        _rem3: T.uint64
+                                        T.ptx.mapa(_rem3, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                                        T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem3), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                                        if umma_next_job == T.uint32(4294967295):
+                                            umma_job_valid = 0
+                                        else:
+                                            umma_job_block_idx = T.Cast("int32", umma_next_job)
+                                        umma_outer_loop_phase = T.bitwise_xor(umma_outer_loop_phase, 1)
+                                T.cuda.iket.range_end(mma_token)
+                            else:
+                                if warp_idx == 9:
+                                    valid_mask_token: T.uint32 = T.cuda.iket.range_start("h128-small-valid-mask")
+                                    if lane_idx < 8:
+                                        lane_indices = T.alloc_local((8,), "int32")
+                                        valid_job_valid: T.int32 = 1
+                                        valid_job_block_idx: T.int32 = block_idx
+                                        valid_outer_loop_phase: T.int32 = 0
+                                        valid_rs: T.int32 = 0
+                                        while valid_job_valid != 0:
+                                            valid_s_q_idx: T.let[T.int32] = valid_job_block_idx // 2
+                                            valid_topk_len: T.int32 = topk
+                                            if have_topk_length:
+                                                T.ptx.ld.global_.s32(valid_topk_len, topk_length.ptr_to([valid_s_q_idx]))
+                                            valid_num_k_blocks: T.let[T.int32] = T.max((valid_topk_len + 64 - 1) // 64, 1)
+                                            valid_g_indices_base: T.let[T.int32] = valid_s_q_idx * stride_indices_s_q
+                                            for k in T.serial(valid_num_k_blocks, unroll=False):
+                                                row_base: T.let[T.int32] = valid_g_indices_base + k * 64 + lane_idx * 8
+                                                buffer_13 = T.decl_buffer((8,), "int32", data=lane_indices.data, scope="local")
+                                                buffer_14 = buffer_13.view("uint32")
+                                                T.ptx.ld(buffer_14[0], buffer_14[1], buffer_14[2], buffer_14[3], buffer_14[4], buffer_14[5], buffer_14[6], buffer_14[7], T.address_of(indices[row_base]), "", "", "global", "", "nc", "L1::no_allocate", "L2::evict_normal", "L2::256B", "v8", "u32", "")
+                                                abs_pos_start: T.let[T.int32] = k * 64
+                                                mask: T.let[T.int8] = T.Cast("int8", T.bitwise_or(T.bitwise_or(T.bitwise_or(T.Select(T.bitwise_and(T.bitwise_and(lane_indices[0] >= 0, lane_indices[0] < s_kv), abs_pos_start + lane_idx * 8 < valid_topk_len), 1, 0), T.Select(T.bitwise_and(T.bitwise_and(lane_indices[1] >= 0, lane_indices[1] < s_kv), abs_pos_start + lane_idx * 8 + 1 < valid_topk_len), 2, 0)), T.bitwise_or(T.Select(T.bitwise_and(T.bitwise_and(lane_indices[2] >= 0, lane_indices[2] < s_kv), abs_pos_start + lane_idx * 8 + 2 < valid_topk_len), 4, 0), T.Select(T.bitwise_and(T.bitwise_and(lane_indices[3] >= 0, lane_indices[3] < s_kv), abs_pos_start + lane_idx * 8 + 3 < valid_topk_len), 8, 0))), T.bitwise_or(T.bitwise_or(T.Select(T.bitwise_and(T.bitwise_and(lane_indices[4] >= 0, lane_indices[4] < s_kv), abs_pos_start + lane_idx * 8 + 4 < valid_topk_len), 16, 0), T.Select(T.bitwise_and(T.bitwise_and(lane_indices[5] >= 0, lane_indices[5] < s_kv), abs_pos_start + lane_idx * 8 + 5 < valid_topk_len), 32, 0)), T.bitwise_or(T.Select(T.bitwise_and(T.bitwise_and(lane_indices[6] >= 0, lane_indices[6] < s_kv), abs_pos_start + lane_idx * 8 + 6 < valid_topk_len), 64, 0), T.Select(T.bitwise_and(T.bitwise_and(lane_indices[7] >= 0, lane_indices[7] < s_kv), abs_pos_start + lane_idx * 8 + 7 < valid_topk_len), 128, 0)))))
+                                                index_buf_idx: T.let[T.int32] = valid_rs % 4
+                                                index_bar_phase: T.let[T.int32] = T.bitwise_and(valid_rs // 4, 1)
+                                                T.cuda.mbarrier_wait(T.address_of(bar_valid_coord_scales_empty_buf[index_buf_idx]), T.bitwise_xor(T.bitwise_xor(index_bar_phase, 1), 0))
+                                                T.ptx.st.shared.b8(is_k_valid.ptr_to([index_buf_idx, lane_idx]), T.reinterpret("uint8", mask))
+                                                T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_valid_coord_scales_full_buf[index_buf_idx])), T.uint32(1), "arrive", "", "", "shared", "b64", "")
+                                                valid_rs = valid_rs + 1
+                                            T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(valid_outer_loop_phase, 0))
+                                            valid_next_job: T.uint32
+                                            query_cancel_first_ctaid_x(valid_next_job, T.address_of(clc_response[0]))
+                                            _rem4: T.uint64
+                                            T.ptx.mapa(_rem4, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                                            T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem4), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                                            if valid_next_job == T.uint32(4294967295):
+                                                valid_job_valid = 0
+                                            else:
+                                                valid_job_block_idx = T.Cast("int32", valid_next_job)
+                                            valid_outer_loop_phase = T.bitwise_xor(valid_outer_loop_phase, 1)
+                                    T.cuda.iket.range_end(valid_mask_token)
+                                else:
+                                    if warp_idx >= 10:
+                                        clc_token: T.uint32 = T.cuda.iket.sentinel_token("h128-small-clc")
+                                        if warp_idx == 10:
+                                            clc_token = T.cuda.iket.range_start("h128-small-clc")
+                                        if T.cuda.elect_sync():
+                                            if warp_idx == 10:
+                                                clc_job_valid: T.int32 = 1
+                                                clc_outer_loop_phase: T.int32 = 0
+                                                while clc_job_valid != 0:
+                                                    if cta_idx == 0:
+                                                        T.cuda.mbarrier_wait(T.address_of(bar_clc_empty_buf[0]), T.bitwise_xor(T.bitwise_xor(clc_outer_loop_phase, 1), 0))
+                                                        T.ptx.clusterlaunchcontrol(T.cuda.cvta_generic_to_shared(T.address_of(clc_response[0])), T.cuda.cvta_generic_to_shared(T.address_of(buffer_8[0])), "try_cancel", "async", "shared::cta", "mbarrier::complete_tx::bytes", "multicast::cluster::all", "b128", "")
+                                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_8[0])), T.uint32(16), "arrive", "expect_tx", "", "", "shared", "b64", "")
+                                                    T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(clc_outer_loop_phase, 0))
+                                                    clc_next_job: T.uint32
+                                                    query_cancel_first_ctaid_x(clc_next_job, T.address_of(clc_response[0]))
+                                                    _rem5: T.uint64
+                                                    T.ptx.mapa(_rem5, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                                                    T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem5), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                                                    if clc_next_job == T.uint32(4294967295):
+                                                        clc_job_valid = 0
+                                                    clc_outer_loop_phase = T.bitwise_xor(clc_outer_loop_phase, 1)
+                                        T.cuda.iket.range_end(clc_token)
+                        else:
+                            softmax_token: T.uint32 = T.cuda.iket.range_start("h128-small-softmax")
+                            T.ptx.setmaxnreg(160, "inc", "sync", "aligned", "u32", "")
+                            local_warp_idx: T.let[T.int32] = warp_idx - 12
+                            wg3_job_valid: T.int32 = 1
+                            wg3_job_block_idx: T.int32 = block_idx
+                            wg3_outer_loop_phase: T.int32 = 0
+                            wg3_rs: T.int32 = 0
+                            while wg3_job_valid != 0:
+                                wg3_s_q_idx: T.let[T.int32] = wg3_job_block_idx // 2
+                                wg3_topk_len: T.int32 = topk
+                                if have_topk_length:
+                                    T.ptx.ld.global_.s32(wg3_topk_len, topk_length.ptr_to([wg3_s_q_idx]))
+                                wg3_num_k_blocks: T.let[T.int32] = T.max((wg3_topk_len + 64 - 1) // 64, 1)
+                                mi: T.float32 = T.float32(-1000000000000000019884624838656.0)
+                                li: T.float32 = T.float32(0.0)
+                                real_mi: T.float32 = T.float32("-inf")
+                                scale_pair: T.let[T.uint64] = T.cuda.make_float2(T.float32(sm_scale_div_log2), T.float32(sm_scale_div_log2))
+                                for k in T.serial(wg3_num_k_blocks, unroll=False):
+                                    k_buf_idx: T.let[T.int32] = wg3_rs % 4
+                                    k_bar_phase: T.let[T.int32] = T.bitwise_and(wg3_rs // 4, 1)
+                                    index_buf_idx: T.let[T.int32] = wg3_rs % 4
+                                    index_bar_phase: T.let[T.int32] = T.bitwise_and(wg3_rs // 4, 1)
+                                    T.cuda.mbarrier_wait(T.address_of(bar_valid_coord_scales_full_buf[index_buf_idx]), T.bitwise_xor(index_bar_phase, 0))
+                                    buffer_13 = T.alloc_local((32,))
+                                    p_frag = buffer_13.view(128, 32, layout=T.TileLayout(T.S[(128, 32):(1 @ Axis.tid_in_wg, 1)]))
+                                    buffer_14 = T.alloc_local((32,))
+                                    p_peer_frag = buffer_14.view(128, 32, layout=T.TileLayout(T.S[(128, 32):(1 @ Axis.tid_in_wg, 1)]))
+                                    buffer_15 = p_frag.local()
+                                    p = buffer_15.view("uint32")
+                                    buffer_16 = p_peer_frag.local()
+                                    p_peer = buffer_16.view("uint32")
+                                    T.cuda.mbarrier_wait(T.address_of(buffer_6[0]), T.bitwise_xor(T.bitwise_and(wg3_rs, 1), 0))
+                                    T.ptx.tcgen05("fence::after_thread_sync", "")
+                                    if local_warp_idx < 2:
+                                        buffer_17 = T.decl_buffer((64, 2, 64), scope="tmem", layout=T.TileLayout(T.S[(64, 2, 64):(1 @ Axis.TLane, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        buffer_18 = T.decl_buffer((2, 64, 64), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 64):(64 @ Axis.TLane, 1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        p_win = T.decl_buffer((128, 64), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 64):(64 @ Axis.TLane, 1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        local_storage = p_frag.local()
+                                        T.ptx.tcgen05(local_storage[0], local_storage[1], local_storage[2], local_storage[3], local_storage[4], local_storage[5], local_storage[6], local_storage[7], local_storage[8], local_storage[9], local_storage[10], local_storage[11], local_storage[12], local_storage[13], local_storage[14], local_storage[15], local_storage[16], local_storage[17], local_storage[18], local_storage[19], local_storage[20], local_storage[21], local_storage[22], local_storage[23], local_storage[24], local_storage[25], local_storage[26], local_storage[27], local_storage[28], local_storage[29], local_storage[30], local_storage[31], T.uint32(384), "ld", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                        local_storage_1 = p_peer_frag.local()
+                                        T.ptx.tcgen05(local_storage_1[0], local_storage_1[1], local_storage_1[2], local_storage_1[3], local_storage_1[4], local_storage_1[5], local_storage_1[6], local_storage_1[7], local_storage_1[8], local_storage_1[9], local_storage_1[10], local_storage_1[11], local_storage_1[12], local_storage_1[13], local_storage_1[14], local_storage_1[15], local_storage_1[16], local_storage_1[17], local_storage_1[18], local_storage_1[19], local_storage_1[20], local_storage_1[21], local_storage_1[22], local_storage_1[23], local_storage_1[24], local_storage_1[25], local_storage_1[26], local_storage_1[27], local_storage_1[28], local_storage_1[29], local_storage_1[30], local_storage_1[31], T.cuda.get_tmem_addr(T.uint32(384), 0, 32), "ld", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                    else:
+                                        buffer_17 = T.decl_buffer((64, 2, 64), scope="tmem", layout=T.TileLayout(T.S[(64, 2, 64):(1 @ Axis.TLane, 64 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        buffer_18 = T.decl_buffer((2, 64, 64), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 64):(64 @ Axis.TLane, 1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        p_win = T.decl_buffer((128, 64), scope="tmem", layout=T.TileLayout(T.S[(2, 64, 64):(64 @ Axis.TLane, 1 @ Axis.TLane, 1 @ Axis.TCol)]), allocated_addr=384)
+                                        local_storage = p_peer_frag.local()
+                                        T.ptx.tcgen05(local_storage[0], local_storage[1], local_storage[2], local_storage[3], local_storage[4], local_storage[5], local_storage[6], local_storage[7], local_storage[8], local_storage[9], local_storage[10], local_storage[11], local_storage[12], local_storage[13], local_storage[14], local_storage[15], local_storage[16], local_storage[17], local_storage[18], local_storage[19], local_storage[20], local_storage[21], local_storage[22], local_storage[23], local_storage[24], local_storage[25], local_storage[26], local_storage[27], local_storage[28], local_storage[29], local_storage[30], local_storage[31], T.uint32(384), "ld", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                        local_storage_1 = p_frag.local()
+                                        T.ptx.tcgen05(local_storage_1[0], local_storage_1[1], local_storage_1[2], local_storage_1[3], local_storage_1[4], local_storage_1[5], local_storage_1[6], local_storage_1[7], local_storage_1[8], local_storage_1[9], local_storage_1[10], local_storage_1[11], local_storage_1[12], local_storage_1[13], local_storage_1[14], local_storage_1[15], local_storage_1[16], local_storage_1[17], local_storage_1[18], local_storage_1[19], local_storage_1[20], local_storage_1[21], local_storage_1[22], local_storage_1[23], local_storage_1[24], local_storage_1[25], local_storage_1[26], local_storage_1[27], local_storage_1[28], local_storage_1[29], local_storage_1[30], local_storage_1[31], T.cuda.get_tmem_addr(T.uint32(384), 0, 32), "ld", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                    T.ptx.tcgen05("wait::ld", "sync", "aligned", "")
+                                    T.ptx.tcgen05("fence::before_thread_sync", "")
+                                    buffer_17: T.uint32
+                                    T.ptx.mapa(buffer_17, T.cuda.cvta_generic_to_shared(T.address_of(bar_P_empty_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                    T.ptx.mbarrier(buffer_17, "arrive", "", "", "shared::cluster", "b64", "")
+                                    valid_word_offset: T.let[T.int32] = T.if_then_else(local_warp_idx >= 2, 1, 0)
+                                    buffer_18 = T.decl_buffer((4, 2), "uint32", data=is_k_valid.data, elem_offset=55552, scope="shared.dyn", align=16)
+                                    is_k_valid_u32: T.uint32
+                                    T.ptx.ld.shared.u32(is_k_valid_u32, buffer_18.ptr_to([index_buf_idx, valid_word_offset]))
+                                    for p_i in T.unroll(32):
+                                        invalid_p_predicate: T.let[T.bool] = T.bitwise_and(T.shift_right(is_k_valid_u32, T.Cast("uint32", p_i)), T.uint32(1)) == T.uint32(0)
+                                        p[p_i] = T.if_then_else(invalid_p_predicate, T.uint32(4286578688), p[p_i])
+                                    sum_pair0: T.uint64
+                                    sum_pair1: T.uint64
+                                    for exchange_i in T.unroll(8):
+                                        exchange_offset: T.int32 = exchange_i * 32 * 4 + lane_idx * 4
+                                        p_peer_offset: T.let[T.int32] = exchange_i * 4
+                                        buffer_19 = T.decl_buffer((32,), "uint32", data=p_peer.data, scope="local", layout=T.TileLayout(T.S[(32, 1):(1, 1)]))
+                                        buffer_20 = T.decl_buffer((32,), "uint32", data=buffer_19.data, scope="local", layout=T.TileLayout(T.S[(32, 1, 1):(1, 1, 1)]))
+                                        T.ptx.st(T.cuda.cvta_generic_to_shared(T.address_of(p_exchange[T.bitwise_xor(local_warp_idx, 2), exchange_offset])), buffer_20[p_peer_offset], buffer_20[p_peer_offset + 1], buffer_20[p_peer_offset + 2], buffer_20[p_peer_offset + 3], "", "", "shared", "", "", "", "v4", "u32", "")
+                                    T.ptx.bar(T.Cast("uint32", 2 + T.bitwise_and(local_warp_idx, 1)), T.uint32(64), "", "sync", "")
+                                    for exchange_i in T.unroll(8):
+                                        exchange_offset: T.int32 = exchange_i * 32 * 4 + lane_idx * 4
+                                        p_exchange_tmp = T.alloc_local((4,), "uint32")
+                                        buffer_19 = T.decl_buffer((4,), "uint32", data=p_exchange_tmp.data, scope="local")
+                                        buffer_20 = T.decl_buffer((4,), "uint32", data=buffer_19.data, scope="local", layout=T.TileLayout(T.S[(4, 1):(1, 1)]))
+                                        T.ptx.ld(buffer_20[0], buffer_20[1], buffer_20[2], buffer_20[3], T.cuda.cvta_generic_to_shared(T.address_of(p_exchange[local_warp_idx, exchange_offset])), "", "", "shared", "", "", "", "", "", "v4", "u32", "")
+                                        p_pair0: T.let[T.uint64] = T.cuda.make_float2(T.cuda.uint_as_float(p[exchange_i * 4]), T.cuda.uint_as_float(p[exchange_i * 4 + 1]))
+                                        peer_pair0: T.let[T.uint64] = T.cuda.make_float2(T.cuda.uint_as_float(p_exchange_tmp[0]), T.cuda.uint_as_float(p_exchange_tmp[1]))
+                                        T.ptx.add(sum_pair0, p_pair0, peer_pair0, "rn", "", "", "f32x2", "", "")
+                                        p[exchange_i * 4] = T.cuda.float_as_uint(T.cuda.float2_x(sum_pair0))
+                                        p[exchange_i * 4 + 1] = T.cuda.float_as_uint(T.cuda.float2_y(sum_pair0))
+                                        p_pair1: T.let[T.uint64] = T.cuda.make_float2(T.cuda.uint_as_float(p[exchange_i * 4 + 2]), T.cuda.uint_as_float(p[exchange_i * 4 + 3]))
+                                        peer_pair1: T.let[T.uint64] = T.cuda.make_float2(T.cuda.uint_as_float(p_exchange_tmp[2]), T.cuda.uint_as_float(p_exchange_tmp[3]))
+                                        T.ptx.add(sum_pair1, p_pair1, peer_pair1, "rn", "", "", "f32x2", "", "")
+                                        p[exchange_i * 4 + 2] = T.cuda.float_as_uint(T.cuda.float2_x(sum_pair1))
+                                        p[exchange_i * 4 + 3] = T.cuda.float_as_uint(T.cuda.float2_y(sum_pair1))
+                                    cur_pi_max: T.float32 = T.float32("-inf")
+                                    for p_i in T.unroll(32):
+                                        cur_pi_max = T.max(cur_pi_max, T.cuda.uint_as_float(p[p_i]))
+                                    cur_pi_max = cur_pi_max * T.float32(sm_scale_div_log2)
+                                    T.ptx.st.shared.f32(rowwise_max_buf.ptr_to([idx_in_warpgroup]), cur_pi_max)
+                                    T.ptx.bar(T.Cast("uint32", 2 + T.bitwise_and(local_warp_idx, 1)), T.uint32(64), "", "sync", "")
+                                    peer_pi_max: T.float32
+                                    T.ptx.ld.shared.f32(peer_pi_max, rowwise_max_buf.ptr_to([T.bitwise_xor(idx_in_warpgroup, 64)]))
+                                    cur_pi_max = T.max(cur_pi_max, peer_pi_max)
+                                    real_mi = T.max(real_mi, cur_pi_max)
+                                    should_scale_o: T.let[T.bool] = T.cuda.any_sync(T.uint32(4294967295), cur_pi_max - mi > T.float32(6.0)) != 0
+                                    new_max: T.float32
+                                    scale_for_old: T.float32
+                                    if not should_scale_o:
+                                        scale_for_old = T.float32(1.0)
+                                        new_max = mi
+                                    else:
+                                        new_max = T.max(cur_pi_max, mi)
+                                        T.ptx.ex2(scale_for_old, mi - new_max, "approx", "ftz", "f32", "")
+                                    mi = new_max
+                                    s_frag = T.alloc_local((64, 64), "bfloat16", layout=T.TileLayout(T.S[(2, 32, 2, 32):(1 @ Axis.wid_in_wg, 1 @ Axis.laneid, 2 @ Axis.wid_in_wg, 1)]))
+                                    buffer_19 = s_frag.local()
+                                    s_pack = buffer_19.view("uint32")
+                                    cur_sum_pair: T.uint64 = T.cuda.make_float2(T.float32(0.0), T.float32(0.0))
+                                    neg_new_max_pair: T.let[T.uint64] = T.cuda.make_float2(new_max * T.float32(-1.0), new_max * T.float32(-1.0))
+                                    fma_pair: T.uint64
+                                    for s_i in T.unroll(16):
+                                        p_pair: T.let[T.uint64] = T.cuda.make_float2(T.cuda.uint_as_float(p[s_i * 2]), T.cuda.uint_as_float(p[s_i * 2 + 1]))
+                                        T.ptx.fma(fma_pair, p_pair, scale_pair, neg_new_max_pair, "rn", "", "", "f32x2", "", "")
+                                        s_x: T.float32
+                                        s_y: T.float32
+                                        T.ptx.ex2(s_x, T.cuda.float2_x(fma_pair), "approx", "ftz", "f32", "")
+                                        T.ptx.ex2(s_y, T.cuda.float2_y(fma_pair), "approx", "ftz", "f32", "")
+                                        s_pair: T.let[T.uint64] = T.cuda.make_float2(s_x, s_y)
+                                        T.ptx.add(cur_sum_pair, cur_sum_pair, s_pair, "rn", "", "", "f32x2", "", "")
+                                        s_pack[s_i] = T.cuda.float22bfloat162_rn(s_x, s_y)
+                                    cur_sum: T.let[T.float32] = T.cuda.float2_x(cur_sum_pair) + T.cuda.float2_y(cur_sum_pair)
+                                    li_tmp: T.float32
+                                    T.ptx.fma(li_tmp, li, scale_for_old, cur_sum, "rn", "", "", "f32", "", "")
+                                    li = li_tmp
+                                    T.cuda.mbarrier_wait(T.address_of(buffer_7[0]), T.bitwise_xor(T.bitwise_xor(T.bitwise_and(wg3_rs, 1), 1), 0))
+                                    T.ptx.fence("proxy", "async", "shared::cta", "")
+                                    s_base: T.int32 = v_7 // 64 * 2048 + v_7 % 64 * 8
+                                    r_local = s_frag.local()
+                                    r_words = r_local.view("uint32")
+                                    for f in range(4):
+                                        ds: T.int32 = f % 4 * 512
+                                        dr: T.int32 = f % 4 * 8
+                                        s_ptr: T.let = T.ptr_byte_offset(
+                                            T.address_of(s_smem_gemm[0, 0]),
+                                            (s_base + ds) * BF16_BYTES,
+                                            "bfloat16",
+                                        )
+                                        r_w: T.int32 = dr // 2
+                                        T.ptx.st(T.cuda.cvta_generic_to_shared(s_ptr), r_words[r_w], r_words[r_w + 1], r_words[r_w + 2], r_words[r_w + 3], "", "", "shared", "", "", "", "v4", "u32", "")
+                                    if T.bitwise_and(k > 0, should_scale_o):
+                                        T.ptx.tcgen05("fence::after_thread_sync", "")
+                                        buffer_20 = T.alloc_local((32,))
+                                        o_rescale_frag = buffer_20.view(128, 32, layout=T.TileLayout(T.S[(128, 32):(1 @ Axis.tid_in_wg, 1)]))
+                                        for chunk_idx in T.unroll(8):
+                                            local_storage = o_rescale_frag.local()
+                                            T.ptx.tcgen05(local_storage[0], local_storage[1], local_storage[2], local_storage[3], local_storage[4], local_storage[5], local_storage[6], local_storage[7], local_storage[8], local_storage[9], local_storage[10], local_storage[11], local_storage[12], local_storage[13], local_storage[14], local_storage[15], local_storage[16], local_storage[17], local_storage[18], local_storage[19], local_storage[20], local_storage[21], local_storage[22], local_storage[23], local_storage[24], local_storage[25], local_storage[26], local_storage[27], local_storage[28], local_storage[29], local_storage[30], local_storage[31], T.cuda.get_tmem_addr(T.uint32(0), 0, chunk_idx * 32), "ld", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                            T.ptx.tcgen05("wait::ld", "sync", "aligned", "")
+                                            buffer_21 = o_rescale_frag.local(layout=T.TileLayout(T.S[(16, 2):(2, 1)]))
+                                            buffer_22 = o_rescale_frag.local(layout=T.TileLayout(T.S[(16, 2):(2, 1)]))
+                                            for f in range(16):
+                                                dst_lane_indices_0_0: T.int32 = f * 2
+                                                dst_lane_indices_1_0: T.int32 = f * 2 + 1
+                                                buffer_23: T.uint64
+                                                buffer_24: T.uint64
+                                                T.ptx.mov(buffer_23, buffer_22[f * 2], buffer_22[f * 2 + 1], "b64", "")
+                                                T.ptx.mov(buffer_24, scale_for_old, scale_for_old, "b64", "")
+                                                T.ptx.mul(buffer_23, buffer_23, buffer_24, "rz", "ftz", "", "f32x2", "")
+                                                T.ptx.mov(buffer_21[f * 2], buffer_21[f * 2 + 1], buffer_23, "b64", "")
+                                            local_storage_1 = o_rescale_frag.local()
+                                            T.ptx.tcgen05(T.cuda.get_tmem_addr(T.uint32(0), 0, chunk_idx * 32), local_storage_1[0], local_storage_1[1], local_storage_1[2], local_storage_1[3], local_storage_1[4], local_storage_1[5], local_storage_1[6], local_storage_1[7], local_storage_1[8], local_storage_1[9], local_storage_1[10], local_storage_1[11], local_storage_1[12], local_storage_1[13], local_storage_1[14], local_storage_1[15], local_storage_1[16], local_storage_1[17], local_storage_1[18], local_storage_1[19], local_storage_1[20], local_storage_1[21], local_storage_1[22], local_storage_1[23], local_storage_1[24], local_storage_1[25], local_storage_1[26], local_storage_1[27], local_storage_1[28], local_storage_1[29], local_storage_1[30], local_storage_1[31], "st", "sync", "aligned", "32x32b", "x32", "", "b32", "")
+                                            T.ptx.tcgen05("wait::st", "sync", "aligned", "")
+                                        T.ptx.tcgen05("fence::before_thread_sync", "")
+                                    T.ptx.fence("proxy", "async", "shared::cta", "")
+                                    buffer_20: T.uint32
+                                    T.ptx.mapa(buffer_20, T.cuda.cvta_generic_to_shared(T.address_of(bar_S_O_full_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                    T.ptx.mbarrier(buffer_20, "arrive", "", "", "shared::cluster", "b64", "")
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_valid_coord_scales_empty_buf[index_buf_idx])), T.uint32(1), "arrive", "", "", "shared", "b64", "")
+                                    wg3_rs = wg3_rs + 1
+                                if real_mi == T.float32("-inf"):
+                                    li = T.float32(0.0)
+                                    mi = T.float32("-inf")
+                                T.cuda.mbarrier_wait(T.address_of(bar_li_empty_buf[0]), T.bitwise_xor(T.bitwise_xor(wg3_outer_loop_phase, 1), 0))
+                                T.ptx.st.shared.f32(rowwise_li_buf.ptr_to([T.bitwise_xor(idx_in_warpgroup, 64)]), li)
+                                T.ptx.bar(T.uint32(1), T.uint32(128), "", "sync", "")
+                                peer_li: T.float32
+                                T.ptx.ld.shared.f32(peer_li, rowwise_li_buf.ptr_to([idx_in_warpgroup]))
+                                li = li + peer_li
+                                if idx_in_warpgroup < 64:
+                                    head_idx: T.let[T.int32] = cta_idx * 64 + idx_in_warpgroup
+                                    attn_sink_value: T.float32 = T.float32(-float("inf"))
+                                    if have_attn_sink:
+                                        T.ptx.ld.global_.f32(attn_sink_value, attn_sink.ptr_to([head_idx]))
+                                    attn_sink_log2: T.let[T.float32] = attn_sink_value * T.float32(1.4426950408889634)
+                                    sink_exp: T.float32
+                                    T.ptx.ex2(sink_exp, attn_sink_log2 - mi, "approx", "ftz", "f32", "")
+                                    output_scale: T.let[T.float32] = T.cuda.fdividef(T.float32(1.0), li + sink_exp)
+                                    T.ptx.st.shared.f32(rowwise_li_buf.ptr_to([idx_in_warpgroup]), T.if_then_else(li == T.float32(0.0), T.float32(0.0), output_scale))
+                                    T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_li_full_buf[0])), T.uint32(1), "arrive", "", "", "shared", "b64", "")
+                                    cur_lse: T.float32
+                                    T.ptx.fma(cur_lse, mi, T.float32(0.69314718055994529), T.log(li), "rn", "", "", "f32", "", "")
+                                    cur_lse = T.if_then_else(cur_lse == T.float32("-inf"), T.float32("inf"), cur_lse)
+                                    T.ptx.st.global_.f32(max_logits.ptr_to([wg3_s_q_idx, head_idx]), real_mi * T.float32(0.69314718055994529))
+                                    T.ptx.st.global_.f32(lse.ptr_to([wg3_s_q_idx, head_idx]), cur_lse)
+                                T.cuda.mbarrier_wait(T.address_of(buffer_8[0]), T.bitwise_xor(wg3_outer_loop_phase, 0))
+                                wg3_next_job: T.uint32
+                                query_cancel_first_ctaid_x(wg3_next_job, T.address_of(clc_response[0]))
+                                _rem6: T.uint64
+                                T.ptx.mapa(_rem6, T.address_of(bar_clc_empty_buf[0]), T.uint32(0), "shared::cluster", "u64", "")
+                                T.ptx.mbarrier(T.reinterpret(T.handle().ty, _rem6), T.uint32(1), T.bool(True), "arrive", "", "", "", "b64", "pred")
+                                if wg3_next_job == T.uint32(4294967295):
+                                    wg3_job_valid = 0
+                                else:
+                                    wg3_job_block_idx = T.Cast("int32", wg3_next_job)
+                                wg3_outer_loop_phase = T.bitwise_xor(wg3_outer_loop_phase, 1)
+                            T.cuda.iket.range_end(softmax_token)
+                T.cuda.cluster_sync()
+    return _kernel
+# fmt: on
 
 
 def get_kernel(**kwargs: Any):
     cfg = _cfg(**kwargs)
     stride_kv_s_kv = int(kwargs.get("stride_kv_s_kv", cfg.d_qk * cfg.h_kv))
     stride_indices_s_q = int(kwargs.get("stride_indices_s_q", cfg.topk * cfg.h_kv))
-    kernel = _kernel.specialize(
-        s_q=cfg.s_q,
-        s_kv=cfg.s_kv,
-        topk=cfg.topk,
-        d_qk=cfg.d_qk,
-        h_q=cfg.h_q,
-        stride_kv_s_kv=stride_kv_s_kv,
-        stride_indices_s_q=stride_indices_s_q,
-        have_attn_sink=cfg.have_attn_sink,
-        have_topk_length=cfg.have_topk_length,
-        sm_scale_div_log2=(1.0 / math.sqrt(cfg.d_qk)) * LOG_2_E,
+    return _make_low_level_kernel(
+        cfg.s_q,
+        cfg.s_kv,
+        cfg.topk,
+        stride_kv_s_kv,
+        stride_indices_s_q,
+        cfg.have_attn_sink,
+        cfg.have_topk_length,
+        (1.0 / math.sqrt(cfg.d_qk)) * LOG_2_E,
     )
-    return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
 
 
 def run_test(**kwargs: Any) -> None:

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -2,20 +2,17 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, fields
-from functools import partial
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
-from tirx_kernels.flashmla._gemm import tcgen05_config
 from tirx_kernels.flashmla._mask import pack_valid_mask8
-from tirx_kernels.flashmla._tma import tma_config
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.cuda.iket import IketProfiler
 from tvm.tirx.lang.pipeline import MBarrier, TCGen05Bar, TMABar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.layout import S, TileLayout, laneid, wid_in_wg
 
 B_H = 64
@@ -48,11 +45,59 @@ Q_ROPE_DIM = 64
 WG1_NUM_WARPS = 4
 WG1_ROWS_PER_WARP = (B_TOPK // 4) // WG1_NUM_WARPS
 
-# KV gather4 TMA knobs shared by both gather call sites.
-_mma_config = partial(tcgen05_config, cta_group=1)
-_kv_gather_tma = partial(
-    tma_config, dispatch="tma_explicit", cta_group=1, cache_hint=T.uint64(0x14F0000000000000)
+_TMA_G2S_4D_CACHE = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
 )
+_TMA_GATHER4_2D_CACHE = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_S2G_2D = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
+_CP_ASYNC_CG_16B = "cp.async.cg.shared.global.L2::128B"
+_TCGEN_CP_128X256 = "tcgen05.cp.cta_group::1.128x256b"
+_TCGEN_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_MMA_WS_F16 = "tcgen05.mma.ws.cta_group::1.kind::f16"
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_TMEM_ST_32 = "tcgen05.st.sync.aligned.32x32b.x32.b32"
+_Q_TMA_CACHE_HINT = T.uint64(0x12F0000000000000)
+_KV_TMA_CACHE_HINT = T.uint64(0x14F0000000000000)
+def _tmem_load(dst, tmem_col, width):
+    chain = _TMEM_LD_32 if width == 32 else _TMEM_LD_64
+    return T.ptx[chain](*[dst[i] for i in range(width)], tmem_col)
+
+
+def _tmem_store(src, tmem_col, width=32):
+    assert width == 32
+    return T.ptx[_TMEM_ST_32](tmem_col, *[src[i] for i in range(width)])
+
+
+def _cast_f32x2_bf16x2(dst, src, offset):
+    dst_words = dst.view("uint32")
+    return T.ptx.cvt.rn.bf16x2.f32(
+        dst_words[offset // 2], src[offset + 1], src[offset]
+    )
+
+
+def _replace_smem_desc_addr(desc, smem_ptr):
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
+
+
+@T.inline
+def mul_f32x2(values, idx, multiplier):
+    packed: T.uint64
+    rhs: T.uint64
+    T.ptx.mov.b64(packed, values[idx], values[idx + 1])
+    T.ptx.mov.b64(rhs, multiplier, multiplier)
+    T.ptx.mul.rz.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(values[idx], values[idx + 1], packed)
 
 
 @dataclass(frozen=True)
@@ -279,6 +324,137 @@ def _kernel(
     have_topk_length: T.constexpr,
     sm_scale_div_log2: T.constexpr,
 ):
+    kv_part1_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_part1_tensormap,
+        "bfloat16",
+        2,
+        T.handle_add_byte_offset(kv.data, D_V // 2 * BF16_BYTES),
+        D_V // 2,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    kv_part0_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        kv_part0_tensormap,
+        "bfloat16",
+        2,
+        kv.data,
+        D_V // 2,
+        s_kv,
+        stride_kv_s_kv * BF16_BYTES,
+        64,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    out_part1_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        out_part1_tensormap,
+        "bfloat16",
+        2,
+        out.data,
+        D_V,
+        s_q * h_q,
+        D_V * BF16_BYTES,
+        64,
+        B_H,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    out_part0_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        out_part0_tensormap,
+        "bfloat16",
+        2,
+        out.data,
+        D_V,
+        s_q * h_q,
+        D_V * BF16_BYTES,
+        64,
+        B_H,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    q_nope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        q_nope_tensormap,
+        "bfloat16",
+        4,
+        q.data,
+        64,
+        h_q,
+        d_qk // 64,
+        s_q,
+        d_qk * BF16_BYTES,
+        64 * BF16_BYTES,
+        h_q * d_qk * BF16_BYTES,
+        64,
+        B_H,
+        D_V // 64,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        3,
+        0,
+    )
+    if d_qk > D_V:
+        q_rope_tensormap: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            q_rope_tensormap,
+            "bfloat16",
+            4,
+            q.data,
+            32,
+            h_q,
+            d_qk // 32,
+            s_q,
+            d_qk * BF16_BYTES,
+            32 * BF16_BYTES,
+            h_q * d_qk * BF16_BYTES,
+            32,
+            B_H,
+            Q_ROPE_DIM // 32,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            2,
+            3,
+            0,
+        )
     T.device_entry()
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
     iket = IketProfiler()
@@ -290,10 +466,34 @@ def _kernel(
     lane_idx = T.lane_id([32])
     idx_in_warpgroup = T.thread_id_in_wg([128])
     warp_idx: T.let = warpgroup_idx * 4 + warp_idx_in_wg
-    topk_len: T.let = topk_length[s_q_idx] if have_topk_length else topk
     max_k_blocks = T.meta_var(topk // B_TOPK)
-    num_k_blocks: T.let = T.max((topk_len + B_TOPK - 1) // B_TOPK, 1)
+    if have_topk_length:
+        topk_len: T.int32
+        T.ptx.ld.global_.s32(topk_len, topk_length.ptr_to([s_q_idx]))
+        num_k_blocks: T.let = T.max((topk_len + B_TOPK - 1) // B_TOPK, 1)
+    else:
+        topk_len = T.meta_var(topk)
+        num_k_blocks = T.meta_var(max_k_blocks)
     have_rope = T.meta_var(d_qk == 576)
+    if have_rope:
+        if warp_idx == 0:
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_rope_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_nope_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(out_part0_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(out_part1_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_part0_tensormap)))
+    if warp_idx == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(kv_part1_tensormap)))
 
     # CUDA phase1.cuh:73-78, config.h:111-139. Reserve SharedMemoryPlan offsets now;
     # instantiate bf16 MMA views only at their use sites (unused ones trip BF16 legalization).
@@ -328,6 +528,28 @@ def _kernel(
     )
     pool.move_base_to(q_rope_end)
 
+    local_mma_desc = T.meta_var(d_qk > D_V and s_kv == 8192)
+    if not local_mma_desc:
+        if have_rope:
+            qk_rope_desc = SmemDescriptor()
+            qk_rope_desc.init(k_rope_tiled_mma.ptr_to([0, 0]), ldo=0, sdo=32, swizzle=2)
+        pv_b_lo_desc = SmemDescriptor()
+        pv_b_lo_desc.init(k_nope.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3)
+        pv_b_hi_desc = SmemDescriptor()
+        pv_b_hi_desc.init(k_nope.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3)
+        qk_nope_desc = SmemDescriptor()
+        qk_nope_desc.init(k_nope_tiled_mma.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3)
+    if have_rope:
+        q_rope_cp_desc: T.uint64
+        T.cuda.tcgen05.encode_matrix_descriptor(
+            T.address_of(q_rope_cp_desc), T.reinterpret(T.handle().ty, T.uint64(0)), 1, 32, 2
+        )
+    if not local_mma_desc:
+        pv_a_lo_desc = SmemDescriptor()
+        pv_a_lo_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+        pv_a_hi_desc = SmemDescriptor()
+        pv_a_hi_desc.init(s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0)
+
     is_k_valid = pool.alloc((NUM_BUFS, B_TOPK // 8), "int8")
     bar_prologue_q_nope = TMABar(pool, 1)
     bar_prologue_q_rope = TMABar(pool, 1)
@@ -354,24 +576,23 @@ def _kernel(
     tmem_pool = T.TMEMPool(pool, total_cols=512, cta_group=1, tmem_addr=tmem_start_addr)
     # O accumulator: one alloc. Col halves [0:256)/[256:512) = E lo/hi gemm outputs;
     # reads back as a plain (128, 256) datapath-D tile.
-    o_tmem = tmem_pool.alloc_tcgen05_mma_D(
+    o_tmem_col = T.meta_var(tmem_pool.offset)
+    _o_tmem = tmem_pool.alloc_tcgen05_mma_D(
         (B_H, D_V), "float32", M=64, cta_group=1, ws=True, group=(2, 2, 128)
     )
-    o_win = o_tmem.rearrange("h (a b c) -> (b h) (a c)", a=2, b=2, c=128)
-    q_nope_tmem_bmm = tmem_pool.alloc_tcgen05_mma_A(
+    q_nope_tmem_col = T.meta_var(tmem_pool.offset)
+    _q_nope_tmem = tmem_pool.alloc_tcgen05_mma_A(
         (2, B_H, D_V // 2), "bfloat16", M=64, cta_group=1, ws=True
     )
-    q_rope_tmem_bmm = tmem_pool.alloc_tcgen05_mma_A(
+    q_rope_tmem_col = T.meta_var(tmem_pool.offset)
+    _q_rope_tmem = tmem_pool.alloc_tcgen05_mma_A(
         (2, B_H, Q_ROPE_DIM // 2), "bfloat16", M=64, cta_group=1, ws=True
     )
     tmem_p_col = T.meta_var(tmem_pool.offset)
     # .ws logits gemm C: two batched 64x64 lane-half partials.
-    tmem_p_bmm = tmem_pool.alloc_tcgen05_mma_D(
-        (2, B_H, B_TOPK), "float32", M=64, cta_group=1, ws=True
-    )
+    _tmem_p = tmem_pool.alloc_tcgen05_mma_D((2, B_H, B_TOPK), "float32", M=64, cta_group=1, ws=True)
     mma_p_accumulate: T.uint32 = 0
     mma_o_accumulate: T.uint32 = 0
-    mma_smem_desc = T.meta_var("local_hoist" if (d_qk > D_V and s_kv == 8192) else "hoist")
 
     # CUDA phase1.cuh:100-150.  Warp 0 performs descriptor prefetch, Q TMA
     # launch, prologue barrier init, and TMEM allocation.
@@ -383,20 +604,30 @@ def _kernel(
             T.ptx.fence.mbarrier_init.release.cluster()
 
             if have_rope:
-                Tx.copy_async(
-                    q_rope[:, :],
-                    q[s_q_idx : s_q_idx + 1, :, D_V : D_V + Q_ROPE_DIM],
-                    **tma_config(
-                        mbar=bar_prologue_q_rope.ptr_to([0]), cta_group=1, cache_hint="evict_first"
-                    ),
+                T.evaluate(
+                    T.ptx[_TMA_G2S_4D_CACHE](
+                        q_rope.ptr_to([0, 0]),
+                        T.address_of(q_rope_tensormap),
+                        T.int32(0),
+                        T.int32(0),
+                        T.int32(D_V // 32),
+                        T.cast(s_q_idx, "int32"),
+                        T.cuda.cvta_generic_to_shared(bar_prologue_q_rope.ptr_to([0])),
+                        _Q_TMA_CACHE_HINT,
+                    )
                 )
 
-            Tx.copy_async(
-                q_nope[:, :],
-                q[s_q_idx : s_q_idx + 1, :, 0:D_V],
-                **tma_config(
-                    mbar=bar_prologue_q_nope.ptr_to([0]), cta_group=1, cache_hint="evict_first"
-                ),
+            T.evaluate(
+                T.ptx[_TMA_G2S_4D_CACHE](
+                    q_nope.ptr_to([0, 0]),
+                    T.address_of(q_nope_tensormap),
+                    T.int32(0),
+                    T.int32(0),
+                    T.int32(0),
+                    T.cast(s_q_idx, "int32"),
+                    T.cuda.cvta_generic_to_shared(bar_prologue_q_nope.ptr_to([0])),
+                    _Q_TMA_CACHE_HINT,
+                )
             )
             bar_prologue_utccp_rope.init(1)
             bar_prologue_utccp_nope.init(1)
@@ -427,7 +658,9 @@ def _kernel(
         T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
             T.address_of(tmem_start_addr[0]), T.uint32(512)
         )
-        T.cuda.trap_when_assert_failed(tmem_start_addr[0] == T.uint32(0))
+        allocated_tmem_start: T.uint32
+        T.ptx.ld.shared.u32(allocated_tmem_start, tmem_start_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(allocated_tmem_start == T.uint32(0))
         T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
         iket.range_end(prologue_token)
 
@@ -457,23 +690,31 @@ def _kernel(
             p_peer_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, (B_TOPK // 2)), "float32")
             p = p_frag.local()
             p_peer = p_peer_frag.local()
-
-            @T.inline
-            def load_p(lo_dst, hi_dst):
-                p_win = tmem_p_bmm.rearrange("b h t -> (b h) t")
-                Tx.wg.copy_async(lo_dst[:, :], p_win.chunk((None, 2))[:, 0])
-                Tx.wg.copy_async(hi_dst[:, :], p_win.chunk((None, 2))[:, 1])
-
             if warp_idx < 2:
-                load_p(p_frag, p_peer_frag)
+                T.evaluate(_tmem_load(p, T.uint32(tmem_p_col), B_TOPK // 2))
+                T.evaluate(
+                    _tmem_load(
+                        p_peer,
+                        T.cuda.get_tmem_addr(T.uint32(tmem_p_col), 0, B_TOPK // 2),
+                        B_TOPK // 2,
+                    )
+                )
             else:
-                load_p(p_peer_frag, p_frag)
+                T.evaluate(_tmem_load(p_peer, T.uint32(tmem_p_col), B_TOPK // 2))
+                T.evaluate(
+                    _tmem_load(
+                        p, T.cuda.get_tmem_addr(T.uint32(tmem_p_col), 0, B_TOPK // 2), B_TOPK // 2
+                    )
+                )
             T.ptx.tcgen05.wait__ld.sync.aligned()
             T.ptx.tcgen05.fence__before_thread_sync()
             bar_p_free.arrive(0)
 
             valid_word_offset: T.int32 = T.if_then_else(warp_idx >= 2, (B_TOPK // 2) // 32, 0)
-            is_k_valid_u32: T.let = is_k_valid.view("uint32")[cur_buf, valid_word_offset]
+            is_k_valid_u32: T.uint32
+            T.ptx.ld.shared.u32(
+                is_k_valid_u32, is_k_valid.view("uint32").ptr_to([cur_buf, valid_word_offset])
+            )
             for p_i in T.unroll(B_TOPK // 2):
                 invalid_p_predicate: T.let = T.bitwise_and(
                     T.shift_right(is_k_valid_u32, T.uint32(p_i)), T.uint32(1)
@@ -487,10 +728,13 @@ def _kernel(
             for exchange_i in T.unroll((B_TOPK // 2) // 4):
                 exchange_offset = exchange_i * 32 * 4 + lane_idx * 4
                 p_peer_offset: T.let = exchange_i * 4
-                Tx.copy(
-                    p_exchange_buf[warp_idx ^ 2, exchange_offset : exchange_offset + 4],
-                    p_peer[p_peer_offset : p_peer_offset + 4],
-                    dispatch="vec_128b",
+                p_peer_u32 = p_peer.view("uint32")
+                T.ptx.st.shared.v4.u32(
+                    p_exchange_buf.ptr_to([warp_idx ^ 2, exchange_offset]),
+                    p_peer_u32[p_peer_offset],
+                    p_peer_u32[p_peer_offset + 1],
+                    p_peer_u32[p_peer_offset + 2],
+                    p_peer_u32[p_peer_offset + 3],
                 )
             T.ptx.bar.sync(T.uint32(BAR_WG0_WARP02 + T.bitwise_and(warp_idx, T.int32(1))), 64)
             p_add_pair0: T.uint64
@@ -498,10 +742,13 @@ def _kernel(
             for exchange_i in T.unroll((B_TOPK // 2) // 4):
                 exchange_offset = exchange_i * 32 * 4 + lane_idx * 4
                 p_exchange_tmp = T.alloc_local((4,), "float32")
-                Tx.copy(
-                    p_exchange_tmp[0:4],
-                    p_exchange_buf[warp_idx, exchange_offset : exchange_offset + 4],
-                    dispatch="vec_128b",
+                p_exchange_tmp_u32 = p_exchange_tmp.view("uint32")
+                T.ptx.ld.shared.v4.u32(
+                    p_exchange_tmp_u32[0],
+                    p_exchange_tmp_u32[1],
+                    p_exchange_tmp_u32[2],
+                    p_exchange_tmp_u32[3],
+                    p_exchange_buf.ptr_to([warp_idx, exchange_offset]),
                 )
                 p_pair0: T.let = T.cuda.make_float2(p[exchange_i * 4], p[exchange_i * 4 + 1])
                 peer_pair0: T.let = T.cuda.make_float2(p_exchange_tmp[0], p_exchange_tmp[1])
@@ -520,9 +767,11 @@ def _kernel(
             for p_i in T.unroll(B_TOPK // 2):
                 cur_pi_max = T.max(cur_pi_max, p[p_i])
             cur_pi_max = cur_pi_max * sm_scale_div_log2
-            rowwise_max_buf[idx_in_warpgroup] = cur_pi_max
+            T.ptx.st.shared.f32(rowwise_max_buf.ptr_to([idx_in_warpgroup]), cur_pi_max)
             T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-            cur_pi_max = T.max(cur_pi_max, rowwise_max_buf[idx_in_warpgroup ^ 64])
+            peer_pi_max: T.float32
+            T.ptx.ld.shared.f32(peer_pi_max, rowwise_max_buf.ptr_to([idx_in_warpgroup ^ 64]))
+            cur_pi_max = T.max(cur_pi_max, peer_pi_max)
             real_mi = T.max(real_mi, cur_pi_max)
             should_scale_o: T.bool = (
                 T.cuda.any_sync(T.uint32(0xFFFFFFFF), cur_pi_max - mi > 6.0) != 0
@@ -580,20 +829,40 @@ def _kernel(
             T.ptx.fence.proxy.async_.shared__cta()
 
             # CUDA phase1.cuh:229-232 S store (vectorized by the reg copy path).
-            Tx.wg.copy(s_smem_gemm[:, :], s_frag[:, :])
+            s_base: T.let = idx_in_warpgroup // 64 * 2048 + idx_in_warpgroup % 64 * 8
+            s_words = s_frag.local().view("uint32")
+            for s_store_i in T.unroll(4):
+                s_ptr: T.let = T.ptr_byte_offset(
+                    s_smem_gemm.ptr_to([0, 0]), (s_base + s_store_i * 512) * BF16_BYTES, "bfloat16"
+                )
+                s_word: T.let = s_store_i * 4
+                T.ptx.st.shared.v4.u32(
+                    s_ptr,
+                    s_words[s_word],
+                    s_words[s_word + 1],
+                    s_words[s_word + 2],
+                    s_words[s_word + 3],
+                )
             if (k > 0) & should_scale_o:
                 T.ptx.tcgen05.fence__after_thread_sync()
                 # CUDA common_subroutine.h:147-168 rescale_O.
                 o_rescale_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 32), "float32")
                 o_rescale = o_rescale_frag.local()
                 for chunk_idx in T.unroll((D_V // 2) // 32):
-                    Tx.wg.copy_async(
-                        o_rescale_frag[:, :], o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx]
+                    T.evaluate(
+                        _tmem_load(
+                            o_rescale,
+                            T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, chunk_idx * 32),
+                            32,
+                        )
                     )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
-                    Tx.wg.mul(o_rescale_frag[:, :], o_rescale_frag[:, :], scale_for_old)
-                    Tx.wg.copy_async(
-                        o_win.chunk((None, (D_V // 2) // 32))[:, chunk_idx], o_rescale_frag[:, :]
+                    for scale_i in T.unroll(32 // 2):
+                        mul_f32x2(o_rescale, scale_i * 2, scale_for_old)
+                    T.evaluate(
+                        _tmem_store(
+                            o_rescale, T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, chunk_idx * 32)
+                        )
                     )
                     T.ptx.tcgen05.wait__st.sync.aligned()
                 T.ptx.tcgen05.fence__before_thread_sync()
@@ -609,9 +878,11 @@ def _kernel(
             li = 0.0
             mi = T.float32(-float("inf"))
 
-        rowwise_li_buf[idx_in_warpgroup] = li
+        T.ptx.st.shared.f32(rowwise_li_buf.ptr_to([idx_in_warpgroup]), li)
         T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
-        li = li + rowwise_li_buf[idx_in_warpgroup ^ 64]
+        peer_li: T.float32
+        T.ptx.ld.shared.f32(peer_li, rowwise_li_buf.ptr_to([idx_in_warpgroup ^ 64]))
+        li = li + peer_li
 
         if idx_in_warpgroup < B_H:
             cur_lse: T.float32
@@ -620,8 +891,8 @@ def _kernel(
             cur_lse = T.if_then_else(
                 cur_lse == T.float32(-float("inf")), T.float32(float("inf")), cur_lse
             )
-            max_logits[s_q_idx, idx_in_warpgroup] = real_mi * LN_2
-            lse[s_q_idx, idx_in_warpgroup] = cur_lse
+            T.ptx.st.global_.f32(max_logits.ptr_to([s_q_idx, idx_in_warpgroup]), real_mi * LN_2)
+            T.ptx.st.global_.f32(lse.ptr_to([s_q_idx, idx_in_warpgroup]), cur_lse)
 
         last_k: T.int32 = num_k_blocks - 1
         last_buf: T.int32 = _ring_mod3(last_k, max_k_blocks)
@@ -644,9 +915,7 @@ def _kernel(
         o_epi_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 64), "float32")
         o_epi = o_epi_frag.local()
         o_epi_bf16_frag = T.alloc_tcgen05_ldst_frag("32x32b", (128, 64), "bfloat16")
-        # O smem viewed the same way as o_tmem: (128, 256) so a (128,64) frag
-        # chunk copies straight in (row r = lane-half*64 + h, col = D_V fold).
-        o_smem_win = o_smem.rearrange("h (a b c) -> (b h) (a c)", a=2, b=2, c=128)
+        o_epi_bf16 = o_epi_bf16_frag.local()
         have_valid_indices: T.let = T.cuda.any_sync(T.uint32(0xFFFFFFFF), li != 0.0) != 0
         if not have_valid_indices:
             for o_zero_i in T.unroll(64):
@@ -656,36 +925,81 @@ def _kernel(
             for epi_k in T.unroll((D_V // 4) // 64):
                 if have_valid_indices:
                     # CUDA phase1.cuh:314-317: TMEM O load/fence.
-                    Tx.wg.copy_async(
-                        o_epi_frag[:, :],
-                        o_win.chunk((None, (D_V // 2) // 64))[:, epi_c * 2 + epi_k],
+                    T.evaluate(
+                        _tmem_load(
+                            o_epi,
+                            T.cuda.get_tmem_addr(T.uint32(o_tmem_col), 0, epi_c * 128 + epi_k * 64),
+                            64,
+                        )
                     )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
-                Tx.wg.mul(o_epi_frag[:, :], o_epi_frag[:, :], output_scale)
-                Tx.wg.cast(o_epi_bf16_frag[:, :], o_epi_frag[:, :])
-                Tx.wg.copy(
-                    o_smem_win.chunk((None, (D_V // 2) // 64))[:, epi_c * 2 + epi_k],
-                    o_epi_bf16_frag[:, :],
-                )
+                for scale_i in T.unroll(64 // 2):
+                    mul_f32x2(o_epi, scale_i * 2, output_scale)
+                for cast_i in T.unroll(64 // 2):
+                    T.evaluate(_cast_f32x2_bf16x2(o_epi_bf16, o_epi, cast_i * 2))
+                o_epi_words = o_epi_bf16.view("uint32")
+                for o_store_i in T.unroll(8):
+                    s_off: T.let = (
+                        (epi_k // 2 + epi_c) % 2 * 16384
+                        + idx_in_warpgroup // 64 * 8192
+                        + epi_k % 2 * 4096
+                        + idx_in_warpgroup % 64 * 64
+                        + T.bitwise_xor(
+                            o_store_i * 8,
+                            T.shift_left(
+                                T.bitwise_and(
+                                    (epi_k // 2 + epi_c) % 2 * 256
+                                    + idx_in_warpgroup // 64 * 128
+                                    + epi_k % 2 * 64
+                                    + idx_in_warpgroup % 64,
+                                    7,
+                                ),
+                                3,
+                            ),
+                        )
+                    )
+                    s_ptr: T.let = T.ptr_byte_offset(
+                        o_smem.ptr_to([0, 0]), s_off * BF16_BYTES, "bfloat16"
+                    )
+                    o_word: T.let = o_store_i * 4
+                    T.ptx.st.shared.v4.u32(
+                        s_ptr,
+                        o_epi_words[o_word],
+                        o_epi_words[o_word + 1],
+                        o_epi_words[o_word + 2],
+                        o_epi_words[o_word + 3],
+                    )
                 T.ptx.fence.proxy.async_.shared__cta()
                 T.ptx.bar.sync(T.uint32(BAR_WG0_SYNC), 128)
                 if warp_idx == 0:
                     if T.cuda.elect_sync():
                         # CUDA phase1.cuh:335-342: first half O TMA store.
-                        epi_chunk_idx: T.let = epi_c * (D_V // 2 // 64) + epi_k
-                        Tx.copy_async(
-                            out.chunk((None, None, D_V // 64))[s_q_idx, :, epi_chunk_idx],
-                            o_smem.chunk((None, D_V // 64))[:, epi_chunk_idx],
-                            **tma_config(),
+                        T.evaluate(
+                            T.ptx[_TMA_S2G_2D](
+                                T.address_of(out_part0_tensormap),
+                                T.cast(epi_c * 256 + epi_k * 64, "int32"),
+                                T.cast(s_q_idx * B_H, "int32"),
+                                T.ptr_byte_offset(
+                                    o_smem.ptr_to([0, 0]),
+                                    (epi_c * 256 + epi_k * 64) * B_H * BF16_BYTES,
+                                    "bfloat16",
+                                ),
+                            )
                         )
                 if warp_idx == 1:
                     if T.cuda.elect_sync():
                         # CUDA phase1.cuh:343-350: second half O TMA store.
-                        epi_chunk_idx: T.let = epi_c * (D_V // 2 // 64) + (D_V // 64 // 4) + epi_k
-                        Tx.copy_async(
-                            out.chunk((None, None, D_V // 64))[s_q_idx, :, epi_chunk_idx],
-                            o_smem.chunk((None, D_V // 64))[:, epi_chunk_idx],
-                            **tma_config(),
+                        T.evaluate(
+                            T.ptx[_TMA_S2G_2D](
+                                T.address_of(out_part1_tensormap),
+                                T.cast(epi_c * 256 + epi_k * 64 + 128, "int32"),
+                                T.cast(s_q_idx * B_H, "int32"),
+                                T.ptr_byte_offset(
+                                    o_smem.ptr_to([0, 0]),
+                                    (epi_c * 256 + epi_k * 64 + 128) * B_H * BF16_BYTES,
+                                    "bfloat16",
+                                ),
+                            )
                         )
 
         if warp_idx == 0:
@@ -705,12 +1019,19 @@ def _kernel(
                 selected_idx = T.alloc_local((WG1_ROWS_PER_WARP, 4), "int32")
                 max_indices: T.int32 = -1
                 min_indices: T.int32 = s_kv
-                # This warp's 16 indices from the (local_row, warp, j) split:
-                # one strided copy (auto-vectorizes to 4x 128b ld.global.nc).
-                idx_block = indices.view(
-                    s_q, stride_indices_s_q // B_TOPK, WG1_ROWS_PER_WARP, WG1_NUM_WARPS, 4
-                ).sub[s_q_idx, k, :, wg1_warp_idx, :]
-                Tx.copy(selected_idx[:, :], idx_block[:, :], cache="nc")
+                # This warp's 16 indices from the (local_row, warp, j) split.
+                selected_words = selected_idx.view(16).view("uint32")
+                for selected_load_i in T.unroll(4):
+                    selected_word: T.let = selected_load_i * 4
+                    T.ptx.ld.global_.nc.v4.u32(
+                        selected_words[selected_word],
+                        selected_words[selected_word + 1],
+                        selected_words[selected_word + 2],
+                        selected_words[selected_word + 3],
+                        indices.ptr_to(
+                            [g_indices_base + k * B_TOPK + wg1_warp_idx * 4 + selected_load_i * 16]
+                        ),
+                    )
                 for local_row in T.unroll(WG1_ROWS_PER_WARP):
                     for j in T.unroll(4):
                         idx: T.let = selected_idx[local_row, j]
@@ -727,36 +1048,57 @@ def _kernel(
                 cur_phase: T.int32 = _ring_phase_parity(k, max_k_blocks)
                 bar_sv_done.wait(cur_buf, T.bitwise_xor(cur_phase, T.int32(1)))
 
-                kv_nope_tma = kv.view(
-                    s_kv, D_V, layout=TileLayout(S[(s_kv, D_V) : (stride_kv_s_kv, 1)])
-                )
-
-                @T.inline
-                def gather_nope_part(part_idx, bar):
-                    dst_part = k_nope_warp.sub[
-                        cur_buf, :, part_idx * (D_V // 2) : (part_idx + 1) * (D_V // 2)
-                    ]
-                    src_part = kv_nope_tma.sub[
-                        :, part_idx * (D_V // 2) : (part_idx + 1) * (D_V // 2)
-                    ]
+                if not should_skip_tma:
+                    dst_part0 = k_nope_warp.sub[cur_buf, :, 0 : D_V // 2]
                     for row_group in T.unroll(WG1_ROWS_PER_WARP):
                         for col_atom in T.unroll((D_V // 2) // 64):
-                            Tx.copy_async(
-                                dst_part[
-                                    row_group * 4 : row_group * 4 + 4,
-                                    col_atom * 64 : col_atom * 64 + 64,
-                                ],
-                                src_part[0:1, col_atom * 64 : col_atom * 64 + 64],
-                                **_kv_gather_tma(
-                                    mbar=bar.ptr_to([cur_buf]),
-                                    mbarrier_addr=d_qk == D_V and s_kv >= 65536,
-                                    gather4=[selected_idx[row_group, j] for j in range(4)],
-                                ),
+                            dst_part0_offset: T.let = (
+                                cur_buf * B_TOPK * D_V
+                                + col_atom * 64 * B_TOPK
+                                + (wg1_warp_idx * 4 + row_group * 16) * 64
+                            ) * BF16_BYTES
+                            T.evaluate(
+                                T.ptx[_TMA_GATHER4_2D_CACHE](
+                                    T.ptr_byte_offset(
+                                        k_nope.ptr_to([0, 0, 0]), dst_part0_offset, "bfloat16"
+                                    ),
+                                    T.address_of(kv_part0_tensormap),
+                                    T.cast(col_atom * 64, "int32"),
+                                    selected_idx[row_group, 0],
+                                    selected_idx[row_group, 1],
+                                    selected_idx[row_group, 2],
+                                    selected_idx[row_group, 3],
+                                    T.cuda.cvta_generic_to_shared(
+                                        bar_kv_nope_ready_part0.ptr_to([cur_buf])
+                                    ),
+                                    _KV_TMA_CACHE_HINT,
+                                )
                             )
-
-                if not should_skip_tma:
-                    gather_nope_part(0, bar_kv_nope_ready_part0)
-                    gather_nope_part(1, bar_kv_nope_ready_part1)
+                    dst_part1 = k_nope_warp.sub[cur_buf, :, D_V // 2 : D_V]
+                    for row_group in T.unroll(WG1_ROWS_PER_WARP):
+                        for col_atom in T.unroll((D_V // 2) // 64):
+                            dst_part1_offset: T.let = (
+                                cur_buf * B_TOPK * D_V
+                                + (D_V // 2 + col_atom * 64) * B_TOPK
+                                + (wg1_warp_idx * 4 + row_group * 16) * 64
+                            ) * BF16_BYTES
+                            T.evaluate(
+                                T.ptx[_TMA_GATHER4_2D_CACHE](
+                                    T.ptr_byte_offset(
+                                        k_nope.ptr_to([0, 0, 0]), dst_part1_offset, "bfloat16"
+                                    ),
+                                    T.address_of(kv_part1_tensormap),
+                                    T.cast(col_atom * 64, "int32"),
+                                    selected_idx[row_group, 0],
+                                    selected_idx[row_group, 1],
+                                    selected_idx[row_group, 2],
+                                    selected_idx[row_group, 3],
+                                    T.cuda.cvta_generic_to_shared(
+                                        bar_kv_nope_ready_part1.ptr_to([cur_buf])
+                                    ),
+                                    _KV_TMA_CACHE_HINT,
+                                )
+                            )
                 else:
                     tx_bytes = T.uint32(WG1_ROWS_PER_WARP * 4 * (D_V // 2) * BF16_BYTES)
                     T.ptx.mbarrier.complete_tx.relaxed.cluster.shared__cluster.b64(
@@ -768,8 +1110,8 @@ def _kernel(
         iket.range_end(kv_nope_token)
 
     else:
-        # CUDA phase1.cuh:413-572. MMA warpgroup. Keep issue-thread control flow
-        # source-ordered; materialize tcgen05.cp/gemm_async + cp.async paths later.
+        # CUDA phase1.cuh:413-572. MMA warpgroup. Keep every low-level async
+        # issue and its completion barrier in source order on the elected thread.
         if warp_idx == 8:
             mma_token = iket.range_start("h64-qk-pv-issue")
             if T.cuda.elect_sync():
@@ -777,21 +1119,53 @@ def _kernel(
                     bar_prologue_q_rope.arrive(0, tx_count=B_H * (d_qk - D_V) * BF16_BYTES)
                     bar_prologue_q_rope.wait(0, 0)
                     T.ptx.tcgen05.fence__after_thread_sync()
-                    q_rope_tmem_cp = q_rope_tmem_bmm.rearrange("b h k -> h (b k)")
-                    Tx.copy_async(q_rope_tmem_cp[:, :], q_rope[:, :])
-                    bar_prologue_utccp_rope.arrive(0)
+                    for q_rope_flat in T.unroll(2):
+                        q_rope_src: T.let = T.ptr_byte_offset(
+                            q_rope.ptr_to([0, 0]), q_rope_flat % 2 * 2 * 16, "bfloat16"
+                        )
+                        T.evaluate(
+                            T.ptx[_TCGEN_CP_128X256](
+                                T.cast(q_rope_tmem_col + q_rope_flat % 2 * 8, "uint32"),
+                                _replace_smem_desc_addr(q_rope_cp_desc, q_rope_src),
+                            )
+                        )
+                    T.evaluate(
+                        T.ptx[_TCGEN_COMMIT](
+                            T.cuda.cvta_generic_to_shared(bar_prologue_utccp_rope.ptr_to([0]))
+                        )
+                    )
 
                 bar_prologue_q_nope.arrive(0, tx_count=B_H * D_V * BF16_BYTES)
                 bar_prologue_q_nope.wait(0, 0)
                 T.ptx.tcgen05.fence__after_thread_sync()
-                q_nope_tmem_cp = q_nope_tmem_bmm.rearrange("b h (dc di) -> h dc b di", di=64)
-                Tx.copy_async(
-                    q_nope_tmem_cp[:, :, :, :],
-                    q_nope.view(B_H, D_V // 128, 2, 64)[:, :, :, :],
-                    shape="128x256b",
-                    cta_group=1,
+                q_nope_cp_desc: T.uint64
+                T.cuda.tcgen05.encode_matrix_descriptor(
+                    T.address_of(q_nope_cp_desc),
+                    T.reinterpret(T.handle().ty, T.uint64(0)),
+                    1,
+                    64,
+                    3,
                 )
-                bar_prologue_utccp_nope.arrive(0)
+                for q_nope_flat in T.unroll(16):
+                    q_nope_src: T.let = T.ptr_byte_offset(
+                        q_nope.ptr_to([0, 0]),
+                        (q_nope_flat % 4 * 1024 + q_nope_flat // 4 % 4 * 2) * 16,
+                        "bfloat16",
+                    )
+                    T.evaluate(
+                        T.ptx[_TCGEN_CP_128X256](
+                            T.cast(
+                                q_nope_tmem_col + (q_nope_flat % 4 * 32 + q_nope_flat // 4 % 4 * 8),
+                                "uint32",
+                            ),
+                            _replace_smem_desc_addr(q_nope_cp_desc, q_nope_src),
+                        )
+                    )
+                T.evaluate(
+                    T.ptx[_TCGEN_COMMIT](
+                        T.cuda.cvta_generic_to_shared(bar_prologue_utccp_nope.ptr_to([0]))
+                    )
+                )
 
                 if have_rope:
                     bar_prologue_utccp_rope.wait(0, 0)
@@ -808,13 +1182,53 @@ def _kernel(
                             T.ptx.tcgen05.fence__after_thread_sync()
                             # CUDA phase1.cuh:489 Q RoPE x K RoPE MMA.
                             mma_p_accumulate = T.uint32(0)
-                            Tx.gemm_async(
-                                tmem_p_bmm[:, :, :],
-                                q_rope_tmem_bmm[:, :, :],
-                                k_rope_tiled_mma[:, :],
-                                **_mma_config(accum=mma_p_accumulate, smem_desc=mma_smem_desc),
+                            if local_mma_desc:
+                                qk_rope_desc_local = SmemDescriptor()
+                                qk_rope_desc_local.init(
+                                    k_rope_tiled_mma.ptr_to([0, 0]), ldo=0, sdo=32, swizzle=2
+                                )
+                                for mma_mi in T.unroll(1):
+                                    for mma_ni in T.unroll(1):
+                                        for mma_ki in T.unroll(2):
+                                            T.evaluate(
+                                                T.ptx[_MMA_WS_F16](
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    T.cast(q_rope_tmem_col + mma_ki * 8, "uint32"),
+                                                    qk_rope_desc_local.add_16B_offset(
+                                                        (mma_ni * 4096 + mma_ki * 16) // 8
+                                                    ),
+                                                    T.uint32(69207184),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                    T.uint64(0),
+                                                )
+                                            )
+                            else:
+                                for mma_mi in T.unroll(1):
+                                    for mma_ni in T.unroll(1):
+                                        for mma_ki in T.unroll(2):
+                                            T.evaluate(
+                                                T.ptx[_MMA_WS_F16](
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    T.cast(q_rope_tmem_col + mma_ki * 8, "uint32"),
+                                                    qk_rope_desc.add_16B_offset(
+                                                        (mma_ni * 4096 + mma_ki * 16) // 8
+                                                    ),
+                                                    T.uint32(69207184),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                    T.uint64(0),
+                                                )
+                                            )
+                            T.evaluate(
+                                T.ptx[_TCGEN_COMMIT](
+                                    T.cuda.cvta_generic_to_shared(bar_qk_rope_done.ptr_to([0]))
+                                )
                             )
-                            bar_qk_rope_done.arrive(0)
 
                         if k == 0:
                             bar_prologue_utccp_nope.wait(0, 0)
@@ -833,15 +1247,79 @@ def _kernel(
                             mma_p_accumulate = T.if_then_else(
                                 clear_nope_accum, T.uint32(0), T.uint32(1)
                             )
-                            Tx.gemm_async(
-                                tmem_p_bmm[:, :, :],
-                                q_nope_tmem_bmm.chunk((None, None, 2))[:, :, kv_nope_part_idx],
-                                k_nope_tiled_mma.chunk((None, None, 2))[
-                                    cur_buf, :, kv_nope_part_idx
-                                ],
-                                **_mma_config(accum=mma_p_accumulate, smem_desc=mma_smem_desc),
+                            if local_mma_desc:
+                                qk_nope_desc_local = SmemDescriptor()
+                                qk_nope_desc_local.init(
+                                    k_nope_tiled_mma.ptr_to([0, 0, 0]), ldo=1024, sdo=64, swizzle=3
+                                )
+                                for mma_mi in T.unroll(1):
+                                    for mma_ni in T.unroll(1):
+                                        for mma_ki in T.unroll(8):
+                                            qk_nope_offset: T.let = (
+                                                mma_ki // 1024 * 32768
+                                                + mma_ni * 32768
+                                                + cur_buf * 32768
+                                                + kv_nope_part_idx % 2 * 16384
+                                                + mma_ki % 8 // 4 * 8192
+                                                + mma_ki % 1024 // 8 * 64
+                                                + mma_ki % 4 * 16
+                                            ) // 8
+                                            T.evaluate(
+                                                T.ptx[_MMA_WS_F16](
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    T.cast(
+                                                        q_nope_tmem_col
+                                                        + kv_nope_part_idx * 64
+                                                        + mma_ki * 8,
+                                                        "uint32",
+                                                    ),
+                                                    qk_nope_desc_local.add_16B_offset(
+                                                        qk_nope_offset
+                                                    ),
+                                                    T.uint32(69207184),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                    T.uint64(0),
+                                                )
+                                            )
+                            else:
+                                for mma_mi in T.unroll(1):
+                                    for mma_ni in T.unroll(1):
+                                        for mma_ki in T.unroll(8):
+                                            qk_nope_offset: T.let = (
+                                                mma_ki // 1024 * 32768
+                                                + mma_ni * 32768
+                                                + cur_buf * 32768
+                                                + kv_nope_part_idx % 2 * 16384
+                                                + mma_ki % 8 // 4 * 8192
+                                                + mma_ki % 1024 // 8 * 64
+                                                + mma_ki % 4 * 16
+                                            ) // 8
+                                            T.evaluate(
+                                                T.ptx[_MMA_WS_F16](
+                                                    T.cast(tmem_p_col + mma_ni * 64, "uint32"),
+                                                    T.cast(
+                                                        q_nope_tmem_col
+                                                        + kv_nope_part_idx * 64
+                                                        + mma_ki * 8,
+                                                        "uint32",
+                                                    ),
+                                                    qk_nope_desc.add_16B_offset(qk_nope_offset),
+                                                    T.uint32(69207184),
+                                                    T.Or(
+                                                        mma_ki != 0,
+                                                        T.cast(mma_p_accumulate, "bool"),
+                                                    ),
+                                                    T.uint64(0),
+                                                )
+                                            )
+                        T.evaluate(
+                            T.ptx[_TCGEN_COMMIT](
+                                T.cuda.cvta_generic_to_shared(bar_qk_nope_done.ptr_to([cur_buf]))
                             )
-                        bar_qk_nope_done.arrive(cur_buf)
+                        )
 
                     if k > 0:
                         cur_buf_prev: T.int32 = _ring_mod3(k - 1, max_k_blocks)
@@ -849,21 +1327,140 @@ def _kernel(
                         T.ptx.tcgen05.fence__after_thread_sync()
                         # CUDA phase1.cuh:521-523 S(i-1) x V(i-1) MMA.
                         mma_o_accumulate = T.if_then_else(k == 1, T.uint32(0), T.uint32(1))
-
-                        @T.inline
-                        def gemm_o(dst, col_lo, col_hi):
-                            Tx.gemm_async(
-                                dst[:, :],
-                                s_smem_gemm[:, :],
-                                k_nope[cur_buf_prev, :, col_lo:col_hi],
-                                transB=True,
-                                **_mma_config(accum=mma_o_accumulate, smem_desc=mma_smem_desc),
+                        if local_mma_desc:
+                            pv_b_lo_desc_local = SmemDescriptor()
+                            pv_b_lo_desc_local.init(
+                                k_nope.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3
                             )
-
-                        gemm_o(o_tmem.sub[:, 0 : D_V // 2], 0, D_V // 2)
-                        gemm_o(o_tmem.sub[:, D_V // 2 : D_V], D_V // 2, D_V)
+                            pv_a_lo_desc_local = SmemDescriptor()
+                            pv_a_lo_desc_local.init(
+                                s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0
+                            )
+                            for mma_mi in T.unroll(1):
+                                for mma_ni in T.unroll(1):
+                                    for mma_ki in T.unroll(4):
+                                        T.evaluate(
+                                            T.ptx[_MMA_WS_F16](
+                                                T.cast(o_tmem_col + mma_ni * 128, "uint32"),
+                                                pv_a_lo_desc_local.add_16B_offset(
+                                                    (
+                                                        mma_ki % 4 * 1024
+                                                        + mma_mi * 512
+                                                        + mma_ki // 4 * 8
+                                                    )
+                                                    // 8
+                                                ),
+                                                pv_b_lo_desc_local.add_16B_offset(
+                                                    (
+                                                        (mma_ki * 16 + mma_ni) // 64 * 32768
+                                                        + cur_buf_prev * 32768
+                                                        + (mma_ki * 16 + mma_ni) % 64 * 64
+                                                    )
+                                                    // 8
+                                                ),
+                                                T.uint32(71369872),
+                                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                                                T.uint64(0),
+                                            )
+                                        )
+                            pv_b_hi_desc_local = SmemDescriptor()
+                            pv_b_hi_desc_local.init(
+                                k_nope.ptr_to([0, 0, 0]), ldo=512, sdo=64, swizzle=3
+                            )
+                            pv_a_hi_desc_local = SmemDescriptor()
+                            pv_a_hi_desc_local.init(
+                                s_smem_gemm.ptr_to([0, 0]), ldo=64, sdo=8, swizzle=0
+                            )
+                            for mma_mi in T.unroll(1):
+                                for mma_ni in T.unroll(1):
+                                    for mma_ki in T.unroll(4):
+                                        T.evaluate(
+                                            T.ptx[_MMA_WS_F16](
+                                                T.cast(o_tmem_col + 128 + mma_ni * 128, "uint32"),
+                                                pv_a_hi_desc_local.add_16B_offset(
+                                                    (
+                                                        mma_ki % 4 * 1024
+                                                        + mma_mi * 512
+                                                        + mma_ki // 4 * 8
+                                                    )
+                                                    // 8
+                                                ),
+                                                pv_b_hi_desc_local.add_16B_offset(
+                                                    (
+                                                        (mma_ki * 16 + mma_ni) // 64 * 32768
+                                                        + cur_buf_prev * 32768
+                                                        + (mma_ki * 16 + mma_ni) % 64 * 64
+                                                        + 16384
+                                                    )
+                                                    // 8
+                                                ),
+                                                T.uint32(71369872),
+                                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                                                T.uint64(0),
+                                            )
+                                        )
+                        else:
+                            for mma_mi in T.unroll(1):
+                                for mma_ni in T.unroll(1):
+                                    for mma_ki in T.unroll(4):
+                                        T.evaluate(
+                                            T.ptx[_MMA_WS_F16](
+                                                T.cast(o_tmem_col + mma_ni * 128, "uint32"),
+                                                pv_a_lo_desc.add_16B_offset(
+                                                    (
+                                                        mma_ki % 4 * 1024
+                                                        + mma_mi * 512
+                                                        + mma_ki // 4 * 8
+                                                    )
+                                                    // 8
+                                                ),
+                                                pv_b_lo_desc.add_16B_offset(
+                                                    (
+                                                        (mma_ki * 16 + mma_ni) // 64 * 32768
+                                                        + cur_buf_prev * 32768
+                                                        + (mma_ki * 16 + mma_ni) % 64 * 64
+                                                    )
+                                                    // 8
+                                                ),
+                                                T.uint32(71369872),
+                                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                                                T.uint64(0),
+                                            )
+                                        )
+                            for mma_mi in T.unroll(1):
+                                for mma_ni in T.unroll(1):
+                                    for mma_ki in T.unroll(4):
+                                        T.evaluate(
+                                            T.ptx[_MMA_WS_F16](
+                                                T.cast(o_tmem_col + 128 + mma_ni * 128, "uint32"),
+                                                pv_a_hi_desc.add_16B_offset(
+                                                    (
+                                                        mma_ki % 4 * 1024
+                                                        + mma_mi * 512
+                                                        + mma_ki // 4 * 8
+                                                    )
+                                                    // 8
+                                                ),
+                                                pv_b_hi_desc.add_16B_offset(
+                                                    (
+                                                        (mma_ki * 16 + mma_ni) // 64 * 32768
+                                                        + cur_buf_prev * 32768
+                                                        + (mma_ki * 16 + mma_ni) % 64 * 64
+                                                        + 16384
+                                                    )
+                                                    // 8
+                                                ),
+                                                T.uint32(71369872),
+                                                T.Or(mma_ki != 0, T.cast(mma_o_accumulate, "bool")),
+                                                T.uint64(0),
+                                            )
+                                        )
                         mma_o_accumulate = T.uint32(1)
-                        bar_sv_done.arrive(cur_buf_prev)
+                        T.evaluate(
+                            T.ptx[_TCGEN_COMMIT](
+                                T.cuda.cvta_generic_to_shared(bar_sv_done.ptr_to([cur_buf_prev]))
+                            )
+                        )
             iket.range_end(mma_token)
 
         elif warp_idx == 9:
@@ -874,14 +1471,19 @@ def _kernel(
                 for k in T.serial(0, num_k_blocks, unroll=False):
                     abs_pos_start: T.let = k * B_TOPK
                     row_base: T.let = g_indices_base + k * B_TOPK + lane_idx * 8
-                    Tx.copy(
-                        lane_indices[0:8],
-                        indices[row_base : row_base + 8],
-                        dispatch="vec_256b",
-                        cache="nc",
-                        l1_evict="L1::no_allocate",
-                        l2_evict="L2::evict_normal",
-                        prefetch_size="L2::256B",
+                    lane_index_words = lane_indices.view("uint32")
+                    T.evaluate(
+                        T.ptx["ld.global.nc.L1::no_allocate.L2::evict_normal.L2::256B.v8.u32"](
+                            lane_index_words[0],
+                            lane_index_words[1],
+                            lane_index_words[2],
+                            lane_index_words[3],
+                            lane_index_words[4],
+                            lane_index_words[5],
+                            lane_index_words[6],
+                            lane_index_words[7],
+                            indices.ptr_to([row_base]),
+                        )
                     )
                     is_ks_valid_mask: T.int8 = pack_valid_mask8(
                         lane_indices, abs_pos_start, lane_idx, topk_len, s_kv
@@ -890,7 +1492,10 @@ def _kernel(
                     cur_buf: T.int32 = _ring_mod3(k, max_k_blocks)
                     cur_phase: T.int32 = _ring_phase_parity(k, max_k_blocks)
                     bar_k_valid_free.wait(cur_buf, T.bitwise_xor(cur_phase, T.int32(1)))
-                    is_k_valid[cur_buf, lane_idx] = is_ks_valid_mask
+                    T.ptx.st.shared.b8(
+                        is_k_valid.ptr_to([cur_buf, lane_idx]),
+                        T.reinterpret("uint8", is_ks_valid_mask),
+                    )
                     bar_k_valid_ready.arrive(cur_buf)
             iket.range_end(valid_mask_token)
 
@@ -916,16 +1521,15 @@ def _kernel(
                         index = rope_indices[local_row]
                         is_valid_index: T.let = (index >= 0) & (index < s_kv)
                         kv_off: T.let = index * stride_kv_s_kv + D_V + idx_in_group * 8
-                        Tx.copy_async(
-                            k_rope.chunk((None, Q_ROPE_DIM // 8))[
-                                group_idx + local_row * (64 // 8), idx_in_group
-                            ],
-                            kv[kv_off : kv_off + 8],
-                            dispatch="ldgsts",
-                            direct=True,
-                            prefetch_size=128,
-                            predicate=is_valid_index,
-                            fill_mode="zero",
+                        T.evaluate(
+                            T.ptx[_CP_ASYNC_CG_16B](
+                                k_rope.ptr_to(
+                                    [group_idx + local_row * (64 // 8), idx_in_group * 8]
+                                ),
+                                kv.ptr_to([kv_off]),
+                                T.int32(16),
+                                T.if_then_else(is_valid_index, T.uint32(16), T.uint32(0)),
+                            )
                         )
                     T.ptx.cp.async_.mbarrier.arrive.noinc.shared__cta.b64(
                         bar_kv_rope_ready.ptr_to([0])

--- a/tirx_kernels/gemm/fp16_bf16_gemm.py
+++ b/tirx_kernels/gemm/fp16_bf16_gemm.py
@@ -4,9 +4,9 @@ import torch
 
 import tvm
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench
 from tvm.tirx.lang.pipeline import Pipeline, PipelineState
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.lang.tile_scheduler import ClusterLaunchControlScheduler
 
 
@@ -27,6 +27,20 @@ def prepare_data(dtype, M, N, K):
 
 
 _DTYPE_MAP = {"fp16": tvm.DataType("float16"), "bf16": tvm.DataType("bfloat16")}
+
+_TMA_G2S_2SM = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.cta_group::2"
+)
+_TMA_G2S_3D_2SM = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.cta_group::2"
+)
+_TMA_S2G_EVICT_FIRST = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+_MMA_F16_2SM = "tcgen05.mma.cta_group::2.kind::f16"
+_MMA_KEEP_ALL_LANES = (0, 0, 0, 0, 0, 0, 0, 0)
+_TMEM_LD_16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_EVICT_FIRST_L2_POLICY = 0x12F0000000000000
 
 
 def _swizzle_for_row_bytes(row_bytes):
@@ -125,6 +139,114 @@ def _kernel(
     BLK_M = T.meta_var(128)  # CTA_M/2: per-CTA A rows (2-SM MMA combines the cluster)
     BLK_N = T.meta_var(MMA_N // 2)  # per-CTA B rows (cluster covers MMA_N)
     EPI_N = T.meta_var(MMA_N // WB_PIPE_DEPTH)  # epilogue N tile
+    AB_DTYPE = T.meta_var(str(ab_type))
+    D_SWIZZLE = T.meta_var(_swizzle_for_row_bytes(EPI_N * (ab_type.bits // 8)).value)
+    CVT_F32X2 = T.meta_var("cvt.rn.f16x2.f32" if AB_DTYPE == "float16" else "cvt.rn.bf16x2.f32")
+    TMEM_LD_OVERLAP = T.meta_var(_TMEM_LD_32 if EPI_N == 32 else _TMEM_LD_64)
+
+    A_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    B_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    D_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if BLK_K == 128:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            A_tensor_map,
+            AB_DTYPE,
+            3,
+            A.data,
+            64,
+            M,
+            K // 64,
+            K * (ab_type.bits // 8),
+            64 * (ab_type.bits // 8),
+            64,
+            BLK_M,
+            BLK_K // 64,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            B_tensor_map,
+            AB_DTYPE,
+            3,
+            B.data,
+            64,
+            N,
+            K // 64,
+            K * (ab_type.bits // 8),
+            64 * (ab_type.bits // 8),
+            64,
+            BLK_N,
+            BLK_K // 64,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            A_tensor_map,
+            AB_DTYPE,
+            2,
+            A.data,
+            K,
+            M,
+            K * (ab_type.bits // 8),
+            BLK_K,
+            BLK_M,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            B_tensor_map,
+            AB_DTYPE,
+            2,
+            B.data,
+            K,
+            N,
+            K * (ab_type.bits // 8),
+            BLK_K,
+            BLK_N,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        D_tensor_map,
+        AB_DTYPE,
+        2,
+        D.data,
+        N,
+        M,
+        N * (ab_type.bits // 8),
+        EPI_N,
+        BLK_M,
+        1,
+        1,
+        0,
+        D_SWIZZLE,
+        2,
+        0,
+    )
 
     T.device_entry()
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
@@ -133,6 +255,12 @@ def _kernel(
     wg_id = T.warpgroup_id([(NUM_CONSUMER + 1)])
     warp_id = T.warp_id_in_wg([4])
     lane_id = T.lane_id([32])
+
+    if (wg_id == 0) & (warp_id == 0):
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(A_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(B_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(D_tensor_map)))
 
     pool = T.SMEMPool()
     tmem_addr = pool.alloc((1,), "uint32")
@@ -163,7 +291,7 @@ def _kernel(
     pool.commit()
     smem_full_cta0 = smem_pipe.full.remote_view(0)
     tmem = tmem_pool.alloc((128, 512), "float32")
-    # TMEMPool.commit/dealloc wraps the tcgen05 alloc/dealloc handshake.
+    # Keep pool allocation/layout bookkeeping; teardown is emitted explicitly below.
     tmem_pool.commit()
     T.ptx.fence.proxy.async_.shared__cta()
     T.ptx.fence.mbarrier_init.release.cluster()
@@ -190,25 +318,54 @@ def _kernel(
             def tma_load_stage(k_tile, m_idx, n_idx):
                 smem_pipe.empty.wait(tma_cur.stage, tma_cur.phase)
                 stage = tma_cur.stage
-                tma_config = T.meta_var(
-                    {
-                        "dispatch": "tma_auto",
-                        "cta_group": 2,
-                        "mbar": smem_full_cta0.ptr_to([stage]),
-                        # Prefetch the A/B tensormaps at entry.
-                        "prefetch_tensormap": True,
-                    }
-                )
                 k = T.meta_var(k_tile * BLK_K)
                 b_n = T.meta_var((n_idx * 2 + cbx) * BLK_N)
                 # Each CTA loads its OWN A rows / B cols (depend on cbx); cta_group=2
                 # routes the completion mbarrier to the cluster, not a data multicast.
                 for c in T.unroll(NUM_CONSUMER):
                     a_m = T.meta_var(((m_idx * 2 + cbx) * NUM_CONSUMER + c) * BLK_M)
-                    Tx.copy_async(
-                        Asmem[stage, c], A[a_m : a_m + BLK_M, k : k + BLK_K], **tma_config
+                    if BLK_K == 128:
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_3D_2SM](
+                                Asmem.ptr_to([stage, c, 0, 0]),
+                                T.address_of(A_tensor_map),
+                                T.int32(0),
+                                T.cast(a_m, "int32"),
+                                T.cast(k // 64, "int32"),
+                                T.cuda.cvta_generic_to_shared(smem_full_cta0.ptr_to([stage])),
+                            )
+                        )
+                    else:
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_2SM](
+                                Asmem.ptr_to([stage, c, 0, 0]),
+                                T.address_of(A_tensor_map),
+                                T.cast(k, "int32"),
+                                T.cast(a_m, "int32"),
+                                T.cuda.cvta_generic_to_shared(smem_full_cta0.ptr_to([stage])),
+                            )
+                        )
+                if BLK_K == 128:
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_3D_2SM](
+                            Bsmem.ptr_to([stage, 0, 0]),
+                            T.address_of(B_tensor_map),
+                            T.int32(0),
+                            T.cast(b_n, "int32"),
+                            T.cast(k // 64, "int32"),
+                            T.cuda.cvta_generic_to_shared(smem_full_cta0.ptr_to([stage])),
+                        )
                     )
-                Tx.copy_async(Bsmem[stage], B[b_n : b_n + BLK_N, k : k + BLK_K], **tma_config)
+                else:
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_2SM](
+                            Bsmem.ptr_to([stage, 0, 0]),
+                            T.address_of(B_tensor_map),
+                            T.cast(k, "int32"),
+                            T.cast(b_n, "int32"),
+                            T.cuda.cvta_generic_to_shared(smem_full_cta0.ptr_to([stage])),
+                        )
+                    )
                 # Loader-side expect_tx for the whole stage's bytes; cbx==0 owns the mbar.
                 if cbx == 0:
                     smem_full_cta0.arrive(
@@ -242,6 +399,9 @@ def _kernel(
             # tmem wait state: double-buffer (overlap, depth=MMA_PIPE) or a single
             # slot toggled per tile (no-overlap, depth=1).
             tmem_buf = PipelineState(TMEM_PHASE_DEPTH, 1)
+            desc_a = T.meta_var(SmemDescriptor())
+            desc_b = T.meta_var(SmemDescriptor())
+            desc_i = T.alloc_local((1,), "uint32")
             accum: T.int32
             if OVERLAP_EPILOGUE:
                 T.ptx.barrier.cluster.wait.acquire()  # split cluster barrier (MMA)
@@ -253,14 +413,29 @@ def _kernel(
                 tmem_n = T.meta_var(buf * MMA_N)
                 # 2-SM tcgen05 A@B^T (B stored (N,K), transB=False); accum=0 on the
                 # first k-tile (overwrite), 1 thereafter.
-                Tx.gemm_async(
-                    tmem[:, tmem_n : tmem_n + MMA_N],
-                    Asmem[stage, warp_id],
-                    Bsmem[stage],
-                    accum=accum,
-                    dispatch="tcgen05",
-                    cta_group=2,
-                )
+                for ki in T.unroll(BLK_K // 16):
+                    desc_a_ki = T.meta_var(
+                        desc_a.add_16B_offset(
+                            ((stage * NUM_CONSUMER + warp_id) * BLK_M * BLK_K) // 8
+                            + (ki // 4) * BLK_M * 8
+                            + 2 * (ki % 4)
+                        )
+                    )
+                    desc_b_ki = T.meta_var(
+                        desc_b.add_16B_offset(
+                            (stage * BLK_N * BLK_K) // 8 + (ki // 4) * BLK_N * 8 + 2 * (ki % 4)
+                        )
+                    )
+                    T.evaluate(
+                        T.ptx[_MMA_F16_2SM](
+                            T.cast(tmem_n, "uint32"),
+                            desc_a_ki,
+                            desc_b_ki,
+                            desc_i[0],
+                            *_MMA_KEEP_ALL_LANES,
+                            T.ptx.pred(tvm.tirx.any(ki != 0, T.cast(accum, "bool"))),
+                        )
+                    )
                 accum = 1
                 smem_pipe.empty.arrive(mma_smem.stage, cta_group=2, cta_mask=3)
 
@@ -280,6 +455,27 @@ def _kernel(
             mm = clc_sched.worker("mma_sched")
             mm.reset()
             if T.cuda.elect_sync():
+                desc_a.init(
+                    Asmem.ptr_to([0, 0, 0, 0]),
+                    ldo=BLK_M * 8 if BLK_K == 128 else 0,
+                    sdo=64,
+                    swizzle=3,
+                )
+                desc_b.init(
+                    Bsmem.ptr_to([0, 0, 0]), ldo=BLK_N * 8 if BLK_K == 128 else 0, sdo=64, swizzle=3
+                )
+                T.cuda.tcgen05.encode_instr_descriptor(
+                    T.address_of(desc_i[0]),
+                    d_dtype="float32",
+                    a_dtype=AB_DTYPE,
+                    b_dtype=AB_DTYPE,
+                    M=256,
+                    N=MMA_N,
+                    K=16,
+                    trans_a=False,
+                    trans_b=False,
+                    n_cta_groups=2,
+                )
                 while mm.valid():
                     mm.consume()
                     mma()
@@ -303,24 +499,34 @@ def _kernel(
             tmem_base = T.meta_var(slot * MMA_N)
             if OVERLAP_EPILOGUE:
                 # Fused per-chunk load+store, overlapping the next MMA. Keep Dreg_16b
-                # exactly EPI_N wide: a wider frag drops STSM dispatch -> STS.128 and spills
-                # regs 38->255 (measured).
-                Dreg_16b = T.wg_reg_tile(EPI_N, dtype=ab_type)
+                # exactly EPI_N wide: a wider fragment spills registers (measured).
+                Dreg_16b = T.alloc_local((EPI_N // 2,), "uint32", align=16)
                 for i in T.unroll(WB_PIPE_DEPTH):
-                    Dreg = T.wg_reg_tile(EPI_N)
+                    Dreg = T.alloc_local((EPI_N,), "float32")
                     tn = T.meta_var(tmem_base + i * EPI_N)
-                    Tx.wg.copy_async(Dreg, tmem[:, tn : tn + EPI_N])
+                    T.evaluate(
+                        T.ptx[TMEM_LD_OVERLAP](
+                            *[Dreg[j] for j in range(EPI_N)], T.cast(tn, "uint32")
+                        )
+                    )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
-                    Tx.wg.cast(Dreg_16b, Dreg)
+                    for j in T.unroll(EPI_N // 2):
+                        # Packed cvt puts its second source in the low halfword.
+                        T.evaluate(T.ptx[CVT_F32X2](Dreg_16b[j], Dreg[j * 2 + 1], Dreg[j * 2]))
                     if i == WB_PIPE_DEPTH - 1:
                         tmem_pipe.empty.arrive(slot, remote=0, pred=True)
                     db = T.meta_var(i % NUM_D_TILES)
                     T.ptx.cp.async_.bulk.wait_group.read(NUM_D_TILES - 1)
                     T.cuda.warpgroup_sync(wg_id + 10)
-                    # consumer is wg_id==0 here; literal Dsmem[0,...] keeps STSM dispatch.
+                    # consumer is wg_id==0 here; each thread writes one 128-bit row slice.
                     for jv in T.unroll(EPI_N // 8):
-                        Tx.wg.copy(
-                            Dsmem[0, db, :, jv * 8 : jv * 8 + 8], Dreg_16b[:, jv * 8 : jv * 8 + 8]
+                        r0 = T.meta_var(jv * 4)
+                        T.ptx.st.shared.v4.u32(
+                            Dsmem.ptr_to([0, db, warp_id * 32 + lane_id, jv * 8]),
+                            Dreg_16b[r0],
+                            Dreg_16b[r0 + 1],
+                            Dreg_16b[r0 + 2],
+                            Dreg_16b[r0 + 3],
                         )
                     T.cuda.warpgroup_sync(wg_id + 10)
                     if (warp_id == 0) & (lane_id == 0):
@@ -329,12 +535,14 @@ def _kernel(
                         T.ptx.fence.proxy.async_.shared__cta()
                         d_m = T.meta_var(((m_idx * 2 + cbx) * NUM_CONSUMER + wg_id) * BLK_M)
                         d_n = T.meta_var(n_idx * MMA_N + i * EPI_N)
-                        Tx.copy_async(
-                            D[d_m : d_m + BLK_M, d_n : d_n + EPI_N],
-                            Dsmem[0, db],
-                            dispatch="tma_auto",
-                            cache_hint="evict_first",  # evict-first L2 policy for the store
-                            prefetch_tensormap=True,  # prefetch the D tensormap
+                        T.evaluate(
+                            T.ptx[_TMA_S2G_EVICT_FIRST](
+                                T.address_of(D_tensor_map),
+                                T.cast(d_n, "int32"),
+                                T.cast(d_m, "int32"),
+                                Dsmem.ptr_to([0, db, 0, 0]),
+                                T.uint64(_EVICT_FIRST_L2_POLICY),
+                            )
                         )
                     # commit_group collectively reconverges the warpgroup (no post-sync).
                     T.ptx.cp.async_.bulk.commit_group()
@@ -343,24 +551,37 @@ def _kernel(
                 # the tmem->reg f32 load in 16-col sub-chunks so the f32 footprint stays 16
                 # (not EPI_N), else the consumer spills (LDL/STL).
                 NOL = T.meta_var(16)
-                Dreg_16b = T.wg_reg_tile(MMA_N, dtype=ab_type)
+                Dreg_16b = T.alloc_local((MMA_N // 2,), "uint32", align=16)
                 for i in T.unroll(MMA_N // NOL):
-                    Dreg = T.wg_reg_tile(NOL)
+                    Dreg = T.alloc_local((NOL,), "float32")
                     tn = T.meta_var(tmem_base + i * NOL)
-                    Tx.wg.copy_async(Dreg, tmem[:, tn : tn + NOL])
+                    T.evaluate(
+                        T.ptx[_TMEM_LD_16](*[Dreg[j] for j in range(NOL)], T.cast(tn, "uint32"))
+                    )
                     T.ptx.tcgen05.wait__ld.sync.aligned()
-                    Tx.wg.cast(Dreg_16b[:, i * NOL : (i + 1) * NOL], Dreg)
+                    for j in T.unroll(NOL // 2):
+                        # Keep the logical (lo, hi) pair in low/high halfword order.
+                        T.evaluate(
+                            T.ptx[CVT_F32X2](
+                                Dreg_16b[i * (NOL // 2) + j], Dreg[j * 2 + 1], Dreg[j * 2]
+                            )
+                        )
                 tmem_pipe.empty.arrive(wg_id, remote=0, pred=True)
                 for i in T.unroll(WB_PIPE_DEPTH):
                     db = T.meta_var(i % NUM_D_TILES)
                     T.ptx.cp.async_.bulk.wait_group.read(NUM_D_TILES - 1)
                     T.cuda.warpgroup_sync(wg_id + 10)
-                    # Store reg->smem in 8-bf16 (128b) sub-slices -> st.128 (one swizzle
+                    # Store reg->smem in 8x16-bit (128b) sub-slices -> st.128 (one swizzle
                     # chunk each), avoiding the scalar 16b loop / bank conflicts.
                     for jv in T.unroll(EPI_N // 8):
                         c0 = T.meta_var(i * EPI_N + jv * 8)
-                        Tx.wg.copy(
-                            Dsmem[wg_id, db, :, jv * 8 : jv * 8 + 8], Dreg_16b[:, c0 : c0 + 8]
+                        r0 = T.meta_var(c0 // 2)
+                        T.ptx.st.shared.v4.u32(
+                            Dsmem.ptr_to([wg_id, db, warp_id * 32 + lane_id, jv * 8]),
+                            Dreg_16b[r0],
+                            Dreg_16b[r0 + 1],
+                            Dreg_16b[r0 + 2],
+                            Dreg_16b[r0 + 3],
                         )
                     T.cuda.warpgroup_sync(wg_id + 10)
                     if (warp_id == 0) & (lane_id == 0):
@@ -368,12 +589,14 @@ def _kernel(
                         T.ptx.fence.proxy.async_.shared__cta()
                         d_m = T.meta_var(((m_idx * 2 + cbx) * NUM_CONSUMER + wg_id) * BLK_M)
                         d_n = T.meta_var(n_idx * MMA_N + i * EPI_N)
-                        Tx.copy_async(
-                            D[d_m : d_m + BLK_M, d_n : d_n + EPI_N],
-                            Dsmem[wg_id, db],
-                            dispatch="tma_auto",
-                            cache_hint="evict_first",  # evict-first L2 policy
-                            prefetch_tensormap=True,  # prefetch the D tensormap
+                        T.evaluate(
+                            T.ptx[_TMA_S2G_EVICT_FIRST](
+                                T.address_of(D_tensor_map),
+                                T.cast(d_n, "int32"),
+                                T.cast(d_m, "int32"),
+                                Dsmem.ptr_to([wg_id, db, 0, 0]),
+                                T.uint64(_EVICT_FIRST_L2_POLICY),
+                            )
                         )
                     # commit_group collectively reconverges the warpgroup (no post-sync).
                     T.ptx.cp.async_.bulk.commit_group()
@@ -405,7 +628,13 @@ def _kernel(
     if not OVERLAP_EPILOGUE:
         # No-overlap keeps the full cluster_sync teardown.
         T.cuda.cluster_sync()
-    tmem_pool.dealloc()
+    if (wg_id == 0) & (warp_id == 0):
+        # tcgen05 allocation/deallocation are warp-uniform. Read the allocator's
+        # shared slot explicitly so the low-level IR contains a real shared load.
+        T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+        tmem_dealloc_addr: T.uint32
+        T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_addr.ptr_to([0]))
+        T.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](tmem_dealloc_addr, T.uint32(512))
 
 
 def tir_kernel(dtype: str, M: int, N: int, K: int):

--- a/tirx_kernels/gemm/fp8_blockwise_gemm.py
+++ b/tirx_kernels/gemm/fp8_blockwise_gemm.py
@@ -8,14 +8,36 @@ from deep_gemm.utils.math import per_block_cast_to_fp8, per_token_cast_to_fp8
 
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench
 from tvm.tirx.lang.pipeline import MBarrier, Pipeline, PipelineState
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.lang.tile_scheduler import ClusterPersistentScheduler2D
+
+_TMA_G2S_2D = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_S2G_2D = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TMA_EVICT_NORMAL = 0x1000000000000000
+_TCGEN05_CP_2SM = "tcgen05.cp.cta_group::2.32x128b.warpx4"
+_MMA_FP8_2SM = "tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X"
+_TMEM_LD_32X32_X8 = "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+_TMEM_LD_16X256_X1 = "tcgen05.ld.sync.aligned.16x256b.x1.b32"
 
 
 def _align(value: int, alignment: int) -> int:
     return math.ceil(value / alignment) * alignment
+
+
+def _replace_smem_desc_addr(desc, smem_ptr):
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
 
 
 def _swizzle_mode(block_size: int, elem_size: int) -> int:
@@ -224,6 +246,132 @@ def _kernel(
     D_SWIZZLE = T.meta_var(
         SwizzleMode.SWIZZLE_128B_ATOM if SWAP_AB else SwizzleMode.SWIZZLE_64B_ATOM
     )
+    D_TMA_TILE_M = T.meta_var(16 if SWAP_AB else DG_BLOCK_M)
+    D_TMA_TILE_N = T.meta_var(DG_BLOCK_N if SWAP_AB else EPI_TILE)
+    D_TMA_SWIZZLE = T.meta_var(3 if SWAP_AB else 2)
+
+    A_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    B_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    SFA_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    SFB_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    D_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        A_tensor_map,
+        "float8_e4m3fn",
+        2,
+        A.data,
+        K,
+        M,
+        K,
+        BLK_K,
+        BLK_M,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        B_tensor_map,
+        "float8_e4m3fn",
+        2,
+        B.data,
+        K,
+        N,
+        K,
+        BLK_K,
+        BLK_N,
+        1,
+        1,
+        0,
+        3,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        SFA_tensor_map,
+        "uint32",
+        2,
+        SFA.data,
+        M,
+        K // 512,
+        M * 4,
+        DG_BLOCK_M,
+        1,
+        1,
+        1,
+        0,
+        0,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        SFB_tensor_map,
+        "uint32",
+        2,
+        SFB.data,
+        N,
+        K // 512,
+        N * 4,
+        DG_BLOCK_N,
+        1,
+        1,
+        1,
+        0,
+        0,
+        2,
+        0,
+    )
+    if SWAP_AB:
+        # Split the contiguous N axis into 64-element atoms.  The resulting 3-D
+        # descriptor is the legal 128-byte/swizzle-128 encoding of a 16x128 BF16
+        # store tile used by the reference dispatcher.
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            D_tensor_map,
+            "bfloat16",
+            3,
+            D.data,
+            64,
+            M,
+            N // 64,
+            N * 2,
+            128,
+            64,
+            16,
+            2,
+            1,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            D_tensor_map,
+            "bfloat16",
+            2,
+            D.data,
+            N,
+            M,
+            N * 2,
+            D_TMA_TILE_N,
+            D_TMA_TILE_M,
+            1,
+            1,
+            0,
+            D_TMA_SWIZZLE,
+            2,
+            0,
+        )
     T.device_entry()
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
     cbx, cby = T.cta_id_in_cluster([M_CLUSTER, N_CLUSTER])
@@ -233,12 +381,21 @@ def _kernel(
     warp_id = T.warp_id_in_wg([4])
     tid_in_wg = T.thread_id_in_wg([128])
     lane_id = T.lane_id([32])
+    if (wg_id == 0) & (warp_id == 0):
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(A_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(B_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFA_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFB_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(D_tensor_map)))
     pool = T.SMEMPool()
+    tmem_addr = pool.alloc((1,), "uint32")
     barrier_leader = (wg_id == 0) & (warp_id == 1) & (T.cuda.elect_sync() != T.uint32(0))
     tmem_pool = T.TMEMPool(
         pool,
         total_cols=512,
         cta_group=CTA_GROUP,
+        tmem_addr=tmem_addr,
         alloc_warp=2,
         dealloc_warp=0,
         sync_after_alloc=False,
@@ -258,7 +415,6 @@ def _kernel(
     acc_buf = tmem_pool.alloc_tcgen05_mma_D(
         (128, TMEM_DEPTH * MMA_N), "float32", M=128 * CTA_GROUP, cta_group=CTA_GROUP
     )
-    acc = T.meta_var(acc_buf.rearrange("m (s n) -> s m n", s=TMEM_DEPTH))
     SFA_tmem = tmem_pool.alloc_sf(
         (TMEM_DEPTH, BLK_SFA, 4 * K_ITERS), "float8_e8m0fnu", sf_per_mma=1, sf_reuse=K_ITERS
     )
@@ -288,7 +444,9 @@ def _kernel(
     tmem_pool.commit()
     T.cuda.cluster_sync()
     T.evaluate(T.ptx.griddepcontrol.wait())
-    T.cuda.trap_when_assert_failed(tmem_pool.addr == 0)
+    tmem_allocated: T.uint32
+    T.ptx.ld.shared.u32(tmem_allocated, tmem_addr.ptr_to([0]))
+    T.cuda.trap_when_assert_failed(tmem_allocated == T.uint32(0))
 
     m_idx = T.meta_var(tile_scheduler.n_idx if SWAP_AB else tile_scheduler.m_idx)
     n_idx = T.meta_var(tile_scheduler.m_idx if SWAP_AB else tile_scheduler.n_idx)
@@ -310,27 +468,46 @@ def _kernel(
                 smem_pipe.empty.wait(tma_cur.stage, tma_cur.phase)
                 stage = tma_cur.stage
                 k = T.meta_var(k_tile * BLK_K)
-                tma_copy = T.meta_var(
-                    {
-                        "dispatch": "tma_auto",
-                        "mbar": smem_pipe.full.ptr_to([stage]),
-                        "cta_group": 1,
-                        "cache_hint": "evict_normal",
-                        "prefetch_tensormap": True,
-                    }
-                )
-                Tx.copy_async(A_smem[stage], A[a_m : a_m + BLK_M, k : k + BLK_K], **tma_copy)
-                Tx.copy_async(B_smem[stage], B[b_n : b_n + BLK_N, k : k + BLK_K], **tma_copy)
-                if k_tile % 4 == 0:
-                    Tx.copy_async(
-                        SFA_smem[stage, 0:DG_BLOCK_M],
-                        SFA[k_tile // 4, sf_m : sf_m + DG_BLOCK_M],
-                        **tma_copy,
+                T.evaluate(
+                    T.ptx[_TMA_G2S_2D](
+                        A_smem.ptr_to([stage, 0, 0]),
+                        T.address_of(A_tensor_map),
+                        T.cast(k, "int32"),
+                        T.cast(a_m, "int32"),
+                        smem_pipe.full.ptr_to([stage]),
+                        T.uint64(_TMA_EVICT_NORMAL),
                     )
-                    Tx.copy_async(
-                        SFB_smem[stage, 0:DG_BLOCK_N],
-                        SFB[k_tile // 4, sf_n : sf_n + DG_BLOCK_N],
-                        **tma_copy,
+                )
+                T.evaluate(
+                    T.ptx[_TMA_G2S_2D](
+                        B_smem.ptr_to([stage, 0, 0]),
+                        T.address_of(B_tensor_map),
+                        T.cast(k, "int32"),
+                        T.cast(b_n, "int32"),
+                        smem_pipe.full.ptr_to([stage]),
+                        T.uint64(_TMA_EVICT_NORMAL),
+                    )
+                )
+                if k_tile % 4 == 0:
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_2D](
+                            SFA_smem.ptr_to([stage, 0]),
+                            T.address_of(SFA_tensor_map),
+                            T.cast(sf_m, "int32"),
+                            T.cast(k_tile // 4, "int32"),
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_NORMAL),
+                        )
+                    )
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_2D](
+                            SFB_smem.ptr_to([stage, 0]),
+                            T.address_of(SFB_tensor_map),
+                            T.cast(sf_n, "int32"),
+                            T.cast(k_tile // 4, "int32"),
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_NORMAL),
+                        )
                     )
 
                 smem_pipe.full.arrive(
@@ -349,24 +526,75 @@ def _kernel(
                     tma_iter()
                     tile_scheduler.next_tile()
         elif warp_id == 2:
-            SFA_smem_post = SFA_smem.view(SMEM_DEPTH, BLK_SFA, layout=SFA_post_layout)
-            SFB_smem_post = SFB_smem.view(SMEM_DEPTH, BLK_SFB, layout=SFB_post_layout)
             trans_state = PipelineState(SMEM_DEPTH, 0)
 
             @T.inline
             def transpose(ks, k_tile):
                 smem_pipe.full.wait(ks, trans_state.phase)
                 if k_tile % 4 == 0:
-                    Tx.warp.permute_layout(SFA_smem_post[ks, :], SFA_smem[ks, :])
-                    Tx.warp.permute_layout(SFB_smem_post[ks, :], SFB_smem[ks, :])
+                    sfa_regs = T.alloc_local((BLK_SFA // 32,), "uint32")
+                    for r in T.unroll(BLK_SFA // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        src = T.meta_var(
+                            T.ptr_byte_offset(
+                                SFA_smem.ptr_to([ks, 0]), (quad * 32 + lane_id) * 4, "uint32"
+                            )
+                        )
+                        T.ptx.ld.shared.b32(sfa_regs[r], src)
+                    T.cuda.warp_sync()
+                    for r in T.unroll(BLK_SFA // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        post = T.meta_var(quad // 4 * 128 + quad % 4 + lane_id * 4)
+                        dst = T.meta_var(
+                            T.ptr_byte_offset(SFA_smem.ptr_to([ks, 0]), post * 4, "uint32")
+                        )
+                        T.ptx.st.shared.b32(dst, sfa_regs[r])
+                    T.cuda.warp_sync()
+                    sfb_regs = T.alloc_local((BLK_SFB // 32,), "uint32")
+                    for r in T.unroll(BLK_SFB // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        src = T.meta_var(
+                            T.ptr_byte_offset(
+                                SFB_smem.ptr_to([ks, 0]), (quad * 32 + lane_id) * 4, "uint32"
+                            )
+                        )
+                        T.ptx.ld.shared.b32(sfb_regs[r], src)
+                    T.cuda.warp_sync()
+                    for r in T.unroll(BLK_SFB // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        post = T.meta_var(quad // 4 * 128 + quad % 4 + lane_id * 4)
+                        dst = T.meta_var(
+                            T.ptr_byte_offset(SFB_smem.ptr_to([ks, 0]), post * 4, "uint32")
+                        )
+                        T.ptx.st.shared.b32(dst, sfb_regs[r])
+                    T.cuda.warp_sync()
                     T.ptx.fence.proxy.async_.shared__cta()
                 trans_done.arrive(ks, remote=0)
 
             @T.inline
             def trans_iter():
-                for k_tile in T.serial(K_TILES):
-                    transpose(trans_state.stage, k_tile)
-                    trans_state.advance()
+                if K_TILES <= 16:
+                    # Short-K kernels fully materialize the pipeline body in the reference
+                    # codegen, avoiding loop-control overhead altogether.
+                    for k_tile in T.unroll(K_TILES):
+                        transpose(trans_state.stage, k_tile)
+                        trans_state.advance()
+                else:
+                    # Long-K kernels use a four-way body.  Keeping this grouping explicit
+                    # makes the wait/arrive cadence independent of nvcc's heuristic.
+                    for k_group in T.serial(K_TILES // 4, unroll=False):
+                        for k_inner in T.unroll(4):
+                            k_tile = T.meta_var(k_group * 4 + k_inner)
+                            transpose(trans_state.stage, k_tile)
+                            trans_state.advance()
 
             while tile_scheduler.valid():
                 trans_iter()
@@ -378,6 +606,26 @@ def _kernel(
             SFB_smem_fp8 = SFB_smem.view("float8_e8m0fnu").view(
                 SMEM_DEPTH, BLK_SFB, 4 * K_ITERS, layout=SFB_smem_fp8_layout
             )
+            desc_a = T.meta_var(SmemDescriptor())
+            desc_b = T.meta_var(SmemDescriptor())
+            desc_sf = T.meta_var(SmemDescriptor())
+            if SWAP_AB:
+                desc_a.init(B_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+                desc_b.init(A_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+            else:
+                desc_a.init(A_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+                desc_b.init(B_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+            desc_sf.init(T.reinterpret("handle", T.uint64(0)), ldo=0, sdo=8, swizzle=0)
+            MMA_A_ROWS = T.meta_var(BLK_N if SWAP_AB else BLK_M)
+            MMA_B_ROWS = T.meta_var(BLK_M if SWAP_AB else BLK_N)
+            MMA_SFA_BASE = T.meta_var(
+                SFB_tmem.allocated_addr[0] if SWAP_AB else SFA_tmem.allocated_addr[0]
+            )
+            MMA_SFB_BASE = T.meta_var(
+                SFA_tmem.allocated_addr[0] if SWAP_AB else SFB_tmem.allocated_addr[0]
+            )
+            MMA_SFA_STAGE_COLS = T.meta_var(BLK_SFB // 32 if SWAP_AB else BLK_SFA // 32)
+            MMA_SFB_STAGE_COLS = T.meta_var(BLK_SFA // 32 if SWAP_AB else BLK_SFB // 32)
             tmem_idx: T.int32
             tmem_phase: T.int32
             mma_state = PipelineState(SMEM_DEPTH, 0)
@@ -387,30 +635,69 @@ def _kernel(
             def mma(ks, k_tile):
                 trans_done.wait(ks, mma_state.phase)
                 if k_tile % 4 == 0:
-                    Tx.copy_async(SFA_tmem[tmem_idx], SFA_smem_fp8[ks], cta_group=CTA_GROUP)
-                    Tx.copy_async(SFB_tmem[tmem_idx], SFB_smem_fp8[ks], cta_group=CTA_GROUP)
-                scale_k = T.meta_var((k_tile % 4) * K_ITERS)
-                if SWAP_AB:
-                    Tx.gemm_async(
-                        acc[tmem_idx, :, :],
-                        B_smem[ks],
-                        A_smem[ks],
-                        SFA=SFB_tmem[tmem_idx, :, scale_k : scale_k + K_ITERS],
-                        SFB=SFA_tmem[tmem_idx, :, scale_k : scale_k + K_ITERS],
-                        accum=accum,
-                        dispatch="tcgen05",
-                        cta_group=CTA_GROUP,
+                    for sf_chunk in T.unroll(BLK_SFA // 128):
+                        sfa_desc = T.meta_var(
+                            _replace_smem_desc_addr(
+                                desc_sf.desc, SFA_smem_fp8.ptr_to([ks, sf_chunk * 128, 0])
+                            )
+                        )
+                        T.ptx[_TCGEN05_CP_2SM](
+                            T.cast(
+                                SFA_tmem.allocated_addr[0]
+                                + tmem_idx * (BLK_SFA // 32)
+                                + sf_chunk * 4,
+                                "uint32",
+                            ),
+                            sfa_desc,
+                        )
+                    for sf_chunk in T.unroll(BLK_SFB // 128):
+                        sfb_desc = T.meta_var(
+                            _replace_smem_desc_addr(
+                                desc_sf.desc, SFB_smem_fp8.ptr_to([ks, sf_chunk * 128, 0])
+                            )
+                        )
+                        T.ptx[_TCGEN05_CP_2SM](
+                            T.cast(
+                                SFB_tmem.allocated_addr[0]
+                                + tmem_idx * (BLK_SFB // 32)
+                                + sf_chunk * 4,
+                                "uint32",
+                            ),
+                            sfb_desc,
+                        )
+                desc_i: T.uint32
+                T.cuda.tcgen05.encode_instr_descriptor_block_scaled(
+                    T.address_of(desc_i),
+                    d_dtype="float32",
+                    a_dtype="float8_e4m3fn",
+                    b_dtype="float8_e4m3fn",
+                    sfa_dtype="float8_e8m0fnu",
+                    sfb_dtype="float8_e8m0fnu",
+                    sfa_tmem_addr=MMA_SFA_BASE + tmem_idx * MMA_SFA_STAGE_COLS,
+                    sfb_tmem_addr=MMA_SFB_BASE + tmem_idx * MMA_SFB_STAGE_COLS,
+                    M=128 * CTA_GROUP,
+                    N=MMA_N,
+                    K=MMA_K,
+                    trans_a=False,
+                    trans_b=False,
+                    n_cta_groups=CTA_GROUP,
+                )
+                for ki in T.unroll(K_ITERS):
+                    T.cuda.runtime_instr_desc(T.address_of(desc_i), k_tile % 4)
+                    desc_a_ki = T.meta_var(
+                        desc_a.add_16B_offset((ks * MMA_A_ROWS * BLK_K + ki * MMA_K) // 16)
                     )
-                else:
-                    Tx.gemm_async(
-                        acc[tmem_idx, :, :],
-                        A_smem[ks],
-                        B_smem[ks],
-                        SFA=SFA_tmem[tmem_idx, :, scale_k : scale_k + K_ITERS],
-                        SFB=SFB_tmem[tmem_idx, :, scale_k : scale_k + K_ITERS],
-                        accum=accum,
-                        dispatch="tcgen05",
-                        cta_group=CTA_GROUP,
+                    desc_b_ki = T.meta_var(
+                        desc_b.add_16B_offset((ks * MMA_B_ROWS * BLK_K + ki * MMA_K) // 16)
+                    )
+                    T.ptx[_MMA_FP8_2SM](
+                        T.cast(acc_buf.allocated_addr[0] + tmem_idx * MMA_N, "uint32"),
+                        desc_a_ki,
+                        desc_b_ki,
+                        desc_i,
+                        T.cast(MMA_SFA_BASE + tmem_idx * MMA_SFA_STAGE_COLS, "uint32"),
+                        T.cast(MMA_SFB_BASE + tmem_idx * MMA_SFB_STAGE_COLS, "uint32"),
+                        T.Or(ki != 0, T.cast(accum, "bool")),
                     )
                 accum = 1
                 smem_pipe.empty.arrive(ks, cta_group=CTA_GROUP, cta_mask=3)
@@ -438,13 +725,11 @@ def _kernel(
         # acc -> D_smem step (stmatrix transpose vs straight copy) and the tiling.
         EPI = T.meta_var(16 if SWAP_AB else EPI_TILE)
         STORE_TILES = T.meta_var(MMA_N // EPI)
-        D_TILE_M = T.meta_var(16 if SWAP_AB else DG_BLOCK_M)
-        D_TILE_N = T.meta_var(DG_BLOCK_N if SWAP_AB else EPI_TILE)
 
         @T.inline
         def epilogue():
-            swap_frag = T.alloc_tcgen05_ldst_frag("16x256b", (128, 8), "float32")
-            swap_bf16 = T.alloc_cast_frag(swap_frag, "bfloat16")
+            swap_frag = T.alloc_local((8,), "float32")
+            swap_bf16 = T.alloc_local((4,), "uint32", align=16)
             for ot in T.unroll(STORE_TILES):
                 store_iter: T.let = tile_scheduler.tile_idx * STORE_TILES + ot
                 stage = store_iter % TMEM_DEPTH
@@ -455,25 +740,64 @@ def _kernel(
                 if SWAP_AB:
                     for atom_m in T.unroll(2):
                         col_st: T.let = ot * 16 + atom_m * 8
-                        Tx.wg.copy_async(swap_frag[:, :], acc[tmem_idx, :, col_st : col_st + 8])
+                        for slab in T.unroll(2):
+                            reg_base = T.meta_var(slab * 4)
+                            T.ptx[_TMEM_LD_16X256_X1](
+                                swap_frag[reg_base],
+                                swap_frag[reg_base + 1],
+                                swap_frag[reg_base + 2],
+                                swap_frag[reg_base + 3],
+                                T.cuda.get_tmem_addr(
+                                    acc_buf.allocated_addr[0], slab * 16, tmem_idx * MMA_N + col_st
+                                ),
+                            )
                         T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Tx.wg.cast(swap_bf16, swap_frag)
-                        rs = T.meta_var(atom_m * 8)
-                        Tx.wg.copy(
-                            D_smem[stage, rs : rs + 8, 0:128],
-                            swap_bf16.permute(1, 0),
-                            dispatch="ldstmatrix",
+                        for pair in T.unroll(4):
+                            T.ptx.cvt.rn.bf16x2.f32(
+                                swap_bf16[pair], swap_frag[pair * 2 + 1], swap_frag[pair * 2]
+                            )
+                        row = T.meta_var(lane_id % 8)
+                        col = T.meta_var(warp_id % 2 * 4 + lane_id // 8)
+                        smem_off = T.meta_var(
+                            stage * D_SMEM_M * D_SMEM_N
+                            + warp_id // 2 * 16 * 64
+                            + atom_m * 8 * 64
+                            + row * 64
+                            + T.bitwise_xor(col, row) * 8
+                        )
+                        smem_ptr = T.meta_var(
+                            T.ptr_byte_offset(D_smem.ptr_to([0, 0, 0]), smem_off * 2, "bfloat16")
+                        )
+                        T.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                            smem_ptr, swap_bf16[0], swap_bf16[1], swap_bf16[2], swap_bf16[3]
                         )
                 else:
                     for ki in T.unroll(EPI_TILE // TMEM_LD_SIZE):
-                        Dreg = T.wg_reg_tile(TMEM_LD_SIZE)
+                        Dreg = T.alloc_local((TMEM_LD_SIZE,), "float32")
                         acc_n = T.meta_var(ot * EPI_TILE + ki * TMEM_LD_SIZE)
-                        Tx.wg.copy_async(Dreg, acc[tmem_idx, :, acc_n : acc_n + TMEM_LD_SIZE])
+                        T.ptx[_TMEM_LD_32X32_X8](
+                            Dreg[0],
+                            Dreg[1],
+                            Dreg[2],
+                            Dreg[3],
+                            Dreg[4],
+                            Dreg[5],
+                            Dreg[6],
+                            Dreg[7],
+                            T.cast(acc_buf.allocated_addr[0] + tmem_idx * MMA_N + acc_n, "uint32"),
+                        )
                         T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Dreg_bf16 = T.wg_reg_tile(TMEM_LD_SIZE, dtype="bfloat16")
-                        Tx.wg.cast(Dreg_bf16, Dreg)
-                        Tx.wg.copy(
-                            D_smem[stage, :, ki * TMEM_LD_SIZE : (ki + 1) * TMEM_LD_SIZE], Dreg_bf16
+                        Dreg_bf16 = T.alloc_local((TMEM_LD_SIZE // 2,), "uint32", align=16)
+                        for pair in T.unroll(TMEM_LD_SIZE // 2):
+                            T.ptx.cvt.rn.bf16x2.f32(
+                                Dreg_bf16[pair], Dreg[pair * 2 + 1], Dreg[pair * 2]
+                            )
+                        T.ptx.st.shared.v4.u32(
+                            D_smem.ptr_to([stage, tid_in_wg, ki * TMEM_LD_SIZE]),
+                            Dreg_bf16[0],
+                            Dreg_bf16[1],
+                            Dreg_bf16[2],
+                            Dreg_bf16[3],
                         )
                 if ot == STORE_TILES - 1:
                     tmem_pipe.empty.arrive(tmem_idx, remote=0)
@@ -483,15 +807,30 @@ def _kernel(
                 d_n: T.let = n_idx * DG_BLOCK_N + (0 if SWAP_AB else ot * EPI_TILE)
                 if warp_id == 0:
                     if T.cuda.elect_sync():
-                        Tx.copy_async(
-                            D[d_m : d_m + D_TILE_M, d_n : d_n + D_TILE_N],
-                            D_smem[stage],
-                            dispatch="tma_auto",
-                            prefetch_tensormap=True,
-                        )
+                        if SWAP_AB:
+                            T.evaluate(
+                                T.ptx[_TMA_S2G_3D](
+                                    T.address_of(D_tensor_map),
+                                    T.int32(0),
+                                    T.cast(d_m, "int32"),
+                                    T.cast(d_n // 64, "int32"),
+                                    D_smem.ptr_to([stage, 0, 0]),
+                                )
+                            )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_S2G_2D](
+                                    T.address_of(D_tensor_map),
+                                    T.cast(d_n, "int32"),
+                                    T.cast(d_m, "int32"),
+                                    D_smem.ptr_to([stage, 0, 0]),
+                                )
+                            )
                         T.ptx.cp.async_.bulk.commit_group()
 
-        T.cuda.trap_when_assert_failed(tmem_pool.addr == 0)
+        epilogue_tmem_allocated: T.uint32
+        T.ptx.ld.shared.u32(epilogue_tmem_allocated, tmem_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(epilogue_tmem_allocated == T.uint32(0))
         while tile_scheduler.valid():
             tmem_idx = tile_scheduler.tile_idx % TMEM_DEPTH
             tmem_phase = tile_scheduler.tile_idx // TMEM_DEPTH & 1
@@ -503,10 +842,16 @@ def _kernel(
         T.cuda.warpgroup_sync(10)
     # The epilogue warpgroup and peer CTA must finish all TMEM reads first.
     T.cuda.cluster_sync()
-    tmem_pool.dealloc()
+    if (wg_id == 0) & (warp_id == 0):
+        T.ptx.tcgen05.relinquish_alloc_permit.cta_group__2.sync.aligned()
+        tmem_dealloc_addr: T.uint32
+        T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_addr.ptr_to([0]))
+        T.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](tmem_dealloc_addr, T.uint32(512))
 
 
 def tir_kernel(M: int, N: int, K: int):
+    if K % 512 != 0:
+        raise ValueError("K must be divisible by 512 for packed block scales")
     swap_ab, dg_block_m, dg_block_n, smem_pipe_depth, log_m, log_n = _choose_deepgemm_config(
         M, N, K
     )

--- a/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/gemm/grouped_fp8_gemm_contiguous.py
@@ -14,9 +14,9 @@ load("cuda")
 import tvm
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench
 from tvm.tirx.lang.pipeline import MBarrier, Pipeline, PipelineState
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.lang.tile_scheduler import ClusterPersistentScheduler2D
 
 KERNEL_META = {"name": "grouped_fp8_gemm_contiguous", "category": "gemm", "compute_capability": 10}
@@ -110,6 +110,23 @@ CONTIGUOUS_M_ALIGNMENT = 240
 _DEEPGEMM_SF_RECIPE = (1, 128)
 _DEEPGEMM_GEMM_RECIPE = (1, 1, 128)
 
+_TMA_G2S_1D = (
+    "cp.async.bulk.tensor.1d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_G2S_2D = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_S2G_2D = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TMA_EVICT_NORMAL = 0x1000000000000000
+_TMA_EVICT_LAST = 0x14F0000000000000
+
 
 def _align(value: int, alignment: int) -> int:
     return ((value + alignment - 1) // alignment) * alignment
@@ -144,6 +161,20 @@ def _num_smem_stages(
     smem_capacity = 232448
     num_stages = (smem_capacity - smem_cd - smem_barriers - smem_tmem_ptr) // smem_per_stage
     return min(num_stages, 32)
+
+
+def _tma_l2_promotion_code(promotion: str) -> int:
+    return {"L2::128B": 2, "L2::256B": 3}[promotion]
+
+
+def _replace_smem_desc_addr(desc, smem_ptr):
+    start_addr = T.cast(
+        T.bitwise_and(
+            T.shift_right(T.cuda.cvta_generic_to_shared(smem_ptr), T.uint32(4)), T.uint32(0x3FFF)
+        ),
+        "uint64",
+    )
+    return T.bitwise_or(T.bitwise_and(desc, T.bitwise_not(T.uint64(0x3FFF))), start_addr)
 
 
 @T.jit
@@ -210,6 +241,174 @@ def _kernel(
     D_SWIZZLE = T.meta_var(
         SwizzleMode.SWIZZLE_128B_ATOM if SWAP_AB else SwizzleMode.SWIZZLE_64B_ATOM
     )
+    D_TMA_ISSUES = T.meta_var(2 if SWAP_AB and NUM_GROUPS == 4 else 1)
+    D_TMA_TILE_N = T.meta_var(D_SMEM_N // D_TMA_ISSUES)
+    TMA_L2_PROMOTION_CODE = T.meta_var(_tma_l2_promotion_code(TMA_L2_PROMOTION))
+    T.static_assert(SWAP_AB, "grouped contiguous FP8 GEMM requires the swapped-A/B schedule")
+
+    A_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        A_tensor_map,
+        "float8_e4m3fn",
+        2,
+        A.data,
+        K,
+        M,
+        K,
+        BLK_K,
+        BLK_M,
+        1,
+        1,
+        0,
+        3,
+        TMA_L2_PROMOTION_CODE,
+        0,
+    )
+    B_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        B_tensor_map,
+        "float8_e4m3fn",
+        3,
+        B.data,
+        K,
+        N,
+        NUM_GROUPS,
+        K,
+        N * K,
+        BLK_K,
+        BLK_N,
+        1,
+        1,
+        1,
+        1,
+        0,
+        3,
+        TMA_L2_PROMOTION_CODE,
+        0,
+    )
+    SFA_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if K == 512:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            SFA_tensor_map,
+            "uint32",
+            1,
+            SFA.data,
+            M,
+            DG_BLOCK_M,
+            1,
+            0,
+            0,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            SFA_tensor_map,
+            "uint32",
+            2,
+            SFA.data,
+            M,
+            K // 512,
+            M * 4,
+            DG_BLOCK_M,
+            1,
+            1,
+            1,
+            0,
+            0,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
+    SFB_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if K == 512:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            SFB_tensor_map,
+            "uint32",
+            2,
+            SFB.data,
+            N,
+            NUM_GROUPS,
+            N * 4,
+            DG_BLOCK_N,
+            1,
+            1,
+            1,
+            0,
+            0,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            SFB_tensor_map,
+            "uint32",
+            3,
+            SFB.data,
+            N,
+            NUM_GROUPS,
+            K // 512,
+            (K // 512) * N * 4,
+            N * 4,
+            DG_BLOCK_N,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
+    D_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if D_TMA_ISSUES == 2:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            D_tensor_map,
+            "bfloat16",
+            2,
+            D.data,
+            N,
+            M,
+            N * 2,
+            D_TMA_TILE_N,
+            D_SMEM_M,
+            1,
+            1,
+            0,
+            3,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            D_tensor_map,
+            "bfloat16",
+            3,
+            D.data,
+            64,
+            M,
+            N // 64,
+            N * 2,
+            128,
+            64,
+            D_SMEM_M,
+            D_SMEM_N // 64,
+            1,
+            1,
+            1,
+            0,
+            3,
+            TMA_L2_PROMOTION_CODE,
+            0,
+        )
     T.device_entry()
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
     cluster_rank: T.int32
@@ -222,12 +421,21 @@ def _kernel(
     warp_id = T.warp_id_in_wg([4])
     tid_in_wg = T.thread_id_in_wg([128])
     lane_id = T.lane_id([32])
+    if (wg_id == 0) & (warp_id == 0):
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(A_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(B_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFA_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFB_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(D_tensor_map)))
     pool = T.SMEMPool()
+    tmem_addr = pool.alloc((1,), "uint32")
     barrier_leader = (wg_id == 0) & (warp_id == 1) & (T.cuda.elect_sync() != T.uint32(0))
     tmem_pool = T.TMEMPool(
         pool,
         total_cols=512,
         cta_group=CTA_GROUP,
+        tmem_addr=tmem_addr,
         alloc_warp=2,
         dealloc_warp=0,
         sync_after_alloc=False,
@@ -281,7 +489,9 @@ def _kernel(
     else:
         T.cuda.cta_sync()
     T.evaluate(T.ptx.griddepcontrol.wait())
-    T.cuda.trap_when_assert_failed(tmem_pool.addr == 0)
+    tmem_allocated: T.uint32
+    T.ptx.ld.shared.u32(tmem_allocated, tmem_addr.ptr_to([0]))
+    T.cuda.trap_when_assert_failed(tmem_allocated == T.uint32(0))
 
     m_idx = T.meta_var(tile_scheduler.n_idx if SWAP_AB else tile_scheduler.m_idx)
     n_idx = T.meta_var(
@@ -303,58 +513,99 @@ def _kernel(
             sf_n = T.meta_var(n_idx * DG_BLOCK_N)
 
             @T.inline
-            def tma_load(k_tile):
+            def tma_load(k_tile, group):
                 smem_pipe.empty.wait(tma_cur.stage, tma_cur.phase)
                 stage = tma_cur.stage
                 k = T.meta_var(k_tile * BLK_K)
-                group: T.let = GROUPED_LAYOUT[sf_m]
-                tma_copy = T.meta_var(
-                    {
-                        "dispatch": "tma_auto",
-                        "mbar": smem_pipe.full.ptr_to([stage]),
-                        "cta_group": 1,
-                        "cache_hint": "evict_normal",
-                        "tensormap_l2_promotion": TMA_L2_PROMOTION,
-                        "prefetch_tensormap": True,
-                    }
-                )
-                tma_copy_evict_last = T.meta_var(
-                    {
-                        "dispatch": "tma_auto",
-                        "mbar": smem_pipe.full.ptr_to([stage]),
-                        "cta_group": 1,
-                        "cache_hint": "evict_last",
-                        "tensormap_l2_promotion": TMA_L2_PROMOTION,
-                        "prefetch_tensormap": True,
-                    }
-                )
                 if NUM_GROUPS == 8 and K >= 4096:
-                    Tx.copy_async(
-                        A_smem[stage], A[a_m : a_m + BLK_M, k : k + BLK_K], **tma_copy_evict_last
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_2D](
+                            A_smem.ptr_to([stage, 0, 0]),
+                            T.address_of(A_tensor_map),
+                            k,
+                            a_m,
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_LAST),
+                        )
                     )
                 else:
-                    Tx.copy_async(A_smem[stage], A[a_m : a_m + BLK_M, k : k + BLK_K], **tma_copy)
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_2D](
+                            A_smem.ptr_to([stage, 0, 0]),
+                            T.address_of(A_tensor_map),
+                            k,
+                            a_m,
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_NORMAL),
+                        )
+                    )
                 if (NUM_GROUPS == 4 and K == 4096) or (NUM_GROUPS == 8 and K == 2048):
-                    Tx.copy_async(
-                        B_smem[stage],
-                        B[group, b_n : b_n + BLK_N, k : k + BLK_K],
-                        **tma_copy_evict_last,
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_3D](
+                            B_smem.ptr_to([stage, 0, 0]),
+                            T.address_of(B_tensor_map),
+                            k,
+                            b_n,
+                            group,
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_LAST),
+                        )
                     )
                 else:
-                    Tx.copy_async(
-                        B_smem[stage], B[group, b_n : b_n + BLK_N, k : k + BLK_K], **tma_copy
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_3D](
+                            B_smem.ptr_to([stage, 0, 0]),
+                            T.address_of(B_tensor_map),
+                            k,
+                            b_n,
+                            group,
+                            smem_pipe.full.ptr_to([stage]),
+                            T.uint64(_TMA_EVICT_NORMAL),
+                        )
                     )
                 if k_tile % 4 == 0:
-                    Tx.copy_async(
-                        SFA_smem[stage, 0:DG_BLOCK_M],
-                        SFA[k_tile // 4, sf_m : sf_m + DG_BLOCK_M],
-                        **tma_copy,
-                    )
-                    Tx.copy_async(
-                        SFB_smem[stage, 0:DG_BLOCK_N],
-                        SFB[group, k_tile // 4, sf_n : sf_n + DG_BLOCK_N],
-                        **tma_copy,
-                    )
+                    if K == 512:
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_1D](
+                                SFA_smem.ptr_to([stage, 0]),
+                                T.address_of(SFA_tensor_map),
+                                sf_m,
+                                smem_pipe.full.ptr_to([stage]),
+                                T.uint64(_TMA_EVICT_NORMAL),
+                            )
+                        )
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_2D](
+                                SFB_smem.ptr_to([stage, 0]),
+                                T.address_of(SFB_tensor_map),
+                                sf_n,
+                                group,
+                                smem_pipe.full.ptr_to([stage]),
+                                T.uint64(_TMA_EVICT_NORMAL),
+                            )
+                        )
+                    else:
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_2D](
+                                SFA_smem.ptr_to([stage, 0]),
+                                T.address_of(SFA_tensor_map),
+                                sf_m,
+                                k_tile // 4,
+                                smem_pipe.full.ptr_to([stage]),
+                                T.uint64(_TMA_EVICT_NORMAL),
+                            )
+                        )
+                        T.evaluate(
+                            T.ptx[_TMA_G2S_3D](
+                                SFB_smem.ptr_to([stage, 0]),
+                                T.address_of(SFB_tensor_map),
+                                sf_n,
+                                group,
+                                k_tile // 4,
+                                smem_pipe.full.ptr_to([stage]),
+                                T.uint64(_TMA_EVICT_NORMAL),
+                            )
+                        )
 
                 smem_pipe.full.arrive(
                     tma_cur.stage,
@@ -363,8 +614,10 @@ def _kernel(
 
             @T.inline
             def tma_iter():
+                group: T.int32
+                T.ptx.ld.global_.s32(group, GROUPED_LAYOUT.ptr_to([sf_m]))
                 for k_tile in T.serial(K_TILES):
-                    tma_load(k_tile)
+                    tma_load(k_tile, group)
                     tma_cur.advance()
 
             if T.cuda.elect_sync():
@@ -372,16 +625,40 @@ def _kernel(
                     tma_iter()
                     tile_scheduler.next_tile()
         elif warp_id == 2:
-            SFA_smem_post = SFA_smem.view(SMEM_DEPTH, BLK_SFA, layout=SFA_post_layout)
-            SFB_smem_post = SFB_smem.view(SMEM_DEPTH, BLK_SFB, layout=SFB_post_layout)
             trans_state = PipelineState(SMEM_DEPTH, 0)
 
             @T.inline
             def transpose(ks, k_tile):
                 smem_pipe.full.wait(ks, trans_state.phase)
                 if k_tile % 4 == 0:
-                    Tx.warp.permute_layout(SFA_smem_post[ks, :], SFA_smem[ks, :])
-                    Tx.warp.permute_layout(SFB_smem_post[ks, :], SFB_smem[ks, :])
+                    sfa_regs = T.alloc_local((BLK_SFA // 32,), "uint32")
+                    for r in T.unroll(BLK_SFA // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        T.ptx.ld.shared.u32(sfa_regs[r], SFA_smem.ptr_to([ks, quad * 32 + lane_id]))
+                    T.cuda.warp_sync()
+                    for r in T.unroll(BLK_SFA // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        post = T.meta_var(quad // 4 * 128 + quad % 4 + lane_id * 4)
+                        T.ptx.st.shared.u32(SFA_smem.ptr_to([ks, post]), sfa_regs[r])
+                    T.cuda.warp_sync()
+                    sfb_regs = T.alloc_local((BLK_SFB // 32,), "uint32")
+                    for r in T.unroll(BLK_SFB // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        T.ptx.ld.shared.u32(sfb_regs[r], SFB_smem.ptr_to([ks, quad * 32 + lane_id]))
+                    T.cuda.warp_sync()
+                    for r in T.unroll(BLK_SFB // 32):
+                        quad = T.meta_var(
+                            T.bitwise_xor(r, T.bitwise_and(T.shift_right(lane_id, 3), 3))
+                        )
+                        post = T.meta_var(quad + lane_id * 4)
+                        T.ptx.st.shared.u32(SFB_smem.ptr_to([ks, post]), sfb_regs[r])
+                    T.cuda.warp_sync()
                     T.ptx.fence.proxy.async_.shared__cta()
                 trans_done.arrive(ks, remote=0)
 
@@ -401,6 +678,12 @@ def _kernel(
             SFB_smem_fp8 = SFB_smem.view("float8_e8m0fnu").view(
                 SMEM_DEPTH, BLK_SFB, 4 * K_ITERS, layout=SFB_smem_fp8_layout
             )
+            desc_a = T.meta_var(SmemDescriptor())
+            desc_b = T.meta_var(SmemDescriptor())
+            desc_sf = T.meta_var(SmemDescriptor())
+            desc_a.init(B_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+            desc_b.init(A_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+            desc_sf.init(T.reinterpret("handle", T.uint64(0)), ldo=0, sdo=8, swizzle=0)
             tmem_idx: T.int32
             tmem_phase: T.int32
             mma_state = PipelineState(SMEM_DEPTH, 0)
@@ -418,34 +701,81 @@ def _kernel(
 
                 @T.inline
                 def gemm_with_sf(sf_off: T.constexpr):
-                    if SWAP_AB:
-                        Tx.gemm_async(
-                            acc[tmem_idx, :, :],
-                            B_smem[ks_desc],
-                            A_smem[ks_desc],
-                            SFA=SFB_tmem[tmem_idx, :, sf_off : sf_off + K_ITERS],
-                            SFB=SFA_tmem[tmem_idx, :, sf_off : sf_off + K_ITERS],
-                            accum=accum,
-                            dispatch="tcgen05",
-                            cta_group=CTA_GROUP,
+                    desc_i: T.uint32
+                    T.cuda.tcgen05.encode_instr_descriptor_block_scaled(
+                        T.address_of(desc_i),
+                        d_dtype="float32",
+                        a_dtype="float8_e4m3fn",
+                        b_dtype="float8_e4m3fn",
+                        sfa_dtype="float8_e8m0fnu",
+                        sfb_dtype="float8_e8m0fnu",
+                        sfa_tmem_addr=(SFB_tmem.allocated_addr[0] + tmem_idx * (BLK_SFB // 32)),
+                        sfb_tmem_addr=(SFA_tmem.allocated_addr[0] + tmem_idx * (BLK_SFA // 32)),
+                        M=BLK_N * CTA_GROUP,
+                        N=MMA_N,
+                        K=MMA_K,
+                        trans_a=False,
+                        trans_b=False,
+                        n_cta_groups=CTA_GROUP,
+                    )
+                    for ki in T.unroll(K_ITERS):
+                        T.cuda.runtime_instr_desc(T.address_of(desc_i), sf_off // K_ITERS)
+                        desc_a_ki = T.meta_var(
+                            desc_a.add_16B_offset((ks_desc * BLK_N * BLK_K + ki * MMA_K) // 16)
                         )
-                    else:
-                        Tx.gemm_async(
-                            acc[tmem_idx, :, :],
-                            A_smem[ks_desc],
-                            B_smem[ks_desc],
-                            SFA=SFA_tmem[tmem_idx, :, sf_off : sf_off + K_ITERS],
-                            SFB=SFB_tmem[tmem_idx, :, sf_off : sf_off + K_ITERS],
-                            accum=accum,
-                            dispatch="tcgen05",
-                            cta_group=CTA_GROUP,
+                        desc_b_ki = T.meta_var(
+                            desc_b.add_16B_offset((ks_desc * BLK_M * BLK_K + ki * MMA_K) // 16)
+                        )
+                        T.ptx[
+                            f"tcgen05.mma.cta_group::{CTA_GROUP}.kind::mxf8f6f4"
+                            ".block_scale.scale_vec::1X"
+                        ](
+                            T.cast(acc_buf.allocated_addr[0] + tmem_idx * MMA_N, "uint32"),
+                            desc_a_ki,
+                            desc_b_ki,
+                            desc_i,
+                            T.cast(
+                                SFB_tmem.allocated_addr[0] + tmem_idx * (BLK_SFB // 32), "uint32"
+                            ),
+                            T.cast(
+                                SFA_tmem.allocated_addr[0] + tmem_idx * (BLK_SFA // 32), "uint32"
+                            ),
+                            T.Or(ki != 0, T.cast(accum, "bool")),
                         )
 
                 mma_issue = T.cuda.elect_sync()
                 if mma_issue:
                     if copy_sf:
-                        Tx.copy_async(SFA_tmem[tmem_idx], SFA_smem_fp8[ks], cta_group=CTA_GROUP)
-                        Tx.copy_async(SFB_tmem[tmem_idx], SFB_smem_fp8[ks], cta_group=CTA_GROUP)
+                        for sf_chunk in T.unroll(BLK_SFA // 128):
+                            sf_desc = T.meta_var(
+                                _replace_smem_desc_addr(
+                                    desc_sf.desc, SFA_smem_fp8.ptr_to([ks, sf_chunk * 128, 0])
+                                )
+                            )
+                            T.ptx[f"tcgen05.cp.cta_group::{CTA_GROUP}.32x128b.warpx4"](
+                                T.cast(
+                                    SFA_tmem.allocated_addr[0]
+                                    + tmem_idx * (BLK_SFA // 32)
+                                    + sf_chunk * 4,
+                                    "uint32",
+                                ),
+                                sf_desc,
+                            )
+                        for sf_chunk in T.unroll(BLK_SFB // 128):
+                            sf_desc = T.meta_var(
+                                _replace_smem_desc_addr(
+                                    desc_sf.desc, SFB_smem_fp8.ptr_to([ks, sf_chunk * 128, 0])
+                                )
+                            )
+                            T.ptx[f"tcgen05.cp.cta_group::{CTA_GROUP}.32x128b.warpx4"](
+                                T.cast(
+                                    SFB_tmem.allocated_addr[0]
+                                    + tmem_idx * (BLK_SFB // 32)
+                                    + sf_chunk * 4,
+                                    "uint32",
+                                ),
+                                sf_desc,
+                            )
                     gemm_with_sf(sf_off)
                 accum = 1
                 T.cuda.warp_sync()
@@ -484,18 +814,11 @@ def _kernel(
         # acc -> D_smem step (stmatrix transpose vs straight copy) and the tiling.
         EPI = T.meta_var(16 if SWAP_AB else EPI_TILE)
         STORE_TILES = T.meta_var(MMA_N // EPI)
-        D_TILE_M = T.meta_var(16 if SWAP_AB else DG_BLOCK_M)
-        D_TILE_N = T.meta_var(DG_BLOCK_N if SWAP_AB else EPI_TILE)
-        # Four-group shapes regress when the two 2 KiB legacy stores are fused
-        # into one 4 KiB rank-3 store. Eight-group shapes do not benefit from
-        # retaining that split, so keep the direct auto plan there.
-        D_TMA_ISSUES = T.meta_var(2 if SWAP_AB and NUM_GROUPS == 4 else 1)
-        D_TMA_TILE_N = T.meta_var(D_TILE_N // D_TMA_ISSUES)
 
         @T.inline
         def epilogue():
-            swap_frag = T.alloc_tcgen05_ldst_frag("16x256b", (128, 8), "float32")
-            swap_bf16 = T.alloc_cast_frag(swap_frag, "bfloat16")
+            swap_words = T.alloc_local((8,), "uint32")
+            swap_bf16 = T.alloc_local((4,), "uint32", align=16)
             for ot in T.unroll(STORE_TILES):
                 store_iter: T.let = tile_scheduler.tile_idx * STORE_TILES + ot
                 stage = store_iter % TMEM_DEPTH
@@ -503,29 +826,40 @@ def _kernel(
                     if warp_id == 0:
                         T.ptx.cp.async_.bulk.wait_group(TMEM_DEPTH - 1)
                     T.cuda.warpgroup_sync(10)
-                if SWAP_AB:
-                    for atom_m in T.unroll(2):
-                        col_st: T.let = ot * 16 + atom_m * 8
-                        Tx.wg.copy_async(swap_frag[:, :], acc[tmem_idx, :, col_st : col_st + 8])
-                        T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Tx.wg.cast(swap_bf16, swap_frag)
-                        rs = T.meta_var(atom_m * 8)
-                        Tx.wg.copy(
-                            D_smem[stage, rs : rs + 8, 0:128],
-                            swap_bf16.permute(1, 0),
-                            dispatch="ldstmatrix",
+                for atom_m in T.unroll(2):
+                    col_st: T.let = ot * 16 + atom_m * 8
+                    for slab in T.unroll(2):
+                        reg_base = T.meta_var(slab * 4)
+                        T.ptx["tcgen05.ld.sync.aligned.16x256b.x1.b32"](
+                            swap_words[reg_base],
+                            swap_words[reg_base + 1],
+                            swap_words[reg_base + 2],
+                            swap_words[reg_base + 3],
+                            T.cuda.get_tmem_addr(
+                                acc_buf.allocated_addr[0], slab * 16, tmem_idx * MMA_N + col_st
+                            ),
                         )
-                else:
-                    for ki in T.unroll(EPI_TILE // TMEM_LD_SIZE):
-                        Dreg = T.wg_reg_tile(TMEM_LD_SIZE)
-                        acc_n = T.meta_var(ot * EPI_TILE + ki * TMEM_LD_SIZE)
-                        Tx.wg.copy_async(Dreg, acc[tmem_idx, :, acc_n : acc_n + TMEM_LD_SIZE])
-                        T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Dreg_bf16 = T.wg_reg_tile(TMEM_LD_SIZE, dtype="bfloat16")
-                        Tx.wg.cast(Dreg_bf16, Dreg)
-                        Tx.wg.copy(
-                            D_smem[stage, :, ki * TMEM_LD_SIZE : (ki + 1) * TMEM_LD_SIZE], Dreg_bf16
+                    T.ptx.tcgen05.wait__ld.sync.aligned()
+                    for pair in T.unroll(4):
+                        swap_bf16[pair] = T.cuda.float22bfloat162_rn(
+                            T.cuda.uint_as_float(swap_words[pair * 2]),
+                            T.cuda.uint_as_float(swap_words[pair * 2 + 1]),
                         )
+                    row = T.meta_var(lane_id % 8)
+                    col = T.meta_var(warp_id % 2 * 4 + lane_id // 8)
+                    smem_off = T.meta_var(
+                        stage * D_SMEM_M * D_SMEM_N
+                        + warp_id // 2 * 16 * 64
+                        + atom_m * 8 * 64
+                        + row * 64
+                        + T.bitwise_xor(col, row) * 8
+                    )
+                    smem_ptr = T.meta_var(
+                        T.ptr_byte_offset(D_smem.ptr_to([0, 0, 0]), smem_off * 2, "bfloat16")
+                    )
+                    T.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        smem_ptr, swap_bf16[0], swap_bf16[1], swap_bf16[2], swap_bf16[3]
+                    )
                 if ot == STORE_TILES - 1:
                     tmem_pipe.empty.arrive(tmem_idx, remote=0)
                 T.ptx.fence.proxy.async_.shared__cta()
@@ -534,21 +868,32 @@ def _kernel(
                 d_n: T.let = n_idx * DG_BLOCK_N + (0 if SWAP_AB else ot * EPI_TILE)
                 if warp_id == 0:
                     if T.cuda.elect_sync():
-                        for d_atom in T.unroll(D_TMA_ISSUES):
-                            d_atom_n = T.meta_var(d_atom * D_TMA_TILE_N)
-                            Tx.copy_async(
-                                D[
-                                    d_m : d_m + D_TILE_M,
-                                    d_n + d_atom_n : d_n + d_atom_n + D_TMA_TILE_N,
-                                ],
-                                D_smem[stage, :, d_atom_n : d_atom_n + D_TMA_TILE_N],
-                                dispatch="tma_auto",
-                                tensormap_l2_promotion=TMA_L2_PROMOTION,
-                                prefetch_tensormap=True,
+                        if D_TMA_ISSUES == 2:
+                            for d_atom in T.unroll(D_TMA_ISSUES):
+                                d_atom_n = T.meta_var(d_atom * D_TMA_TILE_N)
+                                T.evaluate(
+                                    T.ptx[_TMA_S2G_2D](
+                                        T.address_of(D_tensor_map),
+                                        d_n + d_atom_n,
+                                        d_m,
+                                        D_smem.ptr_to([stage, 0, d_atom_n]),
+                                    )
+                                )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_S2G_3D](
+                                    T.address_of(D_tensor_map),
+                                    0,
+                                    d_m,
+                                    d_n // 64,
+                                    D_smem.ptr_to([stage, 0, 0]),
+                                )
                             )
                         T.ptx.cp.async_.bulk.commit_group()
 
-        T.cuda.trap_when_assert_failed(tmem_pool.addr == 0)
+        epilogue_tmem_allocated: T.uint32
+        T.ptx.ld.shared.u32(epilogue_tmem_allocated, tmem_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(epilogue_tmem_allocated == T.uint32(0))
         while tile_scheduler.valid():
             tmem_idx = tile_scheduler.tile_idx % TMEM_DEPTH
             tmem_phase = tile_scheduler.tile_idx // TMEM_DEPTH & 1
@@ -563,7 +908,13 @@ def _kernel(
         T.cuda.cluster_sync()
     else:
         T.cuda.cta_sync()
-    tmem_pool.dealloc()
+    if (wg_id == 0) & (warp_id == 0):
+        T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
+        tmem_dealloc_addr: T.uint32
+        T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_addr.ptr_to([0]))
+        T.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](
+            tmem_dealloc_addr, T.uint32(512)
+        )
 
 
 def grouped_fp8_gemm_contiguous(num_groups: int, M: int, N: int, K: int):

--- a/tirx_kernels/gemm/nvfp4_gemm.py
+++ b/tirx_kernels/gemm/nvfp4_gemm.py
@@ -14,9 +14,9 @@ import tvm
 from tvm.backend.cuda.tile_primitive.gemm_async.tcgen05 import sf_smem_layout
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as T
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import bench
 from tvm.tirx.lang.pipeline import MBarrier, Pipeline, PipelineState, TMABar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
 from tvm.tirx.lang.tile_scheduler import ClusterPersistentScheduler2D
 
 
@@ -24,6 +24,24 @@ class WarpRole(IntEnum):
     MMA = 0
     TMA = 2
     EPILOGUE = 4
+
+
+_TMA_G2S_2D = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2.L2::cache_hint"
+)
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2.L2::cache_hint"
+)
+_TMA_S2G_EVICT_FIRST = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+_TCGEN05_CP_2SM = "tcgen05.cp.cta_group::2.32x128b.warpx4"
+_MMA_NVFP4_2SM = "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X"
+_TMEM_LD_X2 = "tcgen05.ld.sync.aligned.16x256b.x2.b32"
+_TMEM_LD_X4 = "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+_TMEM_LD_X8 = "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+_EVICT_NORMAL_L2_POLICY = 0x1000000000000000
+_EVICT_FIRST_L2_POLICY = 0x12F0000000000000
 
 
 def prepare_data(M: int, N: int, K: int, *, return_origin: bool = False):
@@ -246,17 +264,15 @@ def _mapa_u64(ptr, rank):
     return mapped[0]
 
 
-def _tma_g2s_args(bar, stage, cta_mask, cta_group):
-    """Shared kwargs for the A/B and SF TMA g2s loads; only the mbarrier and
-    cta_mask vary."""
-    return {
-        "dispatch": "tma_auto",
-        "cta_group": cta_group,
-        "mbar": T.reinterpret("handle", _mapa_u64(bar.ptr_to([stage]), 0)),
-        "cta_mask": cta_mask,
-        "cache_hint": "evict_normal",
-        "prefetch_tensormap": True,
-    }
+@T.inline
+def _mul_f32x2_inplace(values, index, multiplier):
+    """Keep the packed multiply's register lifetime explicit in inline PTX."""
+    packed: T.uint64
+    rhs: T.uint64
+    T.ptx.mov.b64(packed, values[index], values[index + 1])
+    T.ptx.mov.b64(rhs, multiplier, multiplier)
+    T.ptx.mul.rz.ftz.f32x2(packed, packed, rhs)
+    T.ptx.mov.b64(values[index], values[index + 1], packed)
 
 
 @T.jit
@@ -311,6 +327,117 @@ def _kernel(
     K_TILES = T.meta_var(K // CTA_K)
     CLUSTER_M_TILES = T.meta_var(M // CTA_M // CLUSTER_M)
     CLUSTER_N_TILES = T.meta_var(N // MMA_N // CLUSTER_N)
+    TMEM_LD = T.meta_var(
+        _TMEM_LD_X2 if EPI_TILE == 16 else _TMEM_LD_X4 if EPI_TILE == 32 else _TMEM_LD_X8
+    )
+
+    # The packed FP4 operands are ordinary 2-D row-major byte tensors.  The
+    # scale factors retain FlashInfer's layout_128x4 packing: represent that
+    # physical layout as a 3-D uint16 tensor map rather than reinterpreting or
+    # reshuffling any E4M3 payloads in the kernel.
+    A_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    B_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    SFA_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    SFB_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    D_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        A_tensor_map,
+        "uint8",
+        2,
+        A_packed.data,
+        K // 2,
+        M,
+        K // 2,
+        CTA_K // 2,
+        CTA_M,
+        1,
+        1,
+        0,
+        SwizzleMode.SWIZZLE_128B_ATOM.value,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        B_tensor_map,
+        "uint8",
+        2,
+        B_packed.data,
+        K // 2,
+        N,
+        K // 2,
+        CTA_K // 2,
+        CTA_N,
+        1,
+        1,
+        0,
+        SwizzleMode.SWIZZLE_128B_ATOM.value,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        SFA_tensor_map,
+        "uint16",
+        3,
+        SFA_in.data,
+        256,
+        K // 64,
+        M // 128,
+        512,
+        K * 8,
+        256,
+        4,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        SFB_tensor_map,
+        "uint16",
+        3,
+        SFB_in.data,
+        256,
+        K // 64,
+        N // 128,
+        512,
+        K * 8,
+        256,
+        4,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        2,
+        0,
+    )
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        D_tensor_map,
+        "bfloat16",
+        2,
+        D.data,
+        N,
+        M,
+        N * 2,
+        EPI_TILE,
+        CTA_M,
+        1,
+        1,
+        0,
+        D_SWIZZLE_MODE.value,
+        2,
+        0,
+    )
     T.device_entry()
     cluster_rank = T.cta_id_in_cluster([CLUSTER_SIZE], preferred=[CLUSTER_SIZE])
     cta_idx = T.cta_id([SM_COUNT])
@@ -319,6 +446,13 @@ def _kernel(
     tid_in_wg = T.thread_id_in_wg([128])
     wg_id = T.warpgroup_id([NUM_WARPS // 4])
     warp_id = T.warp_id([NUM_WARPS])
+    if warp_id == 0:
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(A_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(B_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFA_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(SFB_tensor_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(D_tensor_map)))
     cb_m: T.let = cluster_rank % CLUSTER_M
     cb_n: T.let = cluster_rank // CLUSTER_M
     pair_id: T.let = cluster_rank // CTA_GROUP
@@ -392,6 +526,12 @@ def _kernel(
     SFB_tmem = tmem_pool.alloc_sf(
         (128 * SFB_n_chunks, sf_mma_k * MMA_K_BLOCKS), "float8_e4m3fn", sf_per_mma=sf_mma_k
     )
+    sf_desc = T.meta_var(SmemDescriptor())
+    desc_a = T.meta_var(SmemDescriptor())
+    desc_b = T.meta_var(SmemDescriptor())
+    sf_desc.init(T.reinterpret("handle", T.uint64(0)), ldo=0, sdo=8, swizzle=0)
+    desc_a.init(A_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
+    desc_b.init(B_smem.ptr_to([0, 0, 0]), ldo=0, sdo=64, swizzle=3)
     # Publish the weak shared-memory store performed by tcgen05.alloc through
     # the existing cluster release/acquire before any other warp consumes the
     # TMEM base address.
@@ -412,7 +552,7 @@ def _kernel(
     epi_cur = PipelineState(TMEM_PIPE_DEPTH, 0)
     epi_wb_state = PipelineState(WB_PIPE_DEPTH, 1)
     alpha_local: T.float32
-    alpha_local = alpha[0]
+    T.ptx.ld.global_.nc.f32(alpha_local, alpha.ptr_to([0]))
     if warp_id == int(WarpRole.TMA):
 
         @T.inline
@@ -430,18 +570,28 @@ def _kernel(
                     _rem1[0], T.uint32(tile_bytes), pred=T.bool(True)
                 )
             single_cta_mask: T.int32 = 1 << id_in_pair
-            # Barrier pre-mapped to the cluster leader (the g2s primitive maps
-            # neither the barrier nor expect_tx — both handled above).
-            tile_copy = T.meta_var(_tma_g2s_args(tile_full_bar, stage, single_cta_mask, CTA_GROUP))
-            Tx.copy_async(
-                A_smem_packed[stage, 0:CTA_M, 0 : CTA_K // 2],
-                A_packed[a_m : a_m + CTA_M, k : k + CTA_K // 2],
-                **tile_copy,
+            mapped_tile_bar = _mapa_u64(tile_full_bar.ptr_to([stage]), 0)
+            T.evaluate(
+                T.ptx[_TMA_G2S_2D](
+                    A_smem_packed.ptr_to([stage, 0, 0]),
+                    T.address_of(A_tensor_map),
+                    T.cast(k, "int32"),
+                    T.cast(a_m, "int32"),
+                    T.cuda.cvta_generic_to_shared(T.reinterpret("handle", mapped_tile_bar)),
+                    T.cast(single_cta_mask, "uint16"),
+                    T.uint64(_EVICT_NORMAL_L2_POLICY),
+                )
             )
-            Tx.copy_async(
-                B_smem_packed[stage, 0:CTA_N, 0 : CTA_K // 2],
-                B_packed[b_n : b_n + CTA_N, k : k + CTA_K // 2],
-                **tile_copy,
+            T.evaluate(
+                T.ptx[_TMA_G2S_2D](
+                    B_smem_packed.ptr_to([stage, 0, 0]),
+                    T.address_of(B_tensor_map),
+                    T.cast(k, "int32"),
+                    T.cast(b_n, "int32"),
+                    T.cuda.cvta_generic_to_shared(T.reinterpret("handle", mapped_tile_bar)),
+                    T.cast(single_cta_mask, "uint16"),
+                    T.uint64(_EVICT_NORMAL_L2_POLICY),
+                )
             )
 
         if T.cuda.elect_sync():
@@ -471,25 +621,46 @@ def _kernel(
             single_cta_mask: T.int32 = 1 << id_in_pair
             # SFA: each CTA loads its half (single_cta_mask). SFB: multicast to
             # both CTAs (pair_mask).
-            sfa_copy = T.meta_var(_tma_g2s_args(scale_full_bar, stage, single_cta_mask, CTA_GROUP))
-            Tx.copy_async(
-                SFA_smem[stage, 0:CTA_M, 0:SF_CTA_K],
-                SFA_in[sf_m : sf_m + CTA_M, sf_k : sf_k + SF_CTA_K],
-                **sfa_copy,
+            mapped_sfa_bar = _mapa_u64(scale_full_bar.ptr_to([stage]), 0)
+            T.evaluate(
+                T.ptx[_TMA_G2S_3D](
+                    SFA_smem.ptr_to([stage, 0, 0]),
+                    T.address_of(SFA_tensor_map),
+                    T.int32(0),
+                    T.cast(sf_k // 4, "int32"),
+                    T.cast(sf_m // 128, "int32"),
+                    T.cuda.cvta_generic_to_shared(T.reinterpret("handle", mapped_sfa_bar)),
+                    T.cast(single_cta_mask, "uint16"),
+                    T.uint64(_EVICT_NORMAL_L2_POLICY),
+                )
             )
-            sfb_copy = T.meta_var(_tma_g2s_args(scale_full_bar, stage, pair_mask, CTA_GROUP))
+            mapped_sfb_bar = _mapa_u64(scale_full_bar.ptr_to([stage]), 0)
             if SFB_N == 128:
                 if id_in_pair == 0:
-                    Tx.copy_async(
-                        SFB_smem[stage, 0:SFB_N, 0:SF_CTA_K],
-                        SFB_in[sf_n : sf_n + SFB_N, sf_k : sf_k + SF_CTA_K],
-                        **sfb_copy,
+                    T.evaluate(
+                        T.ptx[_TMA_G2S_3D](
+                            SFB_smem.ptr_to([stage, 0, 0]),
+                            T.address_of(SFB_tensor_map),
+                            T.int32(0),
+                            T.cast(sf_k // 4, "int32"),
+                            T.cast(sf_n // 128, "int32"),
+                            T.cuda.cvta_generic_to_shared(T.reinterpret("handle", mapped_sfb_bar)),
+                            T.cast(pair_mask, "uint16"),
+                            T.uint64(_EVICT_NORMAL_L2_POLICY),
+                        )
                     )
             else:
-                Tx.copy_async(
-                    SFB_smem[stage, cb_m * 128 : cb_m * 128 + 128, 0:SF_CTA_K],
-                    SFB_in[sf_n + cb_m * 128 : sf_n + cb_m * 128 + 128, sf_k : sf_k + SF_CTA_K],
-                    **sfb_copy,
+                T.evaluate(
+                    T.ptx[_TMA_G2S_3D](
+                        SFB_smem.ptr_to([stage, cb_m * 128, 0]),
+                        T.address_of(SFB_tensor_map),
+                        T.int32(0),
+                        T.cast(sf_k // 4, "int32"),
+                        T.cast(sf_n // 128 + cb_m, "int32"),
+                        T.cuda.cvta_generic_to_shared(T.reinterpret("handle", mapped_sfb_bar)),
+                        T.cast(pair_mask, "uint16"),
+                        T.uint64(_EVICT_NORMAL_L2_POLICY),
+                    )
                 )
 
         if T.cuda.elect_sync():
@@ -505,18 +676,90 @@ def _kernel(
             stage = mma_smem.stage
             scale_full_bar.wait(mma_smem.stage, mma_smem.phase)
             tile_full_bar.wait(mma_smem.stage, mma_smem.phase)
-            Tx.copy_async(SFA_tmem, SFA_smem[stage], cta_group=CTA_GROUP)
-            Tx.copy_async(SFB_tmem, SFB_smem[stage], cta_group=CTA_GROUP)
-            Tx.gemm_async(
-                tmem[:, 0:MMA_N],
-                A_smem[stage],
-                B_smem[stage],
-                SFA=SFA_tmem,
-                SFB=SFB_tmem,
-                accum=accum,
-                dispatch="tcgen05",
-                cta_group=CTA_GROUP,
+            for flat in T.unroll(CTA_M // 32):
+                sfa_row = T.meta_var(flat % 4 * 32)
+                sfa_shared_addr: T.uint32 = T.cuda.cvta_generic_to_shared(
+                    T.ptr_byte_offset(
+                        SFA_smem.ptr_to([0, 0, 0]), (stage * CTA_M + sfa_row) * SF_CTA_K, "uint8"
+                    )
+                )
+                sfa_cp_desc: T.uint64 = T.bitwise_or(
+                    T.bitwise_and(sf_desc.desc, T.bitwise_not(T.uint64(0x3FFF))),
+                    T.cast(
+                        T.bitwise_and(
+                            T.shift_right(sfa_shared_addr, T.uint32(4)), T.uint32(0x3FFF)
+                        ),
+                        "uint64",
+                    ),
+                )
+                T.ptx[_TCGEN05_CP_2SM](
+                    T.cast(SFA_tmem.allocated_addr[0] + flat % 4 * 4, "uint32"), sfa_cp_desc
+                )
+            for flat in T.unroll(SFB_N // 32):
+                sfb_row = T.meta_var(flat % 4 * 32 + flat // 4 * 128)
+                sfb_shared_addr: T.uint32 = T.cuda.cvta_generic_to_shared(
+                    T.ptr_byte_offset(
+                        SFB_smem.ptr_to([0, 0, 0]), (stage * SFB_N + sfb_row) * SF_CTA_K, "uint8"
+                    )
+                )
+                sfb_cp_desc: T.uint64 = T.bitwise_or(
+                    T.bitwise_and(sf_desc.desc, T.bitwise_not(T.uint64(0x3FFF))),
+                    T.cast(
+                        T.bitwise_and(
+                            T.shift_right(sfb_shared_addr, T.uint32(4)), T.uint32(0x3FFF)
+                        ),
+                        "uint64",
+                    ),
+                )
+                T.ptx[_TCGEN05_CP_2SM](
+                    T.cast(
+                        SFB_tmem.allocated_addr[0] + flat % 4 * SFB_n_chunks * 4 + flat // 4 * 4,
+                        "uint32",
+                    ),
+                    sfb_cp_desc,
+                )
+            desc_i: T.uint32
+            T.cuda.tcgen05.encode_instr_descriptor_block_scaled(
+                T.address_of(desc_i),
+                d_dtype="float32",
+                a_dtype="float4_e2m1fn",
+                b_dtype="float4_e2m1fn",
+                sfa_dtype="float8_e4m3fn",
+                sfb_dtype="float8_e4m3fn",
+                sfa_tmem_addr=SFA_tmem.allocated_addr[0],
+                sfb_tmem_addr=SFB_tmem.allocated_addr[0],
+                M=CTA_M * CTA_GROUP,
+                N=MMA_N,
+                K=MMA_K,
+                trans_a=False,
+                trans_b=False,
+                n_cta_groups=CTA_GROUP,
             )
+            for ki in T.unroll(MMA_K_BLOCKS):
+                desc_a_ki = T.meta_var(
+                    desc_a.add_16B_offset((stage * CTA_M * CTA_K + ki * MMA_K) // 32)
+                )
+                desc_b_ki = T.meta_var(
+                    desc_b.add_16B_offset((stage * CTA_N * CTA_K + ki * MMA_K) // 32)
+                )
+                sf_linear = T.meta_var(ki * sf_mma_k)
+                T.ptx[_MMA_NVFP4_2SM](
+                    T.cast(tmem.allocated_addr[0], "uint32"),
+                    desc_a_ki,
+                    desc_b_ki,
+                    desc_i,
+                    T.cuda.get_tmem_addr(
+                        SFA_tmem.allocated_addr[0],
+                        sf_linear % 512 // 16,
+                        sf_linear % 16 // sf_mma_k * sf_mma_k + sf_linear // 512,
+                    ),
+                    T.cuda.get_tmem_addr(
+                        SFB_tmem.allocated_addr[0],
+                        sf_linear % 512 // 16,
+                        sf_linear % 16 // sf_mma_k * sf_mma_k * SFB_n_chunks + sf_linear // 512,
+                    ),
+                    tvm.tirx.any(ki != 0, T.cast(accum, "bool")),
+                )
             accum = 1
             smem_pipe.empty.arrive(mma_smem.stage, cta_group=CTA_GROUP, cta_mask=pair_mask)
 
@@ -533,16 +776,38 @@ def _kernel(
     elif warp_id >= int(WarpRole.EPILOGUE):
 
         @T.inline
-        def regs_to_smem(reg_ldst_16b):
-            # R->S in 16-col chunks to match stmatrix.x4 granularity (one wide
-            # copy schedules worse).
+        def regs_to_smem(reg_bf16_words, chunk_index: T.constexpr, fragment_cols: T.constexpr):
+            # Each epilogue warp owns 32 rows.  stmatrix.x4 publishes two
+            # 16-row halves and one 16-column band at a time.  The former
+            # ldstmatrix dispatcher addressed the physical row-major tile
+            # first and then applied the hardware atom swizzle.  Reproduce
+            # that ordering explicitly instead of applying the buffer's
+            # logical tiled layout to the stmatrix seed coordinate.
+            swizzle_mask = T.meta_var(0x40 if EPI_TILE == 16 else 0xC0 if EPI_TILE == 32 else 0x1C0)
             for cj in T.unroll(EPI_TILE // 16):
-                cc = T.meta_var(cj * 16)
-                Tx.wg.copy(
-                    output_smem[epi_wb_state.stage, 0:CTA_M, cc : cc + 16],
-                    reg_ldst_16b[:, cc : cc + 16],
-                    dispatch="ldstmatrix",
-                )
+                for mm in T.unroll(2):
+                    linear = T.meta_var(
+                        epi_wb_state.stage * CTA_M * EPI_TILE
+                        + warp_id % 4 * 32 * EPI_TILE
+                        + (lane_id % 16 + mm * 16) * EPI_TILE
+                        + lane_id // 16 * 8
+                        + cj * 16
+                    )
+                    swizzled = T.meta_var(
+                        T.bitwise_xor(
+                            linear, T.shift_right(T.bitwise_and(linear, swizzle_mask), T.int32(3))
+                        )
+                    )
+                    word_base = T.meta_var(
+                        mm * (fragment_cols // 4) + chunk_index * (EPI_TILE // 4) + cj * 4
+                    )
+                    T.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        T.ptr_byte_offset(output_smem.ptr_to([0, 0, 0]), swizzled * 2, "bfloat16"),
+                        reg_bf16_words[word_base],
+                        reg_bf16_words[word_base + 1],
+                        reg_bf16_words[word_base + 2],
+                        reg_bf16_words[word_base + 3],
+                    )
 
         @T.inline
         def epilogue():
@@ -550,21 +815,28 @@ def _kernel(
 
             # Per-chunk store: R->S (stmatrix) then S->G (TMA). Shared by both schedules.
             @T.inline
-            def store_epi_chunk(reg_ldst_16b, linear_n: T.constexpr):
+            def store_epi_chunk(
+                reg_bf16_words,
+                chunk_index: T.constexpr,
+                linear_n: T.constexpr,
+                fragment_cols: T.constexpr,
+            ):
                 T.ptx.cp.async_.bulk.wait_group.read(WB_PIPE_DEPTH - 1)
                 T.cuda.warpgroup_sync(1)
-                regs_to_smem(reg_ldst_16b)
+                regs_to_smem(reg_bf16_words, chunk_index, fragment_cols)
                 T.cuda.warpgroup_sync(1)
                 d_n_out: T.int32
                 d_n_out = d_n + linear_n
                 if tid_in_wg == 0:
                     T.ptx.fence.proxy.async_.shared__cta()
-                    Tx.copy_async(
-                        D[d_m : d_m + CTA_M, d_n_out : d_n_out + EPI_TILE],
-                        output_smem[epi_wb_state.stage, 0:CTA_M, 0:EPI_TILE],
-                        dispatch="tma_auto",
-                        cache_hint="evict_first",
-                        prefetch_tensormap=True,
+                    T.evaluate(
+                        T.ptx[_TMA_S2G_EVICT_FIRST](
+                            T.address_of(D_tensor_map),
+                            T.cast(d_n_out, "int32"),
+                            T.cast(d_m, "int32"),
+                            output_smem.ptr_to([epi_wb_state.stage, 0, 0]),
+                            T.uint64(_EVICT_FIRST_L2_POLICY),
+                        )
                     )
                     T.ptx.cp.async_.bulk.commit_group()
                 epi_wb_state.advance()
@@ -573,39 +845,63 @@ def _kernel(
             # a small (128, EPI_TILE) frag; non-overlap splits the loops, needing a big
             # (128, MMA_N) frag (all chunks live between load and store).
             if OVERLAP_EPI:
-                reg_ldst = T.alloc_tcgen05_ldst_frag("16x256b", (128, EPI_TILE), "float32")
-                reg_ldst_16b = T.alloc_cast_frag(reg_ldst, "bfloat16")
+                reg_f32 = T.alloc_local((EPI_TILE,), "float32")
+                reg_bf16_words = T.alloc_local((EPI_TILE // 2,), "uint32", align=16)
                 for no in T.unroll(MMA_N // EPI_TILE):
                     linear_n = T.meta_var(no * EPI_TILE)
-                    Tx.wg.copy_async(reg_ldst[:, :], tmem[:, linear_n : linear_n + EPI_TILE])
+                    for slab in T.unroll(2):
+                        reg_base = T.meta_var(slab * (EPI_TILE // 2))
+                        T.ptx[TMEM_LD](
+                            *[reg_f32[reg_base + j] for j in range(EPI_TILE // 2)],
+                            T.cuda.get_tmem_addr(tmem.allocated_addr[0], slab * 16, linear_n),
+                        )
                     if no == MMA_N // EPI_TILE - 1:
                         T.ptx.tcgen05.wait__ld.sync.aligned()
                         if tid_in_wg == 0:
                             tmem_pipe.empty.arrive(
                                 epi_cur.stage, remote=pair_leader_rank, pred=True, count=1
                             )
-                    Tx.wg.mul(reg_ldst, reg_ldst, alpha_local)
-                    Tx.wg.cast(reg_ldst_16b, reg_ldst)
-                    store_epi_chunk(reg_ldst_16b, linear_n)
+                    for pair in T.unroll(EPI_TILE // 2):
+                        _mul_f32x2_inplace(reg_f32, pair * 2, alpha_local)
+                    for pair in T.unroll(EPI_TILE // 2):
+                        # PTX's packed cvt names the high-half source first.
+                        T.ptx.cvt.rn.bf16x2.f32(
+                            reg_bf16_words[pair], reg_f32[pair * 2 + 1], reg_f32[pair * 2]
+                        )
+                    store_epi_chunk(reg_bf16_words, 0, linear_n, EPI_TILE)
             else:
-                # Keep the 2D frag so it can be column-sliced for the chunked store.
-                reg_all = T.alloc_tcgen05_ldst_frag("16x256b", (128, MMA_N), "float32")
-                reg_all_16b = T.alloc_cast_frag(reg_all, "bfloat16")
+                # Preserve the dispatcher's two-slab register ordering: the
+                # first/second 64 TMEM rows occupy the two local halves.
+                reg_all_f32 = T.alloc_local((MMA_N,), "float32")
+                reg_all_pairs = reg_all_f32.view("uint64")
+                reg_all_bf16_words = T.alloc_local((MMA_N // 2,), "uint32", align=16)
                 for no in T.unroll(MMA_N // EPI_TILE):
-                    ln = T.meta_var(no * EPI_TILE)
-                    Tx.wg.copy_async(reg_all[:, ln : ln + EPI_TILE], tmem[:, ln : ln + EPI_TILE])
+                    linear_n = T.meta_var(no * EPI_TILE)
+                    for slab in T.unroll(2):
+                        reg_base = T.meta_var(no * (EPI_TILE // 2) + slab * (MMA_N // 2))
+                        T.ptx[TMEM_LD](
+                            *[reg_all_f32[reg_base + j] for j in range(EPI_TILE // 2)],
+                            T.cuda.get_tmem_addr(tmem.allocated_addr[0], slab * 16, linear_n),
+                        )
                 T.ptx.tcgen05.wait__ld.sync.aligned()
-                # scale + cast the whole frag
-                Tx.wg.mul(reg_all, reg_all, alpha_local)
-                Tx.wg.cast(reg_all_16b, reg_all)
+                for pair in T.unroll(MMA_N // 2):
+                    T.ptx.mul.rz.ftz.f32x2(
+                        reg_all_pairs[pair],
+                        T.cuda.make_float2(reg_all_f32[pair * 2], reg_all_f32[pair * 2 + 1]),
+                        T.cuda.make_float2(alpha_local, alpha_local),
+                    )
+                for pair in T.unroll(MMA_N // 2):
+                    T.ptx.cvt.rn.bf16x2.f32(
+                        reg_all_bf16_words[pair], reg_all_f32[pair * 2 + 1], reg_all_f32[pair * 2]
+                    )
                 if tid_in_wg == 0:
                     tmem_pipe.empty.arrive(
                         epi_cur.stage, remote=pair_leader_rank, pred=True, count=1
                     )
                 T.cuda.warpgroup_sync(1)
                 for no in T.unroll(MMA_N // EPI_TILE):
-                    ln = T.meta_var(no * EPI_TILE)
-                    store_epi_chunk(reg_all_16b[:, ln : ln + EPI_TILE], ln)
+                    linear_n = T.meta_var(no * EPI_TILE)
+                    store_epi_chunk(reg_all_bf16_words, no, linear_n, MMA_N)
 
         while tile_scheduler.valid():
             epilogue()
@@ -622,8 +918,10 @@ def _kernel(
             )
             T.ptx.mbarrier.arrive.b64(_rem3[0], T.uint32(1), pred=T.bool(True))
         T.cuda.mbarrier_wait_acquire_cluster(tmem_finished.ptr_to([0]), 0)
+        tmem_dealloc_addr: T.uint32
+        T.ptx.ld.shared.u32(tmem_dealloc_addr, tmem_addr.ptr_to([0]))
         T.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](
-            tmem_pool.addr, T.uint32(512)
+            tmem_dealloc_addr, T.uint32(512)
         )
 
 

--- a/tirx_kernels/gemm_comm/allgather_gemm.py
+++ b/tirx_kernels/gemm_comm/allgather_gemm.py
@@ -254,25 +254,6 @@ def derive_config(
     )
 
 
-pack_values = """
-__forceinline__ __device__ void pack_values(int32_t rem, int32_t task_type, int32_t task_idx0, int32_t task_idx1, uint64_t* dst_addr) {
-    asm volatile("st.shared::cluster.v4.b32 [%0], {%1, %2, %3, %4};"
-                 :
-                 : "l"(dst_addr), "r"(rem), "r"(task_type), "r"(task_idx0), "r"(task_idx1)
-                 : "memory");
-}
-"""
-
-unpack_values = """
-__forceinline__ __device__ void unpack_values(uint64_t* src_addr, int32_t* rem, int32_t* task_type, int32_t* task_idx0, int32_t* task_idx1) {
-    asm volatile("ld.shared::cluster.v4.b32 {%0, %1, %2, %3}, [%4];"
-                 : "=r"(*rem), "=r"(*task_type), "=r"(*task_idx0), "=r"(*task_idx1)
-                 : "l"(src_addr)
-                 : "memory");
-
-}
-"""
-
 semaphore_notify_remote = """
 __forceinline__ __device__ uint64_t semaphore_notify_remote(int32_t signal_rank, uint64_t* addr, uint64_t signal_value) {
     auto dst_addr = reinterpret_cast<unsigned long long*>(nvshmem_ptr(addr, signal_rank));
@@ -294,36 +275,6 @@ __forceinline__ __device__ void enqueue_remote(int32_t* task_types, int32_t* tas
     __threadfence();
 }
 """
-
-ld_global_acquire = """
-__forceinline__ __device__ int32_t ld_global_acquire(int32_t* addr) {
-  int32_t res;
-  asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\\n" : "=r"(res) : "l"(addr));
-  return res;
-}
-"""
-
-while_ld_global_acquire = """
-__forceinline__ __device__ int32_t while_ld_global_acquire(int32_t* addr) {
-  int32_t res;
-  asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\\n" : "=r"(res) : "l"(addr));
-  while (res < 0) {
-    __nanosleep(40);
-    asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\\n" : "=r"(res) : "l"(addr));
-  }
-  return res;
-}
-"""
-
-warp_broadcast = """
-__forceinline__ __device__ void warp_broadcast(int32_t* rem, int32_t* task_type, int32_t* task_idx0, int32_t* task_idx1) {{
-    *rem = __shfl_sync(0xFFFFFFFF, *rem, 0);
-    *task_type = __shfl_sync(0xFFFFFFFF, *task_type, 0);
-    *task_idx0 = __shfl_sync(0xFFFFFFFF, *task_idx0, 0);
-    *task_idx1 = __shfl_sync(0xFFFFFFFF, *task_idx1, 0);
-}}
-"""
-
 
 @T.meta_class
 class Barriers:
@@ -535,12 +486,14 @@ class GEMMMPMCQueue(MPMCQueue):
                 sem.semaphore_wait(remote_rank)
 
             self.masked_pos[0] = self.head_r[0] & self.mask
-            fetched_task_type[0] = T.cuda.func_call(
-                "while_ld_global_acquire",
-                self.task_types.ptr_to([self.masked_pos[0]]),
-                source_code=while_ld_global_acquire,
-                return_type="int32",
+            T.ptx.ld.global_.acquire.gpu.b32(
+                fetched_task_type[0], self.task_types.ptr_to([self.masked_pos[0]])
             )
+            while fetched_task_type[0] < 0:
+                T.cuda.nano_sleep(40)
+                T.ptx.ld.global_.acquire.gpu.b32(
+                    fetched_task_type[0], self.task_types.ptr_to([self.masked_pos[0]])
+                )
             T.ptx.st.global_.s32(self.task_types.ptr_to([self.masked_pos[0]]), T.int32(-1))
             T.ptx.ld.global_.s32(
                 fetched_task_idx0[0], self.task_idxs.ptr_to([self.masked_pos[0], 0])
@@ -563,14 +516,12 @@ def consumer_fetch(
     fetched_task_idx1,
 ):
     sch_pipe.consumer_wait(0)
-    T.cuda.func_call(
-        "unpack_values",
+    T.ptx.ld.shared__cluster.v4.b32(
+        rs_rem[0],
+        fetched_task_type[0],
+        fetched_task_idx0[0],
+        fetched_task_idx1[0],
         packed_value.ptr_to([0]),
-        rs_rem.ptr_to([0]),
-        fetched_task_type.ptr_to([0]),
-        fetched_task_idx0.ptr_to([0]),
-        fetched_task_idx1.ptr_to([0]),
-        source_code=unpack_values,
     )
     _rem2 = T.alloc_local([1], "uint64")
     T.ptx.mapa.shared__cluster.u64(_rem2[0], sch_pipe.mbar_c2p.ptr_to([sch_pipe.idx, 0]), T.uint32(0))
@@ -609,14 +560,12 @@ class SingleDynamicTileScheduler:
             if cbx == 0:
                 self.sch_pipe.producer_wait(0)
                 self.queue.dequeue(self.fetched_task_type, self.fetched_task_idx0, self.fetched_task_idx1, self.sem, cbx, bx, rank)
-                T.cuda.func_call(
-                    "pack_values",
+                T.ptx.st.shared__cluster.v4.b32(
+                    self.packed_value.ptr_to([0]),
                     self.rs_rem[0],
                     self.fetched_task_type[0],
                     self.fetched_task_idx0[0],
                     self.fetched_task_idx1[0],
-                    self.packed_value.ptr_to([0]),
-                    source_code=pack_values,
                 )
                 # T.cuda.thread_fence()
                 _rem3 = T.alloc_local([1], "uint64")
@@ -629,13 +578,33 @@ class SingleDynamicTileScheduler:
         if ENABLE_WARP_BROADCAST:
             if lane_id == 0:
                 consumer_fetch(self.sch_pipe, self.packed_value, self.rs_rem, self.fetched_task_type, self.fetched_task_idx0, self.fetched_task_idx1)
-            T.cuda.func_call(
-                "warp_broadcast",
-                self.rs_rem.ptr_to([0]),
-                self.fetched_task_type.ptr_to([0]),
-                self.fetched_task_idx0.ptr_to([0]),
-                self.fetched_task_idx1.ptr_to([0]),
-                source_code=warp_broadcast,
+            T.ptx.shfl_sync.idx.b32(
+                self.rs_rem[0],
+                self.rs_rem[0],
+                T.uint32(0),
+                T.uint32(31),
+                T.uint32(0xFFFFFFFF),
+            )
+            T.ptx.shfl_sync.idx.b32(
+                self.fetched_task_type[0],
+                self.fetched_task_type[0],
+                T.uint32(0),
+                T.uint32(31),
+                T.uint32(0xFFFFFFFF),
+            )
+            T.ptx.shfl_sync.idx.b32(
+                self.fetched_task_idx0[0],
+                self.fetched_task_idx0[0],
+                T.uint32(0),
+                T.uint32(31),
+                T.uint32(0xFFFFFFFF),
+            )
+            T.ptx.shfl_sync.idx.b32(
+                self.fetched_task_idx1[0],
+                self.fetched_task_idx1[0],
+                T.uint32(0),
+                T.uint32(31),
+                T.uint32(0xFFFFFFFF),
             )
         else:
             consumer_fetch(self.sch_pipe, self.packed_value, self.rs_rem, self.fetched_task_type, self.fetched_task_idx0, self.fetched_task_idx1)

--- a/tirx_kernels/gemm_comm/allgather_gemm.py
+++ b/tirx_kernels/gemm_comm/allgather_gemm.py
@@ -33,9 +33,8 @@ import tvm
 from tvm.ir.type import PointerType, PrimType
 from tvm.script import tirx as T
 from tvm.script.ir_builder import IRBuilder
-from tvm.script.tirx import tile as Tx
 from tvm.tirx.bench import CudaProfiler
-from tvm.tirx.layout import TCol, TileLayout, TLane, tid_in_wg
+from tvm.tirx.layout import TCol, TileLayout, TLane
 
 from ._baselines import create_baseline_suite
 from ._baselines import ratios as baseline_ratios
@@ -123,9 +122,17 @@ assert SMEM_SIZE <= 232448
 TMEM_LD_SIZE = 64
 N_COLS = 512
 CTA_GROUP = 2
+# TMA instruction spellings emitted by the former ``tma_auto`` calls.
+_TMA_G2S_CG2 = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global"
+    f".mbarrier::complete_tx::bytes.cta_group::{CTA_GROUP}"
+)
+_TMA_S2G = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
 # tcgen05.mma spelling: kind::f16 from the (float32, DTYPE, DTYPE) dtypes.
 _MMA_CHAIN = f"tcgen05.mma.cta_group::{CTA_GROUP}.kind::f16"
 _MMA_ZERO_MASKS = [0] * (4 if CTA_GROUP == 1 else 8)
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_CVT_F32X2 = "cvt.rn.f16x2.f32"
 
 PIPE_CYCLE = (K // BLK_K) // PIPELINE_DEPTH
 PIPE_REMAIN_NUM = (K // BLK_K) % PIPELINE_DEPTH
@@ -189,8 +196,7 @@ def _mapa_u64_tx(ptr, rank):
 
     PTX has no defining form, so mapa writes a register the caller declares;
     a one-element local buffer gives both a writable lvalue and an Expr.
-    `Tx` is the tile-primitive namespace and has no allocation helpers, so the
-    scratch and the call go through `T`.
+    The scratch and the call both go through the full TIRx namespace.
     """
     mapped = T.alloc_local([1], "uint64")
     T.evaluate(T.ptx.mapa.u64(mapped[0], ptr, T.uint32(rank)))
@@ -461,9 +467,7 @@ class Semaphore:
     @T.inline
     def semaphore_wait(self, *coord):
         while 1:
-            T.ptx.ld.acquire.gpu.global_.b64(
-                self.state[0], self.sem.access_ptr("r", offset=self.sem.elem_offset_of(coord))
-            )
+            T.ptx.ld.acquire.gpu.global_.b64(self.state[0], self.sem.ptr_to(list(coord)))
             if self.state[0] == self.cnt:
                 break
             T.cuda.nano_sleep(40)
@@ -521,9 +525,7 @@ class GEMMMPMCQueue(MPMCQueue):
         bx,
         rank,
     ):
-        self.head_r[0] = T.cuda.atomic_add(
-            self.head.access_ptr("rw", offset=self.head.elem_offset_of([T.int32(0)])), 1
-        )
+        T.ptx.atom.global_.add.s32(self.head_r[0], self.head.ptr_to([0]), T.int32(1))
         if self.head_r[0] < self.num_tot_tasks:
             # TODO: modify the wait logic to make it faster
             remote_rank = (
@@ -535,15 +537,17 @@ class GEMMMPMCQueue(MPMCQueue):
             self.masked_pos[0] = self.head_r[0] & self.mask
             fetched_task_type[0] = T.cuda.func_call(
                 "while_ld_global_acquire",
-                self.task_types.access_ptr(
-                    "r", offset=self.task_types.elem_offset_of([self.masked_pos[0]])
-                ),
+                self.task_types.ptr_to([self.masked_pos[0]]),
                 source_code=while_ld_global_acquire,
                 return_type="int32",
             )
-            self.task_types[self.masked_pos[0]] = -1
-            fetched_task_idx0[0] = self.task_idxs[self.masked_pos[0], 0]
-            fetched_task_idx1[0] = self.task_idxs[self.masked_pos[0], 1]
+            T.ptx.st.global_.s32(self.task_types.ptr_to([self.masked_pos[0]]), T.int32(-1))
+            T.ptx.ld.global_.s32(
+                fetched_task_idx0[0], self.task_idxs.ptr_to([self.masked_pos[0], 0])
+            )
+            T.ptx.ld.global_.s32(
+                fetched_task_idx1[0], self.task_idxs.ptr_to([self.masked_pos[0], 1])
+            )
         else:
             fetched_task_type[0] = -1
 
@@ -686,6 +690,120 @@ def _build_kernel():
     def test_mma_ss_tma_2sm_persistent(A: T.Buffer((LOCAL_M, K), a_type), B: T.Buffer((LOCAL_N, K), b_type), ag_out: T.Buffer((M, K), a_type),
                                        semaphore: T.Buffer((WORLD_SIZE,), "uint64"), out: T.Buffer((M, LOCAL_N), d_type), profiler_buffer: T.Buffer((PROFILER_BUFFER_SIZE,), "uint64"),
                                        gemm_task_types: T.Buffer((CAPACITY,), "int32"), gemm_task_idxs: T.Buffer((CAPACITY, 2), "int32"), gemm_head: T.Buffer((1,), "int32"), gemm_tail: T.Buffer((1,), "int32")):
+        A_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        A_tensor_map_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        ag_out_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        ag_out_tensor_map_1: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        B_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        out_tensor_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            A_tensor_map,
+            a_type,
+            2,
+            A.data,
+            K,
+            LOCAL_M,
+            K * F16_BYTES,
+            BLK_K,
+            BLK_M,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            A_tensor_map_1,
+            a_type,
+            2,
+            A.data,
+            K,
+            LOCAL_M,
+            K * F16_BYTES,
+            BLK_K,
+            BLK_M,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            ag_out_tensor_map,
+            a_type,
+            2,
+            ag_out.data,
+            K,
+            M,
+            K * F16_BYTES,
+            BLK_K,
+            BLK_M,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            ag_out_tensor_map_1,
+            a_type,
+            2,
+            ag_out.data,
+            K,
+            M,
+            K * F16_BYTES,
+            BLK_K,
+            BLK_M,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            B_tensor_map,
+            b_type,
+            2,
+            B.data,
+            K,
+            LOCAL_N,
+            K * F16_BYTES,
+            BLK_K,
+            BLK_N,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            out_tensor_map,
+            d_type,
+            2,
+            out.data,
+            LOCAL_N,
+            M,
+            LOCAL_N * F16_BYTES,
+            EPI_TILE,
+            BLK_M,
+            1,
+            1,
+            0,
+            SWIZZLE,
+            2,
+            0,
+        )
         T.device_entry()
         cbx, cby = T.cta_id_in_cluster([M_CLUSTER, N_CLUSTER])
         bx = T.cta_id([SM_NUMBER])
@@ -698,7 +816,7 @@ def _build_kernel():
         # alloc shared memory
         buf = T.alloc_buffer([SMEM_SIZE], "uint8", scope="shared.dyn")
         T.attr({"tirx.dyn_smem_bytes": SMEM_SIZE})
-        tmem_addr = T.decl_scalar("uint32", buf.data, scope="shared.dyn", elem_offset=0)
+        tmem_addr = T.decl_buffer((1,), "uint32", buf.data, scope="shared.dyn", elem_offset=0)
         A_smem = T.decl_buffer((PIPELINE_DEPTH, NUM_CONSUMER, BLK_M, BLK_K), a_type, buf.data, layout=A_layout,
                                 elem_offset=1024 // F16_BYTES)
         B_smem = T.decl_buffer((PIPELINE_DEPTH, BLK_N, BLK_K), b_type, buf.data, layout=B_layout,
@@ -713,6 +831,7 @@ def _build_kernel():
         phase = T.alloc_buffer((1,), "int32", scope="local")
         phase_tmem = T.alloc_buffer((1,), "int32", scope="local")
         stage = T.local_scalar("int32")
+        tmem_addr_local = T.local_scalar("uint32")
 
         # ag + gemm
         sem = T.meta_var(Semaphore(cnt=1, buffer=semaphore))
@@ -754,7 +873,7 @@ def _build_kernel():
 
         # alloc TMEM
         if (wg_id == 0) & (warp_id == 0):
-            T.ptx[f"tcgen05.alloc.cta_group::{CTA_GROUP}.sync.aligned.shared::cta.b32"](T.address_of(tmem_addr), T.uint32(N_COLS))
+            T.ptx[f"tcgen05.alloc.cta_group::{CTA_GROUP}.sync.aligned.shared::cta.b32"](tmem_addr.ptr_to([0]), T.uint32(N_COLS))
 
         T.ptx.barrier.cluster.arrive()
         T.ptx.barrier.cluster.wait()
@@ -763,7 +882,8 @@ def _build_kernel():
         T.ptx.fence.mbarrier_init.release.cluster()
         tile_scheduler.init(cbx, bx, rank, warp_id_in_cta, lane_id)
 
-        T.cuda.trap_when_assert_failed(tmem_addr == 0)
+        T.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
+        T.cuda.trap_when_assert_failed(tmem_addr_local == 0)
         tmem = T.decl_buffer((128, N_COLS), "float32", scope="tmem", allocated_addr=0, layout=TileLayout(T.S[(128, N_COLS) : (1@TLane, 1@TCol)]))
 
         @T.inline
@@ -801,20 +921,49 @@ def _build_kernel():
 
                             @T.inline
                             def tma_load(is_remain, ks):
-                                tma_copy = T.meta_var({"dispatch": "tma_auto", "mbar": tma_finished.ptr_to([ks]), "cta_group": CTA_GROUP})
                                 stage_k = T.meta_var(stage * BLK_K)
                                 mma2tma.wait(ks, 0, phase[0])
                                 if rank * LOCAL_GEMM_M_CLUSTERS <= m_idx and m_idx < (rank + 1) * LOCAL_GEMM_M_CLUSTERS:
                                     m_start0 = T.meta_var(((m_idx % LOCAL_GEMM_M_CLUSTERS) * NUM_CONSUMER * CTA_GROUP + cbx) * BLK_M)
                                     m_start1 = T.meta_var(((m_idx % LOCAL_GEMM_M_CLUSTERS) * NUM_CONSUMER * CTA_GROUP + CTA_GROUP + cbx) * BLK_M)
-                                    Tx.copy_async(A_smem[ks, 0, :, :], A[m_start0 : m_start0 + BLK_M, stage_k : stage_k + BLK_K], **tma_copy)
-                                    Tx.copy_async(A_smem[ks, 1, :, :], A[m_start1 : m_start1 + BLK_M, stage_k : stage_k + BLK_K], **tma_copy)
+                                    T.ptx[_TMA_G2S_CG2](
+                                        A_smem.ptr_to([ks, 0, 0, 0]),
+                                        T.address_of(A_tensor_map),
+                                        T.cast(stage_k, "int32"),
+                                        T.cast(m_start0, "int32"),
+                                        T.cuda.cvta_generic_to_shared(tma_finished.ptr_to([ks])),
+                                    )
+                                    T.ptx[_TMA_G2S_CG2](
+                                        A_smem.ptr_to([ks, 1, 0, 0]),
+                                        T.address_of(A_tensor_map_1),
+                                        T.cast(stage_k, "int32"),
+                                        T.cast(m_start1, "int32"),
+                                        T.cuda.cvta_generic_to_shared(tma_finished.ptr_to([ks])),
+                                    )
                                 else:
                                     m_start0 = T.meta_var((m_idx * NUM_CONSUMER * CTA_GROUP + cbx) * BLK_M)
                                     m_start1 = T.meta_var((m_idx * NUM_CONSUMER * CTA_GROUP + CTA_GROUP + cbx) * BLK_M)
-                                    Tx.copy_async(A_smem[ks, 0, :, :], ag_out[m_start0 : m_start0 + BLK_M, stage_k : stage_k + BLK_K], **tma_copy)
-                                    Tx.copy_async(A_smem[ks, 1, :, :], ag_out[m_start1 : m_start1 + BLK_M, stage_k : stage_k + BLK_K], **tma_copy)
-                                Tx.copy_async(B_smem[ks, :, :], B[n_start : n_start + BLK_N, stage_k : stage_k + BLK_K], **tma_copy)
+                                    T.ptx[_TMA_G2S_CG2](
+                                        A_smem.ptr_to([ks, 0, 0, 0]),
+                                        T.address_of(ag_out_tensor_map),
+                                        T.cast(stage_k, "int32"),
+                                        T.cast(m_start0, "int32"),
+                                        T.cuda.cvta_generic_to_shared(tma_finished.ptr_to([ks])),
+                                    )
+                                    T.ptx[_TMA_G2S_CG2](
+                                        A_smem.ptr_to([ks, 1, 0, 0]),
+                                        T.address_of(ag_out_tensor_map_1),
+                                        T.cast(stage_k, "int32"),
+                                        T.cast(m_start1, "int32"),
+                                        T.cuda.cvta_generic_to_shared(tma_finished.ptr_to([ks])),
+                                    )
+                                T.ptx[_TMA_G2S_CG2](
+                                    B_smem.ptr_to([ks, 0, 0]),
+                                    T.address_of(B_tensor_map),
+                                    T.cast(stage_k, "int32"),
+                                    T.cast(n_start, "int32"),
+                                    T.cuda.cvta_generic_to_shared(tma_finished.ptr_to([ks])),
+                                )
                                 if cbx == 0:
                                     tma2mma.arrive(ks, NUM_CONSUMER * BLK_K * (BLK_M * NUM_CONSUMER + BLK_N) * F16_BYTES)
 
@@ -877,8 +1026,7 @@ def _build_kernel():
                     T.ptx.setmaxnreg.inc.sync.aligned.u32(224)
 
                     reg = T.alloc_buffer((TMEM_LD_SIZE,), "float32", scope="local")
-                    reg_wg = reg.view(128, TMEM_LD_SIZE, layout=TileLayout(T.S[(128, TMEM_LD_SIZE) : (1@tid_in_wg, 1)]))
-                    reg_fp16 = T.alloc_buffer((BLK_N * CTA_GROUP,), d_type, scope="local")
+                    reg_fp16 = T.alloc_buffer((TMEM_LD_SIZE // 2,), "uint32", scope="local", align=16)
 
                     mma2ld.wait(0, wg_id, phase_tmem[0])
                     phase_tmem[0] = phase_tmem[0] ^ 1
@@ -886,25 +1034,65 @@ def _build_kernel():
                     # TMEM -> RF (ld)
                     for i in T.unroll(MMA_N // TMEM_LD_SIZE): # load (MMA_M // 2, MMA_N)
                         col_st = T.meta_var(wg_id * MMA_N + i * TMEM_LD_SIZE)
-                        Tx.wg.copy_async(reg_wg[:, :], tmem[:, col_st : col_st + TMEM_LD_SIZE])
+                        T.ptx[_TMEM_LD_64](
+                            *[reg[j] for j in range(TMEM_LD_SIZE)],
+                            T.cast(col_st, "uint32"),
+                        )
                         T.ptx.tcgen05.wait__ld.sync.aligned()
-                        Tx.cast(reg_fp16[i * TMEM_LD_SIZE : (i + 1) * TMEM_LD_SIZE], reg[:])
 
-                    # the tmem can be overwritten by the next tile
-                    ld2mma.arrive(wg_id)
-                    # # RF -> GMEM
-                    for i in T.unroll(NUM_CONSUMER * BLK_N // EPI_TILE):
-                        Tx.copy(D_smem[wg_id, warp_id * 32 + lane_id, :], reg_fp16[i * EPI_TILE : (i + 1) * EPI_TILE])
+                        # Once the final asynchronous load has completed, no
+                        # later instruction consumes TMEM: conversion and
+                        # output staging read only the register payload.  Let
+                        # the producer reuse TMEM while that tail executes.
+                        if i == MMA_N // TMEM_LD_SIZE - 1:
+                            ld2mma.arrive(wg_id)
+
+                        for j in T.unroll(TMEM_LD_SIZE // 2):
+                            T.ptx[_CVT_F32X2](
+                                reg_fp16[j],
+                                reg[j * 2 + 1],
+                                reg[j * 2],
+                            )
+
+                        # Keep the preceding TMA store in flight while this
+                        # independent TMEM chunk is loaded and converted.  The
+                        # staging buffer is not overwritten until the elected
+                        # thread has observed completion and the warpgroup has
+                        # rendezvoused.
+                        if i > 0:
+                            if lane_id == 0 and warp_id == 0:
+                                T.ptx.cp.async_.bulk.wait_group(0)
+                            T.cuda.warpgroup_sync(wg_id)
+
+                        for jv in T.unroll(EPI_TILE // 8):
+                            r0 = T.meta_var(jv * 4)
+                            T.ptx.st.shared.v4.u32(
+                                D_smem.ptr_to([wg_id, warp_id * 32 + lane_id, jv * 8]),
+                                reg_fp16[r0],
+                                reg_fp16[r0 + 1],
+                                reg_fp16[r0 + 2],
+                                reg_fp16[r0 + 3],
+                            )
                         T.cuda.warpgroup_sync(wg_id)
                         T.ptx.fence.proxy.async_.shared__cta()
                         # st to gmem
                         if lane_id == 0 and warp_id == 0:
                             m_st = T.meta_var((m_idx * NUM_CONSUMER * CTA_GROUP + wg_id * CTA_GROUP + cbx) * BLK_M)
                             n_st = T.meta_var(n_idx * BLK_N * CTA_GROUP + i * EPI_TILE)
-                            Tx.copy_async(out[m_st : m_st + BLK_M, n_st : n_st + EPI_TILE], D_smem[wg_id, :, :], dispatch="tma_auto")
+                            T.ptx[_TMA_S2G](
+                                T.address_of(out_tensor_map),
+                                T.cast(n_st, "int32"),
+                                T.cast(m_st, "int32"),
+                                D_smem.ptr_to([wg_id, 0, 0]),
+                            )
                             T.ptx.cp.async_.bulk.commit_group()
-                            T.ptx.cp.async_.bulk.wait_group(0)
-                        T.cuda.warpgroup_sync(wg_id)
+
+                    # The last store has no following TMEM load to hide its
+                    # latency, but it still must complete before this staging
+                    # buffer is reused by the next scheduled tile.
+                    if lane_id == 0 and warp_id == 0:
+                        T.ptx.cp.async_.bulk.wait_group(0)
+                    T.cuda.warpgroup_sync(wg_id)
 
                 profiler.end(ProfileEventType.GEMM, tid == 0)
 
@@ -917,7 +1105,8 @@ def _build_kernel():
         # dealloc TMEM
         if (wg_id == 0) & (warp_id == 0):
             T.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
-            T.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](tmem_addr, T.uint32(N_COLS))
+            T.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
+            T.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](tmem_addr_local, T.uint32(N_COLS))
 
     # fmt: on
 

--- a/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
+++ b/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
@@ -204,14 +204,7 @@ def derive_config(
 
 
 ld_reduce_8xfp16 = '\n__forceinline__ __device__ void ld_reduce_8_fp16(void* src_addr, void* dst_addr) {\n    int4* source = (int4*) nvshmemx_mc_ptr(NVSHMEM_TEAM_WORLD, src_addr);\n    int4* dest = (int4*) dst_addr;\n    constexpr int UNROLL = 1;\n    union {\n        uint16_t u2[8 * UNROLL];\n        uint64_t u8[2 * UNROLL];\n    };\n    for (int u = 0; u < UNROLL; u++) {\n        asm("multimem.ld_reduce.global.add.v8.f16 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"\n            : "=h"(u2[8 * u]), "=h"(u2[8 * u + 1]), "=h"(u2[8 * u + 2]), "=h"(u2[8 * u + 3]), "=h"(u2[8 * u + 4]), "=h"(u2[8 * u + 5]), "=h"(u2[8 * u + 6]), "=h"(u2[8 * u + 7])\n            : "l"(source + u));\n    }\n    for (int u = 0; u < UNROLL; u++) {\n        asm("st.global.v2.b64 [%0], {%1, %2};" ::"l"(dest + u), "l"(u8[2 * u]),\n            "l"(u8[2 * u + 1]));\n    }\n}\n'
-pack_values = '\n__forceinline__ __device__ void pack_values(int32_t rem, int32_t task_type, int32_t task_idx0, int32_t task_idx1, uint64_t* dst_addr) {\n    asm volatile("st.shared::cluster.v4.b32 [%0], {%1, %2, %3, %4};"\n                 :\n                 : "l"(dst_addr), "r"(rem), "r"(task_type), "r"(task_idx0), "r"(task_idx1)\n                 : "memory");\n}\n'
-unpack_values = '\n__forceinline__ __device__ void unpack_values(uint64_t* src_addr, int32_t* rem, int32_t* task_type, int32_t* task_idx0, int32_t* task_idx1) {\n    asm volatile("ld.shared::cluster.v4.b32 {%0, %1, %2, %3}, [%4];"\n                 : "=r"(*rem), "=r"(*task_type), "=r"(*task_idx0), "=r"(*task_idx1)\n                 : "l"(src_addr)\n                 : "memory");\n\n}\n'
 semaphore_notify_remote = "\n__forceinline__ __device__ uint64_t semaphore_notify_remote(int32_t signal_rank, uint64_t* addr, uint64_t signal_value) {\n    auto dst_addr = reinterpret_cast<unsigned long long*>(nvshmem_ptr(addr, signal_rank));\n    return atomicAdd_system(dst_addr, signal_value);\n}\n"
-thread_fence_system = """
-__forceinline__ __device__ void thread_fence_system() {
-    __threadfence_system();
-}
-"""
 enqueue_remote = """
 __forceinline__ __device__ void enqueue_remote(
         int32_t* task_types, int32_t* task_idxs, int32_t* tail, int32_t mask,
@@ -230,17 +223,8 @@ __forceinline__ __device__ void enqueue_remote(
         : "memory");
 }
 """
-ld_global_acquire = """
-__forceinline__ __device__ int32_t ld_global_acquire(int32_t* addr) {
-    int32_t value;
-    asm volatile(
-        "ld.global.acquire.sys.b32 %0, [%1];"
-        : "=r"(value)
-        : "l"(addr)
-        : "memory");
-    return value;
-}
-"""
+# Keep the acquire-load polling loop in one device helper.  Expanding the loop
+# into TIR can leave worker CTAs spinning indefinitely on queue publication.
 while_ld_global_acquire = """
 __forceinline__ __device__ int32_t while_ld_global_acquire(int32_t* addr) {
     int32_t value;
@@ -427,11 +411,8 @@ class RSMPMCQueue(MPMCQueue):
             Tx.ptx.atom.global_.add.s32(self.head_r[0], self.head.ptr_to([0]), Tx.int32(1))
         if self.head_r[0] < self.num_tot_tasks:
             self.masked_pos[0] = self.head_r[0] & self.mask
-            fetched_task_type[0] = Tx.cuda.func_call(
-                "ld_global_acquire",
-                self.task_types.ptr_to([self.masked_pos[0]]),
-                source_code=ld_global_acquire,
-                return_type="int32",
+            Tx.ptx.ld.global_.acquire.sys.b32(
+                fetched_task_type[0], self.task_types.ptr_to([self.masked_pos[0]])
             )
             if fetched_task_type[0] < 0:
                 rs_rem[0] = self.head_r[0]
@@ -452,14 +433,12 @@ def consumer_fetch(
     sch_pipe, packed_value, rs_rem, fetched_task_type, fetched_task_idx0, fetched_task_idx1
 ):
     sch_pipe.consumer_wait(0)
-    Tx.cuda.func_call(
-        "unpack_values",
+    Tx.ptx.ld.shared__cluster.v4.b32(
+        rs_rem[0],
+        fetched_task_type[0],
+        fetched_task_idx0[0],
+        fetched_task_idx1[0],
         packed_value.ptr_to([0]),
-        rs_rem.ptr_to([0]),
-        fetched_task_type.ptr_to([0]),
-        fetched_task_idx0.ptr_to([0]),
-        fetched_task_idx1.ptr_to([0]),
-        source_code=unpack_values,
     )
     mapped = Tx.alloc_local([1], "uint64")
     Tx.ptx.mapa.shared__cluster.u64(
@@ -511,14 +490,12 @@ class MixedDynamicTileScheduler:
                         bx,
                         rank,
                     )
-                Tx.cuda.func_call(
-                    "pack_values",
+                Tx.ptx.st.shared__cluster.v4.b32(
+                    self.packed_value.ptr_to([0]),
                     self.rs_rem[0],
                     self.fetched_task_type[0],
                     self.fetched_task_idx0[0],
                     self.fetched_task_idx1[0],
-                    self.packed_value.ptr_to([0]),
-                    source_code=pack_values,
                 )
                 Tx.cuda.thread_fence()
                 mapped0 = Tx.alloc_local([1], "uint64")
@@ -564,7 +541,7 @@ class Semaphore:
     @Tx.inline
     def semaphore_notify(self, signal_rank, tid, m_idx, n_idx, rs_queue):
         if tid % 128 == 0:
-            Tx.cuda.func_call("thread_fence_system", source_code=thread_fence_system)
+            Tx.ptx.fence.sc.sys()
             self.state[0] = (
                 Tx.cuda.func_call(
                     "semaphore_notify_remote",

--- a/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
+++ b/tirx_kernels/gemm_comm/gemm_reduce_scatter.py
@@ -32,7 +32,6 @@ import tvm
 from tvm.ir.type import PointerType, PrimType
 from tvm.script import tirx as Tx
 from tvm.tirx.lang.pipeline import Pipeline as DataPipeline
-from tvm.tirx.layout import wg_local_layout
 
 from ._baselines import create_baseline_suite
 from ._baselines import ratios as baseline_ratios
@@ -106,6 +105,8 @@ _TMA_S2G = "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
 # tcgen05.mma spelling: kind::f16 from the (float32, float16, float16) dtypes.
 _MMA_CHAIN = f"tcgen05.mma.cta_group::{CTA_GROUP}.kind::f16"
 _MMA_ZERO_MASKS = [0] * (4 if CTA_GROUP == 1 else 8)
+_TMEM_LD_64 = "tcgen05.ld.sync.aligned.32x32b.x64.b32"
+_CVT_F32X2 = "cvt.rn.f16x2.f32"
 PIPE_CYCLE = K // BLK_K // PIPELINE_DEPTH
 PIPE_REMAIN_NUM = K // BLK_K % PIPELINE_DEPTH
 assert PIPELINE_DEPTH == 4
@@ -144,13 +145,8 @@ class GemmRSConfig:
 
 
 def _mapa_u64_tx(ptr, rank):
-    """`mapa.u64` into a declared register, returned as an ordinary value.
+    """`mapa.u64` into a declared register, returned as an ordinary value."""
 
-    PTX has no defining form, so mapa writes a register the caller declares;
-    a one-element local buffer gives both a writable lvalue and an Expr.
-    In this file `Tx` is the full tirx namespace (`from tvm.script import tirx
-    as Tx`), not the tile submodule.
-    """
     mapped = Tx.alloc_local([1], "uint64")
     Tx.evaluate(Tx.ptx.mapa.u64(mapped[0], ptr, Tx.uint32(rank)))
     return mapped[0]
@@ -392,22 +388,22 @@ class GEMMMPMCQueue(MPMCQueue):
         bx,
         rank,
     ):
-        self.head_r[0] = Tx.cuda.atomic_add(
-            self.head.access_ptr("rw", offset=self.head.elem_offset_of([Tx.int32(0)])), 1
-        )
+        Tx.ptx.atom.global_.add.s32(self.head_r[0], self.head.ptr_to([0]), Tx.int32(1))
         if self.head_r[0] < self.num_tot_tasks:
             self.masked_pos[0] = self.head_r[0] & self.mask
             fetched_task_type[0] = Tx.cuda.func_call(
                 "while_ld_global_acquire",
-                self.task_types.access_ptr(
-                    "r", offset=self.task_types.elem_offset_of([self.masked_pos[0]])
-                ),
+                self.task_types.ptr_to([self.masked_pos[0]]),
                 source_code=while_ld_global_acquire,
                 return_type="int32",
             )
-            self.task_types[self.masked_pos[0]] = -1
-            fetched_task_idx0[0] = self.task_idxs[self.masked_pos[0], 0]
-            fetched_task_idx1[0] = self.task_idxs[self.masked_pos[0], 1]
+            Tx.ptx.st.global_.s32(self.task_types.ptr_to([self.masked_pos[0]]), Tx.int32(-1))
+            Tx.ptx.ld.global_.s32(
+                fetched_task_idx0[0], self.task_idxs.ptr_to([self.masked_pos[0], 0])
+            )
+            Tx.ptx.ld.global_.s32(
+                fetched_task_idx1[0], self.task_idxs.ptr_to([self.masked_pos[0], 1])
+            )
         else:
             fetched_task_type[0] = -1
 
@@ -428,25 +424,25 @@ class RSMPMCQueue(MPMCQueue):
             self.head_r[0] = rs_rem[0]
             rs_rem[0] = -1
         else:
-            self.head_r[0] = Tx.cuda.atomic_add(
-                self.head.access_ptr("rw", offset=self.head.elem_offset_of([Tx.int32(0)])), 1
-            )
+            Tx.ptx.atom.global_.add.s32(self.head_r[0], self.head.ptr_to([0]), Tx.int32(1))
         if self.head_r[0] < self.num_tot_tasks:
             self.masked_pos[0] = self.head_r[0] & self.mask
             fetched_task_type[0] = Tx.cuda.func_call(
                 "ld_global_acquire",
-                self.task_types.access_ptr(
-                    "r", offset=self.task_types.elem_offset_of([self.masked_pos[0]])
-                ),
+                self.task_types.ptr_to([self.masked_pos[0]]),
                 source_code=ld_global_acquire,
                 return_type="int32",
             )
             if fetched_task_type[0] < 0:
                 rs_rem[0] = self.head_r[0]
             else:
-                self.task_types[self.masked_pos[0]] = -1
-                fetched_task_idx0[0] = self.task_idxs[self.masked_pos[0], 0]
-                fetched_task_idx1[0] = self.task_idxs[self.masked_pos[0], 1]
+                Tx.ptx.st.global_.s32(self.task_types.ptr_to([self.masked_pos[0]]), Tx.int32(-1))
+                Tx.ptx.ld.global_.s32(
+                    fetched_task_idx0[0], self.task_idxs.ptr_to([self.masked_pos[0], 0])
+                )
+                Tx.ptx.ld.global_.s32(
+                    fetched_task_idx1[0], self.task_idxs.ptr_to([self.masked_pos[0], 1])
+                )
         else:
             fetched_task_type[0] = -1
 
@@ -465,11 +461,11 @@ def consumer_fetch(
         fetched_task_idx1.ptr_to([0]),
         source_code=unpack_values,
     )
-    _rem1 = Tx.alloc_local([1], "uint64")
+    mapped = Tx.alloc_local([1], "uint64")
     Tx.ptx.mapa.shared__cluster.u64(
-        _rem1[0], sch_pipe.mbar_c2p.ptr_to([sch_pipe.idx, 0]), Tx.uint32(0)
+        mapped[0], sch_pipe.mbar_c2p.ptr_to([sch_pipe.idx, 0]), Tx.uint32(0)
     )
-    Tx.ptx.mbarrier.arrive.b64(_rem1[0], Tx.uint32(1), pred=Tx.bool(True))
+    Tx.ptx.mbarrier.arrive.b64(mapped[0], Tx.uint32(1), pred=Tx.bool(True))
     sch_pipe.p2c_phase = sch_pipe.p2c_phase ^ 1
 
 
@@ -525,16 +521,16 @@ class MixedDynamicTileScheduler:
                     source_code=pack_values,
                 )
                 Tx.cuda.thread_fence()
-                _rem2 = Tx.alloc_local([1], "uint64")
+                mapped0 = Tx.alloc_local([1], "uint64")
                 Tx.ptx.mapa.shared__cluster.u64(
-                    _rem2[0], self.sch_pipe.mbar_p2c.ptr_to([self.sch_pipe.idx, 0]), Tx.uint32(0)
+                    mapped0[0], self.sch_pipe.mbar_p2c.ptr_to([self.sch_pipe.idx, 0]), Tx.uint32(0)
                 )
-                Tx.ptx.mbarrier.arrive.b64(_rem2[0], Tx.uint32(1), pred=Tx.bool(True))
-                _rem3 = Tx.alloc_local([1], "uint64")
+                Tx.ptx.mbarrier.arrive.b64(mapped0[0], Tx.uint32(1), pred=Tx.bool(True))
+                mapped1 = Tx.alloc_local([1], "uint64")
                 Tx.ptx.mapa.shared__cluster.u64(
-                    _rem3[0], self.sch_pipe.mbar_p2c.ptr_to([self.sch_pipe.idx, 0]), Tx.uint32(1)
+                    mapped1[0], self.sch_pipe.mbar_p2c.ptr_to([self.sch_pipe.idx, 0]), Tx.uint32(1)
                 )
-                Tx.ptx.mbarrier.arrive.b64(_rem3[0], Tx.uint32(1), pred=Tx.bool(True))
+                Tx.ptx.mbarrier.arrive.b64(mapped1[0], Tx.uint32(1), pred=Tx.bool(True))
                 self.sch_pipe.c2p_phase = self.sch_pipe.c2p_phase ^ 1
         consumer_fetch(
             self.sch_pipe,
@@ -573,7 +569,7 @@ class Semaphore:
                 Tx.cuda.func_call(
                     "semaphore_notify_remote",
                     signal_rank,
-                    self.sem.access_ptr("rw", offset=self.sem.elem_offset_of((m_idx, n_idx))),
+                    self.sem.ptr_to([m_idx, n_idx]),
                     Tx.uint64(1),
                     source_code=semaphore_notify_remote,
                     return_type="uint64",
@@ -694,14 +690,18 @@ def test_mma_ss_tma_2sm_persistent(
     D_smem = pool.alloc_tcgen05_mma_AB((NUM_CONSUMER, BLK_M, EPI_TILE), d_type)
     pool.commit()
     reg = Tx.alloc_buffer((TMEM_LD_SIZE,), "float32", scope="local")
-    reg_wg = reg.view(128, TMEM_LD_SIZE, layout=wg_local_layout(TMEM_LD_SIZE))
-    reg_fp16 = Tx.alloc_buffer((BLK_N * CTA_GROUP,), d_type, scope="local")
+    reg_fp16 = Tx.alloc_buffer((TMEM_LD_SIZE // 2,), "uint32", scope="local", align=16)
+    copy_word0: Tx.uint32
+    copy_word1: Tx.uint32
+    copy_word2: Tx.uint32
+    copy_word3: Tx.uint32
     descA: Tx.uint64
     descB: Tx.uint64
     descI: Tx.uint32
     phase: Tx.int32
     phase_tmem: Tx.int32
     stage: Tx.int32
+    tmem_addr_local: Tx.uint32
     sem = Tx.meta_var(Semaphore(cnt=2 * WORLD_SIZE, buffer=semaphore))
     offset: Tx.int32
     gemm_queue = Tx.meta_var(
@@ -756,7 +756,8 @@ def test_mma_ss_tma_2sm_persistent(
     Tx.ptx.barrier.cluster.arrive()
     Tx.ptx.barrier.cluster.wait()
     Tx.cuda.cta_sync()
-    Tx.cuda.trap_when_assert_failed(tmem_addr[0] == 0)
+    Tx.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
+    Tx.cuda.trap_when_assert_failed(tmem_addr_local == 0)
     Tx.ptx.fence.proxy.async_.shared__cta()
     Tx.ptx.fence.mbarrier_init.release.cluster()
     tile_scheduler.init(cbx, bx, rank, warp_id_in_cta, lane_id)
@@ -770,14 +771,30 @@ def test_mma_ss_tma_2sm_persistent(
                     m_start = Tx.meta_var(offset // (TILE_N // 8))
                     n_start = Tx.meta_var(offset % (TILE_N // 8) * 8)
                     if WORLD_SIZE == 1:
-                        for vec in Tx.vectorized(8):
-                            out[
-                                TILE_M * m_idx + TILE_M // 2 * cbx + m_start,
-                                TILE_N * n_idx + n_start + vec,
-                            ] = gemm_out[
-                                TILE_M * m_idx + TILE_M // 2 * cbx + m_start,
-                                TILE_N * n_idx + n_start + vec,
-                            ]
+                        Tx.ptx.ld.global_.v4.b32(
+                            copy_word0,
+                            copy_word1,
+                            copy_word2,
+                            copy_word3,
+                            gemm_out.ptr_to(
+                                [
+                                    TILE_M * m_idx + TILE_M // 2 * cbx + m_start,
+                                    TILE_N * n_idx + n_start,
+                                ]
+                            ),
+                        )
+                        Tx.ptx.st.global_.v4.b32(
+                            out.ptr_to(
+                                [
+                                    TILE_M * m_idx + TILE_M // 2 * cbx + m_start,
+                                    TILE_N * n_idx + n_start,
+                                ]
+                            ),
+                            copy_word0,
+                            copy_word1,
+                            copy_word2,
+                            copy_word3,
+                        )
                     else:
                         Tx.cuda.func_call(
                             "ld_reduce_8_fp16",
@@ -967,24 +984,25 @@ def test_mma_ss_tma_2sm_persistent(
                         phase_tmem = phase_tmem ^ 1
             if (0 <= wg_id) & (wg_id < NUM_CONSUMER):
                 Tx.ptx.setmaxnreg.inc.sync.aligned.u32(224)
-                Tx.cuda.trap_when_assert_failed(tmem_addr[0] == 0)
                 tmem_pipe.full.wait(wg_id, phase_tmem)
                 phase_tmem = phase_tmem ^ 1
                 Tx.ptx.tcgen05.fence__after_thread_sync()
                 for i in Tx.unroll(MMA_N // TMEM_LD_SIZE):
                     col_st = Tx.meta_var(wg_id * MMA_N + i * TMEM_LD_SIZE)
-                    Tx.wg.copy_async(reg_wg[:, :], tmem[:, col_st : col_st + TMEM_LD_SIZE])
+                    Tx.ptx[_TMEM_LD_64](
+                        *[reg[j] for j in range(TMEM_LD_SIZE)], Tx.cast(col_st, "uint32")
+                    )
                     Tx.ptx.tcgen05.wait__ld.sync.aligned()
-                    Tx.thread.cast(reg_fp16[i * TMEM_LD_SIZE : (i + 1) * TMEM_LD_SIZE], reg)
-                tmem_pipe.empty.arrive(wg_id, remote=0)
-                for i in Tx.unroll(NUM_CONSUMER * BLK_N // EPI_TILE):
-                    for it in Tx.unroll(EPI_TILE // 8):
-                        # Per-thread 8-element slice store; D_smem's swizzled
-                        # layout computes the address and the 16B chunk emits a
-                        # vector store, so the index never vectorizes.
-                        Tx.thread.copy(
-                            D_smem[wg_id, warp_id * 32 + lane_id, it * 8 : it * 8 + 8],
-                            reg_fp16[i * EPI_TILE + it * 8 : i * EPI_TILE + it * 8 + 8],
+                    for j in Tx.unroll(TMEM_LD_SIZE // 2):
+                        Tx.ptx[_CVT_F32X2](reg_fp16[j], reg[j * 2 + 1], reg[j * 2])
+                    for jv in Tx.unroll(EPI_TILE // 8):
+                        r0 = Tx.meta_var(jv * 4)
+                        Tx.ptx.st.shared.v4.u32(
+                            D_smem.ptr_to([wg_id, warp_id * 32 + lane_id, jv * 8]),
+                            reg_fp16[r0],
+                            reg_fp16[r0 + 1],
+                            reg_fp16[r0 + 2],
+                            reg_fp16[r0 + 3],
                         )
                     Tx.cuda.warpgroup_sync(wg_id)
                     Tx.ptx.fence.proxy.async_.shared__cta()
@@ -998,6 +1016,7 @@ def test_mma_ss_tma_2sm_persistent(
                         Tx.ptx.cp.async_.bulk.commit_group()
                         Tx.ptx.cp.async_.bulk.wait_group(0)
                     Tx.cuda.warpgroup_sync(wg_id)
+                tmem_pipe.empty.arrive(wg_id, remote=0)
                 comm_m_idx = Tx.meta_var(m_idx * 2 + wg_id)
                 comm_m_idx_local = Tx.meta_var(comm_m_idx % (LOCAL_M // TILE_M))
                 signal_rank = Tx.meta_var(comm_m_idx // (LOCAL_M // TILE_M))
@@ -1006,7 +1025,12 @@ def test_mma_ss_tma_2sm_persistent(
     # Synchronize every local and peer-CTA TMEM user before collective deallocation.
     Tx.ptx.barrier.cluster.arrive()
     Tx.ptx.barrier.cluster.wait()
-    tmem_pool.dealloc()
+    if (wg_id == 0) & (warp_id == 0):
+        Tx.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
+        Tx.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
+        Tx.ptx[f"tcgen05.dealloc.cta_group::{CTA_GROUP}.sync.aligned.b32"](
+            tmem_addr_local, Tx.uint32(N_COLS)
+        )
 
 
 def build_kernel(config: GemmRSConfig | None = None) -> tvm.IRModule:

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -1,0 +1,255 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Validate the pre-lowering IR contract for low-level TIRx kernels."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import tvm
+from tvm import tirx
+from tvm.tirx.stmt_functor import StmtExprVisitor
+
+_FORBIDDEN_SCOPE_ROOTS = ("global", "shared")
+_ADDRESS_OF_OP = "tirx.address_of"
+
+
+def _is_forbidden_scope(scope: str) -> bool:
+    return any(scope == root or scope.startswith(f"{root}.") for root in _FORBIDDEN_SCOPE_ROOTS)
+
+
+def _node_name(node: Any) -> str:
+    return type(node).__name__.removesuffix("Node")
+
+
+def _span_text(node: Any) -> str | None:
+    span = getattr(node, "span", None)
+    if span is None:
+        return None
+
+    source_name = getattr(span, "source_name", None)
+    source = getattr(source_name, "name", None)
+    line = getattr(span, "line", None)
+    column = getattr(span, "column", None)
+    end_line = getattr(span, "end_line", None)
+    end_column = getattr(span, "end_column", None)
+    if source is not None and line is not None and column is not None:
+        start = f"{source}:{line}:{column}"
+        if end_line is not None and end_column is not None:
+            return f"{start}-{end_line}:{end_column}"
+        return start
+    return str(span)
+
+
+@dataclass(frozen=True)
+class LowLevelIRFinding:
+    """One observable contract finding in a particular TIRx function."""
+
+    function: str
+    kind: str
+    node_type: str
+    scope: str | None
+    span: str | None
+
+
+@dataclass(frozen=True)
+class LowLevelIRReport:
+    """Structured result of inspecting one kernel return value."""
+
+    checked_functions: tuple[str, ...]
+    violations: tuple[LowLevelIRFinding, ...]
+    address_only_loads: tuple[LowLevelIRFinding, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Whether every visited function satisfies the low-level IR contract."""
+        return not self.violations
+
+    def summary(self) -> str:
+        """Return a compact human-readable result."""
+        address_count = len(self.address_only_loads)
+        if self.ok:
+            return (
+                f"low-level IR contract passed for {len(self.checked_functions)} function(s); "
+                f"recorded {address_count} address-only load(s)"
+            )
+
+        lines = [
+            f"low-level IR contract failed with {len(self.violations)} violation(s) "
+            f"across {len(self.checked_functions)} function(s); "
+            f"recorded {address_count} address-only load(s)"
+        ]
+        for finding in self.violations:
+            scope = f", scope={finding.scope}" if finding.scope is not None else ""
+            span = f", span={finding.span}" if finding.span is not None else ""
+            lines.append(f"- {finding.function}: {finding.kind} ({finding.node_type}{scope}{span})")
+        return "\n".join(lines)
+
+
+class LowLevelIRContractError(ValueError):
+    """Raised when pre-lowering TIRx violates the low-level IR contract."""
+
+    def __init__(self, report: LowLevelIRReport):
+        self.report = report
+        super().__init__(report.summary())
+
+
+class _LowLevelIRVisitor(StmtExprVisitor):
+    """Collect forbidden operations from one pre-lowering ``PrimFunc`` body."""
+
+    def __init__(self, function: str):
+        super().__init__()
+        self.function = function
+        self.violations: list[LowLevelIRFinding] = []
+        self.address_only_loads: list[LowLevelIRFinding] = []
+
+    def _finding(self, node: Any, kind: str, scope: str | None = None) -> LowLevelIRFinding:
+        return LowLevelIRFinding(
+            function=self.function,
+            kind=kind,
+            node_type=_node_name(node),
+            scope=scope,
+            span=_span_text(node),
+        )
+
+    def visit_op_call_(self, op: Any) -> None:
+        self.violations.append(self._finding(op, "tile_primitive"))
+        super().visit_op_call_(op)
+
+    def visit_buffer_load_(self, op: tirx.BufferLoad) -> None:
+        scope = str(op.buffer.scope())
+        if _is_forbidden_scope(scope):
+            self.violations.append(self._finding(op, "buffer_load", scope))
+        # The fixed TIRx visitor only walks BufferLoad.indices.  A predicated
+        # load can itself contain loads, and those are real accesses even when
+        # the outer load is in an allowed scope.
+        for index in op.indices:
+            self.visit_expr(index)
+        if op.predicate is not None:
+            self.visit_expr(op.predicate)
+
+    def visit_buffer_store_(self, op: tirx.BufferStore) -> None:
+        scope = str(op.buffer.scope())
+        if _is_forbidden_scope(scope):
+            self.violations.append(self._finding(op, "buffer_store", scope))
+        self.visit_expr(op.value)
+        for index in op.indices:
+            self.visit_expr(index)
+        if op.predicate is not None:
+            self.visit_expr(op.predicate)
+
+    def visit_call_(self, op: tvm.ir.Call) -> None:
+        op_name = getattr(op.op, "name", None)
+        if op_name == _ADDRESS_OF_OP and len(op.args) == 1:
+            addressed = op.args[0]
+            if isinstance(addressed, tirx.BufferLoad):
+                scope = str(addressed.buffer.scope())
+                if _is_forbidden_scope(scope):
+                    self.address_only_loads.append(
+                        self._finding(addressed, "address_only_buffer_load", scope)
+                    )
+                # The BufferLoad is pointer syntax rather than a memory read.  Its
+                # indices are still expressions, and any loads inside them remain
+                # real accesses that must be checked normally.
+                for index in addressed.indices:
+                    self.visit_expr(index)
+                if addressed.predicate is not None:
+                    self.visit_expr(addressed.predicate)
+                return
+        super().visit_call_(op)
+
+
+def _global_name(global_var: Any) -> str:
+    return str(getattr(global_var, "name_hint", global_var))
+
+
+def _iter_prim_funcs(value: Any, path: str = "root") -> Iterator[tuple[str, tirx.PrimFunc]]:
+    if isinstance(value, tirx.PrimFunc):
+        yield path, value
+        return
+
+    if isinstance(value, tvm.IRModule):
+        for global_var, base_func in value.functions.items():
+            function_path = f"{path}.{_global_name(global_var)}"
+            if not isinstance(base_func, tirx.PrimFunc):
+                raise TypeError(
+                    f"{function_path} is {_node_name(base_func)}, expected tvm.tirx.PrimFunc"
+                )
+            yield function_path, base_func
+        return
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            yield from _iter_prim_funcs(item, f"{path}[{key!r}]")
+        return
+
+    if isinstance(value, list | tuple):
+        for index, item in enumerate(value):
+            yield from _iter_prim_funcs(item, f"{path}[{index}]")
+        return
+
+    raise TypeError(
+        f"{path} is {_node_name(value)}, expected a TIRx PrimFunc, IRModule, "
+        "or a list/tuple/dict containing them"
+    )
+
+
+def inspect_low_level_ir(value: Any) -> LowLevelIRReport:
+    """Inspect a public ``get_kernel`` return value without lowering it.
+
+    ``value`` may be a TIRx ``PrimFunc``, ``IRModule``, or nested list, tuple,
+    or mapping containing those objects.  Direct ``tirx.address_of`` operands
+    are reported separately and do not count as memory reads.
+    """
+    checked_functions: list[str] = []
+    violations: list[LowLevelIRFinding] = []
+    address_only_loads: list[LowLevelIRFinding] = []
+
+    for path, prim_func in _iter_prim_funcs(value):
+        checked_functions.append(path)
+        visitor = _LowLevelIRVisitor(path)
+        visitor(prim_func.body)
+        violations.extend(visitor.violations)
+        address_only_loads.extend(visitor.address_only_loads)
+
+    if not checked_functions:
+        raise TypeError("root must contain at least one TIRx PrimFunc")
+
+    return LowLevelIRReport(
+        checked_functions=tuple(checked_functions),
+        violations=tuple(violations),
+        address_only_loads=tuple(address_only_loads),
+    )
+
+
+def check_low_level_ir(value: Any) -> LowLevelIRReport:
+    """Return a report for valid IR, or raise ``LowLevelIRContractError``."""
+    report = inspect_low_level_ir(value)
+    if not report.ok:
+        raise LowLevelIRContractError(report)
+    return report
+
+
+__all__ = [
+    "LowLevelIRContractError",
+    "LowLevelIRFinding",
+    "LowLevelIRReport",
+    "check_low_level_ir",
+    "inspect_low_level_ir",
+]

--- a/tirx_kernels/normalization/rmsnorm.py
+++ b/tirx_kernels/normalization/rmsnorm.py
@@ -668,11 +668,13 @@ def _get_rmsnorm_kernel(hidden_size):
         x_smem = pool.alloc([hidden_size], "float32")
         sum_sq_smem = pool.alloc([bdy], "float32")
         pool.commit()
-        input_vec: T.f16[vec_size]
-        weight_vec: T.f16[vec_size]
+        input_words: T.uint32[vec_size // 2]
+        weight_words: T.uint32[vec_size // 2]
+        output_words: T.uint32[vec_size // 2]
         input_vec_f32: T.f32[vec_size]
         weight_vec_f32: T.f32[vec_size]
         x_vec: T.f32[vec_size]
+        packed_mul: T.uint64
         x_tmp: T.f32
         sum_sq: T.f32
         rms_norm: T.f32
@@ -682,34 +684,131 @@ def _get_rmsnorm_kernel(hidden_size):
             sum_sq = 0.0
             for ki in T.serial(ceildiv(hidden_size, vec_size * bdx * bdy)):
                 for kv in T.unroll(vec_size):
-                    input_vec[kv] = 0.0
                     x_vec[kv] = 0.0
                 st = T.meta_var((ki * bdx * bdy + thread_id) * vec_size)
                 if st < hidden_size:
-                    Tx.copy(input_vec[:], input_global[idx, st : st + vec_size])
-                    Tx.cast(input_vec_f32[:], input_vec[:])
+                    T.ptx.ld.global_.v4.b32(
+                        input_words[0],
+                        input_words[1],
+                        input_words[2],
+                        input_words[3],
+                        input_global.ptr_to([idx, st]),
+                    )
+                    for pair in T.unroll(vec_size // 2):
+                        input_vec_f32[pair * 2] = T.cast(
+                            T.reinterpret(
+                                "float16",
+                                T.cast(
+                                    T.bitwise_and(input_words[pair], T.uint32(0xFFFF)), "uint16"
+                                ),
+                            ),
+                            "float32",
+                        )
+                        input_vec_f32[pair * 2 + 1] = T.cast(
+                            T.reinterpret(
+                                "float16",
+                                T.cast(T.shift_right(input_words[pair], T.uint32(16)), "uint16"),
+                            ),
+                            "float32",
+                        )
                     for kv in T.unroll(vec_size):
                         x_tmp = input_vec_f32[kv]
                         sum_sq = sum_sq + x_tmp * x_tmp
                         x_vec[kv] = x_tmp
-                    Tx.copy(x_smem[st : st + vec_size], x_vec[:])
-            sum_sq = T.cuda.cta_sum(sum_sq, bdy, sum_sq_smem.ptr_to([0]))
+                    T.ptx.st.shared.v4.f32(
+                        x_smem.ptr_to([st]), x_vec[0], x_vec[1], x_vec[2], x_vec[3]
+                    )
+                    T.ptx.st.shared.v4.f32(
+                        x_smem.ptr_to([st + 4]), x_vec[4], x_vec[5], x_vec[6], x_vec[7]
+                    )
+
+            sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 16, bdx)
+            sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 8, bdx)
+            sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 4, bdx)
+            sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 2, bdx)
+            sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 1, bdx)
+            if tx == 0:
+                T.ptx.st.shared.f32(sum_sq_smem.ptr_to([ty]), sum_sq)
+            T.ptx.bar.sync(0, T.uint32(bdx * bdy))
+            if ty == 0:
+                if tx < bdy:
+                    T.ptx.ld.shared.f32(sum_sq, sum_sq_smem.ptr_to([tx]))
+                else:
+                    sum_sq = 0.0
+                sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 16, bdx)
+                sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 8, bdx)
+                sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 4, bdx)
+                sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 2, bdx)
+                sum_sq = sum_sq + T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_sq, 1, bdx)
+                if tx == 0:
+                    T.ptx.st.shared.f32(sum_sq_smem.ptr_to([0]), sum_sq)
+            T.ptx.bar.sync(0, T.uint32(bdx * bdy))
+            T.ptx.ld.shared.f32(sum_sq, sum_sq_smem.ptr_to([0]))
             rms_norm = T.rsqrt(sum_sq / hidden_size + eps)
             for ki in T.serial(ceildiv(hidden_size, vec_size * bdx * bdy)):
                 for kv in T.unroll(vec_size):
-                    input_vec[kv] = 0.0
                     weight_vec_f32[kv] = 0.0
                     x_vec[kv] = 0.0
                 st = T.meta_var((ki * bdx * bdy + thread_id) * vec_size)
                 if st < hidden_size:
-                    Tx.copy(weight_vec[:], weight_global[st : st + vec_size])
-                    Tx.copy(x_vec[:], x_smem[st : st + vec_size])
-                    Tx.cast(weight_vec_f32[:], weight_vec[:])
-                Tx.mul(input_vec_f32[:], x_vec[:], rms_norm)
-                Tx.mul(input_vec_f32[:], input_vec_f32[:], weight_vec_f32[:])
+                    T.ptx.ld.global_.v4.b32(
+                        weight_words[0],
+                        weight_words[1],
+                        weight_words[2],
+                        weight_words[3],
+                        weight_global.ptr_to([st]),
+                    )
+                    T.ptx.ld.shared.v4.f32(
+                        x_vec[0], x_vec[1], x_vec[2], x_vec[3], x_smem.ptr_to([st])
+                    )
+                    T.ptx.ld.shared.v4.f32(
+                        x_vec[4], x_vec[5], x_vec[6], x_vec[7], x_smem.ptr_to([st + 4])
+                    )
+                    for pair in T.unroll(vec_size // 2):
+                        weight_vec_f32[pair * 2] = T.cast(
+                            T.reinterpret(
+                                "float16",
+                                T.cast(
+                                    T.bitwise_and(weight_words[pair], T.uint32(0xFFFF)), "uint16"
+                                ),
+                            ),
+                            "float32",
+                        )
+                        weight_vec_f32[pair * 2 + 1] = T.cast(
+                            T.reinterpret(
+                                "float16",
+                                T.cast(T.shift_right(weight_words[pair], T.uint32(16)), "uint16"),
+                            ),
+                            "float32",
+                        )
+                for pair in T.unroll(vec_size // 2):
+                    T.ptx.mul.rz.ftz.f32x2(
+                        packed_mul,
+                        T.cuda.make_float2(x_vec[pair * 2], x_vec[pair * 2 + 1]),
+                        T.cuda.make_float2(rms_norm, rms_norm),
+                    )
+                    input_vec_f32[pair * 2] = T.cuda.float2_x(packed_mul)
+                    input_vec_f32[pair * 2 + 1] = T.cuda.float2_y(packed_mul)
+                for pair in T.unroll(vec_size // 2):
+                    T.ptx.mul.rz.ftz.f32x2(
+                        packed_mul,
+                        T.cuda.make_float2(input_vec_f32[pair * 2], input_vec_f32[pair * 2 + 1]),
+                        T.cuda.make_float2(weight_vec_f32[pair * 2], weight_vec_f32[pair * 2 + 1]),
+                    )
+                    input_vec_f32[pair * 2] = T.cuda.float2_x(packed_mul)
+                    input_vec_f32[pair * 2 + 1] = T.cuda.float2_y(packed_mul)
                 if st < hidden_size:
-                    Tx.cast(input_vec[:], input_vec_f32[:])
-                    Tx.copy(out_global[idx, st : st + vec_size], input_vec[:])
+                    for pair in T.unroll(vec_size // 2):
+                        T.ptx.cvt.rn.f16x2.f32(
+                            output_words[pair], input_vec_f32[pair * 2 + 1], input_vec_f32[pair * 2]
+                        )
+                    T.ptx.st.global_.v4.b32(
+                        out_global.ptr_to([idx, st]),
+                        output_words[0],
+                        output_words[1],
+                        output_words[2],
+                        output_words[3],
+                    )
             T.ptx.bar.sync(1, T.uint32(bdx * bdy))
             idx = idx + SM_COUNT
 

--- a/tirx_kernels/registry.py
+++ b/tirx_kernels/registry.py
@@ -31,7 +31,7 @@ _log = logging.getLogger(__name__)
 # CLI / package infra — not kernel categories.
 _SKIP_CATEGORIES = frozenset({"bench", "test", "bench_suite", "experimental"})
 
-_KERNEL_CACHE: dict[str, ModuleType] = {}
+_REQUIRED_META_TYPES = {"name": str, "category": str, "compute_capability": int}
 
 
 def _kernels_root() -> Path:
@@ -59,41 +59,58 @@ def _import_kernel_module(category: str, mod_name: str, *, strict: bool) -> Modu
             raise
         _log.warning("tirx_kernels: failed to import %s.%s: %s", pkg_name, mod_name, e)
         return None
-    meta = getattr(mod, "KERNEL_META", None)
-    if meta is not None and isinstance(meta, dict) and "name" in meta:
-        _KERNEL_CACHE[meta["name"]] = mod
-        return mod
-    return None
+    if not hasattr(mod, "KERNEL_META"):
+        return None
+
+    meta = mod.KERNEL_META
+    errors: list[str] = []
+    if not isinstance(meta, dict):
+        errors.append(f"expected dict, got {type(meta).__name__}")
+    else:
+        for field, expected_type in _REQUIRED_META_TYPES.items():
+            value = meta.get(field)
+            if not isinstance(value, expected_type) or isinstance(value, bool):
+                errors.append(f"{field!r} must be {expected_type.__name__}")
+            elif expected_type is str and not value:
+                errors.append(f"{field!r} must not be empty")
+        if meta.get("category") != category:
+            errors.append(
+                f"'category' is {meta.get('category')!r}, expected containing category {category!r}"
+            )
+
+    if errors:
+        message = f"tirx_kernels.{category}.{mod_name} has invalid KERNEL_META: " + "; ".join(
+            errors
+        )
+        if strict:
+            raise ValueError(message)
+        _log.warning(message)
+        return None
+
+    return mod
 
 
 def load_kernel(name: str, *, strict: bool = False) -> ModuleType:
     """Import a single kernel module by ``KERNEL_META['name']``.
 
-    Uses an in-process cache populated by prior ``load_kernel`` / ``discover_kernels``
-    calls. Raises ``KeyError`` when no matching kernel is installed.
+    The complete registry is validated before selecting the requested name, so
+    duplicate public identities can never be hidden by scan order or a cache.
+    Raises ``KeyError`` when no matching kernel is installed.
     """
-    if name in _KERNEL_CACHE:
-        return _KERNEL_CACHE[name]
-
-    for cat in discover_categories():
-        pkg_path = _kernels_root() / cat
-        if not pkg_path.is_dir():
-            continue
-        for _importer, mod_name, is_pkg in pkgutil.iter_modules([str(pkg_path)]):
-            if mod_name.startswith("_") or is_pkg:
-                continue
-            mod = _import_kernel_module(cat, mod_name, strict=strict)
-            if mod is not None and mod.KERNEL_META["name"] == name:
-                return mod
-
-    raise KeyError(name)
+    kernels = discover_kernels(strict=strict)
+    try:
+        return kernels[name]
+    except KeyError:
+        raise KeyError(name) from None
 
 
 def check_workload_imports(workloads: list[dict], *, strict: bool = True) -> list[str]:
     """Import every unique kernel referenced in a workloads list. Returns kernel names."""
     names = sorted({w["kernel"] for w in workloads})
+    kernels = discover_kernels(strict=strict)
     for name in names:
-        load_kernel(name, strict=strict)
+        if name not in kernels:
+            raise KeyError(name)
     return names
 
 
@@ -108,7 +125,13 @@ def _scan_category(category: str, *, strict: bool) -> dict[str, ModuleType]:
             continue
         mod = _import_kernel_module(category, mod_name, strict=strict)
         if mod is not None:
-            result[mod.KERNEL_META["name"]] = mod
+            name = mod.KERNEL_META["name"]
+            if name in result:
+                raise ValueError(
+                    f"duplicate kernel registry name {name!r}: "
+                    f"{result[name].__name__} and {mod.__name__}"
+                )
+            result[name] = mod
     return result
 
 
@@ -132,7 +155,14 @@ def discover_kernels(
     categories = [category] if category else discover_categories()
     result: dict[str, ModuleType] = {}
     for cat in categories:
-        result.update(_scan_category(cat, strict=strict))
+        category_kernels = _scan_category(cat, strict=strict)
+        for name, mod in category_kernels.items():
+            if name in result:
+                raise ValueError(
+                    f"duplicate kernel registry name {name!r}: "
+                    f"{result[name].__name__} and {mod.__name__}"
+                )
+            result[name] = mod
     if min_compute_capability is not None:
         result = {
             name: mod


### PR DESCRIPTION
## Summary

- land the low-level TIRx migration developed through #18, #20, and #22
- enforce the low-level IR contract across the public kernel registry
- replace supported CUDA source wrappers with registered PTX operations
- express the remaining FlashAttention-4 descriptor offset logic directly in TIR
- rebase the three-commit stack onto current `main` through #21

## Validation

- `git range-diff` reports all three rebased commits as patch-equivalent to the pre-rebase stack
- `ruff check .` passes
- `git diff --check origin/main...HEAD` passes
- the full 796-test suite reached its final GPU test with only two known IKET failures before a TRT-LLM GPU test exited with SIGSEGV
- both IKET failures reproduce identically on pre-rebase `fb9ca74`
- isolated TRT-LLM head64 and head128 SIGSEGVs reproduce on both pre-rebase `fb9ca74` and rebased `89c7761`
