### PR TITLE
feat(kernel): port FlashInfer's FlashKDA cake T=1 precomputed decode kernel

### DIFF
--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
@@ -1,0 +1,376 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashKDA cake T=1 precomputed decode: coarse execution sketch
+
+**Non-executable.** This is the semantic execution skeleton, not runnable code.
+The source of truth for the implementation is
+`tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py`.
+
+Transcribed from FlashInfer's frozen generated export
+`csrc/kda/flashkda_decode_d128_t1_precomputed_direct_split16.cu`, symbol
+`kernel_flashinfer_recurrent_kda_t1_direct` (flashinfer-ai/flashinfer @
+`f2e04400`). Line references below are into that file unless stated otherwise.
+
+**Fixed specialization.** `HEAD_DIM = 128`, `TOKENS = 1`, `GATE_KIND = 0`
+(precomputed log-gate), `LAUNCH_THREADS = 32`, `DIRECT_IMPL = 1`. The only free
+knob is `VALUE_SPLIT ∈ {16, 8}`, chosen by the host from
+`work = num_seqs * num_value_heads` against `2 * sm_count`
+(`recurrent_kda.py:1169-1177`). The `_split16` and `_split8` bodies differ in
+exactly three constants, so this sketch covers both.
+
+**Out of scope.** `T ∈ {2,3,4,5,6}`; the `GATE_KIND = 1` lower-bound variant
+(`d128_t3_lower_bound_split4`); the non-direct `d128_t1_precomputed_split{1,2,4,8}`
+exports (256 threads, shared memory, `ldmatrix` + `mma`, WY transform), which
+`run_recurrent_kda` never selects at T=1 (`recurrent_kda.py:1443-1447`).
+
+## Pipeline at a glance
+
+This kernel has **no asynchronous pipeline, no shared memory, no mbarrier, no
+TMA, no `cp.async`, and no barrier of any kind**. One warp per CTA holds the
+entire working set in registers and exchanges everything by shuffle.
+
+The value split is a **partition, not a reduction**: CTA `(hv, value_tile)` owns
+`TILE_ROW_STRIDE = 128 / VALUE_SPLIT` consecutive value rows of the `[V, K]`
+state, and both the state rows it rewrites and the output elements it produces
+are disjoint from every other CTA's. That is why there is no atomic, no
+semaphore, no workspace and no second kernel.
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, value_tile, n)` | value head `hv`, sequence row `n`, value rows `[value_tile*TILE_ROW_STRIDE, +TILE_ROW_STRIDE)` | independent; no cross-CTA communication |
+| warp (the whole CTA) | one `q`/`k`/`g` vector triple, one `beta`, the full 128-wide K axis | the two L2 norms and `k_dot_q` are warp-wide reductions |
+| lane, phase 1 (`elem_start = lane*4`) | 4 consecutive elements of q, k, g | consumed by the 32-lane L2 butterflies, then redistributed |
+| lane, phase 2 (`k_lane = lane & 15`) | 8 consecutive K elements `k_lane*8 .. +7` of q̂, k̂, γ | 16 lanes tile the 128-wide K axis |
+| `v_lane = lane / 16` | one of two **interleaved** value rows in flight | `row_in_tile = v_lane + 2*(row_block*4 + row_local)` |
+| `k_lane == 0` lane pair | the scalar `v[row]` load and the scalar `out[row]` store | `v` is broadcast to the other 15 lanes by one `shfl.idx` |
+
+The lane split changes once, between the vector loads and the row loop
+(`:153-164`). That redistribution is a pure shuffle stage, not a barrier: it
+exists because the 128-wide vectors are loaded 4-per-lane across 32 lanes but
+consumed 8-per-lane across 16 lanes.
+
+Dependency chain per CTA: load q/k/g -> L2 norms -> redistribute + gate exp ->
+`k_dot_q` -> [per row: load state row -> decay -> `pred`/`base` -> `delta` ->
+rank-1 update -> store state, store out].
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+reg_tile(dtype, shape)              # per-thread register array
+view(tensor[...])                   # logical slice, no instruction
+```
+
+Data movement:
+
+```python
+copy_g2r(gmem_slice, reg, hint=None)   # global -> register
+copy_r2g(reg, gmem_slice, pred=None)   # register -> global
+bcast(value, src_lane)                 # one lane's value to the whole warp
+bfly(value, lane_xor)                  # butterfly exchange
+```
+
+Compute:
+
+```python
+fill(reg, c);  cast(dst, src);  add(a,b);  sub(a,b);  mul(a,b);  fma(a,b,c)
+exp(x);  rsqrt(x);  dot(a, b)          # `dot` is one explicit FMA chain, see below
+```
+
+Control/scalar state only: `row_block`, `row_local`, `active`, `has_token`.
+
+**`dot` is not a compound op here.** Every `dot` below expands to one explicit
+chain of `fma.rn.ftz.f32` in a *fixed association order* copied from the source;
+the order is written out at each site because it is load-bearing for bit-level
+agreement.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+# All from the JIT macro block (flash_kda_decode.py:231-257) plus the host
+# LaunchContext (flashkda_decode_binding_common.cuh:50-59, :336-345).
+HEAD_DIM     = 128
+THREADS      = 32                       # __launch_bounds__(32); one warp
+VALUE_SPLIT                             # 16 or 8; the only free knob
+TILE_ROW_STRIDE = 128 // VALUE_SPLIT    # 8 or 16 value rows per CTA  (:79)
+ROW_BLOCKS      = TILE_ROW_STRIDE // 8  # 1 or 2                      (:182)
+K_LANES, V_LANES = 16, 2
+H, HV, HEAD_RATIO                       # HV % H == 0, HV >= H
+GATE_TOKEN_STRIDE                       # g.stride(1); the only non-compact input
+STATE_SLOT_STRIDE                       # state.stride(0)
+
+# Runtime: scale (f32). `lower_bound`, `A_log`, `dt_bias` exist in the ABI but
+# GATE_KIND == 0 ignores them; `num_accepted_tokens` is in the kernel signature
+# and never dereferenced at T=1 (:52).
+
+grid  = (HV * VALUE_SPLIT, num_seqs)    # binding_direct_impl.cuh:57
+block = (32,)                           # :58 -- dynamic smem is 0
+
+# ===========================================================================
+# Work decomposition and lane roles  (:63-79)
+# ===========================================================================
+work       = cta_id.x
+value_tile = work & (VALUE_SPLIT - 1)
+hv         = work // VALUE_SPLIT
+n          = cta_id.y
+query_head = hv // HEAD_RATIO           # the GQA fold
+lane       = thread_id.x
+k_lane     = lane & 15                  # 16 lanes x 8 elements = 128 K
+v_lane     = lane // 16                 # selects one of two interleaved rows
+
+# ===========================================================================
+# Row activity, resolved before any load  (:72-79)
+# ===========================================================================
+raw_token_pos = cu_seqlens[n]
+seq_len       = cu_seqlens[n + 1] - raw_token_pos
+# instruction_selection: ld.global.nc.b32; extent: scalar (x2)
+has_token  = raw_token_pos >= 0 and raw_token_pos < num_seqs and seq_len > 0
+token_pos  = raw_token_pos if has_token else 0
+raw_slot   = ssm_state_indices[n]
+# instruction_selection: ld.global.nc.b32; extent: scalar
+initial_slot = 0 if raw_slot < 0 else raw_slot     # inactive rows clamp to slot 0
+active       = raw_slot >= 0 and has_token
+tile_row_base = value_tile * TILE_ROW_STRIDE
+
+# `has_token`'s `raw_token_pos < gridDim.y` term is why the body only accepts an
+# identity cu_seqlens; the Python layer forbids a user-supplied T=1 cu_seqlens
+# (recurrent_kda.py:1722-1724).
+
+# ===========================================================================
+# Phase 1: q, k, g vector loads, 4 elements per lane  (:88-132)
+# ===========================================================================
+q_src = reg_tile(f32, [4]); k_src = reg_tile(f32, [4]); gate_src = reg_tile(f32, [4])
+elem_start = lane * 4
+
+copy_g2r(q[token_pos, query_head, elem_start : elem_start+4], q_src)
+# instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector (4 bf16)
+copy_g2r(k[token_pos, query_head, elem_start : elem_start+4], k_src)
+# instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector
+copy_g2r(g[token_pos * GATE_TOKEN_STRIDE + hv*128 + elem_start : +4], gate_src)
+# instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector
+
+# The bf16 -> f32 widening is NOT cvt. Each loaded 32-bit word carries two bf16
+# and is split by an integer pair, which is what the source spells inline
+# (:96-102) and what survives to PTX:
+#   lo = word << 16 ; hi = word & 0xffff0000
+# instruction_selection: shl.b32 + and.b32; extent: 2 words per tensor, 3 tensors
+
+# ===========================================================================
+# Phase 2: QK L2 norms -- full 32-lane butterflies  (:133-152)
+# ===========================================================================
+# The association order is fixed by the source (:136) and is copied verbatim:
+#   sum = a0*a0 + a1*a1 + (a2*a2 + a3*a3)
+q_sum_sq = dot(q_src, q_src)
+k_sum_sq = dot(k_src, k_src)
+# instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 + add.ftz.f32; extent: 4-term chain each
+
+for offset in (16, 8, 4, 2, 1):        # full-warp, unlike the 16-lane dot reduce
+    q_sum_sq = add(q_sum_sq, bfly(q_sum_sq, offset))
+    k_sum_sq = add(k_sum_sq, bfly(k_sum_sq, offset))
+# instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds x 2 values
+
+q_scale = mul(rsqrt(add(q_sum_sq, 1e-6)), scale)   # `scale` multiplies q ONLY
+k_scale = rsqrt(add(k_sum_sq, 1e-6))
+# instruction_selection: rsqrt.approx.ftz.f32; extent: scalar (x2)
+# eps is hardcoded 1e-6f in the source (:148,:150), not a runtime argument.
+
+# ===========================================================================
+# Phase 3: lane redistribution 4-per-lane -> 8-per-lane, and the gate  (:153-164)
+# ===========================================================================
+q_reg = reg_tile(f32, [8]); k_reg = reg_tile(f32, [8]); gate_reg = reg_tile(f32, [8])
+for i in range(8):                      # constexpr unroll
+    src_lane = 2 * k_lane + i // 4      # the 4-per-lane -> 8-per-lane remap
+    q_reg[i]    = mul(bcast(q_src[i & 3], src_lane), q_scale)
+    k_reg[i]    = mul(bcast(k_src[i & 3], src_lane), k_scale)
+    gate_reg[i] = exp(bcast(gate_src[i & 3], src_lane))
+    # instruction_selection: shfl.sync.idx.b32 x3 + mul.ftz.f32 x2 + ex2.approx.ftz.f32
+    # extent: 8 iterations; the exp is __expf, i.e. a mul by log2(e) folded into
+    # the ex2 operand -- GATE_KIND == 0 means `g` arrives as a LOG-gate.
+
+# ===========================================================================
+# Phase 4: k_dot_q -- 16-lane butterfly  (:165-176)
+# ===========================================================================
+# Source association (:167), copied verbatim:
+#   (k0q0 + k1q1 + (k2q2 + k3q3)) + (k4q4 + k5q5 + (k6q6 + k7q7))
+k_dot_q = dot(k_reg, q_reg)
+# instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 + add.ftz.f32; extent: 8-term chain
+
+for offset in (8, 4, 2, 1):            # 16-lane group only, NOT 32
+    k_dot_q = add(k_dot_q, bfly(k_dot_q, offset))
+# instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 4 rounds
+# Both half-warps end up holding the value they need; that is why the width is
+# 16 here and 32 for the L2 norms above.
+
+beta_value = cast(f32, beta[token_pos, hv])     # already sigmoided by the caller
+# instruction_selection: ld.global.nc.b16 + cvt.f32.bf16; extent: scalar
+
+# ===========================================================================
+# Phase 5: the row loop  (:181-268)
+# ===========================================================================
+state_rows = reg_tile(f32, [4, 8])     # 4 value rows x 8 K elements; 32 registers
+
+for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:182)
+    # ---- issue all four state-row loads before any math (:184-208) ----------
+    # Prefetching the whole tile first is the source's own structure; the decay
+    # math below depends on every row, so interleaving would serialise the
+    # misses.
+    for row_local in range(4):         # constexpr unroll
+        row = tile_row_base + v_lane + 2 * (row_block * 4 + row_local)
+        copy_g2r(state[initial_slot, hv, row, k_lane*8 : +8],
+                 state_rows[row_local], hint="L1::no_allocate")
+        # instruction_selection: ld.global.L1::no_allocate.v4.b32; extent: one
+        # 16-byte tile (8 bf16) per row, 4 rows
+        # The eviction hint is the source's (:193): the recurrent state streams
+        # through exactly once, so L1 is left for q/k/g/v.
+        # Widened by the same integer pair as phase 1, not by cvt:
+        # instruction_selection: shl.b32 + and.b32; extent: 4 words per row
+
+    # ---- delta rule, one value row at a time (:210-267) ---------------------
+    for row_local in range(4):         # constexpr unroll
+        row = tile_row_base + v_lane + 2 * (row_block * 4 + row_local)
+
+        # Decay and both projections share one pass over the row. The source
+        # accumulates sequentially (:212-216), not as a tree:
+        pred = 0.0; base = 0.0
+        for i in range(8):
+            h_decay = mul(state_rows[row_local][i], gate_reg[i])
+            pred = fma(h_decay, k_reg[i], pred)
+            base = fma(h_decay, q_reg[i], base)
+        # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 x2; extent: 8 iterations
+
+        for offset in (8, 4, 2, 1):
+            pred = add(pred, bfly(pred, offset))
+        for offset in (8, 4, 2, 1):
+            base = add(base, bfly(base, offset))
+        # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 4 rounds x 2
+
+        # ---- v: one scalar load, then a broadcast (:242-245) ----------------
+        v_value = 0.0
+        if k_lane == 0:
+            v_value = cast(f32, v[token_pos, hv, row])
+            # instruction_selection: ld.global.nc.b16 + cvt.f32.bf16; extent: scalar
+        v_value = bcast(v_value, v_lane * 16)
+        # instruction_selection: shfl.sync.idx.b32; extent: scalar
+        # One load per row instead of 16 redundant ones; the source lane index is
+        # v_lane*16 so each half-warp picks up its own row's value.
+
+        delta = mul(sub(v_value, pred), beta_value)
+        # instruction_selection: sub.ftz.f32 + mul.ftz.f32; extent: scalar
+
+        # ---- rank-1 update, in registers (:246-248) ------------------------
+        for i in range(8):
+            state_rows[row_local][i] = fma(delta, k_reg[i],
+                                           mul(state_rows[row_local][i], gate_reg[i]))
+        # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32; extent: 8 iterations
+        # The decayed value is recomputed rather than reused from the pred/base
+        # pass; the source does the same, and it is what keeps the register tile
+        # at 32.
+
+        # ---- publish (:249-266) --------------------------------------------
+        if active:
+            words = reg_tile(u32, [4])
+            for p in range(4):
+                words[p] = cast(bf16x2, (state_rows[row_local][2*p],
+                                         state_rows[row_local][2*p+1]))
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: 4 pairs
+            copy_r2g(words, state[initial_slot, hv, row, k_lane*8 : +8])
+            # instruction_selection: st.global.v4.b32; extent: one 16-byte tile
+            if k_lane == 0:
+                copy_r2g(cast(bf16, add(base, mul(delta, k_dot_q))),
+                         out[token_pos, hv, row])
+                # instruction_selection: fma.rn.ftz.f32 + cvt.rn.bf16.f32 +
+                # st.global.b16; extent: scalar
+                # o = q.S_new is folded as base + delta*k_dot_q, so the updated
+                # state is never re-read.
+        elif has_token and k_lane == 0:
+            copy_r2g(cast(bf16, 0.0), out[token_pos, hv, row])
+            # instruction_selection: st.global.b16; extent: scalar
+            # An in-row but inactive sequence zeroes its output and leaves the
+            # state slot untouched.
+```
+
+## Inactive-row contract
+
+Three states, and the sketch must keep them distinct because the correctness
+gate tests all three:
+
+| `raw_slot` | `has_token` | state | out |
+| --- | --- | --- | --- |
+| `>= 0` | true | rewritten at `raw_slot` | `base + delta*k_dot_q` |
+| `< 0` | true | untouched (`initial_slot` clamps to 0 but `active` gates the store) | zeroed |
+| any | false | untouched | not written at all |
+
+## Static specialization and launch boundary
+
+| value | where it is fixed | note |
+| --- | --- | --- |
+| `VALUE_SPLIT` | host, from `work` vs `2*sm_count` | the only knob; 16 and 8 are the only reachable values at T=1 |
+| `TILE_ROW_STRIDE`, `ROW_BLOCKS` | derived from `VALUE_SPLIT` | the three-line diff between the two exports |
+| `H`, `HV`, `HEAD_RATIO` | host, per call | constexpr in the port; runtime ints in the source |
+| `GATE_TOKEN_STRIDE`, `STATE_SLOT_STRIDE` | host, from tensor strides | constexpr in the port |
+| `scale` | runtime | stays a runtime argument, as in the source |
+| eps `1e-6` | hardcoded in the body | not an argument |
+
+## Instruction-selection summary
+
+Read off the exported line-info PTX for both variants
+(`.porting/flashkda_decode_t1_precomputed/ptx/split{16,8}/kernel.ptx`), which is
+the evidence for every annotation above. Body totals, split16 / split8:
+
+| form | 16 | 8 | where |
+| --- | ---: | ---: | --- |
+| `fma.rn.ftz.f32` | 108 | 108 | every dot chain and the rank-1 update |
+| `mul.ftz.f32` | 69 | 69 | scales, decay, `delta`, the `__expf` log2(e) fold |
+| `add.ftz.f32` | 53 | 53 | butterflies and the dot tails |
+| `shfl.sync.bfly.b32` | 46 | 46 | 2x5 L2 rounds + 4 rounds x (k_dot_q, pred, base) |
+| `shfl.sync.idx.b32` | 29 | 29 | the 3x8 redistribution + one v broadcast per row |
+| `shl.b32` / `and.b32` | 31/25 | 34/25 | bf16 -> f32 widening, vectors and state rows |
+| `cvt.rn.bf16x2.f32` | 16 | 16 | 4 pairs x 4 rows, the state store |
+| `ex2.approx.ftz.f32` | 8 | 8 | the gate, one per K element per lane |
+| `cvt.rn.bf16.f32` + `st.global.b16` | 8 + 8 | 8 + 8 | the scalar out stores, both branches |
+| `cvt.f32.bf16` | 5 | 5 | `beta` (1) and `v` (4 rows) -- the scalar loads |
+| `ld.global.nc.v2.b32` | 3 | 3 | q, k, g |
+| `ld.global.L1::no_allocate.v4.b32` | 4 | 4 | the state rows |
+| `st.global.v4.b32` | 4 | 4 | the state rows |
+| `rsqrt.approx.ftz.f32` | 2 | 2 | the two L2 norms |
+| total | 557 | 571 | |
+
+Three consequences the port must honour:
+
+1. **Everything float is `.ftz`.** `-use_fast_math` (`jit/core.py:545`) plus plain
+   CUDA operators give `mul.ftz.f32` / `add.ftz.f32` / `sub.ftz.f32` /
+   `fma.rn.ftz.f32`, and `__expf` / `rsqrtf` give `ex2.approx.ftz.f32` /
+   `rsqrt.approx.ftz.f32`. This is the **opposite** of the CuTe-DSL KDA decode
+   siblings, whose source emitted no `.ftz` and which therefore needed explicit
+   non-FTZ helpers. Reusing those helpers here would be a divergence.
+2. **`__restrict__` buys `.nc`.** q, k, g, v and beta all load through
+   `ld.global.nc.*`; only the state, which is written, does not. The state's
+   `L1::no_allocate` hint is separate and explicit in the source.
+3. **The widening asymmetry is deliberate.** Vector loads widen with the
+   `shl`/`and` integer pair; the two scalar loads (`beta`, `v`) use
+   `cvt.f32.bf16`. Both forms appear in the PTX and both must be reproduced.
+
+The two variants compile to the same instruction stream; the split8 body differs
+only by the extra `row_block` trip (+3 `shl.b32`, +3 `add.s32`, +1 `bra`, +4
+`mov.pred`), because `#pragma unroll 1` keeps a single copy of the row body.
+
+## TIRx module and benchmark contract
+
+- Module `tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py`,
+  `KERNEL_META["name"] = "flashkda_decode_t1_precomputed"`, cc 10.
+- Reference: the frozen export itself, through the JIT module's direct ABI
+  (`flashinfer.jit.flash_kda_decode.get_flash_kda_decode_module`), so the
+  comparison is kernel-only and inactive rows are reachable.
+- 11 bench rows cover both split sides at `HV = H = 16` and `12` plus GQA
+  `HV = 32, H = 16`; `verify_dispatch.py` asserts each row's split against
+  FlashInfer's own selector.

