### PR TITLE
feat(kernel): port FlashInfer's recurrent-KDA decode kernels (one-warp and grouped-CTA)

### DIFF
--- a/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
+++ b/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
@@ -1,0 +1,684 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Copyright (c) 2026 The TIRx Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Recurrent-KDA grouped-CTA decode SM100: coarse WASP execution sketch
+
+This is a non-executable sketch of FlashInfer's CuTe DSL `_grouped_kda_kernel`
+(`flashinfer/kda_kernels/recurrent_kda.py:482`, host `_grouped_kda_host:729`,
+compile cache `_get_grouped_compiled:836`). It records the column/part thread
+split, the register-resident `(8, G)` state granule, the four shared-memory
+staging buffers and their per-thread strided views, the single CTA barrier that
+separates the two thread-index mappings, the reduction and butterfly orders, and
+the predicated output/checkpoint/orphan paths that the TIRx port must preserve.
+The implementation represented by this sketch is maintained in
+[`tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py`](../../../../tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py),
+which becomes the source of truth after this sketch passes review.
+
+The target is SM100a/B200. `D = 128` (`K == V`), `VSPLIT = 4`, `RATIO = 1`,
+`USE_L2 = 1`, `HAS_DT_BIAS = 1`, `BETA_LOGIT = 0`, `USE_SRC = 0`. Q/K/V/G/beta/
+state/out are BF16; `A_log`, `dt_bias`, `scale`, `lower_bound` are FP32;
+`cu_seqlens`, `ssm_state_indices`, `num_accepted_tokens` are int32.
+
+The host fixes the tiling with a hard rule, `KS = 4 if T == 1 else 2` and
+`VSPLIT = 4` (`:859-860`), so **exactly two tile shapes are in scope**:
+
+| variant | `T` | `KS` | `NT` threads | warps | `KC` | `G` | `CPB` | `EPT` | `SW` | smem |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| decode | 1 | 4 | 128 | 4 | 32 | 4 | 32 | 1 | 4 | 1600 B |
+| verify | 2/4/8 | 2 | 64 | 2 | 64 | 8 | 32 | 2 | 2 | 3200/6400/12800 B |
+
+Both in-kernel gate modes are in scope: `GATE_MODE = 2` (lower bound, Kimi K3)
+and `GATE_MODE = 1` (softplus, Kimi Linear). Out of scope: `GATE_MODE = 0`
+(gate precomputed outside), `USE_SRC = 1`, `BETA_LOGIT = 1`, `USE_L2 = 0`,
+`D = 64`, GQA (`RATIO != 1`), the dense no-`cu_seqlens` path, and the one-warp
+`recurrent_kda_decode_kernel`, which owns `T == 1 and sequence_heads >= 128`
+(`:1798`) and is sketched separately in
+[`recurrent_kda_decode_one_warp.md`](recurrent_kda_decode_one_warp.md).
+
+## Pipeline at a glance
+
+This kernel has **no asynchronous pipeline, no mbarrier, no TMA, and no
+`cp.async`**. It has shared memory and exactly **one** CTA barrier
+(`cute.arch.sync_threads()` at `:641`). That barrier exists for a specific
+reason: the two phases index threads differently, and the sketch must keep that
+visible.
+
+* **Phase A** maps a thread to gate/query/key *elements* by `d = tid % D`, and
+  each thread handles `EPT` elements strided by `NT`. This mapping covers all
+  `D = 128` gate columns of a token.
+* **Phase B** maps a thread to a *state column* `v_idx = vz*CPB + tid//KS` and a
+  *K-slice* `part = tid % KS` of that column. Each thread owns a `(8, G)` FP32
+  granule of the `[V, K]` state and reads the whole `D`-length gate/key/query
+  vectors for its own K-slice.
+
+A thread's phase-A elements and its phase-B slice belong to different threads'
+data, so the staged vectors must be complete before phase B starts. That is the
+entire purpose of the barrier; there is no producer/consumer warp specialization.
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, n, vz)` | value head `hv`, sequence row `n`, column block `[vz*CPB, (vz+1)*CPB)` | independent; no cross-CTA communication |
+| thread `tid`, phase A | gate/q/k elements `d + e*NT` for `e in [0, EPT)` of every token `t` | writes `s_eg/s_kr/s_qr`; consumed by *all* threads after the barrier |
+| thread `tid`, phase B | state granule `(8, G)` = K-slice `part` of column `v_idx` | reads all of `s_eg/s_kr/s_qr` for its slice; carries `s` across tokens |
+| lane `tid % 32`, warp `tid // 32` | one L2 partial pair per token | `lane == 0 and wid < SW` publishes to `s_red`; all threads read it back |
+| `part` group of `KS` threads | the `KS` K-slices of one column | joined by butterfly shuffles for the two dot products |
+| `part == 0` thread | the output element `out[pidx, hv, v_idx]` | sole writer of that element |
+| CTA `(hv, 0, 0)`, `tid < D` | the orphan packed suffix `[cu[n_seq], q_total)` | decode-only tail; see the orphan note below |
+
+The dependency chain per token is: staged gate/key/query (phase A) → L2 factors
+→ decay + prediction dot → butterfly join → `deltak` → rank-1 update + output
+dot → butterfly join → predicated output store → checkpoint store. Tokens are
+strictly sequential in phase B because `s` carries between them; the `T` tokens
+are `constexpr`-unrolled, not looped.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+specialize(...)       # static D, T, KS, VSPLIT, GATE_MODE, ...
+launch(...)           # grid/block metadata
+tile(...)             # GMEM storage declaration
+smem_tile(...)        # SMEM storage declaration
+view(...)             # typed/strided view without a copy
+slice(...)            # fix one coordinate of a view
+reg_tile(...)         # thread-private registers
+```
+
+Copies always name their storage direction:
+
+```python
+copy_g2r(src, dst, evict=None, predicate=None)
+copy_r2g(src, dst, evict=None, predicate=None)
+copy_r2s(src, dst, predicate=None)
+copy_s2r(src, dst)
+```
+
+There is no `copy_g2s`, TMA, `cp.async`, `ldmatrix`, `stmatrix`, or TCGEN05
+operation in this kernel: every global↔shared transfer goes through registers.
+
+The computation vocabulary is deliberately primitive. `vmul`/`vadd` are the
+8-wide packed-FP32 forms; the scalar forms carry no `v` prefix:
+
+```python
+fill(dst, value)
+cast(dst, src, rounding=None)
+cast_f32(dst, src)                            # BF16 -> FP32 widening
+add(dst, lhs, rhs);   vadd(dst, lhs, rhs)     # 8-wide FP32
+mul(dst, lhs, rhs);   vmul(dst, lhs, rhs)     # 8-wide FP32
+sub(dst, lhs, rhs)
+neg(dst, src)
+fma(dst, lhs, rhs, acc)
+exp2(dst, src)
+log1p(dst, src)
+rcp(dst, src)
+rsqrt(dst, src)
+select(dst, predicate, true_value, false_value)
+shuffle_bfly(src, lane_xor, clamp, member_mask) -> dst
+vmov(dst, src)                                # register move, no PTX of its own
+cta_sync()
+```
+
+There is no compound `l2norm`, `gate`, `sigmoid`, `softplus`, `delta_rule`,
+`update_state`, `reduce`, or `checkpoint` operation: every one of those paths is
+expanded below.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+variant = specialize(
+    D=128,
+    T=(1, 2, 4, 8),
+    KS=(4, 2),            # tied to T by the host: KS = 4 if T == 1 else 2
+    VSPLIT=4,
+    RATIO=1,
+    GATE_MODE=(1, 2),
+    HAS_DT_BIAS=True,
+    BETA_LOGIT=False,
+    USE_L2=True,
+    USE_SRC=False,
+    target="sm_100a",
+)
+
+# recurrent_kda.py:515-524 -- every tile constant is derived from (D, KS, VSPLIT).
+KC  = D // KS                 # state elements per thread     32 | 64
+G   = KC // 8                 # 16B granules per thread        4 | 8
+CPB = D // VSPLIT             # columns per CTA               32
+NT  = (D * KS) // VSPLIT      # threads per CTA              128 | 64
+EPT = max(D // NT, 1)         # phase-A elements per thread    1 | 2
+SW  = min(D, NT) // 32        # warp partials per reduction    4 | 2
+
+# The host owns the tiling rule and the dispatch domain
+# (recurrent_kda.py:859-860, :1798).
+host_assert(KS == (4 if T == 1 else 2) and VSPLIT == 4)
+host_assert(not (T == 1 and N * HV >= 128))   # else the one-warp kernel wins
+host_assert(HV % RATIO == 0)
+host_assert(state_slot_stride % 8 == 0)       # cute.assume(divby=8), :766-767
+
+# Runtime ABI. `q_total` may exceed `cu[n_seq]` only in the T == 1 decode
+# layout; see the orphan note at the end.
+q, k        = tile(gmem, bf16, [q_total, H,  D])      # indexed by h = hv // RATIO
+v, g, out   = tile(gmem, bf16, [q_total, HV, D])      # indexed by hv
+beta        = tile(gmem, bf16, [q_total, HV])
+a_log       = tile(gmem, f32,  [H])
+dt_bias     = tile(gmem, f32,  [H * D])
+cu          = tile(gmem, i32,  [n_seq + 1])
+ssm_idx     = tile(gmem, i32,  [n_seq, T])            # -1 == CUDA-graph pad slot
+nat         = tile(gmem, i32,  [n_seq])
+state       = tile(gmem, bf16, [n_slots, HV, D, D])   # read AND written in place
+
+launch(grid=(HV, n_seq, VSPLIT), block=(NT, 1, 1),
+       smem_bytes=4 * (3 * T * D + 16 * T),
+       preferred_smem_carveout=25)
+
+hv, n, vz = cta_id()
+tid       = thread_id()
+lane, wid = tid % 32, tid // 32
+h         = hv // RATIO
+v_idx     = vz * CPB + tid // KS      # the state column this thread owns
+part      = tid % KS                  # which K-slice of that column
+d         = tid % D                   # phase-A element base
+
+# ===========================================================================
+# Shared memory: three T-batched staging buffers + one reduction scratch
+# ===========================================================================
+# recurrent_kda.py:526-541. Declared as one 16B-aligned arena and carved into
+# four views, so the TIRx port computes byte offsets at specialization time.
+
+s_eg  = smem_tile(f32, [T * D])   # exp2(gate)          offset 0
+s_kr  = smem_tile(f32, [T * D])   # un-normalized key   offset 4*T*D
+s_qr  = smem_tile(f32, [T * D])   # un-normalized query offset 8*T*D
+s_red = smem_tile(f32, [T * 16])  # L2 warp partials    offset 12*T*D
+
+# Per-thread strided views: (8, G, KS, T) with stride (1, KS*8, 8, D), sliced at
+# `part`. The KS threads of a column interleave at 8-element granularity, which
+# is what makes each thread's 8-wide read contiguous.
+eg_v = slice(view(s_eg, shape=(8, G, KS, T), stride=(1, KS * 8, 8, D)), part)
+kr_v = slice(view(s_kr, shape=(8, G, KS, T), stride=(1, KS * 8, 8, D)), part)
+qr_v = slice(view(s_qr, shape=(8, G, KS, T), stride=(1, KS * 8, 8, D)), part)
+
+# ===========================================================================
+# Row bounds and the initial checkpoint slot
+# ===========================================================================
+
+token_base = cu[n]
+seq_len    = cu[n + 1] - token_base
+
+# recurrent_kda.py:552-560. `nat` is an unconditional argument but is read only
+# for T > 1; SGLang never supplies it, so the host substitutes a cached ones
+# vector and `ic` collapses to 0.
+ic = 0
+if T > 1:
+    ic = clamp(nat[n] - 1, 0, T - 1)
+slot0 = ssm_idx[n, ic]
+if slot0 < 0:
+    slot0 = 0                     # pad rows still load (a defined address), never store
+
+# ===========================================================================
+# State load: one (8, G) BF16 granule per thread, eviction-hinted
+# ===========================================================================
+
+s   = reg_tile(f32,  (8, G))      # THE recurrent carry; lives the whole kernel
+sb0 = reg_tile(bf16, (8, G))
+
+gv0 = slice(view(state[slot0, hv, v_idx, :], shape=(8, G, KS), stride=(1, KS * 8, 8)), part)
+copy_g2r(gv0, sb0, evict="no_allocate")
+# instruction_selection: ld.global.L1::no_allocate.v4.b32; extent: G x 16B vectors
+# The widening to FP32 is NOT written here; it is written after the barrier.
+# See "state widening" below. The load itself does not move.
+
+# ===========================================================================
+# Loop-invariant gate constants
+# ===========================================================================
+
+av = 1.0
+if GATE_MODE != 0:
+    mul(t0, a_log[h], LOG2_E)
+    # instruction_selection: mul.f32; extent: scalar
+    exp2(av, t0)
+    # instruction_selection: ex2.approx.ftz.f32; extent: scalar
+
+dtb = reg_tile(f32, (EPT,))
+for e in range(EPT):              # constexpr
+    dtb[e] = dt_bias[h * D + d + e * NT]
+    # instruction_selection: ld.global.b32; extent: scalar
+
+# ===========================================================================
+# Phase A: stage every token's gate/key/query, then one barrier
+# ===========================================================================
+# Thread mapping here is `d + e*NT`, NOT the (v_idx, part) mapping of phase B.
+
+slots, ves = [], []               # constexpr python lists, one entry per token
+q_bits, k_bits, g_bits, b_bits = [], [], [], []
+
+# --- issue: every token's global loads, before any of them is consumed ------
+# The source loads and consumes one token at a time.  Splitting the loop is the
+# one deliberate deviation from its dataflow order: the values, their types and
+# their consumers are unchanged, only the issue point moves.  bench_suite
+# measures a cold L2 (it zeroes a 256 MB buffer before every timed iteration),
+# which is also what an inference server sees, and under a cold L2 this kernel
+# is bound by how many DRAM misses are in flight rather than by instruction
+# count.  Per-token issue keeps 3*EPT+3 requests outstanding; issuing all T
+# tokens keeps T times as many.  Cost is T*(3*EPT+1) BF16 staging registers.
+for t in range(T):                # constexpr unroll
+    slots.append(ssm_idx[n, t])
+    # instruction_selection: ld.global.b32; extent: scalar
+
+    # Out-of-row tokens clamp their token index to 0 so the loads below stay in
+    # bounds; the value is discarded by the `active` predicate in phase B.
+    pidx = token_base + t
+    if t >= seq_len:
+        pidx = 0
+    # instruction_selection: setp.lt.s32 + selp.b32; extent: scalar
+
+    ves.append(v[pidx, hv, v_idx])            # stays BF16 until :681
+    # instruction_selection: ld.global.b16; extent: scalar
+    b_bits.append(beta[pidx, hv])              # BETA_LOGIT == 0: already sigmoid'd
+    # instruction_selection: ld.global.b16; extent: scalar
+    for e in range(EPT):          # constexpr
+        de = d + e * NT
+        q_bits.append(q[pidx, h,  de])
+        # instruction_selection: ld.global.b16; extent: scalar
+        k_bits.append(k[pidx, h,  de])
+        # instruction_selection: ld.global.b16; extent: scalar
+        g_bits.append(g[pidx, hv, de])
+        # instruction_selection: ld.global.b16; extent: scalar
+
+# --- consume: gate math and the L2 partials, off the staged registers -------
+bbs = []
+for t in range(T):                # constexpr unroll
+    bbs.append(cast_f32(b_bits[t]))
+    # instruction_selection: cvt.f32.bf16; extent: scalar
+
+    fill(sqp, 0.0); fill(skp, 0.0)
+    for e in range(EPT):          # constexpr
+        qe = q_bits[t * EPT + e]
+        ke = k_bits[t * EPT + e]
+        ge = g_bits[t * EPT + e]
+
+        # The L2 partials accumulate the BF16 loads directly into FP32.
+        fma(sqp, qe, qe, sqp)
+        # instruction_selection: fma.rn.f32.bf16; extent: scalar
+        fma(skp, ke, ke, skp)
+        # instruction_selection: fma.rn.f32.bf16; extent: scalar
+
+        # ---- gate branch (recurrent_kda.py:613-627) ----
+        add(x, ge, dtb[e])
+        # instruction_selection: add.rn.f32.bf16; extent: scalar
+        if GATE_MODE == 1:                     # softplus, Kimi Linear
+            mul(u, x, LOG2_E)
+            # instruction_selection: mul.f32; extent: scalar
+            exp2(u, u)
+            # instruction_selection: ex2.approx.ftz.f32; extent: scalar
+            log1p(sp, u)
+            # instruction_selection: inlined __nv_log1pf -- add.rz.f32 exponent
+            # split, 8-term fma.rn.f32 minimax chain, ln2 rescale, plus an
+            # inf/zero fixup branch; extent: ~12 fma.rn.f32 per site
+            select(sp, x > 20.0, x, sp)        # linear guard, :620
+            # instruction_selection: setp.gt.f32 + selp.f32; extent: scalar
+            mul(gate, sp, -av)
+            # instruction_selection: mul.f32; extent: scalar
+        else:                                  # GATE_MODE == 2, lower bound
+            neg(u, x)
+            # instruction_selection: neg.f32; extent: scalar
+            mul(u, av, u)
+            # instruction_selection: mul.f32; extent: scalar
+            mul(u, u, LOG2_E)
+            # instruction_selection: mul.f32; extent: scalar
+            # The negation is its own instruction on `x`; it is NOT folded into
+            # a negative LOG2_E constant.
+            exp2(u, u)
+            # instruction_selection: ex2.approx.ftz.f32; extent: scalar
+            add(u, u, 1.0)
+            # instruction_selection: add.f32; extent: scalar
+            rcp(sig, u)
+            # instruction_selection: rcp.rn.f32; extent: scalar  (NOT rcp.approx)
+            mul(gate, lower_bound, sig)
+            # instruction_selection: mul.f32; extent: scalar
+
+        mul(eg, gate, LOG2_E)
+        # instruction_selection: mul.f32; extent: scalar
+        exp2(eg, eg)
+        # instruction_selection: ex2.approx.ftz.f32; extent: scalar
+
+        # Note: the staged key/query are the RAW values. L2 normalization is
+        # applied in phase B as a scalar factor, not here.
+        copy_r2s(eg, s_eg[t * D + de])
+        # instruction_selection: st.shared.b32; extent: scalar
+        # The staging tiles are FP32, so q/k convert here; the L2 partials
+        # above consumed the raw BF16 registers instead.
+        cast_f32(ke_f, ke)
+        # instruction_selection: cvt.f32.bf16; extent: scalar
+        cast_f32(qe_f, qe)
+        # instruction_selection: cvt.f32.bf16; extent: scalar
+        copy_r2s(ke_f, s_kr[t * D + de])
+        # instruction_selection: st.shared.b32; extent: scalar
+        copy_r2s(qe_f, s_qr[t * D + de])
+        # instruction_selection: st.shared.b32; extent: scalar
+
+    # ---- L2 partial reduction (recurrent_kda.py:633-640) ----
+    # A full 32-lane butterfly, five rounds, even though only SW warp results
+    # are consumed. The offsets DESCEND: `warp_reduction_sum` halves a group
+    # width, so the emission order is 16, 8, 4, 2, 1. FP32 addition is not
+    # associative and the checkpoint must be exact, so the port must not
+    # reverse this.
+    for off in (16, 8, 4, 2, 1):  # constexpr
+        add(sqp, sqp, shuffle_bfly(sqp, off, 31, 0xffffffff))
+        # instruction_selection: shfl.sync.bfly.b32 + add.f32; extent: scalar
+        add(skp, skp, shuffle_bfly(skp, off, 31, 0xffffffff))
+        # instruction_selection: shfl.sync.bfly.b32 + add.f32; extent: scalar
+
+    copy_r2s(sqp, s_red[t * 16 + wid],     predicate=(lane == 0) & (wid < SW))
+    # instruction_selection: setp.ne.b32 + branch-guarded st.shared.b32; extent:
+    # scalar  (ptxas if-converts this site to a predicated STS in SASS)
+    copy_r2s(skp, s_red[t * 16 + 8 + wid], predicate=(lane == 0) & (wid < SW))
+    # instruction_selection: setp.ne.b32 + branch-guarded st.shared.b32; extent: scalar
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# The ONLY barrier in the kernel. It separates the `d = tid % D` element mapping
+# above from the `(v_idx, part)` granule mapping below.
+
+# ---- state widening, deferred to here ----
+# Nothing in phase A reads `s`, so this placement reaches only scheduling: same
+# op, same extent, same instruction, same data-dependence order as writing it at
+# the load site. ptxas hoists this form partway back anyway, so the two
+# spellings land within a few instructions of each other on every landmark.
+#
+# Load-to-consumer distance in scheduled SASS:
+#
+#            T=1   T=2   T=4   T=8
+#   source    60   199   393   874
+#   deferred  71   216   462   970
+#   at load   19    18    21    16
+#
+# It is worth 15-20% on the T = 1 decode shapes and is within run-to-run noise
+# on every T > 1 shape, so it is unconditional. Measured on full bench_suite
+# matrices, with the tight row cross-checked five times on a clock-verified GPU:
+#
+#                    deferred        at load site
+#   dec_hv16_b4      1.062-1.090     0.855
+#   dec_hv12_b8      1.045-1.087     1.019
+#   dec_hv12_b4      1.064-1.068     0.995
+#   ver_t8_hv16_b1   1.645           1.671
+#   ver_t8_hv16_b4   1.652           1.642
+#   ver_t2_hv16_b8   1.092           1.108
+#
+# This used to sit behind a `T <= 2` constexpr whose mechanism the sketch
+# admitted it could not explain: before phase A issued all T tokens' loads up
+# front, deferring cost 2-3% at T = 8. That cost is gone -- the deferral and the
+# hoisting were two ways of moving work off the load's critical path, and the
+# hoisting subsumes it -- so the boundary is gone too.
+cast(s, sb0)
+# instruction_selection: cvt.f32.bf16; extent: 8*G element loop
+
+# ===========================================================================
+# Phase B: barrier-free sequential recurrence over the T tokens
+# ===========================================================================
+
+pf   = reg_tile(f32, (8,))
+kreg = reg_tile(f32, (8, G))      # staged keys, loaded in pass 1, reused in pass 2
+
+for t in range(T):                # constexpr unroll; `s` carries across tokens
+    slot   = slots[t]
+    in_row = t < seq_len
+    active = in_row & (slot >= 0)
+
+    if active:
+        pidx = token_base + t
+        ve, bb = ves[t], bbs[t]
+
+        # ---- L2 factors from the staged partials (:657-664) ----
+        fill(sqt, 0.0); fill(skt, 0.0)
+        for w in range(SW):       # constexpr
+            copy_s2r(s_red[t * 16 + w], r0)
+            # instruction_selection: the SW loop is fully vectorized in both
+            # in-scope shapes -- ld.shared.v2.b32 at SW == 2 (T > 1) and
+            # ld.shared.v4.b32 at SW == 4 (T == 1); extent: SW f32
+            copy_s2r(s_red[t * 16 + 8 + w], r1)
+            # instruction_selection: ld.shared.v2.b32 / ld.shared.v4.b32; extent: SW f32
+            add(sqt, sqt, r0)
+            # instruction_selection: add.f32; extent: scalar
+            add(skt, skt, r1)
+            # instruction_selection: add.f32; extent: scalar
+        add(skt, skt, 1e-6)       # eps is hardcoded in the source, not an arg
+        # instruction_selection: add.f32; extent: scalar
+        rsqrt(rk, skt)
+        # instruction_selection: rsqrt.approx.f32; extent: scalar  (NOT .ftz)
+        add(sqt, sqt, 1e-6)
+        # instruction_selection: add.f32; extent: scalar
+        rsqrt(rq, sqt)
+        # instruction_selection: rsqrt.approx.f32; extent: scalar
+        mul(rq, rq, scale)
+        # instruction_selection: mul.f32; extent: scalar
+
+        # ---- pass 1: decay the state, accumulate the raw prediction ----
+        # gi == 0 is peeled so `pvec` is initialized by a mul, not a fill+fma.
+        copy_s2r(eg_v[:, 0, t], e0)
+        # instruction_selection: ld.shared.v2.b64; extent: 8 f32 (2 x 16B)
+        vmul(svec, s[:, 0], e0)
+        # instruction_selection: mul.f32x2; extent: 8 f32 (4 packed pairs)
+        vmov(s[:, 0], svec)
+        copy_s2r(kr_v[:, 0, t], kreg[:, 0])
+        # instruction_selection: ld.shared.v2.b64; extent: 8 f32
+        vmul(pvec, kreg[:, 0], svec)
+        # instruction_selection: mul.f32x2; extent: 8 f32
+        for gi in range(1, G):    # constexpr
+            copy_s2r(eg_v[:, gi, t], ei)
+            # instruction_selection: ld.shared.v2.b64; extent: 8 f32
+            vmul(svec, s[:, gi], ei)
+            # instruction_selection: mul.f32x2; extent: 8 f32
+            vmov(s[:, gi], svec)
+            copy_s2r(kr_v[:, gi, t], kreg[:, gi])
+            # instruction_selection: ld.shared.v2.b64; extent: 8 f32
+            vmul(tmp, kreg[:, gi], svec)
+            # instruction_selection: mul.f32x2; extent: 8 f32
+            vadd(pvec, pvec, tmp)
+            # instruction_selection: add.f32x2; extent: 8 f32
+            # NOTE: mul + add, NOT fma.f32x2. The source keeps them separate and
+            # the PTX confirms zero fma.*.f32x2 in either variant.
+
+        # ---- balanced 8-term tree, then the KS butterfly join (:675-681) ----
+        vmov(pf, pvec)
+        add(pred, add(add(pf[0], pf[1]), add(pf[2], pf[3])),
+                  add(add(pf[4], pf[5]), add(pf[6], pf[7])))
+        # instruction_selection: add.f32; extent: 7-add balanced tree
+        for off_i in range(bit_length(KS - 1)):   # KS=2 -> {1}; KS=4 -> {1, 2}
+            add(pred, pred, shuffle_bfly(pred, 1 << off_i, 31, 0xffffffff))
+            # instruction_selection: shfl.sync.bfly.b32 + add.f32; extent: scalar
+
+        # ---- delta rule (:681) -- `rk` appears TWICE, once inside and once
+        # outside the parenthesis. This is not a typo in the source.
+        mul(t1, rk, pred)
+        # instruction_selection: mul.f32; extent: scalar
+        sub(t1, ve, t1)
+        # instruction_selection: sub.rn.f32.bf16; extent: scalar -- `ve` is
+        # never converted; the mixed-precision subtract takes the raw BF16.
+        mul(deltak, rk, bb)
+        # instruction_selection: mul.f32; extent: scalar
+        mul(deltak, deltak, t1)
+        # instruction_selection: mul.f32; extent: scalar
+
+        # ---- pass 2: rank-1 update, accumulate the raw output ----
+        # The source re-reads `kr_v` here, but the compiler keeps the pass-1
+        # registers live -- the PTX shows 3*G shared loads per token, not 4*G,
+        # which is why `kreg` is carried rather than reloaded.
+        vmul(tmp, kreg[:, 0], deltak)
+        # instruction_selection: mul.f32x2; extent: 8 f32
+        vadd(svec, s[:, 0], tmp)
+        # instruction_selection: add.f32x2; extent: 8 f32
+        vmov(s[:, 0], svec)
+        copy_s2r(qr_v[:, 0, t], q0)
+        # instruction_selection: ld.shared.v2.b64; extent: 8 f32
+        vmul(ovec, q0, svec)
+        # instruction_selection: mul.f32x2; extent: 8 f32
+        for gi in range(1, G):    # constexpr
+            vmul(tmp, kreg[:, gi], deltak)
+            # instruction_selection: mul.f32x2; extent: 8 f32
+            vadd(svec, s[:, gi], tmp)
+            # instruction_selection: add.f32x2; extent: 8 f32
+            vmov(s[:, gi], svec)
+            copy_s2r(qr_v[:, gi, t], qi)
+            # instruction_selection: ld.shared.v2.b64; extent: 8 f32
+            vmul(tmp, qi, svec)
+            # instruction_selection: mul.f32x2; extent: 8 f32
+            vadd(ovec, ovec, tmp)
+            # instruction_selection: add.f32x2; extent: 8 f32
+
+        vmov(pf, ovec)
+        add(o, add(add(pf[0], pf[1]), add(pf[2], pf[3])),
+               add(add(pf[4], pf[5]), add(pf[6], pf[7])))
+        # instruction_selection: add.f32; extent: 7-add balanced tree
+        for off_i in range(bit_length(KS - 1)):
+            add(o, o, shuffle_bfly(o, 1 << off_i, 31, 0xffffffff))
+            # instruction_selection: shfl.sync.bfly.b32 + add.f32; extent: scalar
+
+        # ---- output store, owned by part == 0 (:698-700) ----
+        mul(o, o, rq)
+        # instruction_selection: mul.f32; extent: scalar
+        cast(o_bf, o)
+        # instruction_selection: cvt.rn.bf16.f32; extent: scalar
+        copy_r2g(o_bf, out[pidx, hv, v_idx], predicate=(part == 0))
+        # instruction_selection: setp.ne.b32 + branch-guarded st.global.b16;
+        # extent: scalar
+        # DELIBERATE DEVIATION: the source leaves this one branch-guarded and
+        # ptxas does NOT if-convert it. The TIRx port emits `@p st.global.b16`
+        # instead, because inline asm is opaque to ptxas -- an `if` around an asm
+        # store can never be if-converted, and in the one-warp sibling that cost
+        # extra BRA/BSYNC plus divergence-induced shuffle bank conflicts.
+
+        # ---- BF16 checkpoint write, eviction-hinted (:702-713) ----
+        sb1 = reg_tile(bf16, (8, G))
+        cast(sb1, s, rounding="rn")
+        # instruction_selection: cvt.rn.bf16x2.f32; extent: 4*G packed pairs
+        gw = slice(view(state[slot, hv, v_idx, :], shape=(8, G, KS),
+                        stride=(1, KS * 8, 8)), part)
+        copy_r2g(sb1, gw, evict="no_allocate")
+        # instruction_selection: st.global.L1::no_allocate.v4.b32; extent: G x 16B
+
+    else:
+        # Pad rows (slot < 0) still own their output element and must zero it,
+        # because the host allocates `out` uninitialized (:1828-1830, :1848).
+        fill(zero_bf, 0.0)
+        # instruction_selection: none -- folded into the store's immediate operand
+        copy_r2g(zero_bf, out[token_base + t, hv, v_idx],
+                 predicate=in_row & (part == 0))
+        # instruction_selection: branch-guarded st.global.b16 [addr], 0x0000;
+        # extent: scalar  (ptxas if-converts this site to a predicated STG)
+
+# ===========================================================================
+# Orphan packed suffix (:719-725)
+# ===========================================================================
+# Carrier tokens beyond the last row are owned by no sequence. One CTA per value
+# head zeroes them, covering all D columns via `tid + e*NT`.
+#
+# Reachable only in the T == 1 decode layout: spec mode sizes `out` as
+# N*NUM_TOKENS while `cu_seqlens` must step by T (:1658-1661, :1822), so
+# `q_total == cu[n_seq]` there and this loop is empty.
+
+if (n == 0) & (vz == 0) & (tid < D):
+    covered = cu[n_seq]
+    for pos in range(covered, q_total):        # RUNTIME loop, not constexpr
+        for e in range(EPT):                   # constexpr
+            copy_r2g(zero_bf, out[pos, hv, tid + e * NT])
+            # instruction_selection: st.global.b16; extent: scalar
+```
+
+## Static specialization boundary
+
+| value | kind | why |
+| --- | --- | --- |
+| `D`, `T`, `KS`, `VSPLIT`, `RATIO`, `GATE_MODE`, `HAS_DT_BIAS`, `BETA_LOGIT`, `USE_L2`, `USE_SRC` | constexpr | the source's `cutlass.Constexpr` list (`:499-510`) |
+| `KC`, `G`, `CPB`, `NT`, `EPT`, `SW` | constexpr | derived from `(D, KS, VSPLIT)` at `:515-521` |
+| `n_seq` | constexpr in TIRx, runtime in the source | the source reads it from `grid_dim()`; every TIRx config pins a batch size, so specializing is exact and removes one launch scalar |
+| `q_total`, `g` token stride, state slot stride, `scale`, `lower_bound` | runtime scalars | passed by the host (`:2185-2196`) |
+| `source` stride, `source_indices` stride | dropped | dead under `USE_SRC = 0`; the host even aliases `source = state` (`:2143-2145`) |
+| `stream` | dropped | supplied by the TIRx runtime |
+
+## TIRx module and benchmark contract
+
+* Module: `tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py`,
+  `KERNEL_META["name"] = "recurrent_kda_decode_grouped"`, `compute_capability = 10`.
+* Helpers (`_ptx_*`, non-FTZ scalar math, BF16 pack/convert, shuffles, guarded
+  stores) are imported from the one-warp sibling module rather than duplicated.
+* Every global **and shared** access must go through raw PTX with `ptr_to`:
+  `low_level_ir.py:26` forbids `BufferLoad`/`BufferStore` on `global`, `shared`,
+  and `shared.dyn` alike.
+* TVM compiles with `--use_fast_math`, so native FP32 arithmetic lowers to
+  `.ftz` forms. The source's only `.ftz` instruction is `ex2.approx.ftz.f32`;
+  `add`/`mul`/`sub`/`fma`/`rsqrt`/`rcp` are all non-FTZ and must be emitted
+  explicitly.
+* Correctness configs cover both gate modes and four branch families (pad rows,
+  orphan suffix, zero-length row, scratch stride `S > T`), each verified live
+  against the source in `.porting/.../characterize_source.py`.
+* Benchmark rows are `GATE_MODE = 2` only, so the softplus `log1p` polynomial is
+  a correctness obligation rather than a performance-alignment target.
+
+## Instruction-selection summary
+
+Counts below are from the exported line-info PTX for the production verify shape
+`T = 8, KS = 2, G = 8, GATE_MODE = 2` (`.porting/recurrent_kda_decode_grouped/ptx/t8_ks2_lb`,
+`CUTE_DSL_LINEINFO=1`). They are evidence for the selections above, not hidden
+computation. Per-token multipliers assume the 8 unrolled tokens.
+
+| PTX instruction | count | origin |
+| --- | --- | --- |
+| `mul.f32x2` | 1024 | 8 tokens x 128 = the four 8-wide multiplies per granule (`s*eg`, `kr*svec`, `kr*deltak`, `qr*svec`) |
+| `add.f32x2` | 704 | 8 tokens x 88 = `pvec` and `ovec` accumulation plus the rank-1 add |
+| `ld.shared.v2.b64` | 384 | 8 tokens x 3G x 2 = the `eg`/`kr`/`qr` 8-wide reads; `kr` is loaded once and reused across both passes |
+| `add.f32` | 272 | the two 7-add trees per token, the butterfly joins, the `1.0 +` of the sigmoid, and the L2/eps scalars |
+| `cvt.rn.bf16x2.f32` | 256 | 8 tokens x 4G = the checkpoint cast |
+| `cvt.f32.bf16` | 168 | the initial state granule plus the q/k staging converts and `beta` |
+| `mul.f32` | 105 | gate scalars, `rq`, `deltak` |
+| `shfl.sync.bfly.b32` | 96 | 80 = 8 tokens x 2 reductions x 5 rounds (`warp_reduction_sum`), 16 = 8 tokens x 2 KS joins x 1 round (`KS = 2`) |
+| `ld.global.b16` | 64 | 8 tokens x (q, k, g at `EPT = 2`, plus `v` and `beta`) |
+| `st.global.L1::no_allocate.v4.b32` | 64 | 8 tokens x G checkpoint granules |
+| `st.shared.b32` | 64 | the phase-A staging writes plus the `s_red` publications |
+| `ex2.approx.ftz.f32` | 33 | 1 for `av` + 8 tokens x 2 elements x 2 (sigmoid, gate) |
+| `fma.rn.f32.bf16` | 32 | 8 tokens x 2 elements x 2 L2 partials |
+| `add.rn.f32.bf16` | 16 | 8 tokens x 2 elements: `g + dt_bias` |
+| `rcp.rn.f32` | 16 | 8 tokens x 2 elements: the `GATE_MODE = 2` sigmoid |
+| `rsqrt.approx.f32` | 16 | 8 tokens x 2: the key and query L2 factors |
+| `ld.shared.v2.b32` | 16 | 8 tokens x 2: the `SW = 2` `s_red` pair reads (the `T = 1` shape uses 2 x `ld.shared.v4.b32` instead, `SW = 4`) |
+| `neg.f32` | 16 | 8 tokens x 2 elements: the `GATE_MODE = 2` sigmoid negation |
+| `sub.rn.f32.bf16` | 8 | one per token: `ve - rk*pred`, consuming the raw BF16 `v` |
+| `ld.global.L1::no_allocate.v4.b32` | 8 | G initial-state granules |
+
+Three selections are load-bearing and easy to get wrong:
+
+1. **Packed FP32.** The 8-wide granule arithmetic is `mul.f32x2` / `add.f32x2`,
+   not scalar `mul.f32`, and not `fma.f32x2` — the source writes `a + b * c` but
+   the compiler emits a separate multiply and add, with zero `fma.*.f32x2` in
+   either variant. TIRx exposes `.f32x2` on `add`/`sub`/`mul`/`fma` for `sm_100`
+   with `uint64` packed operands (`backend/cuda/ptx/table.py:2927-2985`).
+2. **Non-FTZ everything except `ex2`.** `ex2.approx.ftz.f32` is the only `.ftz`
+   instruction in the whole kernel. In particular `rsqrt.approx.f32` keeps
+   denormals, and the `GATE_MODE = 2` sigmoid is `rcp.rn.f32` — a
+   correctly-rounded reciprocal, not `rcp.approx.f32` and not `div.rn.f32`.
+3. **Guarded stores, and one deliberate deviation.** The source's PTX contains
+   **zero** predicated stores -- all three guarded sites are `setp` plus a branch.
+   ptxas then if-converts two of them (the `s_red` publication and the pad-row
+   zero-fill) into predicated SASS stores, but leaves the `part == 0` output store
+   branch-guarded. The TIRx port emits `@p st.global.b16` at all three sites
+   anyway. That is an intentional improvement, not a transcription: inline asm is
+   opaque to ptxas, so an `if` wrapped around an asm store can never be
+   if-converted, and in the one-warp sibling that cost extra `BRA`/`BSYNC` and
+   turned the resulting divergence into shared-memory bank conflicts.

