### PR TITLE
feat(kernel): add SM100 GDN decode kernel

### DIFF
--- a/.agents/sketch/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.md
+++ b/.agents/sketch/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.md
@@ -1,0 +1,546 @@
+<!--
+Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0
+
+This design sketch documents a modified TIRx port of FlashInfer's
+gdn_decode_bf16_state.py. See LICENSE, NOTICE, and licenses/ for the
+applicable terms.
+-->
+
+# GDN decode BF16 wide-vector T1 SM100: execution sketch
+
+This file is a non-executable execution sketch.  It freezes the lane ownership,
+shared publication, register-resident state update, packed-FP32x2 arithmetic,
+and vector state traffic of FlashInfer's CuTeDSL
+`gdn_wide_vec_kernel_t1`.  The target implementation is
+[`tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py`](../../tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py),
+which may become executable only after this sketch passes independent review.
+
+The frozen FlashInfer commit is
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`; the source SHA256 is
+`61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61`.
+The target is SM100a/B200 and fixes T=1, K=V=128, BF16 Q/K/V/state/output,
+FP32 A_log/dt_bias/accumulators, and packed `fma.rn.f32x2`.  `tile_v` is 64
+or 128.  The direct-source branches for Q/K L2 normalization, same/split state
+pool, padded slot stride, packed QKV batch strides, negative slot indices,
+disabled state update, and intermediate-state caching remain in scope.
+
+The production dispatcher reaches this body only when `B*HV >= 512`: it uses
+`tile_v=64` for `[512,1024)` and `tile_v=128` at `>=1024`.  T>1, K/V other
+than 128, FP32 state, the ILP4 kernel, and the source's direct-only
+`tile_v=32` specialization are out of scope.
+
+## Pipeline at a glance
+
+There is no asynchronous pipeline and no mbarrier.  A single CTA barrier is
+the only publication edge.  T=1 specializes the source's four-warps-over-T
+precompute loop to one active logical warp: warp 0 performs the complete Q,
+K, K-Q dot, g, and beta producer chain while warps 1..3 wait at the barrier.
+After the barrier all eight 16-lane groups run independently.
+
+| Physical lanes | Role-local program | Publication/reuse edge |
+| --- | --- | --- |
+| warp 0, lanes 0..31 | two redundant 16-lane halves issue eight scalar Q and eight scalar K loads, optionally normalize both vectors, publish sQ/sK, reduce K-Q, and form the g/beta chains | scalar shared stores for Q/K and three lane-0 g/beta/kq stores, then CTA `bar.sync 0` |
+| warps 1..3 | no Phase-0 producer work for T=1 | wait at the CTA `bar.sync 0` |
+| groups 0..7 after barrier, 16 lanes each | each lane owns eight adjacent K values; each group owns 8 V rows at tile 64 or 16 V rows at tile 128 and processes four rows per fully-unrolled iteration | shared Q/K/g/beta are read-only; state remains in registers for each four-row iteration |
+| lane 0 of each 16-lane group | writes four output rows per iteration | no further synchronization; each group owns disjoint V rows |
+| every lane after each iteration | optionally writes four 16-byte state vectors either to intermediate storage or the selected output-pool slot | disjoint `(V-row,K-segment)` ownership |
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)       # compile-time source variant
+launch(...)           # physical grid/block/shared metadata
+raw_shared(...)       # one dynamic shared allocation
+view(...)             # typed storage view without a copy
+alias(...)            # exact read/write storage alias
+reg_tile(...)         # lane-private register tile
+```
+
+Copies expose storage direction:
+
+```python
+copy_g2r(src, dst=None, predicate=None)
+copy_s2r(src, dst=None)
+copy_r2s(src, dst)
+copy_r2g(src, dst, predicate=None)
+```
+
+Computation and synchronization stay primitive:
+
+```python
+cast(dtype, src, rounding=None)
+add(lhs, rhs)
+sub(lhs, rhs)
+mul(lhs, rhs)
+fma(lhs, rhs, acc, lanes=1)
+exp2(src)
+log2(src)
+reciprocal(src)
+rsqrt(src)
+select(predicate, true_value, false_value)
+setp_le(lhs, rhs)
+selp(predicate, true_value, false_value)
+unpack_b32_pair(src)
+shuffle_xor(src, lane_delta, member_mask, clamp)
+warp_uniform(src, source_lane, member_mask, clamp)
+cta_barrier()
+```
+
+`fma(..., lanes=2)` is one packed two-lane FP32 operation with two ordered
+results.  A copy of a stated eight-element tile is one explicit loop of the
+same scalar PTX family; a four-row state copy is four separately stated
+128-bit operations.  Address arithmetic and static view construction are not
+expanded because they do not change ownership, masking, control flow, or
+instruction selection.  There is deliberately no `normalize`, `softplus`,
+`sigmoid`, `reduce`, `delta_rule`, or `update_state` compound primitive.
+
+## Complete sketch
+
+```python
+# ==========================================================================
+# Static specialization, runtime ABI, launch, and storage
+# ==========================================================================
+
+@specialize(
+    T=1,
+    H=(16, 8, 4, 2),
+    HV=(32, 16, 8, 4),
+    K=128,
+    V=128,
+    TILE_V=(64, 128),
+    USE_QK_L2NORM=(False, True),
+    DISABLE_STATE_UPDATE=(False, True),
+    CACHE_INTERMEDIATE_STATES=(False, True),
+    USE_PACKED_FMA=True,
+    SAME_POOL=(False, True),
+    SOFTPLUS_BETA=1.0,
+    SOFTPLUS_THRESHOLD=20.0,
+    SCALE=1.0/sqrt(128.0),
+    target="sm_100a",
+)
+@launch(
+    grid=(batch * HV * (128 // TILE_V), 1, 1),
+    block=(128, 1, 1),
+    num_warps=4,
+    dynamic_smem_bytes=1356,
+)
+def gdn_decode_bf16_wide_vec_t1(
+    state,                  # bf16 [pool,HV,128,128], mutable
+    intermediate,           # bf16 [B,1,HV,128,128] or dummy
+    A_log,                  # f32  [HV]
+    a,                      # bf16 [B,1,HV]
+    dt_bias,                # f32  [HV]
+    q, k,                   # bf16 [B,1,H,128]
+    v, b_gate,              # bf16 [B,1,HV,128], bf16 [B,1,HV]
+    output,                 # bf16 [B,1,HV,128]
+    read_indices,           # i32  [B]
+    write_indices,          # i32  [B], ignored when SAME_POOL or no final pool write survives
+    batch,                  # i32 runtime launch extent
+    state_slot_stride,      # i64 BF16 elements, permits padded 4-D pool
+    q_batch_stride,         # i64 BF16 elements, permits packed QKV view
+    k_batch_stride,         # i64 BF16 elements
+    v_batch_stride,         # i64 BF16 elements
+):
+    NUM_GROUPS = 8
+    LANES_PER_GROUP = 16
+    ELEMS_PER_LANE = 8
+    ILP_ROWS = 4
+    ROWS_PER_GROUP = TILE_V // NUM_GROUPS       # 8 or 16
+    ITERS_PER_GROUP = ROWS_PER_GROUP // ILP_ROWS # 2 or 4
+    NUM_V_TILES = 128 // TILE_V                  # 2 or 1
+
+    tid = thread_id(axis="x", extent=128)
+    warp_raw = tid // 32
+    warp = warp_uniform(
+        warp_raw, source_lane=0, member_mask=0xffffffff, clamp=32)
+    # This mirrors cute.arch.make_warp_uniform(cute.arch.warp_idx()).
+    lane_in_warp = tid % 32
+    group = tid // 16
+    lane = tid % 16
+    k_start = lane * 8
+
+    linear_cta = cta_id(axis="x")
+    v_tile = linear_cta % NUM_V_TILES
+    tmp = linear_cta // NUM_V_TILES
+    hv = tmp % HV
+    n = tmp // HV
+    h = hv // (HV // H)
+
+    read_slot = copy_g2r(read_indices[n])
+    # instruction_selection: ld.global.b32; extent: one i32 slot index per CTA thread, with compiler hoisting/sinking permitted
+    # The source requests 1356 dynamic bytes and gives each typed allocation
+    # 16-byte alignment.  For T=1 the logical cosize of each (1,128),
+    # stride-(136,1) view is 128 floats, so reviewed PTX uses offsets 0, 512,
+    # and 1024.  The remaining 340 bytes are reservation tail.
+    smem = raw_shared(dtype="u8", bytes=1356, alignment=16)
+    sQ = view(
+        smem[0:512], dtype="f32", shape=(1,128), stride=(136,1), alignment=16)
+    sK = view(
+        smem[512:1024], dtype="f32", shape=(1,128), stride=(136,1), alignment=16)
+    sGB = view(
+        smem[1024:1036], dtype="f32", shape=(1,3), stride=(3,1), alignment=16)
+    # Slot 2 holds the source's published K-Q dot.  Phase 1 does not consume
+    # it for T=1, but the frozen generated source retains the producer/store.
+
+    r_q_bf16 = reg_tile(dtype="bf16", shape=(8,))
+    r_k_bf16 = reg_tile(dtype="bf16", shape=(8,))
+    r_q = reg_tile(dtype="f32", shape=(8,))
+    r_k = reg_tile(dtype="f32", shape=(8,))
+    r_h_words = reg_tile(dtype="u32", shape=(4,4))
+    r_h_bf16 = reg_tile(dtype="bf16", shape=(4,8))
+    r_h = reg_tile(dtype="f32", shape=(4,8))
+    r_k_main = reg_tile(dtype="f32", shape=(4,2))
+    r_q_main = reg_tile(dtype="f32", shape=(4,2))
+
+    read_slot = select(read_slot < 0, 0, read_slot)
+    # instruction_selection: max.s32(index,0); extent: one scalar null-slot redirect
+
+    if SAME_POOL:
+        write_slot = read_slot
+        write_state = alias(state[read_slot], state[read_slot])
+    else:
+        write_slot = copy_g2r(write_indices[n])
+        # instruction_selection: ld.global.b32; extent: one i32 split-pool write slot per CTA thread only when not DISABLE_STATE_UPDATE and not CACHE_INTERMEDIATE_STATES; zero instructions after constexpr DCE when no final pool write survives
+        write_slot = select(write_slot < 0, 0, write_slot)
+        # instruction_selection: max.s32(index,0); extent: one scalar null-slot redirect only when not DISABLE_STATE_UPDATE and not CACHE_INTERMEDIATE_STATES; zero instructions after constexpr DCE when no final pool write survives
+        write_state = state[cast("i64", write_slot), hv, :, :]
+
+    read_state = state[cast("i64", read_slot), hv, :, :]
+    # cast to i64 participates in wide state-slot offset arithmetic; the
+    # runtime state_slot_stride is retained and may exceed HV*128*128.
+
+    # ==========================================================================
+    # Phase 0: the only T=1 precompute pass belongs to logical warp 0.
+    # Warps 1..3 execute no producer instructions before the CTA barrier.
+    # ==========================================================================
+
+    if warp == 0:
+        member_pre = lane_in_warp % 16
+        k_pre = member_pre * 8
+
+        # The frozen PTX sinks the two uniform FP32 loads into warp 0 before
+        # the Q/K tile traffic, physically issuing dt_bias and then A_log.
+        dt_value = copy_g2r(dt_bias[hv])
+        A_value = copy_g2r(A_log[hv])
+
+        for i in static_range(8):
+            r_q_bf16[i] = copy_g2r(q[n, 0, h, k_pre+i])
+            # instruction_selection: ld.global.b16; extent: one scalar Q load
+            # per loop instance, using the runtime batch stride
+        for i in static_range(8):
+            r_k_bf16[i] = copy_g2r(k[n, 0, h, k_pre+i])
+            # instruction_selection: ld.global.b16; extent: one scalar K load
+            # per loop instance, using the runtime batch stride
+        for i in static_range(8):
+            r_q[i] = cast("f32", r_q_bf16[i])
+            r_k[i] = cast("f32", r_k_bf16[i])
+            # instruction_selection: cvt.f32.bf16; extent: Q then K scalar
+            # conversions for each element after both complete load tiles
+
+        if USE_QK_L2NORM:
+            sum_q = 0.0
+            sum_k = 0.0
+            for i in static_range(8):
+                sum_q = fma(r_q_bf16[i], r_q_bf16[i], sum_q)
+                sum_k = fma(r_k_bf16[i], r_k_bf16[i], sum_k)
+                # instruction_selection: fma.rn.f32.bf16; extent: two scalar
+                # square-accumulates, eight loop instances
+
+            for delta in (8, 4, 2, 1):
+                peer_q = shuffle_xor(sum_q, delta, member_mask=-1, clamp=31)
+                # instruction_selection: shfl.sync.bfly.b32; extent: one scalar, four explicit stages
+                sum_q = add(sum_q, peer_q)
+                peer_k = shuffle_xor(sum_k, delta, member_mask=-1, clamp=31)
+                sum_k = add(sum_k, peer_k)
+                # instruction_selection: add.f32; extent: two scalars, four explicit stages
+
+            q_eps = add(sum_q, 1.0e-6)
+            # instruction_selection: add.f32; extent: one scalar
+            inv_q = rsqrt(q_eps)
+            # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar
+            q_factor = mul(inv_q, SCALE)
+            # instruction_selection: mul.f32; extent: one scalar
+            k_factor = rsqrt(add(sum_k, 1.0e-6))
+            for i in static_range(8):
+                r_q[i] = mul(r_q[i], q_factor)
+                r_k[i] = mul(r_k[i], k_factor)
+                # instruction_selection: mul.f32; extent: two scalars, eight loop instances
+        else:
+            for i in static_range(8):
+                r_q[i] = mul(r_q[i], SCALE)
+                # instruction_selection: mul.f32; extent: one scalar, eight loop instances
+
+        copy_r2s(r_q, sQ[0, k_pre:k_pre+8])
+        copy_r2s(r_k, sK[0, k_pre:k_pre+8])
+        # instruction_selection: st.shared.b32; extent: explicit unrolled loop
+        # of eight Q and eight K scalar stores; both half-warps write identical locations
+
+        kq = 0.0
+        for i in static_range(8):
+            kq = fma(r_k[i], r_q[i], kq)
+            # instruction_selection: fma.rn.f32; extent: eight ordered scalar FMAs
+        for delta in (8, 4, 2, 1):
+            kq = add(kq, shuffle_xor(kq, delta, member_mask=-1, clamp=31))
+            # instruction_selection: shfl.sync.bfly.b32 plus add.f32;
+            # extent: one scalar at each of four explicit stages
+
+        a_value = copy_g2r(a[n, 0, hv])
+        # instruction_selection: ld.global.b16; extent: one scalar BF16 gate input per active thread
+        x = add(cast("f32", a_value), dt_value)
+        # instruction_selection: add.rn.f32.bf16 in reviewed PTX; extent: one scalar mixed BF16/FP32 add
+        beta_x = x  # constexpr identity because SOFTPLUS_BETA is 1.0; zero instructions
+        beta_x_log2 = mul(beta_x, LOG2E)
+        # instruction_selection: mul.f32; extent: one scalar base conversion
+        exp_beta_x = exp2(beta_x_log2)
+        # instruction_selection: ex2.approx.ftz.f32; extent: one scalar
+        one_plus_exp = add(1.0, exp_beta_x)
+        # instruction_selection: add.f32; extent: one scalar
+        log_softplus = log2(one_plus_exp)
+        # instruction_selection: lg2.approx.ftz.f32; extent: one scalar
+        log_softplus = mul(log_softplus, LN2)
+        # instruction_selection: mul.f32; extent: one scalar base conversion
+        softplus_value = log_softplus  # constexpr reciprocal/multiply fold; zero instructions
+        use_softplus_pred = setp_le(beta_x, SOFTPLUS_THRESHOLD)
+        use_softplus = selp(use_softplus_pred, 1.0, 0.0)
+        # instruction_selection: setp.le.f32 plus selp.f32; extent: one scalar threshold branch without control divergence
+        direct_weight = sub(1.0, use_softplus)
+        # instruction_selection: sub.f32; extent: one scalar
+        softplus_x = mul(x, direct_weight)
+        # instruction_selection: mul.f32; extent: one scalar direct branch
+        softplus_x = fma(softplus_value, use_softplus, softplus_x)
+        # instruction_selection: fma.rn.f32; extent: one scalar selected result
+
+        A_log2 = mul(A_value, LOG2E)
+        # instruction_selection: mul.f32; extent: one scalar base conversion
+        exp_A = exp2(A_log2)
+        # instruction_selection: ex2.approx.ftz.f32; extent: one scalar
+        gate_exponent = mul(-exp_A, softplus_x)
+        # instruction_selection: neg.f32 plus mul.f32; extent: one scalar each
+        if lane_in_warp == 0:
+            b_value = copy_g2r(b_gate[n, 0, hv])
+            neg_b_log2 = mul(cast("f32", b_value), -LOG2E)
+            exp_neg_b = exp2(neg_b_log2)
+            beta = reciprocal(add(1.0, exp_neg_b))
+            # The b load and complete beta chain are physically lane-0-only.
+            gate_log2 = mul(gate_exponent, LOG2E)
+            # instruction_selection: mul.f32; extent: one scalar base conversion
+            g = exp2(gate_log2)
+            # instruction_selection: ex2.approx.ftz.f32; extent: one scalar
+            copy_r2s(g, sGB[0, 0])
+            copy_r2s(beta, sGB[0, 1])
+            copy_r2s(kq, sGB[0, 2])
+            # instruction_selection: st.shared.b32; extent: three scalar
+            # stores by physical warp-0 lane 0
+
+    cta_barrier()
+    # instruction_selection: bar.sync 0; extent: one CTA-wide publication point reached by all 128 threads
+
+    # ==========================================================================
+    # Phase 1: eight independent 16-lane groups, four V rows at a time
+    # Source lines 2163-2410.  The source constexpr loop and reviewed PTX are
+    # fully unrolled to 2 bodies for TILE_V=64 or 4 for TILE_V=128.
+    # ==========================================================================
+
+    for iter_idx in static_range(ITERS_PER_GROUP):
+        v_base = v_tile * TILE_V + group * ROWS_PER_GROUP + iter_idx * 4
+        v_rows = (v_base + 0, v_base + 1, v_base + 2, v_base + 3)
+
+        copy_g2r(read_state[v_rows[0], k_start:k_start+8], r_h_words[0])
+        # instruction_selection: one 16-byte vector containing eight adjacent
+        # BF16 K values; ordinary global cache qualifier for both tile sizes
+        for pair in (3, 2, 1, 0):
+            r_h_bf16[0, 2*pair:2*pair+2] = unpack_b32_pair(r_h_words[0, pair])
+        copy_g2r(read_state[v_rows[1], k_start:k_start+8], r_h_words[1])
+        # instruction_selection: ld.global.v4.b32; extent: one independent 16-byte vector
+        for pair in (3, 2, 1, 0):
+            r_h_bf16[1, 2*pair:2*pair+2] = unpack_b32_pair(r_h_words[1, pair])
+        copy_g2r(read_state[v_rows[2], k_start:k_start+8], r_h_words[2])
+        # instruction_selection: ld.global.v4.b32; extent: one independent 16-byte vector
+        for pair in (3, 2, 1, 0):
+            r_h_bf16[2, 2*pair:2*pair+2] = unpack_b32_pair(r_h_words[2, pair])
+        copy_g2r(read_state[v_rows[3], k_start:k_start+8], r_h_words[3])
+        # instruction_selection: ld.global.v4.b32; extent: one independent 16-byte vector
+        for pair in (3, 2, 1, 0):
+            r_h_bf16[3, 2*pair:2*pair+2] = unpack_b32_pair(r_h_words[3, pair])
+        # Each load is immediately followed by its four mov.b32 pair unpacks
+        # in reverse word order; all 16 unpacks precede any conversion.
+        for element in static_range(8):
+            for row in static_range(4):
+                r_h[row, element] = cast("f32", r_h_bf16[row, element])
+        # instruction_selection: cvt.f32.bf16; extent: 32 scalar conversions,
+        # element-major across the four rows exactly as the frozen PTX
+
+        if iter_idx == 0:
+            g = copy_s2r(sGB[0, 0])
+            beta = copy_s2r(sGB[0, 1])
+            # The source loads g/beta here on first use and retains them across
+            # every later constexpr body.
+
+        s = (0.0, 0.0, 0.0, 0.0)
+        for pair in static_range(4):
+            if iter_idx == 0:
+                r_k_main[pair] = copy_s2r(
+                    sK[0, k_start+2*pair:k_start+2*pair+2])
+            k_pair = r_k_main[pair]
+            # instruction_selection: ld.shared.b32; extent: explicit loop of two scalar loads per K pair, four pairs
+            for row in static_range(4):
+                r_h[row, 2*pair:2*pair+2] = fma(
+                    r_h[row, 2*pair:2*pair+2], (g, g), (0.0, 0.0), lanes=2)
+                # instruction_selection: fma.rn.f32x2; extent: one packed two-lane decay, four rows for each of four K pairs
+                s[row] = fma(r_h[row, 2*pair+0], k_pair[0], s[row])
+                # instruction_selection: fma.rn.f32; extent: one scalar h-k accumulate, four rows for each K pair
+                s[row] = fma(r_h[row, 2*pair+1], k_pair[1], s[row])
+                # instruction_selection: fma.rn.f32; extent: second scalar h-k accumulate, four rows for each K pair
+
+        for delta in (8, 4, 2, 1):
+            for row in static_range(4):
+                peer = shuffle_xor(s[row], delta, member_mask=-1, clamp=31)
+                # instruction_selection: shfl.sync.bfly.b32; extent: one scalar, four rows at each of four explicit stages
+                s[row] = add(s[row], peer)
+                # instruction_selection: add.f32; extent: one scalar, four rows at each of four explicit stages
+
+        value = reg_tile(dtype="f32", shape=(4,))
+        for row in static_range(4):
+            value_bf16 = copy_g2r(v[n, 0, hv, v_rows[row]])
+            # instruction_selection: ld.global.b16; extent: four independent
+            # scalar loads for both tile sizes
+            residual = sub(cast("f32", value_bf16), s[row])
+            # instruction_selection: sub.rn.f32.bf16 in reviewed PTX; extent: one mixed BF16/FP32 scalar subtract per row
+            value[row] = mul(residual, beta)
+            # instruction_selection: mul.f32; extent: one scalar per row
+
+        out_acc = (0.0, 0.0, 0.0, 0.0)
+        for pair in static_range(4):
+            if iter_idx == 0:
+                r_q_main[pair] = copy_s2r(
+                    sQ[0, k_start+2*pair:k_start+2*pair+2])
+            q_pair = r_q_main[pair]
+            # instruction_selection: ld.shared.b32; extent: explicit loop of two scalar loads per K pair, four pairs
+            k_pair = r_k_main[pair]
+            # The reviewed PTX retains K from the decay loop and emits no
+            # redundant reload; Q/K/g/beta all remain live in registers across
+            # later constexpr bodies.
+            for row in static_range(4):
+                r_h[row, 2*pair:2*pair+2] = fma(
+                    k_pair, (value[row], value[row]),
+                    r_h[row, 2*pair:2*pair+2], lanes=2)
+                # instruction_selection: fma.rn.f32x2; extent: one packed rank-one update, four rows for each of four K pairs
+                out_acc[row] = fma(r_h[row, 2*pair+0], q_pair[0], out_acc[row])
+                # instruction_selection: fma.rn.f32; extent: one scalar h-q accumulate, four rows for each K pair
+                out_acc[row] = fma(r_h[row, 2*pair+1], q_pair[1], out_acc[row])
+                # instruction_selection: fma.rn.f32; extent: second scalar h-q accumulate, four rows for each K pair
+
+        for delta in (8, 4, 2, 1):
+            for row in static_range(4):
+                peer = shuffle_xor(out_acc[row], delta, member_mask=-1, clamp=31)
+                # instruction_selection: shfl.sync.bfly.b32; extent: one scalar, four rows at each of four explicit stages
+                out_acc[row] = add(out_acc[row], peer)
+                # instruction_selection: add.f32; extent: one scalar, four rows at each of four explicit stages
+
+        if lane == 0:
+            for row in static_range(4):
+                out_bf16 = cast("bf16", out_acc[row], rounding="rn")
+                # instruction_selection: cvt.rn.bf16.f32; extent: one scalar per owned output row
+                copy_r2g(out_bf16, output[n, 0, hv, v_rows[row]])
+                # instruction_selection: st.global.b16; extent: one scalar per owned output row, subgroup lane 0 only
+
+        if CACHE_INTERMEDIATE_STATES:
+            for row in static_range(4):
+                packed_state = cast("bf16x8", r_h[row], rounding="rn")
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pair conversions for one eight-element row
+                copy_r2g(
+                    packed_state,
+                    intermediate[n, 0, hv, v_rows[row], k_start:k_start+8])
+                # instruction_selection: st.global.v4.b32; extent: one 16-byte vector per row, indexed by batch n rather than pool slot
+
+        if not DISABLE_STATE_UPDATE and not CACHE_INTERMEDIATE_STATES:
+            for row in static_range(4):
+                packed_state = cast("bf16x8", r_h[row], rounding="rn")
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pair conversions for one eight-element row
+                copy_r2g(
+                    packed_state,
+                    write_state[v_rows[row], k_start:k_start+8])
+                # instruction_selection: st.global.v4.b32; extent: one
+                # ordinary 16-byte vector store per row at the aliased or
+                # split-pool slot
+```
+
+## Storage ownership and lifetimes
+
+| storage | logical owner | lifetime and alias rule |
+| --- | --- | --- |
+| sQ/sK | warp 0 publishes both; all groups consume | live from Phase-0 stores through every Phase-1 iteration; immutable after the barrier |
+| sGB | warp-0 lane 0 publishes g, beta, and kq | g/beta are consumed by every Phase-1 thread; kq is stored but not loaded for T=1 |
+| r_h `[4,8]` | one lane in one 16-lane group | loaded, decayed, updated, used for output, and optionally stored within one four-row iteration; no cross-iteration state |
+| state read/write views | one CTA and disjoint V/K segments | exact alias when SAME_POOL; distinct Int64 slot bases otherwise |
+| intermediate | one `(n,hv,V,K)` region | batch-scoped, never indexed by a pool slot; when enabled it owns the final state and suppresses pool writeback |
+
+No data race depends on scheduling: the duplicate Phase-0 half-warps store
+bit-identical values; the CTA barrier completes those stores; Phase 1 assigns
+each `(V,K)` state element to exactly one lane and each V output to exactly one
+subgroup lane 0.
+
+## Frozen source-PTX evidence
+
+The mandatory fresh source build is preserved under
+`.porting/gdn_decode_bf16_wide_vec_t1/source_ptx_stage2/`; its
+[`manifest.md`](../../../.porting/gdn_decode_bf16_wide_vec_t1/source_ptx_stage2/manifest.md)
+records the exact static arguments, toolchain, artifacts, and hashes.  The PTX
+maps `.file 1` to the frozen CuTeDSL source and declares `.reqntid 128,1,1`.
+
+| source region | reviewed line-info PTX consequence |
+| --- | --- |
+| 2088-2120 | sixteen scalar BF16 Q/K loads, BF16/F32 conversion, optional mixed-BF16 square FMAs, 16-lane butterfly normalization, then sixteen scalar shared stores |
+| 2122-2161 | eight scalar K-Q FMAs, four butterfly steps, fast exp/log/reciprocal gate arithmetic, three scalar shared stores by lane 0, and one CTA barrier |
+| 2195-2203 | exactly four `ld.global.v4.b32` and 32 BF16-to-FP32 conversions per unrolled iteration |
+| 2210-2273 | packed two-lane decay, scalar h-k FMA chains, and four independent 16-lane butterfly reductions |
+| 2275-2355 | four scalar V loads, four scalar residual/gate products, packed two-lane rank-one updates, scalar h-q FMA chains, four butterfly reductions, and four lane-zero scalar BF16 output stores |
+| 2403-2410 | four BF16x2 packs and one 128-bit state store for each of four V rows |
+
+For the reviewed tile-64 specialization, the source compiler physically
+duplicates the complete Phase-1 body twice.  Tile 128 must select the same body
+four times; changing the row/group mapping or introducing a serial runtime loop
+would not be a faithful port.
+
+## TIRx module and benchmark contract
+
+- Registry name: `gdn_decode_bf16_wide_vec_t1`; supported compute capability
+  is exactly 10.
+- Correctness uses the direct FlashInfer
+  `gated_delta_rule_t1_wide_vec(..., tile_v=...)` oracle, not the top-level
+  dispatcher, so every semantic branch and both tile sizes execute this body.
+- Performance uses the source production domain only, same-pool contiguous
+  state, Q/K L2 normalization, state update enabled, cache disabled, and the 18
+  Qwen3-Next TP shapes recorded in the module's `BENCH_CONFIGS`.
+- The final performance result is accepted only from a complete unfiltered
+  `python -m tirx_kernels.bench_suite` run and only when every required
+  `source_us / tirx_us` ratio is strictly greater than 0.99.
+
+## Instruction selection is a lowering consequence
+
+The port must state the same placement, lane layout, vector width, unrolled
+iteration count, and synchronization before relying on these opcodes:
+
+- Q/K use eight scalar `ld.global.b16` operations each per active Phase-0
+  thread. V uses four scalar `ld.global.b16` operations at both tile sizes.
+  State uses four ordinary 16-byte vector loads and, when enabled, four
+  ordinary 16-byte vector stores per body.
+- shared publication/consumption uses scalar `st.shared.b32` and
+  `ld.shared.b32`; publication is one `bar.sync 0`.
+- both reductions use `shfl.sync.bfly.b32` with offsets 8, 4, 2, 1 and clamp
+  31, intentionally forming two independent 16-lane reductions per warp.
+- decay and rank-one update use `fma.rn.f32x2`; dot products remain ordered
+  scalar `fma.rn.f32` chains.
+- L2 and gate math use `rsqrt.approx.ftz.f32`, `ex2.approx.ftz.f32`,
+  `lg2.approx.ftz.f32`, and `rcp.rn.f32`.
+- output uses scalar `cvt.rn.bf16.f32`/`st.global.b16`; state uses four
+  `cvt.rn.bf16x2.f32` followed by one `st.global.v4.b32` per row.
+
+The implementation may express these primitives through plain TIRx helpers,
+but may not use tile primitives or substitute a mathematically equivalent
+thread mapping, reduction topology, memory width, fast-math sequence, or
+packed-FMA schedule.