--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
@@ -106,7 +106,7 @@ HEAD_DIM     = 128
 THREADS      = 32                       # __launch_bounds__(32); one warp
 VALUE_SPLIT                             # 16 or 8; the only free knob
 TILE_ROW_STRIDE = 128 // VALUE_SPLIT    # 8 or 16 value rows per CTA  (:79)
-ROW_BLOCKS      = TILE_ROW_STRIDE // 8  # 1 or 2                      (:181)
+ROW_BLOCKS      = TILE_ROW_STRIDE // 8  # 1 or 2                      (:182)
 K_LANES, V_LANES = 16, 2
 H, HV, HEAD_RATIO                       # HV % H == 0, HV >= H
 GATE_TOKEN_STRIDE                       # g.stride(1); the only non-compact input
@@ -234,7 +234,9 @@ beta_value = cast(f32, beta[token_pos, hv])     # already sigmoided by the calle
 # ===========================================================================
 state_rows = reg_tile(f32, [4, 8])     # 4 value rows x 8 K elements; 32 registers
 
-for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:182)
+for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:181)
+    # The trip count itself is the constant on :182, one of the three that
+    # differ between the two exports.
     # ---- issue all four state-row loads before any math (:184-208) ----------
     # Prefetching the whole tile first is the source's own structure; the decay
     # math below depends on every row, so interleaving would serialise the
