### PR TITLE
feat(kernel): port FlashInfer's FlashKDA cake T=2 precomputed decode kernel

### DIFF
--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
@@ -1,0 +1,536 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashKDA cake T=2 precomputed decode: coarse WY execution sketch
+
+**Non-executable.** This is the semantic execution skeleton, not runnable code.
+The source of truth for the implementation is
+`tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py`.
+
+Transcribed from FlashInfer's frozen generated export
+`csrc/kda/flashkda_decode_d128_t2_precomputed_split4.cu`, symbol
+`kernel_flashinfer_recurrent_kda_wy_vtile_short` (flashinfer-ai/flashinfer @
+`f2e04400`). Bare `:NNN` line references are into that file.
+
+**Fixed specialization.** `HEAD_DIM = 128`, `TOKENS = 2`, `GATE_KIND = 0`
+(precomputed log-gate), `VALUE_SPLIT = 4`, `LAUNCH_THREADS = 64`,
+`DIRECT_IMPL` unset. The sm100a selector returns 4 unconditionally at T=2
+(`recurrent_kda.py:1181-1182`), so split4 is the entire dispatch surface — there
+is no split knob in this port.
+
+**Out of scope.** T ∈ {1,3,4,5,6}; the `GATE_KIND = 1` lower-bound variant; the
+`t1_direct` one-warp schedule (a different kernel symbol, ported separately);
+`VALUE_SPLIT = 8`, reachable only on GB300 and not measurable here.
+
+## Pipeline at a glance
+
+Two warps, **no warp specialization**: the value-warp count, the state-warp
+count and the token count all collapse to 2 at this specialization
+(`flash_kda_decode.py:115-137`), so the same two warps play every role in
+sequence. There is **no asynchronous pipeline** — no `cp.async`, no mbarrier, no
+TMA, no atomics, `NUM_MAIN_STAGES 1`, nothing double-buffered.
+
+The value split is a **partition**: CTA `(hv, value_tile)` owns value rows
+`[32·value_tile, +32)` of the `[V,K]` state, and every CTA redundantly recomputes
+the whole token preprocessing for its own `(n, hv)`. No CTA combines anything
+with any other.
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, value_tile, n)` | value head `hv`, sequence `n`, 32 value rows | independent |
+| warp `w`, phases A and C | **token `w`**: its q/k/g vectors, its L2 norms, its sVec columns and L/R row | publishes `sK`/`sD`/`sBeta`/`sSlot`/`sToken`, and (warp 0) `sInit`, across barrier #1; publishes `sVec`/`sL`/`sR` across barrier #2 |
+| thread `tid`, phases B and H | 8 value rows (`group = tid/16`, rows `group*8 + r`) × 8 keys (`k_start = (tid%16)*8`) | gathers the state into registers **and** stages it to `sState` for the MMA; later writes both tokens' checkpoints |
+| warp `w`, phase D | **value rows `w*16 .. +15`** of the 32-row tile | consumes `sState` (all 32 rows staged by both warps) and `sVec` |
+| lane with `lane_quad == 2` | the WY solve, both tokens' outputs, and the `sU` publish for rows `w*16 + lane/4` and `+8` | the only lanes that load `v` and store `out` |
+
+The lane→data mapping changes twice, and both barriers exist for that: `tid`-major
+in phases A/C, `group`-major in phase B, MMA-fragment-major in phase D.
+
+Dependency chain: preprocess → **barrier** → state gather+stage → sVec/L/R →
+**barrier** → MMA → WY solve → outputs → sU → **warp barrier** → recurrence and
+checkpoints.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+reg_tile(dtype, shape)                 # per-thread register array
+smem_view(name, offset, dtype, shape)  # a named region of the one arena
+swz(byte_off)                          # byte_off ^ ((byte_off >> 7 & 7) << 4)
+```
+
+Data movement:
+
+```python
+copy_g2r(gmem_slice, reg)              # global -> register
+copy_r2g(reg, gmem_slice, pred=None)   # register -> global
+copy_r2s(reg, smem_slice)              # register -> shared
+copy_s2r(smem_slice, reg)              # shared -> register
+ldm(smem_addr, frag, trans=False)      # ldmatrix, one x4 group
+bcast(v, src_lane, 31, 0xFFFFFFFF)     # shfl.idx
+bfly(v, lane_xor, 31, 0xFFFFFFFF)      # shfl.bfly
+```
+
+Compute:
+
+```python
+fill(reg, c); cast(dst, src); add(a,b); sub(a,b); mul(a,b); fma(a,b,c)
+exp(x); rsqrt(x); dot(a, b)            # `dot` = one explicit FMA chain
+mma(acc, a_frag, b_frag, init=False)   # one mma.sync.m16n8k16 issue
+```
+
+Sync: `cta_sync()`, `warp_sync()`.
+
+**Every shuffle is width-32 with a full member mask** — the operands are always
+`(31, 0xFFFFFFFF)`. A reduction that wants a narrower group restricts its *xor
+offset set*, never the instruction width. **`dot` is not a compound op**: each
+one expands to an explicit FMA chain in a fixed association order, written out
+at its site because the order is load-bearing.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+HEAD_DIM, TOKENS, VALUE_SPLIT = 128, 2, 4
+ROWS_PER_CTA    = 128 // VALUE_SPLIT      # 32                          (:159)
+H, HV, HEAD_RATIO                          # HV % H == 0, HV >= H
+GATE_TOKEN_STRIDE, STATE_SLOT_STRIDE       # host-derived, constexpr here
+
+grid  = (HV * VALUE_SPLIT, num_seqs)       # binding_impl.cuh:64
+block = (64,)                              # 2 warps
+
+# The source uses dynamic smem (extern __shared__ __align__(1024), the launcher
+# does cudaFuncSetAttribute + <<<..., SMEM_TOTAL, ...>>>). 14720 B fits the
+# static limit, so the port declares one static arena at the same alignment and
+# carves the same byte offsets -- what the swizzled ldmatrix addressing depends
+# on is the offsets and the alignment, both preserved.
+arena     = smem_arena(14720, align=1024)
+sState0   = smem_view(arena,     0, bf16, [32, 64])   # keys   0..63, swizzled
+sState1   = smem_view(arena,  4096, bf16, [32, 64])   # keys  64..127, swizzled
+sVec      = smem_view(arena,  8192, bf16, [128, 16])  # row stride 32 B, swizzled
+sK        = smem_view(arena, 12288, f32,  [2, 128])   # L2-normalized k
+sD        = smem_view(arena, 13312, f32,  [2, 128])   # exp(g)
+sBeta     = smem_view(arena, 14336, f32,  [2])
+sSlot     = smem_view(arena, 14344, i32,  [2])
+sToken    = smem_view(arena, 14352, i32,  [2])
+sInit     = smem_view(arena, 14360, i32,  [1])
+sL        = smem_view(arena, 14376, f32,  [2, 2])     # only sL[1][0] is live
+sR        = smem_view(arena, 14392, f32,  [2, 2])     # sR[0][0], sR[1][0], sR[1][1]
+sU        = smem_view(arena, 14408, f32,  [2, 32])
+# sGramA0/1 (offsets 8192/10240) alias sVec and are t5/t6 machinery: dead here.
+
+# ===========================================================================
+# Work decomposition and lane roles  (:100-179)
+# ===========================================================================
+work       = cta_id.x
+value_tile = work % VALUE_SPLIT
+hv         = work // VALUE_SPLIT
+n          = cta_id.y
+query_head = hv // HEAD_RATIO
+tid        = thread_id.x
+warp       = tid // 32          # == token index in phases A and C
+lane       = tid % 32
+lane_quad  = lane & 3           # the MMA accumulator's column pair
+frag_row   = lane // 4          # the MMA accumulator's row
+quad_base  = lane - lane_quad
+group      = tid // 16          # phases B and H: 4 groups of 8 rows
+lane_group = tid % 16
+k_start    = lane_group * 8     # phases B and H: 8 keys per thread
+elem_start = lane * 4           # phases A and C: 4 keys per lane
+tile_row_base  = value_tile * ROWS_PER_CTA
+owned_row_base = group * 8
+token_base = cu_seqlens[n];  seq_len = cu_seqlens[n+1] - token_base
+# instruction_selection: ld.global.nc.b32; extent: scalar (x2)   (.loc :147,:148)
+# cu_seqlens must step by exactly TOKENS per row. The body does not bound-check
+# token_base -- the contract is the caller's and is deliberately unvalidated for
+# CUDA-graph capture. Padding is signalled ONLY by ssm_state_indices < 0.
+#
+# The source also calls make_warp_uniform(tid/32) at :101, which emits a dead
+# shfl.sync.idx.b32 at .loc :39. It is a uniformity hint; the port omits it.
+
+# ===========================================================================
+# Phase A: token preprocess, warp <-> token  (:180-290)
+# ===========================================================================
+if warp < TOKENS:
+    token         = warp
+    active_token  = token < seq_len
+    token_pos     = token_base + token if active_token else 0
+    qk_base   = (token_pos * H + query_head) * 128 + elem_start
+    gate_base = token_pos * GATE_TOKEN_STRIDE + hv * 128 + elem_start
+
+    r_q = reg_tile(f32, [4]); r_k = reg_tile(f32, [4]); r_d = reg_tile(f32, [4])
+    copy_g2r(q[qk_base : +4],   r_q)
+    # instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector (4 bf16)
+    copy_g2r(k[qk_base : +4],   r_k)
+    # instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector
+    copy_g2r(g[gate_base : +4], r_d)
+    # instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector
+    # Each 32-bit word holds two bf16 and is split by an integer pair, not by
+    # cvt: lo = word << 16, hi = word & 0xffff0000  (:200-206)
+    # instruction_selection: shl.b32 + and.b32; extent: 2 words per tensor, 3 tensors
+
+    # ---- L2 norms: two independent full-warp butterflies ------------------
+    # Association is index-ordered accumulation over i = 0..3  (:241-244)
+    q_sq = dot(r_q, r_q);  k_sq = dot(r_k, r_k)
+    # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32; extent: 4-term chain each
+    for offset in (16, 8, 4, 2, 1):
+        q_sq = add(q_sq, bfly(q_sq, offset, 31, 0xFFFFFFFF))
+    # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds
+    for offset in (16, 8, 4, 2, 1):
+        k_sq = add(k_sq, bfly(k_sq, offset, 31, 0xFFFFFFFF))
+    # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds
+    # The two loops are sequential, not interleaved (.loc :248 then :253).
+    q_norm = mul(rsqrt(add(q_sq, 1e-6)), scale)   # scale folds into q only
+    k_norm = rsqrt(add(k_sq, 1e-6))
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar (x2)
+    # eps is hardcoded inside the rsqrt argument (:255,:257).
+
+    # ---- gate and the shared publish  (:260-271) --------------------------
+    for i in range(4):
+        r_q[i] = mul(r_q[i], q_norm)
+        r_k[i] = mul(r_k[i], k_norm)
+        r_d[i] = exp(r_d[i])       # __expf: mul by log2(e), then ex2
+        # instruction_selection: mul.ftz.f32 x3 + ex2.approx.ftz.f32; extent: 4 iterations
+    copy_r2s(r_k, sK[token, elem_start : +4])
+    copy_r2s(r_d, sD[token, elem_start : +4])
+    # instruction_selection: st.shared.v4.b32; extent: one 16-byte tile each
+
+    if lane == 0:
+        sSlot[token]  = ssm_state_indices[n*2 + token] if active_token else -1
+        sToken[token] = token_pos
+        sBeta[token]  = cast(f32, beta[token_pos * HV + hv])
+        # instruction_selection: ld.global.nc.b32 + ld.global.nc.b16 + cvt.f32.bf16
+        #   + st.shared.b32 x3; extent: scalar each
+        if token == 0:
+            # num_accepted_tokens is LIVE at T=2 (it is not read at all by the
+            # t1_direct sibling). It selects which checkpoint the recurrence
+            # starts from, with both clamp edges reachable.  (:279-287)
+            accepted     = clamp(num_accepted_tokens[n] - 1, 0, TOKENS - 1)
+            initial_slot = ssm_state_indices[n*2 + accepted]
+            sInit[0]     = 0 if initial_slot < 0 else initial_slot
+            # instruction_selection: ld.global.nc.b32 x2 + st.shared.b32; extent: scalar
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# Orders sInit -> the gather base below, and sK/sD/sBeta/sSlot/sToken -> their
+# cross-warp readers in phases C, E, F and H.
+
+# ===========================================================================
+# Phase B: state gather, all 64 threads  (:292-329)
+# ===========================================================================
+# Every thread owns 8 rows x 8 keys and does two things with each row: keeps it
+# as the FP32 recurrent carry, and stages the untouched bf16 bits into sState
+# for the MMA to read back.
+initial_head_base = sInit[0] * STATE_SLOT_STRIDE + hv * 128 * 128
+hist = reg_tile(f32, [8, 8])
+for row_local in range(8):                # constexpr unroll
+    row  = owned_row_base + row_local
+    pack = reg_tile(u32, [4])
+    copy_g2r(state[initial_head_base + (tile_row_base + row)*128 + k_start : +8], pack)
+    # instruction_selection: ld.global.v4.b32; extent: one 16-byte tile (8 bf16), 8 rows
+    # NOT .nc: `state` is written later in this kernel.
+    for p in range(4):
+        hist[row_local][2*p], hist[row_local][2*p+1] = widen(pack[p])
+    # instruction_selection: shl.b32 + and.b32; extent: 4 words per row
+    half = sState0 if lane_group < 8 else sState1
+    copy_r2s(pack, half[row, (k_start % 64) : +8] @ swz)
+    # instruction_selection: st.shared.v4.b32; extent: one 16-byte tile, 8 rows
+    # The bf16 bits go to shared unmodified; the swizzle is on the byte offset:
+    # swz(row*128 + (k_start % 64)*2)  (:322,:324)
+
+# ===========================================================================
+# Phase C: sVec columns and the WY coefficients, warp <-> token  (:330-404)
+# ===========================================================================
+if warp < TOKENS:
+    for i in range(4):                    # constexpr unroll
+        k_idx  = elem_start + i
+        prefix = 1.0
+        for j in range(TOKENS):           # prefix gate: product over j <= token
+            if token >= j:
+                prefix = mul(prefix, sD[j, k_idx])
+        # instruction_selection: ld.shared.b32 + mul.ftz.f32; extent: <= 2 per element
+        sVec[k_idx, token]     = cast(bf16, mul(prefix, r_k[i]))
+        sVec[k_idx, 4 + token] = cast(bf16, mul(prefix, r_q[i]))
+        # instruction_selection: mul.ftz.f32 + cvt.rn.bf16.f32 + st.shared.b16
+        # extent: 2 scalars per element, 4 elements  (.loc :346,:353)
+        # The prefix multiply is FP32; the bf16 rounding happens on the way into
+        # sVec, which is what the MMA will consume as its B operand.
+
+    # ---- L and R: the WY coefficients  (:357-403) -------------------------
+    # ratio_scan accumulates sD of the *source* token between offsets, so the
+    # dots see the decay between source and target.
+    ratio = reg_tile(f32, [4]); fill(ratio, 1.0)
+    for source_offset in range(TOKENS):
+        source_token = token - source_offset
+        if source_token >= 0:
+            dot_kk = 0.0; dot_qk = 0.0
+            for i in range(4):
+                sk = sD_scaled = sK[source_token, elem_start + i]
+                dot_kk = fma(mul(r_k[i], sk), ratio[i], dot_kk)
+                dot_qk = fma(mul(r_q[i], sk), ratio[i], dot_qk)
+            # instruction_selection: ld.shared.b32 + mul.ftz.f32 + fma.rn.ftz.f32
+            # extent: 4 iterations; source order is `r * source_k * ratio` (:372-375)
+            for offset in (16, 8, 4, 2, 1):
+                dot_kk = add(dot_kk, bfly(dot_kk, offset, 31, 0xFFFFFFFF))
+            for offset in (16, 8, 4, 2, 1):
+                dot_qk = add(dot_qk, bfly(dot_qk, offset, 31, 0xFFFFFFFF))
+            # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds x 2
+            if lane == 0:
+                beta_source = sBeta[source_token]
+                if source_token < token:
+                    sL[token, source_token] = mul(beta_source, dot_kk)
+                sR[token, source_token] = mul(beta_source, dot_qk)
+                # instruction_selection: ld.shared.b32 + mul.ftz.f32 + st.shared.b32
+                # extent: scalar  (.loc :390,:392)
+            if source_token > 0:
+                for i in range(4):
+                    ratio[i] = mul(ratio[i], sD[source_token, elem_start + i])
+                # instruction_selection: ld.shared.b32 + mul.ftz.f32; extent: 4
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# Orders sState (written by ALL 64 threads) -> the ldmatrix reads below (issued
+# by both warps, each reading its own 16 rows), and sVec/sL/sR -> their readers.
+
+# ===========================================================================
+# Phase D: the MMA chain, warp <-> 16 value rows  (:406-438)
+# ===========================================================================
+if warp < TOKENS:
+    acc = reg_tile(f32, [4])
+    for state_half in range(2):           # keys 0..63, then 64..127
+        for mma_k in (0, 16, 32, 48):     # constexpr unroll -> 8 issues
+            global_k = state_half * 64 + mma_k
+
+            # B operand: sVec rows `global_k .. +15`, cols 0..15, transposed so
+            # that n = sVec column and k = key.
+            vec_frag = reg_tile(u32, [4])
+            ldm(sVec @ swz((global_k + lane % 16) * 32 + (lane // 16) * 16),
+                vec_frag, trans=True)
+            # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            # extent: one x4 group per issue, 8 issues
+            # vec_frag[2],[3] are cols 8..15 -- loaded by the x4 and never used.
+
+            # A operand: this warp's 16 state rows, keys `mma_k .. +15`.
+            state_frag = reg_tile(u32, [4])
+            half = sState0 if state_half == 0 else sState1
+            ldm(half @ swz((warp*16 + lane % 16) * 128 + (mma_k + (lane//16)*8) * 2),
+                state_frag)
+            # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.shared.b16
+            # extent: one x4 group per issue, 8 issues
+
+            mma(acc, state_frag, vec_frag, init=(state_half == 0 and mma_k == 0))
+            # instruction_selection: mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+            # extent: one issue; the first has an explicit zero C operand
+            # ({0f00000000 x4}), the rest tie C to D  (.loc :431 x1, :435 x7)
+
+# One chain, two projections. C[16 rows][8 cols] += state[row][k] * sVec[k][col]
+# over all 128 keys, so with the sVec column assignment from phase C:
+#   col 0,1 -> (prefix_t (*) k_t) . h0   the delta-rule history term
+#   col 4,5 -> (prefix_t (*) q_t) . h0   the output history term
+#   col 2,3,6,7 -> garbage (sVec columns never written; live at T=4)
+# acc layout: acc[0],[1] = row `frag_row`, cols 2*lane_quad, +1;
+#             acc[2],[3] = row `frag_row + 8`, same cols.
+# So lane_quad == 0 holds the k-side and lane_quad == 2 holds the q-side.
+
+# ===========================================================================
+# Phase E: quad broadcast and the WY forward substitution  (:439-482)
+# ===========================================================================
+if warp < TOKENS:
+    ha_lo = reg_tile(f32, [2]); ha_hi = reg_tile(f32, [2])
+    for t in range(TOKENS):
+        ha_lo[t] = bcast(acc[t],     quad_base, 31, 0xFFFFFFFF)
+        ha_hi[t] = bcast(acc[2 + t], quad_base, 31, 0xFFFFFFFF)
+    # instruction_selection: shfl.sync.idx.b32; extent: scalar, 4 live broadcasts
+    # The source also broadcasts from quad_base+1 into ha_lo[2],[3] / ha_hi[2],[3]
+    # (:443-446,:451-454). Those are MMA columns 2,3 -- T=4 territory, dead here.
+
+    if lane_quad == 2:
+        u_lo = reg_tile(f32, [2]); u_hi = reg_tile(f32, [2])
+        row_lo = warp * 16 + frag_row;  row_hi = row_lo + 8
+        for t in range(TOKENS):         # serial forward substitution
+            base_t = (sToken[t] * HV + hv) * 128
+            solved_lo = sub(cast(f32, v[base_t + tile_row_base + row_lo]), ha_lo[t])
+            solved_hi = sub(cast(f32, v[base_t + tile_row_base + row_hi]), ha_hi[t])
+            # instruction_selection: ld.global.nc.b16 + cvt.f32.bf16 + sub.ftz.f32
+            # extent: 2 scalars per token  (.loc :463,:464)
+            for s in range(TOKENS):
+                if s < t:
+                    solved_lo = sub(solved_lo, mul(sL[t, s], u_lo[s]))
+                    solved_hi = sub(solved_hi, mul(sL[t, s], u_hi[s]))
+                # instruction_selection: ld.shared.b32 + mul.ftz.f32 + sub.ftz.f32
+                # extent: scalar, taken once (only s=0 < t=1)
+            u_lo[t] = solved_lo;  u_hi[t] = solved_hi
+    # The source then broadcasts u_lo/u_hi from quad_base+2 to the whole quad
+    # (:476-482). Its only consumer is the dead BLOCK_CHECKPOINT_MMA block;
+    # every live consumer below is already lane_quad == 2. Dead here.
+
+# ===========================================================================
+# Phase F: both tokens' outputs  (:484-531)
+# ===========================================================================
+if warp < TOKENS and lane_quad == 2:
+    row_lo = warp * 16 + frag_row;  row_hi = row_lo + 8
+    for t in range(TOKENS):
+        out_lo = acc[t];  out_hi = acc[2 + t]     # the q-side MMA columns
+        for s in range(TOKENS):
+            coef = sR[t, s] if s <= t else 0.0    # sR[0][1] is never written
+            out_lo = fma(coef, u_lo[s], out_lo)
+            out_hi = fma(coef, u_hi[s], out_hi)
+            # instruction_selection: ld.shared.b32 + fma.rn.ftz.f32; extent: scalar x2
+        base_t = (sToken[t] * HV + hv) * 128 + tile_row_base
+        active = sSlot[t] >= 0
+        copy_r2g(cast(bf16, out_lo if active else 0.0), out[base_t + row_lo])
+        copy_r2g(cast(bf16, out_hi if active else 0.0), out[base_t + row_hi])
+        # instruction_selection: cvt.rn.bf16.f32 + st.global.b16; extent: 2 scalars
+        # per token, both branches  (.loc :503,:504,:506,:507 and :523,:524,:526,:527)
+        # A padded row writes EXPLICIT zeros -- the upstream test asserts them
+        # bit-exactly, so this is not an "unwritten" path.
+
+# ===========================================================================
+# Phase G: publish sU  (:532-545)
+# ===========================================================================
+if warp < TOKENS:
+    if lane_quad == 2:
+        for t in range(TOKENS):
+            sU[t, warp*16 + frag_row]     = u_lo[t]
+            sU[t, warp*16 + frag_row + 8] = u_hi[t]
+        # instruction_selection: st.shared.b32; extent: 2 scalars per token
+    warp_sync()
+    # instruction_selection: bar.warp.sync; extent: warp
+    # A warp barrier suffices because producer and consumer are the same warp:
+    # writer rows are warp*16 + frag_row{,+8}, i.e. [0,16) for warp 0 and
+    # [16,32) for warp 1; reader rows below are group*8 + r with group = tid/16,
+    # i.e. groups 0,1 -> rows 0..15 and groups 2,3 -> rows 16..31. Any port that
+    # changes the row-to-thread mapping must re-derive this or promote to
+    # cta_sync.
+
+# The BLOCK_CHECKPOINT_MMA != 0 block (:546-658), including the source's third
+# mma.sync site, is statically dead: the macro is 0 and the binding
+# static-asserts it. Not transcribed.
+
+# ===========================================================================
+# Phase H: recurrence and checkpoints, all 64 threads  (:659-695)
+# ===========================================================================
+for t in range(TOKENS):                   # serial over tokens
+    slot_t = sSlot[t]
+    beta_t = sBeta[t]
+    for row_local in range(8):            # constexpr unroll
+        row    = owned_row_base + row_local
+        update = mul(sU[t, row], beta_t)
+        # instruction_selection: ld.shared.b32 x2 + mul.ftz.f32; extent: scalar
+        words = reg_tile(u32, [4])
+        for i in range(8):
+            hist[row_local][i] = fma(update, sK[t, k_start + i],
+                                     mul(hist[row_local][i], sD[t, k_start + i]))
+            # instruction_selection: ld.shared.v2.b32 + mul.ftz.f32 + fma.rn.ftz.f32
+            # extent: 8 iterations
+            # The recurrence advances UNCONDITIONALLY -- only the store below is
+            # predicated -- and it stays FP32, so token 1 consumes the un-rounded
+            # token-0 state rather than the bf16 checkpoint.
+        for p in range(4):
+            words[p] = cast(bf16x2, (hist[row_local][2*p], hist[row_local][2*p+1]))
+        # instruction_selection: cvt.rn.bf16x2.f32; extent: 4 pairs per row
+        if slot_t >= 0:
+            copy_r2g(words, state[slot_t*STATE_SLOT_STRIDE + hv*16384
+                                  + (tile_row_base + row)*128 + k_start : +8])
+            # instruction_selection: st.global.v4.b32; extent: one 16-byte tile,
+            # 8 rows x 2 tokens = 16 stores  (.loc :689)
+# Both tokens' slots receive a full 32-row write: this kernel checkpoints per
+# token, it does not write one final state.
+```
+
+## Inactive-row contract
+
+| `sSlot[t]` | state | `out` for token t |
+| --- | --- | --- |
+| `>= 0` | rewritten at that slot | `acc_q + Σ sR·u` |
+| `< 0` | untouched (the FP32 recurrence still advances) | **explicit 0.0** |
+
+`cu_seqlens` plays no part in this: `active_token` gates only `sSlot`, and under
+the stride-T caller contract it is always true.
+
+## What is deliberately absent
+
+The source is a Loom-generated template covering T=1..6; at T=2/split4 much of it
+is statically dead, and the port carries none of it:
+
+| dead item | site | why |
+| --- | --- | --- |
+| `sGramA0`, `sGramA1` | `:81-86`, `:136-139` | t5/t6 coefficient-gram; alias sVec, never touched |
+| the whole `BLOCK_CHECKPOINT_MMA` block, incl. the 3rd `mma.sync` | `:546-658` | macro is 0, static-asserted |
+| `ha_lo[2],[3]`, `ha_hi[2],[3]` + their 4 broadcasts | `:443-446`, `:451-454` | MMA columns 2,3 — T=4 territory |
+| the `u_lo`/`u_hi` quad broadcasts | `:476-482` | only the dead block consumes them |
+| `vec_frag[2],[3]` | `:415` | the x4 loads sVec cols 8..15; the MMA reads 2 registers |
+| sVec columns 2,3 and 6..15 | — | never written; feed dead accumulator lanes. **Not zeroed** — zeroing is numerically safe but adds stores the source does not issue |
+| `sR[0][1]`, `sL[0][*]`, `sL[1][1]` | `:390-392` | of the two 2×2 matrices only `sL[1][0]` and `sR[{0,0},{1,0},{1,1}]` are written and read |
+| `elem_start < 128` guards | `:194` etc. | statically true at D=128 |
+| `make_warp_uniform` | `:101` | a uniformity hint; emits a dead `shfl.sync.idx.b32` |
+| `A_log`, `dt_bias`, `lower_bound` | `:98` | `GATE_KIND 0`; never dereferenced |
+
+## Instruction-selection summary
+
+Read off line-info PTX exported by re-running FlashInfer's own nvcc command line
+(`.porting/flashkda_decode_t2_precomputed/ptx/d128_t2_precomputed_split4/`).
+Body total **1570 instructions**; the counts every annotation above rests on:
+
+| form | count | where |
+| --- | ---: | --- |
+| `mul.ftz.f32` | 254 | normalization, gate, prefix, dots, decay, coefficients |
+| `fma.rn.ftz.f32` | 224 | every dot chain, the WY solve, the recurrence |
+| `shl.b32` / `and.b32` | 131 / 116 | **38 each** are the bf16 widening pair (`<<16`, `& 0xffff0000`); the rest is index and swizzle arithmetic |
+| `cvt.rn.bf16x2.f32` | 64 | 2 tokens × 8 rows × 4 pairs, the checkpoint packing |
+| `xor.b32` | 34 | the shared swizzle |
+| `add.ftz.f32` | 31 | butterfly tails and the eps adds |
+| `shfl.sync.bfly.b32` | 30 | 2 L2 norms + 2 coefficient dots per token, 5 rounds each |
+| `st.shared.v4.b32` | 18 | 16 sState stages + 2 sK/sD publishes |
+| `st.global.v4.b32` | 16 | the checkpoints, 8 rows × 2 tokens |
+| `cvt.rn.bf16.f32` | 14 | 8 sVec column stores + 8 output stores (both branches) |
+| `shfl.sync.idx.b32` | 13 | quad broadcasts + 1 dead `make_warp_uniform` |
+| `st.shared.b32` | 11 | scalars: sBeta/sSlot/sToken/sInit/sL/sR/sU |
+| `ldmatrix…x4.shared.b16` | **8** | the A operand, one per MMA issue |
+| `ldmatrix…x4.trans.shared.b16` | **8** | the B operand, one per MMA issue |
+| `mma.sync…m16n8k16.f32.bf16.bf16.f32` | **8** | 1 zeroing (`.loc :431`) + 7 accumulating (`.loc :435`) |
+| `ld.global.v4.b32` | 8 | the state gather — **not** `.nc`, since state is written |
+| `st.shared.b16` | 8 | the sVec columns |
+| `st.global.b16` | 8 | the outputs, both branches |
+| `ld.global.nc.{b16,b32,v2.b32}` | 5 / 5 / 3 | v+beta, metadata, q/k/g |
+| `sub.ftz.f32` | 6 | the WY residuals |
+| `cvt.f32.bf16` | 5 | the scalar v and beta loads |
+| `ex2.approx.ftz.f32` | 4 | the gate, one per lane element |
+| `rsqrt.approx.ftz.f32` | 2 | the two L2 norms |
+| `bar.sync` / `bar.warp.sync` | 2 / 1 | the two CTA barriers and the sU warp barrier |
+
+Three consequences the port must honour:
+
+1. **Every float operation is `.ftz`.** `-use_fast_math` plus plain CUDA
+   operators give `mul/add/sub.ftz.f32` and `fma.rn.ftz.f32`; `__expf` and
+   `rsqrtf` give `ex2.approx.ftz.f32` / `rsqrt.approx.ftz.f32`. There is **no
+   plain-`.f32` arithmetic anywhere in the body**. This matches the t1_direct
+   sibling and is the opposite of the two CuTe-DSL KDA decode ports, whose
+   helpers are deliberately non-FTZ.
+2. **`.nc` follows read-only-ness, not `__restrict__` alone.** q, k, g, v, beta
+   and the metadata load through `ld.global.nc.*`; the state gather is a plain
+   `ld.global.v4.b32` because the same kernel writes that buffer.
+3. **The MMA operands are bf16 and the accumulator is FP32.** `prefix⊙k` and
+   `prefix⊙q` are rounded to bf16 on the way into sVec and the state A operand
+   is bf16 straight from global, so the kernel loses precision an FP32 oracle
+   does not — the port's measured gap to a sequential FP32 oracle is 6.1e-05 on
+   the output, versus 6e-08 for the register-only t1_direct sibling.
+
+## TIRx module and benchmark contract
+
+- Module `tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py`,
+  `KERNEL_META["name"] = "flashkda_decode_t2_precomputed"`, cc 10.
+- Reference: the frozen export itself through the JIT module's direct ABI, so
+  the comparison is kernel-only and every metadata combination — negative slots,
+  arbitrary `num_accepted_tokens` — is reachable.
+- 9 bench rows: `hv32h16` × N{8,16,32,64,128} (parity with FlashInfer's own
+  export bench), plus `hv16h16` and `hv12h12` at N{8,64}. `verify_dispatch.py`
+  asserts every row reaches `d128_t2_precomputed_split4`.

--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
@@ -400,7 +400,10 @@ if warp < TOKENS and lane_quad == 2:
             coef = sR[t, s] if s <= t else 0.0    # sR[0][1] is never written
             out_lo = fma(coef, u_lo[s], out_lo)
             out_hi = fma(coef, u_hi[s], out_hi)
-            # instruction_selection: ld.shared.b32 + fma.rn.ftz.f32; extent: scalar x2
+            # instruction_selection: ld.shared.b32 (token 0 reads the single
+            # sR[0][0]) / ld.shared.v2.b32 (token 1 reads the sR[1][0..1] pair)
+            # + fma.rn.ftz.f32; extent: scalar x2 per (t, s). The s > t
+            # coefficient is a real zero-operand fma, not a skipped iteration.
         base_t = (sToken[t] * HV + hv) * 128 + tile_row_base
         active = sSlot[t] >= 0
         copy_r2g(cast(bf16, out_lo if active else 0.0), out[base_t + row_lo])
@@ -517,7 +520,7 @@ Body total **1570 instructions**; the counts every annotation above rests on:
 | `shfl.sync.bfly.b32` | 30 | 2 L2 norms + 2 coefficient dots per token, 5 rounds each |
 | `st.shared.v4.b32` | 18 | 16 sState stages + 2 sK/sD publishes |
 | `st.global.v4.b32` | 16 | the checkpoints, 8 rows × 2 tokens |
-| `cvt.rn.bf16.f32` | 14 | 8 sVec column stores + 8 output stores (both branches) |
+| `cvt.rn.bf16.f32` | 14 | 8 sVec column stores + 6 output conversions (2 per token in the active branch, 1 per token in the zero branch where both stores reuse the converted zero) |
 | `shfl.sync.idx.b32` | 13 | 12 quad broadcasts + 1 `make_warp_uniform` (identity, but its result is `warp`) |
 | `st.shared.b32` | 11 | scalars: sBeta/sSlot/sToken/sInit/sL/sR/sU |
 | `ldmatrix…x4.shared.b16` | **8** | the A operand, one per MMA issue |
@@ -528,8 +531,8 @@ Body total **1570 instructions**; the counts every annotation above rests on:
 | `st.global.b16` | 8 | the outputs, both branches |
 | `ld.global.nc.{b16,b32,v2.b32}` | 5 / 5 / 3 | v+beta, metadata, q/k/g |
 | `ld.shared.v4.b32` | 19 | the sK/sD slices in phases C and H, the sBeta/sSlot block, sU runs |
-| `ld.shared.b32` | 19 | the scalars only: sInit, prefix gate, sBeta, sL, sR, sSlot, sToken |
-| `ld.shared.v2.b32` | 8 | sToken pairs and the sU row runs |
+| `ld.shared.b32` | 19 | the scalars only: sInit, prefix gate, sBeta, sL, `sR[0][0]`, sSlot, sToken |
+| `ld.shared.v2.b32` | 8 | the sToken pair, the token-1 `sR[1][0..1]` pair, and the sU row runs |
 | `sub.ftz.f32` | 6 | the WY residuals |
 | `cvt.f32.bf16` | 5 | the scalar v and beta loads |
 | `ex2.approx.ftz.f32` | 4 | the gate, one per lane element |

--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
@@ -20,7 +20,7 @@ Transcribed from FlashInfer's frozen generated export
 **Fixed specialization.** `HEAD_DIM = 128`, `TOKENS = 2`, `GATE_KIND = 0`
 (precomputed log-gate), `VALUE_SPLIT = 4`, `LAUNCH_THREADS = 64`,
 `DIRECT_IMPL` unset. The sm100a selector returns 4 unconditionally at T=2
-(`recurrent_kda.py:1181-1182`), so split4 is the entire dispatch surface — there
+(`recurrent_kda.py:1177-1178`), so split4 is the entire dispatch surface — there
 is no split knob in this port.
 
 **Out of scope.** T ∈ {1,3,4,5,6}; the `GATE_KIND = 1` lower-bound variant; the
@@ -61,8 +61,10 @@ Structural operations do not move or compute data:
 
 ```python
 reg_tile(dtype, shape)                 # per-thread register array
-smem_view(name, offset, dtype, shape)  # a named region of the one arena
+smem_arena(bytes, align)               # the single shared allocation
+smem_view(name, offset, dtype, shape)  # a named region of that arena
 swz(byte_off)                          # byte_off ^ ((byte_off >> 7 & 7) << 4)
+widen(word)                            # one u32 -> two f32, as shl.b32 / and.b32
 ```
 
 Data movement:
@@ -153,8 +155,12 @@ token_base = cu_seqlens[n];  seq_len = cu_seqlens[n+1] - token_base
 # token_base -- the contract is the caller's and is deliberately unvalidated for
 # CUDA-graph capture. Padding is signalled ONLY by ssm_state_indices < 0.
 #
-# The source also calls make_warp_uniform(tid/32) at :101, which emits a dead
-# shfl.sync.idx.b32 at .loc :39. It is a uniformity hint; the port omits it.
+# The source computes `warp` as make_warp_uniform(tid/32) at :101, which emits a
+# shfl.sync.idx.b32 at .loc :39. It is semantically the identity -- a uniformity
+# hint -- but its result IS `warp` and is live throughout, so it is not dead
+# code; the port spells the same value as `tid // 32`. (The one-warp t1_direct
+# sibling emits the same instruction with an unused result, which is where the
+# "dead" characterization comes from; it does not carry over.)
 
 # ===========================================================================
 # Phase A: token preprocess, warp <-> token  (:180-290)
@@ -180,7 +186,8 @@ if warp < TOKENS:
     # ---- L2 norms: two independent full-warp butterflies ------------------
     # Association is index-ordered accumulation over i = 0..3  (:241-244)
     q_sq = dot(r_q, r_q);  k_sq = dot(r_k, r_k)
-    # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32; extent: 4-term chain each
+    # instruction_selection: fma.rn.ftz.f32; extent: 4-term chain each, the first
+    # with C = 0f00000000 -- there is no mul at these sites
     for offset in (16, 8, 4, 2, 1):
         q_sq = add(q_sq, bfly(q_sq, offset, 31, 0xFFFFFFFF))
     # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds
@@ -273,11 +280,16 @@ if warp < TOKENS:
         if source_token >= 0:
             dot_kk = 0.0; dot_qk = 0.0
             for i in range(4):
-                sk = sD_scaled = sK[source_token, elem_start + i]
+                sk = sK[source_token, elem_start + i]
                 dot_kk = fma(mul(r_k[i], sk), ratio[i], dot_kk)
                 dot_qk = fma(mul(r_q[i], sk), ratio[i], dot_qk)
-            # instruction_selection: ld.shared.b32 + mul.ftz.f32 + fma.rn.ftz.f32
-            # extent: 4 iterations; source order is `r * source_k * ratio` (:372-375)
+            # instruction_selection: ld.shared.v4.b32 (the 4 contiguous sK floats)
+            # + mul.ftz.f32 + fma.rn.ftz.f32; extent: 4 iterations
+            # Source order is `r * source_k * ratio` (:372-375). At
+            # source_offset == 0 the ratio is still 1.0 and folds away, so that
+            # offset emits 4 bare fma (the first with C = 0f00000000) and only
+            # source_offset == 1 emits the mul+fma pair -- 4 mul + 8 fma per dot
+            # line across the two offsets.
             for offset in (16, 8, 4, 2, 1):
                 dot_kk = add(dot_kk, bfly(dot_kk, offset, 31, 0xFFFFFFFF))
             for offset in (16, 8, 4, 2, 1):
@@ -293,12 +305,17 @@ if warp < TOKENS:
             if source_token > 0:
                 for i in range(4):
                     ratio[i] = mul(ratio[i], sD[source_token, elem_start + i])
-                # instruction_selection: ld.shared.b32 + mul.ftz.f32; extent: 4
+                # instruction_selection: ld.shared.v4.b32 + mul.ftz.f32; extent: 4
 
 cta_sync()
 # instruction_selection: bar.sync 0; extent: CTA
-# Orders sState (written by ALL 64 threads) -> the ldmatrix reads below (issued
-# by both warps, each reading its own 16 rows), and sVec/sL/sR -> their readers.
+# The genuinely cross-warp edges are sVec (warp 0 writes columns 0 and 4, warp 1
+# writes 1 and 5, and both warps' ldmatrix read columns 0..7) and sL/sR (written
+# by one warp's lane 0, read by both warps in phases E and F). The sState edge is
+# intra-warp by the same row-set argument as the phase-G warp barrier -- groups
+# 0,1 are warp 0 and write rows 0..15, which is exactly what warp 0 reads back --
+# and is ordered here only as a side effect. A port narrowing this barrier must
+# reason from sVec/sL/sR, not from sState.
 
 # ===========================================================================
 # Phase D: the MMA chain, warp <-> 16 value rows  (:406-438)
@@ -388,8 +405,10 @@ if warp < TOKENS and lane_quad == 2:
         active = sSlot[t] >= 0
         copy_r2g(cast(bf16, out_lo if active else 0.0), out[base_t + row_lo])
         copy_r2g(cast(bf16, out_hi if active else 0.0), out[base_t + row_hi])
-        # instruction_selection: cvt.rn.bf16.f32 + st.global.b16; extent: 2 scalars
-        # per token, both branches  (.loc :503,:504,:506,:507 and :523,:524,:526,:527)
+        # instruction_selection: st.global.b16, 2 per token per branch (8 total);
+        # cvt.rn.bf16.f32, 2 per token in the active branch but only 1 per token
+        # in the zero branch, where both stores reuse the single converted zero
+        # (6 total)  (.loc :503,:504,:506,:507 and :523,:524,:526,:527)
         # A padded row writes EXPLICIT zeros -- the upstream test asserts them
         # bit-exactly, so this is not an "unwritten" path.
 
@@ -424,13 +443,20 @@ for t in range(TOKENS):                   # serial over tokens
     for row_local in range(8):            # constexpr unroll
         row    = owned_row_base + row_local
         update = mul(sU[t, row], beta_t)
-        # instruction_selection: ld.shared.b32 x2 + mul.ftz.f32; extent: scalar
+        # instruction_selection: ld.shared.v4.b32 (the hoisted sBeta/sSlot block)
+        # + ld.shared.v2.b32/v4.b32 over the 8 consecutive sU rows + mul.ftz.f32
+        # extent: scalar per row; phase H emits no scalar ld.shared.b32 at all
         words = reg_tile(u32, [4])
         for i in range(8):
-            hist[row_local][i] = fma(update, sK[t, k_start + i],
-                                     mul(hist[row_local][i], sD[t, k_start + i]))
-            # instruction_selection: ld.shared.v2.b32 + mul.ftz.f32 + fma.rn.ftz.f32
-            # extent: 8 iterations
+            hist[row_local][i] = fma(hist[row_local][i], sD[t, k_start + i],
+                                     mul(update, sK[t, k_start + i]))
+            # instruction_selection: ld.shared.v4.b32 x2 (sD) + x2 (sK) per token
+            # + mul.ftz.f32 + fma.rn.ftz.f32; extent: 8 iterations
+            # The source writes `hist*sD + update*sK` (:673) and the compiler
+            # contracts the FIRST product: `update*sK` is the rounded one and
+            # `hist*sD` is fused into the FMA. Inverting this rounds the wrong
+            # product at the kernel's only stateful accumulation, which feeds
+            # both the checkpoint and token 1's history.
             # The recurrence advances UNCONDITIONALLY -- only the store below is
             # predicated -- and it stays FP32, so token 1 consumes the un-rounded
             # token-0 state rather than the bf16 checkpoint.
@@ -470,8 +496,8 @@ is statically dead, and the port carries none of it:
 | `vec_frag[2],[3]` | `:415` | the x4 loads sVec cols 8..15; the MMA reads 2 registers |
 | sVec columns 2,3 and 6..15 | — | never written; feed dead accumulator lanes. **Not zeroed** — zeroing is numerically safe but adds stores the source does not issue |
 | `sR[0][1]`, `sL[0][*]`, `sL[1][1]` | `:390-392` | of the two 2×2 matrices only `sL[1][0]` and `sR[{0,0},{1,0},{1,1}]` are written and read |
-| `elem_start < 128` guards | `:194` etc. | statically true at D=128 |
-| `make_warp_uniform` | `:101` | a uniformity hint; emits a dead `shfl.sync.idx.b32` |
+| `elem_start < 128` guards, and the `r_q/r_k/r_d = 0.0f` prologue they guard | `:188-194` etc. | statically true at D=128, so the zero-init is unreachable |
+| `group < 4` guards around phases B and H | `:294`, `:659` | statically true at 64 threads (`group = tid/16 ∈ {0..3}`) |
 | `A_log`, `dt_bias`, `lower_bound` | `:98` | `GATE_KIND 0`; never dereferenced |
 
 ## Instruction-selection summary
@@ -492,7 +518,7 @@ Body total **1570 instructions**; the counts every annotation above rests on:
 | `st.shared.v4.b32` | 18 | 16 sState stages + 2 sK/sD publishes |
 | `st.global.v4.b32` | 16 | the checkpoints, 8 rows × 2 tokens |
 | `cvt.rn.bf16.f32` | 14 | 8 sVec column stores + 8 output stores (both branches) |
-| `shfl.sync.idx.b32` | 13 | quad broadcasts + 1 dead `make_warp_uniform` |
+| `shfl.sync.idx.b32` | 13 | 12 quad broadcasts + 1 `make_warp_uniform` (identity, but its result is `warp`) |
 | `st.shared.b32` | 11 | scalars: sBeta/sSlot/sToken/sInit/sL/sR/sU |
 | `ldmatrix…x4.shared.b16` | **8** | the A operand, one per MMA issue |
 | `ldmatrix…x4.trans.shared.b16` | **8** | the B operand, one per MMA issue |
@@ -501,6 +527,9 @@ Body total **1570 instructions**; the counts every annotation above rests on:
 | `st.shared.b16` | 8 | the sVec columns |
 | `st.global.b16` | 8 | the outputs, both branches |
 | `ld.global.nc.{b16,b32,v2.b32}` | 5 / 5 / 3 | v+beta, metadata, q/k/g |
+| `ld.shared.v4.b32` | 19 | the sK/sD slices in phases C and H, the sBeta/sSlot block, sU runs |
+| `ld.shared.b32` | 19 | the scalars only: sInit, prefix gate, sBeta, sL, sR, sSlot, sToken |
+| `ld.shared.v2.b32` | 8 | sToken pairs and the sU row runs |
 | `sub.ftz.f32` | 6 | the WY residuals |
 | `cvt.f32.bf16` | 5 | the scalar v and beta loads |
 | `ex2.approx.ftz.f32` | 4 | the gate, one per lane element |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ point each port backs:
 | `recurrent_kda_decode_one_warp` | bf16 | Recurrent KDA decode, one warp per CTA (T=1, `sequence_heads >= 128`) |
 | `recurrent_kda_decode_grouped` | bf16 | Recurrent KDA decode, grouped CTA (small-batch T=1 and all speculative T>1) |
 | `flashkda_decode_t1_precomputed` | bf16 | FlashKDA "cake" decode, T=1 precomputed gate |
+| `flashkda_decode_t2_precomputed` | bf16 | FlashKDA "cake" decode, T=2 precomputed gate (WY, tensor cores) |
 
 `flashinfer/gdn_prefill/` — `flashinfer.gdn_prefill`:
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "ea0950ab",
-    "tirx-kernels": "98747523",
+    "tirx-kernels": "022c384a",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "2b7792906e560fab01fb004a811cce56381d4ca4"
+    "tirx-kernels:tirx_kernels": "65581c0667f9f4fc84412841bef4e99d5c8bfbdc"
   },
   "baselines": {
     "torch": {
@@ -1793,6 +1793,132 @@
       "impls": {
         "tirx": 6.2427481930603355,
         "flashinfer_cake": 7.913243303966552
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv12h12_b64_t2",
+      "label": "hv12h12_b64_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 20.891704334660023,
+        "flashinfer_cake": 24.007318980868945
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv12h12_b8_t2",
+      "label": "hv12h12_b8_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.350220182292079,
+        "flashinfer_cake": 8.282665345053852
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv16h16_b64_t2",
+      "label": "hv16h16_b64_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 25.377645220511624,
+        "flashinfer_cake": 30.16673546717479
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv16h16_b8_t2",
+      "label": "hv16h16_b8_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.986833881473316,
+        "flashinfer_cake": 8.800366793582626
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv32h16_b128_t2",
+      "label": "hv32h16_b128_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 83.2297856610106,
+        "flashinfer_cake": 94.88444040868747
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv32h16_b16_t2",
+      "label": "hv32h16_b16_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.446455942158458,
+        "flashinfer_cake": 17.832382828820197
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv32h16_b32_t2",
+      "label": "hv32h16_b32_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 25.36455503688244,
+        "flashinfer_cake": 29.94247059479419
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv32h16_b64_t2",
+      "label": "hv32h16_b64_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 44.90519007664209,
+        "flashinfer_cake": 51.21532156395486
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t2_precomputed",
+      "config": "hv32h16_b8_t2",
+      "label": "hv32h16_b8_t2",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.08968844266317,
+        "flashinfer_cake": 10.977688391352567
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '98747523', 'tirx-bench-ci': None}`
-- Workloads: 269 ok, 0 failed
+- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '022c384a', 'tirx-bench-ci': None}`
+- Workloads: 278 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -213,6 +213,20 @@ Grouped workloads show one row per config and one timing column per implementati
 | `hv16h16_b8_s16` | tirx | 5.0008 | flashinfer_cake | 6.3387 | 1.268 | — |
 | `hv32h16_b32_s8` | tirx | 16.6276 | flashinfer_cake | 19.3684 | 1.165 | — |
 | `hv32h16_b8_s16` | tirx | 6.2427 | flashinfer_cake | 7.9132 | 1.268 | — |
+
+## flashkda_decode_t2_precomputed
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv12h12_b64_t2` | tirx | 20.8917 | flashinfer_cake | 24.0073 | 1.149 | — |
+| `hv12h12_b8_t2` | tirx | 6.3502 | flashinfer_cake | 8.2827 | 1.304 | — |
+| `hv16h16_b64_t2` | tirx | 25.3776 | flashinfer_cake | 30.1667 | 1.189 | — |
+| `hv16h16_b8_t2` | tirx | 6.9868 | flashinfer_cake | 8.8004 | 1.260 | — |
+| `hv32h16_b128_t2` | tirx | 83.2298 | flashinfer_cake | 94.8844 | 1.140 | — |
+| `hv32h16_b16_t2` | tirx | 15.4465 | flashinfer_cake | 17.8324 | 1.154 | — |
+| `hv32h16_b32_t2` | tirx | 25.3646 | flashinfer_cake | 29.9425 | 1.180 | — |
+| `hv32h16_b64_t2` | tirx | 44.9052 | flashinfer_cake | 51.2153 | 1.141 | — |
+| `hv32h16_b8_t2` | tirx | 9.0897 | flashinfer_cake | 10.9777 | 1.208 | — |
 
 ## fp16_bf16_gemm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t2_precomputed.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t2_precomputed.yaml
@@ -1,0 +1,28 @@
+# FlashKDA "cake" T=2 precomputed-gate decode, against the frozen FlashInfer
+# export it is ported from.
+#
+# Unlike the T=1 sibling there is no split dimension to cover: the sm100a
+# selector returns value_split 4 for every T=2 shape
+# (recurrent_kda.py:1177-1178), so d128_t2_precomputed_split4 is the entire
+# dispatch surface and the matrix varies only (HV, H, N).
+# .porting/.../verify_dispatch.py asserts that for every row by feeding the real
+# tensors into FlashInfer's own selector -- at T=2 what that actually guards is
+# the rest of the contract (num_spec_tokens == 1, ssm_state_indices of exactly
+# N*2 entries, cu_seqlens stepping by two), any of which makes the selector
+# return None rather than a wrong variant.
+#
+#   hv32h16_*   H=16, HV=32 (GQA ratio 2) -- exact parity with FlashInfer's own
+#               T=2 export bench, which sweeps N in {8,16,32,64,128}
+#   hv16h16_*   the non-GQA head count, at both ends of the batch range
+#   hv12h12_*   Kimi K3's TP8 per-rank head count, same two batch sizes
+kernel: flashkda_decode_t2_precomputed
+configs:
+  - {config: hv32h16_b8_t2, default: true}
+  - {config: hv32h16_b16_t2, default: true}
+  - {config: hv32h16_b32_t2, default: true}
+  - {config: hv32h16_b64_t2, default: true}
+  - {config: hv32h16_b128_t2, default: true}
+  - {config: hv16h16_b8_t2, default: true}
+  - {config: hv16h16_b64_t2, default: true}
+  - {config: hv12h12_b8_t2, default: true}
+  - {config: hv12h12_b64_t2, default: true}

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -259,6 +259,16 @@ def _ld_shared_i32(arena, byte_off):
     return T.reinterpret("int32", out[0])
 
 
+def _ld_shared_f32x4(arena, byte_off, dst, base):
+    """``ld.shared.v4.b32`` -- four contiguous shared floats."""
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx.ld.shared.v4.b32(words[0], words[1], words[2], words[3], arena.ptr_to([byte_off]))
+    )
+    for i in range(4):
+        T.buffer_store(dst, T.reinterpret("float32", words[i]), [base + i])
+
+
 def _st_shared_u32x4(arena, byte_off, words):
     """``st.shared.v4.b32`` -- the sState stage and the sK/sD publish."""
     T.evaluate(
@@ -463,6 +473,12 @@ def _flashkda_decode_t2_precomputed(
     ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
     nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
     T.device_entry()
+    # The source body declares __launch_bounds__(256) -- a vestigial Loom
+    # constant, since the binding launches 64 threads -- together with
+    # --maxrregcount=128. TIRx would otherwise emit __launch_bounds__(64), which
+    # lets ptxas spend 118 registers per thread against the source's 105; at 64
+    # threads that is 8 blocks/SM instead of 9. Asking for 9 brings it to 96.
+    T.attr({"tirx.launch_bounds_min_blocks_per_sm": 9})
 
     # The source uses dynamic smem; 14720 B fits the static limit, so the same
     # bytes are declared statically at the same alignment. The region offsets
@@ -615,13 +631,14 @@ def _flashkda_decode_t2_precomputed(
             if source_token >= 0:
                 dot_kk: T.float32 = T.float32(0.0)
                 dot_qk: T.float32 = T.float32(0.0)
+                sk_vec = T.alloc_local((4,), "float32")
+                _ld_shared_f32x4(
+                    arena, OFF_SK + (source_token * HEAD_DIM + elem_start) * 4, sk_vec, 0
+                )
                 for i in T.unroll(4):
-                    sk: T.float32 = _ld_shared_f32(
-                        arena, OFF_SK + (source_token * HEAD_DIM + elem_start + i) * 4
-                    )
                     # Source order: r * source_k * ratio  (:372-375).
-                    dot_kk = _fma(_mul(r_k[i], sk), ratio[i], dot_kk)
-                    dot_qk = _fma(_mul(r_q[i], sk), ratio[i], dot_qk)
+                    dot_kk = _fma(_mul(r_k[i], sk_vec[i]), ratio[i], dot_kk)
+                    dot_qk = _fma(_mul(r_q[i], sk_vec[i]), ratio[i], dot_qk)
                 for off in T.unroll(5):
                     dot_kk = _add(dot_kk, _shfl_bfly(dot_kk, 16 >> off))
                 for off in T.unroll(5):
@@ -640,13 +657,12 @@ def _flashkda_decode_t2_precomputed(
                         _mul(beta_source, dot_qk),
                     )
                 if source_token > 0:
+                    sd_vec = T.alloc_local((4,), "float32")
+                    _ld_shared_f32x4(
+                        arena, OFF_SD + (source_token * HEAD_DIM + elem_start) * 4, sd_vec, 0
+                    )
                     for i in T.unroll(4):
-                        ratio[i] = _mul(
-                            ratio[i],
-                            _ld_shared_f32(
-                                arena, OFF_SD + (source_token * HEAD_DIM + elem_start + i) * 4
-                            ),
-                        )
+                        ratio[i] = _mul(ratio[i], sd_vec[i])
 
     T.cuda.cta_sync()
 
@@ -1179,10 +1195,47 @@ def run_bench(
     timer: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Benchmark entry point. Implemented in the performance gate."""
-    raise SkipTest(
-        "flashkda_decode_t2_precomputed is at the scaffold stage; benchmarking is "
-        "enabled in the performance gate"
+    """Time the port against the frozen cake export on identical inputs."""
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region. Both sides mutate their own state
+    # pool in place, so this also proves the pools stayed independent.
+    executable(*args)
+    reference_out = _flashinfer_reference(case)
+    torch.cuda.synchronize(case["device"])
+    torch.testing.assert_close(
+        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+    )
+    torch.testing.assert_close(
+        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # The nvcc JIT build and warmup both happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cake": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
     )
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -1,0 +1,552 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx port of FlashInfer's FlashKDA "cake" T=2 precomputed-gate decode kernel.
+
+Source: ``csrc/kda/flashkda_decode_d128_t2_precomputed_split4.cu``, symbol
+``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- a frozen machine-generated
+export ("Generated from a recurrent-KDA Loom schedule") whose SHA256 it declares
+in its own header.
+
+This is the WY-transform schedule: 2 warps, a 14720-byte shared-memory arena,
+``ldmatrix`` + ``mma.sync`` tensor-core products, and a per-token checkpoint
+contract -- structurally unrelated to the one-warp ``t1_direct`` sibling, which
+serves only as a contract reference.
+
+Dispatch reaches this body whenever ``num_tokens == 2`` with
+``num_spec_tokens == 1`` (MTP with one draft token). The sm100a split selector
+returns 4 unconditionally at T=2 (``recurrent_kda.py:1170-1192``), so
+``d128_t2_precomputed_split4`` is the only reachable -- and the only locally
+measurable -- specialization; ``_specialization`` raises for anything else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+# --- source pinning -------------------------------------------------------
+# The generated body declares its own digest at
+# flashkda_decode_d128_t2_precomputed_split4.cu:19-20. Two digests are printed
+# there, "Raw" and "Normalized", and they differ for this export; the hash of
+# the bytes between the BEGIN/END markers is the *raw* one.
+FROZEN_FLASHINFER_COMMIT = "f2e04400"
+FROZEN_BODY_SHA256 = "e0cf2ece1b50e851579df8822fa2f03262a3399e25643a6bd3df03c875cc5ea2"
+
+HEAD_DIM = 128
+NUM_TOKENS = 2
+VALUE_SPLIT = 4  # the sm100a selector returns 4 unconditionally at T = 2
+L2_EPS = 1.0e-6
+LOG2_E = 1.4426950408889634
+
+THREADS = 64  # 2 warps (flash_kda_decode.py:_variant_metadata)
+ROWS_PER_CTA = HEAD_DIM // VALUE_SPLIT  # 32 value rows per CTA
+ROWS_PER_THREAD = 8  # each of the 64 threads owns 8 rows x 8 keys
+K_PER_THREAD = 8
+
+# Shared-memory arena, byte offsets copied from the source's #define block
+# (.cu:45-87). The source declares it `extern __shared__ __align__(1024)` and
+# the launcher passes SMEM_TOTAL dynamically; the port declares the same bytes
+# with the same alignment as a static arena, which needs no launch tag.
+OFF_SSTATE0 = 0
+OFF_SSTATE1 = 4096
+OFF_SVEC = 8192
+OFF_SK = 12288
+OFF_SD = 13312
+OFF_SBETA = 14336
+OFF_SSLOT = 14344
+OFF_STOKEN = 14352
+OFF_SINIT = 14360
+OFF_SL = 14376
+OFF_SR = 14392
+OFF_SU = 14408
+SMEM_TOTAL = 14720
+# sGramA0/sGramA1 (offsets 8192/10240) alias sVec and are dead at T=2/split4 --
+# they belong to the t5/t6 coefficient-gram schedules. Not declared here.
+
+# TIRX_TRANSCRIBE_START flashkda_decode_t2_precomputed
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror FlashInfer's T=2 export bench."""
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 8,
+        "num_heads": 16,
+        "num_value_heads": 32,
+        "pool_slack": 6,  # state_slots = num_seqs*T + slack (upstream bench)
+        "padded_seqs": 0,
+        "slot_stride_pad": 0,
+        "gate_token_stride_pad": 0,
+        "accepted": None,  # None -> all ones (initial slot = ssm_idx[n, 0])
+        "scale": None,
+        "seed": 20260813,
+    }
+    config.update(overrides)
+    return config
+
+
+# Every T=2 shape selects split4, so the matrix varies only (HV, H, N).
+# hv32h16 mirrors FlashInfer's own export bench exactly.
+BENCH_CONFIGS = [
+    _case("hv32h16_b8_t2", num_seqs=8),
+    _case("hv32h16_b16_t2", num_seqs=16),
+    _case("hv32h16_b32_t2", num_seqs=32),
+    _case("hv32h16_b64_t2", num_seqs=64),
+    _case("hv32h16_b128_t2", num_seqs=128),
+    _case("hv16h16_b8_t2", num_seqs=8, num_heads=16, num_value_heads=16),
+    _case("hv16h16_b64_t2", num_seqs=64, num_heads=16, num_value_heads=16),
+    _case("hv12h12_b8_t2", num_seqs=8, num_heads=12, num_value_heads=12),
+    _case("hv12h12_b64_t2", num_seqs=64, num_heads=12, num_value_heads=12),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # num_accepted_tokens is live at T=2 (unlike t1_direct): it selects the
+    # initial checkpoint slot as ssm_idx[n*2 + clamp(nat-1, 0, 1)]. The upstream
+    # test sweeps 0/1/2/9, covering both clamp edges (.cu:279-286).
+    _case("hv32h16_b8_t2_nat0", num_seqs=8, accepted="zeros"),
+    _case("hv32h16_b8_t2_nat2", num_seqs=8, accepted="twos"),
+    _case("hv32h16_b8_t2_nat9", num_seqs=8, accepted="nines"),
+    _case("hv32h16_b8_t2_natmix", num_seqs=8, accepted="mixed"),
+    # CUDA-graph padding: ssm_state_indices == -1 rows must zero their output
+    # bit-exactly and leave their state slots untouched (.cu:501-530).
+    _case("hv32h16_b8_t2_padded", num_seqs=8, padded_seqs=2),
+    # Envelope-strided state pool and gate.
+    _case("hv32h16_b8_t2_strided", num_seqs=8, slot_stride_pad=8),
+    _case("hv32h16_b8_t2_gstride", num_seqs=8, gate_token_stride_pad=8),
+    # Non-default scale; GQA ratio 4; the smallest grid.
+    _case("hv32h16_b8_t2_scale", num_seqs=8, scale=0.05),
+    _case("hv64h16_b8_t2", num_seqs=8, num_heads=16, num_value_heads=64),
+    _case("hv32h16_b1_t2", num_seqs=1),
+]
+
+KERNEL_META = {
+    "name": "flashkda_decode_t2_precomputed",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    gate_token_stride_pad = int(kwargs.get("gate_token_stride_pad", 0))
+    pool_slack = int(kwargs.get("pool_slack", 6))
+
+    if num_value_heads % num_heads != 0 or num_value_heads < num_heads:
+        raise ValueError("num_value_heads must be a multiple of num_heads and >= it")
+    if not 0 < num_seqs <= 65535:
+        raise ValueError("num_seqs must fit grid.y (binding_common.cuh:284-287)")
+    if slot_stride_pad % 8 != 0:
+        raise ValueError("state slot stride padding must stay 8-element aligned")
+    if gate_token_stride_pad % 4 != 0:
+        raise ValueError("gate token stride padding must stay 4-element aligned")
+
+    # The sm100a policy is `if num_tokens == 2: return 4` with no shape
+    # dependence, so there is nothing to select -- but assert it, because a
+    # different split would be a different kernel.
+    if VALUE_SPLIT != 4:
+        raise ValueError("only d128_t2_precomputed_split4 is in this port's scope")
+
+    total_tokens = num_seqs * NUM_TOKENS
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    gate_token_stride = num_value_heads * HEAD_DIM + gate_token_stride_pad
+    state_slots = total_tokens + pool_slack
+    return {
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "HEAD_RATIO": num_value_heads // num_heads,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "GATE_TOKEN_STRIDE": gate_token_stride,
+        "Q_ELEMENTS": total_tokens * num_heads * HEAD_DIM,
+        "V_ELEMENTS": total_tokens * num_value_heads * HEAD_DIM,
+        "GATE_ELEMENTS": total_tokens * gate_token_stride,
+        "BETA_ELEMENTS": total_tokens * num_value_heads,
+        "STATE_ELEMENTS": state_slots * slot_stride,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": num_seqs * NUM_TOKENS,
+        "NAT_ELEMENTS": num_seqs,
+    }
+
+
+@T.jit
+def _flashkda_decode_t2_precomputed(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    num_accepted_tokens_h: T.handle,
+    scale: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    HEAD_RATIO: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    GATE_TOKEN_STRIDE: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    GATE_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+    NAT_ELEMENTS: T.constexpr,
+):
+    """FlashKDA "cake" T=2 precomputed-gate decode -- scaffold body.
+
+    The implementation is written in the correctness gate, after the kernel
+    sketch has passed review.
+    """
+    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized FlashKDA cake T=2 decode PrimFunc."""
+    return _flashkda_decode_t2_precomputed.specialize(**_specialization(kwargs))
+
+
+def _accepted_tensor(kind: Any, num_seqs: int, device: str) -> torch.Tensor:
+    """num_accepted_tokens per case.
+
+    The kernel clamps `nat - 1` into [0, 1] and uses it to pick the initial
+    checkpoint slot, so 0 and 1 both select index 0 while 2 and anything larger
+    select index 1 (.cu:279-286).
+    """
+    if kind is None:
+        return torch.ones(num_seqs, device=device, dtype=torch.int32)
+    if kind == "zeros":
+        return torch.zeros(num_seqs, device=device, dtype=torch.int32)
+    if kind == "twos":
+        return torch.full((num_seqs,), 2, device=device, dtype=torch.int32)
+    if kind == "nines":
+        return torch.full((num_seqs,), 9, device=device, dtype=torch.int32)
+    if kind == "mixed":
+        # The upstream test's sweep, tiled to the batch size
+        # (test_recurrent_kda_decode_export.py:1269-1282).
+        pattern = torch.tensor([0, 1, 2, 9, 1, 0, 1, 2], dtype=torch.int32)
+        reps = (num_seqs + pattern.numel() - 1) // pattern.numel()
+        return pattern.repeat(reps)[:num_seqs].to(device)
+    raise ValueError(f"unknown accepted-token pattern {kind!r}")
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state."""
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for FlashKDA cake T=2 decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"FlashKDA cake decode targets compute capability 10.x, got {capability}")
+
+    spec = _specialization(kwargs)
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    gate_token_stride = spec["GATE_TOKEN_STRIDE"]
+    total_tokens = num_seqs * NUM_TOKENS
+    state_slots = spec["STATE_ELEMENTS"] // slot_stride
+    padded_seqs = int(kwargs.get("padded_seqs", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    # Packed [1, N*2, ...] layout -- the form the upstream tests and benches use
+    # (recurrent_kda.py:1770-1795).
+    q = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, total_tokens, num_value_heads, HEAD_DIM, gain=0.5)
+    # GATE_KIND == 0: g holds the per-K log-gate computed on the host; the
+    # kernel applies exp() to it.
+    gate_logits = torch.randn(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        device=device,
+        dtype=torch.float32,
+        generator=gen,
+    )
+    g_dense = torch.nn.functional.logsigmoid(gate_logits).to(torch.bfloat16)
+    g_raw = torch.zeros((total_tokens * gate_token_stride,), device=device, dtype=torch.bfloat16)
+    g = g_raw.as_strided(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        (total_tokens * gate_token_stride, gate_token_stride, HEAD_DIM, 1),
+    )
+    g.copy_(g_dense)
+    beta = torch.sigmoid(randn(1, total_tokens, num_value_heads, dtype=torch.float32, gain=0.5)).to(
+        torch.bfloat16
+    )
+
+    # cu_seqlens steps by exactly NUM_TOKENS per row; the body assumes this
+    # stride-T contract and does not bound-check token_base.
+    cu_seqlens = torch.arange(0, total_tokens + 1, NUM_TOKENS, device=device, dtype=torch.int32)
+    # Slot 0 is deliberately never a checkpoint target, matching the upstream
+    # bench (bench_recurrent_kda_decode_export.py:232-236).
+    slots = torch.arange(1, total_tokens + 1, device=device, dtype=torch.int32).reshape(
+        num_seqs, NUM_TOKENS
+    )
+    if padded_seqs:
+        slots[num_seqs - padded_seqs :, :] = -1
+    ssm_state_indices = slots.contiguous().view(-1)
+    num_accepted_tokens = _accepted_tensor(kwargs.get("accepted"), num_seqs, device)
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(state_slots * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, total_tokens, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    scale = kwargs.get("scale")
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "g_raw": g_raw,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": ssm_state_indices,
+        "ssm_state_indices_2d": slots,
+        "num_accepted_tokens": num_accepted_tokens,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": float(scale) if scale is not None else HEAD_DIM**-0.5,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g_raw"],
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+    )
+
+
+def _source_body_path() -> str:
+    """Absolute path of the frozen generated body this port transcribes."""
+    import flashinfer  # local: keep kernel discovery free of optional deps
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t2_precomputed_split4.cu")
+
+
+def assert_frozen_source() -> None:
+    """Fail loudly if the upstream generated body was regenerated."""
+    path = _source_body_path()
+    with open(path, "rb") as handle:
+        text = handle.read().decode()
+    marker = "// BEGIN FROZEN GENERATED BODY\n"
+    start = text.index(marker) + len(marker)
+    end = text.index("// END FROZEN GENERATED BODY")
+    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
+    if digest != FROZEN_BODY_SHA256:
+        raise AssertionError(
+            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
+            "upstream export was regenerated and this port must be re-verified"
+        )
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the frozen cake export itself on the reference state pool.
+
+    Uses the JIT module's direct ABI rather than
+    ``kda_decode.recurrent_kda(backend="cake")`` so the comparison is
+    kernel-only and every metadata combination (negative slots, arbitrary
+    num_accepted_tokens) is reachable.
+    """
+    from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
+
+    device = case["device"]
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        target = "sm100f" if torch.version.cuda and torch.version.cuda >= "12.9" else "sm100a"
+    elif (major, minor) == (10, 3):
+        # Non-direct variants are not exported for sm103a
+        # (flash_kda_decode.py:213-217).
+        target = "sm100f"
+    else:
+        raise SkipTest(f"FlashKDA cake decode has no export for compute capability {major}.{minor}")
+
+    module = get_flash_kda_decode_module("d128_t2_precomputed_split4", target)
+    reference_out = torch.empty_like(case["tirx_out"])
+    dummy_f32 = torch.ones(1, device=device, dtype=torch.float32)
+
+    module.run(
+        case["q"],
+        case["k"],
+        case["v"],
+        case["g"],
+        case["beta"],
+        dummy_f32,
+        dummy_f32,
+        case["reference_state"],
+        reference_out,
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+        0.0,
+        int(torch.cuda.current_stream(device).cuda_stream),
+    )
+    torch.cuda.synchronize(device)
+    return reference_out
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the T=2 delta rule.
+
+    Written as the sequential recurrence the WY transform computes in blocked
+    form, which is the point: it agrees only if the WY algebra is right. It
+    keeps the kernel's two structural choices -- the recurrent state advances in
+    FP32 across both tokens (only the stored checkpoint is rounded to bf16), and
+    the initial slot is selected by the clamped num_accepted_tokens.
+    """
+    spec = case["spec"]
+    num_seqs = spec["NUM_SEQS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    head_ratio = spec["HEAD_RATIO"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+
+    q = case["q"][0].float()
+    k = case["k"][0].float()
+    v = case["v"][0].float()
+    g = case["g"][0].float()
+    beta = case["beta"][0].float()
+    slots2d = case["ssm_state_indices_2d"]
+    nat = case["num_accepted_tokens"]
+
+    state_raw = case["initial_state_raw"].clone()
+    state_slots = state_raw.numel() // slot_stride
+    state = state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    out = torch.zeros(
+        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
+        device=case["device"],
+        dtype=torch.float32,
+    )
+
+    scale = float(case["scale"])
+    for n in range(num_seqs):
+        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
+        init_slot = int(slots2d[n, accepted].item())
+        if init_slot < 0:
+            init_slot = 0
+        for hv in range(num_value_heads):
+            h = hv // head_ratio
+            # FP32 carry across both tokens; only the checkpoint store rounds.
+            s = state[init_slot, hv].float()
+            for t in range(NUM_TOKENS):
+                row = n * NUM_TOKENS + t
+                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
+                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
+                gamma = torch.exp(g[row, hv])
+
+                decayed = s * gamma.unsqueeze(0)
+                pred = decayed @ kn
+                u = v[row, hv] - pred
+                delta = u * beta[row, hv]
+                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
+                out[row, hv] = s @ qn
+
+                slot = int(slots2d[n, t].item())
+                if slot >= 0:
+                    state[slot, hv] = s.to(torch.bfloat16)
+                else:
+                    out[row, hv] = 0.0
+
+    return out.to(torch.bfloat16).unsqueeze(0), state_raw
+
+
+def run_test(**kwargs: Any) -> None:
+    """Correctness entry point. Implemented in the correctness gate."""
+    raise SkipTest(
+        "flashkda_decode_t2_precomputed is at the scaffold stage; the kernel body "
+        "is written in the correctness gate"
+    )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point. Implemented in the performance gate."""
+    raise SkipTest(
+        "flashkda_decode_t2_precomputed is at the scaffold stage; benchmarking is "
+        "enabled in the performance gate"
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "assert_frozen_source",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -76,6 +76,241 @@ SMEM_TOTAL = 14720
 # TIRX_TRANSCRIBE_START flashkda_decode_t2_precomputed
 
 
+# ---------------------------------------------------------------------------
+# PTX helpers
+# ---------------------------------------------------------------------------
+# Every float op is `.ftz`: the source compiles from plain CUDA operators under
+# -use_fast_math and its PTX contains no plain-.f32 arithmetic at all. Both
+# families are registered in the PTX table, so this is an explicit choice --
+# importing the CuTe-DSL KDA ports' deliberately non-FTZ helpers would be a
+# silent divergence.
+
+_MMA_ZERO_C = (T.float32(0.0), T.float32(0.0), T.float32(0.0), T.float32(0.0))
+
+
+def _ptx_un(chain: str, a, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a))
+    return out[0]
+
+
+def _ptx_bin(chain: str, a, b, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b))
+    return out[0]
+
+
+def _ptx_ter(chain: str, a, b, c, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], a, b, c))
+    return out[0]
+
+
+def _mul(a, b):
+    """``mul.ftz.f32``."""
+    return _ptx_bin("mul.ftz.f32", a, b)
+
+
+def _add(a, b):
+    """``add.ftz.f32``."""
+    return _ptx_bin("add.ftz.f32", a, b)
+
+
+def _sub(a, b):
+    """``sub.ftz.f32``."""
+    return _ptx_bin("sub.ftz.f32", a, b)
+
+
+def _fma(a, b, c):
+    """``fma.rn.ftz.f32``."""
+    return _ptx_ter("fma.rn.ftz.f32", a, b, c)
+
+
+def _rsqrt(a):
+    """``rsqrt.approx.ftz.f32`` -- `rsqrtf` under fast math."""
+    return _ptx_un("rsqrt.approx.ftz.f32", a)
+
+
+def _expf(a):
+    """``__expf``: one mul by log2(e), then ``ex2.approx.ftz.f32``."""
+    return _ptx_un("ex2.approx.ftz.f32", _mul(a, T.float32(LOG2_E)))
+
+
+def _shfl_bfly(value, lane_xor):
+    """``shfl.sync.bfly.b32``, clamp 31 and full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _shfl_idx(value, source_lane):
+    """``shfl.sync.idx.b32``, clamp 31 and full member mask."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.idx.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.cast(source_lane, "uint32"),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _load_i32(buffer, index):
+    """``ld.global.nc.b32`` -- the read-only metadata loads."""
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _load_bf16_f32(buffer, index):
+    """``ld.global.nc.b16`` + ``cvt.f32.bf16`` -- the scalar v and beta loads."""
+    bits = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.nc.b16(bits[0], buffer.ptr_to([index])))
+    return _ptx_un("cvt.f32.bf16", bits[0])
+
+
+def _widen_lo(word):
+    """``shl.b32 d, word, 16`` -- the low bf16 of a packed word."""
+    return T.reinterpret("float32", T.shift_left(word, T.uint32(16)))
+
+
+def _widen_hi(word):
+    """``and.b32 d, word, 0xffff0000`` -- the high bf16."""
+    return T.reinterpret("float32", T.bitwise_and(word, T.uint32(0xFFFF0000)))
+
+
+def _load_u32x2(buffer, index):
+    """``ld.global.nc.v2.b32`` -- one 8-byte tile (four bf16), left packed."""
+    words = T.alloc_local((2,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.v2.b32(words[0], words[1], buffer.ptr_to([index])))
+    return words
+
+
+def _load_u32x4(buffer, index):
+    """``ld.global.v4.b32`` -- one 16-byte state tile.
+
+    Not ``.nc``: the same kernel writes `state`.
+    """
+    words = T.alloc_local((4,), "uint32")
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    return words
+
+
+def _store_u32x4(buffer, index, words):
+    """``st.global.v4.b32`` -- one 16-byte state tile."""
+    T.evaluate(
+        T.ptx.st.global_.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3])
+    )
+
+
+def _pack_bf16x2(hi, lo):
+    """``cvt.rn.bf16x2.f32 d, hi, lo``."""
+    return _ptx_bin("cvt.rn.bf16x2.f32", hi, lo, dtype="uint32")
+
+
+def _store_f32_as_bf16(buffer, index, value, pred):
+    """``cvt.rn.bf16.f32`` + predicated ``st.global.b16``."""
+    bits = _ptx_un("cvt.rn.bf16.f32", value, dtype="uint16")
+    T.evaluate(T.ptx.st.global_.b16(buffer.ptr_to([index]), bits, pred=pred))
+
+
+# --- shared memory --------------------------------------------------------
+# The swizzle the source applies to every sState/sVec byte offset (:322 etc).
+
+
+def _swz(byte_off):
+    return T.bitwise_xor(byte_off, T.shift_left(T.bitwise_and(T.shift_right(byte_off, 7), 7), 4))
+
+
+def _st_shared_f32(arena, byte_off, value):
+    """``st.shared.b32``."""
+    T.evaluate(T.ptx.st.shared.b32(arena.ptr_to([byte_off]), T.reinterpret("uint32", value)))
+
+
+def _ld_shared_f32(arena, byte_off):
+    """``ld.shared.b32``."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], arena.ptr_to([byte_off])))
+    return T.reinterpret("float32", out[0])
+
+
+def _st_shared_i32(arena, byte_off, value):
+    """``st.shared.b32`` for an int32 payload."""
+    T.evaluate(T.ptx.st.shared.b32(arena.ptr_to([byte_off]), T.reinterpret("uint32", value)))
+
+
+def _ld_shared_i32(arena, byte_off):
+    """``ld.shared.b32`` for an int32 payload."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], arena.ptr_to([byte_off])))
+    return T.reinterpret("int32", out[0])
+
+
+def _st_shared_u32x4(arena, byte_off, words):
+    """``st.shared.v4.b32`` -- the sState stage and the sK/sD publish."""
+    T.evaluate(
+        T.ptx.st.shared.v4.b32(arena.ptr_to([byte_off]), words[0], words[1], words[2], words[3])
+    )
+
+
+def _st_shared_b16(arena, byte_off, bits):
+    """``st.shared.b16`` -- one sVec element."""
+    T.evaluate(T.ptx.st.shared.b16(arena.ptr_to([byte_off]), bits))
+
+
+def _ldmatrix_x4(arena, byte_off, frag, trans: bool):
+    """``ldmatrix.sync.aligned.m8n8.x4[.trans].shared.b16`` -- one x4 group."""
+    if trans:
+        T.evaluate(
+            T.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                frag[0], frag[1], frag[2], frag[3], arena.ptr_to([byte_off])
+            )
+        )
+    else:
+        T.evaluate(
+            T.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                frag[0], frag[1], frag[2], frag[3], arena.ptr_to([byte_off])
+            )
+        )
+
+
+def _mma_zero(acc, a, b):
+    """``mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32`` with an explicit zero C."""
+    T.evaluate(
+        T.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+            acc[0], acc[1], acc[2], acc[3],
+            a[0], a[1], a[2], a[3],
+            b[0], b[1],
+            *_MMA_ZERO_C,
+        )
+    )  # fmt: skip
+
+
+def _mma_acc(acc, a, b):
+    """Same, accumulating: C aliases D, matching the source's `+f` tied registers."""
+    T.evaluate(
+        T.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+            acc[0], acc[1], acc[2], acc[3],
+            a[0], a[1], a[2], a[3],
+            b[0], b[1],
+            acc[0], acc[1], acc[2], acc[3],
+        )
+    )  # fmt: skip
+
+
 def _case(label: str, **overrides: Any) -> dict[str, Any]:
     """One config row. Defaults mirror FlashInfer's T=2 export bench."""
     config: dict[str, Any] = {
@@ -211,21 +446,344 @@ def _flashkda_decode_t2_precomputed(
     STATE_INDEX_ELEMENTS: T.constexpr,
     NAT_ELEMENTS: T.constexpr,
 ):
-    """FlashKDA "cake" T=2 precomputed-gate decode -- scaffold body.
+    """FlashKDA "cake" T=2 precomputed-gate decode, WY schedule, 2 warps.
 
-    The implementation is written in the correctness gate, after the kernel
-    sketch has passed review.
+    Transcribed from `kernel_flashinfer_recurrent_kda_wy_vtile_short`; bare
+    `:NNN` references are into
+    `flashkda_decode_d128_t2_precomputed_split4.cu`.
     """
-    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    cu = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    T.device_entry()
+
+    # The source uses dynamic smem; 14720 B fits the static limit, so the same
+    # bytes are declared statically at the same alignment. The region offsets
+    # and the alignment are what the swizzled ldmatrix addressing depends on.
+    arena = T.alloc_buffer((SMEM_TOTAL,), "uint8", scope="shared", align=1024)
+
+    # --- work decomposition and lane roles (:142-160) ----------------------
+    work, n = T.cta_id([NUM_VALUE_HEADS * VALUE_SPLIT, NUM_SEQS])
+    tid = T.thread_id([THREADS])
+    value_tile: T.int32 = work % VALUE_SPLIT
+    hv: T.int32 = work // VALUE_SPLIT
+    query_head: T.int32 = hv // HEAD_RATIO
+    warp: T.int32 = tid // 32  # == token index in phases A and C
+    lane: T.int32 = tid % 32
+    lane_quad: T.int32 = lane % 4
+    frag_row: T.int32 = lane // 4
+    quad_base: T.int32 = lane - lane_quad
+    group: T.int32 = tid // 16
+    lane_group: T.int32 = tid % 16
+    k_start: T.int32 = lane_group * 8
+    elem_start: T.int32 = lane * 4
+    tile_row_base: T.int32 = value_tile * ROWS_PER_CTA
+    owned_row_base: T.int32 = group * 8
+    token_base: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - token_base
+
+    r_q = T.alloc_local((4,), "float32")
+    r_k = T.alloc_local((4,), "float32")
+    r_d = T.alloc_local((4,), "float32")
+
+    # =======================================================================
+    # Phase A: token preprocess, warp <-> token  (:180-290)
+    # =======================================================================
+    if warp < NUM_TOKENS:
+        token: T.int32 = warp
+        active_token = token < seq_len
+        token_pos: T.int32 = T.if_then_else(active_token, token_base + token, 0)
+        qk_base: T.int32 = (token_pos * NUM_HEADS + query_head) * HEAD_DIM + elem_start
+        gate_base: T.int32 = token_pos * GATE_TOKEN_STRIDE + hv * HEAD_DIM + elem_start
+
+        q_words = _load_u32x2(q, qk_base)
+        k_words = _load_u32x2(k, qk_base)
+        g_words = _load_u32x2(g, gate_base)
+        for pair in T.unroll(2):
+            r_q[2 * pair] = _widen_lo(q_words[pair])
+            r_q[2 * pair + 1] = _widen_hi(q_words[pair])
+            r_k[2 * pair] = _widen_lo(k_words[pair])
+            r_k[2 * pair + 1] = _widen_hi(k_words[pair])
+            r_d[2 * pair] = _widen_lo(g_words[pair])
+            r_d[2 * pair + 1] = _widen_hi(g_words[pair])
+
+        # Index-ordered accumulation (:241-244); the first term has a zero addend.
+        q_sq: T.float32 = _fma(
+            r_q[3],
+            r_q[3],
+            _fma(r_q[2], r_q[2], _fma(r_q[1], r_q[1], _fma(r_q[0], r_q[0], T.float32(0.0)))),
+        )
+        k_sq: T.float32 = _fma(
+            r_k[3],
+            r_k[3],
+            _fma(r_k[2], r_k[2], _fma(r_k[1], r_k[1], _fma(r_k[0], r_k[0], T.float32(0.0)))),
+        )
+        # Two sequential full-warp butterflies, not interleaved (:245-254).
+        for off in T.unroll(5):
+            q_sq = _add(q_sq, _shfl_bfly(q_sq, 16 >> off))
+        for off in T.unroll(5):
+            k_sq = _add(k_sq, _shfl_bfly(k_sq, 16 >> off))
+        q_norm: T.float32 = _mul(_rsqrt(_add(q_sq, T.float32(L2_EPS))), scale)
+        k_norm: T.float32 = _rsqrt(_add(k_sq, T.float32(L2_EPS)))
+
+        k_pub = T.alloc_local((4,), "uint32")
+        d_pub = T.alloc_local((4,), "uint32")
+        for i in T.unroll(4):
+            r_q[i] = _mul(r_q[i], q_norm)
+            r_k[i] = _mul(r_k[i], k_norm)
+            r_d[i] = _expf(r_d[i])
+            k_pub[i] = T.reinterpret("uint32", r_k[i])
+            d_pub[i] = T.reinterpret("uint32", r_d[i])
+        _st_shared_u32x4(arena, OFF_SK + (token * HEAD_DIM + elem_start) * 4, k_pub)
+        _st_shared_u32x4(arena, OFF_SD + (token * HEAD_DIM + elem_start) * 4, d_pub)
+
+        if lane == 0:
+            raw_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + token)
+            _st_shared_i32(arena, OFF_SSLOT + token * 4, T.if_then_else(active_token, raw_slot, -1))
+            _st_shared_i32(arena, OFF_STOKEN + token * 4, token_pos)
+            _st_shared_f32(
+                arena, OFF_SBETA + token * 4, _load_bf16_f32(beta, token_pos * NUM_VALUE_HEADS + hv)
+            )
+            if token == 0:
+                # nat is live at T=2: it picks the initial checkpoint slot,
+                # clamped at both ends (:279-287).
+                accepted: T.int32 = T.min(T.max(_load_i32(nat, n) - 1, 0), NUM_TOKENS - 1)
+                initial_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + accepted)
+                _st_shared_i32(arena, OFF_SINIT, T.max(initial_slot, 0))
+
+    T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase B: state gather and sState stage, all 64 threads  (:292-329)
+    # =======================================================================
+    init_slot: T.int32 = _ld_shared_i32(arena, OFF_SINIT)
+    head_base = T.cast(init_slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        hv * HEAD_DIM * HEAD_DIM, "int64"
+    )
+    hist = T.alloc_local((8 * 8,), "float32")
+    for row_local in T.unroll(8):
+        row_l: T.int32 = owned_row_base + row_local
+        pack = _load_u32x4(
+            state, head_base + T.cast((tile_row_base + row_l) * HEAD_DIM + k_start, "int64")
+        )
+        for pr in T.unroll(4):
+            hist[row_local * 8 + 2 * pr] = _widen_lo(pack[pr])
+            hist[row_local * 8 + 2 * pr + 1] = _widen_hi(pack[pr])
+        # The bf16 bits go to shared unmodified; the swizzle is on the byte
+        # offset. lane_group < 8 lands in sState0, the rest in sState1.
+        if lane_group < 8:
+            _st_shared_u32x4(arena, OFF_SSTATE0 + _swz(row_l * 128 + k_start * 2), pack)
+        else:
+            _st_shared_u32x4(arena, OFF_SSTATE1 + _swz(row_l * 128 + (k_start - 64) * 2), pack)
+
+    # =======================================================================
+    # Phase C: sVec columns and the WY coefficients  (:330-404)
+    # =======================================================================
+    if warp < NUM_TOKENS:
+        token_c: T.int32 = warp
+        for i in T.unroll(4):
+            k_idx: T.int32 = elem_start + i
+            prefix: T.float32 = T.float32(1.0)
+            for j in T.unroll(NUM_TOKENS):
+                if token_c >= j:
+                    prefix = _mul(
+                        prefix, _ld_shared_f32(arena, OFF_SD + (j * HEAD_DIM + k_idx) * 4)
+                    )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + token_c * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_k[i]), dtype="uint16"),
+            )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + (4 + token_c) * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_q[i]), dtype="uint16"),
+            )
+
+        ratio = T.alloc_local((4,), "float32")
+        for i in T.unroll(4):
+            ratio[i] = T.float32(1.0)
+        for source_offset in T.unroll(NUM_TOKENS):
+            source_token: T.int32 = token_c - source_offset
+            if source_token >= 0:
+                dot_kk: T.float32 = T.float32(0.0)
+                dot_qk: T.float32 = T.float32(0.0)
+                for i in T.unroll(4):
+                    sk: T.float32 = _ld_shared_f32(
+                        arena, OFF_SK + (source_token * HEAD_DIM + elem_start + i) * 4
+                    )
+                    # Source order: r * source_k * ratio  (:372-375).
+                    dot_kk = _fma(_mul(r_k[i], sk), ratio[i], dot_kk)
+                    dot_qk = _fma(_mul(r_q[i], sk), ratio[i], dot_qk)
+                for off in T.unroll(5):
+                    dot_kk = _add(dot_kk, _shfl_bfly(dot_kk, 16 >> off))
+                for off in T.unroll(5):
+                    dot_qk = _add(dot_qk, _shfl_bfly(dot_qk, 16 >> off))
+                if lane == 0:
+                    beta_source: T.float32 = _ld_shared_f32(arena, OFF_SBETA + source_token * 4)
+                    if source_token < token_c:
+                        _st_shared_f32(
+                            arena,
+                            OFF_SL + (token_c * NUM_TOKENS + source_token) * 4,
+                            _mul(beta_source, dot_kk),
+                        )
+                    _st_shared_f32(
+                        arena,
+                        OFF_SR + (token_c * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, dot_qk),
+                    )
+                if source_token > 0:
+                    for i in T.unroll(4):
+                        ratio[i] = _mul(
+                            ratio[i],
+                            _ld_shared_f32(
+                                arena, OFF_SD + (source_token * HEAD_DIM + elem_start + i) * 4
+                            ),
+                        )
+
+    T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase D: the MMA chain, warp <-> 16 value rows  (:406-438)
+    # =======================================================================
+    acc = T.alloc_local((4,), "float32", align=4)
+    if warp < NUM_TOKENS:
+        vec_frag = T.alloc_local((4,), "uint32", align=4)
+        state_frag = T.alloc_local((4,), "uint32", align=4)
+        for state_half in T.unroll(2):
+            for mma_step in T.unroll(4):
+                mma_k: T.int32 = mma_step * 16
+                global_k: T.int32 = state_half * 64 + mma_k
+                _ldmatrix_x4(
+                    arena,
+                    OFF_SVEC + _swz((global_k + lane % 16) * 32 + lane // 16 * 16),
+                    vec_frag,
+                    True,
+                )
+                if state_half == 0:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE0
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                else:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE1
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                if state_half == 0 and mma_step == 0:
+                    _mma_zero(acc, state_frag, vec_frag)
+                else:
+                    _mma_acc(acc, state_frag, vec_frag)
+
+    # =======================================================================
+    # Phase E/F: quad broadcast, WY solve, and both tokens' outputs (:439-531)
+    # =======================================================================
+    u_lo = T.alloc_local((NUM_TOKENS,), "float32")
+    u_hi = T.alloc_local((NUM_TOKENS,), "float32")
+    if warp < NUM_TOKENS:
+        ha_lo = T.alloc_local((NUM_TOKENS,), "float32")
+        ha_hi = T.alloc_local((NUM_TOKENS,), "float32")
+        for t in T.unroll(NUM_TOKENS):
+            ha_lo[t] = _shfl_idx(acc[t], quad_base)
+            ha_hi[t] = _shfl_idx(acc[2 + t], quad_base)
+
+        if lane_quad == 2:
+            row_lo: T.int32 = warp * 16 + frag_row
+            row_hi: T.int32 = row_lo + 8
+            for t in T.unroll(NUM_TOKENS):
+                base_t: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + t * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM
+                solved_lo: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_lo), ha_lo[t]
+                )
+                solved_hi: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_hi), ha_hi[t]
+                )
+                for prev in T.unroll(NUM_TOKENS):
+                    if prev < t:
+                        lts: T.float32 = _ld_shared_f32(arena, OFF_SL + (t * NUM_TOKENS + prev) * 4)
+                        solved_lo = _sub(solved_lo, _mul(lts, u_lo[prev]))
+                        solved_hi = _sub(solved_hi, _mul(lts, u_hi[prev]))
+                u_lo[t] = solved_lo
+                u_hi[t] = solved_hi
+
+            # ---- outputs, both tokens (:484-531) --------------------------
+            for t in T.unroll(NUM_TOKENS):
+                out_lo: T.float32 = acc[t]
+                out_hi: T.float32 = acc[2 + t]
+                for src in T.unroll(NUM_TOKENS):
+                    # The s > t coefficient is a real zero-operand fma, not a
+                    # skipped iteration (:491-493, :515-517).
+                    coef: T.float32 = T.float32(0.0)
+                    if src <= t:
+                        coef = _ld_shared_f32(arena, OFF_SR + (t * NUM_TOKENS + src) * 4)
+                    out_lo = _fma(coef, u_lo[src], out_lo)
+                    out_hi = _fma(coef, u_hi[src], out_hi)
+                active_t = _ld_shared_i32(arena, OFF_SSLOT + t * 4) >= 0
+                base_o: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + t * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM + tile_row_base
+                _store_f32_as_bf16(out, base_o + row_lo, out_lo, active_t)
+                _store_f32_as_bf16(out, base_o + row_hi, out_hi, active_t)
+                _store_f32_as_bf16(out, base_o + row_lo, T.float32(0.0), T.Not(active_t))
+                _store_f32_as_bf16(out, base_o + row_hi, T.float32(0.0), T.Not(active_t))
+
+            # ---- publish sU (:532-541) ------------------------------------
+            for t in T.unroll(NUM_TOKENS):
+                _st_shared_f32(arena, OFF_SU + (t * 32 + row_lo) * 4, u_lo[t])
+                _st_shared_f32(arena, OFF_SU + (t * 32 + row_hi) * 4, u_hi[t])
+        # A warp barrier suffices: the sU rows this warp writes are exactly the
+        # rows its own threads read back below (:543).
+        T.cuda.warp_sync()
+
+    # =======================================================================
+    # Phase H: recurrence and checkpoints, all 64 threads  (:659-695)
+    # =======================================================================
+    words_w = T.alloc_local((4,), "uint32")
+    for t in T.unroll(NUM_TOKENS):
+        slot_t: T.int32 = _ld_shared_i32(arena, OFF_SSLOT + t * 4)
+        beta_t: T.float32 = _ld_shared_f32(arena, OFF_SBETA + t * 4)
+        for row_local in T.unroll(8):
+            row_h: T.int32 = owned_row_base + row_local
+            update: T.float32 = _mul(_ld_shared_f32(arena, OFF_SU + (t * 32 + row_h) * 4), beta_t)
+            for i in T.unroll(8):
+                sd_i: T.float32 = _ld_shared_f32(arena, OFF_SD + (t * HEAD_DIM + k_start + i) * 4)
+                sk_i: T.float32 = _ld_shared_f32(arena, OFF_SK + (t * HEAD_DIM + k_start + i) * 4)
+                # The source writes `hist*sD + update*sK` (:673) and the
+                # compiler contracts the FIRST product: update*sK is rounded,
+                # hist*sD is fused. This is the only stateful accumulation and
+                # it feeds both the checkpoint and token 1's history.
+                hist[row_local * 8 + i] = _fma(hist[row_local * 8 + i], sd_i, _mul(update, sk_i))
+            for pr in T.unroll(4):
+                words_w[pr] = _pack_bf16x2(
+                    hist[row_local * 8 + 2 * pr + 1], hist[row_local * 8 + 2 * pr]
+                )
+            # The recurrence advances unconditionally; only the store is
+            # slot-predicated.
+            if slot_t >= 0:
+                _store_u32x4(
+                    state,
+                    T.cast(slot_t, "int64") * T.cast(STATE_SLOT_STRIDE, "int64")
+                    + T.cast(
+                        hv * HEAD_DIM * HEAD_DIM + (tile_row_base + row_h) * HEAD_DIM + k_start,
+                        "int64",
+                    ),
+                    words_w,
+                )
 
 
 def get_kernel(**kwargs: Any):
@@ -518,12 +1076,100 @@ def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
     return out.to(torch.bfloat16).unsqueeze(0), state_raw
 
 
+# The port replicates the source's MMA chain, swizzle and association orders, so
+# it should agree with the frozen export to within bf16 rounding.
+_RTOL = 2.0**-8
+_ATOL = 2.0e-3
+# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
+# operands to bf16, so the band here is genuinely wider and measured, not
+# guessed: at scaffold time the export itself sat 6.1e-05 from the oracle.
+_ORACLE_RTOL = 2.0**-5
+_ORACLE_ATOL = 6.0e-3
+
+
 def run_test(**kwargs: Any) -> None:
-    """Correctness entry point. Implemented in the correctness gate."""
-    raise SkipTest(
-        "flashkda_decode_t2_precomputed is at the scaffold stage; the kernel body "
-        "is written in the correctness gate"
+    """Validate one config against the frozen export and an independent oracle."""
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    assert_frozen_source()
+
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["device"])
+
+    tirx_out = case["tirx_out"]
+    tirx_state = case["tirx_state_raw"].clone()
+
+    # 1. the frozen cake export itself, on an independent state pool
+    reference_out = _flashinfer_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        reference_out.float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"output vs flashinfer cake export\n{m}",
     )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        case["reference_state_raw"].float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"state vs flashinfer cake export\n{m}",
+    )
+
+    # 2. an independent FP32 oracle of the same recurrence
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        oracle_out.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"output vs FP32 oracle\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        oracle_state.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"state vs FP32 oracle\n{m}",
+    )
+
+    # 3. invariants the tolerances cannot express
+    num_seqs = spec["NUM_SEQS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    slots2d = case["ssm_state_indices_2d"]
+    initial = case["initial_state_raw"]
+
+    touched: set[int] = set()
+    for seq in range(num_seqs):
+        for t in range(NUM_TOKENS):
+            slot = int(slots2d[seq, t])
+            row = seq * NUM_TOKENS + t
+            if slot < 0:
+                # A padded row writes explicit zeros, so this is exact.
+                assert tirx_out[0, row].abs().max().item() == 0.0, (
+                    f"padded row {seq} token {t} must have a zeroed output"
+                )
+            else:
+                touched.add(slot)
+    n_slots = initial.numel() // slot_stride
+    for slot in range(min(n_slots, num_seqs * NUM_TOKENS + 2)):
+        if slot in touched:
+            continue
+        lo, hi = slot * slot_stride, (slot + 1) * slot_stride
+        assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+            f"untouched state slot {slot} was modified"
+        )
+    if slot_stride > payload:
+        for slot in sorted(touched)[:4]:
+            lo = slot * slot_stride + payload
+            hi = (slot + 1) * slot_stride
+            assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+                f"inter-slot padding after slot {slot} was modified"
+            )
 
 
 def run_bench(

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -770,20 +770,30 @@ def _flashkda_decode_t2_precomputed(
     # Phase H: recurrence and checkpoints, all 64 threads  (:659-695)
     # =======================================================================
     words_w = T.alloc_local((4,), "uint32")
+    sd_t = T.alloc_local((8,), "float32")
+    sk_t = T.alloc_local((8,), "float32")
     for t in T.unroll(NUM_TOKENS):
         slot_t: T.int32 = _ld_shared_i32(arena, OFF_SSLOT + t * 4)
         beta_t: T.float32 = _ld_shared_f32(arena, OFF_SBETA + t * 4)
+        # The gate and key slices depend only on (t, k_start), not on the row,
+        # so the source loads each 8-float slice once per token as two 16-byte
+        # reads instead of reloading them in the row loop (:673 is 12
+        # ld.shared.v4.b32 with no scalar shared loads at all).
+        _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start) * 4, sd_t, 0)
+        _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start + 4) * 4, sd_t, 4)
+        _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start) * 4, sk_t, 0)
+        _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start + 4) * 4, sk_t, 4)
         for row_local in T.unroll(8):
             row_h: T.int32 = owned_row_base + row_local
             update: T.float32 = _mul(_ld_shared_f32(arena, OFF_SU + (t * 32 + row_h) * 4), beta_t)
             for i in T.unroll(8):
-                sd_i: T.float32 = _ld_shared_f32(arena, OFF_SD + (t * HEAD_DIM + k_start + i) * 4)
-                sk_i: T.float32 = _ld_shared_f32(arena, OFF_SK + (t * HEAD_DIM + k_start + i) * 4)
                 # The source writes `hist*sD + update*sK` (:673) and the
                 # compiler contracts the FIRST product: update*sK is rounded,
                 # hist*sD is fused. This is the only stateful accumulation and
                 # it feeds both the checkpoint and token 1's history.
-                hist[row_local * 8 + i] = _fma(hist[row_local * 8 + i], sd_i, _mul(update, sk_i))
+                hist[row_local * 8 + i] = _fma(
+                    hist[row_local * 8 + i], sd_t[i], _mul(update, sk_t[i])
+                )
             for pr in T.unroll(4):
                 words_w[pr] = _pack_bf16x2(
                     hist[row_local * 8 + 2 * pr + 1], hist[row_local * 8 + 2 * pr]


### PR DESCRIPTION
## Summary

- port FlashInfer's frozen "cake" FlashKDA decode export for **T=2** — `d128_t2_precomputed_split4` — to plain TIRx
- this is the repo's first **WY-skeleton** kernel: shared memory, `ldmatrix`, and `mma.sync` tensor cores, unlike every KDA decode port so far
- add the 9-shape bench-suite matrix and its baseline rows
- include the frozen execution sketch used during the porting design stage

## Impact

T=2 is the MTP-with-one-draft-token leg of the cake decode surface: dispatch reaches this body whenever `num_tokens == 2` with `num_spec_tokens == 1`. The sm100a split selector returns 4 unconditionally at T=2 (`recurrent_kda.py:1177-1178`), so `split4` is the entire dispatch surface and the only locally measurable specialization; `_specialization` raises for anything else.

Structurally this shares nothing with the merged `t1_direct` port (a one-warp, register-only schedule) beyond the host contract. It is 2 warps with **no warp specialization** — the value-warp, state-warp and token counts all collapse to 2 — over a 14720-byte shared arena with an XOR swizzle, two CTA barriers and one warp barrier, and an 8-issue `ldmatrix` + `ldmatrix.trans` + `mma.sync.m16n8k16` chain.

The single MMA accumulator carries **both** projections: because the sVec columns hold prefix-scaled `k` in 0,1 and prefix-scaled `q` in 4,5, one chain over all 128 keys yields the delta-rule history term and the output history term at once. Columns 2,3,6,7 are garbage from never-written sVec columns; the port reproduces that rather than zeroing them, since zeroing would add stores the source does not issue.

## Validation

- **correctness**: 19/19 configs pass, each checked three ways — against the frozen export on an independent state pool, against an independent FP32 oracle of the sequential recurrence, and against invariants the tolerances cannot express (padded rows exactly zero, untouched slots byte-identical, inter-slot padding intact)
- coverage includes both `num_accepted_tokens` clamp edges (0/1/2/9 — it is **live** at T=2, selecting the initial checkpoint slot, unlike T=1 where the kernel never reads it), CUDA-graph padding, an envelope-strided state pool and gate, a non-default scale, GQA ratios 2 and 4, and N=1
- `verify_dispatch.py` feeds the tensors `prepare_data` builds into FlashInfer's own `_select_flash_kda_decode_variant`: **19/19** reach `d128_t2_precomputed_split4`. At T=2 the split has no shape dependence, so what this guards is the rest of the contract — `num_spec_tokens == 1`, `ssm_state_indices` of exactly `N*2` entries, `cu_seqlens` stepping by two — any of which makes the selector return `None` rather than a wrong variant
- `characterize_source.py` proves **7/7** special-case rows are non-degenerate, including that nat 0 and 1 agree, 2 and 9 agree, and the two groups differ, and that both tokens' checkpoint slots are written with different content
- **performance**: complete bench-suite matrix, **9/9 above the 0.99 bar, minimum 1.140x, maximum 1.304x**, on clock-verified GPUs
- no-tile check clean over all 19 specializations and **proven non-vacuous** (injecting a `Tx.fill(0)` makes it report 19 violations)
- `pre-commit run --all-files` clean; bench-suite import check ok

| config | ours µs | reference µs | ratio |
|---|---:|---:|---:|
| `hv12h12_b8_t2` | 6.35 | 8.28 | **1.304** |
| `hv16h16_b8_t2` | 6.99 | 8.80 | **1.260** |
| `hv32h16_b8_t2` | 9.09 | 10.98 | **1.208** |
| `hv16h16_b64_t2` | 25.38 | 30.17 | **1.189** |
| `hv32h16_b32_t2` | 25.36 | 29.94 | **1.181** |
| `hv32h16_b16_t2` | 15.45 | 17.83 | **1.155** |
| `hv12h12_b64_t2` | 20.89 | 24.01 | **1.149** |
| `hv32h16_b64_t2` | 44.91 | 51.22 | **1.141** |
| `hv32h16_b128_t2` | 83.23 | 94.88 | **1.140** |

## What the alignment loop found

The first measurement failed the large shapes (0.950 at N=128) while passing the small ones, and both fixes came from the instruction census against the source PTX rather than from guesswork.

**Shared reads were scalar where the source vectorizes.** The port issued 298 `ld.shared.b32` against the source's 19, with `ld.shared.v4.b32` at 0 against 19 — the sketch had pinned the vector forms correctly and the implementation had transcribed the dataflow without them. The dominant case was structural rather than cosmetic: `sD` and `sK` depend only on `(t, k_start)`, not on the row, so the source loads each 8-float slice once per token as two 16-byte reads while the port reloaded them inside the row and key loops. Fixing that is the whole of the final margin: **0.9902 → 1.1400** on the worst row, 298 → 42 scalar shared loads.

**Registers cost an occupancy step.** TIRx emits `__launch_bounds__(64)` where the source declares a vestigial `256` (a Loom constant that exists only to satisfy a static assert; the binding launches 64), letting ptxas spend 118 registers per thread against the source's 105 — 8 blocks/SM instead of 9 at 64 threads. Requesting 9 minimum blocks brings it to 96 at the cost of 24 bytes of spill, and the spill measured worth it: 0.9312 without the cap against 0.9967 with it, on the same row.

## Notes on fidelity

Three source behaviours are reproduced rather than "fixed", each established during the sketch review:

- the recurrence is `fma(hist, sD, mul(update, sK))`. The source writes `hist*sD + update*sK` and the compiler contracts the **first** product, so `update*sK` is the rounded one — verified uniform across all 192 sites in the PTX. Inverting it would round the wrong product at the kernel's only stateful accumulation, which feeds both the checkpoint and token 1's history.
- the recurrence advances **unconditionally** in FP32 and only the checkpoint store is slot-predicated, so token 1 consumes the un-rounded token-0 state rather than the bf16 checkpoint.
- padded rows write **explicit zeros** rather than being skipped, and the `s > t` output coefficient is a real zero-operand `fma` rather than a skipped iteration.

Every `instruction_selection` annotation in the sketch is read off line-info PTX exported by re-running FlashInfer's own nvcc command line; the sketch passed an independent reviewer gate over three rounds and is frozen.

## Notes for review

- the sketch at `.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md` is the best entry point
- the reference is the export's **direct JIT ABI** rather than `kda_decode.recurrent_kda(backend="cake")`, which keeps the comparison kernel-only and makes every metadata combination reachable
- all shared access goes through `ptr_to` + raw PTX, which matters here in a way it did not for the register-only T=1 sibling: `low_level_ir` forbids shared `BufferLoad`/`BufferStore` exactly as it does global
- absolute microseconds in `baseline.json` are host-specific; regression detection compares the ratio, which is not
