### PR TITLE
Drop the FLASHKDA_PR_WORKTREE requirement now that the m128 reference ships in flashinfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tirx-kernels
+# TIRx kernels
 
 High-performance GPU kernels written in [TIRx](https://github.com/apache/tvm).
 
@@ -74,10 +74,6 @@ point each port backs:
 | Kernel | dtype | What it is |
 | ------ | ----- | ---------- |
 | `tinygemm2_sm100` | bf16 | TinyGEMM2 |
-
-Testing/benching against the `flashinfer_m128` reference requires
-`FLASHKDA_PR_WORKTREE` pointing at the flashinfer-ai/flashinfer#4262 head
-worktree containing the m128 kernel.
 
 `flashmla/` — FlashMLA sparse attention ports:
 

--- a/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
+++ b/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
@@ -34,8 +34,6 @@ Target instance: BF16, head_dim 128, sm_100a, grid = num_seqs * num_heads,
 from __future__ import annotations
 
 import math
-import os
-import sys
 from dataclasses import dataclass, fields
 from typing import Any
 from unittest import SkipTest
@@ -859,41 +857,14 @@ def _reference_torch(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
 
 
 def _load_flashinfer_recurrent_kda():
-    """Import flashinfer.recurrent_kda from the PR head worktree.
-
-    The flashinfer-ai/flashinfer#4262 head worktree is located via the
-    FLASHKDA_PR_WORKTREE environment variable.
-    Handles the case where an installed flashinfer (main, without kda.py) was
-    already imported by purging it and re-importing from the worktree.
-    """
-    worktree = os.environ.get("FLASHKDA_PR_WORKTREE")
-    if worktree is None:
-        try:
-            from flashinfer.kda import recurrent_kda
-
-            return recurrent_kda
-        except ImportError as e:
-            raise RuntimeError(
-                "flashinfer.kda is unavailable; set FLASHKDA_PR_WORKTREE to the "
-                "flashinfer-ai/flashinfer#4262 head worktree containing the m128 kernel"
-            ) from e
-    if worktree not in sys.path:
-        sys.path.insert(0, worktree)
-    import flashinfer
-
-    if not str(getattr(flashinfer, "__file__", "")).startswith(worktree):
-        for mod_name in [
-            m for m in list(sys.modules) if m == "flashinfer" or m.startswith("flashinfer.")
-        ]:
-            del sys.modules[mod_name]
-        import flashinfer
-
-        if not str(getattr(flashinfer, "__file__", "")).startswith(worktree):
-            raise RuntimeError(
-                f"failed to import flashinfer from PR worktree {worktree}; "
-                f"got {getattr(flashinfer, '__file__', None)}"
-            )
-    from flashinfer.kda import recurrent_kda
+    """Import the reference kernel from the installed flashinfer."""
+    try:
+        from flashinfer.kda import recurrent_kda
+    except ImportError as e:
+        raise RuntimeError(
+            "flashinfer.kda is unavailable; the m128 reference needs a flashinfer "
+            "release that carries it (flashinfer-ai/flashinfer#4262 or later)"
+        ) from e
 
     return recurrent_kda
 


### PR DESCRIPTION
`_load_flashinfer_recurrent_kda` carried a worktree override: point `FLASHKDA_PR_WORKTREE` at a checkout of the flashinfer-ai/flashinfer#4262 head, and the loader would prepend it to `sys.path`, then — if an already-imported mainline flashinfer shadowed it — delete every `flashinfer*` entry from `sys.modules` and import again. That existed because mainline flashinfer had no `kda.py` at the time.

#4262 merged on 2026-08-03 and the kernel ships in the release, so `from flashinfer.kda import recurrent_kda` resolves on its own. The override is now dead weight, and a runtime `sys.modules` purge is not something worth keeping once nothing needs it. The loader is a plain import with a clearer failure message; `os` and `sys` were only used by the removed branch and go with it.

The README note instructing people to set the variable is dropped, and the title is now "TIRx kernels". The distribution name in the `pip install` line is unchanged.

### Verification

With `FLASHKDA_PR_WORKTREE` explicitly unset:

- `python -m tirx_kernels.test --kernel flashkda_bf16_fused_m128` — 6/6 passed, flashinfer's JIT loads the m128 reference module
- `python -m tirx_kernels.registry --cc 10 --strict` — 38 kernels
- `pre-commit run` over the touched files — clean, including the `ruff` unused-import check
