### PR TITLE
chore(infra): replace license boilerplate with SPDX tags

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -201,9 +201,9 @@
    limitations under the License.
 
 ------------------------------------------------------------------------------------
-This product contains TIRx ports of kernels from third-party projects under other
-open source licenses. This section summarizes those components and their licenses.
-See licenses/ for text of these licenses.
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See licenses/ for text
+of these licenses.
 
 
 Apache Software Foundation License 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 tirx-kernels
+Copyright (c) 2026 TIRx authors
 
 This product includes modified software from FlashInfer
 (https://github.com/flashinfer-ai/flashinfer):

--- a/README.md
+++ b/README.md
@@ -186,8 +186,11 @@ Except where otherwise noted, this project is licensed under the Apache
 License 2.0; see [LICENSE](LICENSE). Required Apache attribution notices are
 collected in [NOTICE](NOTICE).
 
-Kernel ports derived from third-party projects (DeepGEMM, FlashMLA,
-flash-attention, FlashInfer) reproduce their upstream file headers verbatim and
-retain their upstream terms. The third-party section at the end of
-[LICENSE](LICENSE) lists which components fall under which license, and
-[`licenses/`](licenses) holds the corresponding license texts.
+Every file carries SPDX tags. Kernel ports derived from third-party projects
+(DeepGEMM, FlashMLA, flash-attention, FlashInfer) additionally cite the upstream
+project and the exact commit ported, retain the upstream copyright notice, and
+declare the combined terms — for example `Apache-2.0 AND MIT`. Where an upstream
+license requires its conditions text to travel with the source, that text is kept
+in the file verbatim. The third-party section at the end of [LICENSE](LICENSE)
+lists which components fall under which license, and [`licenses/`](licenses)
+holds the corresponding license texts.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Except where otherwise noted, this project is licensed under the Apache
 License 2.0; see [LICENSE](LICENSE). Required Apache attribution notices are
 collected in [NOTICE](NOTICE).
 
-Every file carries SPDX tags. Kernel ports derived from third-party projects
+Every Python source file carries SPDX tags. Kernel ports derived from third-party projects
 (DeepGEMM, FlashMLA, flash-attention, FlashInfer) additionally cite the upstream
 project and the exact commit ported, retain the upstream copyright notice, and
 declare the combined terms — for example `Apache-2.0 AND MIT`. Where an upstream

--- a/tests/lint/check_gdn_decode_bf16_wide_vec_t1_no_tile.py
+++ b/tests/lint/check_gdn_decode_bf16_wide_vec_t1_no_tile.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Reject tile primitives in every wide-vector GDN T1 specialization."""
 

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -20,17 +20,22 @@ Headers are SPDX tags, in the style of vLLM's. Two shapes are accepted:
       # SPDX-License-Identifier: Apache-2.0 AND MIT
       # SPDX-FileCopyrightText: Copyright TIRx authors
 
-Ports must use the second shape: dropping the upstream notice from a ported
-file is exactly the drift this check exists to prevent. Unlike ASF-style header
-checks, upstream ``Copyright`` lines are required rather than forbidden.
+Ports must use the second shape, and the expected project name, URL and SPDX
+expression are bound to the path: a DeepGEMM port tagged plain ``Apache-2.0``
+(or ``AND BSD-3-Clause``) is an error, not a stylistic choice — the expression
+states which terms apply to the file, and understating or misstating them is
+exactly the drift this check exists to prevent. Unlike ASF-style header checks,
+upstream ``Copyright`` lines are required rather than forbidden.
 
 Full license texts live in ``licenses/``; ``LICENSE`` maps each bucket of the
 tree to its license. Where an upstream license requires the conditions text
-itself to travel with the source (BSD-3), that text stays in the file verbatim
-and is not replaced by a tag.
+itself to travel with the source (BSD-3), that text must stay in the file and
+its absence is an error.
 
 Run ``--fix`` to insert the TIRx header into files that have no header at all;
 port headers are never synthesized, since only a human knows the upstream terms.
+Run ``--self-test`` to prove the checker is not vacuous: it feeds itself a set
+of known violations and fails unless every one is caught.
 """
 
 from __future__ import annotations
@@ -42,29 +47,54 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent
+SELF = "tests/lint/check_license_headers.py"
 
 SPDX_ID = "# SPDX-License-Identifier: "
 SPDX_COPYRIGHT = "# SPDX-FileCopyrightText: Copyright TIRx authors"
 TIRX_HEADER = f"{SPDX_ID}Apache-2.0\n{SPDX_COPYRIGHT}"
 
-# Our own contribution is always Apache-2.0; a port additionally carries the
-# upstream license, spelled as an SPDX `AND` expression.
-ID_RE = re.compile(r"^Apache-2\.0(?: AND (?:MIT|BSD-3-Clause))?$")
-
-# A port must cite the upstream project, its URL and the exact commit ported.
 PORT_LINE = "# This file is a TIRx port of code from "
-CITATION_RE = re.compile(r"\(https://\S+ @ [0-9a-f]{7,40}\)")
+CITATION_RE = re.compile(r"\((https://\S+) @ [0-9a-f]{7,40}\)")
 
-# Buckets holding ports of third-party kernels: every module under them must
-# carry a port header, not the plain TIRx one.
-PORT_DIRS = (
-    "tirx_kernels/deepgemm/",
-    "tirx_kernels/flashattention/",
-    "tirx_kernels/flashinfer/",
-    "tirx_kernels/flashmla/",
-)
+# Path-bound expectations: project name, upstream URL, and the SPDX expression
+# a port under this bucket must carry.
+PORT_BUCKETS = {
+    "tirx_kernels/deepgemm/": (
+        "DeepGEMM",
+        "https://github.com/deepseek-ai/DeepGEMM",
+        "Apache-2.0 AND MIT",
+    ),
+    "tirx_kernels/flashmla/": (
+        "FlashMLA",
+        "https://github.com/deepseek-ai/FlashMLA",
+        "Apache-2.0 AND MIT",
+    ),
+    "tirx_kernels/flashattention/": (
+        "flash-attention",
+        "https://github.com/Dao-AILab/flash-attention",
+        "Apache-2.0 AND BSD-3-Clause",
+    ),
+    "tirx_kernels/flashinfer/": (
+        "FlashInfer",
+        "https://github.com/flashinfer-ai/flashinfer",
+        "Apache-2.0",
+    ),
+}
 
-# Native modules inside those buckets — package markers and our own harnesses.
+# Files whose terms differ from their bucket, with header text the upstream
+# license requires to stay in the file verbatim (BSD-3 clause 1: the copyright
+# notice, the conditions list and the disclaimer travel with the source).
+FILE_OVERRIDES = {
+    "tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py": {
+        "spdx": "Apache-2.0 AND BSD-3-Clause",
+        "required_text": (
+            "Redistribution and use in source and binary forms",
+            'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
+        ),
+    }
+}
+
+# Native modules inside port buckets — package markers and our own harnesses.
 PORT_DIR_EXCEPTIONS = {
     "tirx_kernels/flashinfer/utils/_flashkda_bench.py",
     "tirx_kernels/flashmla/utils/_flashmla_bench.py",
@@ -98,19 +128,24 @@ def header_of(text: str) -> str:
     return "\n".join(out)
 
 
-def is_port(rel: str) -> bool:
+def bucket_of(rel: str):
     if rel in PORT_DIR_EXCEPTIONS or rel.endswith("__init__.py"):
-        return False
-    return rel.startswith(PORT_DIRS)
+        return None
+    for prefix, expect in PORT_BUCKETS.items():
+        if rel.startswith(prefix):
+            return expect
+    return None
 
 
 def check(rel: str, text: str) -> list[str]:
     errors = []
     header = header_of(text)
 
-    for banned in BANNED:
-        if banned in text:
-            errors.append(f"{rel}: contains retired reference {banned!r}")
+    # The checker itself spells out the banned strings; skip only that scan.
+    if rel != SELF:
+        for banned in BANNED:
+            if banned in text:
+                errors.append(f"{rel}: contains retired reference {banned!r}")
 
     if not header:
         errors.append(f"{rel}: missing license header (run --fix to add the TIRx one)")
@@ -120,30 +155,140 @@ def check(rel: str, text: str) -> list[str]:
     ids = [ln[len(SPDX_ID) :] for ln in lines if ln.startswith(SPDX_ID)]
     if len(ids) != 1:
         errors.append(f"{rel}: expected exactly one {SPDX_ID.strip()} line, found {len(ids)}")
-    elif not ID_RE.match(ids[0]):
-        errors.append(f"{rel}: unexpected SPDX license expression {ids[0]!r}")
+        return errors
     if SPDX_COPYRIGHT not in lines:
         errors.append(f"{rel}: missing {SPDX_COPYRIGHT!r}")
 
-    if is_port(rel):
-        if not any(ln.startswith(PORT_LINE) for ln in lines):
-            errors.append(f"{rel}: ported file is missing its {PORT_LINE.strip()!r} citation")
-        if not CITATION_RE.search(header):
-            errors.append(f"{rel}: ported file is missing an upstream '(url @ commit)' citation")
-        if "Copyright" not in header.split(SPDX_COPYRIGHT)[0]:
-            errors.append(f"{rel}: ported file is missing its upstream copyright notice")
-    elif header != TIRX_HEADER:
-        errors.append(f"{rel}: native file must carry exactly the two-line TIRx SPDX header")
+    expect = bucket_of(rel)
+    if expect is None:
+        if header != TIRX_HEADER:
+            errors.append(f"{rel}: native file must carry exactly the two-line TIRx SPDX header")
+        return errors
+
+    project, url, spdx = expect
+    override = FILE_OVERRIDES.get(rel, {})
+    spdx = override.get("spdx", spdx)
+
+    if ids[0] != spdx:
+        errors.append(f"{rel}: SPDX expression must be {spdx!r} for this path, found {ids[0]!r}")
+    if not any(ln.startswith(PORT_LINE + project) for ln in lines):
+        errors.append(f"{rel}: ported file must cite '{PORT_LINE.strip()} {project}'")
+    cited = CITATION_RE.search(header)
+    if not cited:
+        errors.append(f"{rel}: ported file is missing an upstream '(url @ commit)' citation")
+    elif cited.group(1) != url:
+        errors.append(f"{rel}: upstream URL must be {url!r}, found {cited.group(1)!r}")
+    if "Copyright" not in header.split(SPDX_COPYRIGHT)[0]:
+        errors.append(f"{rel}: ported file is missing its upstream copyright notice")
+    for required in override.get("required_text", ()):
+        if required not in header:
+            errors.append(f"{rel}: upstream license requires this text in the header: {required!r}")
 
     return errors
+
+
+def self_test() -> int:
+    """Feed known violations to check(); fail unless every one is caught."""
+    pair = f"{SPDX_ID}{{spdx}}\n{SPDX_COPYRIGHT}"
+    port = (
+        "# This file is a TIRx port of code from {project}\n"
+        "# ({url} @ 559d79fb), Copyright (c) 2025 Upstream\n" + pair + "\n\nx = 1\n"
+    )
+    dg = dict(project="DeepGEMM", url="https://github.com/deepseek-ai/DeepGEMM")
+    fi = dict(project="FlashInfer", url="https://github.com/flashinfer-ai/flashinfer")
+    gdn = "tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py"
+    cases = [
+        # (name, rel, text, must_error)
+        (
+            "valid deepgemm port",
+            "tirx_kernels/deepgemm/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **dg),
+            False,
+        ),
+        ("valid native", "tirx_kernels/x.py", f"{TIRX_HEADER}\n\nx = 1\n", False),
+        (
+            "deepgemm tagged plain Apache-2.0",
+            "tirx_kernels/deepgemm/x.py",
+            port.format(spdx="Apache-2.0", **dg),
+            True,
+        ),
+        (
+            "deepgemm tagged AND BSD-3-Clause",
+            "tirx_kernels/deepgemm/x.py",
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **dg),
+            True,
+        ),
+        (
+            "flashinfer tagged AND MIT",
+            "tirx_kernels/flashinfer/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **fi),
+            True,
+        ),
+        (
+            "gdn_prefill without the BSD conditions text",
+            gdn,
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fi),
+            True,
+        ),
+        (
+            "port citing the wrong upstream URL",
+            "tirx_kernels/deepgemm/x.py",
+            port.format(
+                spdx="Apache-2.0 AND MIT",
+                project="DeepGEMM",
+                url="https://github.com/deepseek-ai/FlashMLA",
+            ),
+            True,
+        ),
+        (
+            "port with no upstream copyright",
+            "tirx_kernels/deepgemm/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **dg).replace(
+                ", Copyright (c) 2025 Upstream", ""
+            ),
+            True,
+        ),
+        (
+            "port missing the citation line",
+            "tirx_kernels/deepgemm/x.py",
+            "\n".join(port.format(spdx="Apache-2.0 AND MIT", **dg).splitlines()[2:]),
+            True,
+        ),
+        (
+            "native with an extra header line",
+            "tirx_kernels/x.py",
+            f"# Copyright (c) 2026 extra\n{TIRX_HEADER}\n\nx = 1\n",
+            True,
+        ),
+        (
+            "banned Modifications block",
+            "tirx_kernels/x.py",
+            f"{TIRX_HEADER}\n# " + "Modifications" + " Copyright (c) 2026\n\nx = 1\n",
+            True,
+        ),
+        ("two SPDX id lines", "tirx_kernels/x.py", f"{TIRX_HEADER}\n{SPDX_ID}MIT\n\nx = 1\n", True),
+    ]
+    failures = 0
+    for name, rel, text, must_error in cases:
+        errors = check(rel, text)
+        ok = bool(errors) == must_error
+        print(
+            f"{'ok' if ok else 'SELF-TEST FAIL'}: {name}"
+            + (f" -> {errors[0]}" if errors and ok else "")
+        )
+        failures += not ok
+    if failures:
+        print(f"\n{failures} self-test case(s) NOT caught; the checker is vacuous somewhere.")
+        return 1
+    print(f"\nself-test: all {len(cases)} cases behave as expected.")
+    return 0
 
 
 def tracked_python_files() -> list[str]:
     out = subprocess.run(
         ["git", "-C", str(REPO), "ls-files", "*.py"], capture_output=True, text=True, check=True
     ).stdout.split()
