### PR TITLE
feat(kernel): port FlashInfer's FlashKDA cake T=4 precomputed and T=3 lower-bound decode kernels

### DIFF
--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t2_precomputed.md
@@ -386,8 +386,10 @@ if warp < TOKENS:
                 # extent: scalar, taken once (only s=0 < t=1)
             u_lo[t] = solved_lo;  u_hi[t] = solved_hi
     # The source then broadcasts u_lo/u_hi from quad_base+2 to the whole quad
-    # (:476-482). Its only consumer is the dead BLOCK_CHECKPOINT_MMA block;
-    # every live consumer below is already lane_quad == 2. Dead here.
+    # (:476-482). At T=2 that is an IDENTITY: every live consumer below runs on
+    # lane_quad == 2, which is the broadcast's own source lane. Dropped here.
+    # (At T=3/T=4 phase F runs on lane_quad >= 2 and the broadcast becomes
+    # load-bearing -- see flashkda_decode_t3_t4_wy.md.)
 
 # ===========================================================================
 # Phase F: both tokens' outputs  (:484-531)
@@ -495,7 +497,7 @@ is statically dead, and the port carries none of it:
 | `sGramA0`, `sGramA1` | `:81-86`, `:136-139` | t5/t6 coefficient-gram; alias sVec, never touched |
 | the whole `BLOCK_CHECKPOINT_MMA` block, incl. the 3rd `mma.sync` | `:546-658` | macro is 0, static-asserted |
 | `ha_lo[2],[3]`, `ha_hi[2],[3]` + their 4 broadcasts | `:443-446`, `:451-454` | MMA columns 2,3 — T=4 territory |
-| the `u_lo`/`u_hi` quad broadcasts | `:476-482` | only the dead block consumes them |
+| the `u_lo`/`u_hi` quad broadcasts | `:476-482` | an identity at T=2: the source lane `quad_base+2` is the only consuming lane |
 | `vec_frag[2],[3]` | `:415` | the x4 loads sVec cols 8..15; the MMA reads 2 registers |
 | sVec columns 2,3 and 6..15 | — | never written; feed dead accumulator lanes. **Not zeroed** — zeroing is numerically safe but adds stores the source does not issue |
 | `sR[0][1]`, `sL[0][*]`, `sL[1][1]` | `:390-392` | of the two 2×2 matrices only `sL[1][0]` and `sR[{0,0},{1,0},{1,1}]` are written and read |