@@ -358,7 +360,7 @@ the evidence for every annotation above. Body totals, split16 / split8:
 | `shfl.sync.bfly.b32` | 46 | 46 | 5+5 L2 rounds, then 4 rounds x (k_dot_q, and pred/base per row) |
 | `shfl.sync.idx.b32` | 29 | 29 | 24 redistribution (:155-162) + 4 v broadcasts (:241,:244) + 1 dead `make_warp_uniform` (:39) |
 | `shl.b32` | 31 | 34 | 22 bf16 widening (6 vector at :102/:116/:130, 16 state at :205); the other 9 are index arithmetic |
-| `and.b32` | 25 | 25 | 23 at the widening sites, 2 index arithmetic (`lane & 15`, `tile_row_base`) |
+| `and.b32` | 25 | 25 | 22 bf16 widening (paired 1:1 with the `shl`), 3 index arithmetic: `lane & 15`, `tile_row_base`, and `lane & 16` for the v-broadcast source lane |
 | `cvt.rn.bf16x2.f32` | 16 | 16 | 4 pairs x 4 rows, the state store |
 | `ex2.approx.ftz.f32` | 8 | 8 | the gate, one per K element per lane |
 | `cvt.rn.bf16.f32` | 8 | 8 | 4 active out stores + 4 zero-fill stores |
@@ -372,6 +374,12 @@ the evidence for every annotation above. Body totals, split16 / split8:
 | `ld.global.nc.b32` | 3 | 3 | `cu_seqlens[n]`, `cu_seqlens[n+1]`, `ssm_state_indices[n]` |
 | `rsqrt.approx.ftz.f32` | 2 | 2 | the two L2 norms |
 | total | 558 | 572 | including the trailing `ret` |
+
+Count the widening pair by its `0xffff0000` operand, not by source line: split16
+schedules `and.b32 %r, %r, 16` (the `v_lane*16` broadcast lane) into `.loc :205`,
+where the state-row widening lives, while split8 attributes the same instruction
+to `.loc :71`. A per-`.loc` census therefore reports a 23rd widening `and` in
+split16 that does not exist; the widening counts are 22 `shl` / 22 `and` in both.
 
 Three consequences the port must honour:
 

--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md
@@ -73,8 +73,11 @@ Data movement:
 ```python
 copy_g2r(gmem_slice, reg, hint=None)   # global -> register
 copy_r2g(reg, gmem_slice, pred=None)   # register -> global
-bcast(value, src_lane)                 # one lane's value to the whole warp
-bfly(value, lane_xor)                  # butterfly exchange
+bcast(value, src_lane, 31, 0xFFFFFFFF) # one lane's value to the whole warp
+bfly(value, lane_xor, 31, 0xFFFFFFFF)  # butterfly exchange
+# Every shuffle in this kernel is width-32 with a full member mask; the operands
+# are always (clamp 31, mask 0xFFFFFFFF). A reduction that only wants 16 lanes
+# restricts its *xor offset set*, never the instruction width.
 ```
 
 Compute:
@@ -103,7 +106,7 @@ HEAD_DIM     = 128
 THREADS      = 32                       # __launch_bounds__(32); one warp
 VALUE_SPLIT                             # 16 or 8; the only free knob
 TILE_ROW_STRIDE = 128 // VALUE_SPLIT    # 8 or 16 value rows per CTA  (:79)
-ROW_BLOCKS      = TILE_ROW_STRIDE // 8  # 1 or 2                      (:182)
+ROW_BLOCKS      = TILE_ROW_STRIDE // 8  # 1 or 2                      (:181)
 K_LANES, V_LANES = 16, 2
 H, HV, HEAD_RATIO                       # HV % H == 0, HV >= H
 GATE_TOKEN_STRIDE                       # g.stride(1); the only non-compact input
@@ -125,6 +128,11 @@ hv         = work // VALUE_SPLIT
 n          = cta_id.y
 query_head = hv // HEAD_RATIO           # the GQA fold
 lane       = thread_id.x
+# The source also calls make_warp_uniform(tid/32) at :55. With one warp per CTA
+# the result is unused, but it is `asm volatile` so it survives DCE and emits a
+# dead `mov.b32 0` + `shfl.sync.idx.b32` at kernel entry (.loc :39). The port has
+# no reason to reproduce it; it is called out here only so the 29 shfl.sync.idx
+# in the table below reconcile.
 k_lane     = lane & 15                  # 16 lanes x 8 elements = 128 K
 v_lane     = lane // 16                 # selects one of two interleaved rows
 
@@ -174,15 +182,19 @@ q_sum_sq = dot(q_src, q_src)
 k_sum_sq = dot(k_src, k_src)
 # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 + add.ftz.f32; extent: 4-term chain each
 
-for offset in (16, 8, 4, 2, 1):        # full-warp, unlike the 16-lane dot reduce
-    q_sum_sq = add(q_sum_sq, bfly(q_sum_sq, offset))
-    k_sum_sq = add(k_sum_sq, bfly(k_sum_sq, offset))
-# instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds x 2 values
+# Two independent reduction loops, run back to back (:139-143 then :144-148).
+# They are NOT fused: q_sum_sq completes all five rounds before k_sum_sq starts.
+for offset in (16, 8, 4, 2, 1):        # offsets reach 16 -> the group is 32 lanes
+    q_sum_sq = add(q_sum_sq, bfly(q_sum_sq, offset, 31, 0xFFFFFFFF))
+# instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds
+for offset in (16, 8, 4, 2, 1):
+    k_sum_sq = add(k_sum_sq, bfly(k_sum_sq, offset, 31, 0xFFFFFFFF))
+# instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds
 
 q_scale = mul(rsqrt(add(q_sum_sq, 1e-6)), scale)   # `scale` multiplies q ONLY
 k_scale = rsqrt(add(k_sum_sq, 1e-6))
 # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar (x2)
-# eps is hardcoded 1e-6f in the source (:148,:150), not a runtime argument.
+# eps is hardcoded 1e-6f in the source (:149,:151), not a runtime argument.
 
 # ===========================================================================
 # Phase 3: lane redistribution 4-per-lane -> 8-per-lane, and the gate  (:153-164)
@@ -190,12 +202,14 @@ k_scale = rsqrt(add(k_sum_sq, 1e-6))
 q_reg = reg_tile(f32, [8]); k_reg = reg_tile(f32, [8]); gate_reg = reg_tile(f32, [8])
 for i in range(8):                      # constexpr unroll
     src_lane = 2 * k_lane + i // 4      # the 4-per-lane -> 8-per-lane remap
-    q_reg[i]    = mul(bcast(q_src[i & 3], src_lane), q_scale)
-    k_reg[i]    = mul(bcast(k_src[i & 3], src_lane), k_scale)
-    gate_reg[i] = exp(bcast(gate_src[i & 3], src_lane))
-    # instruction_selection: shfl.sync.idx.b32 x3 + mul.ftz.f32 x2 + ex2.approx.ftz.f32
-    # extent: 8 iterations; the exp is __expf, i.e. a mul by log2(e) folded into
-    # the ex2 operand -- GATE_KIND == 0 means `g` arrives as a LOG-gate.
+    q_reg[i]    = mul(bcast(q_src[i & 3], src_lane, 31, 0xFFFFFFFF), q_scale)
+    k_reg[i]    = mul(bcast(k_src[i & 3], src_lane, 31, 0xFFFFFFFF), k_scale)
+    gate_reg[i] = exp(bcast(gate_src[i & 3], src_lane, 31, 0xFFFFFFFF))
+    # instruction_selection: shfl.sync.idx.b32 x3 + mul.ftz.f32 x3 + ex2.approx.ftz.f32
+    # extent: 8 iterations. `__expf(x)` lowers to `mul.ftz.f32 x, 0f3FB8AA3B`
+    # (log2 e) followed by `ex2.approx.ftz.f32` -- a separate emitted mul, not an
+    # operand fold, which is why this loop issues three muls per iteration.
+    # GATE_KIND == 0 means `g` arrives as a LOG-gate.
 
 # ===========================================================================
 # Phase 4: k_dot_q -- 16-lane butterfly  (:165-176)
@@ -205,11 +219,12 @@ for i in range(8):                      # constexpr unroll
 k_dot_q = dot(k_reg, q_reg)
 # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 + add.ftz.f32; extent: 8-term chain
 
-for offset in (8, 4, 2, 1):            # 16-lane group only, NOT 32
-    k_dot_q = add(k_dot_q, bfly(k_dot_q, offset))
+for offset in (8, 4, 2, 1):            # offsets stop at 8 -> the group is 16 lanes
+    k_dot_q = add(k_dot_q, bfly(k_dot_q, offset, 31, 0xFFFFFFFF))
 # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 4 rounds
-# Both half-warps end up holding the value they need; that is why the width is
-# 16 here and 32 for the L2 norms above.
+# The instruction stays full-warp (clamp 31, mask 0xFFFFFFFF); dropping the 16
+# offset is what makes each half-warp reduce only within itself, so both halves
+# end up holding the value their own value rows need.
 
 beta_value = cast(f32, beta[token_pos, hv])     # already sigmoided by the caller
 # instruction_selection: ld.global.nc.b16 + cvt.f32.bf16; extent: scalar
@@ -240,12 +255,13 @@ for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:182)
         row = tile_row_base + v_lane + 2 * (row_block * 4 + row_local)
 
         # Decay and both projections share one pass over the row. The source
-        # accumulates sequentially (:212-216), not as a tree:
+        # accumulates sequentially (:217-223), not as a tree:
         pred = 0.0; base = 0.0
+        h_decay = reg_tile(f32, [8])       # stays live into the update below
         for i in range(8):
-            h_decay = mul(state_rows[row_local][i], gate_reg[i])
-            pred = fma(h_decay, k_reg[i], pred)
-            base = fma(h_decay, q_reg[i], base)
+            h_decay[i] = mul(state_rows[row_local][i], gate_reg[i])
+            pred = fma(h_decay[i], k_reg[i], pred)
+            base = fma(h_decay[i], q_reg[i], base)
         # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32 x2; extent: 8 iterations
 
         for offset in (8, 4, 2, 1):
@@ -267,16 +283,18 @@ for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:182)
         delta = mul(sub(v_value, pred), beta_value)
         # instruction_selection: sub.ftz.f32 + mul.ftz.f32; extent: scalar
 
-        # ---- rank-1 update, in registers (:246-248) ------------------------
+        # ---- rank-1 update, in registers (:247-250) ------------------------
         for i in range(8):
-            state_rows[row_local][i] = fma(delta, k_reg[i],
-                                           mul(state_rows[row_local][i], gate_reg[i]))
-        # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32; extent: 8 iterations
-        # The decayed value is recomputed rather than reused from the pred/base
-        # pass; the source does the same, and it is what keeps the register tile
-        # at 32.
+            state_rows[row_local][i] = fma(delta, k_reg[i], h_decay[i])
+        # instruction_selection: fma.rn.ftz.f32; extent: 8 iterations, no mul
+        # The source spells this as `state*gate + delta*k` (:249), but the decayed
+        # product is the h_decay computed in the pred/base pass and the compiler
+        # keeps it: `.loc :249` emits 8 fma per row (32 across the unrolled tile)
+        # and ZERO mul, with the `.loc :219` h_decay registers as the addends.
+        # Recomputing the product here would add 8 mul per row that the source
+        # does not issue.
 
-        # ---- publish (:249-266) --------------------------------------------
+        # ---- publish (:251-266) --------------------------------------------
         if active:
             words = reg_tile(u32, [4])
             for p in range(4):