-    # This checker is skipped: it spells out the retired strings it bans.
-    return [f for f in out if not f.startswith("tests/lint/")]
+    return out
 
 
 def main() -> int:
@@ -151,13 +296,18 @@ def main() -> int:
     parser.add_argument(
         "--fix", action="store_true", help="insert the TIRx header into files that have none"
     )
+    parser.add_argument(
+        "--self-test", action="store_true", help="verify the checker catches known violations"
+    )
     args = parser.parse_args()
+    if args.self_test:
+        return self_test()
 
     errors: list[str] = []
     for rel in tracked_python_files():
         path = REPO / rel
         text = path.read_text()
-        if args.fix and not header_of(text) and not is_port(rel):
+        if args.fix and not header_of(text) and bucket_of(rel) is None:
             lines = text.splitlines()
             shebang = [lines.pop(0)] if lines and lines[0].startswith("#!") else []
             body = "\n".join(lines).lstrip("\n")

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -1,62 +1,59 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Check that every tracked Python file carries an acceptable license header.
 
-Two shapes are accepted:
+Headers are SPDX tags, in the style of vLLM's. Two shapes are accepted:
 
-* the TIRx Apache header, for code with no upstream lineage; and
-* a port header, for files ported from an upstream project: the upstream
-  copyright notice (reproduced verbatim from the upstream file, or an explicit
-  statement of the upstream terms where upstream ships no per-file header),
-  followed by the TIRx modification block.
+* the TIRx header alone, for code with no upstream lineage::
+
+      # SPDX-License-Identifier: Apache-2.0
+      # SPDX-FileCopyrightText: Copyright TIRx authors
+
+* a port header, for files ported from an upstream project: a citation naming
+  the project, its URL and the exact upstream commit, the upstream copyright
+  notice, and an SPDX expression covering the upstream license as well as ours::
+
+      # This file is a TIRx port of code from DeepGEMM
+      # (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+      # SPDX-License-Identifier: Apache-2.0 AND MIT
+      # SPDX-FileCopyrightText: Copyright TIRx authors
 
 Ports must use the second shape: dropping the upstream notice from a ported
 file is exactly the drift this check exists to prevent. Unlike ASF-style header
 checks, upstream ``Copyright`` lines are required rather than forbidden.
 