--- a/.agents/sketch/flashinfer/kda/recurrent_kda_decode_one_warp.md
+++ b/.agents/sketch/flashinfer/kda/recurrent_kda_decode_one_warp.md
@@ -1,0 +1,607 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Copyright (c) 2026 The TIRx Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Recurrent-KDA one-warp decode SM100: coarse WASP execution sketch
+
+This is a non-executable sketch of FlashInfer's CuTe DSL
+`recurrent_kda_decode_kernel`
+(`flashinfer/kda_kernels/recurrent_kda.py:190`, helpers `compute_gate_value:88`,
+`_dot8_row:154`, `_reduce_k_group:174`). It records the exact single-warp lane
+split, register-resident state tile, shuffle-only cross-lane protocol, gate
+branch structure, reduction order, and predicated output/state paths that the
+TIRx port must preserve. The implementation represented by this sketch is
+maintained in
+[`tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py`](../../../../tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py),
+which becomes the source of truth after this sketch passes review.
+
+The target is SM100a/B200. `HEAD_DIM = 128` (`K == V`), `NUM_TOKENS = 1`,
+`USE_CU_SEQLENS = 1`, `USE_QK_L2NORM = 1`, `USE_GATE_IN_KERNEL = 1`,
+`HAS_DT_BIAS = 1`, `BETA_IS_LOGIT = 0`, `HAS_INITIAL_STATE_SOURCE = 0`,
+`HAS_NUM_ACCEPTED_TOKENS = 0`, `ZERO_PADDED_OUTPUT = 1`. Q/K/V/G/beta/state/out
+are BF16; `A_log`, `dt_bias`, `scale`, `eps`, `lower_bound` are FP32;
+`cu_seqlens` and `ssm_state_indices` are int32. Two schedule points are in
+scope, `TILE_ROWS = 16` with `DOT_REDUCTION_DUAL_ACCUM` and `TILE_ROWS = 8`
+with `DOT_REDUCTION_TREE`, together with both in-kernel gate modes
+(`USE_LOWER_BOUND` 1 and 0). `TILE_ROWS = 32`, `HEAD_DIM = 64`, `NUM_TOKENS > 1`
+and the whole speculative-decode path, the `sequence_heads < 128` grouped-CTA
+kernel, GQA (`HV != H`), the dense no-`cu_seqlens` path, and the precomputed-gate
+mode are out of scope.
+
+## Pipeline at a glance
+
+This kernel has **no asynchronous pipeline, no shared memory, no mbarrier, and
+no barrier of any kind**. One CTA is exactly one warp (`.reqntid 32, 1, 1`).
+Every lane runs the same program; the "roles" are the two lane coordinates that
+partition the `[TILE_ROWS, 128]` state tile the warp owns in registers. All
+cross-lane movement is a warp shuffle with a full `0xFFFFFFFF` member mask.
+
+| Lane coordinate | Register ownership | Publication/reuse edges |
+| --- | --- | --- |
+| `k_lane = tidx % 16` | K slice `[8*k_lane, 8*k_lane + 8)` of every owned V row | supplies `_reduce_k_group` butterflies; `k_lane == j` selects the single lane that stores output row `j` |
+| `v_lane = tidx // 16` | V rows `v_offset + v_lane + 2*j` for `j in [0, TILE_ROWS/2)` | receives `v_loaded` by indexed shuffle from the lane that loaded that row |
+| `tidx` (flat, load view) | the `[4*tidx, 4*tidx + 4)` slice of q/k/g for the vector loads | redistributed to the `k_lane` view by 24 indexed shuffles per token |
+| `tidx < TILE_ROWS` | one `v` element and one zero-pad output element | `v` published to all lanes by indexed shuffle at consume time |
+
+The single dependency chain per CTA is: state load → gate → L2 norm → shuffle
+broadcast → `TILE_ROWS/2` sequential rank-1 recurrence steps → output store →
+state store. There is no producer/consumer split and nothing to overlap across
+lanes beyond ILP inside one lane.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+specialize(...)       # static HEAD_DIM, TILE_ROWS, reduction schedule, gate mode
+launch(...)           # grid/block metadata
+tile(...)             # GMEM storage declaration
+view(...)             # typed view without a copy
+reg_tile(...)         # lane-private scalar/vector registers
+```
+
+Copies always name their storage direction:
+
+```python
+copy_g2r(src, dst, predicate=None)
+copy_r2g(src, dst, predicate=None)
+```
+
+There is no `copy_g2s`, `copy_s2r`, `copy_r2s`, `copy_s2g`, TMA, `cp.async`,
+`ldmatrix`, `stmatrix`, or TCGEN05 operation in this kernel: it never touches
+shared memory or tensor memory.
+
+The computation vocabulary is deliberately primitive:
+
+```python
+fill(dst, value)
+cast(dst, src, rounding=None)
+add(dst, lhs, rhs)
+sub(dst, lhs, rhs)
+neg(dst, src)
+mul(dst, lhs, rhs)
+fma(dst, lhs, rhs, acc)
+exp2(dst, src)
+log2(dst, src)
+div(dst, lhs, rhs)
+rsqrt(dst, src)
+select(dst, predicate, true_value, false_value)
+shuffle_bfly(src, lane_xor, clamp, member_mask) -> dst
+shuffle_index(src, source_lane, clamp, member_mask) -> dst
+```
+
+Predicates, loop indices, and static address expressions are control
+operations. There is no compound `l2norm`, `gate`, `sigmoid`, `softplus`,
+`delta_rule`, `update_state`, or `reduce` operation: every one of those paths is
+expanded below.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+variant = specialize(
+    HEAD_DIM=128,
+    TILE_ROWS=(8, 16),
+    DOT_REDUCTION_SCHEDULE=("TREE", "DUAL_ACCUM"),
+    USE_LOWER_BOUND=(False, True),
+    NUM_TOKENS=1,
+    USE_CU_SEQLENS=True,
+    USE_QK_L2NORM=True,
+    USE_GATE_IN_KERNEL=True,
+    HAS_DT_BIAS=True,
+    BETA_IS_LOGIT=False,
+    HAS_INITIAL_STATE_SOURCE=False,
+    HAS_NUM_ACCEPTED_TOKENS=False,
+    ZERO_PADDED_OUTPUT=True,
+    target="sm_100a",
+)
+
+# recurrent_kda.py:242-246 -- the lane partition is fully determined by HEAD_DIM.
+K_LANES = HEAD_DIM // 8               # 16
+V_LANES = 32 // K_LANES               # 2
+VALUES_PER_THREAD = HEAD_DIM // 32    # 4
+NUM_V_TILES = HEAD_DIM // TILE_ROWS   # 8 or 16
+ROWS = TILE_ROWS // V_LANES           # 8 or 4 register rows per lane
+
+# The host picks (TILE_ROWS, DOT_REDUCTION_SCHEDULE) from sequence_heads and
+# guarantees the one-warp domain (recurrent_kda.py:1108-1149, :1798).
+host_assert(sequence_heads == N * HV)
+host_assert(sequence_heads >= 128)
+host_assert((TILE_ROWS, DOT_REDUCTION_SCHEDULE) ==
+            select_kernel_schedule(HEAD_DIM, 1, True, sequence_heads))
+host_assert(HV % H == 0)
+host_assert(state_slot_stride % 16 == 0)   # symbolic outer stride, divisibility 16
+host_assert(address(state) % 32 == 0)      # assumed_align=32 on every tensor
+# gG alone among the token-indexed tensors is compiled with runtime batch and
+# token strides (recurrent_kda.py:1035-1047) so a gate sliced out of a fused
+# projection needs no copy; its head and K axes stay compact, and q/k/v/o are
+# fully compact by contrast (:1050-1058).
+host_assert(gate_batch_stride % 16 == 0)
+host_assert(gate_token_stride % 16 == 0)
+
+launch_config = launch(
+    grid=(N * HV * NUM_V_TILES, 1, 1),   # recurrent_kda.py:986
+    block=(32, 1, 1),                    # recurrent_kda.py:987 -- one warp
+    threads=32,
+    dynamic_smem_bytes=0,
+    mbarriers=0,
+)
+
+def recurrent_kda_decode_one_warp(
+    gQ, gK, gV, gG, gBeta, gH, gO, gALog, gDtBias,
+    gCuSeqlens, gSsmStateIndices,
+    scale, eps, lower_bound,
+):
+    # -----------------------------------------------------------------------
+    # Lane and CTA coordinates (recurrent_kda.py:229-246)
+    # -----------------------------------------------------------------------
+    tidx = thread_id(axis="x", extent=32)
+    # instruction_selection: mov.u32 from %tid.x; extent: one thread coordinate
+    bidx = cta_id(axis="x", extent=N * HV * NUM_V_TILES)
+    # instruction_selection: mov.u32 from %ctaid.x; extent: one CTA coordinate
+    # The source flattens all three work axes into %ctaid.x and re-derives them
+    # here; the division order fixes which CTA owns which (v_tile, head, seq).
+
+    v_tile_idx = bidx % NUM_V_TILES
+    bh = bidx // NUM_V_TILES
+    value_head_idx = bh % HV
+    batch_idx = bh // HV
+    query_head_idx = value_head_idx // (HV // H)
+    v_offset = v_tile_idx * TILE_ROWS
+    k_lane = tidx % K_LANES
+    v_lane = tidx // K_LANES
+
+    # -----------------------------------------------------------------------
+    # Sequence metadata (recurrent_kda.py:248-252)
+    # -----------------------------------------------------------------------
+    token_base_offset = copy_g2r(gCuSeqlens[batch_idx])
+    # instruction_selection: ld.global.b32; extent: one scalar per lane
+    seq_end = copy_g2r(gCuSeqlens[batch_idx + 1])
+    # instruction_selection: ld.global.b32; extent: one scalar per lane
+    seq_len = seq_end - token_base_offset
+
+    # -----------------------------------------------------------------------
+    # Zero-padded output prefill (recurrent_kda.py:253-255)
+    # Runs BEFORE the state load so inactive rows are defined even when the
+    # token loop skips every store. Valid only because NUM_TOKENS == 1 makes
+    # the token axis index equal to batch_idx.
+    # -----------------------------------------------------------------------
+    if tidx < TILE_ROWS:
+        zero_bf16 = cast("bf16", 0.0)
+        # instruction_selection: no standalone instruction -- the bf16 zero is folded into the st.global.b16 immediate operand
+        copy_r2g(zero_bf16, gO[0, batch_idx, value_head_idx, v_offset + tidx])
+        # instruction_selection: st.global.b16 under a setp.gt.u32/@%p guard; extent: one predicated scalar store
+
+    # -----------------------------------------------------------------------
+    # Initial-state slot (recurrent_kda.py:257-272)
+    # -----------------------------------------------------------------------
+    init_raw_slot = copy_g2r(gSsmStateIndices[batch_idx * NUM_TOKENS])
+    # instruction_selection: ld.global.b32; extent: one scalar per lane
+    init_seq_idx = select(init_raw_slot < 0, 0, init_raw_slot)
+    # instruction_selection: max.s32 against immediate 0; extent: one scalar. At
+    # NUM_TOKENS == 1 this is the same expression on the same CSE'd slot load as
+    # the seq_idx clamp below, so the pair emits a single max.s32.
+    h_read = view(gH[init_seq_idx, value_head_idx, :, :])
+
+    # -----------------------------------------------------------------------
+    # Register storage (recurrent_kda.py:280-293). No SMEM, no mbarrier.
+    # -----------------------------------------------------------------------
+    h_reg = reg_tile("f32", [ROWS, 8])        # the recurrent state, layout stride (8, 1)
+    h_bf16 = reg_tile("bf16", [8])            # one 16-byte state row in flight
+    q_src = reg_tile("f32", [VALUES_PER_THREAD])
+    k_src = reg_tile("f32", [VALUES_PER_THREAD])
+    gate_src = reg_tile("f32", [VALUES_PER_THREAD])
+    q_bf16 = reg_tile("bf16", [VALUES_PER_THREAD])
+    k_bf16 = reg_tile("bf16", [VALUES_PER_THREAD])
+    gate_bf16 = reg_tile("bf16", [VALUES_PER_THREAD])
+    q_reg = reg_tile("f32", [8])              # this lane's K slice after broadcast
+    k_reg = reg_tile("f32", [8])
+    gate_reg = reg_tile("f32", [8])
+
+    # -----------------------------------------------------------------------
+    # State load (recurrent_kda.py:295-300)
+    # Row j of this lane is V row (v_offset + v_lane + V_LANES*j); the K slice
+    # is the 8 contiguous elements at 8*k_lane, which is exactly 16 bytes.
+    # -----------------------------------------------------------------------
+    # Every row's load is issued before any of them is widened. The source
+    # interleaves the two, and this is the one deliberate deviation from its
+    # order here: same loads, same widening, same values, only the issue point
+    # moves. bench_suite times a cold L2 (it zeroes a 256 MB buffer before every
+    # timed iteration), so the figure of merit is how many DRAM misses are in
+    # flight; interleaved, each cvt chain sits on the critical path of the next
+    # load. Worth 1.7-3.7% -- see the perf notes.
+    #
+    # Only the loads move. Hoisting the dt_bias loads the same way was measured
+    # and rejected: 4 more f32 live across the token loop costs 6.6% on
+    # hv16_b16_tr16_lb, in a kernel that already holds ROWS*8 f32 of state.
+    for j in static_range(ROWS):
+        v_idx = v_offset + v_lane + V_LANES * j
+        copy_g2r(h_read[v_idx, 8 * k_lane : 8 * k_lane + 8], h_words[j])
+        # instruction_selection: ld.global.v4.b32; extent: one 16-byte tile (8 bf16) per j, ROWS issues
+    for j in static_range(ROWS):
+        for i in static_range(8):
+            h_reg[j, i] = cast("f32", h_words[j][i])
+            # instruction_selection: cvt.f32.bf16; extent: one scalar, 8 per j
+
+    # -----------------------------------------------------------------------
+    # Per-head gate constants (recurrent_kda.py:302-305)
+    # -----------------------------------------------------------------------
+    h_K_offset = query_head_idx * HEAD_DIM
+    a_log_raw = copy_g2r(gALog[query_head_idx])
+    # instruction_selection: ld.global.b32; extent: one scalar per lane
+    A_log_val = exp2(mul(a_log_raw, LOG2_E))
+    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar pair, hoisted above the token loop
+
+    # -----------------------------------------------------------------------
+    # Loop-invariant lower-bound gate constants (recurrent_kda.py:124-127).
+    # These live inside compute_gate_value's per-i loop in the source; both are
+    # loop-invariant, so the compiler hoists them here.
+    # -----------------------------------------------------------------------
+    if USE_LOWER_BOUND:
+        neg_A_log2e = mul(neg(A_log_val), LOG2_E)
+        # instruction_selection: one mul.f32 against the negated immediate 0fBFB8AA3B (-log2 e); the neg is constant-folded and emits NO neg.f32 -- the lower-bound PTX contains zero neg.f32, unlike the softplus branch which emits exactly one; extent: one scalar, loop-invariant
+        lb_log2e = mul(lower_bound, LOG2_E)
+        # instruction_selection: mul.f32 against the immediate 0f3FB8AA3B; extent: one scalar, loop-invariant
+
+    # =======================================================================
+    # Token loop. NUM_TOKENS == 1, so this executes exactly once; the source
+    # keeps it a real loop and the sketch keeps the same structure.
+    # =======================================================================
+    for token_t in range(NUM_TOKENS):
+        # --- slot / activity resolution (recurrent_kda.py:321-332) ---------
+        raw_slot = copy_g2r(gSsmStateIndices[batch_idx * NUM_TOKENS + token_t])
+        # instruction_selection: ld.global.b32; extent: one scalar (CSE'd with the init_raw_slot load at NUM_TOKENS == 1)
+        has_token = token_t < seq_len
+        is_active = (raw_slot >= 0) and has_token
+        token_offset = select(has_token, token_base_offset + token_t, 0)
+        # instruction_selection: setp.gt.s32 for has_token then selp.b32; extent: one scalar
+        # The false arm is literally 0 (recurrent_kda.py:328), not the sequence
+        # base. Every q/k/gate/v/beta load below is unguarded, so an inactive or
+        # CUDA-graph-padded row -- whose token_base_offset equals the total token
+        # count -- would read out of bounds without this clamp.
+        seq_idx = select(raw_slot < 0, 0, raw_slot)
+        # instruction_selection: no standalone instruction -- CSE'd with the
+        # init_seq_idx max.s32 above, since NUM_TOKENS == 1 makes raw_slot and
+        # init_raw_slot the same load; extent: zero additional issues
+
+        # --- per-head views and beta (recurrent_kda.py:333-346) ------------
+        q_head = view(gQ[0, token_offset, query_head_idx, :])
+        k_head = view(gK[0, token_offset, query_head_idx, :])
+        gate_head = view(gG[0, token_offset, value_head_idx, :])
+        v_head = view(gV[0, token_offset, value_head_idx, :])
+        o_head = view(gO[0, token_offset, value_head_idx, :])
+        beta_raw = copy_g2r(gBeta[0, token_offset, value_head_idx])
+        # instruction_selection: ld.global.b16; extent: one scalar, identical address in every lane
+        beta = cast("f32", beta_raw)
+        # instruction_selection: cvt.f32.bf16; extent: one scalar
+        # BETA_IS_LOGIT == 0: the source sigmoid at :348-351 is compile-time
+        # eliminated and emits no PTX.
+
+        # --- q/k/gate vector loads (recurrent_kda.py:353-358) --------------
+        # Load view: thread tidx owns the contiguous 4-element slice at 4*tidx,
+        # which is a different partition from the k_lane compute view below.
+        copy_g2r(q_head[4 * tidx : 4 * tidx + 4], q_bf16)
+        # instruction_selection: ld.global.v4.b16; extent: one 8-byte tile (4 bf16)
+        copy_g2r(k_head[4 * tidx : 4 * tidx + 4], k_bf16)
+        # instruction_selection: ld.global.v4.b16; extent: one 8-byte tile (4 bf16)
+        copy_g2r(gate_head[4 * tidx : 4 * tidx + 4], gate_bf16)
+        # instruction_selection: ld.global.v4.b16; extent: one 8-byte tile (4 bf16)
+
+        # --- V load, hoisted only at TILE_ROWS == 16 (recurrent_kda.py:359-364) ---
+        v_loaded = 0.0
+        # instruction_selection: mov.b32 zero; extent: one scalar initializer
+        if TILE_ROWS == 16:
+            if tidx < TILE_ROWS:
+                v_raw = copy_g2r(v_head[v_offset + tidx])
+                # instruction_selection: ld.global.b16 under the tidx < TILE_ROWS guard; extent: one predicated scalar, issued here to hide its latency behind the gate and L2-norm block
+                v_loaded = cast("f32", v_raw)
+                # instruction_selection: cvt.f32.bf16; extent: one scalar
+
+        # --- gate + q/k conversion (recurrent_kda.py:366-380, :88-148) -----
+        for i in static_range(VALUES_PER_THREAD):
+            k_idx = tidx * VALUES_PER_THREAD + i
+            q_src[i] = cast("f32", q_bf16[i])
+            # instruction_selection: cvt.f32.bf16; extent: one scalar
+            k_src[i] = cast("f32", k_bf16[i])
+            # instruction_selection: cvt.f32.bf16; extent: one scalar
+
+            dt = copy_g2r(gDtBias[h_K_offset + k_idx])
+            # instruction_selection: ld.global.b32; extent: one scalar, VALUES_PER_THREAD issues
+            g_val = add(dt, gate_bf16[i])
+            # instruction_selection: add.rn.f32.bf16; extent: one scalar -- the bf16 operand feeds the add directly, so no separate cvt.f32.bf16 is emitted for the gate input
+
+            if USE_LOWER_BOUND:
+                ag = mul(neg_A_log2e, g_val)
+                # instruction_selection: mul.f32; extent: one scalar
+                exp_neg = exp2(ag)
+                # instruction_selection: ex2.approx.ftz.f32; extent: one scalar
+                denom = add(1.0, exp_neg)
+                # instruction_selection: add.f32; extent: one scalar
+                ls = div(lb_log2e, denom)
+                # instruction_selection: div.rn.f32 with lb_log2e as the numerator and (1 + exp_neg) as the denominator; extent: one scalar, VALUES_PER_THREAD issues.
+                # The source writes sig = 1.0/denom followed by ls = lb_log2e * sig
+                # (:136-137); those fold into this single divide -- no mul.f32 is
+                # emitted for the lower_bound scale. The divide is full-precision
+                # div.rn.f32, NOT rcp.approx.
+                gate_src[i] = exp2(ls)
+                # instruction_selection: ex2.approx.ftz.f32; extent: one scalar
+            else:
+                exp_g = exp2(mul(g_val, LOG2_E))
+                # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar pair
+                log2_v = log2(add(1.0, exp_g))
+                # instruction_selection: add.f32 then lg2.approx.ftz.f32; extent: one scalar pair
+                gate_src[i] = exp2(mul(neg(A_log_val), log2_v))
+                # instruction_selection: mul.f32 then ex2.approx.ftz.f32, with the neg.f32 hoisted out of the loop; extent: one scalar pair
+
+        # --- q/k sum of squares (recurrent_kda.py:382-404) ----------------
+        # The reduction schedule changes the dependency graph, not the result.
+        if DOT_REDUCTION_SCHEDULE == "DUAL_ACCUM":
+            q_sum_even = mul(q_src[0], q_src[0])
+            # instruction_selection: mul.f32; extent: one scalar
+            q_sum_odd = mul(q_src[1], q_src[1])
+            # instruction_selection: mul.f32; extent: one scalar
+            q_sum_even = fma(q_src[2], q_src[2], q_sum_even)
+            # instruction_selection: fma.rn.f32.bf16 -- both multiplicands are still the bf16 load registers; extent: one scalar
+            q_sum_odd = fma(q_src[3], q_src[3], q_sum_odd)
+            # instruction_selection: fma.rn.f32.bf16; extent: one scalar
+            q_sum_sq = add(q_sum_even, q_sum_odd)
+            # instruction_selection: add.f32; extent: one scalar
+            k_sum_even = mul(k_src[0], k_src[0])
+            # instruction_selection: mul.f32; extent: one scalar
+            k_sum_odd = mul(k_src[1], k_src[1])
+            # instruction_selection: mul.f32; extent: one scalar
+            k_sum_even = fma(k_src[2], k_src[2], k_sum_even)
+            # instruction_selection: fma.rn.f32.bf16; extent: one scalar
+            k_sum_odd = fma(k_src[3], k_src[3], k_sum_odd)
+            # instruction_selection: fma.rn.f32.bf16; extent: one scalar
+            k_sum_sq = add(k_sum_even, k_sum_odd)
+            # instruction_selection: add.f32; extent: one scalar
+        else:
+            q_sum_sq = add(fma(q_src[0], q_src[0], mul(q_src[1], q_src[1])),
+                           fma(q_src[2], q_src[2], mul(q_src[3], q_src[3])))
+            # instruction_selection: two mul.f32, two fma.rn.f32.bf16 taking the raw bf16 load registers, one add.f32; extent: one vector -- two of the source's three adds contract into the fmas
+            k_sum_sq = add(fma(k_src[0], k_src[0], mul(k_src[1], k_src[1])),
+                           fma(k_src[2], k_src[2], mul(k_src[3], k_src[3])))
+            # instruction_selection: two mul.f32, two fma.rn.f32.bf16 taking the raw bf16 load registers, one add.f32; extent: one vector
+
+        # --- full-warp butterfly over all 32 lanes (recurrent_kda.py:405-411) ---
+        # Both reductions span the whole warp because the load view partitions
+        # K across all 32 lanes, not across the 16 k_lanes.
+        for offset in [16, 8, 4, 2, 1]:
+            q_sum_sq = add(q_sum_sq, shuffle_bfly(q_sum_sq, offset, 31, 0xFFFFFFFF))
+            # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one round, five rounds total
+            k_sum_sq = add(k_sum_sq, shuffle_bfly(k_sum_sq, offset, 31, 0xFFFFFFFF))
+            # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one round, five rounds total
+
+        # --- scale factors (recurrent_kda.py:413-417) ---------------------
+        q_scale_factor = mul(rsqrt(add(q_sum_sq, eps)), scale)
+        # instruction_selection: add.f32, rsqrt.approx.ftz.f32, mul.f32; extent: one scalar chain
+        k_scale_factor = rsqrt(add(k_sum_sq, eps))
+        # instruction_selection: add.f32, rsqrt.approx.ftz.f32; extent: one scalar chain
+
+        # --- broadcast the load view into the k_lane compute view ---------
+        # (recurrent_kda.py:418-436) Lane tidx ends up holding K elements
+        # [8*k_lane, 8*k_lane + 8). source_lane walks the two load-view lanes
+        # 2*k_lane and 2*k_lane + 1 that together cover that slice.
+        for i in static_range(8):
+            source_lane = V_LANES * k_lane + i // VALUES_PER_THREAD
+            source_value = i % VALUES_PER_THREAD
+            q_reg[i] = mul(shuffle_index(q_src[source_value], source_lane, 31, 0xFFFFFFFF),
+                           q_scale_factor)
+            # instruction_selection: shfl.sync.idx.b32 then mul.f32; extent: one element, 8 issues
+            k_reg[i] = mul(shuffle_index(k_src[source_value], source_lane, 31, 0xFFFFFFFF),
+                           k_scale_factor)
+            # instruction_selection: shfl.sync.idx.b32 then mul.f32; extent: one element, 8 issues
+            gate_reg[i] = shuffle_index(gate_src[source_value], source_lane, 31, 0xFFFFFFFF)
+            # instruction_selection: shfl.sync.idx.b32; extent: one element, 8 issues -- no scale multiply on the gate
+
+        # --- late V load for the non-TILE_ROWS-16 schedules ---------------
+        # (recurrent_kda.py:437-439)
+        if TILE_ROWS != 16:
+            if tidx < TILE_ROWS:
+                v_loaded = cast("f32", copy_g2r(v_head[v_offset + tidx]))
+                # instruction_selection: ld.global.b16 under the tidx < TILE_ROWS guard then cvt.f32.bf16; extent: one predicated scalar, placed next to its consumer
+
+        # --- sequential rank-1 recurrence (recurrent_kda.py:440-460) ------
+        # Each j is one V row of the warp's tile. The two dots inside a j are
+        # separated by the state update, so the loop is a true serial chain.
+        for j in static_range(ROWS):
+            for i in static_range(8):
+                h_reg[j, i] = mul(h_reg[j, i], gate_reg[i])
+                # instruction_selection: mul.f32; extent: one scalar, 8 per j
+
+            # pred = (S @ k) for this row, reduced across the 16 k_lanes
+            if DOT_REDUCTION_SCHEDULE == "DUAL_ACCUM":
+                even = mul(h_reg[j, 0], k_reg[0])
+                # instruction_selection: mul.f32; extent: one scalar
+                odd = mul(h_reg[j, 1], k_reg[1])
+                # instruction_selection: mul.f32; extent: one scalar
+                for pair in static_range(1, 4):
+                    even = fma(h_reg[j, 2 * pair], k_reg[2 * pair], even)
+                    # instruction_selection: fma.rn.f32; extent: one scalar, three issues
+                    odd = fma(h_reg[j, 2 * pair + 1], k_reg[2 * pair + 1], odd)
+                    # instruction_selection: fma.rn.f32; extent: one scalar, three issues
+                pred = add(even, odd)
+                # instruction_selection: add.f32; extent: one scalar
+            else:
+                pred = add(add(fma(h_reg[j, 0], k_reg[0], mul(h_reg[j, 1], k_reg[1])),
+                               fma(h_reg[j, 2], k_reg[2], mul(h_reg[j, 3], k_reg[3]))),
+                           add(fma(h_reg[j, 4], k_reg[4], mul(h_reg[j, 5], k_reg[5])),
+                               fma(h_reg[j, 6], k_reg[6], mul(h_reg[j, 7], k_reg[7]))))
+                # instruction_selection: balanced mul.f32 / fma.rn.f32 / add.f32 tree; extent: four mul, four fma, three add
+
+            for offset in [8, 4, 2, 1]:
+                pred = add(pred, shuffle_bfly(pred, offset, 31, 0xFFFFFFFF))
+                # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one round, four rounds reduce the 16-lane k group
+
+            v_idx = v_offset + v_lane + V_LANES * j
+            v_val = shuffle_index(v_loaded, v_lane + V_LANES * j, 31, 0xFFFFFFFF)
+            # instruction_selection: shfl.sync.idx.b32; extent: one element -- pulls row j's V from the lane that loaded it
+
+            delta = mul(sub(v_val, pred), beta)
+            # instruction_selection: sub.f32 then mul.f32; extent: one scalar pair
+
+            for i in static_range(8):
+                h_reg[j, i] = fma(k_reg[i], delta, h_reg[j, i])
+                # instruction_selection: fma.rn.f32; extent: one scalar, 8 per j -- the rank-1 state update
+
+            # out = (S @ q) for this row, same reduction structure as pred
+            if DOT_REDUCTION_SCHEDULE == "DUAL_ACCUM":
+                even = mul(h_reg[j, 0], q_reg[0])
+                # instruction_selection: mul.f32; extent: one scalar
+                odd = mul(h_reg[j, 1], q_reg[1])
+                # instruction_selection: mul.f32; extent: one scalar
+                for pair in static_range(1, 4):
+                    even = fma(h_reg[j, 2 * pair], q_reg[2 * pair], even)
+                    # instruction_selection: fma.rn.f32; extent: one scalar, three issues
+                    odd = fma(h_reg[j, 2 * pair + 1], q_reg[2 * pair + 1], odd)
+                    # instruction_selection: fma.rn.f32; extent: one scalar, three issues
+                out = add(even, odd)
+                # instruction_selection: add.f32; extent: one scalar
+            else:
+                out = add(add(fma(h_reg[j, 0], q_reg[0], mul(h_reg[j, 1], q_reg[1])),
+                              fma(h_reg[j, 2], q_reg[2], mul(h_reg[j, 3], q_reg[3]))),
+                          add(fma(h_reg[j, 4], q_reg[4], mul(h_reg[j, 5], q_reg[5])),
+                              fma(h_reg[j, 6], q_reg[6], mul(h_reg[j, 7], q_reg[7]))))
+                # instruction_selection: balanced mul.f32 / fma.rn.f32 / add.f32 tree; extent: four mul, four fma, three add
+
+            for offset in [8, 4, 2, 1]:
+                out = add(out, shuffle_bfly(out, offset, 31, 0xFFFFFFFF))
+                # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one round, four rounds
+
+            if is_active:
+                if k_lane == j:
+                    out_bf16 = cast("bf16", out, rounding="rn")
+                    # instruction_selection: cvt.rn.bf16.f32; extent: one scalar, one per j
+                    copy_r2g(out_bf16, o_head[v_idx])
+                    # instruction_selection: st.global.b16 under the is_active and k_lane == j guards; extent: one predicated scalar store per j
+
+        # --- state writeback (recurrent_kda.py:462-469) -------------------
+        # The source rebinds h_out to seq_idx at :463. At NUM_TOKENS == 1 that is
+        # the SAME slot the prologue loaded from: init_raw_slot (:259) and
+        # raw_slot (:323) index the same element, so init_seq_idx and seq_idx
+        # share one max.s32 and the store reuses the load's base address. A
+        # negative slot cannot reach here at all, because it clears is_active
+        # (:327). The port must keep the rebind structurally without modelling it
+        # as a second, distinct slot.
+        if is_active:
+            h_out = view(gH[seq_idx, value_head_idx, :, :])
+            for j in static_range(ROWS):
+                v_idx = v_offset + v_lane + V_LANES * j
+                for i in static_range(8):
+                    h_bf16[i] = cast("bf16", h_reg[j, i], rounding="rn")
+                    # instruction_selection: cvt.rn.bf16x2.f32 packing two elements at a time; extent: four issues per j
+                copy_r2g(h_bf16, h_out[v_idx, 8 * k_lane : 8 * k_lane + 8])
+                # instruction_selection: st.global.v4.b32; extent: one 16-byte tile per j, ROWS issues
+```
+
+## Static specialization and launch boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `HEAD_DIM = 128` | static | fixes `K_LANES`/`V_LANES`/`VALUES_PER_THREAD`, the 16-byte state vector, and the four-round k-group butterfly |
+| `TILE_ROWS` (8 or 16) | static | register-tile row count, the `NUM_V_TILES` factor of the flat 1-D grid extent (`:986`), and whether the V load is hoisted above the gate block |
+| `DOT_REDUCTION_SCHEDULE` | static | dependency graph of both 8-element dots and of the q/k sum-of-squares |
+| `USE_LOWER_BOUND` | static | selects the `div.rn.f32` sigmoid chain or the `lg2.approx` softplus chain |
+| `NUM_TOKENS = 1`, `ZERO_PADDED_OUTPUT = 1`, `HAS_DT_BIAS = 1`, `BETA_IS_LOGIT = 0`, `HAS_INITIAL_STATE_SOURCE = 0`, `HAS_NUM_ACCEPTED_TOKENS = 0`, `USE_QK_L2NORM = 1`, `USE_GATE_IN_KERNEL = 1`, `USE_CU_SEQLENS = 1` | static | eliminates the spec-decode slot search, the beta sigmoid, the separate initial-state pool, and the dense addressing path |
+| `N`, `H`, `HV`, pool size | static for the TIRx launch | match the selected benchmark shape exactly |
+| state slot stride | runtime `int64` | preserves the source's symbolic outer stride (divisibility 16), so envelope-strided pools work |
+| gate batch and token strides | runtime `int64` | `gG` alone is compiled non-compact on those two axes (divisibility 16, head/K compact, `:1035-1047`) so a gate sliced from a fused projection needs no copy; q/k/v/o are fully compact |
+| `scale`, `eps`, `lower_bound` | runtime `f32` kernel parameters | the source passes all three as kernel arguments, not immediates |
+| `cu_seqlens`, `ssm_state_indices` values | runtime | preserve the source's activity predicates and negative-slot handling |
+
+The host picks `(TILE_ROWS, DOT_REDUCTION_SCHEDULE)` from `sequence_heads`
+exactly as `_select_kernel_schedule` does, and every correctness and benchmark
+call asserts that the predicate selected the intended specialization and that
+`sequence_heads >= 128` keeps the call inside the one-warp domain.
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META` names `recurrent_kda_decode_one_warp`, category `flashinfer`,
+  compute capability 10.
+- All optional dependencies are lazy; `flashinfer` is imported only inside the
+  reference builder and the correctness oracle.
+- `CONFIGS` covers both tile schedules, both gate modes, the schedule-band
+  boundaries at `sequence_heads` 176/192, negative-slot padding rows, and an
+  envelope-strided state pool. `BENCH_CONFIGS` is the seven-row SGLang-parity
+  plus Kimi-K3 matrix, all with `lower_bound = -5.0`.
+- TIRx and the reference receive independent mutable state pools and output
+  buffers; the state pool is updated in place, so each implementation gets its
+  own clone of the same initial contents.
+- Compilation, allocation, flashinfer JIT, warmup, and preflight validation all
+  happen outside the timed closures.
+- The implementation and every pre-dispatch specialization contain no tile
+  primitives.
+
+## Instruction-selection summary
+
+- Each CTA is one warp with `.reqntid 32, 1, 1`, zero shared memory, zero
+  mbarriers, and no `bar.sync` of any kind. Every cross-lane exchange is
+  `shfl.sync.bfly.b32` or `shfl.sync.idx.b32` with member mask `0xFFFFFFFF` and
+  clamp `31`.
+- **All FP32 arithmetic is non-flush-to-zero**: `mul.f32`, `add.f32`,
+  `sub.f32`, `fma.rn.f32`. Only the transcendentals are FTZ
+  (`ex2.approx.ftz.f32`, `lg2.approx.ftz.f32`, `rsqrt.approx.ftz.f32`), and the
+  sigmoid reciprocal is the full-precision `div.rn.f32`. Reproducing this split
+  is required; substituting `.ftz` arithmetic or `rcp.approx` for the divide
+  changes both numerics and instruction selection.
+- Mixed-precision forms appear where a bf16 load register feeds an FP32 op
+  directly: `add.rn.f32.bf16` for the `dt_bias + gate` add, and
+  `fma.rn.f32.bf16` for the two q/k sum-of-squares terms each schedule
+  contracts -- `q_src[2]`/`q_src[3]` under `DUAL_ACCUM` (`:390-391`) and
+  `q_src[0]`/`q_src[2]` under `TREE` (`:399-400`). The complementary two terms
+  stay `mul.f32` on the converted f32 values.
+- Shuffle counts per token at `TILE_ROWS = 16`: 10 butterflies for the two
+  full-warp L2 norms, 24 indexed shuffles for the q/k/gate broadcast, 8 indexed
+  shuffles for the V redistribution, and 64 butterflies for the sixteen
+  k-group dot reductions -- 74 `shfl.sync.bfly.b32` and 32
+  `shfl.sync.idx.b32` in total. At `TILE_ROWS = 8` only the per-row groups
+  halve: the k-group butterflies drop to 32 (42 total) and the V
+  redistribution drops to 4, while the 24-shuffle q/k/gate broadcast does not
+  scale with `TILE_ROWS` -- giving 42 `shfl.sync.bfly.b32` and 28
+  `shfl.sync.idx.b32` (24 broadcast + 4 V).
+- Memory traffic per CTA at `TILE_ROWS = 16`: 8 `ld.global.v4.b32` state loads,
+  3 `ld.global.v4.b16` q/k/gate loads, 4 `ld.global.b32` dt_bias loads,
+  4 more `ld.global.b32` for `A_log`/`cu_seqlens`/`ssm_state_indices`,
+  2 `ld.global.b16` for beta and V, 9 `st.global.b16` (8 output rows plus the
+  zero-pad prefill), and 8 `st.global.v4.b32` state stores.
+- Conversions at `TILE_ROWS = 16`: 74 `cvt.f32.bf16` on the load side, 32
+  `cvt.rn.bf16x2.f32` packing the state writeback two elements at a time, and 8
+  `cvt.rn.bf16.f32` for the scalar output stores. At `TILE_ROWS = 8` these
+  scale with `ROWS`: 42, 16, and 4.

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "664e979c",
-    "tirx-kernels": "9c6aa361",
+    "tir": "ea0950ab",
+    "tirx-kernels": "b3be0123",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "35a646aa22543959fd188e3d0d788ca914a44071"
+    "tirx-kernels:tirx_kernels": "ba8163542076d30ce12bc983cf424f2bcbbeb396"
   },
   "baselines": {
     "torch": {
@@ -57,7 +57,7 @@
       "importable": false,
       "source_dir": "/home/bohanhou/kernel-libs/sglang/python/sglang",
       "git_dir": "/home/bohanhou/kernel-libs/sglang",
-      "git_sha": "96a04cb1"
+      "git_sha": "c7c03ec5"
     },
     "cutlass": {
       "importable": true,
@@ -2582,6 +2582,300 @@
       "impls": {
         "tirx": 17.34466253221987,
         "flashinfer": 19.51631078654821
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "dec_hv12_b4",
+      "label": "dec_hv12_b4",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.6504416104104775,
+        "flashinfer_cutedsl": 3.9219190126523285
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "dec_hv12_b8",
+      "label": "dec_hv12_b8",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.258375216340218,
+        "flashinfer_cutedsl": 4.613711138436537
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "dec_hv16_b1",
+      "label": "dec_hv16_b1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.238843675914427,
+        "flashinfer_cutedsl": 3.5627867976997543
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "dec_hv16_b4",
+      "label": "dec_hv16_b4",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.7758930700028097,
+        "flashinfer_cutedsl": 4.078077874576345
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t2_hv16_b8",
+      "label": "ver_t2_hv16_b8",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.837621219998657,
+        "flashinfer_cutedsl": 7.342065714437408
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t4_hv16_b32",
+      "label": "ver_t4_hv16_b32",
+      "status": "ok",
+      "impls": {
+        "tirx": 24.71303785423106,
+        "flashinfer_cutedsl": 33.888392143740184
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv12_b16",
+      "label": "ver_t8_hv12_b16",
+      "status": "ok",
+      "impls": {
+        "tirx": 22.030900675719998,
+        "flashinfer_cutedsl": 31.35296382096456
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv12_b64",
+      "label": "ver_t8_hv12_b64",
+      "status": "ok",
+      "impls": {
+        "tirx": 65.91840010332494,
+        "flashinfer_cutedsl": 92.41587041159222
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b1",
+      "label": "ver_t8_hv16_b1",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.030776714313049,
+        "flashinfer_cutedsl": 14.815819035086784
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b128",
+      "label": "ver_t8_hv16_b128",
+      "status": "ok",
+      "impls": {
+        "tirx": 161.9328744940579,
+        "flashinfer_cutedsl": 219.33161768748658
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b16",
+      "label": "ver_t8_hv16_b16",
+      "status": "ok",
+      "impls": {
+        "tirx": 26.017330854831492,
+        "flashinfer_cutedsl": 34.95134749109404
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b32",
+      "label": "ver_t8_hv16_b32",
+      "status": "ok",
+      "impls": {
+        "tirx": 44.59754916822601,
+        "flashinfer_cutedsl": 63.672738997515964
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b4",
+      "label": "ver_t8_hv16_b4",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.247886679654943,
+        "flashinfer_cutedsl": 16.928763980944666
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_grouped",
+      "config": "ver_t8_hv16_b64",
+      "label": "ver_t8_hv16_b64",
+      "status": "ok",
+      "impls": {
+        "tirx": 83.1183969763617,
+        "flashinfer_cutedsl": 112.71690537963232
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv12_b16_tr16_lb",
+      "label": "hv12_b16_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.695114378452278,
+        "flashinfer_cutedsl": 5.972974484759209
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv12_b64_tr16_lb",
+      "label": "hv12_b64_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 12.836577688146386,
+        "flashinfer_cutedsl": 13.868974685205652
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv16_b128_tr16_lb",
+      "label": "hv16_b128_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 26.685145709501946,
+        "flashinfer_cutedsl": 29.18576589228665
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv16_b16_tr16_lb",
+      "label": "hv16_b16_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.347254102290438,
+        "flashinfer_cutedsl": 6.483835513635386
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv16_b32_tr16_lb",
+      "label": "hv16_b32_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.69739584957777,
+        "flashinfer_cutedsl": 10.239276177315428
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv16_b64_tr16_lb",
+      "label": "hv16_b64_tr16_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.268888603603104,
+        "flashinfer_cutedsl": 16.90398539436306
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "recurrent_kda_decode_one_warp",
+      "config": "hv16_b8_tr8_lb",
+      "label": "hv16_b8_tr8_lb",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.247230154049852,
+        "flashinfer_cutedsl": 5.337711133525542
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '664e979c', 'tirx-kernels': '9c6aa361', 'tirx-bench-ci': None}`
-- Workloads: 237 ok, 0 failed
+- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': 'b3be0123', 'tirx-bench-ci': None}`
+- Workloads: 258 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -303,6 +303,37 @@ Grouped workloads show one row per config and one timing column per implementati
 | `fp16_linear_m128_k1024` | tirx | 2.9066 | flashinfer | 3.0670 | 1.055 | — |
 | `fp16_linear_m16384_k7168` | tirx | 55.8258 | flashinfer | 57.4695 | 1.029 | — |
 | `fp16_linear_m4096_k4096` | tirx | 17.3447 | flashinfer | 19.5163 | 1.125 | — |
