### PR TITLE
Fix FA4 TMEM teardown ordering and FlashMLA IKET manifest

### DIFF
--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -1527,6 +1527,7 @@ def _kernel(
                 phase_tmem ^= 1
             phase_q ^= 1
         scheduler.next_tile()
+    T.cuda.cta_sync()
     if (wg_id == 0) & (warp_id == 0):
         dealloc_tmem_addr: T.uint32
         T.ptx.ld.shared.u32(dealloc_tmem_addr, tmem_addr.ptr_to([0]))

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -33,6 +33,15 @@ LOG_2_E = math.log2(math.e)
 
 BF16_BYTES = 2
 
+IKET_EVENT_NAMES = (
+    "h128-small-q-load-output",
+    "h128-small-kv-load",
+    "h128-small-qk-pv-issue",
+    "h128-small-valid-mask",
+    "h128-small-clc",
+    "h128-small-softmax",
+)
+
 
 def _add_smem_desc_offset(desc, offset):
     # Descriptor offsets wrap in the low 32 bits without carrying into the


### PR DESCRIPTION
## Summary

- rendezvous all FlashAttention-4 warpgroups after the persistent scheduler loop and before warp 0 relinquishes/deallocates TMEM
- publish the six existing small-topk FlashMLA IKET ranges through the same `IKET_EVENT_NAMES` contract as the sibling kernels

The two changes are independent and remain separate commits.

## Why

Without the pre-deallocation rendezvous, the correction warpgroup can execute its final TMEM read after warpgroup 0 has deallocated the CTA allocation. NumSim, Synccheck, and Racecheck all observed this ordering, with the representative failure reporting dynamic TMEM column 256 after the live allocation set became empty.

The small-topk FlashMLA kernel already contains all six `range_start`/`range_end` annotations, but omitted the host-visible event manifest. The package IKET contract therefore raised `AttributeError` before it could verify either the source declarations or generated `__iket_meta_info`.

## Performance

Paired AB/BA measurements on an idle NVIDIA B200 (`GPU-e56ad157`) covered the two single-task causal shapes named by the source comment. The added rendezvous costs 0.23-0.32 us, or 0.73-1.14%; all 32 paired warm/cold samples were positive. Both variants were elementwise identical and matched the independent PyTorch oracle.

The repair was replayed on current main `1097cce`. The repaired `_kernel` AST is byte-for-byte equivalent at the AST level to the measured variant (SHA-256 `9059a01fa38bd14c1aac81ebd4cf4cf6c8f22c4b858a67add6f16fc0c8e5b886`); #24 only moved the module and changed headers/category metadata around it.

## Validation

- `CUDA_VISIBLE_DEVICES=6 TVM_CUDA_COMPILE_MODE=nvcc PYTHONPATH=.:/home/hongyij/tir/python python -u -m tirx_kernels.test --kernel flash_attention4` — 32 passed, 0 failed, 0 skipped on B200
- focused downstream canonical case on current main — NumSim `clean`; Synccheck `clean`, 512/512 tasks; Racecheck `review`, 512/512 tasks, exactly two existing same-warp TMEM `read_write` findings and no incomplete result
- FlashMLA declaration plus ordinary/instrumented compile contract — 6 passed across the three variants; the ordinary build strips IKET and the instrumented build emits all declared metadata
- `python tests/lint/check_license_headers.py` — passed
- `PYTHONPATH=.:/home/hongyij/tir/python python -m tirx_kernels.registry --format json` — passed
- `pre-commit run --all-files` — passed

No expected verdict was relaxed to make the FA4 checks pass.