-Run ``--fix`` to insert the TIRx Apache header into files that have no header
-at all; port headers are never synthesized, since only a human knows what the
-upstream terms are.
+Full license texts live in ``licenses/``; ``LICENSE`` maps each bucket of the
+tree to its license. Where an upstream license requires the conditions text
+itself to travel with the source (BSD-3), that text stays in the file verbatim
+and is not replaced by a tag.
+
+Run ``--fix`` to insert the TIRx header into files that have no header at all;
+port headers are never synthesized, since only a human knows the upstream terms.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent.parent
 
-TIRX_APACHE = """\
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License."""
+SPDX_ID = "# SPDX-License-Identifier: "
+SPDX_COPYRIGHT = "# SPDX-FileCopyrightText: Copyright TIRx authors"
+TIRX_HEADER = f"{SPDX_ID}Apache-2.0\n{SPDX_COPYRIGHT}"
+
+# Our own contribution is always Apache-2.0; a port additionally carries the
+# upstream license, spelled as an SPDX `AND` expression.
+ID_RE = re.compile(r"^Apache-2\.0(?: AND (?:MIT|BSD-3-Clause))?$")
+
+# A port must cite the upstream project, its URL and the exact commit ported.
+PORT_LINE = "# This file is a TIRx port of code from "
+CITATION_RE = re.compile(r"\(https://\S+ @ [0-9a-f]{7,40}\)")
 
 # Buckets holding ports of third-party kernels: every module under them must
 # carry a port header, not the plain TIRx one.
@@ -74,11 +71,15 @@ PORT_DIR_EXCEPTIONS = {
     "tirx_kernels/flashmla/utils/_trtllm_gen_bench.py",
 }
 
-MODS_LINE = "# Modifications Copyright (c) 2026 The TIRx Authors."
-MODS_LICENSE_LINE = "# Modifications are licensed under the Apache License, Version 2.0."
-
-# Retired file: attributions live in LICENSE + licenses/ now.
-BANNED = ("THIRD_PARTY_LICENSES", "TIRX Authors")
+# Retired: the old per-file "Modifications" block and the pointer paragraph that
+# went with it; attributions live in the SPDX tags, LICENSE and licenses/ now.
+BANNED = (
+    "THIRD_PARTY_LICENSES",
+    "TIRX Authors",
+    "Modifications Copyright",
+    "Modifications are licensed",
+    "See LICENSE, NOTICE",
+)
 
 
 def header_of(text: str) -> str:
@@ -115,22 +116,24 @@ def check(rel: str, text: str) -> list[str]:
         errors.append(f"{rel}: missing license header (run --fix to add the TIRx one)")
         return errors
 
-    has_tirx_apache = header.startswith(TIRX_APACHE)
-    has_mods = MODS_LINE in header and MODS_LICENSE_LINE in header
+    lines = header.splitlines()
+    ids = [ln[len(SPDX_ID) :] for ln in lines if ln.startswith(SPDX_ID)]
+    if len(ids) != 1:
+        errors.append(f"{rel}: expected exactly one {SPDX_ID.strip()} line, found {len(ids)}")
+    elif not ID_RE.match(ids[0]):
+        errors.append(f"{rel}: unexpected SPDX license expression {ids[0]!r}")
+    if SPDX_COPYRIGHT not in lines:
+        errors.append(f"{rel}: missing {SPDX_COPYRIGHT!r}")
 
     if is_port(rel):