--- a/tests/lint/check_gdn_decode_bf16_wide_vec_t1_no_tile.py
+++ b/tests/lint/check_gdn_decode_bf16_wide_vec_t1_no_tile.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The TIRx Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Reject tile primitives in every wide-vector GDN T1 specialization."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import tvm
+from tirx_kernels.flashinfer.gdn_decode import gdn_decode_bf16_wide_vec_t1 as target
+from tvm.tirx.stmt_functor import StmtExprVisitor
+
+REPO = Path(__file__).resolve().parents[2]
+TARGET = REPO / "tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py"
+
+_TILE_OPS = {
+    "add",
+    "binary_chain",
+    "binary_reduce",
+    "cast",
+    "compose_op",
+    "copy",
+    "copy_async",
+    "exp",
+    "exp2",
+    "fdiv",
+    "fill",
+    "fma",
+    "gemm",
+    "gemm_async",
+    "max",
+    "maximum",
+    "memset",
+    "min",
+    "minimum",
+    "mul",
+    "permute_layout",
+    "reciprocal",
+    "reduce_negate",
+    "select",
+    "silu",
+    "sqrt",
+    "sub",
+    "sum",
+    "unary_reduce",
+    "zero",
+}
+_SCOPES = {"thread", "warp", "wg", "warpgroup", "cta", "cluster"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    path: str
+    detail: str
+
+
+def _qualified_name(node: ast.AST, aliases: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Name):
+        return aliases.get(node.id, node.id)
+    if isinstance(node, ast.Attribute):
+        base = _qualified_name(node.value, aliases)
+        return f"{base}.{node.attr}" if base else None
+    return None
+
+
+def _is_plain_cast(call: ast.Call) -> bool:
+    """Recognize ordinary expression ``T.cast(value, "dtype")`` calls."""
+    return (
+        len(call.args) == 2
+        and not call.keywords
+        and isinstance(call.args[1], ast.Constant)
+        and isinstance(call.args[1].value, str)
+    )
+
+
+def _tile_call_reason(name: str | None, call: ast.Call) -> str | None:
+    if name is None:
+        return None
+    parts = name.split(".")
+    leaf = parts[-1]
+    if leaf == "TilePrimitiveCall" or ".tile." in name:
+        return f"explicit tile primitive call {name}"
+    if "tile_primitive" in parts and leaf not in {"SwizzleMode", "sf_smem_layout"}:
+        return f"tile-primitive helper call {name}"
+
+    # TIRx script exposes both direct and execution-scope tile APIs.  Cast has
+    # a scalar overload, which is legal when its second argument is a dtype.
+    script_root = parts[0] in {"T", "Tx", "tirx"}
+    scoped = len(parts) >= 3 and parts[-2] in _SCOPES
+    direct = len(parts) == 2
+    if script_root and (direct or scoped) and leaf in _TILE_OPS:
+        if leaf == "cast" and _is_plain_cast(call):
+            return None
+        return f"TIRx tile API call {name}"
+    return None
+
+
+class _FunctionScanner(ast.NodeVisitor):
+    def __init__(
+        self, source: str, aliases: dict[str, str], function_names: set[str], function: str
+    ) -> None:
+        self.source = source
+        self.aliases = dict(aliases)
+        self.function_names = function_names
+        self.function = function
+        self.findings: list[Finding] = []
+        self.calls: list[tuple[str, ast.Call]] = []
+
+    def _path(self, node: ast.AST) -> str:
+        return f"{TARGET.relative_to(REPO)}:{node.lineno}:{node.col_offset + 1}"
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        value_name = _qualified_name(node.value, self.aliases)
+        if value_name is not None:
+            for assignment in node.targets:
+                if isinstance(assignment, ast.Name):
+                    self.aliases[assignment.id] = value_name
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and isinstance(node.target, ast.Name):
+            value_name = _qualified_name(node.value, self.aliases)
+            if value_name is not None:
+                self.aliases[node.target.id] = value_name
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = _qualified_name(node.func, self.aliases)
+        reason = _tile_call_reason(name, node)
+        if reason is not None:
+            self.findings.append(Finding("source", self._path(node), reason))
+
+        local_name = name.rsplit(".", 1)[-1] if name else None
+        if local_name in self.function_names:
+            self.calls.append((local_name, node))
+
+        for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+                if argument.value.startswith("tirx.tile."):
+                    self.findings.append(
+                        Finding(
+                            "source",
+                            self._path(argument),
+                            f"dynamic tile operator name {argument.value!r}",
+                        )
+                    )
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Nested function bodies are scanned by their own scanner.
+        if node.name != self.function:
+            return
+        self.generic_visit(node)
+
+
+def _source_findings() -> list[Finding]:
+    source = TARGET.read_text()
+    tree = ast.parse(source, filename=str(TARGET))
+    aliases: dict[str, str] = {}
+    functions = {
+        node.name for node in tree.body if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for item in node.names:
+                aliases[item.asname or item.name.split(".")[0]] = item.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for item in node.names:
+                aliases[item.asname or item.name] = f"{module}.{item.name}"
+        elif isinstance(node, ast.Assign):
+            name = _qualified_name(node.value, aliases)
+            if name is not None:
+                for assignment in node.targets:
+                    if isinstance(assignment, ast.Name):
+                        aliases[assignment.id] = name
+
+    scans: dict[str, _FunctionScanner] = {}
+    findings: list[Finding] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        scanner = _FunctionScanner(source, aliases, functions, node.name)
+        scanner.visit(node)
+        scans[node.name] = scanner
+        findings.extend(scanner.findings)
+
+    # Propagate taint through local wrappers so both the primitive and every
+    # wrapper call site are visible in diagnostics.
+    tainted = {name for name, scanner in scans.items() if scanner.findings}
+    changed = True
+    while changed:
+        changed = False
+        for name, scanner in scans.items():
+            if name in tainted:
+                continue
+            if any(callee in tainted for callee, _ in scanner.calls):
+                tainted.add(name)
+                changed = True
+
+    for name, scanner in scans.items():
+        for callee, call in scanner.calls:
+            if callee in tainted:
+                findings.append(
+                    Finding(
+                        "source",
+                        scanner._path(call),
+                        f"wrapper {name} calls tile-tainted helper {callee}",
+                    )
+                )
+    return findings
+
+
+class _IRScanner(StmtExprVisitor):
+    def __init__(self, specialization: str) -> None:
+        super().__init__()
+        self.specialization = specialization
+        self.findings: list[Finding] = []
+
+    def _record(self, node: Any, detail: str) -> None:
+        span = getattr(node, "span", None)
+        suffix = f" span={span}" if span is not None else ""
+        self.findings.append(Finding("IR", self.specialization, detail + suffix))
+
+    def visit_op_call_(self, op: Any) -> None:
+        op_name = getattr(getattr(op, "op", None), "name", "<unknown>")
+        self._record(op, f"TilePrimitiveCall op={op_name}")
+        super().visit_op_call_(op)
+
+    def visit_call_(self, call: tvm.ir.Call) -> None:
+        op = getattr(call, "op", None)
+        op_name = getattr(op, "name", None)
+        category = op.get_attr("TIRxOpCategory") if isinstance(op, tvm.ir.Op) else None
+        if op_name is not None and op_name.startswith("tirx.tile."):
+            self._record(call, f"forbidden operator {op_name}")
+        elif category == "tile_primitive":
+            self._record(call, f"operator {op_name} has TIRxOpCategory=tile_primitive")
+        super().visit_call_(call)
+
+
+def _ir_findings() -> list[Finding]:
+    findings: list[Finding] = []
+    for config in target.CONFIGS:
+        label = str(config["label"])
+        kernel = target.get_kernel(**config)
+        scanner = _IRScanner(f"CONFIGS[{label!r}]")
+        scanner(kernel.body)
+        findings.extend(scanner.findings)
+    return findings
+
+
+def main() -> int:
+    findings = _source_findings() + _ir_findings()
+    if findings:
+        for finding in findings:
+            print(f"ERROR [{finding.kind}] {finding.path}: {finding.detail}")
+        print(f"\n{len(findings)} tile-primitive violation(s).")
+        return 1
+    print(
+        "PASS: source and all "
+        f"{len(target.CONFIGS)} pre-dispatch specializations contain no tile primitive"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tirx_kernels/bench_suite/config/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.yaml
@@ -1,0 +1,22 @@
+# Complete SM100 BF16 wide-vector T1 production dispatch matrix for Qwen3-Next
+# TP1/2/4/8.  Every shape is required by the port's performance gate.
+kernel: gdn_decode_bf16_wide_vec_t1
+configs:
+  - {config: b16_h16_hv32_tv64, default: true}
+  - {config: b32_h16_hv32_tv128, default: true}
+  - {config: b64_h16_hv32_tv128, default: true}
+  - {config: b128_h16_hv32_tv128, default: true}
+  - {config: b256_h16_hv32_tv128, default: true}
+  - {config: b512_h16_hv32_tv128, default: true}
+  - {config: b32_h8_hv16_tv64, default: true}
+  - {config: b64_h8_hv16_tv128, default: true}
+  - {config: b128_h8_hv16_tv128, default: true}
+  - {config: b256_h8_hv16_tv128, default: true}
+  - {config: b512_h8_hv16_tv128, default: true}
+  - {config: b64_h4_hv8_tv64, default: true}
+  - {config: b128_h4_hv8_tv128, default: true}
+  - {config: b256_h4_hv8_tv128, default: true}
+  - {config: b512_h4_hv8_tv128, default: true}
+  - {config: b128_h2_hv4_tv64, default: true}
+  - {config: b256_h2_hv4_tv128, default: true}
+  - {config: b512_h2_hv4_tv128, default: true}

--- a/tirx_kernels/flashinfer/gdn_decode/__init__.py
+++ b/tirx_kernels/flashinfer/gdn_decode/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The TIRx Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""FlashInfer Gated Delta Net decode kernels."""

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -1,0 +1,1135 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications Copyright (c) 2026 The TIRx Authors.
+# Modifications are licensed under the Apache License, Version 2.0.
+#
+# This file is a TIRx port of FlashInfer's
+# flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
+# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+
+"""SM100 BF16 wide-vector single-token GDN decode kernel."""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import math
+from pathlib import Path
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+from tvm.tirx.bench import bench
+
+KERNEL_META = {
+    "name": "gdn_decode_bf16_wide_vec_t1",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
+FROZEN_FLASHINFER_SOURCE_SHA256 = "61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61"
+
+SEQ_LEN = 1
+K = 128
+V = 128
+THREADS = 128
+NUM_WARPS = 4
+NUM_GROUPS = 8
+LANES_PER_GROUP = 16
+ELEMS_PER_LANE = 8
+ILP_ROWS = 4
+SHARED_BYTES = 1356
+LOG2_E = 1.4426950408889634
+LN_2 = 0.6931471805599453
+SCALE = 1.0 / math.sqrt(K)
+
+
+def _ptx_unary(chain: str, value, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _ptx_ternary(chain: str, lhs, rhs, acc, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _sub_f32(lhs, rhs):
+    return _ptx_binary("sub.f32", lhs, rhs)
+
+
+def _mul_f32(lhs, rhs):
+    return _ptx_binary("mul.f32", lhs, rhs)
+
+
+def _fma_f32(lhs, rhs, acc):
+    return _ptx_ternary("fma.rn.f32", lhs, rhs, acc)
+
+
+def _exp2_f32(value):
+    return _ptx_unary("ex2.approx.ftz.f32", value)
+
+
+def _log2_f32(value):
+    return _ptx_unary("lg2.approx.ftz.f32", value)
+
+
+def _rcp_f32(value):
+    return _ptx_unary("rcp.rn.f32", value)
+
+
+def _rsqrt_f32(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _max_s32(lhs, rhs):
+    return _ptx_binary("max.s32", lhs, rhs, dtype="int32")
+
+
+def _global_load_u16(buffer, index):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_s32(buffer, index):
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.s32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_f32(buffer, index):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _bf16_to_f32(bits):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.cvt.f32.bf16(out[0], T.cast(bits, "uint16")))
+    return out[0]
+
+
+def _f32_to_bf16(value):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.cvt.rn.bf16.f32(out[0], value))
+    return out[0]
+
+
+def _mixed_add_bf16_f32(bits, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.add.rn.f32.bf16(out[0], T.cast(bits, "uint16"), value))
+    return out[0]
+
+
+def _mixed_sub_bf16_f32(bits, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.sub.rn.f32.bf16(out[0], T.cast(bits, "uint16"), value))
+    return out[0]
+
+
+def _bf16_square_fma(bits, acc):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.fma.rn.f32.bf16(out[0], T.cast(bits, "uint16"), T.cast(bits, "uint16"), acc))
+    return out[0]
+
+
+def _shared_load_f32(buffer, index):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], buffer.ptr_to([index])))
+    return T.reinterpret("float32", out[0])
+
+
+def _shared_store_f32(buffer, index, value):
+    T.evaluate(T.ptx.st.shared.b32(buffer.ptr_to([index]), T.reinterpret("uint32", value)))
+
+
+@T.inline
+def _load_state_bf16x8(buffer, index, values, value_offset):
+    words = T.alloc_local((4,), "uint32", align=16)
+    T.evaluate(
+        T.ptx["ld.global.L1::evict_first.v4.b32"](
+            words[0], words[1], words[2], words[3], buffer.ptr_to([index])
+        )
+    )
+    for pair in T.unroll(4):
+        values[value_offset + pair * 2] = T.cuda.uint_as_float(
+            T.shift_left(words[pair], T.uint32(16))
+        )
+        values[value_offset + pair * 2 + 1] = T.cuda.uint_as_float(
+            T.bitwise_and(words[pair], T.uint32(0xFFFF0000))
+        )
+
+
+@T.inline
+def _load_state_bf16x8_evict_first(buffer, index, values, value_offset):
+    words = T.alloc_local((4,), "uint32", align=16)
+    T.evaluate(
+        T.ptx["ld.global.L1::evict_first.v4.b32"](
+            words[0], words[1], words[2], words[3], buffer.ptr_to([index])
+        )
+    )
+    for pair in T.unroll(4):
+        values[value_offset + pair * 2] = T.cuda.uint_as_float(
+            T.shift_left(words[pair], T.uint32(16))
+        )
+        values[value_offset + pair * 2 + 1] = T.cuda.uint_as_float(
+            T.bitwise_and(words[pair], T.uint32(0xFFFF0000))
+        )
+
+
+@T.inline
+def _load_state_bf16x8_vector_buffer(buffer, index, values, value_offset):
+    words = T.alloc_local((4,), "uint32", align=16)
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(
+            words[0], words[1], words[2], words[3], buffer.ptr_to([index // ELEMS_PER_LANE])
+        )
+    )
+    for pair in T.unroll(4):
+        values[value_offset + pair * 2] = T.cuda.uint_as_float(
+            T.shift_left(words[pair], T.uint32(16))
+        )
+        values[value_offset + pair * 2 + 1] = T.cuda.uint_as_float(
+            T.bitwise_and(words[pair], T.uint32(0xFFFF0000))
+        )
+
+
+@T.inline
+def _load_bf16x8_bits(buffer, index, values):
+    words = T.alloc_local((4,), "uint32", align=16)
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    for pair in T.unroll(4):
+        values[pair * 2] = T.cast(T.bitwise_and(words[pair], T.uint32(0xFFFF)), "uint16")
+        values[pair * 2 + 1] = T.cast(T.shift_right(words[pair], T.uint32(16)), "uint16")
+
+
+@T.inline
+def _load_bf16x4_bits(buffer, index, values):
+    words = T.alloc_local((2,), "uint32", align=8)
+    T.evaluate(T.ptx.ld.global_.v2.b32(words[0], words[1], buffer.ptr_to([index])))
+    for pair in T.unroll(2):
+        values[pair * 2] = T.cast(T.bitwise_and(words[pair], T.uint32(0xFFFF)), "uint16")
+        values[pair * 2 + 1] = T.cast(T.shift_right(words[pair], T.uint32(16)), "uint16")
+
+
+@T.inline
+def _store_state_f32x8(buffer, index, values, value_offset):
+    words = T.alloc_local((4,), "uint32", align=16)
+    for pair in T.unroll(4):
+        words[pair] = T.cuda.float22bfloat162_rn(
+            values[value_offset + pair * 2], values[value_offset + pair * 2 + 1]
+        )
+    T.evaluate(
+        T.ptx.st.global_.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3])
+    )
+
+
+@T.inline
+def _store_state_f32x8_vector_buffer(buffer, index, values, value_offset):
+    words = T.alloc_local((4,), "uint32", align=16)
+    for pair in T.unroll(4):
+        words[pair] = T.cuda.float22bfloat162_rn(
+            values[value_offset + pair * 2], values[value_offset + pair * 2 + 1]
+        )
+    T.evaluate(
+        T.ptx["st.global.L1::evict_first.v4.b32"](
+            buffer.ptr_to([index // ELEMS_PER_LANE]), words[0], words[1], words[2], words[3]
+        )
+    )
+
+
+def _packed_fma(lhs0, lhs1, rhs0, rhs1, acc0, acc1):
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(
+        T.ptx.fma.rn.f32x2(
+            out[0],
+            T.cuda.make_float2(lhs0, lhs1),
+            T.cuda.make_float2(rhs0, rhs1),
+            T.cuda.make_float2(acc0, acc1),
+        )
+    )
+    return out[0]
+
+
+def _case(label: str, **kwargs: Any) -> dict[str, Any]:
+    return {"label": label, **kwargs}
+
+
+_TP_HEADS = ((16, 32), (8, 16), (4, 8), (2, 4))
+_BATCH_SWEEP = (1, 4, 8, 16, 32, 64, 128, 256, 512)
+
+
+def _production_tile_v(batch: int, num_v_heads: int) -> int | None:
+    work_units = batch * num_v_heads
+    if work_units >= 1024:
+        return 128
+    if work_units >= 512:
+        return 64
+    return None
+
+
+BENCH_CONFIGS = [
+    _case(
+        f"b{batch}_h{num_heads}_hv{num_v_heads}_tv{tile_v}",
+        batch=batch,
+        num_heads=num_heads,
+        num_v_heads=num_v_heads,
+        tile_v=tile_v,
+        seed=10000 + head_idx * len(_BATCH_SWEEP) + batch_idx,
+    )
+    for head_idx, (num_heads, num_v_heads) in enumerate(_TP_HEADS)
+    for batch_idx, batch in enumerate(_BATCH_SWEEP)
+    if (tile_v := _production_tile_v(batch, num_v_heads)) is not None
+]
+
+_CORRECTNESS_MODES = (
+    ("l2off", {"use_qk_l2norm": False}),
+    ("split", {"same_pool": False}),
+    ("split_l2off", {"same_pool": False, "use_qk_l2norm": False}),
+    ("padded", {"padded_pool": True}),
+    ("padded_split", {"padded_pool": True, "same_pool": False}),
+    ("packed_qkv", {"packed_qkv": True}),
+    ("negative_read", {"negative_read_index": True}),
+    ("negative_write", {"same_pool": False, "negative_write_index": True}),
+    ("disable_update", {"disable_state_update": True}),
+    ("disable_update_split", {"same_pool": False, "disable_state_update": True}),
+    ("cache", {"cache_intermediate_states": True}),
+    ("cache_split", {"same_pool": False, "cache_intermediate_states": True}),
+)
+
+_BOUNDARY_CASES = ((16, 16, 32, 64), (32, 16, 32, 128))
+
+CONFIGS = [dict(config) for config in BENCH_CONFIGS] + [
+    _case(
+        f"b{batch}_h{num_heads}_hv{num_v_heads}_tv{tile_v}_{mode}",
+        batch=batch,
+        num_heads=num_heads,
+        num_v_heads=num_v_heads,
+        tile_v=tile_v,
+        seed=20000 + boundary_idx * len(_CORRECTNESS_MODES) + mode_idx,
+        **mode_kwargs,
+    )
+    for boundary_idx, (batch, num_heads, num_v_heads, tile_v) in enumerate(_BOUNDARY_CASES)
+    for mode_idx, (mode, mode_kwargs) in enumerate(_CORRECTNESS_MODES)
+]
+
+
+@T.jit
+def _gdn_decode_bf16_wide_vec_t1(
+    state_h: T.handle,
+    intermediate_h: T.handle,
+    A_log_h: T.handle,
+    a_h: T.handle,
+    dt_bias_h: T.handle,
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    b_h: T.handle,
+    output_h: T.handle,
+    read_indices_h: T.handle,
+    write_indices_h: T.handle,
+    state_slot_stride: T.int64,
+    q_batch_stride: T.int64,
+    k_batch_stride: T.int64,
+    v_batch_stride: T.int64,
+    batch: T.int32,
+    *,
+    NUM_HEADS: T.constexpr,
+    NUM_V_HEADS: T.constexpr,
+    TILE_V: T.constexpr,
+    NUM_V_TILES: T.constexpr,
+    ROWS_PER_GROUP: T.constexpr,
+    ITERS_PER_GROUP: T.constexpr,
+    POOL_FACTOR: T.constexpr,
+    INTERMEDIATE_BATCH_STRIDE: T.constexpr,
+    INTERMEDIATE_DUMMY_ELEMENTS: T.constexpr,
+    USE_QK_L2NORM: T.constexpr,
+    DISABLE_STATE_UPDATE: T.constexpr,
+    CACHE_INTERMEDIATE_STATES: T.constexpr,
+    SAME_POOL: T.constexpr,
+):
+    # TIRX_KERNEL_SKETCH_START
+    state = T.match_buffer(
+        state_h,
+        (state_slot_stride * T.cast(batch * POOL_FACTOR, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    intermediate = T.match_buffer(
+        intermediate_h,
+        (T.cast(batch * INTERMEDIATE_BATCH_STRIDE + INTERMEDIATE_DUMMY_ELEMENTS, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    A_log = T.match_buffer(A_log_h, (NUM_V_HEADS,), "float32", scope="global")
+    a = T.match_buffer(a_h, (T.cast(batch * NUM_V_HEADS, "int64"),), "bfloat16", scope="global")
+    dt_bias = T.match_buffer(dt_bias_h, (NUM_V_HEADS,), "float32", scope="global")
+    q = T.match_buffer(
+        q_h,
+        (q_batch_stride * T.cast(batch - 1, "int64") + T.cast(NUM_HEADS * K, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    k = T.match_buffer(
+        k_h,
+        (k_batch_stride * T.cast(batch - 1, "int64") + T.cast(NUM_HEADS * K, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    v = T.match_buffer(
+        v_h,
+        (v_batch_stride * T.cast(batch - 1, "int64") + T.cast(NUM_V_HEADS * V, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    b_gate = T.match_buffer(
+        b_h, (T.cast(batch * NUM_V_HEADS, "int64"),), "bfloat16", scope="global"
+    )
+    output = T.match_buffer(
+        output_h, (T.cast(batch * NUM_V_HEADS * V, "int64"),), "bfloat16", scope="global"
+    )
+    read_indices = T.match_buffer(
+        read_indices_h, (T.cast(batch, "int64"),), "int32", scope="global"
+    )
+    write_indices = T.match_buffer(
+        write_indices_h, (T.cast(batch, "int64"),), "int32", scope="global"
+    )
+    state_vector = T.decl_buffer(
+        (state_slot_stride * T.cast(batch * POOL_FACTOR, "int64") // ELEMS_PER_LANE,),
+        "uint32x4",
+        data=state.data,
+        scope="global",
+        align=32,
+    )
+    T.device_entry()
+
+    linear_cta = T.cta_id([batch * NUM_V_HEADS * NUM_V_TILES])
+    tid = T.thread_id([THREADS])
+    warp_raw: T.int32 = tid // 32
+    lane_in_warp: T.int32 = tid % 32
+    group: T.int32 = tid // LANES_PER_GROUP
+    lane: T.int32 = tid % LANES_PER_GROUP
+    k_start: T.int32 = lane * ELEMS_PER_LANE
+
+    v_tile: T.int32 = linear_cta % NUM_V_TILES
+    cta_head: T.int32 = linear_cta // NUM_V_TILES
+    hv: T.int32 = cta_head % NUM_V_HEADS
+    n: T.int32 = cta_head // NUM_V_HEADS
+    h: T.int32 = hv // (NUM_V_HEADS // NUM_HEADS)
+
+    read_slot_raw: T.int32 = _global_load_s32(read_indices, n)
+
+    pool = T.SMEMPool()
+    smem_raw = pool.alloc((SHARED_BYTES,), "uint8", align=16)
+    s_q = T.decl_buffer(
+        (K,), "float32", data=smem_raw.data, scope="shared.dyn", byte_offset=0, align=16
+    )
+    s_k = T.decl_buffer(
+        (K,), "float32", data=smem_raw.data, scope="shared.dyn", byte_offset=512, align=16
+    )
+    s_gb = T.decl_buffer(
+        (3,), "float32", data=smem_raw.data, scope="shared.dyn", byte_offset=1024, align=16
+    )
+    pool.commit()
+
+    read_slot: T.int32 = _max_s32(read_slot_raw, T.int32(0))
+    write_slot: T.int32 = read_slot
+    if not SAME_POOL:
+        write_slot = _max_s32(_global_load_s32(write_indices, n), T.int32(0))
+
+    read_state_base: T.int64 = T.cast(read_slot, "int64") * state_slot_stride + T.cast(
+        hv * V * K, "int64"
+    )
+    write_state_base: T.int64 = read_state_base
+    if not SAME_POOL:
+        write_state_base = T.cast(write_slot, "int64") * state_slot_stride + T.cast(
+            hv * V * K, "int64"
+        )
+    # Phase 0: with the T=1-only kq value dead, independent warps can publish
+    # normalized Q, normalized K, and the scalar gates concurrently.
+    if warp_raw == 0:
+        member_pre: T.int32 = lane_in_warp % LANES_PER_GROUP
+        k_pre: T.int32 = member_pre * ELEMS_PER_LANE
+        q_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+        r_q = T.alloc_local((ELEMS_PER_LANE,), "float32")
+        q_base: T.int64 = T.cast(n, "int64") * q_batch_stride + h * K + k_pre
+        _load_bf16x8_bits(q, q_base, q_bits)
+        for i in T.unroll(ELEMS_PER_LANE):
+            r_q[i] = _bf16_to_f32(q_bits[i])
+
+        if USE_QK_L2NORM:
+            sum_q: T.float32 = 0.0
+            for i in T.unroll(ELEMS_PER_LANE):
+                sum_q = _bf16_square_fma(q_bits[i], sum_q)
+            for delta_index in T.unroll(4):
+                delta: T.int32 = T.shift_right(T.int32(8), delta_index)
+                sum_q = _add_f32(
+                    sum_q, T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_q, delta, 32)
+                )
+            q_factor: T.float32 = _mul_f32(
+                _rsqrt_f32(_add_f32(sum_q, T.float32(1.0e-6))), T.float32(SCALE)
+            )
+            for i in T.unroll(ELEMS_PER_LANE):
+                r_q[i] = _mul_f32(r_q[i], q_factor)
+        else:
+            for i in T.unroll(ELEMS_PER_LANE):
+                r_q[i] = _mul_f32(r_q[i], T.float32(SCALE))
+
+        for i in T.unroll(ELEMS_PER_LANE):
+            _shared_store_f32(s_q, k_pre + i, r_q[i])
+
+    if warp_raw == 1:
+        member_pre: T.int32 = lane_in_warp % LANES_PER_GROUP
+        k_pre: T.int32 = member_pre * ELEMS_PER_LANE
+        k_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+        r_k = T.alloc_local((ELEMS_PER_LANE,), "float32")
+        k_base: T.int64 = T.cast(n, "int64") * k_batch_stride + h * K + k_pre
+        _load_bf16x8_bits(k, k_base, k_bits)
+        for i in T.unroll(ELEMS_PER_LANE):
+            r_k[i] = _bf16_to_f32(k_bits[i])
+
+        if USE_QK_L2NORM:
+            sum_k: T.float32 = 0.0
+            for i in T.unroll(ELEMS_PER_LANE):
+                sum_k = _bf16_square_fma(k_bits[i], sum_k)
+            for delta_index in T.unroll(4):
+                delta: T.int32 = T.shift_right(T.int32(8), delta_index)
+                sum_k = _add_f32(
+                    sum_k, T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sum_k, delta, 32)
+                )
+            k_factor: T.float32 = _rsqrt_f32(_add_f32(sum_k, T.float32(1.0e-6)))
+            for i in T.unroll(ELEMS_PER_LANE):
+                r_k[i] = _mul_f32(r_k[i], k_factor)
+
+        for i in T.unroll(ELEMS_PER_LANE):
+            _shared_store_f32(s_k, k_pre + i, r_k[i])
+
+    if warp_raw == 2:
+        A_value: T.float32 = _global_load_f32(A_log, hv)
+        dt_value: T.float32 = _global_load_f32(dt_bias, hv)
+        a_bits: T.uint16 = _global_load_u16(a, n * NUM_V_HEADS + hv)
+        x_value: T.float32 = _mixed_add_bf16_f32(a_bits, dt_value)
+        softplus_exp: T.float32 = _exp2_f32(_mul_f32(x_value, T.float32(LOG2_E)))
+        softplus_log2: T.float32 = _log2_f32(_add_f32(T.float32(1.0), softplus_exp))
+        softplus_value: T.float32 = _mul_f32(softplus_log2, T.float32(LN_2))
+        use_softplus: T.float32 = T.if_then_else(
+            x_value <= T.float32(20.0), T.float32(1.0), T.float32(0.0)
+        )
+        direct_weight: T.float32 = _sub_f32(T.float32(1.0), use_softplus)
+        softplus_x: T.float32 = _fma_f32(
+            softplus_value, use_softplus, _mul_f32(x_value, direct_weight)
+        )
+        exp_A: T.float32 = _exp2_f32(_mul_f32(A_value, T.float32(LOG2_E)))
+        gate_exponent: T.float32 = _mul_f32(_sub_f32(T.float32(0.0), exp_A), softplus_x)
+
+        if lane_in_warp == 0:
+            g: T.float32 = _exp2_f32(_mul_f32(gate_exponent, T.float32(LOG2_E)))
+            _shared_store_f32(s_gb, 0, g)
+
+    if warp_raw == 3 and lane_in_warp == 0:
+        b_bits: T.uint16 = _global_load_u16(b_gate, n * NUM_V_HEADS + hv)
+        b_value: T.float32 = _bf16_to_f32(b_bits)
+        exp_neg_b: T.float32 = _exp2_f32(_mul_f32(b_value, T.float32(-LOG2_E)))
+        beta: T.float32 = _rcp_f32(_add_f32(T.float32(1.0), exp_neg_b))
+        _shared_store_f32(s_gb, 1, beta)
+
+    T.cuda.cta_sync()
+
+    # Phase 1: eight independent 16-lane groups.  Each source constexpr
+    # iteration is physically unrolled and carries four state rows in registers.
+    # The source compiler retains the same-token Q/K/g/beta shared values across
+    # every unrolled V-row body, so materialize that physical register lifetime
+    # explicitly: inline PTX shared loads are opaque to nvcc's CSE.
+    g_value: T.float32 = _shared_load_f32(s_gb, 0)
+    beta_value: T.float32 = _shared_load_f32(s_gb, 1)
+    r_k_main = T.alloc_local((ELEMS_PER_LANE,), "float32")
+    r_q_main = T.alloc_local((ELEMS_PER_LANE,), "float32")
+    for i in T.unroll(ELEMS_PER_LANE):
+        r_k_main[i] = _shared_load_f32(s_k, k_start + i)
+        r_q_main[i] = _shared_load_f32(s_q, k_start + i)
+
+    for iter_index in T.unroll(ITERS_PER_GROUP):
+        v_base: T.int32 = v_tile * TILE_V + group * ROWS_PER_GROUP + iter_index * ILP_ROWS
+        read_state_offset: T.int64 = read_state_base + T.cast(v_base * K + k_start, "int64")
+        r_h = T.alloc_local((ILP_ROWS * ELEMS_PER_LANE,), "float32")
+        state_bits = T.alloc_local((ILP_ROWS * ELEMS_PER_LANE,), "uint16", align=16)
+        for row in T.unroll(ILP_ROWS):
+            if TILE_V == 64:
+                _load_state_bf16x8_vector_buffer(
+                    state_vector, read_state_offset + row * K, r_h, row * ELEMS_PER_LANE
+                )
+            else:
+                _load_state_bf16x8(state, read_state_offset + row * K, r_h, row * ELEMS_PER_LANE)
+
+        sums = T.alloc_local((ILP_ROWS,), "float32")
+        for row in T.unroll(ILP_ROWS):
+            sums[row] = T.float32(0.0)
+
+        for pair in T.unroll(ELEMS_PER_LANE // 2):
+            for row in T.unroll(ILP_ROWS):
+                pair_value: T.uint64 = _packed_fma(
+                    r_h[row * ELEMS_PER_LANE + pair * 2],
+                    r_h[row * ELEMS_PER_LANE + pair * 2 + 1],
+                    g_value,
+                    g_value,
+                    T.float32(0.0),
+                    T.float32(0.0),
+                )
+                r_h[row * ELEMS_PER_LANE + pair * 2] = T.cuda.float2_x(pair_value)
+                r_h[row * ELEMS_PER_LANE + pair * 2 + 1] = T.cuda.float2_y(pair_value)
+                sums[row] = _fma_f32(
+                    r_h[row * ELEMS_PER_LANE + pair * 2], r_k_main[pair * 2], sums[row]
+                )
+                sums[row] = _fma_f32(
+                    r_h[row * ELEMS_PER_LANE + pair * 2 + 1], r_k_main[pair * 2 + 1], sums[row]
+                )
+
+        for delta_index in T.unroll(4):
+            delta: T.int32 = T.shift_right(T.int32(8), delta_index)
+            for row in T.unroll(ILP_ROWS):
+                sums[row] = _add_f32(
+                    sums[row], T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sums[row], delta, 32)
+                )
+
+        values = T.alloc_local((ILP_ROWS,), "float32")
+        value_bits = T.alloc_local((ILP_ROWS,), "uint16")
+        v_input_base: T.int64 = T.cast(n, "int64") * v_batch_stride + hv * V + v_base
+        if TILE_V == 128:
+            _load_bf16x4_bits(v, v_input_base, value_bits)
+        else:
+            for row in T.unroll(ILP_ROWS):
+                value_bits[row] = _global_load_u16(v, v_input_base + row)
+        for row in T.unroll(ILP_ROWS):
+            values[row] = _mul_f32(_mixed_sub_bf16_f32(value_bits[row], sums[row]), beta_value)
+
+        for row in T.unroll(ILP_ROWS):
+            sums[row] = T.float32(0.0)
+        for pair in T.unroll(ELEMS_PER_LANE // 2):
+            q0: T.float32 = r_q_main[pair * 2]
+            q1: T.float32 = r_q_main[pair * 2 + 1]
+            for row in T.unroll(ILP_ROWS):
+                pair_value: T.uint64 = _packed_fma(
+                    r_k_main[pair * 2],
+                    r_k_main[pair * 2 + 1],
+                    values[row],
+                    values[row],
+                    r_h[row * ELEMS_PER_LANE + pair * 2],
+                    r_h[row * ELEMS_PER_LANE + pair * 2 + 1],
+                )
+                r_h[row * ELEMS_PER_LANE + pair * 2] = T.cuda.float2_x(pair_value)
+                r_h[row * ELEMS_PER_LANE + pair * 2 + 1] = T.cuda.float2_y(pair_value)
+                sums[row] = _fma_f32(r_h[row * ELEMS_PER_LANE + pair * 2], q0, sums[row])
+                sums[row] = _fma_f32(r_h[row * ELEMS_PER_LANE + pair * 2 + 1], q1, sums[row])
+
+        for delta_index in T.unroll(4):
+            delta: T.int32 = T.shift_right(T.int32(8), delta_index)
+            for row in T.unroll(ILP_ROWS):
+                sums[row] = _add_f32(
+                    sums[row], T.cuda.__shfl_xor_sync(T.uint32(0xFFFFFFFF), sums[row], delta, 32)
+                )
+
+        if lane == 0:
+            output_base: T.int64 = T.cast((n * NUM_V_HEADS + hv) * V + v_base, "int64")
+            for row in T.unroll(ILP_ROWS):
+                T.evaluate(
+                    T.ptx.st.global_.b16(
+                        output.ptr_to([output_base + row]), _f32_to_bf16(sums[row])
+                    )
+                )
+
+        if CACHE_INTERMEDIATE_STATES:
+            intermediate_base: T.int64 = T.cast(
+                (n * NUM_V_HEADS + hv) * V * K + v_base * K + k_start, "int64"
+            )
+            for row in T.unroll(ILP_ROWS):
+                _store_state_f32x8(
+                    intermediate, intermediate_base + row * K, r_h, row * ELEMS_PER_LANE
+                )
+
+        if not DISABLE_STATE_UPDATE and not CACHE_INTERMEDIATE_STATES:
+            write_state_offset: T.int64 = (
+                read_state_offset
+                if SAME_POOL
+                else write_state_base + T.cast(v_base * K + k_start, "int64")
+            )
+            for row in T.unroll(ILP_ROWS):
+                if TILE_V == 64:
+                    _store_state_f32x8_vector_buffer(
+                        state_vector, write_state_offset + row * K, r_h, row * ELEMS_PER_LANE
+                    )
+                else:
+                    _store_state_f32x8(
+                        state, write_state_offset + row * K, r_h, row * ELEMS_PER_LANE
+                    )
+
+
+def get_kernel(**kwargs: Any):
+    """Return the source-specialized TIRx PrimFunc."""
+    tile_v = int(kwargs["tile_v"])
+    same_pool = bool(kwargs.get("same_pool", True))
+    kernel = _gdn_decode_bf16_wide_vec_t1.specialize(
+        NUM_HEADS=kwargs["num_heads"],
+        NUM_V_HEADS=kwargs["num_v_heads"],
+        TILE_V=tile_v,
+        NUM_V_TILES=V // tile_v,
+        ROWS_PER_GROUP=tile_v // NUM_GROUPS,
+        ITERS_PER_GROUP=(tile_v // NUM_GROUPS) // ILP_ROWS,
+        POOL_FACTOR=1 if same_pool else 2,
+        INTERMEDIATE_BATCH_STRIDE=(
+            int(kwargs["num_v_heads"]) * V * K
+            if kwargs.get("cache_intermediate_states", False)
+            else 0
+        ),
+        INTERMEDIATE_DUMMY_ELEMENTS=(0 if kwargs.get("cache_intermediate_states", False) else 1),
+        USE_QK_L2NORM=kwargs.get("use_qk_l2norm", True),
+        DISABLE_STATE_UPDATE=kwargs.get("disable_state_update", False),
+        CACHE_INTERMEDIATE_STATES=kwargs.get("cache_intermediate_states", False),
+        SAME_POOL=same_pool,
+    )
+    return kernel.with_attr(
+        "tirx.kernel_launch_params", ["blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory"]
+    )
+
+
+def _require_supported_config(config: dict[str, Any]) -> None:
+    batch = int(config["batch"])
+    num_heads = int(config["num_heads"])
+    num_v_heads = int(config["num_v_heads"])
+    tile_v = int(config["tile_v"])
+    if batch < 1:
+        raise ValueError("batch must be positive")
+    if (num_heads, num_v_heads) not in _TP_HEADS:
+        raise ValueError(f"unsupported Qwen3-Next TP head pair {(num_heads, num_v_heads)}")
+    if num_v_heads % num_heads:
+        raise ValueError("num_v_heads must be divisible by num_heads")
+    if tile_v not in (64, 128) or V % tile_v:
+        raise ValueError("wide-vector T1 port requires tile_v in {64, 128}")
+    if (tile_v // NUM_GROUPS) % ILP_ROWS:
+        raise ValueError("tile_v is incompatible with the 8-group, ILP4 mapping")
+
+
+def _allocate_pool(
+    pool_slots: int,
+    num_v_heads: int,
+    *,
+    padded: bool,
+    device: str | torch.device,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    padding_heads = 1 if padded else 0
+    backing = (
+        torch.randn(
+            (pool_slots, num_v_heads + padding_heads, V, K),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        * 0.1
+    )
+    return backing[:, :num_v_heads], backing
+
+
+def _clone_pool_layout(pool: torch.Tensor, *, padded: bool) -> tuple[torch.Tensor, torch.Tensor]:
+    pool_slots, num_v_heads = pool.shape[:2]
+    padding_heads = 1 if padded else 0
+    backing = torch.empty(
+        (pool_slots, num_v_heads + padding_heads, V, K), dtype=pool.dtype, device=pool.device
+    )
+    view = backing[:, :num_v_heads]
+    view.copy_(pool)
+    return view, backing
+
+
+def _make_qkv(
+    batch: int,
+    num_heads: int,
+    num_v_heads: int,
+    *,
+    packed: bool,
+    device: str | torch.device,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    if not packed:
+        q = (
+            torch.randn(
+                (batch, SEQ_LEN, num_heads, K),
+                dtype=torch.bfloat16,
+                device=device,
+                generator=generator,
+            )
+            * 0.05
+        )
+        k = torch.randn_like(q)
+        v = (
+            torch.randn(
+                (batch, SEQ_LEN, num_v_heads, V),
+                dtype=torch.bfloat16,
+                device=device,
+                generator=generator,
+            )
+            * 0.05
+        )
+        return q, k, v, None
+
+    q_elements = num_heads * K
+    k_elements = num_heads * K
+    v_elements = num_v_heads * V
+    row_elements = q_elements + k_elements + v_elements + 128
+    backing = (
+        torch.randn((batch, row_elements), dtype=torch.bfloat16, device=device, generator=generator)
+        * 0.05
+    )
+    q = backing.as_strided((batch, SEQ_LEN, num_heads, K), (row_elements, row_elements, K, 1), 0)
+    k = backing.as_strided(
+        (batch, SEQ_LEN, num_heads, K), (row_elements, row_elements, K, 1), q_elements
+    )
+    v = backing.as_strided(
+        (batch, SEQ_LEN, num_v_heads, V),
+        (row_elements, row_elements, V, 1),
+        q_elements + k_elements,
+    )
+    return q, k, v, backing
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Create deterministic independent mutable TIRx and FlashInfer cases."""
+    config = dict(kwargs)
+    _require_supported_config(config)
+    device = config.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for BF16 wide-vector GDN decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"BF16 wide-vector GDN decode requires SM100, got {capability}")
+
+    batch = int(config["batch"])
+    num_heads = int(config["num_heads"])
+    num_v_heads = int(config["num_v_heads"])
+    same_pool = bool(config.get("same_pool", True))
+    padded_pool = bool(config.get("padded_pool", False))
+    negative_read = bool(config.get("negative_read_index", False))
+    negative_write = bool(config.get("negative_write_index", False))
+    packed_qkv = bool(config.get("packed_qkv", False))
+    generator = torch.Generator(device=device)
+    generator.manual_seed(int(config.get("seed", 0)) + 20260811)
+
+    extra_null_slot = negative_read or negative_write
+    pool_slots = batch * (1 if same_pool else 2) + int(extra_null_slot)
+    initial_pool, initial_backing = _allocate_pool(
+        pool_slots, num_v_heads, padded=padded_pool, device=device, generator=generator
+    )
+    tirx_state, tirx_state_backing = _clone_pool_layout(initial_pool, padded=padded_pool)
+    source_state, source_state_backing = _clone_pool_layout(initial_pool, padded=padded_pool)
+
+    slot_offset = 1 if extra_null_slot else 0
+    read_indices = torch.arange(batch, dtype=torch.int32, device=device) + slot_offset
+    if negative_read:
+        read_indices[-1] = -1
+    if same_pool:
+        write_indices = read_indices
+    else:
+        write_indices = torch.arange(batch, dtype=torch.int32, device=device) + slot_offset + batch
+        if negative_write:
+            write_indices[-1] = -1
+
+    q, k, v, qkv_backing = _make_qkv(
+        batch, num_heads, num_v_heads, packed=packed_qkv, device=device, generator=generator
+    )
+    A_log = (
+        torch.randn((num_v_heads,), dtype=torch.float32, device=device, generator=generator) * 0.1
+    )
+    dt_bias = (
+        torch.randn((num_v_heads,), dtype=torch.float32, device=device, generator=generator) * 0.1
+    )
+    a = (
+        torch.randn(
+            (batch, SEQ_LEN, num_v_heads), dtype=torch.bfloat16, device=device, generator=generator
+        )
+        * 0.05
+    )
+    b_gate = torch.randn_like(a) * 0.05
+
+    cache = bool(config.get("cache_intermediate_states", False))
+    cache_shape = (batch, SEQ_LEN, num_v_heads, V, K)
+    tirx_intermediate = (
+        torch.empty(cache_shape, dtype=torch.bfloat16, device=device)
+        if cache
+        else torch.zeros((1,), dtype=torch.bfloat16, device=device)
+    )
+    source_intermediate = (
+        torch.empty(cache_shape, dtype=torch.bfloat16, device=device)
+        if cache
+        else torch.zeros((1,), dtype=torch.bfloat16, device=device)
+    )
+
+    return {
+        "config": config,
+        "initial_pool": initial_pool.clone(),
+        "initial_backing": initial_backing,
+        "tirx_state": tirx_state,
+        "tirx_state_backing": tirx_state_backing,
+        "source_state": source_state,
+        "source_state_backing": source_state_backing,
+        "read_indices": read_indices,
+        "write_indices": write_indices,
+        "q": q,
+        "k": k,
+        "v": v,
+        "qkv_backing": qkv_backing,
+        "qkv_snapshot": qkv_backing.clone() if qkv_backing is not None else None,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "a": a,
+        "b_gate": b_gate,
+        "tirx_output": torch.empty(
+            (batch, SEQ_LEN, num_v_heads, V), dtype=torch.bfloat16, device=device
+        ),
+        "source_output": torch.empty(
+            (batch, SEQ_LEN, num_v_heads, V), dtype=torch.bfloat16, device=device
+        ),
+        "tirx_intermediate": tirx_intermediate,
+        "source_intermediate": source_intermediate,
+    }
+
+
+@functools.cache
+def _load_frozen_oracle():
+    import flashinfer.gdn_kernels.gdn_decode_bf16_state as source_module
+
+    source_path = Path(source_module.__file__).resolve()
+    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
+        raise RuntimeError(
+            "GDN wide-vector oracle does not match the reviewed source: "
+            f"{source_path} sha256={digest}"
+        )
+    return source_module.gated_delta_rule_t1_wide_vec
+
+
+@functools.cache
+def _compile_tirx(
+    num_heads: int,
+    num_v_heads: int,
+    tile_v: int,
+    use_qk_l2norm: bool,
+    disable_state_update: bool,
+    cache_intermediate_states: bool,
+    same_pool: bool,
+):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(
+        get_kernel(
+            batch=1,
+            num_heads=num_heads,
+            num_v_heads=num_v_heads,
+            tile_v=tile_v,
+            use_qk_l2norm=use_qk_l2norm,
+            disable_state_update=disable_state_update,
+            cache_intermediate_states=cache_intermediate_states,
+            same_pool=same_pool,
+        )
+    )
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    config = case["config"]
+    state = case["tirx_state"]
+    q = case["q"]
+    k = case["k"]
+    v = case["v"]
+    batch = int(config["batch"])
+    pool_factor = 1 if bool(config.get("same_pool", True)) else 2
+
+    def storage_span(tensor: torch.Tensor, elements: int) -> torch.Tensor:
+        return tensor.as_strided((elements,), (1,))
+
+    return (
+        # Negative-index cases own one extra physical null slot, but the kernel
+        # ABI is deliberately the production B (or 2B) pool span.  All clamped
+        # and shifted indices remain inside that declared span.
+        storage_span(state, int(state.stride(0)) * batch * pool_factor),
+        storage_span(case["tirx_intermediate"], case["tirx_intermediate"].numel()),
+        case["A_log"],
+        case["a"].reshape(-1),
+        case["dt_bias"],
+        storage_span(q, int(q.stride(0)) * (batch - 1) + int(q.shape[2] * q.shape[3])),
+        storage_span(k, int(k.stride(0)) * (batch - 1) + int(k.shape[2] * k.shape[3])),
+        storage_span(v, int(v.stride(0)) * (batch - 1) + int(v.shape[2] * v.shape[3])),
+        case["b_gate"].reshape(-1),
+        case["tirx_output"].reshape(-1),
+        case["read_indices"],
+        case["write_indices"],
+        int(state.stride(0)),
+        int(q.stride(0)),
+        int(k.stride(0)),
+        int(v.stride(0)),
+        batch,
+    )
+
+
+def _tirx_executable(case: dict[str, Any]):
+    config = case["config"]
+    return _compile_tirx(
+        int(config["num_heads"]),
+        int(config["num_v_heads"]),
+        int(config["tile_v"]),
+        bool(config.get("use_qk_l2norm", True)),
+        bool(config.get("disable_state_update", False)),
+        bool(config.get("cache_intermediate_states", False)),
+        bool(config.get("same_pool", True)),
+    )
+
+
+def _run_reference(case: dict[str, Any]) -> torch.Tensor:
+    config = case["config"]
+    cache = bool(config.get("cache_intermediate_states", False))
+    same_pool = bool(config.get("same_pool", True))
+    oracle = _load_frozen_oracle()
+    result = oracle(
+        A_log=case["A_log"],
+        a=case["a"],
+        dt_bias=case["dt_bias"],
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=case["q"],
+        k=case["k"],
+        v=case["v"],
+        b=case["b_gate"],
+        initial_state_source=case["source_state"],
+        initial_state_indices=case["read_indices"],
+        output_state_indices=(case["read_indices"] if same_pool else case["write_indices"]),
+        intermediate_states_buffer=(case["source_intermediate"] if cache else None),
+        disable_state_update=bool(config.get("disable_state_update", False)),
+        use_qk_l2norm_in_kernel=bool(config.get("use_qk_l2norm", True)),
+        scale=SCALE,
+        output=case["source_output"],
+        tile_v=int(config["tile_v"]),
+    )
+    return result
+
+
+def _assert_untouched_slots(case: dict[str, Any], state_key: str) -> None:
+    config = case["config"]
+    pool = case[state_key]
+    initial = case["initial_pool"]
+    update_pool = not bool(config.get("disable_state_update", False)) and not bool(
+        config.get("cache_intermediate_states", False)
+    )
+    touched = torch.zeros((pool.shape[0],), dtype=torch.bool, device=pool.device)
+    if update_pool:
+        indices = (
+            case["read_indices"] if bool(config.get("same_pool", True)) else case["write_indices"]
+        )
+        touched[torch.clamp(indices, min=0).to(torch.int64)] = True
+    torch.testing.assert_close(pool[~touched], initial[~touched], atol=0.0, rtol=0.0)
+
+
+def _assert_case_close(case: dict[str, Any]) -> None:
+    torch.testing.assert_close(
+        case["tirx_output"].float(), case["source_output"].float(), atol=1.0e-3, rtol=5.0e-3
+    )
+    torch.testing.assert_close(
+        case["tirx_state"].float(), case["source_state"].float(), atol=2.0e-2, rtol=1.0e-2
+    )
+    _assert_untouched_slots(case, "tirx_state")
+    _assert_untouched_slots(case, "source_state")
+    if bool(case["config"].get("cache_intermediate_states", False)):
+        torch.testing.assert_close(
+            case["tirx_intermediate"].float(),
+            case["source_intermediate"].float(),
+            atol=2.0e-2,
+            rtol=1.0e-2,
+        )
+    if case["qkv_backing"] is not None:
+        torch.testing.assert_close(case["qkv_backing"], case["qkv_snapshot"], atol=0.0, rtol=0.0)
+
+
+def run_test(**kwargs: Any) -> None:
+    case = prepare_data(**kwargs)
+    executable = _tirx_executable(case)
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize()
+    _run_reference(case)
+    torch.cuda.synchronize()
+    _assert_case_close(case)
+
+
+def run_bench(
+    *,
+    warmup: int | None = None,
+    repeat: int | None = None,
+    timer: str | None = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    case = prepare_data(**kwargs)
+    executable = _tirx_executable(case)
+    args = _tirx_args(case)
+    executable(*args)
+    _run_reference(case)
+    torch.cuda.synchronize()
+    _assert_case_close(case)
+
+    def source_builder():
+        for _ in range(2):
+            _run_reference(case)
+        torch.cuda.synchronize()
+
+        def launch():
+            _run_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        references={"flashinfer_cutedsl": source_builder},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- add an SM100 TIRx port of FlashInfer's BF16 wide-vector T=1 GDN decode kernel
- cover the Qwen3-Next TP1/2/4/8 production dispatch matrix and source control-flow variants
- add the curated 18-shape bench-suite matrix and a lint test that rejects tile primitives in every specialization
- include the frozen execution sketch used during the initial porting design stage

## Impact

This adds a correctness-validated, performance-aligned GDN decode implementation for B200-class GPUs. The implementation preserves the required BF16 state/output behavior while using explicit PTX-level operations and no TIRx tile primitives.

## Validation

- 42/42 correctness configurations passed against the FlashInfer CuTeDSL reference
- complete unpinned 18-workload bench-suite passed with every source/TIRx ratio above `0.99x`; minimum ratio: `1.004336x`
- source and all 42 pre-dispatch specializations passed the no-tile lint check
- targeted bench-suite import check passed
- staged `pre-commit run` passed