@@ -286,15 +304,20 @@ for row_block in range(ROW_BLOCKS):    # `#pragma unroll 1` in the source (:182)
             copy_r2g(words, state[initial_slot, hv, row, k_lane*8 : +8])
             # instruction_selection: st.global.v4.b32; extent: one 16-byte tile
             if k_lane == 0:
-                copy_r2g(cast(bf16, add(base, mul(delta, k_dot_q))),
+                copy_r2g(cast(bf16, fma(delta, k_dot_q, base)),
                          out[token_pos, hv, row])
                 # instruction_selection: fma.rn.ftz.f32 + cvt.rn.bf16.f32 +
                 # st.global.b16; extent: scalar
                 # o = q.S_new is folded as base + delta*k_dot_q, so the updated
-                # state is never re-read.
+                # state is never re-read. The source writes it as `base + delta*kq`
+                # (:262) and the compiler contracts it: `.loc :262` emits ONE
+                # fma.rn.ftz.f32 per row, not a mul and an add. Spelling it as
+                # mul-then-add would round twice and diverge in the last bits.
         elif has_token and k_lane == 0:
             copy_r2g(cast(bf16, 0.0), out[token_pos, hv, row])
-            # instruction_selection: st.global.b16; extent: scalar
+            # instruction_selection: mov.b32 0 + cvt.rn.bf16.f32 + st.global.b16
+            # extent: scalar. The zero is not constant-folded through the cvt,
+            # which is where 4 of the 8 cvt.rn.bf16.f32 come from.
             # An in-row but inactive sequence zeroes its output and leaves the
             # state slot untouched.
 ```
@@ -329,21 +352,26 @@ the evidence for every annotation above. Body totals, split16 / split8:
 
 | form | 16 | 8 | where |
 | --- | ---: | ---: | --- |
-| `fma.rn.ftz.f32` | 108 | 108 | every dot chain and the rank-1 update |
-| `mul.ftz.f32` | 69 | 69 | scales, decay, `delta`, the `__expf` log2(e) fold |
-| `add.ftz.f32` | 53 | 53 | butterflies and the dot tails |
-| `shfl.sync.bfly.b32` | 46 | 46 | 2x5 L2 rounds + 4 rounds x (k_dot_q, pred, base) |
-| `shfl.sync.idx.b32` | 29 | 29 | the 3x8 redistribution + one v broadcast per row |
-| `shl.b32` / `and.b32` | 31/25 | 34/25 | bf16 -> f32 widening, vectors and state rows |
+| `fma.rn.ftz.f32` | 108 | 108 | dot chains (L2, k_dot_q, pred/base) and the rank-1 update; also the contracted out store |
+| `mul.ftz.f32` | 69 | 69 | 4 L2 dots + 4 k_dot_q + 1 q_scale + 16 q/k_reg scaling + 8 `__expf` log2(e) + 32 h_decay + 4 delta |
+| `add.ftz.f32` | 53 | 53 | 10 L2 butterfly + 2 eps + 4 k_dot_q butterfly + 32 pred/base butterfly + 5 dot tails |
+| `shfl.sync.bfly.b32` | 46 | 46 | 5+5 L2 rounds, then 4 rounds x (k_dot_q, and pred/base per row) |
+| `shfl.sync.idx.b32` | 29 | 29 | 24 redistribution (:155-162) + 4 v broadcasts (:241,:244) + 1 dead `make_warp_uniform` (:39) |
+| `shl.b32` | 31 | 34 | 22 bf16 widening (6 vector at :102/:116/:130, 16 state at :205); the other 9 are index arithmetic |
+| `and.b32` | 25 | 25 | 23 at the widening sites, 2 index arithmetic (`lane & 15`, `tile_row_base`) |
 | `cvt.rn.bf16x2.f32` | 16 | 16 | 4 pairs x 4 rows, the state store |
 | `ex2.approx.ftz.f32` | 8 | 8 | the gate, one per K element per lane |
-| `cvt.rn.bf16.f32` + `st.global.b16` | 8 + 8 | 8 + 8 | the scalar out stores, both branches |
+| `cvt.rn.bf16.f32` | 8 | 8 | 4 active out stores + 4 zero-fill stores |
+| `st.global.b16` | 8 | 8 | the same two branches |
 | `cvt.f32.bf16` | 5 | 5 | `beta` (1) and `v` (4 rows) -- the scalar loads |
-| `ld.global.nc.v2.b32` | 3 | 3 | q, k, g |
-| `ld.global.L1::no_allocate.v4.b32` | 4 | 4 | the state rows |
+| `ld.global.nc.b16` | 5 | 5 | `beta` (1) and `v` (4 rows) |
+| `sub.ftz.f32` | 4 | 4 | `v - pred`, one per row |
 | `st.global.v4.b32` | 4 | 4 | the state rows |
+| `ld.global.L1::no_allocate.v4.b32` | 4 | 4 | the state rows |
+| `ld.global.nc.v2.b32` | 3 | 3 | q, k, g |
+| `ld.global.nc.b32` | 3 | 3 | `cu_seqlens[n]`, `cu_seqlens[n+1]`, `ssm_state_indices[n]` |
 | `rsqrt.approx.ftz.f32` | 2 | 2 | the two L2 norms |
-| total | 557 | 571 | |
+| total | 558 | 572 | including the trailing `ret` |
 
 Three consequences the port must honour:
 
@@ -360,9 +388,11 @@ Three consequences the port must honour:
    `shl`/`and` integer pair; the two scalar loads (`beta`, `v`) use
    `cvt.f32.bf16`. Both forms appear in the PTX and both must be reproduced.
 
-The two variants compile to the same instruction stream; the split8 body differs
-only by the extra `row_block` trip (+3 `shl.b32`, +3 `add.s32`, +1 `bra`, +4
-`mov.pred`), because `#pragma unroll 1` keeps a single copy of the row body.
+The two variants compile to the same instruction stream. `#pragma unroll 1` keeps
+a single copy of the row body, so the extra `row_block` trip costs only its loop
+mechanics -- the complete split16 -> split8 delta is `+3 shl.b32`, `+3 add.s32`,
+`+3 mov.pred`, `+2 mov.b32`, `+1 bra`, `+1 cvta.to.global.u64`,
+`+1 ld.param.b64` = +14, and every floating-point count is unchanged.
 
 ## TIRx module and benchmark contract
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ point each port backs:
 | Kernel | dtype | What it is |
 | ------ | ----- | ---------- |
 | `flashkda_bf16_fused_m128` | bf16 | Recurrent KDA prefill, M128 schedule |
+| `recurrent_kda_decode_one_warp` | bf16 | Recurrent KDA decode, one warp per CTA (T=1, `sequence_heads >= 128`) |
+| `recurrent_kda_decode_grouped` | bf16 | Recurrent KDA decode, grouped CTA (small-batch T=1 and all speculative T>1) |
+| `flashkda_decode_t1_precomputed` | bf16 | FlashKDA "cake" decode, T=1 precomputed gate |
 
 `flashinfer/gdn_prefill/` — `flashinfer.gdn_prefill`:
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "ea0950ab",
-    "tirx-kernels": "b3be0123",
+    "tirx-kernels": "98747523",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "ba8163542076d30ce12bc983cf424f2bcbbeb396"
+    "tirx-kernels:tirx_kernels": "2b7792906e560fab01fb004a811cce56381d4ca4"
   },
   "baselines": {
     "torch": {
@@ -1639,6 +1639,160 @@
         "tirx": 432.01961649433497,
         "flashinfer_m128": 436.53779708036194,
         "flashkda_raw": 708.6739694284662
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv12h12_b64_s8",
+      "label": "hv12h12_b64_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.259361494303159,
+        "flashinfer_cake": 15.736388312899836
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv12h12_b8_s16",
+      "label": "hv12h12_b8_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.719541169780189,
+        "flashinfer_cake": 6.262137962531812
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b128_s8",
+      "label": "hv16h16_b128_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 28.778753873422723,
+        "flashinfer_cake": 32.13913212721831
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b16_s16",
+      "label": "hv16h16_b16_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.260000532182204,
+        "flashinfer_cake": 8.152864308839414
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b1_s16",
+      "label": "hv16h16_b1_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.136541655453699,
+        "flashinfer_cake": 5.7675148024992735
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b32_s8",
+      "label": "hv16h16_b32_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.015249772128083,
+        "flashinfer_cake": 13.356300670442216
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b4_s16",
+      "label": "hv16h16_b4_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.5147843857516365,
+        "flashinfer_cake": 5.7301633125823015
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b64_s8",
+      "label": "hv16h16_b64_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 16.60930283625364,
+        "flashinfer_cake": 19.417524169162398
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv16h16_b8_s16",
+      "label": "hv16h16_b8_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.000787580254269,
+        "flashinfer_cake": 6.338666961276744
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv32h16_b32_s8",
+      "label": "hv32h16_b32_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 16.627576137423702,
+        "flashinfer_cake": 19.36841917895613
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t1_precomputed",
+      "config": "hv32h16_b8_s16",
+      "label": "hv32h16_b8_s16",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.2427481930603355,
+        "flashinfer_cake": 7.913243303966552
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': 'b3be0123', 'tirx-bench-ci': None}`
-- Workloads: 258 ok, 0 failed
+- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '98747523', 'tirx-bench-ci': None}`
+- Workloads: 269 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -197,6 +197,22 @@ Grouped workloads show one row per config and one timing column per implementati
 | `h96_fixed8192` | tirx | 500.8359 | flashinfer_m128 | 508.1553 | 1.015 | flashkda_raw=1075.1109 |
 | `h96_mixed` | tirx | 609.2198 | flashinfer_m128 | 622.6901 | 1.022 | flashkda_raw=1403.8307 |
 | `h96_uniform` | tirx | 432.0196 | flashinfer_m128 | 436.5378 | 1.010 | flashkda_raw=708.6740 |
+
+## flashkda_decode_t1_precomputed
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv12h12_b64_s8` | tirx | 14.2594 | flashinfer_cake | 15.7364 | 1.104 | — |
+| `hv12h12_b8_s16` | tirx | 4.7195 | flashinfer_cake | 6.2621 | 1.327 | — |
+| `hv16h16_b128_s8` | tirx | 28.7788 | flashinfer_cake | 32.1391 | 1.117 | — |
+| `hv16h16_b16_s16` | tirx | 6.2600 | flashinfer_cake | 8.1529 | 1.302 | — |
+| `hv16h16_b1_s16` | tirx | 4.1365 | flashinfer_cake | 5.7675 | 1.394 | — |
+| `hv16h16_b32_s8` | tirx | 10.0152 | flashinfer_cake | 13.3563 | 1.334 | — |
+| `hv16h16_b4_s16` | tirx | 4.5148 | flashinfer_cake | 5.7302 | 1.269 | — |
+| `hv16h16_b64_s8` | tirx | 16.6093 | flashinfer_cake | 19.4175 | 1.169 | — |
+| `hv16h16_b8_s16` | tirx | 5.0008 | flashinfer_cake | 6.3387 | 1.268 | — |
+| `hv32h16_b32_s8` | tirx | 16.6276 | flashinfer_cake | 19.3684 | 1.165 | — |
+| `hv32h16_b8_s16` | tirx | 6.2427 | flashinfer_cake | 7.9132 | 1.268 | — |
 
 ## fp16_bf16_gemm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t1_precomputed.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t1_precomputed.yaml
@@ -1,0 +1,27 @@
+# FlashKDA "cake" T=1 precomputed-gate decode, against the frozen FlashInfer
+# export it is ported from.
+#
+# The export's value split is chosen by the host from work = num_seqs *
+# num_value_heads against 2 * sm_count (recurrent_kda.py:1169-1177), so on a
+# 148-SM B200 the boundary is 296. Rows below name the split their shape
+# actually selects, and .porting/.../verify_dispatch.py asserts each one against
+# FlashInfer's own selector -- a row that drifted across the boundary would
+# silently benchmark the other kernel.
+#
+#   hv16h16_b1..b16    split16, HV = H = 16, the whole low-occupancy side
+#   hv16h16_b32..b128  split8, the same head count past the boundary
+#   hv12h12_*          Kimi K3 TP8 per-rank head count, one row per split side
+#   hv32h16_*          GQA ratio 2, matching FlashInfer's own export bench
+kernel: flashkda_decode_t1_precomputed
+configs:
+  - {config: hv16h16_b1_s16, default: true}
+  - {config: hv16h16_b4_s16, default: true}
+  - {config: hv16h16_b8_s16, default: true}
+  - {config: hv16h16_b16_s16, default: true}
+  - {config: hv16h16_b32_s8, default: true}
+  - {config: hv16h16_b64_s8, default: true}
+  - {config: hv16h16_b128_s8, default: true}
+  - {config: hv12h12_b8_s16, default: true}
+  - {config: hv12h12_b64_s8, default: true}
+  - {config: hv32h16_b8_s16, default: true}
+  - {config: hv32h16_b32_s8, default: true}

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -914,10 +914,47 @@ def run_bench(
     timer: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Benchmark entry point. Implemented in the performance gate."""
-    raise SkipTest(
-        "flashkda_decode_t1_precomputed is at the scaffold stage; benchmarking is "
-        "enabled in the performance gate"
+    """Time the port against the frozen cake export on identical inputs."""
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region. Both sides mutate their own state
+    # pool in place, so this also proves the two pools stayed independent.
+    executable(*args)
+    reference_out = _flashinfer_reference(case)
+    torch.cuda.synchronize(case["device"])
+    torch.testing.assert_close(
+        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+    )
+    torch.testing.assert_close(
+        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # The nvcc JIT build and warmup both happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cake": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
     )
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -1,0 +1,516 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx port of FlashInfer's FlashKDA "cake" T=1 precomputed-gate decode kernel.
+
+Source: ``csrc/kda/flashkda_decode_d128_t1_precomputed_direct_split16.cu`` (and
+its ``_split8`` sibling), symbol ``kernel_flashinfer_recurrent_kda_t1_direct``.
+Both bodies are frozen machine-generated exports ("Generated from a recurrent-KDA
+Loom schedule"); FlashInfer asserts their SHA256 in
+``tests/jit/test_flash_kda_decode_jit.py``.
+
+The two exports differ in exactly three lines -- ``value_splits``,
+``tile_row_base``'s multiplier, and the ``row_block`` trip count -- so this module
+carries a single ``VALUE_SPLIT`` constexpr and derives the rest.
+
+Dispatch (``flashinfer/kda_kernels/recurrent_kda.py:1443-1447``) routes every
+``num_tokens == 1`` precomputed call to ``d128_t1_precomputed_direct_split{16,8}``;
+the 679-line non-direct ``t1_precomputed_split{1,2,4,8}`` exports are unreachable
+through ``run_recurrent_kda`` and are out of this port's scope.
+
+Shape of the kernel: one warp per CTA, grid ``(HV * VALUE_SPLIT, num_seqs)``, zero
+shared memory, no barrier, no atomic, no workspace. The value split partitions the
+128 value rows into disjoint slabs, so there is no cross-CTA combine of any kind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+# --- source pinning -------------------------------------------------------
+# The generated body carries its own digest at
+# flashkda_decode_d128_t1_precomputed_direct_split16.cu:19-20; run_test asserts
+# it so a silent upstream regeneration cannot pass unnoticed.
+FROZEN_FLASHINFER_COMMIT = "f2e04400"
+FROZEN_BODY_SHA256 = {16: "9119163b3b5cb6a8760b6a17a7ce01788a0e1c0078f8c812255225f27e5989e5"}
+
+HEAD_DIM = 128
+L2_EPS = 1.0e-6
+# 16 lanes cover the 128-wide K dimension, 8 elements each; the remaining lane
+# bit selects one of two interleaved value rows (direct_split16.cu:69-70).
+K_LANES = 16
+V_LANES = 2
+ELEMS_PER_LANE = HEAD_DIM // 32  # 4: the pre-redistribution q/k/g slice
+K_PER_LANE = HEAD_DIM // K_LANES  # 8: the post-redistribution slice
+ROWS_PER_BLOCK = V_LANES * 4  # 8 value rows per row_block iteration
+
+# TIRX_TRANSCRIBE_START flashkda_decode_t1_precomputed
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror FlashInfer's cake decode export bench."""
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 8,
+        "num_heads": 16,
+        "num_value_heads": 16,
+        "pool_size": 512,
+        "padded_slots": 0,
+        "slot_stride_pad": 0,
+        "gate_token_stride_pad": 0,
+        "scale": None,
+        "seed": 20260812,
+    }
+    config.update(overrides)
+    return config
+
+
+# The split is chosen by `work = num_seqs * num_value_heads` against
+# `2 * sm_count` (recurrent_kda.py:1170-1176); on a 148-SM B200 the boundary is
+# 296. Every row below names the split its shape actually selects, and
+# verify_dispatch.py asserts that against the real selector.
+BENCH_CONFIGS = [
+    # HV == H == 16, split16 side (work = 16, 64, 128, 256).
+    _case("hv16h16_b1_s16", num_seqs=1),
+    _case("hv16h16_b4_s16", num_seqs=4),
+    _case("hv16h16_b8_s16", num_seqs=8),
+    _case("hv16h16_b16_s16", num_seqs=16),
+    # HV == H == 16, split8 side (work = 512, 1024, 2048).
+    _case("hv16h16_b32_s8", num_seqs=32),
+    _case("hv16h16_b64_s8", num_seqs=64),
+    _case("hv16h16_b128_s8", num_seqs=128),
+    # Kimi K3 TP8 per-rank head count, one row per split side (work = 96, 768).
+    _case("hv12h12_b8_s16", num_seqs=8, num_heads=12, num_value_heads=12),
+    _case("hv12h12_b64_s8", num_seqs=64, num_heads=12, num_value_heads=12),
+    # GQA ratio 2, matching FlashInfer's own export bench (work = 256, 1024).
+    _case("hv32h16_b8_s16", num_seqs=8, num_heads=16, num_value_heads=32),
+    _case("hv32h16_b32_s8", num_seqs=32, num_heads=16, num_value_heads=32),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # Split knife edge on a 148-SM B200: work = 296 takes split16, 304 takes
+    # split8 (tests/kda/test_recurrent_kda_decode_export.py:311-320).
+    _case("hv16h16_b18_s16_edge", num_seqs=18),
+    _case("hv16h16_b19_s8_edge", num_seqs=19),
+    # CUDA-graph padding: negative ssm_state_indices rows must leave the state
+    # untouched and zero their output (direct_split16.cu:76-78, :251-266).
+    _case("hv16h16_b16_s16_padded", num_seqs=16, padded_slots=5),
+    # Envelope-strided state pool: slot stride may exceed HV*V*K while staying
+    # 8-element aligned (binding_common.cuh:148-161).
+    _case("hv16h16_b16_s16_strided", num_seqs=16, slot_stride_pad=16),
+    # Envelope-strided gate: g is the only input whose token stride is free
+    # (CheckCompactGate, binding_common.cuh:137-146).
+    _case("hv16h16_b16_s16_gstride", num_seqs=16, gate_token_stride_pad=256),
+    # Non-default scale (the host passes `scale or 1/sqrt(128)`).
+    _case("hv16h16_b8_s16_scale", num_seqs=8, scale=0.05),
+    # GQA ratio 4 on the split8 side.
+    _case("hv64h16_b16_s8", num_seqs=16, num_heads=16, num_value_heads=64),
+]
+
+KERNEL_META = {
+    "name": "flashkda_decode_t1_precomputed",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _sm_count(kwargs: dict[str, Any]) -> int:
+    """SM count driving the split policy; overridable for deterministic tests."""
+    override = kwargs.get("sm_count")
+    if override is not None:
+        return int(override)
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA is required to resolve the FlashKDA decode value split")
+    device = kwargs.get("device", "cuda")
+    return int(torch.cuda.get_device_properties(device).multi_processor_count)
+
+
+def _select_value_split(work: int, sm_count: int) -> int:
+    """Reproduce ``_select_flash_kda_decode_value_split_current`` for T = 1.
+
+    recurrent_kda.py:1170-1176. `work` is `num_seqs * num_value_heads`; the T = 1
+    branch is the whole policy on sm100a, and only 16 and 8 are reachable.
+    """
+    return 16 if work <= 2 * sm_count else 8
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    pool_size = int(kwargs["pool_size"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    gate_token_stride_pad = int(kwargs.get("gate_token_stride_pad", 0))
+
+    if num_value_heads % num_heads != 0 or num_value_heads < num_heads:
+        raise ValueError("num_value_heads must be a multiple of num_heads and >= it")
+    if not 0 < num_seqs <= 65535:
+        raise ValueError("num_seqs must fit grid.y (binding_common.cuh:284-287)")
+    if slot_stride_pad % 8 != 0:
+        raise ValueError("state slot stride padding must stay 8-element aligned")
+    if gate_token_stride_pad % 4 != 0:
+        raise ValueError("gate token stride padding must stay 4-element aligned")
+
+    value_split = _select_value_split(num_seqs * num_value_heads, _sm_count(kwargs))
+    rows_per_cta = HEAD_DIM // value_split
+
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    gate_token_stride = num_value_heads * HEAD_DIM + gate_token_stride_pad
+    return {
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "HEAD_RATIO": num_value_heads // num_heads,
+        "VALUE_SPLIT": value_split,
+        # direct_split{16,8}.cu:79 -- tile_row_base = value_tile * rows_per_cta.
+        "TILE_ROW_STRIDE": rows_per_cta,
+        # direct_split{16,8}.cu:182 -- the `#pragma unroll 1` row_block trip count.
+        "ROW_BLOCKS": rows_per_cta // ROWS_PER_BLOCK,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "GATE_TOKEN_STRIDE": gate_token_stride,
+        "Q_ELEMENTS": num_seqs * num_heads * HEAD_DIM,
+        "V_ELEMENTS": num_seqs * num_value_heads * HEAD_DIM,
+        "GATE_ELEMENTS": num_seqs * gate_token_stride,
+        "BETA_ELEMENTS": num_seqs * num_value_heads,
+        "STATE_ELEMENTS": pool_size * slot_stride,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": num_seqs,
+    }
+
+
+@T.jit
+def _flashkda_decode_t1_precomputed(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    scale: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    HEAD_RATIO: T.constexpr,
+    VALUE_SPLIT: T.constexpr,
+    TILE_ROW_STRIDE: T.constexpr,
+    ROW_BLOCKS: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    GATE_TOKEN_STRIDE: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    GATE_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+):
+    """FlashKDA "cake" T=1 precomputed-gate decode -- scaffold body.
+
+    The implementation is written in the correctness gate, after the kernel
+    sketch has passed review.
+    """
+    T.func_attr({"global_symbol": "flashkda_decode_t1_precomputed", "tir.is_scheduled": 1})
+    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16")
+    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16")
+    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16")
+    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16")
+    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16")
+    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16")
+    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16")
+    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32")
+    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32")
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized FlashKDA cake T=1 decode PrimFunc."""
+    return _flashkda_decode_t1_precomputed.specialize(**_specialization(kwargs))
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state."""
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for FlashKDA cake T=1 decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"FlashKDA cake decode targets compute capability 10.x, got {capability}")
+
+    spec = _specialization({**kwargs, "device": device})
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    gate_token_stride = spec["GATE_TOKEN_STRIDE"]
+    pool_size = int(kwargs["pool_size"])
+    padded_slots = int(kwargs.get("padded_slots", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    q = randn(1, num_seqs, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, num_seqs, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, num_seqs, num_value_heads, HEAD_DIM, gain=0.5)
+    # GATE_KIND == 0: `g` holds the per-K log-gate computed OUTSIDE the kernel,
+    # which applies exp() to it. The upstream test builds it exactly this way
+    # (tests/kda/test_recurrent_kda_decode_export.py:986-1002).
+    gate_logits = torch.randn(
+        (1, num_seqs, num_value_heads, HEAD_DIM), device=device, dtype=torch.float32, generator=gen
+    )
+    g_dense = torch.nn.functional.logsigmoid(gate_logits).to(torch.bfloat16)
+    # `g` is the only input whose token stride is free; an envelope-strided case
+    # exercises the g_stride_token argument.
+    g_raw = torch.zeros((num_seqs * gate_token_stride,), device=device, dtype=torch.bfloat16)
+    g = g_raw.as_strided(
+        (1, num_seqs, num_value_heads, HEAD_DIM),
+        (num_seqs * gate_token_stride, gate_token_stride, HEAD_DIM, 1),
+    )
+    g.copy_(g_dense)
+    # beta arrives pre-sigmoided (kda_decode.py:97-98); the kernel reads it raw.
+    beta = torch.sigmoid(randn(1, num_seqs, num_value_heads, dtype=torch.float32, gain=0.5)).to(
+        torch.bfloat16
+    )
+
+    cu_seqlens = torch.arange(num_seqs + 1, device=device, dtype=torch.int32)
+    slots = torch.arange(num_seqs, device=device, dtype=torch.int32)
+    if padded_slots:
+        slots[num_seqs - padded_slots :] = -1
+    num_accepted_tokens = torch.ones(num_seqs, device=device, dtype=torch.int32)
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(pool_size * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (pool_size, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (pool_size, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, num_seqs, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    scale = kwargs.get("scale")
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "g_raw": g_raw,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": slots,
+        "num_accepted_tokens": num_accepted_tokens,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": float(scale) if scale is not None else HEAD_DIM**-0.5,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g_raw"],
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        float(case["scale"]),
+    )
+
+
+def _source_body_path(value_split: int) -> str:
+    """Absolute path of the frozen generated body this port transcribes."""
+    import flashinfer  # local: keep kernel discovery free of optional deps
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    return os.path.join(
+        root, "csrc", "kda", f"flashkda_decode_d128_t1_precomputed_direct_split{value_split}.cu"
+    )
+
+
+def assert_frozen_source(value_split: int) -> None:
+    """Fail loudly if the upstream generated body was regenerated.
+
+    The body declares its own digest at direct_split16.cu:19-20; this checks the
+    same bytes the port was transcribed from.
+    """
+    expected = FROZEN_BODY_SHA256.get(value_split)
+    if expected is None:
+        return
+    path = _source_body_path(value_split)
+    with open(path, "rb") as handle:
+        text = handle.read().decode()
+    marker = "// BEGIN FROZEN GENERATED BODY\n"
+    start = text.index(marker) + len(marker)
+    end = text.index("// END FROZEN GENERATED BODY")
+    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
+    if digest != expected:
+        raise AssertionError(
+            f"{path}: frozen body digest {digest} != pinned {expected}; the upstream "
+            "export was regenerated and this port must be re-verified against it"
+        )
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the frozen cake export itself on the reference state pool.
+
+    Uses the JIT module's direct ABI rather than
+    ``kda_decode.recurrent_kda(backend="cake")`` so the comparison is kernel-only
+    and so inactive (negative-slot) rows -- which the public T=1 wrapper cannot
+    express, since it synthesizes identity metadata -- are reachable.
+    """
+    from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
+
+    spec = case["spec"]
+    value_split = spec["VALUE_SPLIT"]
+    variant = f"d128_t1_precomputed_direct_split{value_split}"
+
+    device = case["device"]
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        target = "sm100f" if torch.version.cuda and torch.version.cuda >= "12.9" else "sm100a"
+    elif (major, minor) == (10, 3):
+        target = "sm103a"
+    else:
+        raise SkipTest(f"FlashKDA cake decode has no export for compute capability {major}.{minor}")
+
+    module = get_flash_kda_decode_module(variant, target)
+    reference_out = torch.empty_like(case["tirx_out"])
+    dummy_f32 = torch.ones(1, device=device, dtype=torch.float32)
+
+    module.run(
+        case["q"],
+        case["k"],
+        case["v"],
+        case["g"],
+        case["beta"],
+        dummy_f32,
+        dummy_f32,
+        case["reference_state"],
+        reference_out,
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+        0.0,
+        int(torch.cuda.current_stream(device).cuda_stream),
+    )
+    torch.cuda.synchronize(device)
+    return reference_out
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the source math (direct_split16.cu:133-267)."""
+    spec = case["spec"]
+    num_seqs = spec["NUM_SEQS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    head_ratio = spec["HEAD_RATIO"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+
+    q = case["q"][0].float()
+    k = case["k"][0].float()
+    v = case["v"][0].float()
+    g = case["g"][0].float()
+    beta = case["beta"][0].float()
+    slots = case["ssm_state_indices"]
+
+    state_raw = case["initial_state_raw"].clone()
+    state = state_raw.as_strided(
+        (state_raw.numel() // slot_stride, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    out = torch.zeros(
+        (num_seqs, num_value_heads, HEAD_DIM), device=case["device"], dtype=torch.float32
+    )
+
+    scale = float(case["scale"])
+    for n in range(num_seqs):
+        slot = int(slots[n].item())
+        if slot < 0:
+            continue
+        for hv in range(num_value_heads):
+            h = hv // head_ratio
+            qn = q[n, h] * (torch.rsqrt(q[n, h].pow(2).sum() + L2_EPS) * scale)
+            kn = k[n, h] * torch.rsqrt(k[n, h].pow(2).sum() + L2_EPS)
+            gamma = torch.exp(g[n, hv])
+            kq = torch.dot(kn, qn)
+
+            s = state[slot, hv].float()
+            decayed = s * gamma.unsqueeze(0)
+            pred = decayed @ kn
+            base = decayed @ qn
+            delta = (v[n, hv] - pred) * beta[n, hv]
+            state[slot, hv] = (decayed + delta.unsqueeze(1) * kn.unsqueeze(0)).to(torch.bfloat16)
+            out[n, hv] = base + delta * kq
+
+    return out.to(torch.bfloat16).unsqueeze(0), state_raw
+
+
+def run_test(**kwargs: Any) -> None:
+    """Correctness entry point. Implemented in the correctness gate."""
+    raise SkipTest(
+        "flashkda_decode_t1_precomputed is at the scaffold stage; the kernel body "
+        "is written in the correctness gate"
+    )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point. Implemented in the performance gate."""
+    raise SkipTest(
+        "flashkda_decode_t1_precomputed is at the scaffold stage; benchmarking is "
+        "enabled in the performance gate"
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "assert_frozen_source",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -46,6 +46,7 @@ FROZEN_BODY_SHA256 = {16: "9119163b3b5cb6a8760b6a17a7ce01788a0e1c0078f8c81225522
 
 HEAD_DIM = 128
 L2_EPS = 1.0e-6
+LOG2_E = 1.4426950408889634
 # 16 lanes cover the 128-wide K dimension, 8 elements each; the remaining lane
 # bit selects one of two interleaved value rows (direct_split16.cu:69-70).
 K_LANES = 16
@@ -55,6 +56,177 @@ K_PER_LANE = HEAD_DIM // K_LANES  # 8: the post-redistribution slice
 ROWS_PER_BLOCK = V_LANES * 4  # 8 value rows per row_block iteration
 
 # TIRX_TRANSCRIBE_START flashkda_decode_t1_precomputed
+
+
+# ---------------------------------------------------------------------------
+# PTX helpers
+# ---------------------------------------------------------------------------
+# Every float op here is `.ftz`. The source compiles from plain CUDA operators
+# under `-use_fast_math` (jit/core.py:545) and its PTX contains 108
+# fma.rn.ftz.f32, 69 mul.ftz.f32, 53 add.ftz.f32, 4 sub.ftz.f32 and zero
+# plain-.f32 arithmetic. That is the opposite of the CuTe-DSL KDA decode
+# siblings, whose source emits no `.ftz` and whose helpers are deliberately
+# non-FTZ -- importing theirs here would be a silent divergence.
+
+
+def _ptx_un(chain: str, a, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a))
+    return out[0]
+
+
+def _ptx_bin(chain: str, a, b, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b))
+    return out[0]
+
+
+def _ptx_ter(chain: str, a, b, c, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b, c))
+    return out[0]
+
+
+def _mul(a, b):
+    """``mul.ftz.f32``."""
+    return _ptx_bin("mul.ftz.f32", a, b)
+
+
+def _add(a, b):
+    """``add.ftz.f32``."""
+    return _ptx_bin("add.ftz.f32", a, b)
+
+
+def _sub(a, b):
+    """``sub.ftz.f32``."""
+    return _ptx_bin("sub.ftz.f32", a, b)
+
+
+def _fma(a, b, c):
+    """``fma.rn.ftz.f32``."""
+    return _ptx_ter("fma.rn.ftz.f32", a, b, c)
+
+
+def _rsqrt(a):
+    """``rsqrt.approx.ftz.f32`` -- `rsqrtf` under fast math."""
+    return _ptx_un("rsqrt.approx.ftz.f32", a)
+
+
+def _expf(a):
+    """``__expf``: one mul by log2(e), then ``ex2.approx.ftz.f32``.
+
+    The mul is a separate emitted instruction, not an operand fold; the source's
+    PTX shows `mul.ftz.f32 %r, %r, 0f3FB8AA3B` immediately before each ex2.
+    """
+    return _ptx_un("ex2.approx.ftz.f32", _mul(a, T.float32(LOG2_E)))
+
+
+def _shfl_bfly(value, lane_xor):
+    """``shfl.sync.bfly.b32``, clamp 31 and full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _shfl_idx(value, source_lane):
+    """``shfl.sync.idx.b32``, clamp 31 and full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.idx.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.cast(source_lane, "uint32"),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _load_i32(buffer, index):
+    """``ld.global.nc.b32`` -- the read-only metadata loads."""
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _load_bf16_f32(buffer, index):
+    """``ld.global.nc.b16`` + ``cvt.f32.bf16`` -- the two scalar loads.
+
+    The scalar path really does use cvt while the vector paths use the shl/and
+    pair; both forms are in the source PTX and the asymmetry is deliberate.
+    """
+    bits = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.nc.b16(bits[0], buffer.ptr_to([index])))
+    return _ptx_un("cvt.f32.bf16", bits[0])
+
+
+# One 32-bit word carries two bf16. The source widens it with an integer pair
+# (:96-102), not `cvt.f32.bf16`, and that survives to PTX, so reproducing the
+# pair keeps the instruction mix aligned. Split in two because TVMScript has no
+# tuple-unpacking assignment.
+
+
+def _widen_lo(word):
+    """``shl.b32 d, word, 16`` -- the low bf16 of the word."""
+    return T.reinterpret("float32", T.shift_left(word, T.uint32(16)))
+
+
+def _widen_hi(word):
+    """``and.b32 d, word, 0xffff0000`` -- the high bf16 of the word."""
+    return T.reinterpret("float32", T.bitwise_and(word, T.uint32(0xFFFF0000)))
+
+
+def _load_u32x2(buffer, index):
+    """``ld.global.nc.v2.b32`` -- one 8-byte tile (four bf16), left packed."""
+    words = T.alloc_local((2,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.v2.b32(words[0], words[1], buffer.ptr_to([index])))
+    return words
+
+
+def _load_state_row(buffer, index):
+    """``ld.global.L1::no_allocate.v4.b32`` -- one 16-byte state row slice.
+
+    The eviction hint is the source's own (:193): the recurrent state streams
+    through exactly once, so L1 is left to q/k/g/v.
+    """
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx["ld.global.L1::no_allocate.v4.b32"](
+            words[0], words[1], words[2], words[3], buffer.ptr_to([index])
+        )
+    )
+    return words
+
+
+def _pack_bf16x2(hi, lo):
+    """``cvt.rn.bf16x2.f32 d, hi, lo`` -- packs (elem[2p+1], elem[2p])."""
+    return _ptx_bin("cvt.rn.bf16x2.f32", hi, lo, dtype="uint32")
+
+
+def _store_u32x4(buffer, index, words):
+    """``st.global.v4.b32`` -- one 16-byte state row slice."""
+    T.evaluate(
+        T.ptx.st.global_.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3])
+    )
+
+
+def _store_f32_as_bf16(buffer, index, value, pred):
+    """``cvt.rn.bf16.f32`` + predicated ``st.global.b16``.
+
+    The store is predicated at the PTX layer rather than wrapped in `if`: an
+    if-wrapped asm block cannot be if-converted by ptxas and costs a real branch.
+    """
+    bits = _ptx_un("cvt.rn.bf16.f32", value, dtype="uint16")
+    T.evaluate(T.ptx.st.global_.b16(buffer.ptr_to([index]), bits, pred=pred))
 
 
 def _case(label: str, **overrides: Any) -> dict[str, Any]:
@@ -219,21 +391,185 @@ def _flashkda_decode_t1_precomputed(
     CU_SEQLENS_ELEMENTS: T.constexpr,
     STATE_INDEX_ELEMENTS: T.constexpr,
 ):
-    """FlashKDA "cake" T=1 precomputed-gate decode -- scaffold body.
+    """FlashKDA "cake" T=1 precomputed-gate decode, one warp per CTA.
 
-    The implementation is written in the correctness gate, after the kernel
-    sketch has passed review.
+    Transcribed from `kernel_flashinfer_recurrent_kda_t1_direct`; line references
+    are into `flashkda_decode_d128_t1_precomputed_direct_split16.cu`.
     """
-    T.func_attr({"global_symbol": "flashkda_decode_t1_precomputed", "tir.is_scheduled": 1})
-    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16")
-    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16")
-    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16")
-    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16")
-    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16")
-    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16")
-    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16")
-    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32")
-    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32")
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    cu = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+
+    T.device_entry()
+    # --- work decomposition and lane roles (:63-71) ------------------------
+    work, n = T.cta_id([NUM_VALUE_HEADS * VALUE_SPLIT, NUM_SEQS])
+    lane = T.thread_id([32])
+    value_tile: T.int32 = work % VALUE_SPLIT
+    hv: T.int32 = work // VALUE_SPLIT
+    query_head: T.int32 = hv // HEAD_RATIO  # the GQA fold
+    k_lane: T.int32 = lane % K_LANES  # 16 lanes x 8 elements = 128 K
+    v_lane: T.int32 = lane // K_LANES  # one of two interleaved value rows
+
+    # --- row activity, resolved before any load (:72-79) -------------------
+    raw_token_pos: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - raw_token_pos
+    # `raw_token_pos < gridDim.y` is why the body only accepts an identity
+    # cu_seqlens; the host forbids a user-supplied T=1 cu_seqlens.
+    has_token = T.And(T.And(raw_token_pos >= 0, raw_token_pos < NUM_SEQS), seq_len > 0)
+    token_pos: T.int32 = T.if_then_else(has_token, raw_token_pos, 0)
+    raw_slot: T.int32 = _load_i32(ssm_idx, n)
+    initial_slot: T.int32 = T.max(raw_slot, 0)  # inactive rows clamp to slot 0
+    active = T.And(raw_slot >= 0, has_token)
+    tile_row_base: T.int32 = value_tile * TILE_ROW_STRIDE
+
+    # --- phase 1: q, k, g vector loads, 4 elements per lane (:88-132) ------
+    elem_start: T.int32 = lane * ELEMS_PER_LANE
+    q_base: T.int32 = (token_pos * NUM_HEADS + query_head) * HEAD_DIM + elem_start
+    gate_base: T.int32 = token_pos * GATE_TOKEN_STRIDE + hv * HEAD_DIM + elem_start
+
+    q_src = T.alloc_local((ELEMS_PER_LANE,), "float32")
+    k_src = T.alloc_local((ELEMS_PER_LANE,), "float32")
+    gate_src = T.alloc_local((ELEMS_PER_LANE,), "float32")
+    q_words = _load_u32x2(q, q_base)
+    k_words = _load_u32x2(k, q_base)
+    g_words = _load_u32x2(g, gate_base)
+    for pair in T.unroll(2):
+        q_src[2 * pair] = _widen_lo(q_words[pair])
+        q_src[2 * pair + 1] = _widen_hi(q_words[pair])
+        k_src[2 * pair] = _widen_lo(k_words[pair])
+        k_src[2 * pair + 1] = _widen_hi(k_words[pair])
+        gate_src[2 * pair] = _widen_lo(g_words[pair])
+        gate_src[2 * pair + 1] = _widen_hi(g_words[pair])
+
+    # --- phase 2: QK L2 norms, full 32-lane butterflies (:133-152) ---------
+    # Association order copied from :136: a0*a0 + a1*a1 + (a2*a2 + a3*a3).
+    q_sum_sq: T.float32 = _add(
+        _fma(q_src[1], q_src[1], _mul(q_src[0], q_src[0])),
+        _fma(q_src[3], q_src[3], _mul(q_src[2], q_src[2])),
+    )
+    k_sum_sq: T.float32 = _add(
+        _fma(k_src[1], k_src[1], _mul(k_src[0], k_src[0])),
+        _fma(k_src[3], k_src[3], _mul(k_src[2], k_src[2])),
+    )
+    # Two independent loops, run back to back (:139-143 then :144-148); the
+    # source does not interleave them.
+    for offset in T.unroll(5):
+        q_sum_sq = _add(q_sum_sq, _shfl_bfly(q_sum_sq, 16 >> offset))
+    for offset in T.unroll(5):
+        k_sum_sq = _add(k_sum_sq, _shfl_bfly(k_sum_sq, 16 >> offset))
+    # eps is hardcoded in the source (:149,:151); `scale` multiplies q only.
+    q_scale: T.float32 = _mul(_rsqrt(_add(q_sum_sq, T.float32(L2_EPS))), scale)
+    k_scale: T.float32 = _rsqrt(_add(k_sum_sq, T.float32(L2_EPS)))
+
+    # --- phase 3: 4-per-lane -> 8-per-lane redistribution + gate (:153-164) -
+    q_reg = T.alloc_local((K_PER_LANE,), "float32")
+    k_reg = T.alloc_local((K_PER_LANE,), "float32")
+    gate_reg = T.alloc_local((K_PER_LANE,), "float32")
+    for i in T.unroll(K_PER_LANE):
+        source_lane: T.int32 = 2 * k_lane + i // ELEMS_PER_LANE
+        q_reg[i] = _mul(_shfl_idx(q_src[i % ELEMS_PER_LANE], source_lane), q_scale)
+        k_reg[i] = _mul(_shfl_idx(k_src[i % ELEMS_PER_LANE], source_lane), k_scale)
+        gate_reg[i] = _expf(_shfl_idx(gate_src[i % ELEMS_PER_LANE], source_lane))
+
+    # --- phase 4: k_dot_q, 16-lane butterfly (:165-176) --------------------
+    # Association order copied from :167: (k0q0 + k1q1 + (k2q2 + k3q3))
+    #                                   + (k4q4 + k5q5 + (k6q6 + k7q7)).
+    k_dot_q: T.float32 = _add(
+        _add(
+            _fma(k_reg[1], q_reg[1], _mul(k_reg[0], q_reg[0])),
+            _fma(k_reg[3], q_reg[3], _mul(k_reg[2], q_reg[2])),
+        ),
+        _add(
+            _fma(k_reg[5], q_reg[5], _mul(k_reg[4], q_reg[4])),
+            _fma(k_reg[7], q_reg[7], _mul(k_reg[6], q_reg[6])),
+        ),
+    )
+    # Offsets stop at 8, so each half-warp reduces within itself; the
+    # instruction stays full-warp (clamp 31, mask 0xFFFFFFFF).
+    for offset in T.unroll(4):
+        k_dot_q = _add(k_dot_q, _shfl_bfly(k_dot_q, 8 >> offset))
+
+    beta_value: T.float32 = _load_bf16_f32(beta, token_pos * NUM_VALUE_HEADS + hv)
+    head_base = T.cast(initial_slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        hv * HEAD_DIM * HEAD_DIM, "int64"
+    )
+    vg_base: T.int32 = (token_pos * NUM_VALUE_HEADS + hv) * HEAD_DIM
+
+    # --- phase 5: the row loop (:181-268) ----------------------------------
+    state_rows = T.alloc_local((4 * K_PER_LANE,), "float32")
+    h_decay = T.alloc_local((K_PER_LANE,), "float32")
+    words_w = T.alloc_local((4,), "uint32")
+
+    for row_block in T.serial(ROW_BLOCKS, unroll=False):
+        # Issue all four row loads before any math (:184-208). The decay pass
+        # below depends on every row, so interleaving would serialise the misses.
+        for row_local in T.unroll(4):
+            row_a: T.int32 = tile_row_base + v_lane + 2 * (row_block * 4 + row_local)
+            words = _load_state_row(
+                state, head_base + T.cast(row_a * HEAD_DIM + k_lane * 8, "int64")
+            )
+            for pr in T.unroll(4):
+                state_rows[row_local * K_PER_LANE + 2 * pr] = _widen_lo(words[pr])
+                state_rows[row_local * K_PER_LANE + 2 * pr + 1] = _widen_hi(words[pr])
+
+        for row_local in T.unroll(4):
+            row: T.int32 = tile_row_base + v_lane + 2 * (row_block * 4 + row_local)
+
+            # Decay and both projections share one pass; the source accumulates
+            # sequentially (:217-223), not as a tree.
+            pred: T.float32 = T.float32(0.0)
+            base: T.float32 = T.float32(0.0)
+            for i in T.unroll(K_PER_LANE):
+                h_decay[i] = _mul(state_rows[row_local * K_PER_LANE + i], gate_reg[i])
+                pred = _fma(h_decay[i], k_reg[i], pred)
+                base = _fma(h_decay[i], q_reg[i], base)
+            for offset in T.unroll(4):
+                pred = _add(pred, _shfl_bfly(pred, 8 >> offset))
+            for offset in T.unroll(4):
+                base = _add(base, _shfl_bfly(base, 8 >> offset))
+
+            # One scalar v load on k_lane == 0, then a broadcast (:240-245).
+            v_value: T.float32 = T.float32(0.0)
+            if k_lane == 0:
+                v_value = _load_bf16_f32(v, vg_base + row)
+            v_value = _shfl_idx(v_value, v_lane * K_LANES)
+
+            delta: T.float32 = _mul(_sub(v_value, pred), beta_value)
+
+            # Rank-1 update. The source writes `state*gate + delta*k` (:249) but
+            # the decayed product is the h_decay above and the compiler keeps it:
+            # .loc :249 emits 8 fma per row and zero mul.
+            for i in T.unroll(K_PER_LANE):
+                state_rows[row_local * K_PER_LANE + i] = _fma(delta, k_reg[i], h_decay[i])
+
+            if active:
+                for pr in T.unroll(4):
+                    words_w[pr] = _pack_bf16x2(
+                        state_rows[row_local * K_PER_LANE + 2 * pr + 1],
+                        state_rows[row_local * K_PER_LANE + 2 * pr],
+                    )
+                _store_u32x4(
+                    state, head_base + T.cast(row * HEAD_DIM + k_lane * 8, "int64"), words_w
+                )
+            # `o = q.S_new` is folded as base + delta*k_dot_q, so the updated
+            # state is never re-read. The source contracts it to one fma (:262);
+            # spelling it mul-then-add would round twice.
+            _store_f32_as_bf16(
+                out, vg_base + row, _fma(delta, k_dot_q, base), T.And(active, k_lane == 0)
+            )
+            # An in-row but inactive sequence zeroes its output (:264-266).
+            _store_f32_as_bf16(
+                out,
+                vg_base + row,
+                T.float32(0.0),
+                T.And(T.And(has_token, T.Not(active)), k_lane == 0),
+            )
 
 
 def get_kernel(**kwargs: Any):
@@ -482,12 +818,93 @@ def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
     return out.to(torch.bfloat16).unsqueeze(0), state_raw
 
 
+# The port reproduces the source's instruction selection and association orders,
+# so it should agree with the frozen export to within bf16 rounding, not merely
+# to an algorithmic tolerance.
+_RTOL = 2.0**-8
+_ATOL = 1.0e-4
+# The independent FP32 oracle accumulates in a different order, so it gets the
+# looser band.
+_ORACLE_RTOL = 2.0**-6
+_ORACLE_ATOL = 3.0e-4
+
+
 def run_test(**kwargs: Any) -> None:
-    """Correctness entry point. Implemented in the correctness gate."""
-    raise SkipTest(
-        "flashkda_decode_t1_precomputed is at the scaffold stage; the kernel body "
-        "is written in the correctness gate"
+    """Validate one config against the frozen export and an independent oracle."""
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    assert_frozen_source(spec["VALUE_SPLIT"])
+
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["device"])
+
+    tirx_out = case["tirx_out"]
+    tirx_state = case["tirx_state_raw"].clone()
+
+    # 1. the frozen cake export itself, on an independent state pool
+    reference_out = _flashinfer_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        reference_out.float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"output vs flashinfer cake export\n{m}",
     )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        case["reference_state_raw"].float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"state vs flashinfer cake export\n{m}",
+    )
+
+    # 2. an independent FP32 oracle of the same math
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        oracle_out.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"output vs FP32 oracle\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        oracle_state.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"state vs FP32 oracle\n{m}",
+    )
+
+    # 3. invariants the tolerance checks above cannot express
+    num_seqs = spec["NUM_SEQS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    slots = case["ssm_state_indices"]
+    initial = case["initial_state_raw"]
+
+    inactive = [n for n in range(num_seqs) if int(slots[n]) < 0]
+    for n in inactive:
+        assert tirx_out[0, n].abs().max().item() == 0.0, (
+            f"inactive row {n} must have a zeroed output"
+        )
+    touched = {int(slots[n]) for n in range(num_seqs) if int(slots[n]) >= 0}
+    for slot in range(min(num_seqs + 4, initial.numel() // slot_stride)):
+        if slot in touched:
+            continue
+        lo, hi = slot * slot_stride, (slot + 1) * slot_stride
+        assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+            f"untouched state slot {slot} was modified"
+        )
+    if slot_stride > payload:
+        for slot in sorted(touched)[:4]:
+            lo = slot * slot_stride + payload
+            hi = (slot + 1) * slot_stride
+            assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+                f"inter-slot padding after slot {slot} was modified"
+            )
 
 
 def run_bench(


### PR DESCRIPTION
## Summary

- port FlashInfer's frozen "cake" FlashKDA decode export — T=1 precomputed gate, SM100 — to plain TIRx
- one module covers both reachable specializations, `direct_split16` and `direct_split8`, through a single `VALUE_SPLIT` constexpr
- add the 11-shape bench-suite matrix and its baseline rows
- include the frozen execution sketch used during the porting design stage

## Impact

`backend="cake"` is FlashInfer's second KDA decode path: machine-generated CUDA exports under `csrc/kda/`, JIT-compiled and dispatched by `recurrent_kda.py`. This is the T=1 leg of that surface. Dispatch (`recurrent_kda.py:1443-1447`) routes every `num_tokens == 1` precomputed call to `d128_t1_precomputed_direct_split{16,8}`; the 679-line non-direct `t1_precomputed_split{1,2,4,8}` exports are unreachable through `run_recurrent_kda` and are out of scope.

The kernel is one warp per CTA over grid `(HV * VALUE_SPLIT, N)` with **zero shared memory, no barrier, no atomic and no workspace**. The value split partitions the 128 value rows into disjoint slabs, so no result is ever combined across CTAs. The two exports differ in exactly three constants — the split, the tile-row multiplier and the `row_block` trip count — which is why one module with one knob covers both.

All arithmetic goes through local `.ftz` helpers. That is the **opposite** of the two CuTe-DSL recurrent-KDA decode ports, whose helpers are deliberately non-FTZ because their source emits no `.ftz`; this source compiles from plain CUDA operators under `-use_fast_math` and its PTX is `.ftz` throughout. Both families are registered in the PTX table, so the choice is explicit either way, and importing the siblings' arithmetic helpers would have been a silent numerical divergence.

## Validation

- **correctness**: 18/18 configs pass, each checked three ways — against the frozen export itself on an independent state pool, against an independent FP32 oracle, and against invariants the tolerances cannot express (inactive rows zero their output, untouched state slots stay bit-identical, inter-slot padding survives)
- coverage includes both splits, both sides of the split knife edge (`work` 288 vs 304 on this 148-SM box), CUDA-graph padding rows, an envelope-strided state pool, an envelope-strided gate, a non-default scale, and GQA ratios 2 and 4
- `verify_dispatch.py` feeds the tensors `prepare_data` actually builds into FlashInfer's own `_select_flash_kda_decode_variant`, so the entire guard chain runs: **18/18 reach the predicted variant**
- `characterize_source.py` proves each special-case row exercises real behaviour rather than degenerating into the base case: **5/5**
- `assert_frozen_source` pins the generated body's own declared SHA256, so an upstream regeneration cannot pass unnoticed
- **performance**: complete bench-suite matrix, **11/11 above the 0.99 bar, minimum 1.104x, maximum 1.394x**, on clock-verified GPUs. No alignment loop was needed — the first measurement already cleared every row, so nothing was tuned
- no-tile check clean over all 18 specializations, and **proven non-vacuous**: injecting a `Tx.fill(0)` makes it report 18 violations
- `pre-commit run --all-files` clean; bench-suite import check ok

| config | ours µs | reference µs | ratio |
|---|---:|---:|---:|
| `hv16h16_b1_s16` | 4.14 | 5.77 | **1.394** |
| `hv16h16_b32_s8` | 10.02 | 13.36 | **1.334** |
| `hv12h12_b8_s16` | 4.72 | 6.26 | **1.327** |
| `hv16h16_b16_s16` | 6.26 | 8.15 | **1.302** |
| `hv16h16_b4_s16` | 4.51 | 5.73 | **1.269** |
| `hv32h16_b8_s16` | 6.24 | 7.91 | **1.268** |
| `hv16h16_b8_s16` | 5.00 | 6.34 | **1.268** |
| `hv16h16_b64_s8` | 16.61 | 19.42 | **1.169** |
| `hv32h16_b32_s8` | 16.63 | 19.37 | **1.165** |
| `hv16h16_b128_s8` | 28.78 | 32.14 | **1.117** |
| `hv12h12_b64_s8` | 14.26 | 15.74 | **1.104** |

The margin is widest where the grid is smallest (1.39x at 16 CTAs) and narrowest at the largest shapes, which is the ordering a launch-and-occupancy explanation predicts rather than an instruction-count one.

## Note on instruction selection

Every `instruction_selection` annotation in the sketch was read off line-info PTX exported by re-running FlashInfer's own nvcc command line with `-ptx -lineinfo --source-in-ptx`, not inferred from the CUDA source. That mattered — the PTX contradicted three assumptions the plan had carried, and the sketch review caught three more places where the sketch would have made the port emit code the source does not:

- the **rank-1 update** reuses the `h_decay` computed in the pred/base pass, so it is eight `fma` and no `mul` (`.loc :249` is 32 `fma`, zero `mul`). Recomputing the decayed product would have added 32 muls per row block.
- the **output store** is one contracted `fma(delta, k_dot_q, base)`; spelling it as a mul and an add would round twice and diverge in the last bits, since the port pins PTX explicitly.
- the **two L2 butterflies** run back to back, not interleaved. The fused form was carried over from the CuTe-DSL sibling sketch, where it *is* faithful.

The bf16 widening asymmetry is also reproduced rather than normalised: vector loads widen with the `shl.b32`/`and.b32` integer pair, the two scalar loads use `cvt.f32.bf16`. Both forms are in the source PTX.

One counting pitfall is recorded in the sketch for whoever re-counts later: the widening pair must be counted by its `0xffff0000` operand, not by source line, because split16 schedules the `lane & 16` v-broadcast index into the same `.loc` as the state-row widening while split8 attributes it elsewhere.

## Notes for review

- the sketch at `.agents/sketch/flashinfer/kda/flashkda_decode_t1_precomputed.md` is the best entry point; it passed an independent reviewer gate and is frozen
- the reference is the export's **direct JIT ABI** rather than `kda_decode.recurrent_kda(backend="cake")`, which keeps the comparison kernel-only and makes inactive (negative-slot) rows reachable — the public T=1 wrapper synthesizes identity metadata and cannot express them
- absolute microseconds in `baseline.json` are specific to the measuring host; regression detection compares the ratio, which is not