-        if not has_mods:
-            errors.append(f"{rel}: ported file is missing the TIRx modification block")
-        upstream = header.split(MODS_LINE)[0]
-        if "Copyright" not in upstream and "licensed under" not in upstream:
-            errors.append(f"{rel}: ported file is missing its upstream copyright / license notice")
-        if has_tirx_apache:
-            errors.append(
-                f"{rel}: ported file uses the plain TIRx header; reproduce the upstream "
-                "header and add the modification block instead"
-            )
-    elif not has_tirx_apache and not has_mods:
-        errors.append(f"{rel}: header is neither the TIRx Apache header nor a port header")
+        if not any(ln.startswith(PORT_LINE) for ln in lines):
+            errors.append(f"{rel}: ported file is missing its {PORT_LINE.strip()!r} citation")
+        if not CITATION_RE.search(header):
+            errors.append(f"{rel}: ported file is missing an upstream '(url @ commit)' citation")
+        if "Copyright" not in header.split(SPDX_COPYRIGHT)[0]:
+            errors.append(f"{rel}: ported file is missing its upstream copyright notice")
+    elif header != TIRX_HEADER:
+        errors.append(f"{rel}: native file must carry exactly the two-line TIRx SPDX header")
 
     return errors
 
@@ -159,7 +162,7 @@ def main() -> int:
             shebang = [lines.pop(0)] if lines and lines[0].startswith("#!") else []
             body = "\n".join(lines).lstrip("\n")
             path.write_text(
-                "\n".join(shebang) + ("\n" if shebang else "") + TIRX_APACHE + "\n\n" + body
+                "\n".join(shebang) + ("\n" if shebang else "") + TIRX_HEADER + "\n\n" + body
             )
             text = path.read_text()
         errors += check(rel, text)

--- a/tirx_kernels/__init__.py
+++ b/tirx_kernels/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx kernel library."""

--- a/tirx_kernels/_protocol.py
+++ b/tirx_kernels/_protocol.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Standard kernel interface protocol.
 

--- a/tirx_kernels/basic/__init__.py
+++ b/tirx_kernels/basic/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Native TIRx kernels with no single upstream project."""

--- a/tirx_kernels/basic/allgather_gemm.py
+++ b/tirx_kernels/basic/allgather_gemm.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Tensor-parallel AllGather + FP16 GEMM for SM100."""
 

--- a/tirx_kernels/basic/fp16_bf16_gemm.py
+++ b/tirx_kernels/basic/fp16_bf16_gemm.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Direct TP1/TP4 port of the fused persistent dynamic-multimem GemmRS kernel."""
 

--- a/tirx_kernels/basic/nvfp4_gemm.py
+++ b/tirx_kernels/basic/nvfp4_gemm.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/basic/rmsnorm.py
+++ b/tirx_kernels/basic/rmsnorm.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 import math
 

--- a/tirx_kernels/basic/utils/__init__.py
+++ b/tirx_kernels/basic/utils/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared helpers for the basic kernels."""

--- a/tirx_kernels/basic/utils/_baselines.py
+++ b/tirx_kernels/basic/utils/_baselines.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Rank-local cuBLASMp and cuBLAS+NCCL GemmComm baselines."""
 

--- a/tirx_kernels/basic/utils/_model_shapes.py
+++ b/tirx_kernels/basic/utils/_model_shapes.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Model-shape matrix shared by the GemmComm registry entries."""
 

--- a/tirx_kernels/basic/utils/_runtime.py
+++ b/tirx_kernels/basic/utils/_runtime.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Rank-local NCCL/NVSHMEM runtime support for distributed GEMM kernels."""
 

--- a/tirx_kernels/basic/utils/_specialize.py
+++ b/tirx_kernels/basic/utils/_specialize.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Load implementation-preserving, import-time kernel specializations."""
 

--- a/tirx_kernels/bench/__init__.py
+++ b/tirx_kernels/bench/__init__.py
@@ -1,14 +1,2 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/bench/__main__.py
+++ b/tirx_kernels/bench/__main__.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """CLI entry point: python -m tirx_kernels.bench [--kernel <name>] [--config <label>]"""
 

--- a/tirx_kernels/bench_suite/__init__.py
+++ b/tirx_kernels/bench_suite/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Pre-commit regression benchmark orchestration for TIRx kernels."""

--- a/tirx_kernels/bench_suite/__main__.py
+++ b/tirx_kernels/bench_suite/__main__.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from tirx_kernels.bench_suite.run import main
 

--- a/tirx_kernels/bench_suite/baseline_view.py
+++ b/tirx_kernels/bench_suite/baseline_view.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Render a single bench-suite run JSON as a human-readable markdown summary.
 

--- a/tirx_kernels/bench_suite/impls.py
+++ b/tirx_kernels/bench_suite/impls.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Implementation-name classification shared by bench-suite reports."""
 

--- a/tirx_kernels/bench_suite/promote_baseline.py
+++ b/tirx_kernels/bench_suite/promote_baseline.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Promote a bench-suite run JSON to a checked-in baseline and refresh baseline.md.
 

--- a/tirx_kernels/bench_suite/ratio_diff.py
+++ b/tirx_kernels/bench_suite/ratio_diff.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ratio-based regression diff for bench-suite.
 

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """bench-suite: pre-commit regression benchmark for TIRx kernels.
 

--- a/tirx_kernels/deepgemm/__init__.py
+++ b/tirx_kernels/deepgemm/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """DeepGEMM kernel transcriptions and scaffolds."""

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d.py
@@ -14,6 +14,9 @@ modules in this package acting as thin per-entry wrappers.
 
 Module names starting with an underscore are skipped by the kernel registry
 scan, so this file carries no ``KERNEL_META``.
+
+Upstream sources: deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh,
+scheduler/gemm.cuh, csrc/jit_kernels/heuristics/sm100.hpp.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d.py
@@ -1,18 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of DeepGEMM's
-# deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh, together with
-# the reachable helpers it instantiates (scheduler/gemm.cuh,
-# epilogue/sm100_store_cd{,_swap_ab}.cuh) and the host-side layout heuristic
-# in csrc/jit_kernels/heuristics/sm100.hpp.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared implementation of DeepGEMM's SM100 FP8/FP4 1D1D GEMM kernel template.
 

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_data.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_data.py
@@ -1,17 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# Data preparation and reference oracles for the TIRx port of DeepGEMM's
-# sm100_fp8_fp4_gemm_1d1d. The quantization recipes, scale-factor layout
-# transform and accuracy metric mirror deep_gemm/utils/math.py,
-# csrc/apis/layout.hpp and deep_gemm/testing/numeric.py.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Operand construction, scale-factor packing and correctness oracles.
 

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_data.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_data.py
@@ -12,6 +12,8 @@ we build cannot drift from the layout the reference expects.
 
 `deep_gemm` is imported lazily inside each function: kernel discovery must work
 on hosts without it.