--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t3_t4_wy.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t3_t4_wy.md
@@ -1,0 +1,859 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashKDA cake T=4 precomputed and T=3 lower-bound decode: coarse WY execution sketch
+
+**Non-executable.** This is the semantic execution skeleton, not runnable code.
+The source of truth for the implementations is
+`tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py` and
+`tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py`.
+
+Transcribed from two frozen generated exports, both with symbol
+`kernel_flashinfer_recurrent_kda_wy_vtile_short` (flashinfer-ai/flashinfer @
+`f2e04400`):
+
+- `csrc/kda/flashkda_decode_d128_t4_precomputed_split2.cu` (701 lines) — `T4:NNN`
+- `csrc/kda/flashkda_decode_d128_t3_lower_bound_split4.cu` (711 lines) — `T3:NNN`
+
+**One sketch, two kernels.** Both are the same Loom template as the already-ported
+T=2 body, and the structural distance is far smaller than the line counts suggest.
+Stripping every integer literal and diffing phase by phase:
+
+| phase | T=2 → T=4 | T=4 → T=3 |
+| --- | --- | --- |
+| A preprocess | **identical** | **+9 lines**: the `GATE_KIND == 1` chain |
+| B state gather | identical | identical |
+| C sVec / WY coefficients | identical¹ | identical¹ |
+| D MMA chain | identical | identical |
+| E quad broadcast + solve | identical | identical |
+| F outputs | **rewritten**, 48 → 49 lines | **identical** |
+| G publish `sU` | identical | identical |
+| H recurrence + checkpoints | identical | identical |
+
+¹ the only textual difference is the Loom-generated temporary's name hash
+(`_bval_1100091392` vs `_bval_1101446352`), which carries no semantics.
+
+So the whole port is: the ported T=2 skeleton re-parameterized by `T` and the
+geometry, plus **exactly two** structural deltas — phase F's generic rewrite
+(shared by both new bodies, byte-identical between them) and T=3's gate insert.
+This sketch is written against that decomposition: the common skeleton is given
+once with the knobs symbolic, and the two deltas get their own sections.
+
+**Fixed specializations.**
+
+| knob | T=4 | T=3 |
+| --- | --- | --- |
+| `TOKENS` | 4 | 3 |
+| `GATE_KIND` | 0 (precomputed log-gate) | **1 (in-kernel lower-bound gate)** |
+| `VALUE_SPLIT` | 2 | 4 |
+| `LAUNCH_THREADS` | 128 (4 warps) | 96 (3 warps) |
+| `ROWS_PER_CTA` | 64 (`T4:159`) | 32 (`T3:159`) |
+| `SMEM_TOTAL` | 25856 | 15872 |
+| grid | `(HV*2, N)` | `(HV*4, N)` |
+| nat clamp | `[0, 3]` | `[0, 2]` |
+| warp/group guards | **all statically true** | **all live** — see below |
+| shape domain | any `H`, `HV` with `HV % H == 0` | `H == HV == 16`, `N ∈ {1,2,4,8,16}` |
+| dispatch | `_select_flash_kda_decode_value_split` returns 2 at T=4 on sm100a, no shape dependence | no split selector at all: `recurrent_kda.py:1437-1438` early-returns the variant |
+
+`HEAD_DIM = 128`, `DIRECT_IMPL` unset, `DIRECT_PREFIX_CHECKPOINT = 0`,
+`BLOCK_CHECKPOINT_MMA = 0`, `NUM_MAIN_STAGES = 1` for both.
+
+**Out of scope.** T ∈ {1,2,5,6}; the `t1_direct` one-warp schedule (a different
+kernel symbol); `VALUE_SPLIT = 8`, reachable only on GB300 and not measurable
+here; T=3 with precomputed gates, which upstream does not export at all and has
+a dedicated rejection test.
+
+## Pipeline at a glance
+
+No warp specialization, no asynchronous pipeline: no `cp.async`, no mbarrier, no
+TMA, no atomics, nothing double-buffered. The same warps play every role in
+sequence, separated by two CTA barriers and one warp barrier.
+
+The value split is a **partition**: CTA `(hv, value_tile)` owns value rows
+`[ROWS_PER_CTA·value_tile, +ROWS_PER_CTA)` of the `[V,K]` state, and every CTA
+redundantly recomputes the whole token preprocessing for its own `(n, hv)`. No
+CTA combines anything with any other.
+
+### T=4 — 4 warps, fully occupied
+
+Every guard in the body (`warp_0 < 4`, `group < 8`) is statically true at 128
+threads. This is the same "everyone does everything" shape as the T=2 port.
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, value_tile, n)` | value head `hv`, sequence `n`, 64 value rows | independent |
+| warp `w`, phases A and C | **token `w`** (4 warps ⇄ 4 tokens) | publishes `sK`/`sD`/`sBeta`/`sSlot`/`sToken`, and (warp 0) `sInit`, across barrier #1; publishes `sVec`/`sL`/`sR` across barrier #2 |
+| thread `tid`, phases B and H | 8 value rows (`group = tid/16`, rows `group*8 + r`) × 8 keys | gathers state into registers **and** stages it to `sState`; later writes all four tokens' checkpoints |
+| warp `w`, phase D | value rows `w*16 .. +15` of the 64-row tile | consumes `sState` (all 64 rows, staged by all 4 warps) and `sVec` |
+| lane with `lane_quad == 2` | the WY solve for rows `w*16 + frag_row` and `+8`, and the `sU` publish | the only lanes that load `v` |
+| lane with `lane_quad >= 2` | **two output tokens each**: lane `4f+2` writes tokens 0,1 and lane `4f+3` writes tokens 2,3 | the only lanes that store `out` |
+
+The last row is the new shape. At T=2 the solver lane and the only output lane
+were the same lane; at T=4 the output work is split across **two** lanes of each
+quad while the solve still happens on one, so the residuals must cross the quad.
+
+### T=3 — 3 warps, and warp 2 is a token-only warp
+
+The warp count is `max(tokens, value_rows/16, (value_rows/8+1)/2) = max(3,2,2)`
+(`flash_kda_decode.py:115-137`): the **token** term wins. So the third warp
+exists only to preprocess the third token, and every guard is live:
+
+| guard | site | effect at 96 threads |
+| --- | --- | --- |
+| `warp_0 < 3` | `T3:180` (A), `T3:339` (C) | all three warps |
+| `group < 4` | `T3:303` (B), `T3:669` (H) | **excludes groups 4,5 — warp 2** |
+| `warp_0 < 2` | `T3:415` (D), `:493` (F), `:542` (G) | **excludes warp 2** |
+
+`warp_0 < 2` is `value_rows/16`; `group < 4` is `value_rows/8`. Both select the
+same two warps, and neither depends on `T`.
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, value_tile, n)` | value head `hv`, sequence `n`, 32 value rows | independent |
+| warp 0,1, phases A and C | tokens 0,1 | as T=4 |
+| **warp 2** | **token 2 only**: its q/k/g, its L2 norms, its gate, its `sVec` columns 2 and 6, its `sL`/`sR` row | publishes across **both** CTA barriers, then does nothing — it never gathers state, never issues an MMA, never stores |
+| thread `tid` with `group < 4`, phases B and H | 8 value rows × 8 keys | as T=4, but only warps 0,1 participate |
+| warp 0,1, phase D | value rows `w*16 .. +15` of the 32-row tile | consumes all 32 staged rows |
+| lane with `lane_quad == 2` (warps 0,1) | the WY solve, depth 3 | loads `v` |
+| lane with `lane_quad >= 2` (warps 0,1) | lane `4f+2` writes tokens 0,1; lane `4f+3` writes token 2 **and computes a discarded token 3** | see the hazard section |
+
+Both `__syncthreads()` are therefore **real 3-warp cross-warp edges** here, where
+in the T=2 and T=4 bodies every warp reaches every phase. `sU` stays intra-warp,
+so the warp barrier in phase G is still sufficient.
+
+Warp 2 also allocates the full `hist[64]` register array and never fills it —
+that is the source's behaviour and the port reproduces it rather than trying to
+shrink the allocation.
+
+Dependency chain (both bodies): preprocess → **barrier** → state gather+stage →
+sVec/L/R → **barrier** → MMA → WY solve → outputs → sU → **warp barrier** →
+recurrence and checkpoints.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+reg_tile(dtype, shape)                 # per-thread register array
+smem_arena(bytes, align)               # the single shared allocation
+smem_view(name, offset, dtype, shape)  # a named region of that arena
+swz(byte_off)                          # byte_off ^ ((byte_off >> 7 & 7) << 4)
+widen(word)                            # one u32 -> two f32, as shl.b32 / and.b32
+```
+
+Data movement:
+
+```python
+copy_g2r(gmem_slice, reg)              # global -> register
+copy_r2g(reg, gmem_slice, pred=None)   # register -> global
+copy_r2s(reg, smem_slice)              # register -> shared
+copy_s2r(smem_slice, reg)              # shared -> register
+ldm(smem_addr, frag, trans=False)      # ldmatrix, one x4 group
+bcast(v, src_lane, 31, 0xFFFFFFFF)     # shfl.idx
+bfly(v, lane_xor, 31, 0xFFFFFFFF)      # shfl.bfly
+```
+
+Compute:
+
+```python
+fill(reg, c); cast(dst, src); add(a,b); sub(a,b); mul(a,b); fma(a,b,c)
+exp(x); rsqrt(x); neg(x); div(a,b)     # neg and div are T=3-only
+dot(a, b)                              # `dot` = one explicit FMA chain
+mma(acc, a_frag, b_frag, init=False)   # one mma.sync.m16n8k16 issue
+```
+
+Sync: `cta_sync()`, `warp_sync()`.
+
+**Every shuffle is width-32 with a full member mask** — the operands are always
+`(31, 0xFFFFFFFF)`. A reduction that wants a narrower group restricts its *xor
+offset set*, never the instruction width. **`dot` is not a compound op**: each one
+expands to an explicit FMA chain in a fixed association order, written out at its
+site because the order is load-bearing.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+HEAD_DIM = 128
+TOKENS, VALUE_SPLIT, THREADS = (4, 2, 128)   # T=4
+TOKENS, VALUE_SPLIT, THREADS = (3, 4,  96)   # T=3
+ROWS_PER_CTA = 128 // VALUE_SPLIT             # 64 / 32        (T4:159, T3:159)
+H, HV, HEAD_RATIO                             # T=3: pinned at 16, 16, 1
+GATE_TOKEN_STRIDE, STATE_SLOT_STRIDE          # host-derived, constexpr here
+
+grid  = (HV * VALUE_SPLIT, num_seqs)          # binding_impl.cuh:64
+block = (THREADS,)
+
+# Runtime scalars: `scale` in both; T=3 additionally takes `lower_bound` and the
+# A_log / dt_bias buffers, which the precomputed bodies never dereference.
+
+# The source uses dynamic smem (extern __shared__ __align__(1024), the launcher
+# does cudaFuncSetAttribute + <<<..., SMEM_TOTAL, ...>>>). Both totals fit the
+# static limit, so the port declares one static arena at the same alignment and
+# carves the same byte offsets -- what the swizzled ldmatrix addressing depends
+# on is the offsets and the alignment, both preserved.
+#
+#            T=4 (25856 B)                    T=3 (15872 B)
+arena     = smem_arena(SMEM_TOTAL, align=1024)
+sState0   = smem_view(arena,     0, bf16, [ROWS_PER_CTA, 64])   #     0 /     0
+sState1   = smem_view(arena,  ..., bf16, [ROWS_PER_CTA, 64])    #  8192 /  4096
+sVec      = smem_view(arena,  ..., bf16, [128, 16])             # 16384 /  8192
+sK        = smem_view(arena,  ..., f32,  [TOKENS, 128])         # 20480 / 12288
+sD        = smem_view(arena,  ..., f32,  [TOKENS, 128])         # 22528 / 13824
+sBeta     = smem_view(arena,  ..., f32,  [TOKENS])              # 24576 / 15360
+sSlot     = smem_view(arena,  ..., i32,  [TOKENS])              # 24592 / 15372
+sToken    = smem_view(arena,  ..., i32,  [TOKENS])              # 24608 / 15384
+sInit     = smem_view(arena,  ..., i32,  [1])                   # 24624 / 15396
+sL        = smem_view(arena,  ..., f32,  [TOKENS, TOKENS])      # 24640 / 15412
+sR        = smem_view(arena,  ..., f32,  [TOKENS, TOKENS])      # 24704 / 15448
+sU        = smem_view(arena,  ..., f32,  [TOKENS, ROWS_PER_CTA])# 24768 / 15484
+# sGramA0/1 alias sVec and are t5/t6 machinery: dead in both.
+# sVec keeps 16 columns at every T -- the region is sized for the largest T, so
+# only columns 0..TOKENS-1 (k side) and 4..4+TOKENS-1 (q side) are ever written.
+
+# ===========================================================================
+# Work decomposition and lane roles  (T4/T3:100-179 -- identical)
+# ===========================================================================
+work       = cta_id.x
+value_tile = work % VALUE_SPLIT
+hv         = work // VALUE_SPLIT
+n          = cta_id.y
+query_head = hv // HEAD_RATIO
+tid        = thread_id.x
+warp       = tid // 32          # == token index in phases A and C
+lane       = tid % 32
+lane_quad  = lane & 3           # the MMA accumulator's column pair
+frag_row   = lane // 4          # the MMA accumulator's row
+quad_base  = lane - lane_quad
+group      = tid // 16          # phases B and H: 8 groups (T=4) / 6, of which 4 run (T=3)
+lane_group = tid % 16
+k_start    = lane_group * 8     # phases B and H: 8 keys per thread
+elem_start = lane * 4           # phases A and C: 4 keys per lane
+tile_row_base  = value_tile * ROWS_PER_CTA
+owned_row_base = group * 8
+token_base = cu_seqlens[n];  seq_len = cu_seqlens[n+1] - token_base
+# instruction_selection: ld.global.nc.b32; extent: scalar (x2)  (.loc :147,:148)
+# cu_seqlens must step by exactly TOKENS per row. The body does not bound-check
+# token_base -- deliberately unvalidated for CUDA-graph capture. Padding is
+# signalled ONLY by ssm_state_indices < 0.
+#
+# `warp` is make_warp_uniform(tid/32) at :101, one shfl.sync.idx.b32 at .loc :39
+# in both bodies. Semantically the identity -- a uniformity hint -- but its
+# result IS `warp` and is live throughout, so the port spells it `tid // 32`.
+
+# ===========================================================================
+# Phase A: token preprocess, warp <-> token  (T4:180-290, T3:180-299)
+# ===========================================================================
+if warp < TOKENS:                       # T=4: always true. T=3: LIVE, warp 2 is
+    token         = warp                # the token-only warp.
+    active_token  = token < seq_len
+    token_pos     = token_base + token if active_token else 0
+    qk_base   = (token_pos * H + query_head) * 128 + elem_start
+    gate_base = token_pos * GATE_TOKEN_STRIDE + hv * 128 + elem_start
+
+    r_q = reg_tile(f32, [4]); r_k = reg_tile(f32, [4]); r_d = reg_tile(f32, [4])
+    copy_g2r(q[qk_base : +4],   r_q)
+    copy_g2r(k[qk_base : +4],   r_k)
+    copy_g2r(g[gate_base : +4], r_d)
+    # instruction_selection: ld.global.nc.v2.b32; extent: one 8-byte vector
+    # (4 bf16) each, 3 total in both bodies
+    # Each 32-bit word holds two bf16 and is split by an integer pair, not by
+    # cvt: lo = word << 16, hi = word & 0xffff0000
+    # instruction_selection: shl.b32 + and.b32; extent: 2 words per tensor, 3 tensors
+
+    # ---- L2 norms: two independent full-warp butterflies -------------------
+    q_sq = dot(r_q, r_q);  k_sq = dot(r_k, r_k)
+    # instruction_selection: fma.rn.ftz.f32; extent: 4-term chain each, the first
+    # with C = 0f00000000 -- there is no mul at these sites
+    for offset in (16, 8, 4, 2, 1):
+        q_sq = add(q_sq, bfly(q_sq, offset, 31, 0xFFFFFFFF))
+    for offset in (16, 8, 4, 2, 1):
+        k_sq = add(k_sq, bfly(k_sq, offset, 31, 0xFFFFFFFF))
+    # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32; extent: 5 rounds x 2
+    # = 10 shfl in phase A, both bodies. The two loops are sequential, not
+    # interleaved.
+    q_norm = mul(rsqrt(add(q_sq, 1e-6)), scale)   # scale folds into q only
+    k_norm = rsqrt(add(k_sq, 1e-6))
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar (x2)
+    # eps is hardcoded inside the rsqrt argument.
+
+    # ---- the gate: the ONE place the two bodies diverge --------------------
+    # T=4 (GATE_KIND == 0): g already holds log(gamma).
+    for i in range(4):
+        r_q[i] = mul(r_q[i], q_norm)
+        r_k[i] = mul(r_k[i], k_norm)
+        r_d[i] = exp(r_d[i])
+        # instruction_selection: mul.ftz.f32 x3 + ex2.approx.ftz.f32
+        # extent: 4 iterations -> 4 ex2 total in the T=4 body
+
+    # T=3 (GATE_KIND == 1): g is the RAW pre-gate; the gate is derived here.
+    # Hoisted above the element loop, once per lane, every lane (T3:259-263):
+    gate_a     = exp(A_log[query_head])
+    # instruction_selection: ld.global.nc.b32 (scalar; NOT broadcast from lane 0)
+    # + mul.ftz.f32 (x log2e) + ex2.approx.ftz.f32; extent: scalar
+    neg_gate_a = neg(gate_a)
+    # instruction_selection: neg.ftz.f32; extent: scalar -- exactly ONE in the
+    # whole body. The source writes `(-gate_a)` inside the element loop
+    # (T3:274); it is loop-invariant and is hoisted, so the port hoists it too.
+    for i in range(4):
+        r_q[i] = mul(r_q[i], q_norm)
+        r_k[i] = mul(r_k[i], k_norm)
+        biased = add(r_d[i], dt_bias[query_head * 128 + elem_start + i])
+        # instruction_selection: ld.global.nc.b32 + add.ftz.f32; extent: scalar.
+        # FOUR SEPARATE SCALAR LOADS at [%rd30], +4, +8, +12 -- the four fp32 are
+        # contiguous but nvcc does NOT vectorize them. No ld.global.nc.v4.b32
+        # appears anywhere in this body.
+        sig    = exp(mul(biased, neg_gate_a))
+        # instruction_selection: mul.ftz.f32 (biased, -gate_a; that operand
+        # order) + mul.ftz.f32 (x log2e) + ex2.approx.ftz.f32; extent: scalar
+        r_d[i] = exp(div(lower_bound, add(sig, 1.0)))
+        # instruction_selection: add.ftz.f32 (sig first, 0f3F800000 second)
+        # + div.approx.ftz.f32 (numerator = the loop-invariant lower_bound
+        # register) + mul.ftz.f32 (x log2e) + ex2.approx.ftz.f32; extent: scalar
+        #
+        # The division lowers to div.approx.ftz.f32, NOT rcp.approx + mul: 4
+        # div.approx.ftz.f32 in the body, one per element, and zero rcp.
+        # ex2 total in the T=3 body is 9 = 4 elements x 2 + the hoisted gate_a,
+        # against 4 in the T=4 body. That 9-vs-4 count is the arithmetic proof
+        # that gate_a is hoisted and the per-element chain has two exp sites.
+
+    copy_r2s(r_k, sK[token, elem_start : +4])
+    copy_r2s(r_d, sD[token, elem_start : +4])
+    # instruction_selection: st.shared.v4.b32; extent: one 16-byte tile each
+
+    if lane == 0:
+        sSlot[token]  = ssm_state_indices[n*TOKENS + token] if active_token else -1
+        sToken[token] = token_pos
+        sBeta[token]  = cast(f32, beta[token_pos * HV + hv])
+        # instruction_selection: ld.global.nc.b32 + ld.global.nc.b16
+        # + cvt.f32.bf16 + st.shared.b32 x3; extent: scalar each
+        if token == 0:
+            accepted     = clamp(num_accepted_tokens[n] - 1, 0, TOKENS - 1)
+            initial_slot = ssm_state_indices[n*TOKENS + accepted]
+            sInit[0]     = 0 if initial_slot < 0 else initial_slot
+            # instruction_selection: ld.global.nc.b32 x2 + st.shared.b32; extent: scalar
+            # The clamp ceiling is TOKENS-1: 3 at T=4, 2 at T=3. Both edges are
+            # reachable and both are covered by CONFIGS.
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# Orders sInit -> the gather base below, and sK/sD/sBeta/sSlot/sToken -> their
+# cross-warp readers in phases C, E, F and H. At T=3 this is a genuine 3-warp
+# edge: warp 2 publishes token 2's sK/sD/sBeta/sSlot/sToken here and warps 0,1
+# consume them in C and H.
+
+# ===========================================================================
+# Phase B: state gather  (T4:292-329 all 128 threads, T3:301-338 groups 0..3)
+# ===========================================================================
+if group < ROWS_PER_CTA // 8:           # T=4: `group < 8`, statically true.
+                                        # T=3: `group < 4`, LIVE -- warp 2 sits out.
+    initial_head_base = sInit[0] * STATE_SLOT_STRIDE + hv * 128 * 128
+    hist = reg_tile(f32, [8, 8])
+    for row_local in range(8):          # constexpr unroll
+        row  = owned_row_base + row_local
+        pack = reg_tile(u32, [4])
+        copy_g2r(state[initial_head_base + (tile_row_base + row)*128 + k_start : +8], pack)
+        # instruction_selection: ld.global.v4.b32; extent: one 16-byte tile
+        # (8 bf16), 8 rows. NOT .nc: `state` is written later in this kernel.
+        for p in range(4):
+            hist[row_local][2*p], hist[row_local][2*p+1] = widen(pack[p])
+        # instruction_selection: shl.b32 + and.b32; extent: 4 words per row
+        half = sState0 if lane_group < 8 else sState1
+        copy_r2s(pack, half[row, (k_start % 64) : +8] @ swz)
+        # instruction_selection: st.shared.v4.b32; extent: one 16-byte tile, 8 rows
+        # The bf16 bits go to shared unmodified; the swizzle is on the byte
+        # offset: swz(row*128 + (k_start % 64)*2).
+# Identical in all three bodies: 8 ld.global.v4.b32 + 16 st.shared.v4.b32
+# STATIC regardless of T (both arms of the `lane_group < 8` select are emitted;
+# a thread executes 8 of the stores). What changes is how many threads run it (128 vs 64)
+# and therefore how many of the ROWS_PER_CTA rows get staged.
+
+# ===========================================================================
+# Phase C: sVec columns and the WY coefficients  (T4:330-404, T3:339-413)
+# ===========================================================================
+if warp < TOKENS:                       # T=3: warp 2 IS here -- it owns token 2's
+                                        # sVec columns 2 and 6 and sL/sR row 2.
+    for i in range(4):                  # constexpr unroll
+        k_idx  = elem_start + i
+        prefix = 1.0
+        for j in range(TOKENS):         # prefix gate: product over j <= token
+            if token >= j:
+                prefix = mul(prefix, sD[j, k_idx])
+        # instruction_selection: ld.shared.b32 + mul.ftz.f32; extent: <= TOKENS per element
+        sVec[k_idx, token]     = cast(bf16, mul(prefix, r_k[i]))
+        sVec[k_idx, 4 + token] = cast(bf16, mul(prefix, r_q[i]))
+        # instruction_selection: mul.ftz.f32 + cvt.rn.bf16.f32 + st.shared.b16
+        # extent: 2 scalars per element, 4 elements -> 8 st.shared.b16 and 8 of
+        # the 14 cvt.rn.bf16.f32, identical in both bodies
+        # The prefix multiply is FP32; the bf16 rounding happens on the way into
+        # sVec, which is what the MMA consumes as its B operand.
+
+    # ---- L and R: the WY coefficients --------------------------------------
+    # ratio_scan accumulates sD of the *source* token between offsets, so the
+    # dots see the decay between source and target.
+    ratio = reg_tile(f32, [4]); fill(ratio, 1.0)
+    for source_offset in range(TOKENS):
+        source_token = token - source_offset
+        if source_token >= 0:
+            dot_kk = 0.0; dot_qk = 0.0
+            for i in range(4):
+                sk = sK[source_token, elem_start + i]
+                dot_kk = fma(mul(r_k[i], sk), ratio[i], dot_kk)
+                dot_qk = fma(mul(r_q[i], sk), ratio[i], dot_qk)
+            # instruction_selection: ld.shared.v4.b32 (the 4 contiguous sK floats)
+            # + mul.ftz.f32 + fma.rn.ftz.f32; extent: 4 iterations
+            # Source order is `r * source_k * ratio`. At source_offset == 0 the
+            # ratio is still 1.0 and folds away, so that offset emits 4 bare fma
+            # (the first with C = 0f00000000) and the later offsets emit the
+            # mul+fma pair.
+            for offset in (16, 8, 4, 2, 1):
+                dot_kk = add(dot_kk, bfly(dot_kk, offset, 31, 0xFFFFFFFF))
+            for offset in (16, 8, 4, 2, 1):
+                dot_qk = add(dot_qk, bfly(dot_qk, offset, 31, 0xFFFFFFFF))
+            # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32
+            # extent: 5 rounds x 2 dots x TOKENS source offsets
+            # = 40 shfl at T=4, 30 at T=3 (20 at T=2) -- this is the single
+            # biggest shuffle site in either body.
+            if lane == 0:
+                beta_source = sBeta[source_token]
+                if source_token < token:
+                    sL[token, source_token] = mul(beta_source, dot_kk)
+                sR[token, source_token] = mul(beta_source, dot_qk)
+                # instruction_selection: ld.shared.b32 + mul.ftz.f32
+                # + st.shared.b32; extent: scalar
+                # Live entries: sL = strict lower triangle (6 at T=4, 3 at T=3),
+                # sR = lower triangle incl. diagonal (10 at T=4, 6 at T=3).
+            if source_token > 0:
+                for i in range(4):
+                    ratio[i] = mul(ratio[i], sD[source_token, elem_start + i])
+                # instruction_selection: ld.shared.v4.b32 + mul.ftz.f32; extent: 4
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# The genuinely cross-warp edges are sVec (warp w writes columns w and 4+w, and
+# every MMA warp's ldmatrix reads columns 0..7) and sL/sR (written by one warp's
+# lane 0, read by all MMA warps in phases E and F). At T=3 warp 2 writes sVec
+# columns 2 and 6, sL row 2 and sR row 2 here and then leaves -- warps 0,1 depend
+# on that through this barrier and nothing else.
+# The sState edge is intra-warp by the row-set argument in phase G and is ordered
+# here only as a side effect. A port narrowing this barrier must reason from
+# sVec/sL/sR, not from sState.
+
+# ===========================================================================
+# Phase D: the MMA chain  (T4:406-438 warps 0..3, T3:415-447 warps 0,1)
+# ===========================================================================
+if warp < ROWS_PER_CTA // 16:           # T=4: `warp_0 < 4`, statically true.
+                                        # T=3: `warp_0 < 2`, LIVE.
+    acc = reg_tile(f32, [4])
+    for state_half in range(2):         # keys 0..63, then 64..127
+        for mma_k in (0, 16, 32, 48):   # constexpr unroll -> 8 issues
+            global_k = state_half * 64 + mma_k
+
+            # B operand: sVec rows `global_k .. +15`, cols 0..15, transposed so
+            # that n = sVec column and k = key.
+            vec_frag = reg_tile(u32, [4])
+            ldm(sVec @ swz((global_k + lane % 16) * 32 + (lane // 16) * 16),
+                vec_frag, trans=True)
+            # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            # extent: one x4 group per issue, 8 issues
+            # vec_frag[2],[3] are cols 8..15 -- loaded by the x4 and never used.
+
+            # A operand: this warp's 16 state rows, keys `mma_k .. +15`.
+            state_frag = reg_tile(u32, [4])
+            half = sState0 if state_half == 0 else sState1
+            ldm(half @ swz((warp*16 + lane % 16) * 128 + (mma_k + (lane//16)*8) * 2),
+                state_frag)
+            # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.shared.b16
+            # extent: one x4 group per issue, 8 issues
+
+            mma(acc, state_frag, vec_frag, init=(state_half == 0 and mma_k == 0))
+            # instruction_selection: mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32
+            # extent: one issue; the first has an explicit zero C operand
+            # ({0f00000000 x4}), the rest tie C to D
+
+# The MMA chain is byte-identical at T=2, T=3 and T=4: 8 ldmatrix.x4 +
+# 8 ldmatrix.x4.trans + 8 mma in every body. n = 8 was always 8 columns wide;
+# what changes with T is only how many of those columns carry live data.
+# C[16 rows][8 cols] += state[row][k] * sVec[k][col] over all 128 keys:
+#   cols 0..TOKENS-1     -> (prefix_t (*) k_t) . h0   the delta-rule history term
+#   cols 4..4+TOKENS-1   -> (prefix_t (*) q_t) . h0   the output history term
+#   the rest              -> garbage (sVec columns never written)
+# acc layout: acc[0],[1] = row `frag_row`, cols 2*lane_quad, +1;
+#             acc[2],[3] = row `frag_row + 8`, same cols. So:
+#   lane_quad 0 -> k-side tokens 0,1     lane_quad 2 -> q-side tokens 0,1
+#   lane_quad 1 -> k-side tokens 2,3     lane_quad 3 -> q-side tokens 2,3
+# At T=2 only lane_quad 0 and 2 carried live data; at T=4 all four do, and at
+# T=3 all but the token-3 column do.
+
+# ===========================================================================
+# Phase E: quad broadcast and the WY forward substitution  (T4:439-483, T3:448-492)
+# ===========================================================================
+if warp < ROWS_PER_CTA // 16:
+    ha_lo = reg_tile(f32, [4]); ha_hi = reg_tile(f32, [4])
+    u_lo  = reg_tile(f32, [TOKENS]); u_hi = reg_tile(f32, [TOKENS])
+    for t in range(4):                  # NOT range(TOKENS) -- see below
+        ha_lo[t] = bcast(acc[t % 2],     quad_base + t // 2, 31, 0xFFFFFFFF)
+    for t in range(4):                  # the source runs the two loops in this
+        ha_hi[t] = bcast(acc[2 + t % 2], quad_base + t // 2, 31, 0xFFFFFFFF)
+    # order (all four ha_lo, then all four ha_hi), not interleaved.
+    # instruction_selection: shfl.sync.idx.b32; extent: scalar, 8 broadcasts in
+    # BOTH bodies -- the source issues all 8 unconditionally.
+    # The `quad_base + 1` half (ha_*[2],[3]) was dead at T=2. At T=4 both are
+    # live. At T=3, ha_*[2] is live (token 2) and ha_*[3] is dead -- but its two
+    # shuffles still execute, so the count is 8 there too. This is a place where
+    # a "clean" port that skips the dead broadcast would emit fewer instructions
+    # than the source; the port issues all 8.
+
+    if lane_quad == 2:
+        row_lo = warp * 16 + frag_row;  row_hi = row_lo + 8
+        for t in range(TOKENS):         # serial forward substitution, depth TOKENS
+            base_t = (sToken[t] * HV + hv) * 128
+            solved_lo = sub(cast(f32, v[base_t + tile_row_base + row_lo]), ha_lo[t])
+            solved_hi = sub(cast(f32, v[base_t + tile_row_base + row_hi]), ha_hi[t])
+            # instruction_selection: ld.global.nc.b16 + cvt.f32.bf16 + sub.ftz.f32
+            # extent: 2 scalars per token -> 8 ld.global.nc.b16 at T=4, 6 at T=3
+            for s in range(TOKENS):
+                if s < t:
+                    solved_lo = sub(solved_lo, mul(sL[t, s], u_lo[s]))
+                    solved_hi = sub(solved_hi, mul(sL[t, s], u_hi[s]))
+                # instruction_selection: mul.ftz.f32 + sub.ftz.f32; extent: scalar,
+                # taken once per (t,s) with s < t -> 6 taken pairs at T=4, 3 at
+                # T=3; total sub.ftz.f32 in phase E is 20 at T=4 and 12 at T=3.
+                # The sL COEFFICIENTS ARE VECTORIZED, not loaded one scalar per
+                # pair: T=4 fetches its 6 live entries with three instructions --
+                # ld.shared.b32 (sL[1][0], +24656), ld.shared.v2.b32 (sL[2][0..1],
+                # +24672), ld.shared.v4.b32 (sL[3][0..3], +24688, over-fetching
+                # the never-written sL[3][3]); T=3 fetches its 3 with two --
+                # ld.shared.v4.b32 (+15424, spanning sL[1][0..2] and sL[2][0],
+                # over-fetching the dead sL[1][1..2]) and ld.shared.b32
+                # (sL[2][1], +15440). The T=2 sibling's "scalar per pair" reads
+                # correctly there because exactly one pair is taken; it does not
+                # carry over.
+            u_lo[t] = solved_lo;  u_hi[t] = solved_hi
+
+    # ---- the quad broadcast that came back to life -------------------------
+    for t in range(TOKENS):
+        u_lo[t] = bcast(u_lo[t], quad_base + 2, 31, 0xFFFFFFFF)
+        u_hi[t] = bcast(u_hi[t], quad_base + 2, 31, 0xFFFFFFFF)
+    # instruction_selection: shfl.sync.idx.b32; extent: scalar, 2*TOKENS
+    # -> 8 at T=4, 6 at T=3
+    # At T=2 these broadcasts were an IDENTITY: all 32 lanes execute them, but
+    # the only lane that consumes the result is lane_quad == 2, which is the
+    # broadcast's own source lane -- so the consumer received its own value and
+    # no other lane read one. The T=2 port dropped them on that basis.
+    # At T=3/T=4 phase F runs on lane_quad >= 2, so lane 4f+3 needs the residuals
+    # that lane 4f+2 solved, and the broadcast stops being an identity. Dropping
+    # it silently corrupts every output token >= 2.
+    # Total shfl.sync.idx.b32 in the body: 17 at T=4 (1 + 8 + 8), 15 at T=3
+    # (1 + 8 + 6).
+
+# ===========================================================================
+# Phase F: the outputs -- the one rewritten phase  (T4:484-532, T3:493-541)
+# ===========================================================================
+# T=2 had one block per token under `lane_quad == 2`. Both new bodies replace
+# that with ONE generic block under `lane_quad >= 2`, where the lane index picks
+# the token pair. The two bodies' text here is identical apart from the literal
+# TOKENS; this is not a re-parameterization of the T=2 code, it is different code.
+if warp < ROWS_PER_CTA // 16 and lane_quad >= 2:
+    token0 = (lane_quad - 2) * 2        # lane 4f+2 -> 0, lane 4f+3 -> 2
+    token1 = token0 + 1                 #             1,              3
+    row_lo = warp * 16 + frag_row;  row_hi = row_lo + 8
+
+    out0_lo, out1_lo = acc[0], acc[1]   # the q-side columns for THIS lane_quad:
+    out0_hi, out1_hi = acc[2], acc[3]   # cols 4,5 at lane_quad 2; 6,7 at 3
+    # No shuffle is needed to get the right column pair -- the accumulator layout
+    # already keys the column pair off lane_quad, which is why the rewrite works.
+
+    for s in range(TOKENS):
+        residual_lo = u_lo[s];  residual_hi = u_hi[s]
+        coef0 = sR[token0, s] if token0 >= s else 0.0
+        coef1 = sR[token1, s] if (token1 < TOKENS and token1 >= s) else 0.0
+        #                         ^^^^^^^^^^^^^^^^ DEVIATION, T=3 only: the
+        # source has no such term and reads sR[9..11] at lane_quad == 3. See
+        # "The T=3 lane_quad == 3 hazard" below. At T=4 the added term is
+        # statically true and changes nothing.
+        # instruction_selection: ld.shared.b32; extent: scalar per taken mask
+        out0_lo = fma(coef0, residual_lo, out0_lo)
+        out1_lo = fma(coef1, residual_lo, out1_lo)
+        out0_hi = fma(coef0, residual_hi, out0_hi)
+        out1_hi = fma(coef1, residual_hi, out1_hi)
+        # instruction_selection: fma.rn.ftz.f32; extent: 4 per source token
+        # -> 16 fma in phase F at T=4, 12 at T=3. The masked-out coefficient is
+        # a real zero-operand fma, not a skipped iteration.
+
+    slot0 = sSlot[token0]
+    slot1 = sSlot[token1] if token1 < TOKENS else -1   # DEVIATION, T=3 only
+    for (t, slot, o_lo, o_hi) in ((token0, slot0, out0_lo, out0_hi),
+                                  (token1, slot1, out1_lo, out1_hi)):
+        if t < TOKENS:                  # T=4: statically true. T=3: LIVE for token1.
+            base_t = (sToken[t] * HV + hv) * 128 + tile_row_base
+            active = slot >= 0
+            copy_r2g(cast(bf16, o_lo if active else 0.0), out[base_t + row_lo])
+            copy_r2g(cast(bf16, o_hi if active else 0.0), out[base_t + row_hi])
+            # instruction_selection: st.global.b16 (7 in each body) +
+            # cvt.rn.bf16.f32 (6 in each body -- the zero branch converts one 0.0
+            # and reuses it for both rows)
+            # A padded row writes EXPLICIT zeros; the upstream test asserts them
+            # bit-exactly, so this is not an "unwritten" path.
+
+# ===========================================================================
+# Phase G: publish sU  (T4:533-546, T3:542-555)
+# ===========================================================================
+if warp < ROWS_PER_CTA // 16:
+    if lane_quad == 2:
+        for t in range(TOKENS):
+            sU[t, warp*16 + frag_row]     = u_lo[t]
+            sU[t, warp*16 + frag_row + 8] = u_hi[t]
+        # instruction_selection: st.shared.b32; extent: 2 scalars per token
+        # -> 8 at T=4, 6 at T=3
+    warp_sync()
+    # instruction_selection: bar.warp.sync; extent: warp
+    # A warp barrier suffices because producer and consumer are the same warp:
+    # writer rows are warp*16 + frag_row{,+8}, i.e. [16w, 16w+16); reader rows
+    # below are group*8 + r with group = tid/16, i.e. warp w owns groups 2w and
+    # 2w+1 -> rows [16w, 16w+16). This holds at 64, 96 and 128 threads alike.
+    # Any port that changes the row-to-thread mapping must re-derive it or
+    # promote to cta_sync.
+
+# The BLOCK_CHECKPOINT_MMA != 0 block (T4:547-659, T3:556-668), including the
+# source's third mma.sync site, is statically dead: the macro is 0 and the
+# binding static-asserts it. Not transcribed. It emits no instructions at all in
+# either exported PTX.
+
+# ===========================================================================
+# Phase H: recurrence and checkpoints  (T4:660-696, T3:669-705)
+# ===========================================================================
+if group < ROWS_PER_CTA // 8:           # T=4: `group < 8`, statically true.
+                                        # T=3: `group < 4`, LIVE.
+    for t in range(TOKENS):             # serial over tokens
+        slot_t = sSlot[t]
+        beta_t = sBeta[t]
+        for row_local in range(8):      # constexpr unroll
+            row    = owned_row_base + row_local
+            update = mul(sU[t, row], beta_t)
+            # instruction_selection (slot_t, beta_t), PER BODY:
+            #   T=4: ld.shared.b32 x2 per token (8 total) -- sBeta is 16 B at
+            #        24576 and sSlot 16 B at 24592, so sBeta[t] and sSlot[t] are
+            #        16 B apart and can never merge.
+            #   T=3: ONE ld.shared.v4.b32 at 15360 covering sBeta[0..2] AND
+            #        sSlot[0] -- sBeta is only 12 B, so those four words are
+            #        contiguous at a 16-byte-aligned base -- plus ld.shared.b32
+            #        for sSlot[1] (15376) and sSlot[2] (15380). Three
+            #        instructions for the whole phase; sBeta is never
+            #        scalar-loaded IN THIS PHASE at T=3 (phase C still reads it
+            #        scalar, three times).
+            # instruction_selection (the 8 consecutive sU rows), PER BODY:
+            #   T=4: ld.shared.v4.b32 x2 per token (+24768, +24784) -- sU's base
+            #        is 16-byte aligned and the row stride is 256 B, so every
+            #        thread's 8-float run is 0 mod 16.
+            #   T=3: ld.shared.b32 + ld.shared.v4.b32 x2 per token (+15484,
+            #        +15488, +15504) -- sU's base 15484 is 12 mod 16 and every
+            #        run inherits that, so nvcc peels one scalar and OVER-FETCHES
+            #        one float (9 fetched for the 8 needed).
+            # plus mul.ftz.f32; extent: scalar per row
+            #
+            # Every shared-load form that differs between the two bodies differs
+            # for one reason, and it cuts both ways. T=3's 12- and 36-byte
+            # metadata regions (sBeta, sSlot, sToken, sL, sR) push everything
+            # after them OFF the 16-byte grid -- sL to 15412 (4 mod 16) and sU to
+            # 15484 (12 mod 16), even though sU is itself 384 B -- so nvcc peels
+            # a scalar off runs that are clean v4s at T=4. In one place it runs
+            # the other way: sBeta sits at 15360, which IS 16-byte aligned, and
+            # its 12-byte size puts sBeta[0..2] + sSlot[0] in a single aligned
+            # quad, giving T=3 a merged v4 that T=4 cannot form. Either
+            # direction, the port must take its load forms per body, not from the
+            # shared skeleton.
+            words = reg_tile(u32, [4])
+            for i in range(8):
+                hist[row_local][i] = fma(hist[row_local][i], sD[t, k_start + i],
+                                         mul(update, sK[t, k_start + i]))
+                # instruction_selection: ld.shared.v4.b32 x2 (sD) + x2 (sK) PER
+                # TOKEN -- the two slices are invariant across `row_local`, so
+                # nvcc hoists them out of the 8-row loop -- plus mul.ftz.f32 +
+                # fma.rn.ftz.f32; extent: 8 iterations of the arithmetic.
+                # Dynamically that is 4 shared loads per token (16 per thread at
+                # T=4, 12 at T=3); statically the census shows 28/20 because the
+                # whole block is replicated 2*TOKENS-1 times (see below).
+                # The source writes `hist*sD + update*sK` and the compiler
+                # contracts the FIRST product: `update*sK` is the rounded one and
+                # `hist*sD` is fused into the FMA. Inverting this rounds the wrong
+                # product at the kernel's only stateful accumulation, which feeds
+                # both the checkpoint and every later token's history.
+                # The recurrence advances UNCONDITIONALLY -- only the store below
+                # is predicated -- and it stays FP32, so token t+1 consumes the
+                # un-rounded token-t state rather than the bf16 checkpoint.
+            for p in range(4):
+                words[p] = cast(bf16x2, (hist[row_local][2*p], hist[row_local][2*p+1]))
+            # instruction_selection: cvt.rn.bf16x2.f32; extent: 4 pairs per row
+            # -> 128 at T=4 (4 tokens x 8 rows x 4), 96 at T=3
+            if slot_t >= 0:
+                copy_r2g(words, state[slot_t*STATE_SLOT_STRIDE + hv*16384
+                                      + (tile_row_base + row)*128 + k_start : +8])
+                # instruction_selection: st.global.v4.b32; extent: one 16-byte
+                # tile -> 32 at T=4 (8 rows x 4 tokens), 24 at T=3
+# EVERY token's slot receives a full ROWS_PER_CTA-row write: these kernels
+# checkpoint per token, they do not write one final state.
+```
+
+## The T=3 `lane_quad == 3` hazard, and the port's deliberate deviation
+
+Phase F is byte-identical between the two bodies, but `TOKENS = 3` is odd, so at
+`lane_quad == 3` the generic block computes `token0 = 2` (valid) and
+`token1 = 3` (**out of range**). Before the `token1 < 3` mask discards the
+results, the source has already:
+
+| read | lands in | why it is safe in the source |
+| --- | --- | --- |
+| `sR[token1*3 + s]` for `s = 0,1,2`, i.e. `sR[9..11]` | `sR` is `[3][3]` = 36 B at offset 15448, so `sR[9..11]` is the **first 12 bytes of `sU`** (offset 15484) | in-bounds shared memory; the value only feeds `out1_*`, which is never stored |
+| `out1_lo/out1_hi` from `acc[1]`/`acc[3]` | MMA column 7 = `sVec` column 7, never written | garbage in, garbage discarded |
+| `sSlot[token1]` = `sSlot[3]` | `sSlot` is `[3]` = 12 B at 15372, so this is `sToken[0]` | only used as `slot1`, which the mask discards |
+
+**The port predicates those reads on `token1 < TOKENS` instead of issuing them.**
+This is a deliberate deviation from a mechanical transcription, and it is the
+only one in either kernel. The justification:
+
+1. It is **numerically identical** — every value read is provably dead.
+2. TIRx has no equivalent of "read past a `T.decl_buffer` view into the next
+   region and rely on the arena layout". Reproducing the source literally would
+   mean hand-computing byte offsets that deliberately leave the declared region,
+   which `check_low_level_ir` and every reviewer would read as a bug.
+3. The cost is four `ld.shared.b32` (three `sR` plus one `sSlot`) and one
+   predicate, on the 16 threads of 96 with `lane_quad == 3` in warps 0 and 1,
+   in one phase — measurable against the perf gate, not against intuition.
+
+Any port that instead lets `token1 = 3` reach `sR`/`sSlot` **must** keep the
+`token1 < TOKENS` guard on the store, or it writes token 3 of a 3-token sequence
+over another sequence's output.
+
+## Was dead at T=2, alive now
+
+| element | T=2 | T=4 | T=3 |
+| --- | --- | --- | --- |
+| MMA acc columns 2,3,6,7 | garbage | live | live except cols 3 and 7 (token 3) |
+| `quad_base+1` broadcasts → `ha_*[2],[3]` | dead (8 issued) | live (8 issued) | `[2]` live, `[3]` dead (8 still issued) |
+| **`u_lo`/`u_hi` quad broadcasts** | **identity (dropped)** | **live, 8** | **live, 6** |
+| `sL` live entries | 1 | 6 | 3 |
+| `sR` live entries | 3 | 10 | 6 |
+| solve depth | 2 | 4 | 3 |
+| phase-F writer lanes per quad | 1 | 2 | 2 (one with a discarded half) |
+
+Nothing that was live at T=2 died. Still dead in both: `vec_frag[2],[3]`, `sVec`
+columns 8..15, `sGramA0`/`sGramA1`, and the whole `BLOCK_CHECKPOINT_MMA` block.
+
+## Instruction-selection summary
+
+Read off line-info PTX exported by re-running FlashInfer's own nvcc command line
+(`.porting/flashkda_decode_t{4,3}_*/ptx/<variant>/kernel.ptx`), counted with
+`ptx_census.py`, which drops the `--source-in-ptx` comment echo and peels the
+inline-asm braces before matching. Body totals: **2639** instructions at T=4 and
+**2167** at T=3, of which 56 and 48 are predicated (`@%pN`) branches; the
+unpredicated remainder is 2583 / 2119. None of the forms tabulated below is ever
+predicated in these bodies, so every row is a straight count.
+
+| form | T=4 | T=3 | where |
+| --- | ---: | ---: | --- |
+| `mul.ftz.f32` | 588 | 429 | H 504/360, C 59/41, A 13/22, E 12/6 |
+| `fma.rn.ftz.f32` | 504 | 364 | H 448/320, C 32/24, F 16/12, A 8/8 |
+| `shl.b32` / `and.b32` | 182 / 161 | 156 / 141 | the bf16 widening pair plus index and swizzle arithmetic |
+| `cvt.rn.bf16x2.f32` | 128 | 96 | phase H, `TOKENS × 8 rows × 4 pairs` |
+| `add.ftz.f32` | 51 | 49 | butterfly tails, the eps adds, and (T=3) the `1 +` in the gate |
+| `ld.shared.v4.b32` | 51 | 37 | H 42/31 — T=4: 28 sD/sK + 14 sU; T=3: 20 sD/sK + 10 sU + **1 sBeta/sSlot merge**. C 7/5, E 2/1 |
+| `shfl.sync.bfly.b32` | 50 | 40 | C 40/30 (2 dots × 5 rounds × TOKENS), A 10/10 |
+| `ld.shared.b32` | 41 | 37 | scalars: prefix gate, sBeta, sL, sR, sSlot, sToken, sInit |
+| `ld.shared.v2.b32` | 2 | 1 | T=4: the phase-E `sL[2][0..1]` pair and the phase-F `sSlot[token0..1]` pair. T=3: the phase-E `sToken[0..1]` pair |
+| `xor.b32` | 34 | 34 | the shared swizzle — identical, it is a per-access constant folding |
+| `st.global.v4.b32` | 32 | 24 | the checkpoints, `8 rows × TOKENS` |
+| `sub.ftz.f32` | 20 | 12 | the WY residuals |
+| `st.shared.b32` | 19 | 15 | G 8/6, C 7/5, A 4/4 |
+| `st.shared.v4.b32` | 18 | 18 | B 16 + A 2 — **identical**, phase B is T-independent |
+| `shfl.sync.idx.b32` | 17 | 15 | E 16/14 + 1 `make_warp_uniform` |
+| `cvt.rn.bf16.f32` | 14 | 14 | 8 sVec column stores + 6 output conversions |
+| `ld.global.nc.b16` | 9 | 7 | E 8/6 (the `v` loads) + 1 `beta` |
+| `cvt.f32.bf16` | 9 | 7 | same sites |
+| `ldmatrix…x4.shared.b16` | **8** | **8** | the A operand, one per MMA issue |
+| `ldmatrix…x4.trans.shared.b16` | **8** | **8** | the B operand, one per MMA issue |
+| `mma.sync…m16n8k16.f32.bf16.bf16.f32` | **8** | **8** | 1 zeroing + 7 accumulating |
+| `ld.global.v4.b32` | 8 | 8 | the state gather — **not** `.nc` |
+| `st.shared.b16` | 8 | 8 | the sVec columns |
+| `st.global.b16` | 7 | 7 | the outputs |
+| `ld.global.nc.b32` | 5 | **10** | T=3's extra 5 = 4 `dt_bias` + 1 `A_log` |
+| `ld.global.nc.v2.b32` | 3 | 3 | q, k, g |
+| `ex2.approx.ftz.f32` | 4 | **9** | T=4: one per element. T=3: 2 per element + the hoisted `gate_a` |
+| `rsqrt.approx.ftz.f32` | 2 | 2 | the two L2 norms |
+| **`div.approx.ftz.f32`** | — | **4** | the gate, one per element |
+| **`neg.ftz.f32`** | — | **1** | `-gate_a`, hoisted out of the element loop |
+| `bar.sync` / `bar.warp.sync` | 2 / 1 | 2 / 1 | the two CTA barriers and the sU warp barrier |
+
+Consequences the port must honour:
+
+1. **Every float operation is `.ftz`.** `-use_fast_math` plus plain CUDA
+   operators give `mul/add/sub.ftz.f32` and `fma.rn.ftz.f32`; `__expf`,
+   `rsqrtf` and the division give `ex2.approx.ftz.f32`,
+   `rsqrt.approx.ftz.f32` and `div.approx.ftz.f32`. There is **no plain-`.f32`
+   arithmetic anywhere in either body** — including inside T=3's gate. This
+   matches the ported T=1/T=2 siblings and is the opposite of the two CuTe-DSL
+   KDA decode ports, whose helpers are deliberately non-FTZ.
+2. **`.nc` follows read-only-ness, not `__restrict__` alone.** q, k, g, v, beta,
+   the metadata and (T=3) A_log/dt_bias load through `ld.global.nc.*`; the state
+   gather is a plain `ld.global.v4.b32` because the same kernel writes that
+   buffer.
+3. **`dt_bias` is NOT vectorized.** The four fp32 a lane needs are contiguous
+   (`[%rd30]`, `+4`, `+8`, `+12`) and nvcc still emits four scalar
+   `ld.global.nc.b32`. There is no `ld.global.nc.v4.b32` anywhere in the T=3
+   body. A port that "improves" this to one vector load diverges from the source
+   in the one phase every thread executes.
+4. **The MMA operands are bf16 and the accumulator is FP32**, so the kernels lose
+   precision an FP32 oracle does not: the measured gap to a sequential FP32
+   oracle is 6.1e-05 (T=4) and 3.1e-05 (T=3) on the output, against 6e-08 for the
+   register-only t1_direct sibling.
+
+### The `2T−1` static inflation in phase H
+
+Phase H's recurrence appears **`2·TOKENS − 1` times** in the compiled body — 7
+copies at T=4, 5 at T=3, 3 at T=2 — each an exact 64-instruction block
+(8 rows × 8 keys). Verified by basic-block attribution: the `fma.rn.ftz.f32` at
+the recurrence line are spread over exactly 7 / 5 / 3 blocks with 64 in each.
+
+This is **nvcc tail duplication around the `slot_t >= 0` store branch**, not
+extra arithmetic: token 0's recurrence has one incoming path, and every later
+token has two (the taken and not-taken successors of the previous token's store
+predicate), giving `1 + 2(T−1)`. The stores and the bf16 packing are *not*
+duplicated — they sit inside the predicate — which is why `st.global.v4.b32` is
+exactly `8 × TOKENS` and `cvt.rn.bf16x2.f32` exactly `32 × TOKENS`.
+
+At runtime each thread still executes `TOKENS × 64` FMAs. The consequence for
+this port is a measurement one: a **static** PTX-count comparison between the
+port and the source will show phase H inflated by up to 1.75× unless TIRx's
+codegen happens to make the same duplication choice. Compare dynamic work, or
+compare the store and packing counts, which are duplication-free.
+
+## TIRx module and benchmark contract
+
+- Modules `tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py` and
+  `flashkda_decode_t3_lower_bound.py`, `KERNEL_META["name"]` matching, cc 10.
+  Two kernels ⇒ two modules; the registry allows one `KERNEL_META` per module.
+  T=3 sibling-imports every PTX/math/shuffle/global/shared helper from the T=2
+  module, as does T=4; only geometry constants, the data recipe, the oracles and
+  the config matrices are per-module.
+- Reference for both: the frozen export itself through the JIT module's direct
+  ABI, so the comparison is kernel-only and every metadata combination —
+  negative slots, arbitrary `num_accepted_tokens` — is reachable. T=3's call
+  passes **real** `A_log`, `dt_bias` and `lower_bound`; T=4's passes fp32 dummies
+  and `0.0`, which that body never dereferences.
+- **T=4: 9 bench rows** — `hv32h16` × N{8,16,32,64,128} (parity with FlashInfer's
+  own export bench), plus `hv16h16` and `hv12h12` at N{8,64}. All split2.
+- **T=3: 5 bench rows** — `hv16h16` × N{1,2,4,8,16}. That is the kernel's
+  *entire* legal domain: the dispatcher enforces `H == HV == 16` and
+  `N ∈ {1,2,4,8,16}`, so there is no shape outside these five.
+- `verify_dispatch.py` asserts every row reaches its variant, and for T=3 also
+  that 10 near-miss contracts (wrong `num_spec_tokens`, absent or non-negative
+  `lower_bound`, missing/bf16/too-short `A_log`/`dt_bias`, `use_gate_in_kernel`
+  off) and 4 out-of-domain shapes are refused — the negative space is most of
+  T=3's contract.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ point each port backs:
 | `recurrent_kda_decode_grouped` | bf16 | Recurrent KDA decode, grouped CTA (small-batch T=1 and all speculative T>1) |
 | `flashkda_decode_t1_precomputed` | bf16 | FlashKDA "cake" decode, T=1 precomputed gate |
 | `flashkda_decode_t2_precomputed` | bf16 | FlashKDA "cake" decode, T=2 precomputed gate (WY, tensor cores) |
+| `flashkda_decode_t3_lower_bound` | bf16 | FlashKDA "cake" decode, T=3 lower-bound gate computed in-kernel |
+| `flashkda_decode_t4_precomputed` | bf16 | FlashKDA "cake" decode, T=4 precomputed gate (WY, tensor cores) |
 
 `flashinfer/gdn_prefill/` — `flashinfer.gdn_prefill`:
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "ea0950ab",
-    "tirx-kernels": "022c384a",
+    "tirx-kernels": "919312eb",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "65581c0667f9f4fc84412841bef4e99d5c8bfbdc"
+    "tirx-kernels:tirx_kernels": "76f435495502685fed7b2ec94dbb52eac22bef3e"
   },
   "baselines": {
     "torch": {
@@ -1651,8 +1651,8 @@
       "label": "hv12h12_b64_s8",
       "status": "ok",
       "impls": {
-        "tirx": 14.259361494303159,
-        "flashinfer_cake": 15.736388312899836
+        "tirx": 14.339483202981903,
+        "flashinfer_cake": 15.70338554328622
       },
       "aggregated": {
         "rounds": 5,
@@ -1665,8 +1665,8 @@
       "label": "hv12h12_b8_s16",
       "status": "ok",
       "impls": {
-        "tirx": 4.719541169780189,
-        "flashinfer_cake": 6.262137962531812
+        "tirx": 4.7702013154223275,
+        "flashinfer_cake": 6.446833962335925
       },
       "aggregated": {
         "rounds": 5,
@@ -1679,8 +1679,8 @@
       "label": "hv16h16_b128_s8",
       "status": "ok",
       "impls": {
-        "tirx": 28.778753873422723,
-        "flashinfer_cake": 32.13913212721831
+        "tirx": 28.748726959138207,
+        "flashinfer_cake": 31.495596942173464
       },
       "aggregated": {
         "rounds": 5,
@@ -1693,8 +1693,8 @@
       "label": "hv16h16_b16_s16",
       "status": "ok",
       "impls": {
-        "tirx": 6.260000532182204,
-        "flashinfer_cake": 8.152864308839414
+        "tirx": 6.301943875449133,
+        "flashinfer_cake": 7.854504115629423
       },
       "aggregated": {
         "rounds": 5,
@@ -1707,8 +1707,8 @@
       "label": "hv16h16_b1_s16",
       "status": "ok",
       "impls": {
-        "tirx": 4.136541655453699,
-        "flashinfer_cake": 5.7675148024992735
+        "tirx": 4.011037211573264,
+        "flashinfer_cake": 5.609428760453247
       },
       "aggregated": {
         "rounds": 5,
@@ -1721,8 +1721,8 @@
       "label": "hv16h16_b32_s8",
       "status": "ok",
       "impls": {
-        "tirx": 10.015249772128083,
-        "flashinfer_cake": 13.356300670442216
+        "tirx": 9.965755244470524,
+        "flashinfer_cake": 13.344626777624649
       },
       "aggregated": {
         "rounds": 5,
@@ -1735,8 +1735,8 @@
       "label": "hv16h16_b4_s16",
       "status": "ok",
       "impls": {
-        "tirx": 4.5147843857516365,
-        "flashinfer_cake": 5.7301633125823015
+        "tirx": 4.425668303444357,
+        "flashinfer_cake": 6.013968566001348
       },
       "aggregated": {
         "rounds": 5,
@@ -1749,8 +1749,8 @@
       "label": "hv16h16_b64_s8",
       "status": "ok",
       "impls": {
-        "tirx": 16.60930283625364,
-        "flashinfer_cake": 19.417524169162398
+        "tirx": 16.485547640087454,
+        "flashinfer_cake": 19.3742274750777
       },
       "aggregated": {
         "rounds": 5,
@@ -1763,8 +1763,8 @@
       "label": "hv16h16_b8_s16",
       "status": "ok",
       "impls": {
-        "tirx": 5.000787580254269,
-        "flashinfer_cake": 6.338666961276744
+        "tirx": 4.947001416376249,
+        "flashinfer_cake": 6.825502754014199
       },
       "aggregated": {
         "rounds": 5,
@@ -1777,8 +1777,8 @@
       "label": "hv32h16_b32_s8",
       "status": "ok",
       "impls": {
-        "tirx": 16.627576137423702,
-        "flashinfer_cake": 19.36841917895613
+        "tirx": 16.80393459426296,
+        "flashinfer_cake": 19.170531987141658
       },
       "aggregated": {
         "rounds": 5,
@@ -1791,8 +1791,8 @@
       "label": "hv32h16_b8_s16",
       "status": "ok",
       "impls": {
-        "tirx": 6.2427481930603355,
-        "flashinfer_cake": 7.913243303966552
+        "tirx": 6.209117871436839,
+        "flashinfer_cake": 8.327738443563472
       },
       "aggregated": {
         "rounds": 5,
@@ -1805,8 +1805,8 @@
       "label": "hv12h12_b64_t2",
       "status": "ok",
       "impls": {
-        "tirx": 20.891704334660023,
-        "flashinfer_cake": 24.007318980868945
+        "tirx": 20.849174827140168,
+        "flashinfer_cake": 24.28899769693229
       },
       "aggregated": {
         "rounds": 5,
@@ -1819,8 +1819,8 @@
       "label": "hv12h12_b8_t2",
       "status": "ok",
       "impls": {
-        "tirx": 6.350220182292079,
-        "flashinfer_cake": 8.282665345053852
+        "tirx": 6.374156442481507,
+        "flashinfer_cake": 8.377837915302791
       },
       "aggregated": {
         "rounds": 5,
@@ -1833,8 +1833,8 @@
       "label": "hv16h16_b64_t2",
       "status": "ok",
       "impls": {
-        "tirx": 25.377645220511624,
-        "flashinfer_cake": 30.16673546717479
+        "tirx": 25.414999029017768,
+        "flashinfer_cake": 29.988170488854422
       },
       "aggregated": {
         "rounds": 5,
@@ -1847,8 +1847,8 @@
       "label": "hv16h16_b8_t2",
       "status": "ok",
       "impls": {
-        "tirx": 6.986833881473316,
-        "flashinfer_cake": 8.800366793582626
+        "tirx": 7.032893290308618,
+        "flashinfer_cake": 9.311554206473549
       },
       "aggregated": {
         "rounds": 5,
@@ -1861,8 +1861,8 @@
       "label": "hv32h16_b128_t2",
       "status": "ok",
       "impls": {
-        "tirx": 83.2297856610106,
-        "flashinfer_cake": 94.88444040868747
+        "tirx": 83.1121574697481,
+        "flashinfer_cake": 95.18804950568678
       },
       "aggregated": {
         "rounds": 5,
@@ -1875,8 +1875,8 @@
       "label": "hv32h16_b16_t2",
       "status": "ok",
       "impls": {
-        "tirx": 15.446455942158458,
-        "flashinfer_cake": 17.832382828820197
+        "tirx": 15.66989601299443,
+        "flashinfer_cake": 18.241979632674116
       },
       "aggregated": {
         "rounds": 5,
@@ -1889,8 +1889,8 @@
       "label": "hv32h16_b32_t2",
       "status": "ok",
       "impls": {
-        "tirx": 25.36455503688244,
-        "flashinfer_cake": 29.94247059479419
+        "tirx": 25.640840713336193,
+        "flashinfer_cake": 30.02172307480613
       },
       "aggregated": {
         "rounds": 5,
@@ -1903,8 +1903,8 @@
       "label": "hv32h16_b64_t2",
       "status": "ok",
       "impls": {
-        "tirx": 44.90519007664209,
-        "flashinfer_cake": 51.21532156395486
+        "tirx": 44.91374631310782,
+        "flashinfer_cake": 51.739787532167675
       },
       "aggregated": {
         "rounds": 5,
@@ -1917,8 +1917,204 @@
       "label": "hv32h16_b8_t2",
       "status": "ok",
       "impls": {
-        "tirx": 9.08968844266317,
-        "flashinfer_cake": 10.977688391352567
+        "tirx": 9.007080987034804,
+        "flashinfer_cake": 11.312913600352381
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t3_lower_bound",
+      "config": "hv16h16_b16_t3",
+      "label": "hv16h16_b16_t3",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.581029397577948,
+        "flashinfer_cake": 14.016056104796148
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t3_lower_bound",
+      "config": "hv16h16_b1_t3",
+      "label": "hv16h16_b1_t3",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.924036915949224,
+        "flashinfer_cake": 6.077056287911471
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t3_lower_bound",
+      "config": "hv16h16_b2_t3",
+      "label": "hv16h16_b2_t3",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.0873213148889,
+        "flashinfer_cake": 6.293167199493816
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t3_lower_bound",
+      "config": "hv16h16_b4_t3",
+      "label": "hv16h16_b4_t3",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.761728764387974,
+        "flashinfer_cake": 6.974412798265498
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t3_lower_bound",
+      "config": "hv16h16_b8_t3",
+      "label": "hv16h16_b8_t3",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.886985979694978,
+        "flashinfer_cake": 7.969388697231371
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv12h12_b64_t4",
+      "label": "hv12h12_b64_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 32.185142335409466,
+        "flashinfer_cake": 33.9351206883906
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv12h12_b8_t4",
+      "label": "hv12h12_b8_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.818268273311162,
+        "flashinfer_cake": 10.481047852053491
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv16h16_b64_t4",
+      "label": "hv16h16_b64_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 40.82463446971685,
+        "flashinfer_cake": 42.53704180234865
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv16h16_b8_t4",
+      "label": "hv16h16_b8_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.15147500667413,
+        "flashinfer_cake": 10.821097204367238
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv32h16_b128_t4",
+      "label": "hv32h16_b128_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 136.04335459411334,
+        "flashinfer_cake": 138.298075534864
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv32h16_b16_t4",
+      "label": "hv32h16_b16_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 22.369841016036652,
+        "flashinfer_cake": 24.63347483171318
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv32h16_b32_t4",
+      "label": "hv32h16_b32_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 40.46614351015531,
+        "flashinfer_cake": 41.808063391071784
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv32h16_b64_t4",
+      "label": "hv32h16_b64_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 71.71584813869262,
+        "flashinfer_cake": 73.734534104721
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t4_precomputed",
+      "config": "hv32h16_b8_t4",
+      "label": "hv32h16_b8_t4",
+      "status": "ok",
+      "impls": {
+        "tirx": 12.766413260734272,
+        "flashinfer_cake": 14.745371736659923
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '022c384a', 'tirx-bench-ci': None}`
-- Workloads: 278 ok, 0 failed
+- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '919312eb', 'tirx-bench-ci': None}`
+- Workloads: 292 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -202,31 +202,55 @@ Grouped workloads show one row per config and one timing column per implementati
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_s8` | tirx | 14.2594 | flashinfer_cake | 15.7364 | 1.104 | — |
-| `hv12h12_b8_s16` | tirx | 4.7195 | flashinfer_cake | 6.2621 | 1.327 | — |
-| `hv16h16_b128_s8` | tirx | 28.7788 | flashinfer_cake | 32.1391 | 1.117 | — |
-| `hv16h16_b16_s16` | tirx | 6.2600 | flashinfer_cake | 8.1529 | 1.302 | — |
-| `hv16h16_b1_s16` | tirx | 4.1365 | flashinfer_cake | 5.7675 | 1.394 | — |
-| `hv16h16_b32_s8` | tirx | 10.0152 | flashinfer_cake | 13.3563 | 1.334 | — |
-| `hv16h16_b4_s16` | tirx | 4.5148 | flashinfer_cake | 5.7302 | 1.269 | — |
-| `hv16h16_b64_s8` | tirx | 16.6093 | flashinfer_cake | 19.4175 | 1.169 | — |
-| `hv16h16_b8_s16` | tirx | 5.0008 | flashinfer_cake | 6.3387 | 1.268 | — |
-| `hv32h16_b32_s8` | tirx | 16.6276 | flashinfer_cake | 19.3684 | 1.165 | — |
-| `hv32h16_b8_s16` | tirx | 6.2427 | flashinfer_cake | 7.9132 | 1.268 | — |
+| `hv12h12_b64_s8` | tirx | 14.3395 | flashinfer_cake | 15.7034 | 1.095 | — |
+| `hv12h12_b8_s16` | tirx | 4.7702 | flashinfer_cake | 6.4468 | 1.351 | — |
+| `hv16h16_b128_s8` | tirx | 28.7487 | flashinfer_cake | 31.4956 | 1.096 | — |
+| `hv16h16_b16_s16` | tirx | 6.3019 | flashinfer_cake | 7.8545 | 1.246 | — |
+| `hv16h16_b1_s16` | tirx | 4.0110 | flashinfer_cake | 5.6094 | 1.398 | — |
+| `hv16h16_b32_s8` | tirx | 9.9658 | flashinfer_cake | 13.3446 | 1.339 | — |
+| `hv16h16_b4_s16` | tirx | 4.4257 | flashinfer_cake | 6.0140 | 1.359 | — |
+| `hv16h16_b64_s8` | tirx | 16.4855 | flashinfer_cake | 19.3742 | 1.175 | — |
+| `hv16h16_b8_s16` | tirx | 4.9470 | flashinfer_cake | 6.8255 | 1.380 | — |
+| `hv32h16_b32_s8` | tirx | 16.8039 | flashinfer_cake | 19.1705 | 1.141 | — |
+| `hv32h16_b8_s16` | tirx | 6.2091 | flashinfer_cake | 8.3277 | 1.341 | — |
 
 ## flashkda_decode_t2_precomputed
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_t2` | tirx | 20.8917 | flashinfer_cake | 24.0073 | 1.149 | — |
-| `hv12h12_b8_t2` | tirx | 6.3502 | flashinfer_cake | 8.2827 | 1.304 | — |
-| `hv16h16_b64_t2` | tirx | 25.3776 | flashinfer_cake | 30.1667 | 1.189 | — |
-| `hv16h16_b8_t2` | tirx | 6.9868 | flashinfer_cake | 8.8004 | 1.260 | — |
-| `hv32h16_b128_t2` | tirx | 83.2298 | flashinfer_cake | 94.8844 | 1.140 | — |
-| `hv32h16_b16_t2` | tirx | 15.4465 | flashinfer_cake | 17.8324 | 1.154 | — |
-| `hv32h16_b32_t2` | tirx | 25.3646 | flashinfer_cake | 29.9425 | 1.180 | — |
-| `hv32h16_b64_t2` | tirx | 44.9052 | flashinfer_cake | 51.2153 | 1.141 | — |
-| `hv32h16_b8_t2` | tirx | 9.0897 | flashinfer_cake | 10.9777 | 1.208 | — |
+| `hv12h12_b64_t2` | tirx | 20.8492 | flashinfer_cake | 24.2890 | 1.165 | — |
+| `hv12h12_b8_t2` | tirx | 6.3742 | flashinfer_cake | 8.3778 | 1.314 | — |
+| `hv16h16_b64_t2` | tirx | 25.4150 | flashinfer_cake | 29.9882 | 1.180 | — |
+| `hv16h16_b8_t2` | tirx | 7.0329 | flashinfer_cake | 9.3116 | 1.324 | — |
+| `hv32h16_b128_t2` | tirx | 83.1122 | flashinfer_cake | 95.1880 | 1.145 | — |
+| `hv32h16_b16_t2` | tirx | 15.6699 | flashinfer_cake | 18.2420 | 1.164 | — |
+| `hv32h16_b32_t2` | tirx | 25.6408 | flashinfer_cake | 30.0217 | 1.171 | — |
+| `hv32h16_b64_t2` | tirx | 44.9137 | flashinfer_cake | 51.7398 | 1.152 | — |
+| `hv32h16_b8_t2` | tirx | 9.0071 | flashinfer_cake | 11.3129 | 1.256 | — |
+
+## flashkda_decode_t3_lower_bound
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv16h16_b16_t3` | tirx | 13.5810 | flashinfer_cake | 14.0161 | 1.032 | — |
+| `hv16h16_b1_t3` | tirx | 5.9240 | flashinfer_cake | 6.0771 | 1.026 | — |
+| `hv16h16_b2_t3` | tirx | 6.0873 | flashinfer_cake | 6.2932 | 1.034 | — |
+| `hv16h16_b4_t3` | tirx | 6.7617 | flashinfer_cake | 6.9744 | 1.031 | — |
+| `hv16h16_b8_t3` | tirx | 7.8870 | flashinfer_cake | 7.9694 | 1.010 | — |
+
+## flashkda_decode_t4_precomputed
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv12h12_b64_t4` | tirx | 32.1851 | flashinfer_cake | 33.9351 | 1.054 | — |
+| `hv12h12_b8_t4` | tirx | 8.8183 | flashinfer_cake | 10.4810 | 1.189 | — |
+| `hv16h16_b64_t4` | tirx | 40.8246 | flashinfer_cake | 42.5370 | 1.042 | — |
+| `hv16h16_b8_t4` | tirx | 9.1515 | flashinfer_cake | 10.8211 | 1.182 | — |
+| `hv32h16_b128_t4` | tirx | 136.0434 | flashinfer_cake | 138.2981 | 1.017 | — |
+| `hv32h16_b16_t4` | tirx | 22.3698 | flashinfer_cake | 24.6335 | 1.101 | — |
+| `hv32h16_b32_t4` | tirx | 40.4661 | flashinfer_cake | 41.8081 | 1.033 | — |
+| `hv32h16_b64_t4` | tirx | 71.7158 | flashinfer_cake | 73.7345 | 1.028 | — |
+| `hv32h16_b8_t4` | tirx | 12.7664 | flashinfer_cake | 14.7454 | 1.155 | — |
 
 ## fp16_bf16_gemm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t3_lower_bound.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t3_lower_bound.yaml
@@ -1,0 +1,25 @@
+# FlashKDA "cake" T=3 lower-bound decode, against the frozen FlashInfer export
+# it is ported from.
+#
+# These five rows are not a sample of the kernel's domain -- they are the whole
+# of it. T=3 is the only cake variant that computes its gate in-kernel
+# (GATE_KIND 1), and the dispatcher pins its shape box hard: H == HV == 16 and
+# N in {1,2,4,8,16} (recurrent_kda.py:1352-1359), on top of requiring
+# num_spec_tokens == 2, use_gate_in_kernel, a finite lower_bound < 0 and fp32
+# contiguous A_log/dt_bias (:1285-1294, :1406-1416). There is also no split
+# dimension: the variant is early-returned at :1437-1438 without ever consulting
+# the value-split selector.
+#
+# .porting/.../verify_dispatch.py checks both directions for this kernel --
+# every row below selects d128_t3_lower_bound_split4, and ten near-miss
+# contracts plus four out-of-domain shapes are refused -- because for T=3 the
+# negative space is most of the contract.
+#
+#   hv16h16_b{1,2,4,8,16}_t3   parity with FlashInfer's own T=3 export bench
+kernel: flashkda_decode_t3_lower_bound
+configs:
+  - {config: hv16h16_b1_t3, default: true}
+  - {config: hv16h16_b2_t3, default: true}
+  - {config: hv16h16_b4_t3, default: true}
+  - {config: hv16h16_b8_t3, default: true}
+  - {config: hv16h16_b16_t3, default: true}

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t4_precomputed.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t4_precomputed.yaml
@@ -1,0 +1,28 @@
+# FlashKDA "cake" T=4 precomputed-gate decode, against the frozen FlashInfer
+# export it is ported from.
+#
+# As at T=2 there is no split dimension to cover: on sm100a the selector returns
+# value_split 2 for every T=4 shape (recurrent_kda.py:1179-1180, :1449-1458 --
+# the shape-dependent branch is sm103a only), so d128_t4_precomputed_split2 is
+# the entire dispatch surface and the matrix varies only (HV, H, N).
+# .porting/.../verify_dispatch.py asserts that for every row by feeding the real
+# tensors into FlashInfer's own selector; what it actually guards at T=4 is the
+# rest of the contract (num_spec_tokens == 3, ssm_state_indices of exactly N*4
+# entries, cu_seqlens stepping by four), any of which makes the selector return
+# None rather than a wrong variant.
+#
+#   hv32h16_*   H=16, HV=32 (GQA ratio 2) -- exact parity with FlashInfer's own
+#               T=4 export bench, which sweeps N in {8,16,32,64,128}
+#   hv16h16_*   the non-GQA head count, at both ends of the batch range
+#   hv12h12_*   Kimi K3's TP8 per-rank head count, same two batch sizes
+kernel: flashkda_decode_t4_precomputed
+configs:
+  - {config: hv32h16_b8_t4, default: true}
+  - {config: hv32h16_b16_t4, default: true}
+  - {config: hv32h16_b32_t4, default: true}
+  - {config: hv32h16_b64_t4, default: true}
+  - {config: hv32h16_b128_t4, default: true}
+  - {config: hv16h16_b8_t4, default: true}
+  - {config: hv16h16_b64_t4, default: true}
+  - {config: hv12h12_b8_t4, default: true}
+  - {config: hv12h12_b64_t4, default: true}

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -1112,10 +1112,47 @@ def run_bench(
     timer: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Benchmark entry point. Implemented in the performance gate."""
-    raise SkipTest(
-        "flashkda_decode_t3_lower_bound is at the scaffold stage; benchmarking is "
-        "enabled in the performance gate"
+    """Time the port against the frozen cake export on identical inputs."""
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region. Both sides mutate their own state
+    # pool in place, so this also proves the pools stayed independent.
+    executable(*args)
+    reference_out = _flashinfer_reference(case)
+    torch.cuda.synchronize(case["device"])
+    torch.testing.assert_close(
+        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+    )
+    torch.testing.assert_close(
+        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # The nvcc JIT build and warmup both happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cake": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
     )
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -1,0 +1,594 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx port of FlashInfer's FlashKDA "cake" T=3 lower-bound decode kernel.
+
+Source: ``csrc/kda/flashkda_decode_d128_t3_lower_bound_split4.cu``, symbol
+``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- the same frozen WY
+template as the T=2 and T=4 siblings, re-instantiated at TOKENS=3 with
+**GATE_KIND = 1**.
+
+T=3 bypasses the value-split selector entirely: the dispatcher early-returns
+``d128_t3_lower_bound_split4`` from the ``is_t3_lower_bound`` predicate
+(``recurrent_kda.py:1285-1294``, ``:1437-1438``). Its legal domain is narrow and
+enforced host-side -- ``num_spec_tokens == 2``, a finite ``lower_bound < 0``,
+``A_log``/``dt_bias`` present, ``N in {1,2,4,8,16}`` and ``H == HV == 16``
+(``:1352-1359``, ``:1406-1416``).
+
+Two things make this body different from every cake kernel ported so far:
+
+* **the gate is computed in-kernel** (GATE_KIND 1), so ``A_log``, ``dt_bias``
+  and ``lower_bound`` are live arguments rather than the dummies the
+  precomputed variants pass. Per element the source computes
+  ``lower_bound / (1 + exp(-exp(A_log[h]) * (g + dt_bias[h*128 + k])))`` and
+  then exponentiates it -- three transcendental sites against T=2's one, and
+  the family's only division.
+* **warp 2 is a token-only warp.** At 96 threads with 32 value rows the
+  state-side bounds are still 2 warps and 4 groups (they derive from rows/16
+  and rows/8, not from T), so warp 2 runs the token preprocess and its share of
+  the WY coefficients, hits both barriers, and then does nothing: it never
+  gathers state, never issues an MMA, never stores. Both CTA barriers are
+  therefore genuine three-warp edges.
+
+Helper vocabulary is shared with the T=2 module; only the geometry constants,
+the gate, the frozen digest and the kernel body are per-specialization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+from . import flashkda_decode_t2_precomputed as _t2
+
+# Shared helper vocabulary (identical PTX forms, identical swizzle -- verified
+# against all three bodies).
+_ptx_un = _t2._ptx_un
+_ptx_bin = _t2._ptx_bin
+_ptx_ter = _t2._ptx_ter
+_mul = _t2._mul
+_add = _t2._add
+_sub = _t2._sub
+_fma = _t2._fma
+_rsqrt = _t2._rsqrt
+_expf = _t2._expf
+_shfl_bfly = _t2._shfl_bfly
+_shfl_idx = _t2._shfl_idx
+_load_i32 = _t2._load_i32
+_load_bf16_f32 = _t2._load_bf16_f32
+_widen_lo = _t2._widen_lo
+_widen_hi = _t2._widen_hi
+_load_u32x2 = _t2._load_u32x2
+_load_u32x4 = _t2._load_u32x4
+_store_u32x4 = _t2._store_u32x4
+_pack_bf16x2 = _t2._pack_bf16x2
+_store_f32_as_bf16 = _t2._store_f32_as_bf16
+_swz = _t2._swz
+_st_shared_f32 = _t2._st_shared_f32
+_ld_shared_f32 = _t2._ld_shared_f32
+_st_shared_i32 = _t2._st_shared_i32
+_ld_shared_i32 = _t2._ld_shared_i32
+_ld_shared_f32x4 = _t2._ld_shared_f32x4
+_st_shared_u32x4 = _t2._st_shared_u32x4
+_st_shared_b16 = _t2._st_shared_b16
+_ldmatrix_x4 = _t2._ldmatrix_x4
+_mma_zero = _t2._mma_zero
+_mma_acc = _t2._mma_acc
+
+# --- source pinning -------------------------------------------------------
+# Raw and normalized digests differ for this export; the hash of the bytes
+# between the BEGIN/END markers is the raw one (verified).
+FROZEN_FLASHINFER_COMMIT = "f2e04400"
+FROZEN_BODY_SHA256 = "70c838b717a9eb7765bf9291db786b2b7a0387fbf80a3c337d5c04e7a553fe21"
+
+HEAD_DIM = _t2.HEAD_DIM
+NUM_TOKENS = 3
+VALUE_SPLIT = 4  # T = 3 bypasses the selector; split4 is the whole surface
+L2_EPS = _t2.L2_EPS
+LOG2_E = _t2.LOG2_E
+
+THREADS = 96  # 3 warps (flash_kda_decode.py:_variant_metadata)
+ROWS_PER_CTA = HEAD_DIM // VALUE_SPLIT  # tile_row_base = value_tile * 32 (.cu:159)
+ROWS_PER_THREAD = 8  # groups 0..3 (warps 0,1) own 8 rows x 8 keys each
+K_PER_THREAD = 8
+
+# Arena offsets copied from the source's #define block (.cu:45-88). sState and sVec keep the T=2 offsets exactly.
+OFF_SSTATE0 = 0
+OFF_SSTATE1 = 4096
+OFF_SVEC = 8192
+OFF_SK = 12288
+OFF_SD = 13824
+OFF_SBETA = 15360
+OFF_SSLOT = 15372
+OFF_STOKEN = 15384
+OFF_SINIT = 15396
+OFF_SL = 15412
+OFF_SR = 15448
+OFF_SU = 15484
+SMEM_TOTAL = 15872
+# sGramA0/sGramA1 alias sVec and are t5/t6 machinery -- dead here.
+
+# TIRX_TRANSCRIBE_START flashkda_decode_t3_lower_bound
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror FlashInfer's T=3 export bench.
+
+    H and HV are pinned at 16 and cannot vary: the dispatcher rejects anything
+    else (recurrent_kda.py:1352-1359).
+    """
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 8,
+        "num_heads": 16,
+        "num_value_heads": 16,
+        "pool_slack": 6,
+        "padded_seqs": 0,
+        "slot_stride_pad": 0,
+        "gate_token_stride_pad": 0,
+        "accepted": None,
+        "lower_bound": -5.0,
+        "scale": None,
+        "seed": 20260814,
+    }
+    config.update(overrides)
+    return config
+
+
+# T=3's legal domain IS the matrix: the dispatcher enforces H == HV == 16 and
+# N in {1,2,4,8,16}, so these five rows are every shape the kernel can serve.
+# They match FlashInfer's own T=3 export bench exactly.
+BENCH_CONFIGS = [
+    _case("hv16h16_b1_t3", num_seqs=1),
+    _case("hv16h16_b2_t3", num_seqs=2),
+    _case("hv16h16_b4_t3", num_seqs=4),
+    _case("hv16h16_b8_t3", num_seqs=8),
+    _case("hv16h16_b16_t3", num_seqs=16),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # nat selects the initial checkpoint slot as ssm_idx[n*3 + clamp(nat-1, 0, 2)];
+    # the upstream test sweeps 0/1/3/10, covering both clamp edges (.cu:287-296).
+    _case("hv16h16_b8_t3_nat0", num_seqs=8, accepted="zeros"),
+    _case("hv16h16_b8_t3_nat3", num_seqs=8, accepted="threes"),
+    _case("hv16h16_b8_t3_nat10", num_seqs=8, accepted="tens"),
+    _case("hv16h16_b8_t3_natmix", num_seqs=8, accepted="mixed"),
+    _case("hv16h16_b8_t3_padded", num_seqs=8, padded_seqs=2),
+    _case("hv16h16_b8_t3_strided", num_seqs=8, slot_stride_pad=8),
+    _case("hv16h16_b8_t3_gstride", num_seqs=8, gate_token_stride_pad=8),
+    _case("hv16h16_b8_t3_scale", num_seqs=8, scale=0.05),
+    # The gate is computed in-kernel, so lower_bound is a real input: a second
+    # value must move the output.
+    _case("hv16h16_b8_t3_lb1", num_seqs=8, lower_bound=-1.0),
+]
+
+KERNEL_META = {
+    "name": "flashkda_decode_t3_lower_bound",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    gate_token_stride_pad = int(kwargs.get("gate_token_stride_pad", 0))
+    pool_slack = int(kwargs.get("pool_slack", 6))
+
+    # The dispatcher rejects anything outside this box (recurrent_kda.py:1352-1359).
+    if num_heads != 16 or num_value_heads != 16:
+        raise ValueError("t3 lower-bound requires num_heads == num_value_heads == 16")
+    if num_seqs not in (1, 2, 4, 8, 16):
+        raise ValueError("t3 lower-bound requires num_seqs in {1, 2, 4, 8, 16}")
+    if slot_stride_pad % 8 != 0:
+        raise ValueError("state slot stride padding must stay 8-element aligned")
+    if gate_token_stride_pad % 4 != 0:
+        raise ValueError("gate token stride padding must stay 4-element aligned")
+    if VALUE_SPLIT != 4:
+        raise ValueError("only d128_t3_lower_bound_split4 is in this port's scope")
+
+    total_tokens = num_seqs * NUM_TOKENS
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    gate_token_stride = num_value_heads * HEAD_DIM + gate_token_stride_pad
+    state_slots = total_tokens + pool_slack
+    return {
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "HEAD_RATIO": num_value_heads // num_heads,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "GATE_TOKEN_STRIDE": gate_token_stride,
+        "Q_ELEMENTS": total_tokens * num_heads * HEAD_DIM,
+        "V_ELEMENTS": total_tokens * num_value_heads * HEAD_DIM,
+        "GATE_ELEMENTS": total_tokens * gate_token_stride,
+        "BETA_ELEMENTS": total_tokens * num_value_heads,
+        "STATE_ELEMENTS": state_slots * slot_stride,
+        "A_LOG_ELEMENTS": num_heads,
+        "DT_BIAS_ELEMENTS": num_heads * HEAD_DIM,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": total_tokens,
+        "NAT_ELEMENTS": num_seqs,
+    }
+
+
+@T.jit
+def _flashkda_decode_t3_lower_bound(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    a_log_h: T.handle,
+    dt_bias_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    num_accepted_tokens_h: T.handle,
+    scale: T.float32,
+    lower_bound: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    HEAD_RATIO: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    GATE_TOKEN_STRIDE: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    GATE_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    A_LOG_ELEMENTS: T.constexpr,
+    DT_BIAS_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+    NAT_ELEMENTS: T.constexpr,
+):
+    """FlashKDA "cake" T=3 lower-bound decode -- scaffold body.
+
+    The implementation is written in the correctness gate, after the kernel
+    sketch has passed review.
+    """
+    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(a_log_h, (A_LOG_ELEMENTS,), "float32", scope="global")
+    T.match_buffer(dt_bias_h, (DT_BIAS_ELEMENTS,), "float32", scope="global")
+    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized FlashKDA cake T=3 decode PrimFunc."""
+    return _flashkda_decode_t3_lower_bound.specialize(**_specialization(kwargs))
+
+
+_NAT_PATTERNS = {"zeros": 0, "threes": 3, "tens": 10}
+
+
+def _accepted_tensor(kind: Any, num_seqs: int, device: str) -> torch.Tensor:
+    """num_accepted_tokens per case; the kernel clamps nat-1 into [0, 2]."""
+    if kind is None:
+        return torch.ones(num_seqs, device=device, dtype=torch.int32)
+    if kind == "mixed":
+        # The upstream test's sweep, tiled to the batch size.
+        pattern = torch.tensor([0, 1, 3, 10, 2, 0, 1, 3], dtype=torch.int32)
+        reps = (num_seqs + pattern.numel() - 1) // pattern.numel()
+        return pattern.repeat(reps)[:num_seqs].to(device)
+    if kind in _NAT_PATTERNS:
+        return torch.full((num_seqs,), _NAT_PATTERNS[kind], device=device, dtype=torch.int32)
+    raise ValueError(f"unknown accepted-token pattern {kind!r}")
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state.
+
+    Follows the upstream T=3 recipe: packed [1, N*3, ...] bf16, a RAW
+    pre-gate g (NOT log-space -- the kernel computes the gate itself), plus the
+    fp32 A_log / dt_bias the lower-bound gate consumes.
+    """
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for FlashKDA cake T=3 decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"FlashKDA cake decode targets compute capability 10.x, got {capability}")
+
+    spec = _specialization({**kwargs, "device": device})
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    gate_token_stride = spec["GATE_TOKEN_STRIDE"]
+    total_tokens = num_seqs * NUM_TOKENS
+    state_slots = spec["STATE_ELEMENTS"] // slot_stride
+    padded_seqs = int(kwargs.get("padded_seqs", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    q = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, total_tokens, num_value_heads, HEAD_DIM, gain=0.5)
+    # GATE_KIND == 1: g is the RAW pre-gate input; the kernel derives the gate
+    # from it with A_log, dt_bias and lower_bound (upstream recipe
+    # test_recurrent_kda_decode_export.py:_make_t3_lower_bound_case).
+    g_dense = torch.randn(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        device=device,
+        dtype=torch.float32,
+        generator=gen,
+    ).to(torch.bfloat16)
+    g_raw = torch.zeros((total_tokens * gate_token_stride,), device=device, dtype=torch.bfloat16)
+    g = g_raw.as_strided(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        (total_tokens * gate_token_stride, gate_token_stride, HEAD_DIM, 1),
+    )
+    g.copy_(g_dense)
+    beta = torch.sigmoid(randn(1, total_tokens, num_value_heads, dtype=torch.float32, gain=0.5)).to(
+        torch.bfloat16
+    )
+
+    # gate_a = exp(A_log) lands in [1, 2) with this recipe.
+    a_log = torch.log(
+        torch.rand((num_heads,), device=device, dtype=torch.float32, generator=gen) + 1.0
+    )
+    dt_bias = torch.randn(
+        (num_heads * HEAD_DIM,), device=device, dtype=torch.float32, generator=gen
+    )
+    lower_bound = float(kwargs.get("lower_bound", -5.0))
+    if not lower_bound < 0.0:
+        raise ValueError("t3 lower-bound requires a finite negative lower_bound")
+
+    cu_seqlens = torch.arange(0, total_tokens + 1, NUM_TOKENS, device=device, dtype=torch.int32)
+    # Slot 0 is deliberately never a checkpoint target (upstream bench recipe).
+    slots = torch.arange(1, total_tokens + 1, device=device, dtype=torch.int32).reshape(
+        num_seqs, NUM_TOKENS
+    )
+    if padded_seqs:
+        slots[num_seqs - padded_seqs :, :] = -1
+    ssm_state_indices = slots.contiguous().view(-1)
+    num_accepted_tokens = _accepted_tensor(kwargs.get("accepted"), num_seqs, device)
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(state_slots * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, total_tokens, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    scale = kwargs.get("scale")
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "g_raw": g_raw,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": ssm_state_indices,
+        "ssm_state_indices_2d": slots,
+        "num_accepted_tokens": num_accepted_tokens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "lower_bound": lower_bound,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": float(scale) if scale is not None else HEAD_DIM**-0.5,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g_raw"],
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["a_log"],
+        case["dt_bias"],
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+        float(case["lower_bound"]),
+    )
+
+
+def _source_body_path() -> str:
+    """Absolute path of the frozen generated body this port transcribes."""
+    import flashinfer
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t3_lower_bound_split4.cu")
+
+
+def assert_frozen_source() -> None:
+    """Fail loudly if the upstream generated body was regenerated."""
+    path = _source_body_path()
+    with open(path, "rb") as handle:
+        text = handle.read().decode()
+    marker = "// BEGIN FROZEN GENERATED BODY\n"
+    start = text.index(marker) + len(marker)
+    end = text.index("// END FROZEN GENERATED BODY")
+    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
+    if digest != FROZEN_BODY_SHA256:
+        raise AssertionError(
+            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
+            "upstream export was regenerated and this port must be re-verified"
+        )
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the frozen cake export itself on the reference state pool."""
+    from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
+
+    device = case["device"]
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        target = "sm100f" if torch.version.cuda and torch.version.cuda >= "12.9" else "sm100a"
+    elif (major, minor) == (10, 3):
+        target = "sm100f"  # non-direct variants are never built for sm103a
+    else:
+        raise SkipTest(f"no FlashKDA cake export for compute capability {major}.{minor}")
+
+    module = get_flash_kda_decode_module("d128_t3_lower_bound_split4", target)
+    reference_out = torch.empty_like(case["tirx_out"])
+
+    # Unlike the precomputed variants, GATE_KIND == 1 dereferences A_log and
+    # dt_bias and uses lower_bound.
+    module.run(
+        case["q"], case["k"], case["v"], case["g"], case["beta"],
+        case["a_log"], case["dt_bias"],
+        case["reference_state"], reference_out,
+        case["cu_seqlens"], case["ssm_state_indices"], case["num_accepted_tokens"],
+        float(case["scale"]), float(case["lower_bound"]),
+        int(torch.cuda.current_stream(device).cuda_stream),
+    )  # fmt: skip
+    torch.cuda.synchronize(device)
+    return reference_out
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the T=3 delta rule (sequential form)."""
+    spec = case["spec"]
+    num_seqs = spec["NUM_SEQS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    head_ratio = spec["HEAD_RATIO"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+
+    a_log = case["a_log"].float()
+    dt_bias = case["dt_bias"].float().reshape(spec["NUM_HEADS"], HEAD_DIM)
+    lower_bound = float(case["lower_bound"])
+
+    q = case["q"][0].float()
+    k = case["k"][0].float()
+    v = case["v"][0].float()
+    g = case["g"][0].float()
+    beta = case["beta"][0].float()
+    slots2d = case["ssm_state_indices_2d"]
+    nat = case["num_accepted_tokens"]
+
+    state_raw = case["initial_state_raw"].clone()
+    state_slots = state_raw.numel() // slot_stride
+    state = state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    out = torch.zeros(
+        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
+        device=case["device"],
+        dtype=torch.float32,
+    )
+
+    scale = float(case["scale"])
+    for n in range(num_seqs):
+        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
+        init_slot = int(slots2d[n, accepted].item())
+        if init_slot < 0:
+            init_slot = 0
+        for hv in range(num_value_heads):
+            h = hv // head_ratio
+            # FP32 carry across all tokens; only the checkpoint store rounds.
+            s = state[init_slot, hv].float()
+            for t in range(NUM_TOKENS):
+                row = n * NUM_TOKENS + t
+                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
+                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
+                # GATE_KIND == 1: the gate is derived here, not supplied.
+                # log_gate = lower_bound * sigmoid(exp(A_log[h]) * (g + dt_bias))
+                gate_a = torch.exp(a_log[h])
+                biased = g[row, hv] + dt_bias[h]
+                log_gate = lower_bound / (1.0 + torch.exp(-gate_a * biased))
+                gamma = torch.exp(log_gate)
+
+                decayed = s * gamma.unsqueeze(0)
+                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
+                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
+                out[row, hv] = s @ qn
+
+                slot = int(slots2d[n, t].item())
+                if slot >= 0:
+                    state[slot, hv] = s.to(torch.bfloat16)
+                else:
+                    out[row, hv] = 0.0
+
+    return out.to(torch.bfloat16).unsqueeze(0), state_raw
+
+
+def run_test(**kwargs: Any) -> None:
+    """Correctness entry point. Implemented in the correctness gate."""
+    raise SkipTest(
+        "flashkda_decode_t3_lower_bound is at the scaffold stage; the kernel body "
+        "is written in the correctness gate"
+    )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point. Implemented in the performance gate."""
+    raise SkipTest(
+        "flashkda_decode_t3_lower_bound is at the scaffold stage; benchmarking is "
+        "enabled in the performance gate"
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "assert_frozen_source",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -84,6 +84,35 @@ _ldmatrix_x4 = _t2._ldmatrix_x4
 _mma_zero = _t2._mma_zero
 _mma_acc = _t2._mma_acc
 
+
+# --- GATE_KIND == 1 additions ---------------------------------------------
+# The three forms the precomputed siblings never need. All compile-probed with
+# a known-bad control (`mul.ftz.f64` is rejected), and all three appear in the
+# frozen export's PTX: 4 div.approx.ftz.f32 (one per element, and NOT
+# rcp.approx + mul), 1 neg.ftz.f32 (hoisted), 5 extra ld.global.nc.b32.
+
+
+def _neg(a):
+    """``neg.ftz.f32``."""
+    return _ptx_un("neg.ftz.f32", a)
+
+
+def _div(a, b):
+    """``div.approx.ftz.f32`` -- what ``-use_fast_math`` lowers ``/`` to here."""
+    return _ptx_bin("div.approx.ftz.f32", a, b)
+
+
+def _load_f32(buffer, index):
+    """``ld.global.nc.b32`` -- one read-only fp32 (A_log / dt_bias).
+
+    dt_bias's four elements per lane are contiguous and nvcc still emits four
+    scalar loads, not an ld.global.nc.v4.b32; the port matches that.
+    """
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buffer.ptr_to([index])))
+    return T.reinterpret("float32", out[0])
+
+
 # --- source pinning -------------------------------------------------------
 # Raw and normalized digests differ for this export; the hash of the bytes
 # between the BEGIN/END markers is the raw one (verified).
@@ -98,6 +127,8 @@ LOG2_E = _t2.LOG2_E
 
 THREADS = 96  # 3 warps (flash_kda_decode.py:_variant_metadata)
 ROWS_PER_CTA = HEAD_DIM // VALUE_SPLIT  # tile_row_base = value_tile * 32 (.cu:159)
+MMA_WARPS = HEAD_DIM // VALUE_SPLIT // 16  # phase D-G guard: value_rows/16
+ROW_GROUPS = HEAD_DIM // VALUE_SPLIT // 8  # phase B/H guard: value_rows/8
 ROWS_PER_THREAD = 8  # groups 0..3 (warps 0,1) own 8 rows x 8 keys each
 K_PER_THREAD = 8
 
@@ -257,23 +288,441 @@ def _flashkda_decode_t3_lower_bound(
     STATE_INDEX_ELEMENTS: T.constexpr,
     NAT_ELEMENTS: T.constexpr,
 ):
-    """FlashKDA "cake" T=3 lower-bound decode -- scaffold body.
+    """FlashKDA "cake" T=3 lower-bound decode, WY schedule, 3 warps.
 
-    The implementation is written in the correctness gate, after the kernel
-    sketch has passed review.
+    Transcribed from `kernel_flashinfer_recurrent_kda_wy_vtile_short`; bare
+    `:NNN` references are into
+    `flashkda_decode_d128_t3_lower_bound_split4.cu`. Design sketch:
+    `.agents/sketch/flashinfer/kda/flashkda_decode_t3_t4_wy.md`.
     """
-    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(a_log_h, (A_LOG_ELEMENTS,), "float32", scope="global")
-    T.match_buffer(dt_bias_h, (DT_BIAS_ELEMENTS,), "float32", scope="global")
-    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    a_log = T.match_buffer(a_log_h, (A_LOG_ELEMENTS,), "float32", scope="global")
+    dt_bias = T.match_buffer(dt_bias_h, (DT_BIAS_ELEMENTS,), "float32", scope="global")
+    cu = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    T.device_entry()
+
+    # The source uses dynamic smem; 15872 B fits the static limit, so the same
+    # bytes are declared statically at the same alignment. The region offsets
+    # and the alignment are what the swizzled ldmatrix addressing depends on.
+    arena = T.alloc_buffer((SMEM_TOTAL,), "uint8", scope="shared", align=1024)
+
+    # --- work decomposition and lane roles (:142-160) ----------------------
+    work, n = T.cta_id([NUM_VALUE_HEADS * VALUE_SPLIT, NUM_SEQS])
+    tid = T.thread_id([THREADS])
+    value_tile: T.int32 = work % VALUE_SPLIT
+    hv: T.int32 = work // VALUE_SPLIT
+    query_head: T.int32 = hv // HEAD_RATIO
+    warp: T.int32 = tid // 32  # == token index in phases A and C
+    lane: T.int32 = tid % 32
+    lane_quad: T.int32 = lane % 4
+    frag_row: T.int32 = lane // 4
+    quad_base: T.int32 = lane - lane_quad
+    group: T.int32 = tid // 16
+    lane_group: T.int32 = tid % 16
+    k_start: T.int32 = lane_group * 8
+    elem_start: T.int32 = lane * 4
+    tile_row_base: T.int32 = value_tile * ROWS_PER_CTA
+    owned_row_base: T.int32 = group * 8
+    token_base: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - token_base
+
+    r_q = T.alloc_local((4,), "float32")
+    r_k = T.alloc_local((4,), "float32")
+    r_d = T.alloc_local((4,), "float32")
+
+    # =======================================================================
+    # Phase A: token preprocess, warp <-> token  (:180-299)
+    # =======================================================================
+    # Unlike every other body in this family the guards here are LIVE: at 96
+    # threads `warp < 3` admits all three warps, but `group < 4` (phases B, H)
+    # and `warp < 2` (phases D-G) do not. Warp 2 is a token-only warp -- it
+    # preprocesses token 2, builds token 2's sVec columns and sL/sR row, hits
+    # both CTA barriers, and then never gathers state, never issues an MMA and
+    # never stores.
+    if warp < NUM_TOKENS:
+        token: T.int32 = warp
+        active_token = token < seq_len
+        token_pos: T.int32 = T.if_then_else(active_token, token_base + token, 0)
+        qk_base: T.int32 = (token_pos * NUM_HEADS + query_head) * HEAD_DIM + elem_start
+        gate_base: T.int32 = token_pos * GATE_TOKEN_STRIDE + hv * HEAD_DIM + elem_start
+
+        q_words = _load_u32x2(q, qk_base)
+        k_words = _load_u32x2(k, qk_base)
+        g_words = _load_u32x2(g, gate_base)
+        for pair in T.unroll(2):
+            r_q[2 * pair] = _widen_lo(q_words[pair])
+            r_q[2 * pair + 1] = _widen_hi(q_words[pair])
+            r_k[2 * pair] = _widen_lo(k_words[pair])
+            r_k[2 * pair + 1] = _widen_hi(k_words[pair])
+            r_d[2 * pair] = _widen_lo(g_words[pair])
+            r_d[2 * pair + 1] = _widen_hi(g_words[pair])
+
+        # Index-ordered accumulation (:250-253); the first term has a zero addend.
+        q_sq: T.float32 = _fma(
+            r_q[3],
+            r_q[3],
+            _fma(r_q[2], r_q[2], _fma(r_q[1], r_q[1], _fma(r_q[0], r_q[0], T.float32(0.0)))),
+        )
+        k_sq: T.float32 = _fma(
+            r_k[3],
+            r_k[3],
+            _fma(r_k[2], r_k[2], _fma(r_k[1], r_k[1], _fma(r_k[0], r_k[0], T.float32(0.0)))),
+        )
+        # Two sequential full-warp butterflies, not interleaved (:254-263).
+        for off in T.unroll(5):
+            q_sq = _add(q_sq, _shfl_bfly(q_sq, 16 >> off))
+        for off in T.unroll(5):
+            k_sq = _add(k_sq, _shfl_bfly(k_sq, 16 >> off))
+        q_norm: T.float32 = _mul(_rsqrt(_add(q_sq, T.float32(L2_EPS))), scale)
+        k_norm: T.float32 = _rsqrt(_add(k_sq, T.float32(L2_EPS)))
+
+        # ---- GATE_KIND == 1: the gate is derived here (:259-278) ----------
+        # `g` is the RAW pre-gate, not a log-gate. Hoisted above the element
+        # loop and loaded by EVERY lane -- there is no lane-0 broadcast to
+        # reproduce -- and `-gate_a` is loop-invariant, so it is one
+        # neg.ftz.f32 for the whole body, not one per element.
+        gate_a: T.float32 = _expf(_load_f32(a_log, query_head))
+        neg_gate_a: T.float32 = _neg(gate_a)
+
+        k_pub = T.alloc_local((4,), "uint32")
+        d_pub = T.alloc_local((4,), "uint32")
+        for i in T.unroll(4):
+            k_idx_a: T.int32 = elem_start + i
+            r_q[i] = _mul(r_q[i], q_norm)
+            r_k[i] = _mul(r_k[i], k_norm)
+            # biased = g + dt_bias[qh*128 + k]; sigmoid; scale by lower_bound;
+            # exponentiate. Operand orders follow the export's PTX exactly:
+            # mul(biased, -gate_a), add(sig, 1.0), div(lower_bound, denom).
+            biased: T.float32 = _add(r_d[i], _load_f32(dt_bias, query_head * HEAD_DIM + k_idx_a))
+            sig: T.float32 = _expf(_mul(biased, neg_gate_a))
+            r_d[i] = _expf(_div(lower_bound, _add(sig, T.float32(1.0))))
+            k_pub[i] = T.reinterpret("uint32", r_k[i])
+            d_pub[i] = T.reinterpret("uint32", r_d[i])
+        _st_shared_u32x4(arena, OFF_SK + (token * HEAD_DIM + elem_start) * 4, k_pub)
+        _st_shared_u32x4(arena, OFF_SD + (token * HEAD_DIM + elem_start) * 4, d_pub)
+
+        if lane == 0:
+            raw_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + token)
+            _st_shared_i32(arena, OFF_SSLOT + token * 4, T.if_then_else(active_token, raw_slot, -1))
+            _st_shared_i32(arena, OFF_STOKEN + token * 4, token_pos)
+            _st_shared_f32(
+                arena, OFF_SBETA + token * 4, _load_bf16_f32(beta, token_pos * NUM_VALUE_HEADS + hv)
+            )
+            if token == 0:
+                # nat picks the initial checkpoint slot; at T=3 the clamp
+                # ceiling is 2 and both edges are reachable (:288-295).
+                accepted: T.int32 = T.min(T.max(_load_i32(nat, n) - 1, 0), NUM_TOKENS - 1)
+                initial_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + accepted)
+                _st_shared_i32(arena, OFF_SINIT, T.max(initial_slot, 0))
+
+    T.cuda.cta_sync()
+    # A genuine three-warp edge: warp 2 publishes token 2's sK/sD/sBeta/sSlot/
+    # sToken here and warps 0,1 consume them in phases C and H.
+
+    # =======================================================================
+    # Phase B: state gather and sState stage, groups 0..3 only  (:301-338)
+    # =======================================================================
+    hist = T.alloc_local((8 * 8,), "float32")
+    if group < ROW_GROUPS:
+        init_slot: T.int32 = _ld_shared_i32(arena, OFF_SINIT)
+        head_base = T.cast(init_slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+            hv * HEAD_DIM * HEAD_DIM, "int64"
+        )
+        for row_local in T.unroll(8):
+            row_l: T.int32 = owned_row_base + row_local
+            pack = _load_u32x4(
+                state, head_base + T.cast((tile_row_base + row_l) * HEAD_DIM + k_start, "int64")
+            )
+            for pr in T.unroll(4):
+                hist[row_local * 8 + 2 * pr] = _widen_lo(pack[pr])
+                hist[row_local * 8 + 2 * pr + 1] = _widen_hi(pack[pr])
+            # The bf16 bits go to shared unmodified; the swizzle is on the byte
+            # offset. lane_group < 8 lands in sState0, the rest in sState1.
+            if lane_group < 8:
+                _st_shared_u32x4(arena, OFF_SSTATE0 + _swz(row_l * 128 + k_start * 2), pack)
+            else:
+                _st_shared_u32x4(arena, OFF_SSTATE1 + _swz(row_l * 128 + (k_start - 64) * 2), pack)
+
+    # =======================================================================
+    # Phase C: sVec columns and the WY coefficients  (:339-413)
+    # =======================================================================
+    if warp < NUM_TOKENS:
+        token_c: T.int32 = warp
+        for i in T.unroll(4):
+            k_idx: T.int32 = elem_start + i
+            prefix: T.float32 = T.float32(1.0)
+            for j in T.unroll(NUM_TOKENS):
+                if token_c >= j:
+                    prefix = _mul(
+                        prefix, _ld_shared_f32(arena, OFF_SD + (j * HEAD_DIM + k_idx) * 4)
+                    )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + token_c * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_k[i]), dtype="uint16"),
+            )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + (4 + token_c) * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_q[i]), dtype="uint16"),
+            )
+
+        ratio = T.alloc_local((4,), "float32")
+        for i in T.unroll(4):
+            ratio[i] = T.float32(1.0)
+        for source_offset in T.unroll(NUM_TOKENS):
+            source_token: T.int32 = token_c - source_offset
+            if source_token >= 0:
+                dot_kk: T.float32 = T.float32(0.0)
+                dot_qk: T.float32 = T.float32(0.0)
+                sk_vec = T.alloc_local((4,), "float32")
+                _ld_shared_f32x4(
+                    arena, OFF_SK + (source_token * HEAD_DIM + elem_start) * 4, sk_vec, 0
+                )
+                for i in T.unroll(4):
+                    # Source order: r * source_k * ratio  (:381-384).
+                    dot_kk = _fma(_mul(r_k[i], sk_vec[i]), ratio[i], dot_kk)
+                    dot_qk = _fma(_mul(r_q[i], sk_vec[i]), ratio[i], dot_qk)
+                for off in T.unroll(5):
+                    dot_kk = _add(dot_kk, _shfl_bfly(dot_kk, 16 >> off))
+                for off in T.unroll(5):
+                    dot_qk = _add(dot_qk, _shfl_bfly(dot_qk, 16 >> off))
+                if lane == 0:
+                    beta_source: T.float32 = _ld_shared_f32(arena, OFF_SBETA + source_token * 4)
+                    if source_token < token_c:
+                        _st_shared_f32(
+                            arena,
+                            OFF_SL + (token_c * NUM_TOKENS + source_token) * 4,
+                            _mul(beta_source, dot_kk),
+                        )
+                    _st_shared_f32(
+                        arena,
+                        OFF_SR + (token_c * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, dot_qk),
+                    )
+                if source_token > 0:
+                    sd_vec = T.alloc_local((4,), "float32")
+                    _ld_shared_f32x4(
+                        arena, OFF_SD + (source_token * HEAD_DIM + elem_start) * 4, sd_vec, 0
+                    )
+                    for i in T.unroll(4):
+                        ratio[i] = _mul(ratio[i], sd_vec[i])
+
+    T.cuda.cta_sync()
+    # The second three-warp edge: warp 2 wrote sVec columns 2 and 6, sL row 2
+    # and sR row 2 above and then leaves; warps 0,1 depend on that through here.
+
+    # =======================================================================
+    # Phase D: the MMA chain, warps 0,1 <-> 16 value rows  (:415-447)
+    # =======================================================================
+    # Byte-identical to the T=2/T=4 chain: 8 ldmatrix.x4 + 8 .trans + 8 mma.
+    acc = T.alloc_local((4,), "float32", align=4)
+    if warp < MMA_WARPS:
+        vec_frag = T.alloc_local((4,), "uint32", align=4)
+        state_frag = T.alloc_local((4,), "uint32", align=4)
+        for state_half in T.unroll(2):
+            for mma_step in T.unroll(4):
+                mma_k: T.int32 = mma_step * 16
+                global_k: T.int32 = state_half * 64 + mma_k
+                _ldmatrix_x4(
+                    arena,
+                    OFF_SVEC + _swz((global_k + lane % 16) * 32 + lane // 16 * 16),
+                    vec_frag,
+                    True,
+                )
+                if state_half == 0:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE0
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                else:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE1
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                if state_half == 0 and mma_step == 0:
+                    _mma_zero(acc, state_frag, vec_frag)
+                else:
+                    _mma_acc(acc, state_frag, vec_frag)
+
+    # =======================================================================
+    # Phase E: quad broadcast and the WY forward substitution  (:448-492)
+    # =======================================================================
+    u_lo = T.alloc_local((NUM_TOKENS,), "float32")
+    u_hi = T.alloc_local((NUM_TOKENS,), "float32")
+    if warp < MMA_WARPS:
+        # 8 broadcasts, all four ha_lo then all four ha_hi (:448-463). ha_*[3]
+        # is MMA column 3 -- token 3, which does not exist at T=3 -- but the
+        # source issues its two shuffles anyway, so the port does too.
+        ha_lo = T.alloc_local((4,), "float32")
+        ha_hi = T.alloc_local((4,), "float32")
+        for t in T.unroll(4):
+            ha_lo[t] = _shfl_idx(acc[t % 2], quad_base + t // 2)
+        for t in T.unroll(4):
+            ha_hi[t] = _shfl_idx(acc[2 + t % 2], quad_base + t // 2)
+
+        if lane_quad == 2:
+            row_lo: T.int32 = warp * 16 + frag_row
+            row_hi: T.int32 = row_lo + 8
+            for t in T.unroll(NUM_TOKENS):
+                base_t: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + t * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM
+                solved_lo: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_lo), ha_lo[t]
+                )
+                solved_hi: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_hi), ha_hi[t]
+                )
+                for prev in T.unroll(NUM_TOKENS):
+                    if prev < t:
+                        lts: T.float32 = _ld_shared_f32(arena, OFF_SL + (t * NUM_TOKENS + prev) * 4)
+                        solved_lo = _sub(solved_lo, _mul(lts, u_lo[prev]))
+                        solved_hi = _sub(solved_hi, _mul(lts, u_hi[prev]))
+                u_lo[t] = solved_lo
+                u_hi[t] = solved_hi
+
+        # The residuals must cross the quad: phase F below runs on lane_quad
+        # >= 2, so lane 4f+3 consumes what lane 4f+2 solved (:485-491). This
+        # broadcast was an identity at T=2 and the T=2 port dropped it; here it
+        # is load-bearing for output token 2.
+        for t in T.unroll(NUM_TOKENS):
+            u_lo[t] = _shfl_idx(u_lo[t], quad_base + 2)
+            u_hi[t] = _shfl_idx(u_hi[t], quad_base + 2)
+
+    # =======================================================================
+    # Phase F: the outputs, two tokens per writer lane  (:493-541)
+    # =======================================================================
+    # Byte-identical to the T=4 body's phase F apart from the literal TOKENS.
+    # No shuffle is needed to pick the accumulator column pair: the m16n8k16 D
+    # layout already keys columns 2*lane_quad, +1 off lane_quad.
+    #
+    # DELIBERATE DEVIATION, T=3 only. TOKENS is odd, so at lane_quad == 3 the
+    # source computes token1 = 3 -- out of range -- and reads sR[9..11] (which
+    # aliases the first 12 bytes of sU) and sSlot[3] (which aliases sToken[0])
+    # before the `token1 < 3` mask discards the results. Those reads are safe in
+    # the source (in-bounds shared memory, provably dead values) but a TIRx port
+    # cannot express "read past a declared region and rely on the arena layout".
+    # The port predicates them on `token1 < NUM_TOKENS` instead. This is
+    # numerically identical: coef1 stays 0.0, so out1_* stays acc[1]/acc[3],
+    # which is never stored; slot1's -1 sentinel is never consulted because the
+    # store itself is guarded by the same condition.
+    if warp < MMA_WARPS and lane_quad >= 2:
+        token0: T.int32 = (lane_quad - 2) * 2
+        token1: T.int32 = token0 + 1
+        row_lo_f: T.int32 = warp * 16 + frag_row
+        row_hi_f: T.int32 = row_lo_f + 8
+        out0_lo: T.float32 = acc[0]
+        out1_lo: T.float32 = acc[1]
+        out0_hi: T.float32 = acc[2]
+        out1_hi: T.float32 = acc[3]
+        for src in T.unroll(NUM_TOKENS):
+            residual_lo: T.float32 = u_lo[src]
+            residual_hi: T.float32 = u_hi[src]
+            coef0: T.float32 = T.float32(0.0)
+            coef1: T.float32 = T.float32(0.0)
+            # The masked-out coefficient is a real zero-operand fma, not a
+            # skipped iteration (:506-514).
+            if token0 >= src:
+                coef0 = _ld_shared_f32(arena, OFF_SR + (token0 * NUM_TOKENS + src) * 4)
+            if token1 < NUM_TOKENS and token1 >= src:
+                coef1 = _ld_shared_f32(arena, OFF_SR + (token1 * NUM_TOKENS + src) * 4)
+            out0_lo = _fma(coef0, residual_lo, out0_lo)
+            out1_lo = _fma(coef1, residual_lo, out1_lo)
+            out0_hi = _fma(coef0, residual_hi, out0_hi)
+            out1_hi = _fma(coef1, residual_hi, out1_hi)
+
+        for half in T.unroll(2):
+            token_o: T.int32 = T.if_then_else(half == 0, token0, token1)
+            o_lo: T.float32 = T.if_then_else(half == 0, out0_lo, out1_lo)
+            o_hi: T.float32 = T.if_then_else(half == 0, out0_hi, out1_hi)
+            if token_o < NUM_TOKENS:
+                active_o = _ld_shared_i32(arena, OFF_SSLOT + token_o * 4) >= 0
+                base_o: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + token_o * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM + tile_row_base
+                # A padded row writes EXPLICIT zeros; the upstream test asserts
+                # them bit-exactly, so this is not an "unwritten" path.
+                _store_f32_as_bf16(out, base_o + row_lo_f, o_lo, active_o)
+                _store_f32_as_bf16(out, base_o + row_hi_f, o_hi, active_o)
+                _store_f32_as_bf16(out, base_o + row_lo_f, T.float32(0.0), T.Not(active_o))
+                _store_f32_as_bf16(out, base_o + row_hi_f, T.float32(0.0), T.Not(active_o))
+
+    # =======================================================================
+    # Phase G: publish sU  (:542-555)
+    # =======================================================================
+    if warp < MMA_WARPS:
+        if lane_quad == 2:
+            row_lo_g: T.int32 = warp * 16 + frag_row
+            for t in T.unroll(NUM_TOKENS):
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g) * 4, u_lo[t])
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g + 8) * 4, u_hi[t])
+        # A warp barrier suffices: warp w owns groups 2w and 2w+1, i.e. rows
+        # [16w, 16w+16), which is exactly the row set it wrote above (:553).
+        T.cuda.warp_sync()
+
+    # =======================================================================
+    # Phase H: recurrence and checkpoints, groups 0..3 only  (:669-705)
+    # =======================================================================
+    if group < ROW_GROUPS:
+        words_w = T.alloc_local((4,), "uint32")
+        sd_t = T.alloc_local((8,), "float32")
+        sk_t = T.alloc_local((8,), "float32")
+        for t in T.unroll(NUM_TOKENS):
+            slot_t: T.int32 = _ld_shared_i32(arena, OFF_SSLOT + t * 4)
+            beta_t: T.float32 = _ld_shared_f32(arena, OFF_SBETA + t * 4)
+            # The gate and key slices depend only on (t, k_start), not on the
+            # row, so they are loaded once per token as two 16-byte reads
+            # rather than reloaded in the row loop (:683).
+            _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start) * 4, sd_t, 0)
+            _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start + 4) * 4, sd_t, 4)
+            _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start) * 4, sk_t, 0)
+            _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start + 4) * 4, sk_t, 4)
+            for row_local in T.unroll(8):
+                row_h: T.int32 = owned_row_base + row_local
+                update: T.float32 = _mul(
+                    _ld_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_h) * 4), beta_t
+                )
+                for i in T.unroll(8):
+                    # The source writes `hist*sD + update*sK` (:683) and the
+                    # compiler contracts the FIRST product: update*sK is
+                    # rounded, hist*sD is fused. This is the only stateful
+                    # accumulation and it feeds both the checkpoint and every
+                    # later token's history.
+                    hist[row_local * 8 + i] = _fma(
+                        hist[row_local * 8 + i], sd_t[i], _mul(update, sk_t[i])
+                    )
+                for pr in T.unroll(4):
+                    words_w[pr] = _pack_bf16x2(
+                        hist[row_local * 8 + 2 * pr + 1], hist[row_local * 8 + 2 * pr]
+                    )
+                # The recurrence advances unconditionally; only the store is
+                # slot-predicated, and it stays FP32 so token t+1 consumes the
+                # un-rounded token-t state rather than the bf16 checkpoint.
+                if slot_t >= 0:
+                    _store_u32x4(
+                        state,
+                        T.cast(slot_t, "int64") * T.cast(STATE_SLOT_STRIDE, "int64")
+                        + T.cast(
+                            hv * HEAD_DIM * HEAD_DIM + (tile_row_base + row_h) * HEAD_DIM + k_start,
+                            "int64",
+                        ),
+                        words_w,
+                    )
 
 
 def get_kernel(**kwargs: Any):
@@ -560,12 +1009,100 @@ def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
     return out.to(torch.bfloat16).unsqueeze(0), state_raw
 
 
+# The port replicates the source's MMA chain, swizzle and association orders, so
+# it should agree with the frozen export to within bf16 rounding.
+_RTOL = 2.0**-8
+_ATOL = 2.0e-3
+# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
+# operands to bf16, so the band here is genuinely wider and measured, not
+# guessed: at scaffold time the export itself sat 3.1e-05 from the oracle.
+_ORACLE_RTOL = 2.0**-5
+_ORACLE_ATOL = 6.0e-3
+
+
 def run_test(**kwargs: Any) -> None:
-    """Correctness entry point. Implemented in the correctness gate."""
-    raise SkipTest(
-        "flashkda_decode_t3_lower_bound is at the scaffold stage; the kernel body "
-        "is written in the correctness gate"
+    """Validate one config against the frozen export and an independent oracle."""
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    assert_frozen_source()
+
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["device"])
+
+    tirx_out = case["tirx_out"]
+    tirx_state = case["tirx_state_raw"].clone()
+
+    # 1. the frozen cake export itself, on an independent state pool
+    reference_out = _flashinfer_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        reference_out.float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"output vs flashinfer cake export\n{m}",
     )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        case["reference_state_raw"].float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"state vs flashinfer cake export\n{m}",
+    )
+
+    # 2. an independent FP32 oracle of the same recurrence
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        oracle_out.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"output vs FP32 oracle\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        oracle_state.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"state vs FP32 oracle\n{m}",
+    )
+
+    # 3. invariants the tolerances cannot express
+    num_seqs = spec["NUM_SEQS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    slots2d = case["ssm_state_indices_2d"]
+    initial = case["initial_state_raw"]
+
+    touched: set[int] = set()
+    for seq in range(num_seqs):
+        for t in range(NUM_TOKENS):
+            slot = int(slots2d[seq, t])
+            row = seq * NUM_TOKENS + t
+            if slot < 0:
+                # A padded row writes explicit zeros, so this is exact.
+                assert tirx_out[0, row].abs().max().item() == 0.0, (
+                    f"padded row {seq} token {t} must have a zeroed output"
+                )
+            else:
+                touched.add(slot)
+    n_slots = initial.numel() // slot_stride
+    for slot in range(min(n_slots, num_seqs * NUM_TOKENS + 2)):
+        if slot in touched:
+            continue
+        lo, hi = slot * slot_stride, (slot + 1) * slot_stride
+        assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+            f"untouched state slot {slot} was modified"
+        )
+    if slot_stride > payload:
+        for slot in sorted(touched)[:4]:
+            lo = slot * slot_stride + payload
+            hi = (slot + 1) * slot_stride
+            assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+                f"inter-slot padding after slot {slot} was modified"
+            )
 
 
 def run_bench(

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -1,0 +1,544 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx port of FlashInfer's FlashKDA "cake" T=4 precomputed-gate decode kernel.
+
+Source: ``csrc/kda/flashkda_decode_d128_t4_precomputed_split2.cu``, symbol
+``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- the same frozen WY
+template as the ported T=2 sibling, re-instantiated at TOKENS=4 and
+VALUE_SPLIT=2.
+
+Dispatch reaches this body whenever ``num_tokens == 4`` with
+``num_spec_tokens == 3``. The sm100a selector returns value split 2
+unconditionally at T=4 (``recurrent_kda.py:1179-1180``), so
+``d128_t4_precomputed_split2`` is the only reachable -- and only locally
+measurable -- specialization.
+
+Relative to T=2 the geometry doubles (128 threads = 4 warps, 64 value rows per
+CTA, a 25856-byte arena) and three things that were dead at T=2 come alive: MMA
+accumulator columns 2,3 and 6,7, the ``quad_base + 1`` broadcasts, and the
+``u_lo``/``u_hi`` quad broadcasts -- Phase F now runs on ``lane_quad >= 2``,
+where lane ``4f+2`` writes tokens 0,1 and lane ``4f+3`` writes tokens 2,3, so
+the WY residuals have to cross the quad.
+
+Helper vocabulary is shared with the T=2 module; only the geometry constants,
+the frozen digest and the kernel body are per-specialization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+from . import flashkda_decode_t2_precomputed as _t2
+
+# Shared helper vocabulary (identical PTX forms, identical swizzle -- verified
+# against all three bodies).
+_ptx_un = _t2._ptx_un
+_ptx_bin = _t2._ptx_bin
+_ptx_ter = _t2._ptx_ter
+_mul = _t2._mul
+_add = _t2._add
+_sub = _t2._sub
+_fma = _t2._fma
+_rsqrt = _t2._rsqrt
+_expf = _t2._expf
+_shfl_bfly = _t2._shfl_bfly
+_shfl_idx = _t2._shfl_idx
+_load_i32 = _t2._load_i32
+_load_bf16_f32 = _t2._load_bf16_f32
+_widen_lo = _t2._widen_lo
+_widen_hi = _t2._widen_hi
+_load_u32x2 = _t2._load_u32x2
+_load_u32x4 = _t2._load_u32x4
+_store_u32x4 = _t2._store_u32x4
+_pack_bf16x2 = _t2._pack_bf16x2
+_store_f32_as_bf16 = _t2._store_f32_as_bf16
+_swz = _t2._swz
+_st_shared_f32 = _t2._st_shared_f32
+_ld_shared_f32 = _t2._ld_shared_f32
+_st_shared_i32 = _t2._st_shared_i32
+_ld_shared_i32 = _t2._ld_shared_i32
+_ld_shared_f32x4 = _t2._ld_shared_f32x4
+_st_shared_u32x4 = _t2._st_shared_u32x4
+_st_shared_b16 = _t2._st_shared_b16
+_ldmatrix_x4 = _t2._ldmatrix_x4
+_mma_zero = _t2._mma_zero
+_mma_acc = _t2._mma_acc
+
+# --- source pinning -------------------------------------------------------
+# Raw and normalized digests differ for this export; the hash of the bytes
+# between the BEGIN/END markers is the raw one (verified).
+FROZEN_FLASHINFER_COMMIT = "f2e04400"
+FROZEN_BODY_SHA256 = "6ee50e300a2f20f305252a49e3e84fde957542ccb97b7fcb7ba7f075c7733077"
+
+HEAD_DIM = _t2.HEAD_DIM
+NUM_TOKENS = 4
+VALUE_SPLIT = 2  # the sm100a selector returns 2 unconditionally at T = 4
+L2_EPS = _t2.L2_EPS
+LOG2_E = _t2.LOG2_E
+
+THREADS = 128  # 4 warps (flash_kda_decode.py:_variant_metadata)
+ROWS_PER_CTA = HEAD_DIM // VALUE_SPLIT  # 64 value rows per CTA
+ROWS_PER_THREAD = 8  # each of the 128 threads owns 8 rows x 8 keys
+K_PER_THREAD = 8
+
+# Arena offsets copied from the source's #define block (.cu:45-88).
+OFF_SSTATE0 = 0
+OFF_SSTATE1 = 8192
+OFF_SVEC = 16384
+OFF_SK = 20480
+OFF_SD = 22528
+OFF_SBETA = 24576
+OFF_SSLOT = 24592
+OFF_STOKEN = 24608
+OFF_SINIT = 24624
+OFF_SL = 24640
+OFF_SR = 24704
+OFF_SU = 24768
+SMEM_TOTAL = 25856
+# sGramA0/sGramA1 alias sVec and are t5/t6 machinery -- dead here.
+
+# TIRX_TRANSCRIBE_START flashkda_decode_t4_precomputed
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror FlashInfer's T=4 export bench."""
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 8,
+        "num_heads": 16,
+        "num_value_heads": 32,
+        "pool_slack": 6,
+        "padded_seqs": 0,
+        "slot_stride_pad": 0,
+        "gate_token_stride_pad": 0,
+        "accepted": None,
+        "scale": None,
+        "seed": 20260814,
+    }
+    config.update(overrides)
+    return config
+
+
+# Every T=4 shape selects split2, so the matrix varies only (HV, H, N).
+# hv32h16 mirrors FlashInfer's own export bench exactly.
+BENCH_CONFIGS = [
+    _case("hv32h16_b8_t4", num_seqs=8),
+    _case("hv32h16_b16_t4", num_seqs=16),
+    _case("hv32h16_b32_t4", num_seqs=32),
+    _case("hv32h16_b64_t4", num_seqs=64),
+    _case("hv32h16_b128_t4", num_seqs=128),
+    _case("hv16h16_b8_t4", num_seqs=8, num_value_heads=16),
+    _case("hv16h16_b64_t4", num_seqs=64, num_value_heads=16),
+    _case("hv12h12_b8_t4", num_seqs=8, num_heads=12, num_value_heads=12),
+    _case("hv12h12_b64_t4", num_seqs=64, num_heads=12, num_value_heads=12),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # nat selects the initial checkpoint slot as ssm_idx[n*4 + clamp(nat-1, 0, 3)];
+    # the upstream test sweeps 0/1/4/11, covering both clamp edges (.cu:283-286).
+    _case("hv32h16_b8_t4_nat0", num_seqs=8, accepted="zeros"),
+    _case("hv32h16_b8_t4_nat4", num_seqs=8, accepted="fours"),
+    _case("hv32h16_b8_t4_nat11", num_seqs=8, accepted="elevens"),
+    _case("hv32h16_b8_t4_natmix", num_seqs=8, accepted="mixed"),
+    _case("hv32h16_b8_t4_padded", num_seqs=8, padded_seqs=2),
+    _case("hv32h16_b8_t4_strided", num_seqs=8, slot_stride_pad=8),
+    _case("hv32h16_b8_t4_gstride", num_seqs=8, gate_token_stride_pad=8),
+    _case("hv32h16_b8_t4_scale", num_seqs=8, scale=0.05),
+    _case("hv64h16_b8_t4", num_seqs=8, num_value_heads=64),
+    _case("hv32h16_b1_t4", num_seqs=1),
+]
+
+KERNEL_META = {
+    "name": "flashkda_decode_t4_precomputed",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    gate_token_stride_pad = int(kwargs.get("gate_token_stride_pad", 0))
+    pool_slack = int(kwargs.get("pool_slack", 6))
+
+    if num_value_heads % num_heads != 0 or num_value_heads < num_heads:
+        raise ValueError("num_value_heads must be a multiple of num_heads and >= it")
+    if not 0 < num_seqs <= 65535:
+        raise ValueError("num_seqs must fit grid.y (binding_common.cuh:284-287)")
+    if slot_stride_pad % 8 != 0:
+        raise ValueError("state slot stride padding must stay 8-element aligned")
+    if gate_token_stride_pad % 4 != 0:
+        raise ValueError("gate token stride padding must stay 4-element aligned")
+    if VALUE_SPLIT != 2:
+        raise ValueError("only d128_t4_precomputed_split2 is in this port's scope")
+
+    total_tokens = num_seqs * NUM_TOKENS
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    gate_token_stride = num_value_heads * HEAD_DIM + gate_token_stride_pad
+    state_slots = total_tokens + pool_slack
+    return {
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "HEAD_RATIO": num_value_heads // num_heads,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "GATE_TOKEN_STRIDE": gate_token_stride,
+        "Q_ELEMENTS": total_tokens * num_heads * HEAD_DIM,
+        "V_ELEMENTS": total_tokens * num_value_heads * HEAD_DIM,
+        "GATE_ELEMENTS": total_tokens * gate_token_stride,
+        "BETA_ELEMENTS": total_tokens * num_value_heads,
+        "STATE_ELEMENTS": state_slots * slot_stride,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": total_tokens,
+        "NAT_ELEMENTS": num_seqs,
+    }
+
+
+@T.jit
+def _flashkda_decode_t4_precomputed(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    num_accepted_tokens_h: T.handle,
+    scale: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    HEAD_RATIO: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    GATE_TOKEN_STRIDE: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    GATE_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+    NAT_ELEMENTS: T.constexpr,
+):
+    """FlashKDA "cake" T=4 precomputed-gate decode -- scaffold body.
+
+    The implementation is written in the correctness gate, after the kernel
+    sketch has passed review.
+    """
+    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized FlashKDA cake T=4 decode PrimFunc."""
+    return _flashkda_decode_t4_precomputed.specialize(**_specialization(kwargs))
+
+
+_NAT_PATTERNS = {None: None, "zeros": 0, "fours": 4, "elevens": 11}
+
+
+def _accepted_tensor(kind: Any, num_seqs: int, device: str) -> torch.Tensor:
+    """num_accepted_tokens per case; the kernel clamps nat-1 into [0, 3]."""
+    if kind is None:
+        return torch.ones(num_seqs, device=device, dtype=torch.int32)
+    if kind == "mixed":
+        # The upstream test's sweep, tiled to the batch size.
+        pattern = torch.tensor([0, 1, 4, 11, 3, 0, 1, 4], dtype=torch.int32)
+        reps = (num_seqs + pattern.numel() - 1) // pattern.numel()
+        return pattern.repeat(reps)[:num_seqs].to(device)
+    if kind in _NAT_PATTERNS:
+        return torch.full((num_seqs,), _NAT_PATTERNS[kind], device=device, dtype=torch.int32)
+    raise ValueError(f"unknown accepted-token pattern {kind!r}")
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state.
+
+    Same shape as the T=2 recipe at T=4: packed [1, N*4, ...] bf16, a log-space
+    gate, pre-sigmoided beta, flat [N*4] slot indices. Written locally rather
+    than parameterizing the already-merged T=2 module.
+    """
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for FlashKDA cake T=4 decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"FlashKDA cake decode targets compute capability 10.x, got {capability}")
+
+    spec = _specialization({**kwargs, "device": device})
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    gate_token_stride = spec["GATE_TOKEN_STRIDE"]
+    total_tokens = num_seqs * NUM_TOKENS
+    state_slots = spec["STATE_ELEMENTS"] // slot_stride
+    padded_seqs = int(kwargs.get("padded_seqs", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    q = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, total_tokens, num_value_heads, HEAD_DIM, gain=0.5)
+    # GATE_KIND == 0: g holds the per-K log-gate; the kernel applies exp().
+    gate_logits = torch.randn(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        device=device,
+        dtype=torch.float32,
+        generator=gen,
+    )
+    g_dense = torch.nn.functional.logsigmoid(gate_logits).to(torch.bfloat16)
+    g_raw = torch.zeros((total_tokens * gate_token_stride,), device=device, dtype=torch.bfloat16)
+    g = g_raw.as_strided(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        (total_tokens * gate_token_stride, gate_token_stride, HEAD_DIM, 1),
+    )
+    g.copy_(g_dense)
+    beta = torch.sigmoid(randn(1, total_tokens, num_value_heads, dtype=torch.float32, gain=0.5)).to(
+        torch.bfloat16
+    )
+
+    cu_seqlens = torch.arange(0, total_tokens + 1, NUM_TOKENS, device=device, dtype=torch.int32)
+    # Slot 0 is deliberately never a checkpoint target (upstream bench recipe).
+    slots = torch.arange(1, total_tokens + 1, device=device, dtype=torch.int32).reshape(
+        num_seqs, NUM_TOKENS
+    )
+    if padded_seqs:
+        slots[num_seqs - padded_seqs :, :] = -1
+    ssm_state_indices = slots.contiguous().view(-1)
+    num_accepted_tokens = _accepted_tensor(kwargs.get("accepted"), num_seqs, device)
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(state_slots * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, total_tokens, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    scale = kwargs.get("scale")
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "g_raw": g_raw,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": ssm_state_indices,
+        "ssm_state_indices_2d": slots,
+        "num_accepted_tokens": num_accepted_tokens,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": float(scale) if scale is not None else HEAD_DIM**-0.5,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g_raw"],
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+    )
+
+
+def _source_body_path() -> str:
+    """Absolute path of the frozen generated body this port transcribes."""
+    import flashinfer
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t4_precomputed_split2.cu")
+
+
+def assert_frozen_source() -> None:
+    """Fail loudly if the upstream generated body was regenerated."""
+    path = _source_body_path()
+    with open(path, "rb") as handle:
+        text = handle.read().decode()
+    marker = "// BEGIN FROZEN GENERATED BODY\n"
+    start = text.index(marker) + len(marker)
+    end = text.index("// END FROZEN GENERATED BODY")
+    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
+    if digest != FROZEN_BODY_SHA256:
+        raise AssertionError(
+            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
+            "upstream export was regenerated and this port must be re-verified"
+        )
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the frozen cake export itself on the reference state pool."""
+    from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
+
+    device = case["device"]
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        target = "sm100f" if torch.version.cuda and torch.version.cuda >= "12.9" else "sm100a"
+    elif (major, minor) == (10, 3):
+        target = "sm100f"  # non-direct variants are never built for sm103a
+    else:
+        raise SkipTest(f"no FlashKDA cake export for compute capability {major}.{minor}")
+
+    module = get_flash_kda_decode_module("d128_t4_precomputed_split2", target)
+    reference_out = torch.empty_like(case["tirx_out"])
+    dummy_f32 = torch.ones(1, device=device, dtype=torch.float32)
+
+    module.run(
+        case["q"], case["k"], case["v"], case["g"], case["beta"],
+        dummy_f32, dummy_f32,
+        case["reference_state"], reference_out,
+        case["cu_seqlens"], case["ssm_state_indices"], case["num_accepted_tokens"],
+        float(case["scale"]), 0.0,
+        int(torch.cuda.current_stream(device).cuda_stream),
+    )  # fmt: skip
+    torch.cuda.synchronize(device)
+    return reference_out
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the T=4 delta rule (sequential form)."""
+    spec = case["spec"]
+    num_seqs = spec["NUM_SEQS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    head_ratio = spec["HEAD_RATIO"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+
+    q = case["q"][0].float()
+    k = case["k"][0].float()
+    v = case["v"][0].float()
+    g = case["g"][0].float()
+    beta = case["beta"][0].float()
+    slots2d = case["ssm_state_indices_2d"]
+    nat = case["num_accepted_tokens"]
+
+    state_raw = case["initial_state_raw"].clone()
+    state_slots = state_raw.numel() // slot_stride
+    state = state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    out = torch.zeros(
+        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
+        device=case["device"],
+        dtype=torch.float32,
+    )
+
+    scale = float(case["scale"])
+    for n in range(num_seqs):
+        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
+        init_slot = int(slots2d[n, accepted].item())
+        if init_slot < 0:
+            init_slot = 0
+        for hv in range(num_value_heads):
+            h = hv // head_ratio
+            # FP32 carry across all tokens; only the checkpoint store rounds.
+            s = state[init_slot, hv].float()
+            for t in range(NUM_TOKENS):
+                row = n * NUM_TOKENS + t
+                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
+                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
+                gamma = torch.exp(g[row, hv])
+
+                decayed = s * gamma.unsqueeze(0)
+                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
+                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
+                out[row, hv] = s @ qn
+
+                slot = int(slots2d[n, t].item())
+                if slot >= 0:
+                    state[slot, hv] = s.to(torch.bfloat16)
+                else:
+                    out[row, hv] = 0.0
+
+    return out.to(torch.bfloat16).unsqueeze(0), state_raw
+
+
+def run_test(**kwargs: Any) -> None:
+    """Correctness entry point. Implemented in the correctness gate."""
+    raise SkipTest(
+        "flashkda_decode_t4_precomputed is at the scaffold stage; the kernel body "
+        "is written in the correctness gate"
+    )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point. Implemented in the performance gate."""
+    raise SkipTest(
+        "flashkda_decode_t4_precomputed is at the scaffold stage; benchmarking is "
+        "enabled in the performance gate"
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "assert_frozen_source",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -89,6 +89,8 @@ LOG2_E = _t2.LOG2_E
 
 THREADS = 128  # 4 warps (flash_kda_decode.py:_variant_metadata)
 ROWS_PER_CTA = HEAD_DIM // VALUE_SPLIT  # 64 value rows per CTA
+MMA_WARPS = HEAD_DIM // VALUE_SPLIT // 16  # phase D-G guard: value_rows/16
+ROW_GROUPS = HEAD_DIM // VALUE_SPLIT // 8  # phase B/H guard: value_rows/8
 ROWS_PER_THREAD = 8  # each of the 128 threads owns 8 rows x 8 keys
 K_PER_THREAD = 8
 
@@ -237,21 +239,406 @@ def _flashkda_decode_t4_precomputed(
     STATE_INDEX_ELEMENTS: T.constexpr,
     NAT_ELEMENTS: T.constexpr,
 ):
-    """FlashKDA "cake" T=4 precomputed-gate decode -- scaffold body.
+    """FlashKDA "cake" T=4 precomputed-gate decode, WY schedule, 4 warps.
 
-    The implementation is written in the correctness gate, after the kernel
-    sketch has passed review.
+    Transcribed from `kernel_flashinfer_recurrent_kda_wy_vtile_short`; bare
+    `:NNN` references are into
+    `flashkda_decode_d128_t4_precomputed_split2.cu`. Design sketch:
+    `.agents/sketch/flashinfer/kda/flashkda_decode_t3_t4_wy.md`.
     """
-    T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
-    T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
-    T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    cu = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    T.device_entry()
+
+    # The source uses dynamic smem; 25856 B fits the static limit, so the same
+    # bytes are declared statically at the same alignment. The region offsets
+    # and the alignment are what the swizzled ldmatrix addressing depends on.
+    arena = T.alloc_buffer((SMEM_TOTAL,), "uint8", scope="shared", align=1024)
+
+    # --- work decomposition and lane roles (:142-160) ----------------------
+    work, n = T.cta_id([NUM_VALUE_HEADS * VALUE_SPLIT, NUM_SEQS])
+    tid = T.thread_id([THREADS])
+    value_tile: T.int32 = work % VALUE_SPLIT
+    hv: T.int32 = work // VALUE_SPLIT
+    query_head: T.int32 = hv // HEAD_RATIO
+    warp: T.int32 = tid // 32  # == token index in phases A and C
+    lane: T.int32 = tid % 32
+    lane_quad: T.int32 = lane % 4
+    frag_row: T.int32 = lane // 4
+    quad_base: T.int32 = lane - lane_quad
+    group: T.int32 = tid // 16
+    lane_group: T.int32 = tid % 16
+    k_start: T.int32 = lane_group * 8
+    elem_start: T.int32 = lane * 4
+    tile_row_base: T.int32 = value_tile * ROWS_PER_CTA
+    owned_row_base: T.int32 = group * 8
+    token_base: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - token_base
+
+    r_q = T.alloc_local((4,), "float32")
+    r_k = T.alloc_local((4,), "float32")
+    r_d = T.alloc_local((4,), "float32")
+
+    # =======================================================================
+    # Phase A: token preprocess, warp <-> token  (:180-290)
+    # =======================================================================
+    # `warp < 4` is statically true at 128 threads, as is `group < 8` below:
+    # every guard in this body is satisfied by every thread. (The T=3 sibling
+    # is the one where these are live.)
+    if warp < NUM_TOKENS:
+        token: T.int32 = warp
+        active_token = token < seq_len
+        token_pos: T.int32 = T.if_then_else(active_token, token_base + token, 0)
+        qk_base: T.int32 = (token_pos * NUM_HEADS + query_head) * HEAD_DIM + elem_start
+        gate_base: T.int32 = token_pos * GATE_TOKEN_STRIDE + hv * HEAD_DIM + elem_start
+
+        q_words = _load_u32x2(q, qk_base)
+        k_words = _load_u32x2(k, qk_base)
+        g_words = _load_u32x2(g, gate_base)
+        for pair in T.unroll(2):
+            r_q[2 * pair] = _widen_lo(q_words[pair])
+            r_q[2 * pair + 1] = _widen_hi(q_words[pair])
+            r_k[2 * pair] = _widen_lo(k_words[pair])
+            r_k[2 * pair + 1] = _widen_hi(k_words[pair])
+            r_d[2 * pair] = _widen_lo(g_words[pair])
+            r_d[2 * pair + 1] = _widen_hi(g_words[pair])
+
+        # Index-ordered accumulation (:241-244); the first term has a zero addend.
+        q_sq: T.float32 = _fma(
+            r_q[3],
+            r_q[3],
+            _fma(r_q[2], r_q[2], _fma(r_q[1], r_q[1], _fma(r_q[0], r_q[0], T.float32(0.0)))),
+        )
+        k_sq: T.float32 = _fma(
+            r_k[3],
+            r_k[3],
+            _fma(r_k[2], r_k[2], _fma(r_k[1], r_k[1], _fma(r_k[0], r_k[0], T.float32(0.0)))),
+        )
+        # Two sequential full-warp butterflies, not interleaved (:245-254).
+        for off in T.unroll(5):
+            q_sq = _add(q_sq, _shfl_bfly(q_sq, 16 >> off))
+        for off in T.unroll(5):
+            k_sq = _add(k_sq, _shfl_bfly(k_sq, 16 >> off))
+        q_norm: T.float32 = _mul(_rsqrt(_add(q_sq, T.float32(L2_EPS))), scale)
+        k_norm: T.float32 = _rsqrt(_add(k_sq, T.float32(L2_EPS)))
+
+        # GATE_KIND == 0: `g` already holds log(gamma), so one exp per element.
+        k_pub = T.alloc_local((4,), "uint32")
+        d_pub = T.alloc_local((4,), "uint32")
+        for i in T.unroll(4):
+            r_q[i] = _mul(r_q[i], q_norm)
+            r_k[i] = _mul(r_k[i], k_norm)
+            r_d[i] = _expf(r_d[i])
+            k_pub[i] = T.reinterpret("uint32", r_k[i])
+            d_pub[i] = T.reinterpret("uint32", r_d[i])
+        _st_shared_u32x4(arena, OFF_SK + (token * HEAD_DIM + elem_start) * 4, k_pub)
+        _st_shared_u32x4(arena, OFF_SD + (token * HEAD_DIM + elem_start) * 4, d_pub)
+
+        if lane == 0:
+            raw_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + token)
+            _st_shared_i32(arena, OFF_SSLOT + token * 4, T.if_then_else(active_token, raw_slot, -1))
+            _st_shared_i32(arena, OFF_STOKEN + token * 4, token_pos)
+            _st_shared_f32(
+                arena, OFF_SBETA + token * 4, _load_bf16_f32(beta, token_pos * NUM_VALUE_HEADS + hv)
+            )
+            if token == 0:
+                # nat picks the initial checkpoint slot; at T=4 the clamp
+                # ceiling is 3 and both edges are reachable (:279-287).
+                accepted: T.int32 = T.min(T.max(_load_i32(nat, n) - 1, 0), NUM_TOKENS - 1)
+                initial_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + accepted)
+                _st_shared_i32(arena, OFF_SINIT, T.max(initial_slot, 0))
+
+    T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase B: state gather and sState stage, all 128 threads  (:292-329)
+    # =======================================================================
+    init_slot: T.int32 = _ld_shared_i32(arena, OFF_SINIT)
+    head_base = T.cast(init_slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        hv * HEAD_DIM * HEAD_DIM, "int64"
+    )
+    hist = T.alloc_local((8 * 8,), "float32")
+    for row_local in T.unroll(8):
+        row_l: T.int32 = owned_row_base + row_local
+        pack = _load_u32x4(
+            state, head_base + T.cast((tile_row_base + row_l) * HEAD_DIM + k_start, "int64")
+        )
+        for pr in T.unroll(4):
+            hist[row_local * 8 + 2 * pr] = _widen_lo(pack[pr])
+            hist[row_local * 8 + 2 * pr + 1] = _widen_hi(pack[pr])
+        # The bf16 bits go to shared unmodified; the swizzle is on the byte
+        # offset. lane_group < 8 lands in sState0, the rest in sState1.
+        if lane_group < 8:
+            _st_shared_u32x4(arena, OFF_SSTATE0 + _swz(row_l * 128 + k_start * 2), pack)
+        else:
+            _st_shared_u32x4(arena, OFF_SSTATE1 + _swz(row_l * 128 + (k_start - 64) * 2), pack)
+
+    # =======================================================================
+    # Phase C: sVec columns and the WY coefficients  (:330-404)
+    # =======================================================================
+    if warp < NUM_TOKENS:
+        token_c: T.int32 = warp
+        for i in T.unroll(4):
+            k_idx: T.int32 = elem_start + i
+            prefix: T.float32 = T.float32(1.0)
+            for j in T.unroll(NUM_TOKENS):
+                if token_c >= j:
+                    prefix = _mul(
+                        prefix, _ld_shared_f32(arena, OFF_SD + (j * HEAD_DIM + k_idx) * 4)
+                    )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + token_c * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_k[i]), dtype="uint16"),
+            )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + (4 + token_c) * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_q[i]), dtype="uint16"),
+            )
+
+        ratio = T.alloc_local((4,), "float32")
+        for i in T.unroll(4):
+            ratio[i] = T.float32(1.0)
+        for source_offset in T.unroll(NUM_TOKENS):
+            source_token: T.int32 = token_c - source_offset
+            if source_token >= 0:
+                dot_kk: T.float32 = T.float32(0.0)
+                dot_qk: T.float32 = T.float32(0.0)
+                sk_vec = T.alloc_local((4,), "float32")
+                _ld_shared_f32x4(
+                    arena, OFF_SK + (source_token * HEAD_DIM + elem_start) * 4, sk_vec, 0
+                )
+                for i in T.unroll(4):
+                    # Source order: r * source_k * ratio  (:372-375).
+                    dot_kk = _fma(_mul(r_k[i], sk_vec[i]), ratio[i], dot_kk)
+                    dot_qk = _fma(_mul(r_q[i], sk_vec[i]), ratio[i], dot_qk)
+                for off in T.unroll(5):
+                    dot_kk = _add(dot_kk, _shfl_bfly(dot_kk, 16 >> off))
+                for off in T.unroll(5):
+                    dot_qk = _add(dot_qk, _shfl_bfly(dot_qk, 16 >> off))
+                if lane == 0:
+                    beta_source: T.float32 = _ld_shared_f32(arena, OFF_SBETA + source_token * 4)
+                    if source_token < token_c:
+                        _st_shared_f32(
+                            arena,
+                            OFF_SL + (token_c * NUM_TOKENS + source_token) * 4,
+                            _mul(beta_source, dot_kk),
+                        )
+                    _st_shared_f32(
+                        arena,
+                        OFF_SR + (token_c * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, dot_qk),
+                    )
+                if source_token > 0:
+                    sd_vec = T.alloc_local((4,), "float32")
+                    _ld_shared_f32x4(
+                        arena, OFF_SD + (source_token * HEAD_DIM + elem_start) * 4, sd_vec, 0
+                    )
+                    for i in T.unroll(4):
+                        ratio[i] = _mul(ratio[i], sd_vec[i])
+
+    T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase D: the MMA chain, warp <-> 16 value rows  (:406-438)
+    # =======================================================================
+    # The chain is byte-identical at every T: 8 ldmatrix.x4 + 8 .trans + 8 mma.
+    # n = 8 was always 8 columns wide; T only decides how many carry live data.
+    acc = T.alloc_local((4,), "float32", align=4)
+    if warp < MMA_WARPS:
+        vec_frag = T.alloc_local((4,), "uint32", align=4)
+        state_frag = T.alloc_local((4,), "uint32", align=4)
+        for state_half in T.unroll(2):
+            for mma_step in T.unroll(4):
+                mma_k: T.int32 = mma_step * 16
+                global_k: T.int32 = state_half * 64 + mma_k
+                _ldmatrix_x4(
+                    arena,
+                    OFF_SVEC + _swz((global_k + lane % 16) * 32 + lane // 16 * 16),
+                    vec_frag,
+                    True,
+                )
+                if state_half == 0:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE0
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                else:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE1
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                if state_half == 0 and mma_step == 0:
+                    _mma_zero(acc, state_frag, vec_frag)
+                else:
+                    _mma_acc(acc, state_frag, vec_frag)
+
+    # =======================================================================
+    # Phase E: quad broadcast and the WY forward substitution  (:439-483)
+    # =======================================================================
+    u_lo = T.alloc_local((NUM_TOKENS,), "float32")
+    u_hi = T.alloc_local((NUM_TOKENS,), "float32")
+    if warp < MMA_WARPS:
+        # 8 broadcasts, all four ha_lo then all four ha_hi (:439-454). The
+        # `quad_base + 1` half feeds MMA columns 2,3 -- dead at T=2, live here.
+        ha_lo = T.alloc_local((4,), "float32")
+        ha_hi = T.alloc_local((4,), "float32")
+        for t in T.unroll(4):
+            ha_lo[t] = _shfl_idx(acc[t % 2], quad_base + t // 2)
+        for t in T.unroll(4):
+            ha_hi[t] = _shfl_idx(acc[2 + t % 2], quad_base + t // 2)
+
+        if lane_quad == 2:
+            row_lo: T.int32 = warp * 16 + frag_row
+            row_hi: T.int32 = row_lo + 8
+            for t in T.unroll(NUM_TOKENS):
+                base_t: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + t * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM
+                solved_lo: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_lo), ha_lo[t]
+                )
+                solved_hi: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_hi), ha_hi[t]
+                )
+                for prev in T.unroll(NUM_TOKENS):
+                    if prev < t:
+                        lts: T.float32 = _ld_shared_f32(arena, OFF_SL + (t * NUM_TOKENS + prev) * 4)
+                        solved_lo = _sub(solved_lo, _mul(lts, u_lo[prev]))
+                        solved_hi = _sub(solved_hi, _mul(lts, u_hi[prev]))
+                u_lo[t] = solved_lo
+                u_hi[t] = solved_hi
+
+        # The residuals must cross the quad: phase F below runs on lane_quad
+        # >= 2, so lane 4f+3 consumes what lane 4f+2 solved (:476-482). This
+        # broadcast was an identity at T=2 and the T=2 port dropped it; here it
+        # is load-bearing for every output token >= 2.
+        for t in T.unroll(NUM_TOKENS):
+            u_lo[t] = _shfl_idx(u_lo[t], quad_base + 2)
+            u_hi[t] = _shfl_idx(u_hi[t], quad_base + 2)
+
+    # =======================================================================
+    # Phase F: the outputs, two tokens per writer lane  (:484-532)
+    # =======================================================================
+    # One generic block keyed off lane_quad, replacing T=2's per-token blocks.
+    # No shuffle is needed to pick the right accumulator column pair: the
+    # m16n8k16 D layout already keys columns 2*lane_quad, +1 off lane_quad, so
+    # lane 4f+2 holds the q-side columns of tokens 0,1 and lane 4f+3 those of
+    # tokens 2,3.
+    if warp < MMA_WARPS and lane_quad >= 2:
+        token0: T.int32 = (lane_quad - 2) * 2
+        token1: T.int32 = token0 + 1
+        row_lo_f: T.int32 = warp * 16 + frag_row
+        row_hi_f: T.int32 = row_lo_f + 8
+        out0_lo: T.float32 = acc[0]
+        out1_lo: T.float32 = acc[1]
+        out0_hi: T.float32 = acc[2]
+        out1_hi: T.float32 = acc[3]
+        for src in T.unroll(NUM_TOKENS):
+            residual_lo: T.float32 = u_lo[src]
+            residual_hi: T.float32 = u_hi[src]
+            coef0: T.float32 = T.float32(0.0)
+            coef1: T.float32 = T.float32(0.0)
+            # The masked-out coefficient is a real zero-operand fma, not a
+            # skipped iteration (:497-505).
+            if token0 >= src:
+                coef0 = _ld_shared_f32(arena, OFF_SR + (token0 * NUM_TOKENS + src) * 4)
+            if token1 >= src:
+                coef1 = _ld_shared_f32(arena, OFF_SR + (token1 * NUM_TOKENS + src) * 4)
+            out0_lo = _fma(coef0, residual_lo, out0_lo)
+            out1_lo = _fma(coef1, residual_lo, out1_lo)
+            out0_hi = _fma(coef0, residual_hi, out0_hi)
+            out1_hi = _fma(coef1, residual_hi, out1_hi)
+
+        for half in T.unroll(2):
+            token_o: T.int32 = T.if_then_else(half == 0, token0, token1)
+            o_lo: T.float32 = T.if_then_else(half == 0, out0_lo, out1_lo)
+            o_hi: T.float32 = T.if_then_else(half == 0, out0_hi, out1_hi)
+            active_o = _ld_shared_i32(arena, OFF_SSLOT + token_o * 4) >= 0
+            base_o: T.int32 = (
+                _ld_shared_i32(arena, OFF_STOKEN + token_o * 4) * NUM_VALUE_HEADS + hv
+            ) * HEAD_DIM + tile_row_base
+            # A padded row writes EXPLICIT zeros; the upstream test asserts them
+            # bit-exactly, so this is not an "unwritten" path.
+            _store_f32_as_bf16(out, base_o + row_lo_f, o_lo, active_o)
+            _store_f32_as_bf16(out, base_o + row_hi_f, o_hi, active_o)
+            _store_f32_as_bf16(out, base_o + row_lo_f, T.float32(0.0), T.Not(active_o))
+            _store_f32_as_bf16(out, base_o + row_hi_f, T.float32(0.0), T.Not(active_o))
+
+    # =======================================================================
+    # Phase G: publish sU  (:533-546)
+    # =======================================================================
+    if warp < MMA_WARPS:
+        if lane_quad == 2:
+            row_lo_g: T.int32 = warp * 16 + frag_row
+            for t in T.unroll(NUM_TOKENS):
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g) * 4, u_lo[t])
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g + 8) * 4, u_hi[t])
+        # A warp barrier suffices: warp w owns groups 2w and 2w+1, i.e. rows
+        # [16w, 16w+16), which is exactly the row set it wrote above (:544).
+        T.cuda.warp_sync()
+
+    # =======================================================================
+    # Phase H: recurrence and checkpoints, all 128 threads  (:660-696)
+    # =======================================================================
+    words_w = T.alloc_local((4,), "uint32")
+    sd_t = T.alloc_local((8,), "float32")
+    sk_t = T.alloc_local((8,), "float32")
+    for t in T.unroll(NUM_TOKENS):
+        slot_t: T.int32 = _ld_shared_i32(arena, OFF_SSLOT + t * 4)
+        beta_t: T.float32 = _ld_shared_f32(arena, OFF_SBETA + t * 4)
+        # The gate and key slices depend only on (t, k_start), not on the row,
+        # so they are loaded once per token as two 16-byte reads rather than
+        # reloaded in the row loop (:674).
+        _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start) * 4, sd_t, 0)
+        _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start + 4) * 4, sd_t, 4)
+        _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start) * 4, sk_t, 0)
+        _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start + 4) * 4, sk_t, 4)
+        for row_local in T.unroll(8):
+            row_h: T.int32 = owned_row_base + row_local
+            update: T.float32 = _mul(
+                _ld_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_h) * 4), beta_t
+            )
+            for i in T.unroll(8):
+                # The source writes `hist*sD + update*sK` (:674) and the
+                # compiler contracts the FIRST product: update*sK is rounded,
+                # hist*sD is fused. This is the only stateful accumulation and
+                # it feeds both the checkpoint and every later token's history.
+                hist[row_local * 8 + i] = _fma(
+                    hist[row_local * 8 + i], sd_t[i], _mul(update, sk_t[i])
+                )
+            for pr in T.unroll(4):
+                words_w[pr] = _pack_bf16x2(
+                    hist[row_local * 8 + 2 * pr + 1], hist[row_local * 8 + 2 * pr]
+                )
+            # The recurrence advances unconditionally; only the store is
+            # slot-predicated, and it stays FP32 so token t+1 consumes the
+            # un-rounded token-t state rather than the bf16 checkpoint.
+            if slot_t >= 0:
+                _store_u32x4(
+                    state,
+                    T.cast(slot_t, "int64") * T.cast(STATE_SLOT_STRIDE, "int64")
+                    + T.cast(
+                        hv * HEAD_DIM * HEAD_DIM + (tile_row_base + row_h) * HEAD_DIM + k_start,
+                        "int64",
+                    ),
+                    words_w,
+                )
 
 
 def get_kernel(**kwargs: Any):
@@ -510,12 +897,100 @@ def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
     return out.to(torch.bfloat16).unsqueeze(0), state_raw
 
 
+# The port replicates the source's MMA chain, swizzle and association orders, so
+# it should agree with the frozen export to within bf16 rounding.
+_RTOL = 2.0**-8
+_ATOL = 2.0e-3
+# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
+# operands to bf16, so the band here is genuinely wider and measured, not
+# guessed: at scaffold time the export itself sat 6.1e-05 from the oracle.
+_ORACLE_RTOL = 2.0**-5
+_ORACLE_ATOL = 6.0e-3
+
+
 def run_test(**kwargs: Any) -> None:
-    """Correctness entry point. Implemented in the correctness gate."""
-    raise SkipTest(
-        "flashkda_decode_t4_precomputed is at the scaffold stage; the kernel body "
-        "is written in the correctness gate"
+    """Validate one config against the frozen export and an independent oracle."""
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    assert_frozen_source()
+
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["device"])
+
+    tirx_out = case["tirx_out"]
+    tirx_state = case["tirx_state_raw"].clone()
+
+    # 1. the frozen cake export itself, on an independent state pool
+    reference_out = _flashinfer_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        reference_out.float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"output vs flashinfer cake export\n{m}",
     )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        case["reference_state_raw"].float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"state vs flashinfer cake export\n{m}",
+    )
+
+    # 2. an independent FP32 oracle of the same recurrence
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        oracle_out.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"output vs FP32 oracle\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        oracle_state.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"state vs FP32 oracle\n{m}",
+    )
+
+    # 3. invariants the tolerances cannot express
+    num_seqs = spec["NUM_SEQS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    slots2d = case["ssm_state_indices_2d"]
+    initial = case["initial_state_raw"]
+
+    touched: set[int] = set()
+    for seq in range(num_seqs):
+        for t in range(NUM_TOKENS):
+            slot = int(slots2d[seq, t])
+            row = seq * NUM_TOKENS + t
+            if slot < 0:
+                # A padded row writes explicit zeros, so this is exact.
+                assert tirx_out[0, row].abs().max().item() == 0.0, (
+                    f"padded row {seq} token {t} must have a zeroed output"
+                )
+            else:
+                touched.add(slot)
+    n_slots = initial.numel() // slot_stride
+    for slot in range(min(n_slots, num_seqs * NUM_TOKENS + 2)):
+        if slot in touched:
+            continue
+        lo, hi = slot * slot_stride, (slot + 1) * slot_stride
+        assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+            f"untouched state slot {slot} was modified"
+        )
+    if slot_stride > payload:
+        for slot in sorted(touched)[:4]:
+            lo = slot * slot_stride + payload
+            hi = (slot + 1) * slot_stride
+            assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+                f"inter-slot padding after slot {slot} was modified"
+            )
 
 
 def run_bench(

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -1000,10 +1000,47 @@ def run_bench(
     timer: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    """Benchmark entry point. Implemented in the performance gate."""
-    raise SkipTest(
-        "flashkda_decode_t4_precomputed is at the scaffold stage; benchmarking is "
-        "enabled in the performance gate"
+    """Time the port against the frozen cake export on identical inputs."""
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region. Both sides mutate their own state
+    # pool in place, so this also proves the pools stayed independent.
+    executable(*args)
+    reference_out = _flashinfer_reference(case)
+    torch.cuda.synchronize(case["device"])
+    torch.testing.assert_close(
+        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+    )
+    torch.testing.assert_close(
+        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # The nvcc JIT build and warmup both happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cake": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
     )
 
 


### PR DESCRIPTION
## Summary

- port FlashInfer's frozen "cake" FlashKDA decode exports for **T=4** (`d128_t4_precomputed_split2`) and **T=3** (`d128_t3_lower_bound_split4`) to plain TIRx
- T=3 is the family's first **in-kernel gate**: `A_log`, `dt_bias` and `lower_bound` are live arguments rather than the dummies every precomputed variant passes
- add both bench-suite matrices (9 + 5 rows) and their baseline rows
- include the frozen execution sketch used during the porting design stage, covering both bodies

## Impact

These are the last two speculative-decode legs of the cake surface that share the WY skeleton merged in #31. T=4 is reached whenever `num_tokens == 4` with `num_spec_tokens == 3`; on sm100a the selector returns value split 2 unconditionally (`recurrent_kda.py:1179-1180`), so `split2` is the entire dispatch surface. T=3 does not consult the split selector at all — `recurrent_kda.py:1437-1438` early-returns the variant from the `is_t3_lower_bound` predicate — and its legal domain is narrow and enforced host-side: `num_spec_tokens == 2`, `use_gate_in_kernel`, a finite `lower_bound < 0`, fp32 contiguous `A_log`/`dt_bias`, `H == HV == 16` and `N ∈ {1,2,4,8,16}`.

Both bodies are the same Loom template as the merged T=2 port, and the structural distance is much smaller than the line counts suggest. Stripping every integer literal and diffing phase by phase, **A/B/C/D/E/G/H are identical across all three bodies**; there are exactly two structural deltas.

**Phase F is rewritten** (shared by both new bodies, byte-identical between them). T=2 had one block per token under `lane_quad == 2`; both new bodies replace it with a single generic block under `lane_quad >= 2` where `token0 = (lane_quad - 2) * 2`, so lane `4f+2` writes tokens 0,1 and lane `4f+3` writes tokens 2,3. No shuffle is needed to select the accumulator column pair — the `m16n8k16` D layout already keys columns `2*lane_quad, +1` off `lane_quad`. Because the WY solve still runs on one lane per quad while two lanes now write, the `u_lo`/`u_hi` quad broadcasts — an *identity* at T=2, which is why the T=2 port dropped them — become load-bearing for every output token ≥ 2.

**T=3 adds the gate.** `g` is the raw pre-gate, and per element the kernel computes `exp(lower_bound / (1 + exp(-exp(A_log[qh]) * (g + dt_bias[qh*128 + k]))))`. The port follows the export's lowering exactly: `gate_a` and `-gate_a` are hoisted out of the element loop (one `neg.ftz.f32` for the whole body), the division is `div.approx.ftz.f32` rather than `rcp.approx` + `mul`, and `dt_bias`'s four contiguous fp32 per lane load as four scalar `ld.global.nc.b32` because nvcc does not vectorize them.

**T=3 is also the only body in this family whose warp/group guards are live.** At 96 threads with 32 value rows, `warp < 3` admits all three warps but `group < 4` and `warp < 2` do not, so warp 2 is a **token-only warp**: it preprocesses token 2 and builds token 2's sVec columns and sL/sR row, hits both CTA barriers, and then never gathers state, never issues an MMA and never stores. Both `__syncthreads()` are therefore genuine three-warp edges here.

### One deliberate deviation

T=3's phase F is byte-identical to T=4's, but `TOKENS` is odd, so at `lane_quad == 3` the source computes an out-of-range `token1 = 3` and reads `sR[9..11]` — which aliases the first 12 bytes of `sU` — and `sSlot[3]` — which aliases `sToken[0]` — *before* the `token1 < 3` mask discards the results. Those reads are safe in the source (in-bounds shared memory, provably dead values), but a TIRx port cannot express "address past a declared region and rely on the arena layout". The port predicates them on `token1 < TOKENS` instead. This is numerically identical: `coef1` stays `0.0` so `out1_*` stays `acc[1]`/`acc[3]`, which is never stored, and the `-1` slot sentinel is never consulted because the store carries the same condition. It costs four `ld.shared.b32` on the 16 of 96 threads with `lane_quad == 3`.

## Validation

### T=4 — `d128_t4_precomputed_split2`

- **correctness**: 19/19 configs pass, each checked three ways — against the frozen export on an independent state pool, against an independent FP32 oracle of the sequential recurrence, and against invariants the tolerances cannot express (padded rows exactly zero, untouched slots byte-identical, inter-slot padding intact)
- coverage includes both `num_accepted_tokens` clamp edges (0/1/4/11 — the ceiling moved from 1 at T=2 to 3 here), a mixed nat pattern, CUDA-graph padding, an envelope-strided state pool and gate, a non-default scale, GQA ratios 2 and 4, and N=1
- `verify_dispatch.py` feeds the tensors `prepare_data` builds into FlashInfer's own `_select_flash_kda_decode_variant`: **19/19** reach `d128_t4_precomputed_split2`
- `characterize_source.py` proves the special-case rows exercise real behaviour rather than degenerating (8/8), including that all four per-token checkpoints are written with pairwise different content — the extra tokens are exactly where the rewritten phase F writes
- **performance**: 9/9 shapes above source, **min 1.0166x**, max 1.1886x

### T=3 — `d128_t3_lower_bound_split4`

- **correctness**: 14/14 configs pass, same three-way check; coverage includes the nat sweep 0/1/3/10, padding, strided state and gate, a non-default scale, and a second `lower_bound`
- `verify_dispatch.py` checks **both directions** for this kernel, because for T=3 the negative space is most of the contract: all 14 rows select the variant, **and** 10 near-miss contracts (wrong `num_spec_tokens`; absent, zero, positive or infinite `lower_bound`; missing, bf16 or too-short `A_log`/`dt_bias`; `use_gate_in_kernel` off) plus 4 out-of-domain shapes are refused
- `characterize_source.py` proves the gate is genuinely derived in-kernel (10/10) without relying on the oracle: perturbing `A_log[0]` or `dt_bias[5]` moves value head 0 and nothing else, perturbing `dt_bias[128+5]` moves head 1 and leaves head 0 alone, and the output is **bit-identical at `g = +1000` and `g = +2000`** — the sigmoid saturating. `gamma = exp(g)`, the precomputed formula a port could accidentally implement, cannot produce that last result, so the check falsifies the most likely wrong implementation outright
- **performance**: 5/5 shapes above source, **min 1.0104x**, max 1.0338x

### Both

- no-tile-primitive gates pass on every specialization, and were proven non-vacuous by injecting a real `Tx.copy` that both the AST route and the pre-dispatch IR route flag
- the design sketch was reviewed by an independent agent against both sources and both line-info PTX exports, PASS on all five checks after three rounds of findings
- performance evidence is one complete bench-suite run on clean GPUs (1963 MHz, 4.44 cycles/FMA probed before the run); an earlier independent complete run agrees within noise on all 14 rows. Baseline merged from the final run: exactly 14 rows added, none removed (278 → 292)

The review also caught a wrong claim in the merged T=2 sketch — the same quad broadcasts described there as consumed only by dead code, when they are in fact an identity — corrected here so the next port in this family does not inherit it.