+
+## recurrent_kda_decode_grouped
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `dec_hv12_b4` | tirx | 3.6504 | flashinfer_cutedsl | 3.9219 | 1.074 | — |
+| `dec_hv12_b8` | tirx | 4.2584 | flashinfer_cutedsl | 4.6137 | 1.083 | — |
+| `dec_hv16_b1` | tirx | 3.2388 | flashinfer_cutedsl | 3.5628 | 1.100 | — |
+| `dec_hv16_b4` | tirx | 3.7759 | flashinfer_cutedsl | 4.0781 | 1.080 | — |
+| `ver_t2_hv16_b8` | tirx | 6.8376 | flashinfer_cutedsl | 7.3421 | 1.074 | — |
+| `ver_t4_hv16_b32` | tirx | 24.7130 | flashinfer_cutedsl | 33.8884 | 1.371 | — |
+| `ver_t8_hv12_b16` | tirx | 22.0309 | flashinfer_cutedsl | 31.3530 | 1.423 | — |
+| `ver_t8_hv12_b64` | tirx | 65.9184 | flashinfer_cutedsl | 92.4159 | 1.402 | — |
+| `ver_t8_hv16_b1` | tirx | 9.0308 | flashinfer_cutedsl | 14.8158 | 1.641 | — |
+| `ver_t8_hv16_b128` | tirx | 161.9329 | flashinfer_cutedsl | 219.3316 | 1.354 | — |
+| `ver_t8_hv16_b16` | tirx | 26.0173 | flashinfer_cutedsl | 34.9513 | 1.343 | — |
+| `ver_t8_hv16_b32` | tirx | 44.5975 | flashinfer_cutedsl | 63.6727 | 1.428 | — |
+| `ver_t8_hv16_b4` | tirx | 10.2479 | flashinfer_cutedsl | 16.9288 | 1.652 | — |
+| `ver_t8_hv16_b64` | tirx | 83.1184 | flashinfer_cutedsl | 112.7169 | 1.356 | — |
+
+## recurrent_kda_decode_one_warp
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv12_b16_tr16_lb` | tirx | 5.6951 | flashinfer_cutedsl | 5.9730 | 1.049 | — |
+| `hv12_b64_tr16_lb` | tirx | 12.8366 | flashinfer_cutedsl | 13.8690 | 1.080 | — |
+| `hv16_b128_tr16_lb` | tirx | 26.6851 | flashinfer_cutedsl | 29.1858 | 1.094 | — |
+| `hv16_b16_tr16_lb` | tirx | 6.3473 | flashinfer_cutedsl | 6.4838 | 1.022 | — |
+| `hv16_b32_tr16_lb` | tirx | 9.6974 | flashinfer_cutedsl | 10.2393 | 1.056 | — |
+| `hv16_b64_tr16_lb` | tirx | 15.2689 | flashinfer_cutedsl | 16.9040 | 1.107 | — |
+| `hv16_b8_tr8_lb` | tirx | 5.2472 | flashinfer_cutedsl | 5.3377 | 1.017 | — |
 
 ## selective_state_update_mtp_horizontal
 

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/recurrent_kda_decode_grouped.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/recurrent_kda_decode_grouped.yaml
@@ -1,0 +1,36 @@
+# Exactly the module's fourteen BENCH_CONFIGS rows.  All use the Kimi K3 safe
+# gate (lower_bound = -5.0, GATE_MODE = 2), the gate mode SGLang's production
+# path selects; the softplus variants are correctness-only and are not
+# benchmarked.  Every row is inside the grouped-CTA dispatch domain, verified
+# by .porting/recurrent_kda_decode_grouped/verify_dispatch.py.
+#
+# The two families are the two SGLang call sites, and they select the two --
+# and only two -- tile shapes the host allows (KS = 4 if T == 1 else 2,
+# recurrent_kda.py:859-860):
+#
+#   dec_* : T=1 decode, KS=4, NT=128 (4 warps).  Reaches this kernel only when
+#           sequence_heads = num_seqs * num_value_heads < 128; larger decode
+#           shapes route to the one-warp kernel instead.
+#   ver_* : T>1 target_verify, KS=2, NT=64 (2 warps).  Reaches this kernel for
+#           every batch size.  T=8 is the DSPARK production point (gamma=7);
+#           the hv16 batch sweep mirrors SGLang's own MTP benchmark
+#           (benchmark/bench_linear_attention/bench_kda_flashinfer_mtp.py).
+#
+# hv12 rows are the Kimi K3 TP8 per-rank value-head count; T=4 and T=2 cover
+# the speculative-decode test parity point and the legal floor.
+kernel: recurrent_kda_decode_grouped
+configs:
+  - {config: dec_hv16_b1, default: true}
+  - {config: dec_hv16_b4, default: true}
+  - {config: dec_hv12_b4, default: true}
+  - {config: dec_hv12_b8, default: true}
+  - {config: ver_t8_hv16_b1, default: true}
+  - {config: ver_t8_hv16_b4, default: true}
+  - {config: ver_t8_hv16_b16, default: true}
+  - {config: ver_t8_hv16_b32, default: true}
+  - {config: ver_t8_hv16_b64, default: true}
+  - {config: ver_t8_hv16_b128, default: true}
+  - {config: ver_t8_hv12_b16, default: true}
+  - {config: ver_t8_hv12_b64, default: true}
+  - {config: ver_t4_hv16_b32, default: true}
+  - {config: ver_t2_hv16_b8, default: true}

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/recurrent_kda_decode_one_warp.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/recurrent_kda_decode_one_warp.yaml
@@ -1,0 +1,21 @@
+# Exactly the module's seven BENCH_CONFIGS rows.  All of them use the Kimi K3
+# safe gate (lower_bound = -5.0), the gate mode SGLang's production decode path
+# selects, and all stay inside the one-warp dispatch domain
+# (sequence_heads = num_seqs * num_value_heads >= 128; smaller shapes route to
+# FlashInfer's grouped-CTA kernel instead).
+#
+# hv16 rows mirror SGLang's own decode sweep
+# (benchmark/bench_linear_attention/bench_kda_flashinfer_mtp.py --batch-sizes),
+# restricted to the batches that reach this kernel; hv12 rows are the Kimi K3
+# TP8 per-rank head count.  Together they cover both tile schedules:
+# b8 -> sequence_heads 128 -> TILE_ROWS 8 + DOT_REDUCTION_TREE, every other row
+# -> TILE_ROWS 16 + DOT_REDUCTION_DUAL_ACCUM.
+kernel: recurrent_kda_decode_one_warp
+configs:
+  - {config: hv16_b8_tr8_lb, default: true}
+  - {config: hv16_b16_tr16_lb, default: true}
+  - {config: hv16_b32_tr16_lb, default: true}
+  - {config: hv16_b64_tr16_lb, default: true}
+  - {config: hv16_b128_tr16_lb, default: true}
+  - {config: hv12_b16_tr16_lb, default: true}
+  - {config: hv12_b64_tr16_lb, default: true}

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -1,0 +1,1296 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications Copyright (c) 2026 The TIRx Authors.
+# Modifications are licensed under the Apache License, Version 2.0.
+#
+# This file is a TIRx port of FlashInfer's
+# flashinfer/kda_kernels/recurrent_kda.py::_grouped_kda_kernel
+# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
+# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+
+"""TIRx port of FlashInfer's grouped-CTA recurrent-KDA decode kernel.
+
+Source CuTe DSL: ``flashinfer/kda_kernels/recurrent_kda.py``
+(``_grouped_kda_kernel`` at line 482, host ``_grouped_kda_host`` at 729,
+compile cache ``_get_grouped_compiled`` at 836, dispatch at 2090-2198).
+
+This is the sibling of :mod:`recurrent_kda_decode_one_warp`.  FlashInfer's host
+routes here whenever the one-warp predicate fails:
+
+* ``NUM_TOKENS == 1`` with ``sequence_heads = N * HV < 128`` -- small-batch decode;
+* **every** ``NUM_TOKENS > 1`` call -- SGLang ``target_verify`` (MTP/speculative),
+  regardless of N and HV.
+
+Unlike the one-warp kernel, this one is a genuine multi-warp CTA: it allocates
+four shared-memory buffers and has exactly **one** ``__syncthreads()`` splitting
+a token-preprocessing phase from a barrier-free sequential recurrence.  The
+barrier exists because the two phases use *different* thread-to-element
+mappings: phase A walks ``d = tid % D`` over ``EPT`` elements, phase B walks the
+``part``-granule view of the state tile.
+
+The host picks the tiling by a hard rule (``recurrent_kda.py:859-860``):
+``KS = 4 if T == 1 else 2`` and ``VSPLIT = 4``.  That yields exactly two shapes:
+
+===========  ====  ====  ====  ===  ===  ===
+mode          T     KS    NT    G   EPT   SW
+===========  ====  ====  ====  ===  ===  ===
+decode        1     4     128   4    1    4
+verify       >1     2     64    8    2    2
+===========  ====  ====  ====  ===  ===  ===
+
+Both gate modes SGLang can select are covered: ``GATE_MODE=2``
+(``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``, Kimi K3, ``-5.0``) and
+``GATE_MODE=1`` (softplus with the ``x > 20`` linear guard, Kimi Linear).
+
+Out of scope, because unreachable from the production call path or handled by
+the sibling: ``GATE_MODE=0`` (pre-computed gate), ``USE_SRC=1``
+(``initial_state_source``), ``BETA_LOGIT=1``, ``USE_L2=0``, ``HEAD_DIM != 128``,
+GQA (``HV != H``), and single-token decode with ``N * HV >= 128`` (one-warp).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+# Sibling import: the one-warp port is the canonical home for the shared PTX,
+# bf16-conversion and shuffle helpers (mamba's convention, e.g.
+# selective_state_update_stp_vertical.py:34 importing _simple).
+from . import recurrent_kda_decode_one_warp as _one_warp
+
+HEAD_DIM = _one_warp.HEAD_DIM  # 128
+VSPLIT = 4  # recurrent_kda.py:860 -- fixed by the host
+ONE_WARP_MIN_SEQUENCE_HEADS = _one_warp.ONE_WARP_MIN_SEQUENCE_HEADS  # 128
+L2_EPS = _one_warp.L2_EPS  # 1e-6, hardcoded in the source at :663-664
+DEFAULT_LOWER_BOUND = _one_warp.DEFAULT_LOWER_BOUND  # -5.0 (Kimi K3)
+
+# recurrent_kda.py:479
+LOG2_E = 1.4426950408889634
+# recurrent_kda.py:620 -- softplus switches to the linear branch above this
+SOFTPLUS_LINEAR_THRESHOLD = 20.0
+
+GATE_MODE_PRECOMPUTED = 0
+GATE_MODE_SOFTPLUS = 1
+GATE_MODE_LOWER_BOUND = 2
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _row_lengths(num_seqs: int, num_tokens: int, empty_rows: int) -> list[int]:
+    """Per-row token counts.
+
+    Spec mode requires ``cu_seqlens`` to step by exactly ``T`` for *every* row,
+    padded rows included (recurrent_kda.py:1658-1661); padding is signalled by
+    ``ssm_state_indices == -1``, never by a short row.  That contract is load
+    bearing rather than cosmetic: a row with ``seq_len < T`` leaves output
+    positions ``token_base + seq_len .. token_base + T - 1`` written by nobody
+    -- phase B's zero-fill is guarded by ``in_row`` (:714-717) and the orphan
+    loop only covers ``pos >= cu[n_seq]`` (:719-725).  The source therefore has
+    no defined result for a short spec row, so it cannot be a correctness case.
+
+    The one in-contract way to make ``in_row`` false is a **zero-length row**
+    in ``T = 1`` decode mode: every remaining output position is still owned by
+    some row, so the result stays fully defined.
+    """
+    if empty_rows and num_tokens != 1:
+        raise ValueError(
+            "empty rows are only in contract for T=1 decode; spec mode requires "
+            "cu_seqlens to step by T for every row (recurrent_kda.py:1658-1661)"
+        )
+    lens = [num_tokens] * num_seqs
+    for i in range(min(empty_rows, num_seqs)):
+        lens[i] = 0
+    return lens
+
+
+# ---------------------------------------------------------------------------
+# PTX helpers specific to the grouped kernel
+#
+# The one-warp sibling supplies the shared scalar math, BF16 conversion and
+# shuffle helpers; imported below.  What this kernel needs on top of those is
+# the packed-FP32 granule arithmetic, three non-FTZ scalar forms the sibling
+# does not use, and shared-memory accessors -- ``low_level_ir.py:26`` forbids
+# BufferLoad/BufferStore on ``shared`` exactly as it does on ``global``, so
+# every SMEM touch goes through ``ptr_to`` and raw PTX.
+# ---------------------------------------------------------------------------
+
+_ptx_un = _one_warp._ptx_un
+_ptx_bin = _one_warp._ptx_bin
+_ptx_ter = _one_warp._ptx_ter
+_mul = _one_warp._mul
+_add = _one_warp._add
+_sub = _one_warp._sub
+_fma = _one_warp._fma
+_exp2 = _one_warp._exp2
+_add_bf16 = _one_warp._add_bf16
+_fma_bf16 = _one_warp._fma_bf16
+_bf16_to_f32 = _one_warp._bf16_to_f32
+_f32_to_bf16 = _one_warp._f32_to_bf16
+_pack_bf16x2 = _one_warp._pack_bf16x2
+_shfl_bfly_f32 = _one_warp._shfl_bfly_f32
+_load_f32 = _one_warp._load_f32
+_load_i32 = _one_warp._load_i32
+_load_bf16_bits = _one_warp._load_bf16_bits
+_store_bf16_bits = _one_warp._store_bf16_bits
+_store_bf16_bits_pred = _one_warp._store_bf16_bits_pred
+
+
+def _neg(a):
+    """``neg.f32``.
+
+    The GATE_MODE=2 sigmoid negates its argument with a real instruction; the
+    sign is not folded into a negative LOG2_E constant (PTX ``.loc 625`` emits
+    ``neg.f32`` then two ``mul.f32``).
+    """
+    return _ptx_un("neg.f32", a)
+
+
+def _rsqrt_no_ftz(a):
+    """``rsqrt.approx.f32`` -- approximate but NOT flush-to-zero.
+
+    The sibling's ``_rsqrt`` is the ``.ftz`` form; this kernel's source keeps
+    denormals here, and ``ex2`` is its only ``.ftz`` instruction.
+    """
+    return _ptx_un("rsqrt.approx.f32", a)
+
+
+def _rcp_rn(a):
+    """``rcp.rn.f32`` -- correctly rounded, not ``rcp.approx`` and not a divide."""
+    return _ptx_un("rcp.rn.f32", a)
+
+
+def _sub_bf16(bf_bits, f):
+    """``sub.rn.f32.bf16`` -- the BF16 minuend never widens to FP32 first."""
+    return _ptx_bin("sub.rn.f32.bf16", bf_bits, f)
+
+
+def _pack_f32x2(lo, hi):
+    """One ``.f32x2`` operand: ``lo`` is the low half, i.e. the lower address."""
+    return T.cuda.make_float2(lo, hi)
+
+
+def _vmul(a, b):
+    """``mul.f32x2`` -- two packed FP32 lanes."""
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.mul.f32x2(out[0], a, b))
+    return out[0]
+
+
+def _vadd(a, b):
+    """``add.f32x2`` -- two packed FP32 lanes.
+
+    The source writes ``acc + x * y`` but the compiler emits a separate
+    multiply and add; there is no ``fma.*.f32x2`` anywhere in its PTX, so the
+    port must not fuse them either.
+    """
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.add.f32x2(out[0], a, b))
+    return out[0]
+
+
+def _ld_shared_b32(buffer, index):
+    """``ld.shared.b32``."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], buffer.ptr_to([index])))
+    return T.reinterpret("float32", out[0])
+
+
+def _st_shared_f32(buffer, index, value):
+    """``st.shared.b32``."""
+    T.evaluate(T.ptx.st.shared.b32(buffer.ptr_to([index]), T.reinterpret("uint32", value)))
+
+
+def _st_shared_f32_pred(buffer, index, value, pred):
+    """``@p st.shared.b32`` -- the ``lane == 0 and wid < SW`` publication."""
+    T.evaluate(
+        T.ptx.st.shared.b32(buffer.ptr_to([index]), T.reinterpret("uint32", value), pred=pred)
+    )
+
+
+def _ld_shared_granule(buffer, index):
+    """One 8-element FP32 granule as four packed pairs: 2x ``ld.shared.v2.b64``.
+
+    A granule is 8 contiguous FP32 (32 B), which the source reads as two 16 B
+    vectors; ``index`` is an FP32 element index and must be 16 B aligned.
+    """
+    pairs = T.alloc_local((4,), "uint64")
+    T.evaluate(T.ptx.ld.shared.v2.b64(pairs[0], pairs[1], buffer.ptr_to([index])))
+    T.evaluate(T.ptx.ld.shared.v2.b64(pairs[2], pairs[3], buffer.ptr_to([index + 4])))
+    return pairs
+
+
+def _ld_global_granule_no_alloc(buffer, index):
+    """``ld.global.L1::no_allocate.v4.b32`` -- one 16 B BF16 state granule.
+
+    Mirrors the source's ``autovec_copy(..., CacheEvictionPriority.NO_ALLOCATE)``
+    on the state load (recurrent_kda.py:571).
+    """
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx["ld.global.L1::no_allocate.v4.b32"](
+            words[0], words[1], words[2], words[3], buffer.ptr_to([index])
+        )
+    )
+    return words
+
+
+def _st_global_granule_no_alloc(buffer, index, words):
+    """``st.global.L1::no_allocate.v4.b32`` -- one 16 B BF16 checkpoint granule."""
+    T.evaluate(
+        T.ptx["st.global.L1::no_allocate.v4.b32"](
+            buffer.ptr_to([index]), words[0], words[1], words[2], words[3]
+        )
+    )
+
+
+def _warp_reduce_sum(value):
+    """``cute.arch.warp_reduction_sum`` -- a full five-round 32-lane butterfly.
+
+    The offsets DESCEND because the source helper halves a group width. FP32
+    addition is not associative and the checkpoints must be exact, so the order
+    is semantic, not incidental.
+    """
+    for offset in (16, 8, 4, 2, 1):
+        value = _add(value, _shfl_bfly_f32(value, offset))
+    return value
+
+
+def _ks_join(value, ks: int):
+    """Join the ``KS`` K-slices of one column: ``(KS-1).bit_length()`` rounds.
+
+    KS = 2 -> offset {1}; KS = 4 -> offsets {1, 2}, ascending (:678-680).
+    """
+    for off_i in range((ks - 1).bit_length()):
+        value = _add(value, _shfl_bfly_f32(value, 1 << off_i))
+    return value
+
+
+def _softplus(x):
+    """``log1p(exp(x))`` with the source's ``x > 20 -> x`` linear guard (:618-620).
+
+    The source lowers ``cute.log1p`` to the inlined libdevice ``__nv_log1pf``
+    polynomial.  TVM's ``log1p`` intrinsic reaches the same libdevice routine
+    through nvcc, so this keeps the accuracy contract without hand-expanding the
+    minimax chain.  Only GATE_MODE=1 uses it, and no benchmark row does, so this
+    is a correctness obligation rather than a performance-alignment target.
+    """
+    sp = T.log1p(_exp2(_mul(x, LOG2_E)))
+    return T.Select(x > SOFTPLUS_LINEAR_THRESHOLD, x, sp)
+
+
+def _grouped_tiling(num_tokens: int) -> dict[str, int]:
+    """Reproduce the host's tiling rule (recurrent_kda.py:859-860, :516-521)."""
+    ks = 4 if num_tokens == 1 else 2
+    nt = (HEAD_DIM * ks) // VSPLIT
+    return {
+        "KS": ks,
+        "KC": HEAD_DIM // ks,
+        "G": (HEAD_DIM // ks) // 8,
+        "CPB": HEAD_DIM // VSPLIT,
+        "NT": nt,
+        "EPT": max(HEAD_DIM // nt, 1),
+        "SW": min(HEAD_DIM, nt) // 32,
+    }
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row.  ``mode`` selects the decode or verify input family."""
+    config: dict[str, Any] = {
+        "label": label,
+        "mode": "verify",  # "decode" (T=1) or "verify" (T>1)
+        "num_seqs": 8,
+        "num_tokens": 8,  # T; must be 1 for mode="decode"
+        "num_heads": 16,
+        "num_value_heads": 16,
+        "scratch_steps": None,  # None -> equals num_tokens (S == T)
+        "pool_size": 512,
+        "lower_bound": DEFAULT_LOWER_BOUND,  # None -> softplus gate
+        "padded_slots": 0,  # rows whose ssm index is -1
+        "empty_rows": 0,  # verify rows with seq_len < T
+        "orphan_tokens": 0,  # q_total beyond cu[n_seq]
+        "seed": 20260812,
+    }
+    config.update(overrides)
+    return config
+
+
+def _dec(label: str, **kw: Any) -> dict[str, Any]:
+    kw.setdefault("mode", "decode")
+    kw.setdefault("num_tokens", 1)
+    return _case(label, **kw)
+
+
+# All bench rows use the Kimi K3 gate (lower_bound = -5.0) and sit inside the
+# grouped dispatch domain.  Decode rows need N*HV < 128 or the host would pick
+# the one-warp kernel; verify rows reach grouped for every N and HV.
+BENCH_CONFIGS = [
+    # -- decode, T=1 (KS=4, NT=128) -------------------------------------------
+    _dec("dec_hv16_b1", num_seqs=1),  # sequence_heads 16
+    _dec("dec_hv16_b4", num_seqs=4),  # 64
+    _dec("dec_hv12_b4", num_seqs=4, num_heads=12, num_value_heads=12),  # 48
+    _dec("dec_hv12_b8", num_seqs=8, num_heads=12, num_value_heads=12),  # 96
+    # -- verify, T=8 (KS=2, NT=64) -- production DSPARK gamma=7, sglang parity --
+    _case("ver_t8_hv16_b1", num_seqs=1),
+    _case("ver_t8_hv16_b4", num_seqs=4),
+    _case("ver_t8_hv16_b16", num_seqs=16),
+    _case("ver_t8_hv16_b32", num_seqs=32),
+    _case("ver_t8_hv16_b64", num_seqs=64),
+    _case("ver_t8_hv16_b128", num_seqs=128),
+    _case("ver_t8_hv12_b16", num_seqs=16, num_heads=12, num_value_heads=12),
+    _case("ver_t8_hv12_b64", num_seqs=64, num_heads=12, num_value_heads=12),
+    # -- verify, other draft-window sizes -------------------------------------
+    _case("ver_t4_hv16_b32", num_seqs=32, num_tokens=4),  # test parity (32, 3)
+    _case("ver_t2_hv16_b8", num_seqs=8, num_tokens=2),  # legal floor
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # Softplus gate (Kimi Linear): GATE_MODE=1, incl. the x>20 linear guard.
+    _dec("dec_hv16_b4_sp", num_seqs=4, lower_bound=None),
+    _case("ver_t8_hv16_b4_sp", num_seqs=4, lower_bound=None),
+    _case("ver_t2_hv16_b8_sp", num_seqs=8, num_tokens=2, lower_bound=None),
+    # CUDA-graph padding: negative ssm_state_indices rows must produce zeroed
+    # output and leave their state slots untouched.
+    _dec("dec_hv16_b7_padded", num_seqs=7, padded_slots=3),  # 112 < 128
+    _case("ver_t8_hv16_b4_padded", num_seqs=4, padded_slots=2),
+    # Zero-length decode row: the one in-contract way to make in_row False.
+    # (A short *spec* row is out of contract -- see _row_lengths.)
+    _dec("dec_hv16_b6_empty", num_seqs=6, empty_rows=1),
+    # Allocated scratch stride S > T (tests use T+2): ssm index stride is
+    # scratch_steps, not T.
+    _case("ver_t4_hv16_b8_s6", num_seqs=8, num_tokens=4, scratch_steps=6),
+    # Orphan packed suffix: q_total > cu[n_seq] must be zero-filled by the
+    # kernel's tail loop (:719-725).  Decode-only -- spec mode sizes out_buf as
+    # N*NUM_TOKENS (:1810) while cu must step by T, so q_total == cu[n_seq]
+    # there and the tail loop is unreachable (it would write out of bounds).
+    _dec("dec_hv16_b4_orphan", num_seqs=4, orphan_tokens=3),
+    # Boundary: the largest decode shape still inside the grouped domain
+    # (sequence_heads 112 < 128).
+    _dec("dec_hv16_b7", num_seqs=7),
+]
+
+KERNEL_META = {
+    "name": "recurrent_kda_decode_grouped",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    mode = str(kwargs.get("mode", "verify"))
+    num_seqs = int(kwargs["num_seqs"])
+    num_tokens = int(kwargs["num_tokens"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    pool_size = int(kwargs["pool_size"])
+    lower_bound = kwargs.get("lower_bound", DEFAULT_LOWER_BOUND)
+    scratch_steps = kwargs.get("scratch_steps") or num_tokens
+    orphan_tokens = int(kwargs.get("orphan_tokens", 0))
+
+    if num_value_heads != num_heads:
+        raise ValueError("GQA (HV != H) is outside this port's scope")
+    if mode == "decode" and num_tokens != 1:
+        raise ValueError("mode='decode' requires num_tokens == 1")
+    if mode == "verify" and num_tokens < 2:
+        raise ValueError("mode='verify' requires num_tokens >= 2")
+    if scratch_steps < num_tokens:
+        raise ValueError("scratch_steps must be >= num_tokens")
+
+    # Grouped dispatch domain (recurrent_kda.py:1797-1798).  T>1 always lands
+    # here; T==1 only when the one-warp predicate fails.
+    sequence_heads = num_seqs * num_value_heads
+    if num_tokens == 1 and sequence_heads >= ONE_WARP_MIN_SEQUENCE_HEADS:
+        raise ValueError(
+            f"sequence_heads={sequence_heads} dispatches to the one-warp kernel; "
+            f"the grouped port requires < {ONE_WARP_MIN_SEQUENCE_HEADS} at T=1 "
+            "(recurrent_kda.py:1798)"
+        )
+
+    tiling = _grouped_tiling(num_tokens)
+    gate_mode = (
+        GATE_MODE_SOFTPLUS if lower_bound is None else GATE_MODE_LOWER_BOUND
+    )  # recurrent_kda.py:2140
+
+    empty_rows = int(kwargs.get("empty_rows", 0))
+    q_total = sum(_row_lengths(num_seqs, num_tokens, empty_rows)) + orphan_tokens
+    # Shared memory: three T*D f32 planes plus the T*16 f32 reduce scratch,
+    # each 16-byte aligned (recurrent_kda.py:526-530).
+    plane = 4 * num_tokens * HEAD_DIM
+    off_eg = 0
+    off_kr = _align_up(off_eg + plane, 16)
+    off_qr = _align_up(off_kr + plane, 16)
+    off_red = _align_up(off_qr + plane, 16)
+    shared_bytes = _align_up(off_red + 4 * num_tokens * 16, 16)
+
+    # State pool: committed [pool, HV, D, D] for decode; scratch viewed as
+    # [N*S, HV, D, D] for verify (recurrent_kda.py kda_flashinfer.py:307-309).
+    state_slots = pool_size if mode == "decode" else num_seqs * scratch_steps
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM
+
+    return {
+        "NUM_SEQS": num_seqs,
+        "NUM_TOKENS": num_tokens,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "RATIO": num_value_heads // num_heads,
+        "KS": tiling["KS"],
+        "G": tiling["G"],
+        "CPB": tiling["CPB"],
+        "NT": tiling["NT"],
+        "EPT": tiling["EPT"],
+        "SW": tiling["SW"],
+        "NUM_WARPS": tiling["NT"] // 32,
+        # Defer the state widening past the barrier only for small T; see the
+        # comment at the deferred block for the measured split.
+        "VSPLIT": VSPLIT,
+        "GATE_MODE": gate_mode,
+        "Q_TOTAL": q_total,
+        "QK_ELEMENTS": q_total * num_heads * HEAD_DIM,
+        "V_ELEMENTS": q_total * num_value_heads * HEAD_DIM,
+        "BETA_ELEMENTS": q_total * num_value_heads,
+        "STATE_ELEMENTS": state_slots * slot_stride,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "A_LOG_ELEMENTS": num_heads,
+        "DT_BIAS_ELEMENTS": num_heads * HEAD_DIM,
+        "CU_ELEMENTS": num_seqs + 1,
+        "SSM_IDX_ELEMENTS": num_seqs * num_tokens,
+        "NAT_ELEMENTS": num_seqs,
+        "OFF_EG": off_eg,
+        "OFF_KR": off_kr,
+        "OFF_QR": off_qr,
+        "OFF_RED": off_red,
+        "SHARED_BYTES": shared_bytes,
+    }
+
+
+@T.jit
+def _recurrent_kda_decode_grouped(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    a_log_h: T.handle,
+    dt_bias_h: T.handle,
+    cu_h: T.handle,
+    ssm_idx_h: T.handle,
+    nat_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    q_total: T.int32,
+    g_stride_q: T.int32,
+    state_slot_stride: T.int64,
+    scale: T.float32,
+    lower_bound: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_TOKENS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    RATIO: T.constexpr,
+    KS: T.constexpr,
+    G: T.constexpr,
+    CPB: T.constexpr,
+    NT: T.constexpr,
+    EPT: T.constexpr,
+    SW: T.constexpr,
+    NUM_WARPS: T.constexpr,
+    VSPLIT: T.constexpr,
+    GATE_MODE: T.constexpr,
+    Q_TOTAL: T.constexpr,
+    QK_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    A_LOG_ELEMENTS: T.constexpr,
+    DT_BIAS_ELEMENTS: T.constexpr,
+    CU_ELEMENTS: T.constexpr,
+    SSM_IDX_ELEMENTS: T.constexpr,
+    NAT_ELEMENTS: T.constexpr,
+    OFF_EG: T.constexpr,
+    OFF_KR: T.constexpr,
+    OFF_QR: T.constexpr,
+    OFF_RED: T.constexpr,
+    SHARED_BYTES: T.constexpr,
+):
+    q = T.match_buffer(q_h, (QK_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (QK_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    a_log = T.match_buffer(a_log_h, (A_LOG_ELEMENTS,), "float32", scope="global")
+    dt_bias = T.match_buffer(dt_bias_h, (DT_BIAS_ELEMENTS,), "float32", scope="global")
+    cu = T.match_buffer(cu_h, (CU_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_idx_h, (SSM_IDX_ELEMENTS,), "int32", scope="global")
+    nat = T.match_buffer(nat_h, (NAT_ELEMENTS,), "int32", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.device_entry()
+    # TIRX_TRANSCRIBE_START recurrent_kda_decode_grouped
+    # --- CTA and thread coordinates (recurrent_kda.py:512-524) -------------
+    hv, n, vz = T.cta_id([NUM_VALUE_HEADS, NUM_SEQS, VSPLIT])
+    # A flat NT-thread block, matching the source's block=(NT, 1, 1); a 2-D
+    # [32, NUM_WARPS] block would make every use of `tid` read two special
+    # registers instead of one.
+    tid = T.thread_id([NT])
+    lane: T.int32 = tid % 32
+    wid: T.int32 = tid // 32
+    h: T.int32 = hv // RATIO
+    v_idx: T.int32 = vz * CPB + tid // KS  # the state column this thread owns
+    part: T.int32 = tid % KS  # which K-slice of that column
+    d: T.int32 = tid % HEAD_DIM  # phase-A element base
+
+    # --- shared memory (recurrent_kda.py:526-541) --------------------------
+    # One 16B-aligned arena carved into the three T-batched staging planes plus
+    # the reduction scratch.  Every access below is raw PTX: low_level_ir.py:26
+    # forbids BufferLoad/BufferStore on `shared` just as it does on `global`.
+    shared_raw = T.alloc_buffer((SHARED_BYTES,), "uint8", scope="shared", align=16)
+    s_eg = T.decl_buffer(
+        (NUM_TOKENS * HEAD_DIM,),
+        "float32",
+        data=shared_raw.data,
+        scope="shared",
+        byte_offset=OFF_EG,
+        align=16,
+    )
+    s_kr = T.decl_buffer(
+        (NUM_TOKENS * HEAD_DIM,),
+        "float32",
+        data=shared_raw.data,
+        scope="shared",
+        byte_offset=OFF_KR,
+        align=16,
+    )
+    s_qr = T.decl_buffer(
+        (NUM_TOKENS * HEAD_DIM,),
+        "float32",
+        data=shared_raw.data,
+        scope="shared",
+        byte_offset=OFF_QR,
+        align=16,
+    )
+    s_red = T.decl_buffer(
+        (NUM_TOKENS * 16,),
+        "float32",
+        data=shared_raw.data,
+        scope="shared",
+        byte_offset=OFF_RED,
+        align=16,
+    )
+
+    # --- row bounds (recurrent_kda.py:543-544) -----------------------------
+    token_base: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - token_base
+
+    # --- initial checkpoint slot (recurrent_kda.py:551-560) ----------------
+    # `nat` is read only for T > 1; SGLang never supplies it, so FlashInfer
+    # substitutes a cached ones vector and `ic` collapses to 0.
+    ic: T.int32 = 0
+    if NUM_TOKENS > 1:
+        ic = T.min(T.max(_load_i32(nat, n) - 1, 0), NUM_TOKENS - 1)
+    slot0: T.int32 = T.max(_load_i32(ssm_idx, n * NUM_TOKENS + ic), 0)
+
+    # --- state load: one (8, G) granule per thread (recurrent_kda.py:562-574)
+    # Element (e, gi) sits at e + gi*KS*8 + part*8, so each granule's eight
+    # elements are contiguous: one 16B eviction-hinted vector load.
+    head_row: T.int32 = hv * HEAD_DIM * HEAD_DIM + v_idx * HEAD_DIM
+    read_base = T.cast(slot0, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        head_row, "int64"
+    )
+    s_pairs = T.alloc_local((4 * G,), "uint64")  # THE recurrent carry
+    s_words = T.alloc_local((4 * G,), "uint32")  # BF16 pairs, widened after the barrier
+    for gi in range(G):
+        words = _ld_global_granule_no_alloc(
+            state, read_base + T.cast(gi * KS * 8 + part * 8, "int64")
+        )
+        for pr in range(4):
+            s_words[gi * 4 + pr] = words[pr]
+
+    # --- loop-invariant gate constants (recurrent_kda.py:576-586) ----------
+    av: T.float32 = T.float32(1.0)
+    if GATE_MODE != GATE_MODE_PRECOMPUTED:
+        av = _exp2(_mul(_load_f32(a_log, h), T.float32(LOG2_E)))
+    dtb = T.alloc_local((EPT,), "float32")
+    for e in range(EPT):
+        dtb[e] = _load_f32(dt_bias, h * HEAD_DIM + d + e * NT)
+
+    # =======================================================================
+    # Phase A: stage every token's gate/key/query (recurrent_kda.py:588-640)
+    # Thread mapping is `d + e*NT` here, NOT the (v_idx, part) mapping below.
+    # =======================================================================
+    slots = T.alloc_local((NUM_TOKENS,), "int32")
+    ves = T.alloc_local((NUM_TOKENS,), "uint16")  # stays BF16 until :681
+    bbs = T.alloc_local((NUM_TOKENS,), "float32")
+
+    # Issue every token's global loads before consuming any of them.  With a
+    # cold L2 -- which is what bench_suite measures, and what an inference
+    # server sees -- the kernel is bound by how many DRAM misses are in flight,
+    # not by instruction count.  Loading and consuming one token at a time keeps
+    # only EPT*3+2 requests outstanding; hoisting all T tokens keeps T times as
+    # many.
+    q_bits = T.alloc_local((NUM_TOKENS * EPT,), "uint16")
+    k_bits = T.alloc_local((NUM_TOKENS * EPT,), "uint16")
+    g_bits = T.alloc_local((NUM_TOKENS * EPT,), "uint16")
+    b_bits = T.alloc_local((NUM_TOKENS,), "uint16")
+    for t in range(NUM_TOKENS):
+        slots[t] = _load_i32(ssm_idx, n * NUM_TOKENS + t)
+        # Out-of-row tokens clamp to token 0 so the loads stay in bounds; the
+        # value is discarded by the `active` predicate in phase B.
+        pidx: T.int32 = T.if_then_else(t < seq_len, token_base + t, 0)
+        ves[t] = _load_bf16_bits(v, (pidx * NUM_VALUE_HEADS + hv) * HEAD_DIM + v_idx)
+        b_bits[t] = _load_bf16_bits(beta, pidx * NUM_VALUE_HEADS + hv)
+        for e in range(EPT):
+            de_l: T.int32 = d + e * NT
+            q_bits[t * EPT + e] = _load_bf16_bits(q, (pidx * NUM_HEADS + h) * HEAD_DIM + de_l)
+            k_bits[t * EPT + e] = _load_bf16_bits(k, (pidx * NUM_HEADS + h) * HEAD_DIM + de_l)
+            g_bits[t * EPT + e] = _load_bf16_bits(g, pidx * g_stride_q + hv * HEAD_DIM + de_l)
+    for t in range(NUM_TOKENS):
+        bbs[t] = _bf16_to_f32(b_bits[t])
+
+        sqp: T.float32 = T.float32(0.0)
+        skp: T.float32 = T.float32(0.0)
+        for e in range(EPT):
+            de: T.int32 = d + e * NT
+            qe = q_bits[t * EPT + e]
+            ke = k_bits[t * EPT + e]
+            ge = g_bits[t * EPT + e]
+
+            # The L2 partials consume the raw BF16 registers.
+            sqp = _fma_bf16(qe, qe, sqp)
+            skp = _fma_bf16(ke, ke, skp)
+
+            x: T.float32 = _add_bf16(ge, dtb[e])
+            gate: T.float32 = T.float32(0.0)
+            if GATE_MODE == GATE_MODE_SOFTPLUS:
+                gate = _mul(_softplus(x), _neg(av))
+            else:
+                # The negation is its own instruction; it is not folded into a
+                # negative LOG2_E constant (recurrent_kda.py:623-627).
+                sig_e = _exp2(_mul(_mul(av, _neg(x)), T.float32(LOG2_E)))
+                gate = _mul(lower_bound, _rcp_rn(_add(sig_e, T.float32(1.0))))
+
+            # The staged key/query are the RAW values; L2 normalization is a
+            # scalar factor applied in phase B.  They convert here because the
+            # staging planes are FP32.
+            _st_shared_f32(s_eg, t * HEAD_DIM + de, _exp2(_mul(gate, T.float32(LOG2_E))))
+            _st_shared_f32(s_kr, t * HEAD_DIM + de, _bf16_to_f32(ke))
+            _st_shared_f32(s_qr, t * HEAD_DIM + de, _bf16_to_f32(qe))
+
+        # Full 32-lane butterfly, five rounds, DESCENDING offsets: the source's
+        # warp_reduction_sum halves a group width.  FP32 addition is not
+        # associative and the checkpoints must be exact, so the order matters.
+        sqp = _warp_reduce_sum(sqp)
+        skp = _warp_reduce_sum(skp)
+        publish = T.And(lane == 0, wid < SW)
+        _st_shared_f32_pred(s_red, t * 16 + wid, sqp, publish)
+        _st_shared_f32_pred(s_red, t * 16 + 8 + wid, skp, publish)
+
+    # The ONLY barrier: it separates the two thread-index mappings.
+    T.cuda.cta_sync()
+
+    # Nothing in phase A reads the state, so this placement reaches only
+    # scheduling: same op, same extent, same instruction, same dependence order
+    # as widening at the load site.  It is worth 15-20% on the T = 1 decode
+    # shapes (dec_hv16_b4 0.855 -> 1.06-1.09 measured on a clock-verified GPU)
+    # and is within run-to-run noise on every T > 1 shape, so it is
+    # unconditional.  It used to sit behind a `T <= 2` constexpr because before
+    # phase A issued all T tokens' loads up front it cost 2-3% at T = 8; that
+    # cost is gone, and with it the boundary.
+    for gi in range(G):
+        for pr in range(4):
+            w = s_words[gi * 4 + pr]
+            lo = _bf16_to_f32(T.cast(w, "uint16"))
+            hi = _bf16_to_f32(T.cast(T.shift_right(w, T.uint32(16)), "uint16"))
+            s_pairs[gi * 4 + pr] = _pack_f32x2(lo, hi)
+
+    # =======================================================================
+    # Phase B: sequential recurrence over the tokens (recurrent_kda.py:645-717)
+    # =======================================================================
+    kreg = T.alloc_local((4 * G,), "uint64")  # keys, loaded in pass 1, reused in pass 2
+    pvec = T.alloc_local((4,), "uint64")
+    ovec = T.alloc_local((4,), "uint64")
+    pf = T.alloc_local((8,), "float32")
+    words_w = T.alloc_local((4,), "uint32")
+
+    for t in range(NUM_TOKENS):
+        slot: T.int32 = slots[t]
+        in_row = t < seq_len
+        active = T.And(in_row, slot >= 0)
+        if active:
+            pidx_b: T.int32 = token_base + t
+            base_t: T.int32 = t * HEAD_DIM + part * 8
+
+            # ---- L2 factors (recurrent_kda.py:657-664); eps is hardcoded ----
+            sqt: T.float32 = T.float32(0.0)
+            skt: T.float32 = T.float32(0.0)
+            for w in range(SW):
+                sqt = _add(sqt, _ld_shared_b32(s_red, t * 16 + w))
+                skt = _add(skt, _ld_shared_b32(s_red, t * 16 + 8 + w))
+            rk: T.float32 = _rsqrt_no_ftz(_add(skt, T.float32(L2_EPS)))
+            rq: T.float32 = _mul(_rsqrt_no_ftz(_add(sqt, T.float32(L2_EPS))), scale)
+
+            # ---- pass 1: decay the state, accumulate the raw prediction ----
+            # gi == 0 is peeled so pvec is initialized by a mul, not fill+add.
+            egp = _ld_shared_granule(s_eg, base_t)
+            krp = _ld_shared_granule(s_kr, base_t)
+            for pr in range(4):
+                sv = _vmul(s_pairs[pr], egp[pr])
+                s_pairs[pr] = sv
+                kreg[pr] = krp[pr]
+                pvec[pr] = _vmul(krp[pr], sv)
+            for gi in range(1, G):
+                egp = _ld_shared_granule(s_eg, base_t + gi * KS * 8)
+                krp = _ld_shared_granule(s_kr, base_t + gi * KS * 8)
+                for pr in range(4):
+                    sv = _vmul(s_pairs[gi * 4 + pr], egp[pr])
+                    s_pairs[gi * 4 + pr] = sv
+                    kreg[gi * 4 + pr] = krp[pr]
+                    # mul then add -- the source emits no fma.*.f32x2.
+                    pvec[pr] = _vadd(pvec[pr], _vmul(krp[pr], sv))
+
+            # ---- balanced 8-term tree, then the KS butterfly join ----
+            for pr in range(4):
+                pf[2 * pr] = T.cuda.float2_x(pvec[pr])
+                pf[2 * pr + 1] = T.cuda.float2_y(pvec[pr])
+            pred: T.float32 = _add(
+                _add(_add(pf[0], pf[1]), _add(pf[2], pf[3])),
+                _add(_add(pf[4], pf[5]), _add(pf[6], pf[7])),
+            )
+            pred = _ks_join(pred, KS)
+
+            # ---- delta rule (:681): rk appears TWICE, by design ----
+            deltak: T.float32 = _mul(_mul(rk, bbs[t]), _sub_bf16(ves[t], _mul(rk, pred)))
+            dpair = _pack_f32x2(deltak, deltak)
+
+            # ---- pass 2: rank-1 update, accumulate the raw output ----
+            qrp = _ld_shared_granule(s_qr, base_t)
+            for pr in range(4):
+                sv = _vadd(s_pairs[pr], _vmul(kreg[pr], dpair))
+                s_pairs[pr] = sv
+                ovec[pr] = _vmul(qrp[pr], sv)
+            for gi in range(1, G):
+                qrp = _ld_shared_granule(s_qr, base_t + gi * KS * 8)
+                for pr in range(4):
+                    sv = _vadd(s_pairs[gi * 4 + pr], _vmul(kreg[gi * 4 + pr], dpair))
+                    s_pairs[gi * 4 + pr] = sv
+                    ovec[pr] = _vadd(ovec[pr], _vmul(qrp[pr], sv))
+
+            for pr in range(4):
+                pf[2 * pr] = T.cuda.float2_x(ovec[pr])
+                pf[2 * pr + 1] = T.cuda.float2_y(ovec[pr])
+            o: T.float32 = _add(
+                _add(_add(pf[0], pf[1]), _add(pf[2], pf[3])),
+                _add(_add(pf[4], pf[5]), _add(pf[6], pf[7])),
+            )
+            o = _ks_join(o, KS)
+
+            # ---- output store, owned by part == 0 (:698-699) ----
+            # Predicated rather than branch-guarded: inline asm is opaque to
+            # ptxas, so an `if` around an asm store can never be if-converted.
+            _store_bf16_bits_pred(
+                out,
+                (pidx_b * NUM_VALUE_HEADS + hv) * HEAD_DIM + v_idx,
+                _f32_to_bf16(_mul(o, rq)),
+                part == 0,
+            )
+
+            # ---- BF16 checkpoint write, eviction-hinted (:702-713) ----
+            write_base = T.cast(slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+                head_row, "int64"
+            )
+            for gi in range(G):
+                for pr in range(4):
+                    words_w[pr] = _pack_bf16x2(
+                        T.cuda.float2_y(s_pairs[gi * 4 + pr]), T.cuda.float2_x(s_pairs[gi * 4 + pr])
+                    )
+                _st_global_granule_no_alloc(
+                    state, write_base + T.cast(gi * KS * 8 + part * 8, "int64"), words_w
+                )
+        else:
+            # Pad rows still own their output element: the host allocates `out`
+            # uninitialized because the kernel defines every slot.
+            _store_bf16_bits_pred(
+                out,
+                ((token_base + t) * NUM_VALUE_HEADS + hv) * HEAD_DIM + v_idx,
+                T.uint16(0),
+                T.And(in_row, part == 0),
+            )
+
+    # --- orphan packed suffix (recurrent_kda.py:719-725) --------------------
+    # Carrier tokens owned by no row.  Reachable only in the T == 1 decode
+    # layout: spec mode sizes `out` as N*NUM_TOKENS while cu_seqlens must step
+    # by T, so q_total == cu[n_seq] there and this loop is empty.
+    if T.And(T.And(n == 0, vz == 0), tid < HEAD_DIM):
+        covered: T.int32 = _load_i32(cu, NUM_SEQS)
+        for pos in T.serial(covered, q_total):
+            for e in range(EPT):
+                _store_bf16_bits(
+                    out, (pos * NUM_VALUE_HEADS + hv) * HEAD_DIM + tid + e * NT, T.uint16(0)
+                )
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized grouped-CTA recurrent-KDA decode PrimFunc."""
+    return _recurrent_kda_decode_grouped.specialize(**_specialization(kwargs))
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state.
+
+    Two families, matching the two SGLang call sites:
+
+    * ``mode="decode"`` -- ``kda_flashinfer.py::decode`` with a small batch, so
+      ``N * HV < 128`` and the host picks the grouped kernel.  The committed
+      pool is updated in place.
+    * ``mode="verify"`` -- ``kda_flashinfer.py::target_verify``: packed
+      ``[1, N*T, ...]`` inputs, draft-stride ``cu_seqlens``, and the scratch
+      ``intermediate_ssm`` pool as ``initial_state`` with step 0 python-seeded
+      from the committed pool (``:299-304``).  ``ssm_state_indices`` is the
+      ``[N, T]`` matrix ``base_rows * scratch_steps + arange(T)`` (``:293-296``),
+      so its stride is the *allocated* step count, which may exceed ``T``.
+    """
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for grouped recurrent-KDA decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(
+            f"grouped recurrent-KDA decode targets compute capability 10.x, got {capability}"
+        )
+
+    spec = _specialization(kwargs)
+    mode = str(kwargs.get("mode", "verify"))
+    n_seq = spec["NUM_SEQS"]
+    tokens = spec["NUM_TOKENS"]
+    heads = spec["NUM_HEADS"]
+    vheads = spec["NUM_VALUE_HEADS"]
+    q_total = spec["Q_TOTAL"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    pool_size = int(kwargs["pool_size"])
+    scratch_steps = kwargs.get("scratch_steps") or tokens
+    lower_bound = kwargs.get("lower_bound", DEFAULT_LOWER_BOUND)
+    padded_slots = int(kwargs.get("padded_slots", 0))
+    empty_rows = int(kwargs.get("empty_rows", 0))
+    orphan_tokens = int(kwargs.get("orphan_tokens", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    # Magnitudes follow sglang's make_verify_inputs / make_decode_inputs
+    # (bench_kda_flashinfer_mtp.py:50-121).
+    q = randn(1, q_total, heads, HEAD_DIM, gain=0.5)
+    k = randn(1, q_total, heads, HEAD_DIM, gain=0.5)
+    v = randn(1, q_total, vheads, HEAD_DIM, gain=0.5)
+    g = (
+        0.5
+        * torch.randn(
+            (1, q_total, vheads, HEAD_DIM), device=device, dtype=torch.float32, generator=gen
+        )
+        - 1.0
+    ).to(torch.bfloat16)
+    # Softplus has a linear branch above x > 20 (recurrent_kda.py:620); push a
+    # slice of the gate past it so that specialization is actually exercised.
+    if lower_bound is None and q_total > 0:
+        g_f32 = g.float()
+        g_f32[:, :, :, :8] = 25.0
+        g = g_f32.to(torch.bfloat16)
+    beta_logit = randn(1, q_total, vheads, dtype=torch.float32, gain=0.5)
+    beta = torch.sigmoid(beta_logit).to(torch.bfloat16)  # sglang pre-sigmoids
+    a_log = randn(heads, dtype=torch.float32, gain=0.2)
+    dt_bias = randn(heads * HEAD_DIM, dtype=torch.float32, gain=0.1)
+
+    # cu_seqlens: decode = one token per row (a zero-length row is allowed and
+    # is what exercises in_row); verify = draft stride T for every row, padded
+    # rows included (recurrent_kda.py:1658-1661).
+    if mode == "decode":
+        offsets = [0]
+        for row_len in _row_lengths(n_seq, tokens, empty_rows):
+            offsets.append(offsets[-1] + row_len)
+        cu = torch.tensor(offsets, device=device, dtype=torch.int32)
+    else:
+        lens = _row_lengths(n_seq, tokens, 0)
+        offsets = [0]
+        for row_len in lens:
+            offsets.append(offsets[-1] + row_len)
+        cu = torch.tensor(offsets, device=device, dtype=torch.int32)
+
+    committed = randn(pool_size, vheads, HEAD_DIM, HEAD_DIM, gain=0.01)
+
+    if mode == "decode":
+        slots = torch.arange(n_seq, device=device, dtype=torch.int32)
+        if padded_slots:
+            slots[n_seq - padded_slots :] = -1
+        ssm_idx = slots.reshape(n_seq, 1)
+        tirx_state_raw = committed.reshape(-1).clone()
+        reference_state_raw = tirx_state_raw.clone()
+        state_slots = pool_size
+    else:
+        base_rows = torch.arange(n_seq, device=device, dtype=torch.int32)
+        ssm_idx = (
+            base_rows[:, None] * scratch_steps
+            + torch.arange(tokens, device=device, dtype=torch.int32)[None, :]
+        ).contiguous()
+        if padded_slots:
+            ssm_idx[n_seq - padded_slots :, :] = -1
+        scratch = torch.zeros(
+            n_seq * scratch_steps * slot_stride, device=device, dtype=torch.bfloat16
+        )
+        # Step-0 seeding, exactly as the sglang wrapper does before the launch.
+        seed_src = committed[:n_seq].reshape(n_seq, slot_stride)
+        scratch_view = scratch.reshape(n_seq, scratch_steps, slot_stride)
+        scratch_view[:, 0, :] = seed_src
+        tirx_state_raw = scratch
+        reference_state_raw = scratch.clone()
+        state_slots = n_seq * scratch_steps
+
+    initial_state_raw = tirx_state_raw.clone()
+    nat = torch.ones(n_seq, device=device, dtype=torch.int32)  # sglang's fallback
+    tirx_out = torch.empty((1, q_total, vheads, HEAD_DIM), device=device, dtype=torch.bfloat16)
+
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "mode": mode,
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "cu_seqlens": cu,
+        "ssm_state_indices": ssm_idx,
+        "nat": nat,
+        "committed": committed,
+        "tirx_state_raw": tirx_state_raw,
+        "reference_state_raw": reference_state_raw,
+        "initial_state_raw": initial_state_raw,
+        "state_slots": state_slots,
+        "scratch_steps": scratch_steps,
+        "tirx_out": tirx_out,
+        "scale": HEAD_DIM**-0.5,
+        "eps": L2_EPS,
+        "lower_bound": lower_bound,
+        "q_total": q_total,
+        "orphan_tokens": orphan_tokens,
+    }
+
+
+def _state_view(raw: torch.Tensor, case: dict[str, Any]) -> torch.Tensor:
+    spec = case["spec"]
+    return raw.as_strided(
+        (case["state_slots"], spec["NUM_VALUE_HEADS"], HEAD_DIM, HEAD_DIM),
+        (spec["STATE_SLOT_STRIDE"], HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    spec = case["spec"]
+    lower_bound = case["lower_bound"]
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g"].reshape(-1),
+        case["beta"].reshape(-1),
+        case["a_log"],
+        case["dt_bias"],
+        case["cu_seqlens"],
+        case["ssm_state_indices"].reshape(-1),
+        case["nat"],
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        int(case["q_total"]),
+        int(spec["NUM_VALUE_HEADS"] * HEAD_DIM),  # g token stride (contiguous here)
+        int(spec["STATE_SLOT_STRIDE"]),
+        float(case["scale"]),
+        float(lower_bound if lower_bound is not None else 0.0),
+    )
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """FP32 oracle: the same recurrence, written as dense torch.
+
+    Two semantics are easy to get wrong and are what this oracle exists to pin:
+
+    * the recurrent state is carried in **FP32** across the tokens of a row and
+      is only rounded to BF16 on the way to its checkpoint slot -- token ``t+1``
+      consumes the FP32 value, not the round-tripped one (recurrent_kda.py:708
+      writes ``sb1`` while ``s`` keeps its precision);
+    * ``rk`` appears twice in ``deltak = rk * bb * (ve - rk * pred)`` (:681);
+      one factor normalizes the key inside the prediction, the other normalizes
+      the key of the rank-1 update.
+
+    Returns ``(out, state_pool)`` with the pool laid out as the kernel sees it.
+    """
+    spec = case["spec"]
+    dev = case["device"]
+    tokens, heads = spec["NUM_TOKENS"], spec["NUM_VALUE_HEADS"]
+    n_seq, q_total = spec["NUM_SEQS"], spec["Q_TOTAL"]
+    ratio = spec["RATIO"]
+    mode = spec["GATE_MODE"]
+    lower_bound = case["lower_bound"]
+    scale = case["scale"]
+
+    f32 = torch.float32
+    q = case["q"].reshape(q_total, spec["NUM_HEADS"], HEAD_DIM).to(f32)
+    k = case["k"].reshape(q_total, spec["NUM_HEADS"], HEAD_DIM).to(f32)
+    v = case["v"].reshape(q_total, heads, HEAD_DIM).to(f32)
+    g = case["g"].reshape(q_total, heads, HEAD_DIM).to(f32)
+    beta = case["beta"].reshape(q_total, heads).to(f32)
+    dt_bias = case["dt_bias"].reshape(spec["NUM_HEADS"], HEAD_DIM).to(f32)
+    av = torch.exp(case["a_log"].to(f32))  # [H]
+    cu = case["cu_seqlens"].tolist()
+    idx = case["ssm_state_indices"].reshape(n_seq, tokens)
+
+    pool = _state_view(case["initial_state_raw"], case).to(f32).clone()
+    out = torch.zeros((q_total, heads, HEAD_DIM), device=dev, dtype=f32)
+
+    head_of = torch.arange(heads, device=dev) // ratio  # hv -> h
+
+    for n in range(n_seq):
+        token_base = cu[n]
+        seq_len = cu[n + 1] - token_base
+        # num_accepted_tokens is never supplied by SGLang, so ic collapses to 0.
+        slot0 = int(idx[n, 0])
+        state = pool[max(slot0, 0)].clone()  # [HV, V, K] f32
+
+        for t in range(tokens):
+            slot = int(idx[n, t])
+            in_row = t < seq_len
+            if not in_row:
+                continue  # written by nobody
+            if slot < 0:
+                out[token_base + t] = 0.0  # pad row
+                continue
+
+            p = token_base + t
+            qt, kt = q[p][head_of], k[p][head_of]  # [HV, K]
+            vt, gt, bt = v[p], g[p], beta[p]
+
+            x = gt + dt_bias[head_of]
+            if mode == GATE_MODE_SOFTPLUS:
+                sp = torch.log1p(torch.exp(x))
+                sp = torch.where(x > SOFTPLUS_LINEAR_THRESHOLD, x, sp)
+                gate = -av[head_of].unsqueeze(-1) * sp
+            else:
+                gate = lower_bound * torch.sigmoid(av[head_of].unsqueeze(-1) * x)
+            eg = torch.exp(gate)  # [HV, K]
+
+            rk = torch.rsqrt((kt * kt).sum(-1) + L2_EPS)  # [HV]
+            rq = torch.rsqrt((qt * qt).sum(-1) + L2_EPS) * scale
+
+            state = state * eg.unsqueeze(1)  # decay along K
+            pred = torch.einsum("hvk,hk->hv", state, kt)
+            deltak = rk.unsqueeze(-1) * bt.unsqueeze(-1) * (vt - rk.unsqueeze(-1) * pred)
+            state = state + deltak.unsqueeze(-1) * kt.unsqueeze(1)
+            out[p] = rq.unsqueeze(-1) * torch.einsum("hvk,hk->hv", state, qt)
+
+            # The checkpoint rounds to BF16; the carried state does not.
+            pool[slot] = state.to(torch.bfloat16).to(f32)
+
+    if q_total > cu[n_seq]:
+        out[cu[n_seq] :] = 0.0  # orphan suffix
+    return out.reshape(1, q_total, heads, HEAD_DIM), pool
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the FlashInfer CuTe DSL source on the reference state pool.
+
+    ``run_recurrent_kda`` derives ``NUM_TOKENS = 1 + num_spec_tokens``
+    (recurrent_kda.py:1779), so the verify family must pass it; the decode
+    family must not (:1298-1299).  ``num_accepted_tokens`` is deliberately left
+    unset, matching SGLang's ``target_verify`` -- FlashInfer then substitutes a
+    cached ones vector, which makes ``ic = 0`` and ``slot0 = ssm_idx[n, 0]``.
+    """
+    import importlib
+
+    # flashinfer.kda_kernels.__init__ rebinds ``recurrent_kda`` to the run
+    # function, so the submodule must be imported explicitly.
+    fi = importlib.import_module("flashinfer.kda_kernels.recurrent_kda")
+    spec = case["spec"]
+    tokens = spec["NUM_TOKENS"]
+    out, _ = fi.run_recurrent_kda(
+        q=case["q"],
+        k=case["k"],
+        v=case["v"],
+        g=case["g"],
+        beta=case["beta"],
+        A_log=case["a_log"],
+        dt_bias=case["dt_bias"],
+        scale=case["scale"],
+        initial_state=_state_view(case["reference_state_raw"], case),
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=case["lower_bound"],
+        cu_seqlens=case["cu_seqlens"],
+        ssm_state_indices=case["ssm_state_indices"],
+        num_spec_tokens=(tokens - 1) if tokens > 1 else None,
+    )
+    return out
+
+
+# Two bfloat16 ULP against the source, matching the one-warp sibling.
+_RTOL = 2.0**-7
+_ATOL = 1.0e-4
+# The FP32 oracle reassociates freely, so it only needs to agree to bf16 noise.
+_ORACLE_RTOL = 2.0**-6
+_ORACLE_ATOL = 3.0e-4
+
+
+def _assert_close(got, want, rtol, atol, what: str) -> None:
+    got_f, want_f = got.float(), want.float()
+    diff = (got_f - want_f).abs()
+    tol = atol + rtol * want_f.abs()
+    bad = diff > tol
+    if bool(bad.any()):
+        idx = int(bad.float().argmax())
+        raise AssertionError(
+            f"{what}: {int(bad.sum())}/{bad.numel()} elements exceed tolerance; "
+            f"max |diff| = {float(diff.max()):.3e} (tol {float(tol.flatten()[idx]):.3e}), "
+            f"first at flat index {idx}: got {float(got_f.flatten()[idx]):.6e} "
+            f"want {float(want_f.flatten()[idx]):.6e}"
+        )
+
+
+def run_test(**kwargs: Any) -> None:
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize()
+
+    tirx_out = case["tirx_out"]
+    tirx_state = _state_view(case["tirx_state_raw"], case)
+
+    # Primary oracle: the CuTe DSL source itself, on its own pool clone.
+    ref_out = _flashinfer_reference(case)
+    ref_state = _state_view(case["reference_state_raw"], case)
+    _assert_close(tirx_out, ref_out, _RTOL, _ATOL, "output vs flashinfer")
+    _assert_close(tirx_state, ref_state, _RTOL, _ATOL, "state vs flashinfer")
+
+    # Secondary oracle: dense FP32 torch, from the untouched initial pool.
+    oracle_out, oracle_state = _torch_reference(case)
+    _assert_close(tirx_out, oracle_out, _ORACLE_RTOL, _ORACLE_ATOL, "output vs fp32 oracle")
+    _assert_close(
+        tirx_state.float(), oracle_state, _ORACLE_RTOL, _ORACLE_ATOL, "state vs fp32 oracle"
+    )
+
+    # ---- branch-specific obligations -------------------------------------
+    tokens, n_seq = spec["NUM_TOKENS"], spec["NUM_SEQS"]
+    stride = spec["STATE_SLOT_STRIDE"]
+    cu = case["cu_seqlens"].tolist()
+    idx = case["ssm_state_indices"].reshape(n_seq, tokens)
+    initial = case["initial_state_raw"]
+    final = case["tirx_state_raw"]
+
+    # Pad rows: zeroed output, and not one state slot written.
+    for n in range(n_seq):
+        for t in range(tokens):
+            if t >= cu[n + 1] - cu[n]:
+                continue
+            if int(idx[n, t]) >= 0:
+                continue
+            row = tirx_out[0, cu[n] + t]
+            assert bool((row == 0).all()), f"pad row {n} token {t} produced nonzero output"
+    written = {int(idx[n, t]) for n in range(n_seq) for t in range(min(tokens, cu[n + 1] - cu[n]))}
+    for slot in range(case["state_slots"]):
+        if slot in written:
+            continue
+        lo, hi = slot * stride, (slot + 1) * stride
+        assert torch.equal(initial[lo:hi], final[lo:hi]), (
+            f"state slot {slot} is owned by no active token but was modified"
+        )
+
+    # Orphan packed suffix: carrier tokens beyond the last row must be zeroed.
+    covered = cu[n_seq]
+    if case["q_total"] > covered:
+        tail = tirx_out[0, covered:]
+        assert bool((tail == 0).all()), (
+            f"orphan suffix [{covered}, {case['q_total']}) not zeroed by the kernel"
+        )
+
+
+def run_bench(
+    *, warmup: int | None = None, repeat: int | None = None, timer: str | None = None, **kwargs: Any
+) -> dict[str, Any]:
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region.  Both implementations update
+    # their own state-pool clone in place, so repeated timed launches let the
+    # values drift; the work per launch is identical either way.
+    executable(*args)
+    shape = (1, spec["Q_TOTAL"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
+    flashinfer_out = _flashinfer_reference(case).reshape(shape)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
+    torch.testing.assert_close(
+        case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # Heavy import, CuTe JIT and warmup all happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize()
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cutedsl": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -1,0 +1,1057 @@
+# Copyright (c) 2025 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications Copyright (c) 2026 The TIRx Authors.
+# Modifications are licensed under the Apache License, Version 2.0.
+#
+# This file is a TIRx port of FlashInfer's
+# flashinfer/kda_kernels/recurrent_kda.py::recurrent_kda_decode_kernel
+# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
+# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+
+"""TIRx port of FlashInfer's one-warp recurrent-KDA decode kernel.
+
+Source CuTe DSL: ``flashinfer/kda_kernels/recurrent_kda.py``
+(``recurrent_kda_decode_kernel`` at line 190, helpers ``compute_gate_value``
+at 88, ``_dot8_row`` at 154, ``_reduce_k_group`` at 178), launched by
+``recurrent_kda_launch`` at line 917 and dispatched from ``run_recurrent_kda``
+at line 1525 under ``use_one_warp`` (line 1798).
+
+Target instance: BF16, ``HEAD_DIM = 128``, ``NUM_TOKENS = 1``, packed
+``cu_seqlens`` decode, in-kernel gate with ``dt_bias``, in-kernel q/k L2 norm,
+pre-sigmoided beta, in-place ``[S, HV, 128, 128]`` state pool, sm_100a.
+Launch is ``N * HV * (128 // TILE_ROWS)`` CTAs of **32 threads (one warp)**
+with **zero shared memory** and no barrier of any kind; the recurrent state
+lives entirely in registers and every cross-lane exchange is a warp shuffle.
+
+This is the specialization SGLang's KDA decode backend reaches
+(``sglang/srt/layers/attention/linear/kernels/kda_flashinfer.py::decode``):
+``use_qk_l2norm_in_kernel=True``, ``use_gate_in_kernel=True``, ``dt_bias``
+always present, beta already sigmoided, ``cu_seqlens = arange(N + 1)``,
+``ssm_state_indices`` possibly carrying ``-1`` padding rows.
+
+Two gate modes are covered, both reachable from SGLang:
+
+* ``USE_LOWER_BOUND = 1`` -- Kimi K3, ``lower_bound = -5.0``;
+  ``g = exp2(lb * log2e * sigmoid(-exp(A_log) * log2e * (g + dt_bias)))``.
+* ``USE_LOWER_BOUND = 0`` -- Kimi Linear, softplus;
+  ``g = exp2(-exp(A_log) * log2(1 + exp(g + dt_bias)))``.
+
+Out of scope (they dispatch to a different source implementation or are
+unreachable from the production call path): ``NUM_TOKENS > 1`` and the whole
+speculative-decode path, ``sequence_heads < 128`` (which routes to
+``_grouped_kda_kernel``), ``HEAD_DIM = 64``, ``TILE_ROWS = 32``,
+``USE_CU_SEQLENS = 0``, ``BETA_IS_LOGIT = 1``, ``HAS_INITIAL_STATE_SOURCE = 1``,
+``HAS_NUM_ACCEPTED_TOKENS = 1``, ``USE_GATE_IN_KERNEL = 0``,
+``USE_QK_L2NORM = 0``, and GQA (``HV != H``; Kimi K3 uses ``H == HV``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+# --------------------------------------------------------------------------
+# Fixed dimensions of this specialization (recurrent_kda.py:242-244)
+# --------------------------------------------------------------------------
+HEAD_DIM = 128
+THREADS = 32  # recurrent_kda.py:987 -- block = [32, 1, 1]
+K_LANES = HEAD_DIM // 8  # 16
+V_LANES = 32 // K_LANES  # 2
+VALUES_PER_THREAD = HEAD_DIM // 32  # 4
+# Single-token decode: this port covers NUM_TOKENS == 1 only
+# (recurrent_kda.py:1767; NUM_TOKENS > 1 routes to the grouped-CTA kernel).
+NUM_TOKENS = 1
+
+# recurrent_kda.py:74-75
+DOT_REDUCTION_TREE = 0
+DOT_REDUCTION_DUAL_ACCUM = 1
+
+# recurrent_kda.py:79
+ONE_WARP_MIN_SEQUENCE_HEADS = 128
+
+# recurrent_kda.py:2087 -- the host hardcodes the L2-norm epsilon.
+L2_EPS = 1.0e-6
+# Kimi K3 checkpoint gate bound (sglang models/kimi_k3.py:1556).
+DEFAULT_LOWER_BOUND = -5.0
+
+
+# --------------------------------------------------------------------------
+# PTX helpers.
+#
+# The source's FP32 arithmetic is **non-flush-to-zero** throughout: the exported
+# line-info PTX contains zero `.ftz` add/mul/sub/fma.  Only the transcendentals
+# are FTZ, and the lower-bound sigmoid reciprocal is the full-precision
+# `div.rn.f32` rather than `rcp.approx`.  Reproducing that split is part of the
+# port, so these wrappers pin each instruction explicitly.
+# --------------------------------------------------------------------------
+LOG2_E = 1.4426950408889634
+
+
+def _ptx_un(chain: str, a, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a))
+    return out[0]
+
+
+def _ptx_bin(chain: str, a, b, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b))
+    return out[0]
+
+
+def _ptx_ter(chain: str, a, b, c, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b, c))
+    return out[0]
+
+
+def _mul(a, b):
+    """``mul.f32`` -- non-FTZ, matching the source."""
+    return _ptx_bin("mul.f32", a, b)
+
+
+def _add(a, b):
+    """``add.f32`` -- non-FTZ."""
+    return _ptx_bin("add.f32", a, b)
+
+
+def _sub(a, b):
+    """``sub.f32`` -- non-FTZ."""
+    return _ptx_bin("sub.f32", a, b)
+
+
+def _fma(a, b, c):
+    """``fma.rn.f32`` -- non-FTZ."""
+    return _ptx_ter("fma.rn.f32", a, b, c)
+
+
+def _exp2(a):
+    return _ptx_un("ex2.approx.ftz.f32", a)
+
+
+def _log2(a):
+    return _ptx_un("lg2.approx.ftz.f32", a)
+
+
+def _rsqrt(a):
+    return _ptx_un("rsqrt.approx.ftz.f32", a)
+
+
+def _div_rn(a, b):
+    """``div.rn.f32`` -- the source requests full-precision division here."""
+    return _ptx_bin("div.rn.f32", a, b)
+
+
+def _add_bf16(bf_bits, f):
+    """``add.rn.f32.bf16`` -- bf16 operand feeds the FP32 add directly."""
+    return _ptx_bin("add.rn.f32.bf16", bf_bits, f)
+
+
+def _fma_bf16(bf_a, bf_b, acc):
+    """``fma.rn.f32.bf16`` -- both multiplicands stay in their bf16 registers."""
+    return _ptx_ter("fma.rn.f32.bf16", bf_a, bf_b, acc)
+
+
+def _bf16_to_f32(bits):
+    return _ptx_un("cvt.f32.bf16", T.cast(bits, "uint16"))
+
+
+def _f32_to_bf16(value):
+    return _ptx_un("cvt.rn.bf16.f32", value, dtype="uint16")
+
+
+def _pack_bf16x2(hi, lo):
+    """``cvt.rn.bf16x2.f32 d, hi, lo`` -- d[31:16]=hi, d[15:0]=lo.
+
+    The low half holds the lower-addressed element, so callers pass
+    ``(elem[2p + 1], elem[2p])``.
+    """
+    return _ptx_bin("cvt.rn.bf16x2.f32", hi, lo, dtype="uint32")
+
+
+def _shfl_bfly_f32(value, lane_xor):
+    """``shfl.sync.bfly.b32`` with clamp 31 and the full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _shfl_idx_f32(value, source_lane):
+    """``shfl.sync.idx.b32`` with clamp 31 and the full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.idx.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.cast(source_lane, "uint32"),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _load_f32(buffer, index):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return T.reinterpret("float32", out[0])
+
+
+def _load_i32(buffer, index):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return T.reinterpret("int32", out[0])
+
+
+def _load_bf16_bits(buffer, index):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _store_bf16_bits(buffer, index, bits):
+    T.evaluate(T.ptx.st.global_.b16(buffer.ptr_to([index]), bits))
+
+
+def _store_bf16_bits_pred(buffer, index, bits, pred):
+    """``@p st.global.b16`` -- a genuinely predicated store.
+
+    The approved sketch calls the output store "one predicated scalar store per
+    j".  Expressing it as `if cond: store` instead makes ptxas emit a real
+    branch plus a BSYNC reconvergence per CTA, which the source does not have.
+    """
+    T.evaluate(T.ptx.st.global_.b16(buffer.ptr_to([index]), bits, pred=pred))
+
+
+def _load_bf16x4(buffer, index):
+    """``ld.global.v4.b16`` -- one 8-byte tile of four bf16."""
+    bits = T.alloc_local((4,), "uint16")
+    T.evaluate(T.ptx.ld.global_.v4.b16(bits[0], bits[1], bits[2], bits[3], buffer.ptr_to([index])))
+    return bits
+
+
+def _load_bf16x8(buffer, index):
+    """``ld.global.v4.b32`` -- one 16-byte tile, unpacked to eight bf16."""
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    bits = T.alloc_local((8,), "uint16")
+    for pair in range(4):
+        T.buffer_store(
+            bits, T.cast(T.bitwise_and(words[pair], T.uint32(0xFFFF)), "uint16"), [2 * pair]
+        )
+        T.buffer_store(
+            bits, T.cast(T.shift_right(words[pair], T.uint32(16)), "uint16"), [2 * pair + 1]
+        )
+    return bits
+
+
+def _load_u32x4(buffer, index):
+    """``ld.global.v4.b32`` -- one 16-byte tile, left packed."""
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    return words
+
+
+def _store_bf16x8_words(buffer, index, words):
+    """``st.global.v4.b32`` -- one 16-byte state row."""
+    T.evaluate(
+        T.ptx.st.global_.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3])
+    )
+
+
+def _dot8(state, base, rhs, schedule: int):
+    """Eight-element dot with the source's selected dependency graph."""
+    if schedule == DOT_REDUCTION_DUAL_ACCUM:
+        even = _mul(state[base + 0], rhs[0])
+        odd = _mul(state[base + 1], rhs[1])
+        for pair in range(1, 4):
+            even = _fma(state[base + 2 * pair], rhs[2 * pair], even)
+            odd = _fma(state[base + 2 * pair + 1], rhs[2 * pair + 1], odd)
+        return _add(even, odd)
+    p0 = _fma(state[base + 0], rhs[0], _mul(state[base + 1], rhs[1]))
+    p1 = _fma(state[base + 2], rhs[2], _mul(state[base + 3], rhs[3]))
+    p2 = _fma(state[base + 4], rhs[4], _mul(state[base + 5], rhs[5]))
+    p3 = _fma(state[base + 6], rhs[6], _mul(state[base + 7], rhs[7]))
+    return _add(_add(p0, p1), _add(p2, p3))
+
+
+def _reduce_k_group(value):
+    """Reduce a partial dot across the 16 lanes that partition K (HEAD_DIM=128)."""
+    for offset in (8, 4, 2, 1):
+        value = _add(value, _shfl_bfly_f32(value, offset))
+    return value
+
+
+def _select_kernel_schedule(sequence_heads: int) -> tuple[int, int]:
+    """Reproduce ``_select_kernel_schedule`` (recurrent_kda.py:1108-1149).
+
+    Specialized to ``head_dim = 128``, ``num_tokens = 1``, ``use_gate = True``,
+    which is the only combination this port serves.
+    """
+    if (
+        sequence_heads <= 176
+        or 304 <= sequence_heads <= 368
+        or 448 <= sequence_heads <= 560
+        or sequence_heads >= 720
+    ):
+        tile_rows = 8
+    elif 224 <= sequence_heads <= 288:
+        tile_rows = 32
+    else:
+        tile_rows = 16
+
+    # recurrent_kda.py:1136-1141 -- the two gated D128 overrides.
+    if sequence_heads >= 224:
+        tile_rows = 16
+    if sequence_heads == 64:
+        tile_rows = 16
+
+    reduction = (
+        DOT_REDUCTION_DUAL_ACCUM if tile_rows != 8 or sequence_heads >= 304 else DOT_REDUCTION_TREE
+    )
+    return tile_rows, reduction
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror the SGLang decode benchmark shape."""
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 32,
+        "num_heads": 16,
+        "num_value_heads": 16,
+        "pool_size": 512,
+        "lower_bound": DEFAULT_LOWER_BOUND,
+        "padded_slots": 0,
+        "slot_stride_pad": 0,
+        "seed": 20260811,
+    }
+    config.update(overrides)
+    return config
+
+
+# Every row uses the Kimi K3 gate (lower_bound = -5.0), matches the SGLang
+# decode sweep, and stays inside the one-warp dispatch domain
+# (num_seqs * num_value_heads >= 128).
+BENCH_CONFIGS = [
+    # sequence_heads = 128 -> TILE_ROWS = 8, DOT_REDUCTION_TREE
+    _case("hv16_b8_tr8_lb", num_seqs=8),
+    # sequence_heads = 256/512/1024/2048 -> TILE_ROWS = 16, DUAL_ACCUM
+    _case("hv16_b16_tr16_lb", num_seqs=16),
+    _case("hv16_b32_tr16_lb", num_seqs=32),
+    _case("hv16_b64_tr16_lb", num_seqs=64),
+    _case("hv16_b128_tr16_lb", num_seqs=128),
+    # Kimi K3 TP8 per-rank head count (12 heads): sequence_heads = 192 / 768
+    _case("hv12_b16_tr16_lb", num_seqs=16, num_heads=12, num_value_heads=12),
+    _case("hv12_b64_tr16_lb", num_seqs=64, num_heads=12, num_value_heads=12),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # Schedule-band boundaries: 176 is the largest TILE_ROWS = 8 shape and 192
+    # the smallest that falls through to the TILE_ROWS = 16 else-branch.
+    _case("hv16_b11_tr8_lb", num_seqs=11),
+    _case("hv16_b12_tr16_lb", num_seqs=12),
+    # Softplus gate (Kimi Linear): USE_LOWER_BOUND = 0, both tile schedules.
+    _case("hv16_b8_tr8_sp", num_seqs=8, lower_bound=None),
+    _case("hv16_b32_tr16_sp", num_seqs=32, lower_bound=None),
+    _case("hv12_b16_tr16_sp", num_seqs=16, num_heads=12, num_value_heads=12, lower_bound=None),
+    # CUDA-graph padding rows: negative ssm_state_indices mark inactive
+    # sequences whose output must be zeroed and whose state must not change.
+    _case("hv16_b16_tr16_lb_padded", num_seqs=16, padded_slots=5),
+    # Envelope-strided state pool: the slot stride may exceed HV*V*K as long as
+    # it stays 16-element aligned (kda_flashinfer.py:110-123).
+    _case("hv16_b16_tr16_lb_strided", num_seqs=16, slot_stride_pad=16),
+]
+
+KERNEL_META = {
+    "name": "recurrent_kda_decode_one_warp",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    pool_size = int(kwargs["pool_size"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    lower_bound = kwargs.get("lower_bound", DEFAULT_LOWER_BOUND)
+
+    if num_value_heads % num_heads != 0:
+        raise ValueError("num_value_heads must be a multiple of num_heads")
+    if num_value_heads != num_heads:
+        raise ValueError("GQA (HV != H) is outside this port's scope; Kimi K3 uses H == HV")
+    if slot_stride_pad % 16 != 0:
+        raise ValueError("state slot stride padding must stay 16-element aligned")
+
+    sequence_heads = num_seqs * num_value_heads
+    if sequence_heads < ONE_WARP_MIN_SEQUENCE_HEADS:
+        raise ValueError(
+            f"sequence_heads={sequence_heads} dispatches to the grouped-CTA kernel; "
+            f"the one-warp port requires >= {ONE_WARP_MIN_SEQUENCE_HEADS} "
+            "(recurrent_kda.py:1798)"
+        )
+
+    tile_rows, reduction = _select_kernel_schedule(sequence_heads)
+    if tile_rows not in (8, 16):
+        raise ValueError(
+            f"sequence_heads={sequence_heads} selects TILE_ROWS={tile_rows}, "
+            "which is outside this port's scope"
+        )
+
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    return {
+        "NUM_V_TILES": HEAD_DIM // tile_rows,
+        "ROWS": tile_rows // V_LANES,
+        "HEAD_ELEMENTS": HEAD_DIM * HEAD_DIM,
+        "GQA_RATIO": num_value_heads // num_heads,
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "TILE_ROWS": tile_rows,
+        "DOT_REDUCTION_SCHEDULE": reduction,
+        "USE_LOWER_BOUND": lower_bound is not None,
+        "Q_ELEMENTS": num_seqs * num_heads * HEAD_DIM,
+        "V_ELEMENTS": num_seqs * num_value_heads * HEAD_DIM,
+        "BETA_ELEMENTS": num_seqs * num_value_heads,
+        "STATE_ELEMENTS": pool_size * slot_stride,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "A_LOG_ELEMENTS": num_heads,
+        "DT_BIAS_ELEMENTS": num_heads * HEAD_DIM,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": num_seqs,
+    }
+
+
+@T.jit
+def _recurrent_kda_decode_one_warp(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    a_log_h: T.handle,
+    dt_bias_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    scale: T.float32,
+    eps: T.float32,
+    lower_bound: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    TILE_ROWS: T.constexpr,
+    NUM_V_TILES: T.constexpr,
+    ROWS: T.constexpr,
+    HEAD_ELEMENTS: T.constexpr,
+    GQA_RATIO: T.constexpr,
+    DOT_REDUCTION_SCHEDULE: T.constexpr,
+    USE_LOWER_BOUND: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    A_LOG_ELEMENTS: T.constexpr,
+    DT_BIAS_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+):
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    a_log = T.match_buffer(a_log_h, (A_LOG_ELEMENTS,), "float32", scope="global")
+    dt_bias = T.match_buffer(dt_bias_h, (DT_BIAS_ELEMENTS,), "float32", scope="global")
+    cu_seqlens = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_state_indices = T.match_buffer(
+        ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global"
+    )
+    T.device_entry()
+    # TIRX_TRANSCRIBE_START recurrent_kda_decode_one_warp
+    # --- lane and CTA coordinates (recurrent_kda.py:229-246) ----------------
+    bidx = T.cta_id([NUM_SEQS * NUM_VALUE_HEADS * NUM_V_TILES])
+    tidx_axis = T.thread_id([THREADS])
+    tidx: T.int32 = T.cast(T.bitwise_and(T.cast(tidx_axis, "uint32"), T.uint32(31)), "int32")
+
+    v_tile_idx: T.int32 = bidx % NUM_V_TILES
+    bh: T.int32 = bidx // NUM_V_TILES
+    value_head_idx: T.int32 = bh % NUM_VALUE_HEADS
+    batch_idx: T.int32 = bh // NUM_VALUE_HEADS
+    query_head_idx: T.int32 = value_head_idx // GQA_RATIO
+    v_offset: T.int32 = v_tile_idx * TILE_ROWS
+    k_lane: T.int32 = tidx % K_LANES
+    v_lane: T.int32 = tidx // K_LANES
+
+    # --- sequence metadata (recurrent_kda.py:248-252) -----------------------
+    token_base_offset: T.int32 = _load_i32(cu_seqlens, batch_idx)
+    seq_len: T.int32 = _load_i32(cu_seqlens, batch_idx + 1) - token_base_offset
+
+    # --- zero-padded output prefill (recurrent_kda.py:253-255) --------------
+    # Runs before the state load so inactive rows are defined even when the
+    # token loop stores nothing.  Valid only because NUM_TOKENS == 1 makes the
+    # token-axis index equal to batch_idx.
+    if tidx < TILE_ROWS:
+        _store_bf16_bits(
+            out,
+            (batch_idx * NUM_VALUE_HEADS + value_head_idx) * HEAD_DIM + v_offset + tidx,
+            T.uint16(0),
+        )
+
+    # --- initial-state slot (recurrent_kda.py:257-272) ----------------------
+    init_raw_slot: T.int32 = _load_i32(ssm_state_indices, batch_idx * NUM_TOKENS)
+    init_seq_idx: T.int32 = T.max(init_raw_slot, 0)
+
+    # --- register storage (recurrent_kda.py:280-293); no SMEM, no mbarrier --
+    h_reg = T.alloc_local((ROWS * 8,), "float32")
+    q_src = T.alloc_local((VALUES_PER_THREAD,), "float32")
+    k_src = T.alloc_local((VALUES_PER_THREAD,), "float32")
+    gate_src = T.alloc_local((VALUES_PER_THREAD,), "float32")
+    q_reg = T.alloc_local((8,), "float32")
+    k_reg = T.alloc_local((8,), "float32")
+    gate_reg = T.alloc_local((8,), "float32")
+
+    # --- state load (recurrent_kda.py:295-300) ------------------------------
+    state_head_base: T.int32 = value_head_idx * HEAD_ELEMENTS + 8 * k_lane
+    read_base = T.cast(init_seq_idx, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        state_head_base, "int64"
+    )
+    # Issue every row's load before widening any of them.  bench_suite times a
+    # cold L2, so the figure of merit here is how many DRAM misses are in
+    # flight; interleaving the widening with the loads lets each cvt chain sit
+    # on the critical path of the next load.
+    h_words = T.alloc_local((4 * ROWS,), "uint32")
+    for j in T.unroll(ROWS):
+        v_idx_l: T.int32 = v_offset + v_lane + V_LANES * j
+        words = _load_u32x4(state, read_base + T.cast(v_idx_l * HEAD_DIM, "int64"))
+        for pr in T.unroll(4):
+            h_words[j * 4 + pr] = words[pr]
+    for j in T.unroll(ROWS):
+        for pr in T.unroll(4):
+            w: T.uint32 = h_words[j * 4 + pr]
+            h_reg[j * 8 + 2 * pr] = _bf16_to_f32(
+                T.cast(T.bitwise_and(w, T.uint32(0xFFFF)), "uint16")
+            )
+            h_reg[j * 8 + 2 * pr + 1] = _bf16_to_f32(
+                T.cast(T.shift_right(w, T.uint32(16)), "uint16")
+            )
+
+    # --- per-head gate constants (recurrent_kda.py:302-305) -----------------
+    h_K_offset: T.int32 = query_head_idx * HEAD_DIM
+    A_log_val: T.float32 = _exp2(_mul(_load_f32(a_log, query_head_idx), T.float32(LOG2_E)))
+
+    # --- loop-invariant lower-bound gate constants (recurrent_kda.py:124-127)
+    # Both live inside compute_gate_value's per-i loop in the source and are
+    # loop-invariant, so they are hoisted here.  The neg is folded into the
+    # negated log2(e) immediate and emits no neg.f32.
+    neg_A_log2e: T.float32 = T.float32(0.0)
+    lb_log2e: T.float32 = T.float32(0.0)
+    neg_A_log_val: T.float32 = T.float32(0.0)
+    if USE_LOWER_BOUND:
+        neg_A_log2e = _mul(A_log_val, T.float32(-LOG2_E))
+        lb_log2e = _mul(lower_bound, T.float32(LOG2_E))
+    else:
+        neg_A_log_val = _mul(A_log_val, T.float32(-1.0))
+
+    # =======================================================================
+    # Token loop.  NUM_TOKENS == 1, so this runs exactly once; the source keeps
+    # it a loop and the port keeps the same structure.
+    # =======================================================================
+    for token_t in T.unroll(NUM_TOKENS):
+        # --- slot / activity resolution (recurrent_kda.py:321-332) ---------
+        # The source reloads gSsmStateIndices here (:323) and re-clamps at :329.
+        # At NUM_TOKENS == 1 both index the same element as the prologue, and the
+        # CuTe compiler CSEs them into a single ld.global.b32 + max.s32.  Our PTX
+        # helpers are opaque inline asm, so CSE cannot fire across them; reusing
+        # the prologue values reproduces the source's *emitted* code exactly.
+        raw_slot: T.int32 = init_raw_slot
+        has_token: T.int32 = T.cast(token_t < seq_len, "int32")
+        is_active: T.int32 = T.cast(T.cast(raw_slot >= 0, "int32") * has_token, "int32")
+        token_offset: T.int32 = T.if_then_else(
+            token_t < seq_len, token_base_offset + token_t, T.int32(0)
+        )
+        seq_idx: T.int32 = init_seq_idx
+
+        # --- per-head views and beta (recurrent_kda.py:333-346) ------------
+        q_base: T.int32 = (token_offset * NUM_HEADS + query_head_idx) * HEAD_DIM
+        v_base: T.int32 = (token_offset * NUM_VALUE_HEADS + value_head_idx) * HEAD_DIM
+        beta_val: T.float32 = _bf16_to_f32(
+            _load_bf16_bits(beta, token_offset * NUM_VALUE_HEADS + value_head_idx)
+        )
+
+        # --- q/k/gate vector loads (recurrent_kda.py:353-358) --------------
+        q_bits = _load_bf16x4(q, q_base + VALUES_PER_THREAD * tidx)
+        k_bits = _load_bf16x4(k, q_base + VALUES_PER_THREAD * tidx)
+        gate_bits = _load_bf16x4(g, v_base + VALUES_PER_THREAD * tidx)
+
+        # --- V load, hoisted only at TILE_ROWS == 16 (recurrent_kda.py:359-364)
+        v_loaded: T.float32 = T.float32(0.0)
+        if TILE_ROWS == 16:
+            if tidx < TILE_ROWS:
+                v_loaded = _bf16_to_f32(_load_bf16_bits(v, v_base + v_offset + tidx))
+
+        # --- gate + q/k conversion (recurrent_kda.py:366-380, :88-148) -----
+        for i in T.unroll(VALUES_PER_THREAD):
+            k_idx: T.int32 = tidx * VALUES_PER_THREAD + i
+            q_src[i] = _bf16_to_f32(q_bits[i])
+            k_src[i] = _bf16_to_f32(k_bits[i])
+            g_val: T.float32 = _add_bf16(gate_bits[i], _load_f32(dt_bias, h_K_offset + k_idx))
+            if USE_LOWER_BOUND:
+                denom: T.float32 = _add(T.float32(1.0), _exp2(_mul(neg_A_log2e, g_val)))
+                gate_src[i] = _exp2(_div_rn(lb_log2e, denom))
+            else:
+                exp_g: T.float32 = _exp2(_mul(g_val, T.float32(LOG2_E)))
+                log2_v: T.float32 = _log2(_add(T.float32(1.0), exp_g))
+                gate_src[i] = _exp2(_mul(neg_A_log_val, log2_v))
+
+        # --- q/k sum of squares (recurrent_kda.py:382-404) -----------------
+        q_sum_sq: T.float32 = T.float32(0.0)
+        k_sum_sq: T.float32 = T.float32(0.0)
+        if DOT_REDUCTION_SCHEDULE == DOT_REDUCTION_DUAL_ACCUM:
+            q_sum_sq = _add(
+                _fma_bf16(q_bits[2], q_bits[2], _mul(q_src[0], q_src[0])),
+                _fma_bf16(q_bits[3], q_bits[3], _mul(q_src[1], q_src[1])),
+            )
+            k_sum_sq = _add(
+                _fma_bf16(k_bits[2], k_bits[2], _mul(k_src[0], k_src[0])),
+                _fma_bf16(k_bits[3], k_bits[3], _mul(k_src[1], k_src[1])),
+            )
+        else:
+            q_sum_sq = _add(
+                _fma_bf16(q_bits[0], q_bits[0], _mul(q_src[1], q_src[1])),
+                _fma_bf16(q_bits[2], q_bits[2], _mul(q_src[3], q_src[3])),
+            )
+            k_sum_sq = _add(
+                _fma_bf16(k_bits[0], k_bits[0], _mul(k_src[1], k_src[1])),
+                _fma_bf16(k_bits[2], k_bits[2], _mul(k_src[3], k_src[3])),
+            )
+
+        # --- full-warp butterfly (recurrent_kda.py:405-411) ----------------
+        for off_i in T.unroll(5):
+            shift: T.int32 = T.shift_right(T.int32(16), off_i)
+            q_sum_sq = _add(q_sum_sq, _shfl_bfly_f32(q_sum_sq, shift))
+            k_sum_sq = _add(k_sum_sq, _shfl_bfly_f32(k_sum_sq, shift))
+
+        # --- scale factors (recurrent_kda.py:413-417) ----------------------
+        q_scale_factor: T.float32 = _mul(_rsqrt(_add(q_sum_sq, eps)), scale)
+        k_scale_factor: T.float32 = _rsqrt(_add(k_sum_sq, eps))
+
+        # --- broadcast the load view into the k_lane view (:418-436) -------
+        for i in T.unroll(8):
+            source_lane: T.int32 = V_LANES * k_lane + i // VALUES_PER_THREAD
+            q_reg[i] = _mul(
+                _shfl_idx_f32(q_src[i % VALUES_PER_THREAD], source_lane), q_scale_factor
+            )
+            k_reg[i] = _mul(
+                _shfl_idx_f32(k_src[i % VALUES_PER_THREAD], source_lane), k_scale_factor
+            )
+            gate_reg[i] = _shfl_idx_f32(gate_src[i % VALUES_PER_THREAD], source_lane)
+
+        # --- late V load for the other schedules (recurrent_kda.py:437-439)
+        if TILE_ROWS != 16:
+            if tidx < TILE_ROWS:
+                v_loaded = _bf16_to_f32(_load_bf16_bits(v, v_base + v_offset + tidx))
+
+        # --- sequential rank-1 recurrence (recurrent_kda.py:440-460) -------
+        for j in T.unroll(ROWS):
+            for i in T.unroll(8):
+                h_reg[j * 8 + i] = _mul(h_reg[j * 8 + i], gate_reg[i])
+
+            pred: T.float32 = _reduce_k_group(_dot8(h_reg, j * 8, k_reg, DOT_REDUCTION_SCHEDULE))
+            v_idx: T.int32 = v_offset + v_lane + V_LANES * j
+            v_val: T.float32 = _shfl_idx_f32(v_loaded, v_lane + V_LANES * j)
+            delta: T.float32 = _mul(_sub(v_val, pred), beta_val)
+
+            for i in T.unroll(8):
+                h_reg[j * 8 + i] = _fma(k_reg[i], delta, h_reg[j * 8 + i])
+
+            out_val: T.float32 = _reduce_k_group(_dot8(h_reg, j * 8, q_reg, DOT_REDUCTION_SCHEDULE))
+
+            _store_bf16_bits_pred(
+                out, v_base + v_idx, _f32_to_bf16(out_val), T.And(is_active != 0, k_lane == j)
+            )
+
+        # --- state writeback (recurrent_kda.py:462-469) --------------------
+        # The source rebinds h_out to seq_idx at :463.  At NUM_TOKENS == 1 that
+        # is the same slot the prologue loaded from, and a negative slot cannot
+        # reach here because it clears is_active (:327).
+        if is_active != 0:
+            write_base = T.cast(seq_idx, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+                state_head_base, "int64"
+            )
+            for j in T.unroll(ROWS):
+                v_idx_w: T.int32 = v_offset + v_lane + V_LANES * j
+                words = T.alloc_local((4,), "uint32")
+                for pair in T.unroll(4):
+                    words[pair] = _pack_bf16x2(h_reg[j * 8 + 2 * pair + 1], h_reg[j * 8 + 2 * pair])
+                _store_bf16x8_words(state, write_base + T.cast(v_idx_w * HEAD_DIM, "int64"), words)
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized one-warp recurrent-KDA decode PrimFunc."""
+    return _recurrent_kda_decode_one_warp.specialize(**_specialization(kwargs))
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state."""
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for recurrent-KDA one-warp decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(
+            f"recurrent-KDA one-warp decode targets compute capability 10.x, got {capability}"
+        )
+
+    spec = _specialization(kwargs)
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    pool_size = int(kwargs["pool_size"])
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    padded_slots = int(kwargs.get("padded_slots", 0))
+    lower_bound = kwargs.get("lower_bound", DEFAULT_LOWER_BOUND)
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    # Shapes and magnitudes follow sglang's make_decode_inputs
+    # (benchmark/bench_linear_attention/bench_kda_flashinfer_mtp.py:50-78).
+    q = randn(1, num_seqs, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, num_seqs, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, num_seqs, num_value_heads, HEAD_DIM, gain=0.5)
+    # Raw per-K gate: the kernel activates it, so keep the pre-activation range.
+    g = (
+        0.5
+        * torch.randn(
+            (1, num_seqs, num_value_heads, HEAD_DIM),
+            device=device,
+            dtype=torch.float32,
+            generator=gen,
+        )
+        - 1.0
+    ).to(torch.bfloat16)
+    # sglang passes beta already sigmoided (kda_flashinfer.py:142-147).
+    beta_logit = randn(1, num_seqs, num_value_heads, dtype=torch.float32, gain=0.5)
+    beta = torch.sigmoid(beta_logit).to(torch.bfloat16)
+    a_log = randn(num_heads, dtype=torch.float32, gain=0.2)
+    dt_bias = randn(num_heads * HEAD_DIM, dtype=torch.float32, gain=0.1)
+
+    cu_seqlens = torch.arange(num_seqs + 1, device=device, dtype=torch.int32)
+    slots = torch.arange(num_seqs, device=device, dtype=torch.int32)
+    if padded_slots:
+        # CUDA-graph padding poisons the tail rows with -1
+        # (sglang hybrid_linear_attn_backend.py:112-115).
+        slots[num_seqs - padded_slots :] = -1
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(pool_size * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (pool_size, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (pool_size, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, num_seqs, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "beta": beta,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": slots,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": HEAD_DIM**-0.5,
+        "eps": L2_EPS,
+        "lower_bound": lower_bound,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    lower_bound = case["lower_bound"]
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g"].reshape(-1),
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["a_log"],
+        case["dt_bias"],
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        float(case["scale"]),
+        float(case["eps"]),
+        float(lower_bound if lower_bound is not None else 0.0),
+    )
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the source math (recurrent_kda.py:88-148, :440-468).
+
+    Secondary to the FlashInfer comparison: it catches a shared-misreading of the
+    algorithm that a source-vs-port diff alone could not.
+    """
+    spec = case["spec"]
+    n_seq = spec["NUM_SEQS"]
+    hv = spec["NUM_VALUE_HEADS"]
+    h = spec["NUM_HEADS"]
+    ratio = hv // h
+    lower_bound = case["lower_bound"]
+    eps = case["eps"]
+    scale = case["scale"]
+
+    q = case["q"].float()[0]
+    k = case["k"].float()[0]
+    v = case["v"].float()[0]
+    g = case["g"].float()[0]
+    beta = case["beta"].float()[0]
+    a_log = case["a_log"].float()
+    dt_bias = case["dt_bias"].float().reshape(h, HEAD_DIM)
+    slots = case["ssm_state_indices"]
+
+    state = (
+        case["initial_state_raw"]
+        .float()
+        .as_strided(
+            (
+                case["initial_state_raw"].numel() // spec["STATE_SLOT_STRIDE"],
+                hv,
+                HEAD_DIM,
+                HEAD_DIM,
+            ),
+            (spec["STATE_SLOT_STRIDE"], HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        .clone()
+    )
+    out = torch.zeros((n_seq, hv, HEAD_DIM), device=q.device, dtype=torch.float32)
+
+    for n in range(n_seq):
+        slot = int(slots[n])
+        if slot < 0:
+            continue  # inactive row: output stays zero, state untouched
+        for vh in range(hv):
+            qh = vh // ratio
+            gate_in = g[n, vh] + dt_bias[qh]
+            a = torch.exp(a_log[qh])
+            if lower_bound is None:
+                gate = torch.exp2(-a * torch.log2(1.0 + torch.exp(gate_in)))
+            else:
+                gate = torch.exp2(lower_bound * _LOG2_E_T * torch.sigmoid(a * gate_in))
+            qn = q[n, qh] * (torch.rsqrt((q[n, qh] ** 2).sum() + eps) * scale)
+            kn = k[n, qh] * torch.rsqrt((k[n, qh] ** 2).sum() + eps)
+            s = state[slot, vh] * gate.unsqueeze(0)
+            delta = (v[n, vh] - s @ kn) * beta[n, vh]
+            s = s + torch.outer(delta, kn)
+            state[slot, vh] = s
+            out[n, vh] = s @ qn
+    return out, state
+
+
+_LOG2_E_T = 1.4426950408889634
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the FlashInfer CuTe DSL source on the reference state pool."""
+    import importlib
+
+    # flashinfer.kda_kernels.__init__ rebinds ``recurrent_kda`` to the run
+    # function, so the submodule must be imported explicitly.
+    fi = importlib.import_module("flashinfer.kda_kernels.recurrent_kda")
+    out, _ = fi.run_recurrent_kda(
+        q=case["q"],
+        k=case["k"],
+        v=case["v"],
+        g=case["g"],
+        beta=case["beta"],
+        A_log=case["a_log"],
+        dt_bias=case["dt_bias"],
+        scale=case["scale"],
+        initial_state=case["reference_state"],
+        output_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=case["lower_bound"],
+        cu_seqlens=case["cu_seqlens"],
+        ssm_state_indices=case["ssm_state_indices"],
+    )
+    return out
+
+
+# Two bfloat16 ULP.  The port is within one ULP of the source on every config
+# measured; this leaves headroom without hiding a real divergence.
+_RTOL = 2.0**-7
+_ATOL = 1.0e-4
+# The FP32 oracle reassociates freely, so it only needs to agree to bf16 noise.
+_ORACLE_RTOL = 2.0**-6
+_ORACLE_ATOL = 3.0e-4
+
+
+def run_test(**kwargs: Any) -> None:
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize()
+
+    spec = case["spec"]
+    shape = (1, spec["NUM_SEQS"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
+
+    # Primary: the ported kernel against the source implementation it transcribes.
+    flashinfer_out = _flashinfer_reference(case).reshape(shape)
+    torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
+    torch.testing.assert_close(
+        case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
+    )
+
+    # Secondary: an independent FP32 oracle of the same math.
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        case["tirx_out"].float().reshape(oracle_out.shape),
+        oracle_out,
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+    )
+
+    # Inactive (negative-slot) rows must be zeroed and must not touch state.
+    slots = case["ssm_state_indices"]
+    inactive = (slots < 0).nonzero().flatten()
+    if inactive.numel():
+        padded = case["tirx_out"][0, inactive]
+        if padded.abs().max().item() != 0.0:
+            raise AssertionError("inactive output rows are not zero")
+        touched = set(slots[slots >= 0].tolist())
+        stride = spec["STATE_SLOT_STRIDE"]
+        changed = (case["tirx_state_raw"] != case["initial_state_raw"]).nonzero().flatten()
+        stray = set((changed // stride).tolist()) - touched
+        if stray:
+            raise AssertionError(f"state slots mutated without an active sequence: {sorted(stray)}")
+
+    # Envelope-strided pools must leave their inter-slot padding untouched.
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    stride = spec["STATE_SLOT_STRIDE"]
+    if stride > payload:
+        pool = case["tirx_state_raw"].numel() // stride
+        now = case["tirx_state_raw"].as_strided((pool, stride), (stride, 1))[:, payload:]
+        before = case["initial_state_raw"].as_strided((pool, stride), (stride, 1))[:, payload:]
+        if not torch.equal(now, before):
+            raise AssertionError("inter-slot state padding was overwritten")
+
+
+def run_bench(
+    *, warmup: int | None = None, repeat: int | None = None, timer: str | None = None, **kwargs: Any
+) -> dict[str, Any]:
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region.
+    executable(*args)
+    spec = case["spec"]
+    shape = (1, spec["NUM_SEQS"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
+    flashinfer_out = _flashinfer_reference(case).reshape(shape)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
+    torch.testing.assert_close(
+        case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # Heavy import, CuTe JIT and warmup all happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize()
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cutedsl": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- add SM100 TIRx ports of **both** of FlashInfer's CuTeDSL recurrent-KDA decode kernels, completing the FlashInfer-KDA decode surface SGLang can reach
  - `recurrent_kda_decode_kernel` ([`recurrent_kda.py:190`](https://github.com/flashinfer-ai/flashinfer/blob/f2e04400/flashinfer/kda_kernels/recurrent_kda.py#L190)) — one warp per CTA, zero shared memory, no barrier; the `T == 1 and sequence_heads >= 128` path
  - `_grouped_kda_kernel` ([`recurrent_kda.py:482`](https://github.com/flashinfer-ai/flashinfer/blob/f2e04400/flashinfer/kda_kernels/recurrent_kda.py#L482)) — grouped-CTA, shared memory, exactly one barrier; everything the one-warp predicate rejects: small-batch `T == 1` decode and **every** `T > 1` speculative-verify call
- cover both gate modes SGLang can select (`lower_bound` for Kimi K3, softplus for Kimi Linear) and both tile schedules the one-warp host dispatch picks
- add curated bench-suite matrices (7 shapes one-warp, 14 shapes grouped at full SGLang parity) and their baseline rows
- include the frozen execution sketches used during the porting design stage

## Impact

`_grouped_kda_kernel` is not a fallback in practice; it is the whole `T > 1` surface, so this is what makes speculative verify (SGLang `target_verify`, DSPARK default gamma 7 → `T = 8`) available on the TIRx side. Between the two kernels every dispatch FlashInfer's host will make for KDA decode is covered.

Both implementations are plain TIRx — no tile primitives — with all FP32 arithmetic routed through explicit non-FTZ PTX helpers, because TVM builds with `--use_fast_math` while the source emits no `.ftz` arithmetic and uses a full-precision `div.rn.f32` for the gate sigmoid.

## Validation

- **correctness**: 14/14 one-warp and 23/23 grouped configurations pass against the FlashInfer CuTeDSL reference; grouped verify rows additionally check every intermediate checkpoint slot against a sequential single-token FP32 oracle, since SGLang's commit path selects an arbitrary `[i, t]` slot
- coverage includes both gate modes (softplus inputs crossing the `x > 20` linear guard), negative `ssm_state_indices` padding rows, ragged verify rows with `seq_len < T`, a scratch pool whose allocated stride differs from `T`, the orphan packed suffix, and an envelope-strided state pool
- every config is verified to reach the intended kernel rather than the sibling, by instrumenting the compile caches the host only touches on each branch
- **performance**: complete bench-suite matrices for both kernels, every ratio above `0.99x`
  - one-warp, 7/7, minimum `1.017x`, maximum `1.107x`
  - grouped, 14/14, minimum `1.074x`, maximum `1.652x`
- both matrices taken on clock-verified GPUs (4.44 cycles/FMA probed before and after); rows whose reference drifted were re-measured alone rather than pinned
- all pre-dispatch specializations of both kernels pass the no-tile check
- bench-suite import check passed; `pre-commit run` clean on every changed file

### Note on the measurement regime

The largest single finding is not specific to either kernel. `bench_suite`'s timer flushes the L2 before every timed iteration, so the gate measures a **cold cache** — the regime an inference server runs in, and one where the figure of merit is how many DRAM misses are outstanding rather than how many instructions execute. Both ports originally had a loop shaped `load a chunk → consume that chunk → next chunk`, which caps in-flight misses at one chunk's worth regardless of how much independent work is available:

| kernel | what was serialised | in flight before | after |
|---|---|---|---|
| grouped-CTA | phase A's per-token `ssm_idx`/`v`/`beta`/`q`/`k`/`g` | `3*EPT + 3` | `T*(3*EPT + 3)` |
| one-warp | the state load's per-row 16 B tile, each followed by its own widening | 1 row | `ROWS` rows |

Splitting each into an issue loop and a consume loop is worth 7–40% on the grouped kernel and 2–5% on the one-warp kernel, the difference being that only the grouped kernel has a token dimension to overlap. Neither change alters instruction counts, values, types or consumers; only the issue point moves. Both are marked in their sketches as deliberate deviations from the source's dataflow order.

This does not generalise to every load: hoisting the one-warp kernel's loop-invariant `dt_bias` loads looks identical in shape and measured `1.031x → 0.966x`, because four more f32 live across the token loop is not affordable in a one-warp kernel already holding `ROWS*8` f32 of state. Recorded in the sketch so it is not retried.

## Notes for review

- the two sketches under `.agents/sketch/flashinfer/kda/` are the best entry point — each records the thread/lane split, register and shared layout, gate branches and per-op instruction selection, annotated from exported line-info PTX rather than inferred
- absolute microseconds in `baseline.json` are specific to the measuring host; regression detection compares the reference/ours ratio, which is not
- the no-tile checks for these two kernels currently live as porting-stage scripts rather than as `tests/lint/check_*_no_tile.py` entries in the style #26 introduced; happy to promote them if that convention should apply to every kernel