+
+Upstream sources: deep_gemm/utils/math.py, csrc/apis/layout.hpp, deep_gemm/testing/numeric.py.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_kernel.py
@@ -20,6 +20,9 @@ warp  role
 3     idle -- no branch selects it, deliberately
 4..   epilogue, bounded by ``kNumUMMAStoreThreads / 32``
 ===== ===============================================================
+
+Upstream sources: deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh,
+scheduler/gemm.cuh.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d_kernel.py
@@ -1,17 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx transcription of DeepGEMM's sm100_fp8_fp4_gemm_1d1d_impl
-# (deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh) together
-# with scheduler/gemm.cuh and epilogue/sm100_store_cd{,_swap_ab}.cuh. The
-# structure follows .agents/sketch/deepgemm/sm100_fp8_fp4_gemm_1d1d.md.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """The kernel body: eight warps, five barrier families, one persistent walk.
 

--- a/tirx_kernels/deepgemm/fp8_bmm.py
+++ b/tirx_kernels/deepgemm/fp8_bmm.py
@@ -18,6 +18,8 @@ expression                   (batch, m, n, k)            majors          output
 ``bhd,hdr->bhr``             ``(h, b, r, d)``            K, MN           bf16
 ``bhd,bhr->hdr``             ``(h, d, r, b)``            MN, MN          fp32+acc
 ===========================  ==========================  ==============  ========
+
+Upstream source: csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:393.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/fp8_bmm.py
+++ b/tirx_kernels/deepgemm/fp8_bmm.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's sm100_fp8_bmm host entry
-# (csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:393).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Batched FP8 GEMM -- `GemmType::Batched`.
 

--- a/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
@@ -8,6 +8,8 @@
 Reference: `deep_gemm.fp8_fp4_gemm_nt` (aliased as `deep_gemm.fp8_gemm_nt`).
 The kernel body lives in :mod:`tirx_kernels.deepgemm._sm100_fp8_fp4_gemm_1d1d`;
 this module only pins the descriptor and the test/benchmark matrices.
+
+Upstream source: csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:93.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's sm100_fp8_fp4_gemm_1d1d host entry
-# (csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:93).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Dense FP8/FP4 GEMM -- `GemmType::Normal` instantiation.
 

--- a/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
@@ -10,6 +10,8 @@ along K with per-group lengths, both operands are MN-major, and the output is
 always FP32 with accumulation (the MoE weight-gradient path), so the epilogue
 takes the `SM90_TMA_REDUCE_ADD` branch.  FP4 is not exercised here -- DeepGEMM's
 own enumerator keeps this entry FP8-only.
+
+Upstream source: csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:313.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's sm100_k_grouped_fp8_gemm_1d1d host entry
-# (csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:313).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """K-grouped contiguous FP8 GEMM -- `KGroupedContiguous[WithPsumLayout]`.
 

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
@@ -10,6 +10,8 @@ Reference: `deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous` (aliased as
 to `GemmType::MGroupedContiguousWithPsumLayout`, which makes the scheduler walk
 per-group psum end offsets instead of a per-row expert id, and makes
 `ensure_zero_padding` meaningful (it gates the aligned-effective-M tail).
+
+Upstream source: csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:161.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's sm100_m_grouped_fp8_fp4_gemm_contiguous_1d1d host
-# entry (csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:161).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """M-grouped contiguous FP8/FP4 GEMM -- `MGroupedContiguous[WithPsumLayout]`.
 

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
@@ -9,6 +9,8 @@ Reference: `deep_gemm.m_grouped_fp8_fp4_gemm_nt_masked` (aliased as
 `m_grouped_fp8_gemm_nt_masked` / `fp8_m_grouped_gemm_nt_masked`).  A is
 `[G, max_m, K]` with a per-group valid row count in `masked_m`, so the shape is
 static while the work is dynamic -- the decode / CUDA-graph MoE path.
+
+Upstream source: csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:244.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's sm100_m_grouped_fp8_fp4_gemm_masked_1d1d host entry
-# (csrc/jit_kernels/impls/sm100_fp8_fp4_gemm_1d1d.hpp:244).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """M-grouped masked FP8/FP4 GEMM -- `GemmType::MGroupedMasked`.
 

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -1,17 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's fused MoE megakernel
-# (deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh with its
-# layout/, scheduler/ and ptx/ helpers, plus csrc/apis/mega.h and
-# csrc/jit_kernels/heuristics/mega_moe.h).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/deepgemm/mega_moe.py
+++ b/tirx_kernels/deepgemm/mega_moe.py
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
+"""TIRx port of DeepGEMM's MegaMoE kernel.
+
+Upstream sources: deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh, csrc/apis/mega.h,
+csrc/jit_kernels/heuristics/mega_moe.h.
+"""
+
 from __future__ import annotations
 
 import ctypes

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
+"""TIRx port of DeepGEMM's MQA logits kernel, FP4 variant.
+
+Upstream source: deep_gemm/include/deep_gemm/impls/sm100_mqa_logits.cuh.
+"""
+
 import os
 from dataclasses import asdict, dataclass
 from functools import cache

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's MQA logits kernel
-# (deep_gemm/include/deep_gemm/impls/sm100_mqa_logits.cuh), FP4 variant.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 import os
 from dataclasses import asdict, dataclass

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
+"""TIRx port of DeepGEMM's MQA logits kernel, FP8 variant.
+
+Upstream source: deep_gemm/include/deep_gemm/impls/sm100_mqa_logits.cuh.
+"""
+
 import os
 from dataclasses import asdict, dataclass
 from functools import cache

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's MQA logits kernel
-# (deep_gemm/include/deep_gemm/impls/sm100_mqa_logits.cuh), FP8 variant.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 import os
 from dataclasses import asdict, dataclass

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
@@ -1,14 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's paged-KV MQA logits kernel, FP4 variant.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 import ctypes
 import os

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -1,14 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's paged-KV MQA logits kernel, FP8 variant.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 import ctypes
 from dataclasses import asdict, dataclass

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from DeepGEMM
-# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.deepgemm.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of DeepGEMM's TF32 prenorm GEMM. The split heuristic follows
-# SGLang's _compute_num_split_for_mhc_pre (Apache-2.0).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashattention/__init__.py
+++ b/tirx_kernels/flashattention/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashAttention kernel ports (Dao-AILab flash-attention)."""

--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -9,6 +9,8 @@
 Run ``python -m tirx_kernels.flashattention.flash_attention4`` to profile the
 annotated kernel.  Correctness and ordinary benchmarks remain exposed through
 ``run_test`` and ``run_bench``.
+
+Upstream source: flash_attn/cute/flash_fwd_sm100.py.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -1,16 +1,8 @@
-# Copyright (c) 2022, the respective contributors, as shown by the AUTHORS
-# file (reproduced at licenses/AUTHORS.flash-attention.txt).
-#
-# Licensed under the BSD 3-Clause License; the full license text is
-# licenses/LICENSE.flash-attention.txt. The upstream source carries no
-# per-file copyright header.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of Dao-AILab/flash-attention's
-# flash_attn/cute/flash_fwd_sm100.py (Dao-AILab/flash-attention @ 00756db9).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from flash-attention
+# (https://github.com/Dao-AILab/flash-attention @ 00756db9), Copyright (c) 2022,
+# the respective contributors, as shown by licenses/AUTHORS.flash-attention.txt
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashAttention-4 TIRx kernel and direct NVIDIA IKET profiling entry point.
 

--- a/tirx_kernels/flashattention/flash_attention_backward.py
+++ b/tirx_kernels/flashattention/flash_attention_backward.py
@@ -1,15 +1,8 @@
+# This file is a TIRx port of code from flash-attention
+# (https://github.com/Dao-AILab/flash-attention @ 00756db9),
 # Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
-
-# Licensed under the BSD 3-Clause License; the AUTHORS file its copyright
-# notice refers to is licenses/AUTHORS.flash-attention.txt and the full
-# license text is licenses/LICENSE.flash-attention.txt.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of Dao-AILab/flash-attention's
-# flash_attn/cute/flash_bwd_sm100.py (Dao-AILab/flash-attention @ 00756db9).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """SM100 two-CTA FlashAttention backward kernel using raw CUDA/PTX wrappers.
 

--- a/tirx_kernels/flashattention/flash_attention_backward.py
+++ b/tirx_kernels/flashattention/flash_attention_backward.py
@@ -1,5 +1,5 @@
 # This file is a TIRx port of code from flash-attention
-# (https://github.com/Dao-AILab/flash-attention @ 00756db9),
+# (https://github.com/Dao-AILab/flash-attention @ d7e4dba3),
 # Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
 # SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 # SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/flashinfer/__init__.py
+++ b/tirx_kernels/flashinfer/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer kernel ports, bucketed by the FlashInfer Python entry point they back."""

--- a/tirx_kernels/flashinfer/activation/__init__.py
+++ b/tirx_kernels/flashinfer/activation/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.activation``."""

--- a/tirx_kernels/flashinfer/activation/act_and_mul.py
+++ b/tirx_kernels/flashinfer/activation/act_and_mul.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2024 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of the act_and_mul_kernel template in FlashInfer's
-# include/flashinfer/activation.cuh (flashinfer-ai/flashinfer @ f2e04400,
-# v0.6.18), which backs silu_and_mul, gelu_and_mul and gelu_tanh_and_mul.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer ``act_and_mul_kernel`` port.
 

--- a/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
+++ b/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
@@ -1,25 +1,8 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
 # Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of cvt_fp16_to_fp4_expert in NVIDIA TensorRT-LLM's
-# quantization.cuh, as vendored by FlashInfer at
-# csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer ``cvt_fp16_to_fp4_expert`` port.
 

--- a/tirx_kernels/flashinfer/gdn_decode/__init__.py
+++ b/tirx_kernels/flashinfer/gdn_decode/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer Gated Delta Net decode kernels."""

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""SM100 BF16 wide-vector single-token GDN decode kernel."""
+"""SM100 BF16 wide-vector single-token GDN decode kernel.
+
+Upstream source: flashinfer/gdn_kernels/gdn_decode_bf16_state.py.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2026 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# flashinfer/gdn_kernels/gdn_decode_bf16_state.py
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """SM100 BF16 wide-vector single-token GDN decode kernel."""
 

--- a/tirx_kernels/flashinfer/gdn_prefill/__init__.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.gdn_prefill``."""

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -34,6 +34,8 @@
 
 The implementation follows the frozen CuTeDSL source order and preserves its
 CUDA/PTX details instead of reorganizing them into a separate implementation.
+
+Upstream source: flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py.
 """
 
 from __future__ import annotations

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,15 +24,11 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
 #
-# This file is a TIRx port of FlashInfer's
-# flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18). FlashInfer's host adapter is
-# used only as an external correctness and benchmark oracle.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400)
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """SM100a FP16 GDN prefill transcribed from FlashInfer's frozen CuTeDSL kernel.
 

--- a/tirx_kernels/flashinfer/gemm/__init__.py
+++ b/tirx_kernels/flashinfer/gemm/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.gemm``."""

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -1,25 +1,8 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's csrc/tinygemm2_sm100.cu
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18). That generated source
-# records its Loom schedules as exact ports of NVIDIA TensorRT-LLM's TinyGEMM2
-# kernel.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer TinyGEMM2 BF16 kernel port for SM100."""
 

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -4,7 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""FlashInfer TinyGEMM2 BF16 kernel port for SM100."""
+"""FlashInfer TinyGEMM2 BF16 kernel port for SM100.
+
+Upstream source: csrc/tinygemm2_sm100.cu.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/kda/__init__.py
+++ b/tirx_kernels/flashinfer/kda/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.kda`` / ``flashinfer.kda_prefill``."""

--- a/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
+++ b/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
@@ -1,24 +1,8 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# csrc/kda/flashkda_bf16_fused_m128.cu (flashinfer-ai/flashinfer @ f2e04400,
-# v0.6.18); the kernel originally landed as flashinfer-ai/flashinfer#4262.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's FlashKDA SM100a BF16 recurrent-KDA prefill
 M128 kernel (flashinfer-ai/flashinfer#4262, head e835e0f5).

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# flashinfer/kda_kernels/recurrent_kda.py::_grouped_kda_kernel
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's grouped-CTA recurrent-KDA decode kernel.
 

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# flashinfer/kda_kernels/recurrent_kda.py::recurrent_kda_decode_kernel
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's one-warp recurrent-KDA decode kernel.
 

--- a/tirx_kernels/flashinfer/mamba/__init__.py
+++ b/tirx_kernels/flashinfer/mamba/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.mamba.selective_state_update``."""

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""TIRx port of FlashInfer's selective-state-update MTP horizontal kernel."""
+"""TIRx port of FlashInfer's selective-state-update MTP horizontal kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_mtp_horizontal.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_mtp_horizontal.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's selective-state-update MTP horizontal kernel."""
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""TIRx port of FlashInfer's selective-state-update MTP simple kernel."""
+"""TIRx port of FlashInfer's selective-state-update MTP simple kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's selective-state-update MTP simple kernel."""
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""TIRx port of FlashInfer's selective-state-update MTP vertical kernel."""
+"""TIRx port of FlashInfer's selective-state-update MTP vertical kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_mtp_vertical.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_mtp_vertical.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's selective-state-update MTP vertical kernel."""
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_stp.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Integration scaffold for FlashInfer's STP producer-consumer horizontal kernel."""
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""Integration scaffold for FlashInfer's STP producer-consumer horizontal kernel."""
+"""Integration scaffold for FlashInfer's STP producer-consumer horizontal kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_stp.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_stp.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's selective-state-update STP simple kernel."""
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""TIRx port of FlashInfer's selective-state-update STP simple kernel."""
+"""TIRx port of FlashInfer's selective-state-update STP simple kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_stp.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""TIRx port of FlashInfer's STP producer-consumer vertical kernel."""
+"""TIRx port of FlashInfer's STP producer-consumer vertical kernel.
+
+Upstream source: include/flashinfer/mamba/kernel_selective_state_update_stp.cuh.
+"""
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of FlashInfer's
-# include/flashinfer/mamba/kernel_selective_state_update_stp.cuh
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx port of FlashInfer's STP producer-consumer vertical kernel."""
 

--- a/tirx_kernels/flashinfer/quantization/__init__.py
+++ b/tirx_kernels/flashinfer/quantization/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Ports of the kernels behind ``flashinfer.quantization``."""

--- a/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
@@ -1,26 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of the MXFP4QuantizeLinearKernel and
-# MXFP4QuantizeSwizzledKernel CuTe-DSL kernels in FlashInfer's
-# flashinfer/quantization/kernels/mxfp4_quantize.py (flashinfer-ai/flashinfer
-# @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer CuTe-DSL ``mxfp4_quantize`` port.
 

--- a/tirx_kernels/flashinfer/quantization/mxfp8_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/mxfp8_quantize.py
@@ -1,26 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of the MXFP8QuantizeLinearKernel and
-# MXFP8QuantizeSwizzledKernel CuTe-DSL kernels in FlashInfer's
-# flashinfer/quantization/kernels/mxfp8_quantize.py (flashinfer-ai/flashinfer
-# @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer CuTe-DSL ``mxfp8_quantize`` port.
 

--- a/tirx_kernels/flashinfer/quantization/nvfp4_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/nvfp4_quantize.py
@@ -1,26 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of the NVFP4QuantizeLinearKernel and
-# NVFP4QuantizeSwizzledKernel CuTe-DSL kernels in FlashInfer's
-# flashinfer/quantization/kernels/nvfp4_quantize.py (flashinfer-ai/flashinfer
-# @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer CuTe-DSL ``nvfp4_quantize`` port.
 

--- a/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
+++ b/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
@@ -1,25 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# This file is a TIRx port of the NVFP4QuantizePerTokenKernel CuTe-DSL kernel
-# in FlashInfer's flashinfer/quantization/kernels/nvfp4_quantize.py
-# (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashInfer CuTe-DSL ``nvfp4_quantize_per_token`` port.
 

--- a/tirx_kernels/flashinfer/utils/__init__.py
+++ b/tirx_kernels/flashinfer/utils/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared benchmark harnesses for the FlashInfer ports."""

--- a/tirx_kernels/flashinfer/utils/_flashkda_bench.py
+++ b/tirx_kernels/flashinfer/utils/_flashkda_bench.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """MoonshotAI/FlashKDA benchmark adapter for the recurrent-KDA port."""
 

--- a/tirx_kernels/flashinfer/utils/fp_quant.py
+++ b/tirx_kernels/flashinfer/utils/fp_quant.py
@@ -1,24 +1,7 @@
-# Copyright (c) 2025 by FlashInfer team.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# Instruction-level helpers shared by the TIRx ports of FlashInfer's CuTe-DSL
-# quantization kernels (flashinfer-ai/flashinfer @ f2e04400, v0.6.18).
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared plain-TIRx helpers for the FlashInfer quantization kernel ports.
 

--- a/tirx_kernels/flashmla/__init__.py
+++ b/tirx_kernels/flashmla/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """FlashMLA kernel ports."""

--- a/tirx_kernels/flashmla/flash_mla_sparse_fwd.py
+++ b/tirx_kernels/flashmla/flash_mla_sparse_fwd.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of FlashMLA's sparse forward entry (csrc/api/sparse_fwd.h); it
-# dispatches to the phase1 kernels ported in the sibling modules.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """TIRx entry for FlashMLA's sparse prefill Python API.
 

--- a/tirx_kernels/flashmla/sparse_decode_head64.py
+++ b/tirx_kernels/flashmla/sparse_decode_head64.py
@@ -1,14 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of FlashMLA's sparse decode kernel, 64 q-heads.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -1,14 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of FlashMLA's sparse prefill phase-1 kernel, 128 q-heads.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of FlashMLA's sparse prefill phase-1 kernel, 128 q-heads, small
-# top-k variant.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -1,14 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# TIRx port of FlashMLA's sparse prefill phase-1 kernel, 64 q-heads.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashmla/utils/__init__.py
+++ b/tirx_kernels/flashmla/utils/__init__.py
@@ -1,16 +1,4 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared helpers and benchmark harnesses for the FlashMLA ports."""

--- a/tirx_kernels/flashmla/utils/_flashmla_bench.py
+++ b/tirx_kernels/flashmla/utils/_flashmla_bench.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/flashmla/utils/_gemm.py
+++ b/tirx_kernels/flashmla/utils/_gemm.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# Shared tcgen05 gemm_async configuration for the TIRx ports of FlashMLA's
-# sparse phase-1 kernels.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared tcgen05 gemm_async config for the sparse FlashMLA phase1 kernels."""
 

--- a/tirx_kernels/flashmla/utils/_mask.py
+++ b/tirx_kernels/flashmla/utils/_mask.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# Shared validity-mask helper for the TIRx ports of FlashMLA's sparse phase-1
-# kernels.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared validity-mask helper for the sparse FlashMLA phase1 kernels."""
 

--- a/tirx_kernels/flashmla/utils/_tma.py
+++ b/tirx_kernels/flashmla/utils/_tma.py
@@ -1,15 +1,7 @@
 # This file is a TIRx port of code from FlashMLA
-# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025
-# DeepSeek, licensed under the MIT License. The upstream sources carry no
-# per-file license header; see licenses/LICENSE.flashmla.txt for the full
-# license text.
-#
-# Modifications Copyright (c) 2026 The TIRx Authors.
-# Modifications are licensed under the Apache License, Version 2.0.
-#
-# Shared TMA copy_async configuration for the TIRx ports of FlashMLA's sparse
-# phase-1 kernels.
-# See LICENSE, NOTICE, and licenses/ for the applicable terms.
+# (https://github.com/deepseek-ai/FlashMLA @ 9241ae3e), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Shared TMA copy_async config for the sparse FlashMLA phase1 kernels."""
 

--- a/tirx_kernels/flashmla/utils/_trtllm_gen_bench.py
+++ b/tirx_kernels/flashmla/utils/_trtllm_gen_bench.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 from __future__ import annotations
 

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -1,17 +1,6 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
 """Validate the pre-lowering IR contract for low-level TIRx kernels."""
 
 from __future__ import annotations

--- a/tirx_kernels/registry.py
+++ b/tirx_kernels/registry.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Kernel registry — auto-discovers kernel modules with KERNEL_META."""
 

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """Unified kernel test and benchmark runner.
 

--- a/tirx_kernels/test/__init__.py
+++ b/tirx_kernels/test/__init__.py
@@ -1,14 +1,2 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/test/__main__.py
+++ b/tirx_kernels/test/__main__.py
@@ -1,17 +1,5 @@
-# Copyright (c) 2026 The TIRx Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
 
 """CLI entry point: python -m tirx_kernels.test [--kernel <name>] [--config <label>]"""
 


### PR DESCRIPTION
## Summary

- replace the per-file license boilerplate with SPDX tags, in the style vLLM uses
- native files carry exactly two lines; ports additionally carry the upstream project, the exact commit ported, and the upstream copyright
- rewrite `tests/lint/check_license_headers.py` to enforce the new convention
- align `LICENSE`'s third-party section with Apache TVM's wording, add the product copyright to `NOTICE`, and correct the `README` License section

Native:

```
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright TIRx authors
```

Port:

```
# This file is a TIRx port of code from DeepGEMM
# (https://github.com/deepseek-ai/DeepGEMM @ 559d79fb), Copyright (c) 2025 DeepSeek
# SPDX-License-Identifier: Apache-2.0 AND MIT
# SPDX-FileCopyrightText: Copyright TIRx authors
```

## Impact

87 of the 88 tracked Python files lose 14–36 lines of preamble each; net −1032 lines, all comments. The information that actually carries attribution weight — which upstream, which commit, whose copyright, which license — is preserved and is now in a form a license scanner can read.

The upstream license travels in the SPDX expression rather than in a prose sentence: `Apache-2.0 AND MIT` for the DeepGEMM and FlashMLA ports, `Apache-2.0 AND BSD-3-Clause` for the flash-attention ports and `gdn_prefill_sm100`, plain `Apache-2.0` elsewhere. Tagging the MIT- and BSD-derived files `Apache-2.0` alone would have understated their terms, so the expression varies per file rather than being a constant.

`gdn_prefill_sm100.py` keeps NVIDIA's BSD-3 conditions text verbatim — clause 1 requires the conditions and disclaimer to travel with the source, so it is the one file where a tag cannot replace the text. Its upstream standalone `SPDX-License-Identifier: BSD-3-Clause` is folded into the single combined expression so the file does not end up with two conflicting tags.

Removed everywhere: the `Modifications Copyright` / `Modifications are licensed` block, the `See LICENSE, NOTICE, and licenses/` pointer, and the per-file transcription paragraphs. The paragraphs' one piece of unique content — the exact upstream source path — turned out NOT to be redundant in 21 files (three of which had no module docstring at all); those paths are migrated into the module docstrings as `Upstream source(s):` lines, so the header stays minimal and the provenance stays in the file.

`licenses/` is untouched. The `NOTICE` FlashInfer attribution stays: FlashInfer ships a NOTICE, so Apache §4(d) requires propagating it.

## Post-review hardening (second commit)

Review found four real gaps in the first commit; `fbd6fbd2` fixes them:

- **the checker now binds licenses to paths.** It previously accepted any expression from a closed set, so a DeepGEMM port tagged plain `Apache-2.0` — or `AND BSD-3-Clause` — passed, and deleting `gdn_prefill_sm100`'s BSD conditions text passed. Expected project, upstream URL and SPDX expression are now per-bucket (`PORT_BUCKETS` / `FILE_OVERRIDES`), and the BSD text is required where the upstream license requires it.
- **`--self-test`**: twelve synthetic cases — the review's three escapes among them — must each be caught (or pass, for the two valid shapes) or the checker exits nonzero.
- **`flash_attention_backward.py` cited the wrong upstream commit.** Its header said `@ 00756db9` while its docstring — written at port time — says `d7e4dba3` (2026-08-05), and `flash_bwd_sm100.py` did change between the two. The header now cites `d7e4dba3`.
- **README** scoped to "Every Python source file", and the checker no longer skips `tests/lint/` wholesale — only its own banned-string scan.

The 21 docstring edits and the commit fix are proven AST-identical modulo the module docstring, so the "comments only" claim below holds in the form: no statement in any kernel file changed.

## Validation

- `python tests/lint/check_license_headers.py` → exit 0 over all 88 files; `--self-test` → 12/12
- the rewritten checker is verified **non-vacuous**: five hand-made violations — missing port citation, missing upstream copyright, wrong SPDX expression, native file with an extra header line, and a reintroduced `Modifications Copyright` — are each caught with a specific message
- `pre-commit run --all-files` → clean
- `python -m tirx_kernels.bench_suite --check-imports` → ok, 39 kernels
- **behavior-preserving proof**: in the first commit, `git diff -G'^[^#[:space:]]'` lists only the checker, `LICENSE`, `NOTICE` and `README.md`; in the second, every kernel-file edit is AST-identical modulo the module docstring — no statement in any kernel file changed across the PR
- the five files needing hand-review (2 flash-attention, 2 NVIDIA-copyright, `gdn_prefill_sm100`) were read in full after rewriting

## Note

The SPDX expression is the one place I did not follow a literal reading of "just Apache-2.0": using it unconditionally would mislabel the MIT and BSD ports. If you would rather every file read plain `Apache-2.0` and leave license mapping entirely to `LICENSE` + `licenses/`, that is a one-line change to the generator and the checker's allowed set.
