### PR TITLE
feat(kernel): port BF16 ILP4 GDN decode

### DIFF
--- a/.agents/sketch/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.md
+++ b/.agents/sketch/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.md
@@ -1,0 +1,668 @@
+<!--
+Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0
+
+This design sketch documents a modified TIRx port of FlashInfer's
+gdn_decode_bf16_state.py. See LICENSE, NOTICE, and licenses/ for the
+applicable terms.
+-->
+
+# GDN decode BF16 ILP4 SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the four-warp
+ownership, the T-dependent shared precompute, the four-row register recurrence,
+the packed-FP32x2 dot/update arithmetic, and the 64-bit state addressing of
+FlashInfer's CuTeDSL `gdn_decode_bf16state_mtp_ilp4_kernel`. The corresponding
+TIRx module is
+[`tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py`](../../../../tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py).
+That module may become executable only after this sketch passes independent
+review.
+
+The frozen FlashInfer commit is
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`; the source SHA256 is
+`61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61`.
+The exact source chain is the T=1 fallback or T>=2 low-work-unit fallback into
+`gated_delta_rule_mtp -> run_gdn_decode_bf16state_mtp_ilp4 ->
+gdn_decode_bf16state_mtp_ilp4_kernel`.
+
+The target is SM100a/B200 and fixes K=V=128, BF16 Q/K/V/state/output, FP32
+head scalars/state/reductions, 128 threads, four warps, one 32-lane group per
+warp, four adjacent K elements per lane, four V rows of ILP, and packed
+`fma.rn.f32x2`. The production domain is T=1 with `B*HV<512` and T>=2 with
+`B*HV<128`; the 48 power-of-two-batch benchmark cases use tile 16 or 32, while
+the reachable T=1 fallback also uses tile 64 once its source occupancy picker
+sees at least four SM waves (for example B=96, HV=4 on the 148-SM target).
+Recovery and tile primitives are out of scope.
+
+Correctness retains T=1 and T>1 branches; Q/K normalization on/off; output and
+state update on/off; same/split and contiguous/padded pools; negative indices;
+dense intermediate caching; per-request accepted steps; and flat/padded
+per-token scatter.
+
+## Pipeline at a glance
+
+There is no asynchronous copy pipeline, TensorMap, TMEM, or mbarrier. For T>1,
+the four warps publish token-shared Q/K and optionally g/beta into dynamic
+shared memory, with one CTA barrier after each four-token pass. T=1 allocates
+no typed shared tensors and performs Q/K/gate work inside every four-row body.
+
+| Physical lanes | Role-local program | Publication/reuse edge |
+| --- | --- | --- |
+| warp `w` for T>1 | precompute tokens `4*p+w`; load four Q/K values per lane, normalize/scale, publish sQ/sK, and for T>2 publish g/beta from lane 0 | scalar shared Q/K stores, one lane-zero packed g/beta store, then `bar.sync 0` after every pass |
+| all four warps for T=2 | publish only Q/K in Phase 0; recompute g/beta inside every four-row/token body | the same per-pass CTA barrier protects sQ/sK |
+| all four warps for T=1 | skip Phase 0 and all shared traffic; every four-row body loads and transforms Q/K and g/beta directly | no publication edge |
+| warp/group 0..3 in the row-quad loop | each warp owns `tile_v/4` V rows; each lane owns K `[4*lane,4*lane+4)`; every body carries four V rows across its serial token loop | register state is private; no post-precompute synchronization |
+| lane 0 of each warp | writes four scalar BF16 output values per processed token/body | disjoint V ownership |
+| every lane | writes four 8-byte BF16 state vectors to dense cache, scatter pool, or final pool as selected | disjoint `(V-row,K-segment)` ownership |
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)       # compile-time source variant
+launch(...)           # physical grid/block/shared metadata
+raw_shared(...)       # one dynamic shared allocation
+view(...)             # typed storage view without a copy
+alias(...)            # exact read/write storage alias
+reg_tile(...)         # lane-private register storage
+```
+
+Copies expose storage direction and one PTX family per occurrence:
+
+```python
+copy_g2r(src, dst=None)
+copy_s2r(src, dst=None)
+copy_r2s(src, dst)
+copy_r2g(src, dst)
+```
+
+Computation and synchronization stay primitive:
+
+```python
+cast(dtype, src, rounding=None)
+add(lhs, rhs)
+sub(lhs, rhs)
+mul(lhs, rhs)
+fma(lhs, rhs, acc, lanes=1)
+exp2(src)
+log2(src)
+reciprocal(src)
+rsqrt(src)
+setp_le(lhs, rhs)
+select(predicate, true_value, false_value)
+shuffle_xor(src, lane_delta, member_mask, clamp)
+warp_uniform(src, source_lane, member_mask, clamp)
+cta_barrier()
+```
+
+`fma(..., lanes=2)` denotes one packed two-result FP32 instruction. A copy is
+written as an explicit scalar loop when PTX emits four scalar operations; a
+four-element copy remains one operation only where line-info PTX proves a
+single vector instruction family. Address arithmetic is omitted unless it changes runtime
+stride, slot selection, ownership, or the dense/flat/padded destination. There
+is deliberately no compound `normalize`, `softplus`, `sigmoid`, `reduce`,
+`delta_rule`, `update_state`, or `scatter_state` primitive.
+
+## Legal source-specialization contract
+
+- `T>=1`, `K=V=128`, and `tile_v` is a multiple of 16 dividing 128; the target
+  production matrix uses tile 16/32 and the reachable T=1 fallback also uses
+  tile 64.
+- Per-token scatter requires T>=2, state update enabled, no dense cache, and no
+  recovery. Flat scatter is selected only for a contiguous pool.
+- Per-request accepted steps use a device-local int32 `[B]` tensor and make the
+  token loop bound `accepted[n]+1`; without it the loop bound is constexpr T.
+- Dense cache is batch-scoped and indexed by `n`, never by a pool slot.
+- SAME_POOL aliases write addressing to read addressing; a split write index is
+  loaded and clamped only when SAME_POOL is false.
+- `recovery_steps>0` is rejected before this source kernel is selected.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, launch, and storage
+# ===========================================================================
+
+@specialize(
+    T=(1..8),
+    H=(16,8,4,2),
+    HV=(32,16,8,4),
+    K=128,
+    V=128,
+    TILE_V=(16,32,64),
+    USE_QK_L2NORM=(False,True),
+    DISABLE_STATE_UPDATE=(False,True),
+    CACHE_INTERMEDIATE_STATES=(False,True),
+    USE_PACKED_FMA=True,
+    SAME_POOL=(False,True),
+    DISABLE_OUTPUT=(False,True),
+    PER_REQUEST_ACCEPTED_STEPS=(False,True),
+    PER_TOKEN_POOL_SCATTER=(False,True),
+    PER_TOKEN_POOL_SCATTER_FLAT=(False,True),
+    SOFTPLUS_BETA=1.0,
+    SOFTPLUS_THRESHOLD=20.0,
+    SCALE=1.0/sqrt(128.0),
+    target="sm_100a",
+)
+@require(not PER_TOKEN_POOL_SCATTER or
+         (T >= 2 and not CACHE_INTERMEDIATE_STATES and
+          not DISABLE_STATE_UPDATE))
+@require(PER_TOKEN_POOL_SCATTER_FLAT implies PER_TOKEN_POOL_SCATTER)
+@launch(
+    grid=(batch * HV * (128 // TILE_V), 1, 1),
+    block=(128, 1, 1),
+    num_warps=4,
+    dynamic_smem_bytes=(128 if T == 1 else 1096*T + 128),
+)
+def gdn_decode_bf16_ilp4(
+    state,                  # bf16 [pool,HV,128,128], arbitrary slot stride
+    intermediate,           # bf16 [B,T,HV,128,128], flat-pool alias, or dummy
+    A_log,                  # f32 [HV]
+    a,                      # bf16 [B,T,HV]
+    dt_bias,                # f32 [HV]
+    q, k,                   # bf16 [B,T,H,128], independent batch strides
+    v, b_gate,              # bf16 [B,T,HV,128], bf16 [B,T,HV]
+    output,                 # bf16 [B,T,HV,128] or dummy
+    read_indices,           # i32 [B]
+    write_indices,          # i32 [B], dummy when SAME_POOL
+    accepted_steps,         # i32 [B], dummy unless PER_REQUEST_ACCEPTED_STEPS
+    ssm_state_indices,      # i32 [B,T], dummy unless PER_TOKEN_POOL_SCATTER
+    state_slot_stride,      # i64 BF16 elements
+    q_batch_stride,         # i64 BF16 elements
+    k_batch_stride,         # i64 BF16 elements
+    v_batch_stride,         # i64 BF16 elements
+    batch,                  # i32 runtime launch extent
+):
+    NUM_GROUPS = 4
+    LANES_PER_GROUP = 32
+    ELEMS_PER_LANE = 4
+    ILP_ROWS = 4
+    ROWS_PER_GROUP = TILE_V // NUM_GROUPS
+    ROW_QUADS = ROWS_PER_GROUP // ILP_ROWS
+    NUM_V_TILES = 128 // TILE_V
+
+    tid = thread_id(axis="x", extent=128)
+    warp_raw = tid // 32
+    warp = warp_uniform(
+        warp_raw, source_lane=0, member_mask=0xffffffff, clamp=31)
+    # instruction_selection: shfl.sync.idx.b32; extent: one warp-index broadcast
+    lane = tid % 32
+    group = warp
+    k_start = lane * 4
+
+    linear_cta = cta_id(axis="x")
+    v_tile = linear_cta % NUM_V_TILES
+    tmp = linear_cta // NUM_V_TILES
+    hv = tmp % HV
+    n = tmp // HV
+    h = hv // (HV // H)
+
+    if PER_REQUEST_ACCEPTED_STEPS:
+        accepted = copy_g2r(accepted_steps[n])
+        # instruction_selection: ld.global.b32; extent: one i32 runtime bound per CTA thread
+        token_bound = accepted + 1
+    else:
+        token_bound = T
+
+    read_slot_raw = copy_g2r(read_indices[n])
+    # instruction_selection: ld.global.b32; extent: one i32 pool index per CTA thread
+    read_slot = select(read_slot_raw < 0, 0, read_slot_raw)
+    # instruction_selection: max.s32; extent: one null-slot redirect
+    if SAME_POOL:
+        write_slot = read_slot
+        write_state = alias(state[read_slot], state[read_slot])
+    else:
+        write_slot_raw = copy_g2r(write_indices[n])
+        # instruction_selection: ld.global.b32; extent: one split-pool index per CTA thread
+        write_slot = select(write_slot_raw < 0, 0, write_slot_raw)
+        # instruction_selection: max.s32; extent: one null-slot redirect
+        write_state = state[cast("i64", write_slot),hv,:,:]
+    read_state = state[cast("i64", read_slot),hv,:,:]
+
+    A_value = copy_g2r(A_log[hv])
+    # instruction_selection: ld.global.b32; extent: one FP32 head scalar per CTA thread
+    dt_value = copy_g2r(dt_bias[hv])
+    # instruction_selection: ld.global.b32; extent: one FP32 head scalar per CTA thread
+
+    if T > 1:
+        smem = raw_shared(dtype="u8", bytes=1096*T+128, alignment=16)
+        sQ = view(smem[0:544*T-32], dtype="f32", shape=(T,128),
+                  stride=(136,1), alignment=16)
+        sK = view(smem[544*T-32:1088*T-64], dtype="f32", shape=(T,128),
+                  stride=(136,1), alignment=16)
+        sGB = view(smem[1088*T-64:1096*T-64], dtype="f32", shape=(T,2),
+                   stride=(2,1), alignment=16)
+        # The remaining 192 bytes are source allocator/launcher reservation.
+    else:
+        smem = raw_shared(dtype="u8", bytes=128, alignment=16)
+        # No typed shared view is allocated or accessed at T=1.
+
+    r_q_bf16 = reg_tile(dtype="bf16", shape=(4,))
+    r_k_bf16 = reg_tile(dtype="bf16", shape=(4,))
+    r_q = reg_tile(dtype="f32", shape=(4,))
+    r_k = reg_tile(dtype="f32", shape=(4,))
+    r_h_bf16 = reg_tile(dtype="bf16", shape=(4,4))
+    r_h = reg_tile(dtype="f32", shape=(4,4))
+    r_v_bf16 = reg_tile(dtype="bf16", shape=(4,))
+    r_o_bf16 = reg_tile(dtype="bf16", shape=(4,))
+
+    # =======================================================================
+    # T>1 token-shared precompute: one source pass per four tokens
+    # =======================================================================
+
+    if T > 1:
+        for pass_index in static_range(ceil_div(T,4)):
+            t_pre = pass_index*4 + group
+            if t_pre < T:
+                if not DISABLE_OUTPUT:
+                    for i in static_range(4):
+                        r_q_bf16[i] = copy_g2r(q[n,t_pre,h,k_start+i])
+                        # instruction_selection: ld.global.b16; extent: one scalar, four instances
+                for i in static_range(4):
+                    r_k_bf16[i] = copy_g2r(k[n,t_pre,h,k_start+i])
+                    # instruction_selection: ld.global.b16; extent: one scalar, four instances
+
+                if not DISABLE_OUTPUT:
+                    for i in static_range(4):
+                        r_q[i] = cast("f32", r_q_bf16[i])
+                        # instruction_selection: cvt.f32.bf16; extent: one scalar, four instances
+                for i in static_range(4):
+                    r_k[i] = cast("f32", r_k_bf16[i])
+                    # instruction_selection: cvt.f32.bf16; extent: one scalar, four instances
+
+                if USE_QK_L2NORM:
+                    sum_k = 0.0
+                    for i in static_range(4):
+                        sum_k = fma(r_k_bf16[i], r_k_bf16[i], sum_k)
+                        # instruction_selection: fma.rn.f32.bf16; extent: one ordered square-accumulate, four instances
+                    for delta in (16,8,4,2,1):
+                        peer_k = shuffle_xor(sum_k, delta, member_mask=-1, clamp=31)
+                        # instruction_selection: shfl.sync.bfly.b32; extent: one scalar at each explicit full-warp stage
+                        sum_k = add(sum_k, peer_k)
+                        # instruction_selection: add.f32; extent: one scalar at each stage
+                    k_factor = rsqrt(add(sum_k,1.0e-6))
+                    # instruction_selection: add.f32 then rsqrt.approx.ftz.f32; extent: one scalar each
+                    for i in static_range(4):
+                        r_k[i] = mul(r_k[i], k_factor)
+                        # instruction_selection: mul.f32; extent: one scalar, four instances
+
+                    if not DISABLE_OUTPUT:
+                        sum_q = 0.0
+                        for i in static_range(4):
+                            sum_q = fma(r_q_bf16[i], r_q_bf16[i], sum_q)
+                            # instruction_selection: fma.rn.f32.bf16; extent: one ordered square-accumulate, four instances
+                        for delta in (16,8,4,2,1):
+                            peer_q = shuffle_xor(sum_q, delta, member_mask=-1, clamp=31)
+                            # instruction_selection: shfl.sync.bfly.b32; extent: one scalar at each explicit full-warp stage
+                            sum_q = add(sum_q, peer_q)
+                            # instruction_selection: add.f32; extent: one scalar at each stage
+                        q_factor = mul(rsqrt(add(sum_q,1.0e-6)), SCALE)
+                        # instruction_selection: add.f32, rsqrt.approx.ftz.f32, mul.f32; extent: one scalar each
+                        for i in static_range(4):
+                            r_q[i] = mul(r_q[i], q_factor)
+                            # instruction_selection: mul.f32; extent: one scalar, four instances
+                elif not DISABLE_OUTPUT:
+                    for i in static_range(4):
+                        r_q[i] = mul(r_q[i], SCALE)
+                        # instruction_selection: mul.f32; extent: one scalar, four instances
+
+                if not DISABLE_OUTPUT:
+                    for i in static_range(4):
+                        copy_r2s(r_q[i], sQ[t_pre,k_start+i])
+                        # instruction_selection: st.shared.b32; extent: one scalar, four instances
+                for i in static_range(4):
+                    copy_r2s(r_k[i], sK[t_pre,k_start+i])
+                    # instruction_selection: st.shared.b32; extent: one scalar, four instances
+
+                if T > 2:
+                    a_value = copy_g2r(a[n,t_pre,hv])
+                    # instruction_selection: ld.global.b16; extent: one BF16 gate scalar
+                    b_bf16 = copy_g2r(b_gate[n,t_pre,hv])
+                    # instruction_selection: ld.global.b16; extent: one BF16 gate scalar
+                    b_value = cast("f32",b_bf16)
+                    # instruction_selection: cvt.f32.bf16; extent: one scalar
+                    x = add(a_value, dt_value)
+                    # instruction_selection: add.rn.f32.bf16; extent: one mixed scalar add
+                    beta_x = mul(SOFTPLUS_BETA, x)
+                    # instruction_selection: constexpr identity at beta=1; otherwise mul.f32; extent: scalar
+                    exp_beta_x = exp2(mul(beta_x, LOG2E))
+                    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+                    softplus_log = log2(add(1.0, exp_beta_x))
+                    # instruction_selection: add.f32 then lg2.approx.ftz.f32; extent: one scalar each
+                    softplus_value = mul(
+                        mul(reciprocal(SOFTPLUS_BETA), softplus_log), LN2)
+                    # instruction_selection: at beta=1 reciprocal and inner mul fold, then exactly one scalar mul.f32 by LN2; non-unit beta additionally emits rcp/mul
+                    use_softplus = select(
+                        setp_le(beta_x,SOFTPLUS_THRESHOLD), 1.0, 0.0)
+                    # instruction_selection: setp.le.f32 then selp.f32; extent: one scalar each
+                    direct = sub(1.0, use_softplus)
+                    # instruction_selection: sub.f32; extent: one scalar
+                    softplus_x = fma(softplus_value, use_softplus, mul(x,direct))
+                    # instruction_selection: mul.f32 then fma.rn.f32; extent: one scalar each
+                    exp_A = exp2(mul(A_value,LOG2E))
+                    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+                    gate_exponent = mul(sub(0.0,exp_A), softplus_x)
+                    # instruction_selection: neg.f32 then mul.f32; extent: one scalar each
+                    beta = reciprocal(add(1.0,exp2(mul(b_value,-LOG2E))))
+                    # instruction_selection: mul.f32, ex2.approx.ftz.f32, add.f32, rcp.rn.f32; extent: one scalar each
+                    g = exp2(mul(gate_exponent,LOG2E))
+                    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+                    if lane == 0:
+                        copy_r2s((g,beta), sGB[t_pre,0:2])
+                        # instruction_selection: st.shared.v2.b32; extent: one 8-byte pair by lane 0
+
+            cta_barrier()
+            # instruction_selection: bar.sync 0; extent: one CTA-wide publication per pass
+
+    # =======================================================================
+    # Four-row bodies: T=1 fully unrolled, T>1 source loop with unroll=1
+    # =======================================================================
+
+    for row_quad in source_range(
+            ROW_QUADS, unroll=1, unroll_full=(T <= 1)):
+        v_base = v_tile*TILE_V + group*ROWS_PER_GROUP + row_quad*4
+        v_rows = (v_base+0,v_base+1,v_base+2,v_base+3)
+
+        for row in static_range(4):
+            copy_g2r(
+                read_state[v_rows[row],k_start:k_start+4], r_h_bf16[row])
+            # instruction_selection: ld.global.v4.b16 in fixed-bound T1/T2/T3/T4 variants, ld.global.v2.b32 in the evidenced accepted-step T5 variant; extent: one 8-byte BF16 state vector, four explicit rows
+        for i in static_range(4):
+            for row in static_range(4):
+                r_h[row,i] = cast("f32", r_h_bf16[row,i])
+                # instruction_selection: cvt.f32.bf16; extent: one scalar, 16 element-major instances
+
+        for t in runtime_or_static_range(
+                token_bound, unroll=1,
+                unroll_full=(T <= 1 and not PER_REQUEST_ACCEPTED_STEPS)):
+            if T > 1:
+                if not DISABLE_OUTPUT:
+                    copy_s2r(sQ[t,k_start:k_start+4], r_q)
+                    # instruction_selection: ld.shared.v2.b64; extent: one 16-byte FP32 Q vector
+                copy_s2r(sK[t,k_start:k_start+4], r_k)
+                # instruction_selection: ld.shared.v2.b64; extent: one 16-byte FP32 K vector
+                if T > 2:
+                    g,beta = copy_s2r(sGB[t,0:2])
+                    # instruction_selection: ld.shared.v2.b32; extent: one 8-byte g/beta pair
+                else:
+                    g,beta = INLINE_GATE(t)
+                    # instruction_selection: see INLINE_GATE; extent: one scalar chain per row-quad/token/thread
+            else:
+                for i in static_range(4):
+                    r_q_bf16[i] = copy_g2r(q[n,t,h,k_start+i])
+                    # instruction_selection: ld.global.b16; extent: one scalar, four instances per row body
+                for i in static_range(4):
+                    r_k_bf16[i] = copy_g2r(k[n,t,h,k_start+i])
+                    # instruction_selection: ld.global.b16; extent: one scalar, four instances per row body
+                for i in static_range(4):
+                    r_q[i] = cast("f32", r_q_bf16[i])
+                    # instruction_selection: cvt.f32.bf16; extent: one scalar, four instances
+                    r_k[i] = cast("f32", r_k_bf16[i])
+                    # instruction_selection: cvt.f32.bf16; extent: one scalar, four instances
+                if USE_QK_L2NORM:
+                    sum_q = 0.0
+                    sum_k = 0.0
+                    for i in static_range(4):
+                        sum_q = fma(r_q_bf16[i],r_q_bf16[i],sum_q)
+                        # instruction_selection: fma.rn.f32.bf16; extent: one ordered scalar, four instances
+                        sum_k = fma(r_k_bf16[i],r_k_bf16[i],sum_k)
+                        # instruction_selection: fma.rn.f32.bf16; extent: one ordered scalar, four instances
+                    for delta in (16,8,4,2,1):
+                        sum_q = add(sum_q,shuffle_xor(
+                            sum_q,delta,member_mask=-1,clamp=31))
+                        # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one scalar at each explicit stage
+                        sum_k = add(sum_k,shuffle_xor(
+                            sum_k,delta,member_mask=-1,clamp=31))
+                        # instruction_selection: shfl.sync.bfly.b32 then add.f32; extent: one scalar at each explicit stage
+                    q_factor = mul(rsqrt(add(sum_q,1.0e-6)),SCALE)
+                    # instruction_selection: add.f32, rsqrt.approx.ftz.f32, mul.f32; extent: one scalar each
+                    k_factor = rsqrt(add(sum_k,1.0e-6))
+                    # instruction_selection: add.f32 then rsqrt.approx.ftz.f32; extent: one scalar each
+                    for i in static_range(4):
+                        r_q[i] = mul(r_q[i],q_factor)
+                        # instruction_selection: mul.f32; extent: one scalar, four instances
+                        r_k[i] = mul(r_k[i],k_factor)
+                        # instruction_selection: mul.f32; extent: one scalar, four instances
+                else:
+                    for i in static_range(4):
+                        r_q[i] = mul(r_q[i],SCALE)
+                        # instruction_selection: mul.f32; extent: one scalar, four instances
+                g,beta = INLINE_GATE(t)
+                # instruction_selection: see INLINE_GATE; extent: one scalar chain per row body/thread
+
+            dot_hk_lo = reg_tile(dtype="f32", shape=(4,), init=0.0)
+            dot_hk_hi = reg_tile(dtype="f32", shape=(4,), init=0.0)
+            for pair in static_range(2):
+                for row in static_range(4):
+                    r_h[row,2*pair+0] = mul(r_h[row,2*pair+0],g)
+                    # instruction_selection: mul.f32; extent: one scalar decay
+                    r_h[row,2*pair+1] = mul(r_h[row,2*pair+1],g)
+                    # instruction_selection: mul.f32; extent: one scalar decay
+                for row in static_range(4):
+                    dot_hk_lo[row],dot_hk_hi[row] = fma(
+                        r_h[row,2*pair:2*pair+2],
+                        r_k[2*pair:2*pair+2],
+                        (dot_hk_lo[row],dot_hk_hi[row]), lanes=2)
+                    # instruction_selection: fma.rn.f32x2; extent: one packed h-k pair, four rows per pair
+
+            dot_hk = reg_tile(dtype="f32", shape=(4,))
+            for row in static_range(4):
+                dot_hk[row] = add(dot_hk_lo[row],dot_hk_hi[row])
+                # instruction_selection: add.f32; extent: one scalar pair fold per row
+            for delta in (16,8,4,2,1):
+                for row in static_range(4):
+                    peer = shuffle_xor(dot_hk[row],delta,member_mask=-1,clamp=31)
+                    # instruction_selection: shfl.sync.bfly.b32; extent: one scalar, four rows at each explicit stage
+                    dot_hk[row] = add(dot_hk[row],peer)
+                    # instruction_selection: add.f32; extent: one scalar, four rows at each stage
+
+            for row in static_range(4):
+                r_v_bf16[row] = copy_g2r(v[n,t,hv,v_base+row])
+                # instruction_selection: ld.global.b16; extent: one scalar, four instances
+            residual = reg_tile(dtype="f32", shape=(4,))
+            for row in static_range(4):
+                residual[row] = sub(r_v_bf16[row],dot_hk[row])
+                # instruction_selection: sub.rn.f32.bf16; extent: one mixed BF16-FP32 scalar subtract
+                residual[row] = mul(residual[row],beta)
+                # instruction_selection: mul.f32; extent: one scalar
+
+            dot_hq_lo = reg_tile(dtype="f32", shape=(4,), init=0.0)
+            dot_hq_hi = reg_tile(dtype="f32", shape=(4,), init=0.0)
+            for pair in static_range(2):
+                for row in static_range(4):
+                    r_h[row,2*pair:2*pair+2] = fma(
+                        r_k[2*pair:2*pair+2],
+                        (residual[row],residual[row]),
+                        r_h[row,2*pair:2*pair+2], lanes=2)
+                    # instruction_selection: fma.rn.f32x2; extent: one packed rank-one update
+                if not DISABLE_OUTPUT:
+                    for row in static_range(4):
+                        dot_hq_lo[row],dot_hq_hi[row] = fma(
+                            r_h[row,2*pair:2*pair+2],
+                            r_q[2*pair:2*pair+2],
+                            (dot_hq_lo[row],dot_hq_hi[row]), lanes=2)
+                        # instruction_selection: fma.rn.f32x2; extent: one packed h-q pair
+
+            if not DISABLE_OUTPUT:
+                dot_hq = reg_tile(dtype="f32", shape=(4,))
+                for row in static_range(4):
+                    dot_hq[row] = add(dot_hq_lo[row],dot_hq_hi[row])
+                    # instruction_selection: add.f32; extent: one scalar pair fold per row, before any state conversion/store
+
+            if CACHE_INTERMEDIATE_STATES or PER_TOKEN_POOL_SCATTER:
+                if PER_TOKEN_POOL_SCATTER and not PER_TOKEN_POOL_SCATTER_FLAT and not SAME_POOL:
+                    for i in static_range(4):
+                        for row in static_range(4):
+                            r_h_bf16[row,i] = cast(
+                                "bf16",r_h[row,i],rounding="rn")
+                            # instruction_selection: cvt.rn.bf16.f32; extent: four row conversions per element, 16 element-major instances
+                else:
+                    for row in static_range(4):
+                        r_h_bf16[row] = cast(
+                            "bf16x4", r_h[row], rounding="rn")
+                        # instruction_selection: cvt.rn.bf16x2.f32; extent: two pair conversions per row in packed variants
+
+            if PER_TOKEN_POOL_SCATTER:
+                pool_slot_t = copy_g2r(ssm_state_indices[n,t])
+                # instruction_selection: ld.global.b32; extent: one per-token slot per CTA thread
+                if PER_TOKEN_POOL_SCATTER_FLAT:
+                    flat = cast("i64",pool_slot_t)*HV + hv
+                    for row in static_range(4):
+                        copy_r2g(
+                            r_h_bf16[row],
+                            intermediate[flat,v_rows[row],k_start:k_start+4])
+                        # instruction_selection: st.global.v2.b32; extent: one 8-byte state vector per row
+                else:
+                    scatter_state = state[cast("i64",pool_slot_t),hv,:,:]
+                    for row in static_range(4):
+                        copy_r2g(
+                            r_h_bf16[row],
+                            scatter_state[v_rows[row],k_start:k_start+4])
+                        # instruction_selection: st.global.v2.b32; extent: one 8-byte padded-pool state vector per row
+            elif CACHE_INTERMEDIATE_STATES:
+                dense = cast("i64",n*T*HV + t*HV + hv)
+                for row in static_range(4):
+                    copy_r2g(
+                        r_h_bf16[row],
+                        intermediate[dense,v_rows[row],k_start:k_start+4])
+                    # instruction_selection: st.global.v2.b32; extent: one 8-byte dense-cache state vector per row
+
+            if not DISABLE_OUTPUT:
+                for delta in (16,8,4,2,1):
+                    for row in static_range(4):
+                        peer = shuffle_xor(
+                            dot_hq[row],delta,member_mask=-1,clamp=31)
+                        # instruction_selection: shfl.sync.bfly.b32; extent: one scalar, four rows at each explicit stage
+                        dot_hq[row] = add(dot_hq[row],peer)
+                        # instruction_selection: add.f32; extent: one scalar, four rows at each stage
+                if lane == 0:
+                    for row in static_range(4):
+                        r_o_bf16[row] = cast(
+                            "bf16",dot_hq[row],rounding="rn")
+                        # instruction_selection: cvt.rn.bf16.f32; extent: one scalar, four rows
+                    for row in static_range(4):
+                        copy_r2g(r_o_bf16[row],output[n,t,hv,v_base+row])
+                        # instruction_selection: st.global.b16; extent: one scalar, four instances by lane 0
+
+        # Source final write is independent of dense caching. In cache/scatter
+        # modes r_h_bf16 already contains the last processed token state.
+        if not DISABLE_STATE_UPDATE:
+            if not (PER_TOKEN_POOL_SCATTER and SAME_POOL):
+                if not CACHE_INTERMEDIATE_STATES and not PER_TOKEN_POOL_SCATTER:
+                    for row in static_range(4):
+                        r_h_bf16[row] = cast(
+                            "bf16x4",r_h[row],rounding="rn")
+                        # instruction_selection: cvt.rn.bf16x2.f32; extent: two pair conversions per row
+                for row in static_range(4):
+                    copy_r2g(
+                        r_h_bf16[row],
+                        write_state[v_rows[row],k_start:k_start+4])
+                    # instruction_selection: st.global.v4.b16 in padded split-scatter, otherwise st.global.v2.b32; extent: one 8-byte final-state vector per row
+
+# ===========================================================================
+# INLINE_GATE — source gate chain for T=1 and T=2
+# ===========================================================================
+
+def INLINE_GATE(t):
+    a_value = copy_g2r(a[n,t,hv])
+    # instruction_selection: ld.global.b16; extent: one BF16 gate scalar
+    b_bf16 = copy_g2r(b_gate[n,t,hv])
+    # instruction_selection: ld.global.b16; extent: one BF16 gate scalar
+    b_value = cast("f32",b_bf16)
+    # instruction_selection: cvt.f32.bf16; extent: one scalar
+    x = add(a_value,dt_value)
+    # instruction_selection: add.rn.f32.bf16; extent: one mixed scalar add
+    beta_x = mul(SOFTPLUS_BETA,x)
+    # instruction_selection: constexpr identity at beta=1; otherwise mul.f32; extent: scalar
+    exp_beta_x = exp2(mul(beta_x,LOG2E))
+    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+    softplus_log = log2(add(1.0,exp_beta_x))
+    # instruction_selection: add.f32 then lg2.approx.ftz.f32; extent: one scalar each
+    softplus_value = mul(
+        mul(reciprocal(SOFTPLUS_BETA),softplus_log),LN2)
+    # instruction_selection: at beta=1 reciprocal and inner mul fold, then exactly one scalar mul.f32 by LN2; non-unit beta additionally emits rcp/mul
+    use_softplus = select(setp_le(beta_x,SOFTPLUS_THRESHOLD),1.0,0.0)
+    # instruction_selection: setp.le.f32 then selp.f32; extent: one scalar each
+    direct = sub(1.0,use_softplus)
+    # instruction_selection: sub.f32; extent: one scalar
+    softplus_x = fma(softplus_value,use_softplus,mul(x,direct))
+    # instruction_selection: mul.f32 then fma.rn.f32; extent: one scalar each
+    exp_A = exp2(mul(A_value,LOG2E))
+    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+    gate_exponent = mul(sub(0.0,exp_A),softplus_x)
+    # instruction_selection: neg.f32 then mul.f32; extent: one scalar each
+    beta = reciprocal(add(1.0,exp2(mul(b_value,-LOG2E))))
+    # instruction_selection: mul.f32, ex2.approx.ftz.f32, add.f32, rcp.rn.f32; extent: one scalar each
+    g = exp2(mul(gate_exponent,LOG2E))
+    # instruction_selection: mul.f32 then ex2.approx.ftz.f32; extent: one scalar each
+    return g,beta
+```
+
+## Storage ownership and lifetimes
+
+| storage | logical owner | lifetime and alias rule |
+| --- | --- | --- |
+| sQ `[T,128]`, stride 136 | token-owning warp publishes its four-element segment | T>1 only; live after the pass barrier through every row-quad/token body; dead when output is disabled |
+| sK `[T,128]`, stride 136 | token-owning warp publishes its four-element segment | T>1 only; live after the pass barrier through all row bodies |
+| sGB `[T,2]` | lane 0 of the token-owning warp | T>2 only; immutable after the pass barrier |
+| r_h `[4,4]` | one lane in one physical warp/group | one row-quad body; loaded once and carried across its accepted token loop |
+| r_h_bf16 `[4,4]` | same lane | initial loads, then reused for cache/scatter/final stores after explicit repacking |
+| read/write state views | one CTA and disjoint V/K segments | exact alias under SAME_POOL; otherwise distinct i64 slot bases |
+| dense intermediate | one `(n,t,hv,V,K)` region | batch-scoped, written after each processed token |
+| flat/padded scatter | one caller-selected slot per `(n,t)` | flat route uses i64 `(slot*HV+hv)`; padded route retains 4-D slot stride |
+
+No data race depends on scheduling. Each warp owns disjoint V rows, each lane
+owns disjoint K segments, lane zero uniquely owns the four output values, and
+every T>1 precompute pass completes at a CTA barrier before shared consumption.
+
+## Control-flow modes
+
+| mode | token loop | state destinations |
+| --- | --- | --- |
+| T=1 production | one fully unrolled token inside each fully unrolled row body | final same/split pool state |
+| T>1 production cache | constexpr T tokens | dense cache after every token; pool remains unchanged because production disables state update |
+| per-request accepted | runtime `accepted[n]+1` tokens | output/cache/scatter only for processed tokens; optional final pool contains h_K |
+| state-only | same token bound, output dot/reduction/store removed | final/cache/scatter routes remain |
+| per-token scatter | same token bound | every h_{t+1} to `ssm_state_indices[n,t]`; same-pool final write suppressed, split final write retained |
+
+## TIRx module and benchmark contract
+
+- Registry name: `gdn_decode_bf16_ilp4`; supported compute capability is 10.
+- Correctness uses the frozen FlashInfer ILP4 path, not a mathematical oracle,
+  and covers all compile-time modes in the legal contract plus T=1/T=2/T>2
+  and odd precompute tails.
+- Performance contains exactly 48 production workloads: T in {1,2,4,8}, the
+  four Qwen3-Next `(H,HV)` pairs, and only batch sizes reaching this fallback.
+- T=1 performance enables final state update without dense cache. T>1
+  performance enables output and dense cache while disabling final pool update.
+- Only a complete target-filtered `python -m tirx_kernels.bench_suite` run may
+  accept performance, and every `flashinfer_cutedsl_us / tirx_us` ratio must be
+  strictly greater than 0.99.
+
+## Instruction selection is a lowering consequence
+
+- T=1 and T>1 Q/K use four scalar `ld.global.b16` operations per segment; T>1
+  shared Q/K consumption uses one `ld.shared.v2.b64`. State loads are
+  `ld.global.v4.b16` in the evidenced fixed-bound variants and `ld.global.v2.b32`
+  in the accepted T5 variant. V and output use four scalar `ld.global.b16` and
+  `st.global.b16` operations per row body/token.
+- Q/K shared publication uses scalar `st.shared.b32`; T>2 g/beta publication
+  uses lane-zero `st.shared.v2.b32`; every pass ends with `bar.sync 0`.
+- Every reduction uses full-warp `shfl.sync.bfly.b32` at offsets
+  16,8,4,2,1 with clamp 31.
+- State decay uses scalar `mul.f32`. h-k and h-q pair accumulation, and the
+  rank-one update, use `fma.rn.f32x2`; pair halves are explicitly folded with
+  `add.f32` before the shuffle tree.
+- L2 and gate math use `rsqrt.approx.ftz.f32`, `ex2.approx.ftz.f32`,
+  `lg2.approx.ftz.f32`, and `rcp.rn.f32`. The BF16 V residual selects
+  `sub.rn.f32.bf16`.
+- Output is four lane-zero scalar `st.global.b16` operations. Packed state modes
+  use two `cvt.rn.bf16x2.f32` conversions per row; padded split-scatter uses four
+  scalar conversions and `st.global.v4.b16` for its final row, while its
+  per-token scatter and other final modes retain `st.global.v2.b32`.
+- The source row-quad loop is fully unrolled only at T=1. T>1 retains the
+  source `unroll=1` loop shape; replacing it with a generic output-element loop
+  or a different warp/lane mapping is not faithful.

--- a/tests/lint/check_gdn_decode_bf16_ilp4_no_tile.py
+++ b/tests/lint/check_gdn_decode_bf16_ilp4_no_tile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every BF16 ILP4 GDN specialization."""
+
+from __future__ import annotations
+
+import sys
+
+import check_gdn_decode_bf16_wide_vec_t1_no_tile as no_tile
+
+from tirx_kernels.flashinfer.gdn_decode import gdn_decode_bf16_ilp4 as target
+
+no_tile.target = target
+no_tile.TARGET = no_tile.REPO / "tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py"
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/config/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.yaml
@@ -1,0 +1,52 @@
+# Complete SM100 BF16 ILP4 fallback production dispatch matrix for Qwen3-Next
+# TP1/2/4/8 and T=1/2/4/8. Every row is required by the port performance gate.
+kernel: gdn_decode_bf16_ilp4
+configs:
+  - {config: t1_b1_h16_hv32_tv16, default: true}
+  - {config: t1_b4_h16_hv32_tv16, default: true}
+  - {config: t1_b8_h16_hv32_tv32, default: true}
+  - {config: t1_b1_h8_hv16_tv16, default: true}
+  - {config: t1_b4_h8_hv16_tv16, default: true}
+  - {config: t1_b8_h8_hv16_tv16, default: true}
+  - {config: t1_b16_h8_hv16_tv32, default: true}
+  - {config: t1_b1_h4_hv8_tv16, default: true}
+  - {config: t1_b4_h4_hv8_tv16, default: true}
+  - {config: t1_b8_h4_hv8_tv16, default: true}
+  - {config: t1_b16_h4_hv8_tv16, default: true}
+  - {config: t1_b32_h4_hv8_tv32, default: true}
+  - {config: t1_b1_h2_hv4_tv16, default: true}
+  - {config: t1_b4_h2_hv4_tv16, default: true}
+  - {config: t1_b8_h2_hv4_tv16, default: true}
+  - {config: t1_b16_h2_hv4_tv16, default: true}
+  - {config: t1_b32_h2_hv4_tv16, default: true}
+  - {config: t1_b64_h2_hv4_tv32, default: true}
+  - {config: t2_b1_h16_hv32_tv16, default: true}
+  - {config: t2_b1_h8_hv16_tv16, default: true}
+  - {config: t2_b4_h8_hv16_tv16, default: true}
+  - {config: t2_b1_h4_hv8_tv16, default: true}
+  - {config: t2_b4_h4_hv8_tv16, default: true}
+  - {config: t2_b8_h4_hv8_tv16, default: true}
+  - {config: t2_b1_h2_hv4_tv16, default: true}
+  - {config: t2_b4_h2_hv4_tv16, default: true}
+  - {config: t2_b8_h2_hv4_tv16, default: true}
+  - {config: t2_b16_h2_hv4_tv16, default: true}
+  - {config: t4_b1_h16_hv32_tv16, default: true}
+  - {config: t4_b1_h8_hv16_tv16, default: true}
+  - {config: t4_b4_h8_hv16_tv16, default: true}
+  - {config: t4_b1_h4_hv8_tv16, default: true}
+  - {config: t4_b4_h4_hv8_tv16, default: true}
+  - {config: t4_b8_h4_hv8_tv16, default: true}
+  - {config: t4_b1_h2_hv4_tv16, default: true}
+  - {config: t4_b4_h2_hv4_tv16, default: true}
+  - {config: t4_b8_h2_hv4_tv16, default: true}
+  - {config: t4_b16_h2_hv4_tv16, default: true}
+  - {config: t8_b1_h16_hv32_tv16, default: true}
+  - {config: t8_b1_h8_hv16_tv16, default: true}
+  - {config: t8_b4_h8_hv16_tv16, default: true}
+  - {config: t8_b1_h4_hv8_tv16, default: true}
+  - {config: t8_b4_h4_hv8_tv16, default: true}
+  - {config: t8_b8_h4_hv8_tv16, default: true}
+  - {config: t8_b1_h2_hv4_tv16, default: true}
+  - {config: t8_b4_h2_hv4_tv16, default: true}
+  - {config: t8_b8_h2_hv4_tv16, default: true}
+  - {config: t8_b16_h2_hv4_tv16, default: true}

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
@@ -1,0 +1,1367 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Integration scaffold for FlashInfer's SM100 BF16 ILP4 GDN decode kernel.
+
+Upstream source: flashinfer/gdn_kernels/gdn_decode_bf16_state.py.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import math
+from pathlib import Path
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+from tvm.tirx.bench import bench
+
+KERNEL_META = {"name": "gdn_decode_bf16_ilp4", "category": "flashinfer", "compute_capability": 10}
+
+FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
+FROZEN_FLASHINFER_SOURCE_SHA256 = "61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61"
+
+K = 128
+V = 128
+THREADS = 128
+NUM_WARPS = 4
+NUM_GROUPS = 4
+LANES_PER_GROUP = 32
+ELEMS_PER_LANE = 4
+ILP_ROWS = 4
+SOURCE_NUM_SMS = 148
+LOG2_E = 1.4426950408889634
+LN_2 = 0.6931471805599453
+SCALE = 1.0 / math.sqrt(K)
+
+
+def _ptx_unary(chain: str, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _ptx_ternary(chain: str, lhs, rhs, acc):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _sub_f32(lhs, rhs):
+    return _ptx_binary("sub.f32", lhs, rhs)
+
+
+def _neg_f32(value):
+    return _ptx_unary("neg.f32", value)
+
+
+def _mul_f32(lhs, rhs):
+    return _ptx_binary("mul.f32", lhs, rhs)
+
+
+def _fma_f32(lhs, rhs, acc):
+    return _ptx_ternary("fma.rn.f32", lhs, rhs, acc)
+
+
+def _exp2_f32(value):
+    return _ptx_unary("ex2.approx.ftz.f32", value)
+
+
+def _log2_f32(value):
+    return _ptx_unary("lg2.approx.ftz.f32", value)
+
+
+def _rcp_f32(value):
+    return _ptx_unary("rcp.rn.f32", value)
+
+
+def _rsqrt_f32(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _max_s32(lhs, rhs):
+    return _ptx_binary("max.s32", lhs, rhs, dtype="int32")
+
+
+def _global_load_u16(buffer, index):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_s32(buffer, index):
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.s32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_f32(buffer, index):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _bf16_to_f32(bits):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.cvt.f32.bf16(out[0], T.cast(bits, "uint16")))
+    return out[0]
+
+
+def _f32_to_bf16(value):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.cvt.rn.bf16.f32(out[0], value))
+    return out[0]
+
+
+def _mixed_add_bf16_f32(bits, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.add.rn.f32.bf16(out[0], T.cast(bits, "uint16"), value))
+    return out[0]
+
+
+def _mixed_sub_bf16_f32(bits, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.sub.rn.f32.bf16(out[0], T.cast(bits, "uint16"), value))
+    return out[0]
+
+
+def _bf16_square_fma(bits, acc):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.fma.rn.f32.bf16(out[0], T.cast(bits, "uint16"), T.cast(bits, "uint16"), acc))
+    return out[0]
+
+
+def _shared_store_f32(buffer, index, value):
+    T.evaluate(T.ptx.st.shared.b32(buffer.ptr_to([index]), T.reinterpret("uint32", value)))
+
+
+def _shared_store_f32x2(buffer, index, value0, value1):
+    T.evaluate(
+        T.ptx.st.shared.v2.b32(
+            buffer.ptr_to([index]), T.reinterpret("uint32", value0), T.reinterpret("uint32", value1)
+        )
+    )
+
+
+@T.inline
+def _global_store_u16x4(buffer, index, values):
+    base: T.let = buffer.ptr_to([index])
+    T.evaluate(T.ptx.st.global_.b16(base, values[0]))
+    T.evaluate(T.ptx.st.global_.b16(T.ptr_byte_offset(base, 2, "bfloat16"), values[1]))
+    T.evaluate(T.ptx.st.global_.b16(T.ptr_byte_offset(base, 4, "bfloat16"), values[2]))
+    T.evaluate(T.ptx.st.global_.b16(T.ptr_byte_offset(base, 6, "bfloat16"), values[3]))
+
+
+@T.inline
+def _shared_load_f32x2(buffer, index, values):
+    words = T.alloc_local((2,), "uint32", align=8)
+    T.evaluate(T.ptx.ld.shared.v2.b32(words[0], words[1], buffer.ptr_to([index])))
+    values[0] = T.reinterpret("float32", words[0])
+    values[1] = T.reinterpret("float32", words[1])
+
+
+@T.inline
+def _shared_load_f32x4(buffer, index, values):
+    pairs = T.alloc_local((2,), "uint64", align=16)
+    T.evaluate(T.ptx.ld.shared.v2.b64(pairs[0], pairs[1], buffer.ptr_to([index])))
+    values[0] = T.cuda.float2_x(pairs[0])
+    values[1] = T.cuda.float2_y(pairs[0])
+    values[2] = T.cuda.float2_x(pairs[1])
+    values[3] = T.cuda.float2_y(pairs[1])
+
+
+@T.inline
+def _load_state_bf16x16(buffer, index, values):
+    bits = T.alloc_local((ILP_ROWS * ELEMS_PER_LANE,), "uint16", align=8)
+    for row in T.unroll(ILP_ROWS):
+        base: T.int32 = row * ELEMS_PER_LANE
+        T.evaluate(
+            T.ptx.ld.global_.v4.b16(
+                bits[base],
+                bits[base + 1],
+                bits[base + 2],
+                bits[base + 3],
+                buffer.ptr_to([index + row * K]),
+            )
+        )
+    for elem in T.unroll(ELEMS_PER_LANE):
+        for row in T.unroll(ILP_ROWS):
+            values[row * ELEMS_PER_LANE + elem] = _bf16_to_f32(bits[row * ELEMS_PER_LANE + elem])
+
+
+@T.inline
+def _store_state_f32x16(buffer, index, values):
+    words = T.alloc_local((ILP_ROWS * 2,), "uint32", align=8)
+    for pair in T.unroll(ELEMS_PER_LANE // 2):
+        for row in T.unroll(ILP_ROWS):
+            words[row * 2 + pair] = T.cuda.float22bfloat162_rn(
+                values[row * ELEMS_PER_LANE + pair * 2], values[row * ELEMS_PER_LANE + pair * 2 + 1]
+            )
+    for row in T.unroll(ILP_ROWS):
+        T.evaluate(
+            T.ptx.st.global_.v2.b32(
+                buffer.ptr_to([index + row * K]), words[row * 2], words[row * 2 + 1]
+            )
+        )
+
+
+def _packed_fma(lhs0, lhs1, rhs0, rhs1, acc0, acc1):
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(
+        T.ptx.fma.rn.f32x2(
+            out[0],
+            T.cuda.make_float2(lhs0, lhs1),
+            T.cuda.make_float2(rhs0, rhs1),
+            T.cuda.make_float2(acc0, acc1),
+        )
+    )
+    return out[0]
+
+
+def _gate_pair(a, b_gate, A_value, dt_value, index):
+    a_bits: T.uint16 = _global_load_u16(a, index)
+    b_bits: T.uint16 = _global_load_u16(b_gate, index)
+    b_value: T.float32 = _bf16_to_f32(b_bits)
+    x_value: T.float32 = _mixed_add_bf16_f32(a_bits, dt_value)
+    softplus_exp: T.float32 = _exp2_f32(_mul_f32(x_value, T.float32(LOG2_E)))
+    softplus_value: T.float32 = _mul_f32(
+        _log2_f32(_add_f32(T.float32(1.0), softplus_exp)), T.float32(LN_2)
+    )
+    use_softplus: T.float32 = T.if_then_else(
+        x_value <= T.float32(20.0), T.float32(1.0), T.float32(0.0)
+    )
+    softplus_x: T.float32 = _fma_f32(
+        softplus_value, use_softplus, _mul_f32(x_value, _sub_f32(T.float32(1.0), use_softplus))
+    )
+    exp_A: T.float32 = _exp2_f32(_mul_f32(A_value, T.float32(LOG2_E)))
+    gate_exponent: T.float32 = _mul_f32(_neg_f32(exp_A), softplus_x)
+    beta: T.float32 = _rcp_f32(
+        _add_f32(T.float32(1.0), _exp2_f32(_mul_f32(b_value, T.float32(-LOG2_E))))
+    )
+    g_value: T.float32 = _exp2_f32(_mul_f32(gate_exponent, T.float32(LOG2_E)))
+    return T.cuda.make_float2(g_value, beta)
+
+
+_SEQ_LENS = (1, 2, 4, 8)
+_HEAD_CONFIGS = ((16, 32), (8, 16), (4, 8), (2, 4))
+_BATCH_SIZES = (1, 4, 8, 16, 32, 64, 128, 256, 512)
+
+
+def _production_tile_v(seq_len: int, batch: int, num_v_heads: int) -> int | None:
+    work_units = batch * num_v_heads
+    if seq_len == 1:
+        if work_units >= 512:
+            return None
+        if work_units <= 128:
+            return 16
+        if work_units * 2 >= 4 * SOURCE_NUM_SMS:
+            return 64
+        return 32
+    return 16 if work_units < 128 else None
+
+
+def _production_case(seq_len: int, batch: int, num_heads: int, num_v_heads: int) -> dict[str, Any]:
+    tile_v = _production_tile_v(seq_len, batch, num_v_heads)
+    if tile_v is None:
+        raise ValueError("shape does not dispatch to the BF16 ILP4 source kernel")
+    return {
+        "label": f"t{seq_len}_b{batch}_h{num_heads}_hv{num_v_heads}_tv{tile_v}",
+        "seq_len": seq_len,
+        "batch": batch,
+        "num_heads": num_heads,
+        "num_v_heads": num_v_heads,
+        "tile_v": tile_v,
+        "use_qk_l2norm": True,
+        "disable_state_update": seq_len > 1,
+        "cache_intermediate_states": seq_len > 1,
+        "disable_output": False,
+    }
+
+
+BENCH_CONFIGS = [
+    _production_case(seq_len, batch, num_heads, num_v_heads)
+    for seq_len in _SEQ_LENS
+    for num_heads, num_v_heads in _HEAD_CONFIGS
+    for batch in _BATCH_SIZES
+    if _production_tile_v(seq_len, batch, num_v_heads) is not None
+]
+
+
+def _correctness_case(
+    label: str,
+    *,
+    seq_len: int = 4,
+    batch: int = 2,
+    num_heads: int = 16,
+    num_v_heads: int = 32,
+    tile_v: int = 16,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    return {
+        "label": label,
+        "seq_len": seq_len,
+        "batch": batch,
+        "num_heads": num_heads,
+        "num_v_heads": num_v_heads,
+        "tile_v": tile_v,
+        **kwargs,
+    }
+
+
+CONFIGS = [dict(config) for config in BENCH_CONFIGS] + [
+    _correctness_case(
+        "t1_tv64_source_picker", seq_len=1, batch=96, num_heads=2, num_v_heads=4, tile_v=64
+    ),
+    _correctness_case("t1_l2off", seq_len=1, use_qk_l2norm=False),
+    _correctness_case(
+        "t1_split_padded_negative",
+        seq_len=1,
+        same_pool=False,
+        padded_pool=True,
+        negative_read_index=True,
+        negative_write_index=True,
+    ),
+    _correctness_case("t1_packed_qkv", seq_len=1, packed_qkv=True),
+    _correctness_case(
+        "t1_accepted", seq_len=1, per_request_accepted_steps=True, accepted_steps=(0, 0)
+    ),
+    _correctness_case("t2_base", seq_len=2),
+    _correctness_case("t2_state_only", seq_len=2, disable_output=True),
+    _correctness_case("t3_precompute_tail", seq_len=3),
+    _correctness_case(
+        "t5_accepted", seq_len=5, per_request_accepted_steps=True, accepted_steps=(1, 4)
+    ),
+    _correctness_case("t4_cache_update", cache_intermediate_states=True),
+    _correctness_case("t4_split", same_pool=False),
+    _correctness_case("t4_padded", padded_pool=True),
+    _correctness_case(
+        "t3_cache_no_output", seq_len=3, cache_intermediate_states=True, disable_output=True
+    ),
+    _correctness_case("t4_scatter_flat", per_token_pool_scatter=True),
+    _correctness_case("t4_scatter_flat_split", same_pool=False, per_token_pool_scatter=True),
+    _correctness_case("t4_scatter_padded", padded_pool=True, per_token_pool_scatter=True),
+    _correctness_case(
+        "t4_scatter_padded_split", padded_pool=True, same_pool=False, per_token_pool_scatter=True
+    ),
+    _correctness_case(
+        "t5_accepted_scatter",
+        seq_len=5,
+        per_request_accepted_steps=True,
+        accepted_steps=(2, 4),
+        per_token_pool_scatter=True,
+    ),
+    _correctness_case("t4_disable_update", disable_state_update=True),
+]
+
+assert len(BENCH_CONFIGS) == 48
+
+
+@T.jit
+def _gdn_decode_bf16_ilp4(
+    state_h: T.handle,
+    intermediate_h: T.handle,
+    A_log_h: T.handle,
+    a_h: T.handle,
+    dt_bias_h: T.handle,
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    b_h: T.handle,
+    output_h: T.handle,
+    read_indices_h: T.handle,
+    write_indices_h: T.handle,
+    accepted_steps_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    state_slot_stride: T.int64,
+    q_batch_stride: T.int64,
+    k_batch_stride: T.int64,
+    v_batch_stride: T.int64,
+    batch: T.int32,
+    *,
+    SEQ_LEN: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_V_HEADS: T.constexpr,
+    TILE_V: T.constexpr,
+    NUM_V_TILES: T.constexpr,
+    ROWS_PER_GROUP: T.constexpr,
+    ITERS_PER_GROUP: T.constexpr,
+    POOL_FACTOR: T.constexpr,
+    INTERMEDIATE_BATCH_STRIDE: T.constexpr,
+    INTERMEDIATE_DUMMY_ELEMENTS: T.constexpr,
+    ACCEPTED_BATCH_STRIDE: T.constexpr,
+    ACCEPTED_DUMMY_ELEMENTS: T.constexpr,
+    SSM_BATCH_STRIDE: T.constexpr,
+    SSM_DUMMY_ELEMENTS: T.constexpr,
+    SHARED_BYTES: T.constexpr,
+    S_K_BYTE_OFFSET: T.constexpr,
+    S_GB_BYTE_OFFSET: T.constexpr,
+    USE_QK_L2NORM: T.constexpr,
+    DISABLE_STATE_UPDATE: T.constexpr,
+    CACHE_INTERMEDIATE_STATES: T.constexpr,
+    SAME_POOL: T.constexpr,
+    DISABLE_OUTPUT: T.constexpr,
+    PER_REQUEST_ACCEPTED_STEPS: T.constexpr,
+    PER_TOKEN_POOL_SCATTER: T.constexpr,
+    PER_TOKEN_POOL_SCATTER_FLAT: T.constexpr,
+):
+    state = T.match_buffer(
+        state_h,
+        (state_slot_stride * T.cast(batch * POOL_FACTOR, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    intermediate = T.match_buffer(
+        intermediate_h,
+        (T.cast(batch * INTERMEDIATE_BATCH_STRIDE + INTERMEDIATE_DUMMY_ELEMENTS, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    A_log = T.match_buffer(A_log_h, (NUM_V_HEADS,), "float32", scope="global")
+    a = T.match_buffer(
+        a_h, (T.cast(batch * SEQ_LEN * NUM_V_HEADS, "int64"),), "bfloat16", scope="global"
+    )
+    dt_bias = T.match_buffer(dt_bias_h, (NUM_V_HEADS,), "float32", scope="global")
+    q = T.match_buffer(
+        q_h,
+        (q_batch_stride * T.cast(batch - 1, "int64") + T.cast(SEQ_LEN * NUM_HEADS * K, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    k = T.match_buffer(
+        k_h,
+        (k_batch_stride * T.cast(batch - 1, "int64") + T.cast(SEQ_LEN * NUM_HEADS * K, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    v = T.match_buffer(
+        v_h,
+        (v_batch_stride * T.cast(batch - 1, "int64") + T.cast(SEQ_LEN * NUM_V_HEADS * V, "int64"),),
+        "bfloat16",
+        scope="global",
+    )
+    b_gate = T.match_buffer(
+        b_h, (T.cast(batch * SEQ_LEN * NUM_V_HEADS, "int64"),), "bfloat16", scope="global"
+    )
+    output = T.match_buffer(
+        output_h, (T.cast(batch * SEQ_LEN * NUM_V_HEADS * V, "int64"),), "bfloat16", scope="global"
+    )
+    read_indices = T.match_buffer(
+        read_indices_h, (T.cast(batch, "int64"),), "int32", scope="global"
+    )
+    write_indices = T.match_buffer(
+        write_indices_h, (T.cast(batch, "int64"),), "int32", scope="global"
+    )
+    accepted_steps = T.match_buffer(
+        accepted_steps_h,
+        (T.cast(batch * ACCEPTED_BATCH_STRIDE + ACCEPTED_DUMMY_ELEMENTS, "int64"),),
+        "int32",
+        scope="global",
+    )
+    ssm_state_indices = T.match_buffer(
+        ssm_state_indices_h,
+        (T.cast(batch * SSM_BATCH_STRIDE + SSM_DUMMY_ELEMENTS, "int64"),),
+        "int32",
+        scope="global",
+    )
+    T.device_entry()
+    T.attr({"tirx.launch_bounds_min_blocks_per_sm": 8})
+
+    linear_cta = T.cta_id([batch * NUM_V_HEADS * NUM_V_TILES])
+    tid = T.thread_id([THREADS])
+    warp: T.int32 = tid // LANES_PER_GROUP
+    lane: T.int32 = tid % LANES_PER_GROUP
+    k_start: T.int32 = lane * ELEMS_PER_LANE
+
+    v_tile: T.int32 = linear_cta % NUM_V_TILES
+    cta_head: T.int32 = linear_cta // NUM_V_TILES
+    hv: T.int32 = cta_head % NUM_V_HEADS
+    n: T.int32 = cta_head // NUM_V_HEADS
+    h: T.int32 = hv // (NUM_V_HEADS // NUM_HEADS)
+
+    read_slot: T.int32 = _max_s32(_global_load_s32(read_indices, n), T.int32(0))
+    write_slot: T.int32 = read_slot
+    if not SAME_POOL:
+        write_slot = _max_s32(_global_load_s32(write_indices, n), T.int32(0))
+    read_state_base: T.int64 = T.cast(read_slot, "int64") * state_slot_stride + T.cast(
+        hv * V * K, "int64"
+    )
+    write_state_base: T.int64 = read_state_base
+    if not SAME_POOL:
+        write_state_base = T.cast(write_slot, "int64") * state_slot_stride + T.cast(
+            hv * V * K, "int64"
+        )
+
+    A_value: T.float32 = _global_load_f32(A_log, hv)
+    dt_value: T.float32 = _global_load_f32(dt_bias, hv)
+    token_bound: T.int32 = T.int32(SEQ_LEN)
+    if PER_REQUEST_ACCEPTED_STEPS:
+        token_bound = _global_load_s32(accepted_steps, n) + T.int32(1)
+
+    pool = T.SMEMPool()
+    smem_raw = pool.alloc((SHARED_BYTES,), "uint8", align=16)
+    if SEQ_LEN > 1:
+        s_q = T.decl_buffer(
+            (SEQ_LEN * (K + 8),),
+            "float32",
+            data=smem_raw.data,
+            scope="shared.dyn",
+            byte_offset=0,
+            align=16,
+        )
+        s_k = T.decl_buffer(
+            (SEQ_LEN * (K + 8),),
+            "float32",
+            data=smem_raw.data,
+            scope="shared.dyn",
+            byte_offset=S_K_BYTE_OFFSET,
+            align=16,
+        )
+        s_gb = T.decl_buffer(
+            (SEQ_LEN * 2,),
+            "float32",
+            data=smem_raw.data,
+            scope="shared.dyn",
+            byte_offset=S_GB_BYTE_OFFSET,
+            align=16,
+        )
+    pool.commit()
+
+    if SEQ_LEN > 1:
+        for pass_index in T.unroll((SEQ_LEN + NUM_WARPS - 1) // NUM_WARPS):
+            t_pre: T.int32 = pass_index * NUM_WARPS + warp
+            if t_pre < SEQ_LEN:
+                q_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+                k_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+                r_q_pre = T.alloc_local((ELEMS_PER_LANE,), "float32")
+                r_k_pre = T.alloc_local((ELEMS_PER_LANE,), "float32")
+                q_base: T.int64 = T.cast(n, "int64") * q_batch_stride + T.cast(
+                    (t_pre * NUM_HEADS + h) * K + k_start, "int64"
+                )
+                k_base: T.int64 = T.cast(n, "int64") * k_batch_stride + T.cast(
+                    (t_pre * NUM_HEADS + h) * K + k_start, "int64"
+                )
+                if not DISABLE_OUTPUT:
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        q_bits[elem] = _global_load_u16(q, q_base + elem)
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    k_bits[elem] = _global_load_u16(k, k_base + elem)
+                if not DISABLE_OUTPUT:
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        r_q_pre[elem] = _bf16_to_f32(q_bits[elem])
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    r_k_pre[elem] = _bf16_to_f32(k_bits[elem])
+
+                if USE_QK_L2NORM:
+                    sum_k: T.float32 = T.float32(0.0)
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        sum_k = _bf16_square_fma(k_bits[elem], sum_k)
+                    for delta_index in T.unroll(5):
+                        delta: T.int32 = T.shift_right(T.int32(16), delta_index)
+                        sum_k = _add_f32(
+                            sum_k,
+                            T.cuda.__shfl_xor_sync(
+                                T.uint32(0xFFFFFFFF), sum_k, delta, LANES_PER_GROUP
+                            ),
+                        )
+                    k_factor: T.float32 = _rsqrt_f32(_add_f32(sum_k, T.float32(1.0e-6)))
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        r_k_pre[elem] = _mul_f32(r_k_pre[elem], k_factor)
+                    if not DISABLE_OUTPUT:
+                        sum_q: T.float32 = T.float32(0.0)
+                        for elem in T.unroll(ELEMS_PER_LANE):
+                            sum_q = _bf16_square_fma(q_bits[elem], sum_q)
+                        for delta_index in T.unroll(5):
+                            delta: T.int32 = T.shift_right(T.int32(16), delta_index)
+                            sum_q = _add_f32(
+                                sum_q,
+                                T.cuda.__shfl_xor_sync(
+                                    T.uint32(0xFFFFFFFF), sum_q, delta, LANES_PER_GROUP
+                                ),
+                            )
+                        q_factor: T.float32 = _mul_f32(
+                            _rsqrt_f32(_add_f32(sum_q, T.float32(1.0e-6))), T.float32(SCALE)
+                        )
+                        for elem in T.unroll(ELEMS_PER_LANE):
+                            r_q_pre[elem] = _mul_f32(r_q_pre[elem], q_factor)
+                elif not DISABLE_OUTPUT:
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        r_q_pre[elem] = _mul_f32(r_q_pre[elem], T.float32(SCALE))
+
+                shared_base: T.int32 = t_pre * (K + 8) + k_start
+                if not DISABLE_OUTPUT:
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        _shared_store_f32(s_q, shared_base + elem, r_q_pre[elem])
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    _shared_store_f32(s_k, shared_base + elem, r_k_pre[elem])
+                if SEQ_LEN > 2:
+                    gate: T.uint64 = _gate_pair(
+                        a, b_gate, A_value, dt_value, (n * SEQ_LEN + t_pre) * NUM_V_HEADS + hv
+                    )
+                    if lane == 0:
+                        _shared_store_f32x2(
+                            s_gb, t_pre * 2, T.cuda.float2_x(gate), T.cuda.float2_y(gate)
+                        )
+            T.cuda.cta_sync()
+
+    for iter_index in T.unroll(ITERS_PER_GROUP):
+        v_base: T.int32 = v_tile * TILE_V + warp * ROWS_PER_GROUP + iter_index * ILP_ROWS
+        state_offset: T.int64 = read_state_base + T.cast(v_base * K + k_start, "int64")
+        r_h = T.alloc_local((ILP_ROWS * ELEMS_PER_LANE,), "float32")
+        _load_state_bf16x16(state, state_offset, r_h)
+        r_q = T.alloc_local((ELEMS_PER_LANE,), "float32", align=16)
+        r_k = T.alloc_local((ELEMS_PER_LANE,), "float32", align=16)
+        gate_values = T.alloc_local((2,), "float32", align=8)
+        sums = T.alloc_local((ILP_ROWS,), "float32")
+        residuals = T.alloc_local((ILP_ROWS,), "float32")
+        output_sums = T.alloc_local((ILP_ROWS,), "float32")
+
+        for t in T.serial(0, token_bound, unroll=4 if SEQ_LEN > 4 else False):
+            if SEQ_LEN > 1:
+                shared_base: T.int32 = t * (K + 8) + k_start
+                if not DISABLE_OUTPUT:
+                    _shared_load_f32x4(s_q, shared_base, r_q)
+                _shared_load_f32x4(s_k, shared_base, r_k)
+                if SEQ_LEN > 2:
+                    _shared_load_f32x2(s_gb, t * 2, gate_values)
+                else:
+                    gate: T.uint64 = _gate_pair(
+                        a, b_gate, A_value, dt_value, (n * SEQ_LEN + t) * NUM_V_HEADS + hv
+                    )
+                    gate_values[0] = T.cuda.float2_x(gate)
+                    gate_values[1] = T.cuda.float2_y(gate)
+            else:
+                q_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+                k_bits = T.alloc_local((ELEMS_PER_LANE,), "uint16")
+                q_base: T.int64 = T.cast(n, "int64") * q_batch_stride + T.cast(
+                    (t * NUM_HEADS + h) * K + k_start, "int64"
+                )
+                k_base: T.int64 = T.cast(n, "int64") * k_batch_stride + T.cast(
+                    (t * NUM_HEADS + h) * K + k_start, "int64"
+                )
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    q_bits[elem] = _global_load_u16(q, q_base + elem)
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    k_bits[elem] = _global_load_u16(k, k_base + elem)
+                for elem in T.unroll(ELEMS_PER_LANE):
+                    r_q[elem] = _bf16_to_f32(q_bits[elem])
+                    r_k[elem] = _bf16_to_f32(k_bits[elem])
+                if USE_QK_L2NORM:
+                    sum_q: T.float32 = T.float32(0.0)
+                    sum_k: T.float32 = T.float32(0.0)
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        sum_q = _bf16_square_fma(q_bits[elem], sum_q)
+                        sum_k = _bf16_square_fma(k_bits[elem], sum_k)
+                    for delta_index in T.unroll(5):
+                        delta: T.int32 = T.shift_right(T.int32(16), delta_index)
+                        sum_q = _add_f32(
+                            sum_q,
+                            T.cuda.__shfl_xor_sync(
+                                T.uint32(0xFFFFFFFF), sum_q, delta, LANES_PER_GROUP
+                            ),
+                        )
+                        sum_k = _add_f32(
+                            sum_k,
+                            T.cuda.__shfl_xor_sync(
+                                T.uint32(0xFFFFFFFF), sum_k, delta, LANES_PER_GROUP
+                            ),
+                        )
+                    q_factor: T.float32 = _mul_f32(
+                        _rsqrt_f32(_add_f32(sum_q, T.float32(1.0e-6))), T.float32(SCALE)
+                    )
+                    k_factor: T.float32 = _rsqrt_f32(_add_f32(sum_k, T.float32(1.0e-6)))
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        r_q[elem] = _mul_f32(r_q[elem], q_factor)
+                        r_k[elem] = _mul_f32(r_k[elem], k_factor)
+                else:
+                    for elem in T.unroll(ELEMS_PER_LANE):
+                        r_q[elem] = _mul_f32(r_q[elem], T.float32(SCALE))
+                gate: T.uint64 = _gate_pair(
+                    a, b_gate, A_value, dt_value, (n * SEQ_LEN + t) * NUM_V_HEADS + hv
+                )
+                gate_values[0] = T.cuda.float2_x(gate)
+                gate_values[1] = T.cuda.float2_y(gate)
+
+            g_value: T.float32 = gate_values[0]
+            beta: T.float32 = gate_values[1]
+            sum_lo = T.alloc_local((ILP_ROWS,), "float32")
+            sum_hi = T.alloc_local((ILP_ROWS,), "float32")
+            for row in T.unroll(ILP_ROWS):
+                sum_lo[row] = T.float32(0.0)
+                sum_hi[row] = T.float32(0.0)
+            for pair in T.unroll(ELEMS_PER_LANE // 2):
+                for row in T.unroll(ILP_ROWS):
+                    r_h[row * ELEMS_PER_LANE + pair * 2] = _mul_f32(
+                        r_h[row * ELEMS_PER_LANE + pair * 2], g_value
+                    )
+                    r_h[row * ELEMS_PER_LANE + pair * 2 + 1] = _mul_f32(
+                        r_h[row * ELEMS_PER_LANE + pair * 2 + 1], g_value
+                    )
+                for row in T.unroll(ILP_ROWS):
+                    packed: T.uint64 = _packed_fma(
+                        r_h[row * ELEMS_PER_LANE + pair * 2],
+                        r_h[row * ELEMS_PER_LANE + pair * 2 + 1],
+                        r_k[pair * 2],
+                        r_k[pair * 2 + 1],
+                        sum_lo[row],
+                        sum_hi[row],
+                    )
+                    sum_lo[row] = T.cuda.float2_x(packed)
+                    sum_hi[row] = T.cuda.float2_y(packed)
+            for row in T.unroll(ILP_ROWS):
+                sums[row] = _add_f32(sum_lo[row], sum_hi[row])
+            for delta_index in T.unroll(5):
+                delta: T.int32 = T.shift_right(T.int32(16), delta_index)
+                for row in T.unroll(ILP_ROWS):
+                    sums[row] = _add_f32(
+                        sums[row],
+                        T.cuda.__shfl_xor_sync(
+                            T.uint32(0xFFFFFFFF), sums[row], delta, LANES_PER_GROUP
+                        ),
+                    )
+
+            v_input_base: T.int64 = T.cast(n, "int64") * v_batch_stride + T.cast(
+                (t * NUM_V_HEADS + hv) * V + v_base, "int64"
+            )
+            for row in T.unroll(ILP_ROWS):
+                v_bits: T.uint16 = _global_load_u16(v, v_input_base + row)
+                residuals[row] = _mul_f32(_mixed_sub_bf16_f32(v_bits, sums[row]), beta)
+
+            output_lo = T.alloc_local((ILP_ROWS,), "float32")
+            output_hi = T.alloc_local((ILP_ROWS,), "float32")
+            for row in T.unroll(ILP_ROWS):
+                output_lo[row] = T.float32(0.0)
+                output_hi[row] = T.float32(0.0)
+            for pair in T.unroll(ELEMS_PER_LANE // 2):
+                for row in T.unroll(ILP_ROWS):
+                    packed: T.uint64 = _packed_fma(
+                        r_k[pair * 2],
+                        r_k[pair * 2 + 1],
+                        residuals[row],
+                        residuals[row],
+                        r_h[row * ELEMS_PER_LANE + pair * 2],
+                        r_h[row * ELEMS_PER_LANE + pair * 2 + 1],
+                    )
+                    r_h[row * ELEMS_PER_LANE + pair * 2] = T.cuda.float2_x(packed)
+                    r_h[row * ELEMS_PER_LANE + pair * 2 + 1] = T.cuda.float2_y(packed)
+                if not DISABLE_OUTPUT:
+                    for row in T.unroll(ILP_ROWS):
+                        packed: T.uint64 = _packed_fma(
+                            r_h[row * ELEMS_PER_LANE + pair * 2],
+                            r_h[row * ELEMS_PER_LANE + pair * 2 + 1],
+                            r_q[pair * 2],
+                            r_q[pair * 2 + 1],
+                            output_lo[row],
+                            output_hi[row],
+                        )
+                        output_lo[row] = T.cuda.float2_x(packed)
+                        output_hi[row] = T.cuda.float2_y(packed)
+            if not DISABLE_OUTPUT:
+                for row in T.unroll(ILP_ROWS):
+                    output_sums[row] = _add_f32(output_lo[row], output_hi[row])
+
+            if CACHE_INTERMEDIATE_STATES or PER_TOKEN_POOL_SCATTER:
+                if PER_TOKEN_POOL_SCATTER:
+                    scatter_slot: T.int32 = _global_load_s32(ssm_state_indices, n * SEQ_LEN + t)
+                    if PER_TOKEN_POOL_SCATTER_FLAT:
+                        state_write_base: T.int64 = T.cast(
+                            (T.cast(scatter_slot, "int64") * NUM_V_HEADS + hv) * V * K
+                            + v_base * K
+                            + k_start,
+                            "int64",
+                        )
+                        _store_state_f32x16(intermediate, state_write_base, r_h)
+                    else:
+                        state_write_base = T.cast(
+                            scatter_slot, "int64"
+                        ) * state_slot_stride + T.cast(hv * V * K + v_base * K + k_start, "int64")
+                        _store_state_f32x16(state, state_write_base, r_h)
+                else:
+                    state_write_base = T.cast(
+                        (((n * SEQ_LEN + t) * NUM_V_HEADS + hv) * V + v_base) * K + k_start, "int64"
+                    )
+                    _store_state_f32x16(intermediate, state_write_base, r_h)
+
+            if not DISABLE_OUTPUT:
+                for delta_index in T.unroll(5):
+                    delta: T.int32 = T.shift_right(T.int32(16), delta_index)
+                    for row in T.unroll(ILP_ROWS):
+                        output_sums[row] = _add_f32(
+                            output_sums[row],
+                            T.cuda.__shfl_xor_sync(
+                                T.uint32(0xFFFFFFFF), output_sums[row], delta, LANES_PER_GROUP
+                            ),
+                        )
+                output_base: T.int64 = T.cast(
+                    ((n * SEQ_LEN + t) * NUM_V_HEADS + hv) * V + v_base, "int64"
+                )
+                if lane == 0:
+                    output_bits = T.alloc_local((ILP_ROWS,), "uint16")
+                    for row in T.unroll(ILP_ROWS):
+                        output_bits[row] = _f32_to_bf16(output_sums[row])
+                    _global_store_u16x4(output, output_base, output_bits)
+
+        if not DISABLE_STATE_UPDATE and not (PER_TOKEN_POOL_SCATTER and SAME_POOL):
+            final_offset: T.int64 = write_state_base + T.cast(v_base * K + k_start, "int64")
+            _store_state_f32x16(state, final_offset, r_h)
+
+
+def _pool_factor(config: dict[str, Any]) -> int:
+    factor = 1
+    if config.get("per_token_pool_scatter", False):
+        factor += int(config["seq_len"])
+    if not config.get("same_pool", True):
+        factor += 1
+    if config.get("negative_read_index", False) or config.get("negative_write_index", False):
+        factor += 1
+    return factor
+
+
+def _require_supported_config(config: dict[str, Any]) -> None:
+    seq_len = int(config["seq_len"])
+    num_heads = int(config["num_heads"])
+    num_v_heads = int(config["num_v_heads"])
+    tile_v = int(config["tile_v"])
+    if int(config["batch"]) < 1:
+        raise ValueError("batch must be positive")
+    if seq_len < 1 or seq_len > 8:
+        raise ValueError("BF16 ILP4 port requires seq_len in [1, 8]")
+    if (num_heads, num_v_heads) not in _HEAD_CONFIGS:
+        raise ValueError(f"unsupported Qwen3-Next TP head pair {(num_heads, num_v_heads)}")
+    if num_v_heads % num_heads:
+        raise ValueError("num_v_heads must be divisible by num_heads")
+    if tile_v not in (16, 32, 64) or V % tile_v:
+        raise ValueError("BF16 ILP4 port requires tile_v in {16, 32, 64}")
+    if (tile_v // NUM_GROUPS) % ILP_ROWS:
+        raise ValueError("tile_v is incompatible with the four-warp ILP4 mapping")
+    if int(config.get("recovery_steps", 0)) != 0:
+        raise ValueError("FlashInfer's BF16 ILP4 path does not support recovery_steps")
+
+    cache = bool(config.get("cache_intermediate_states", False))
+    disable_update = bool(config.get("disable_state_update", False))
+    scatter = bool(config.get("per_token_pool_scatter", False))
+    if scatter and (cache or disable_update or seq_len < 2):
+        raise ValueError("per-token scatter requires update, no dense cache, and T >= 2")
+    if config.get("per_request_accepted_steps", False):
+        accepted = tuple(int(value) for value in config.get("accepted_steps", (0,)))
+        if any(value < 0 or value >= seq_len for value in accepted):
+            raise ValueError("accepted_steps values must be in [0, seq_len)")
+
+
+def get_kernel(**kwargs: Any):
+    """Return the source-specialized TIRx PrimFunc."""
+    config = dict(kwargs)
+    _require_supported_config(config)
+    seq_len = int(config["seq_len"])
+    num_v_heads = int(config["num_v_heads"])
+    tile_v = int(config["tile_v"])
+    cache = bool(config.get("cache_intermediate_states", False))
+    scatter = bool(config.get("per_token_pool_scatter", False))
+    scatter_flat = scatter and not bool(config.get("padded_pool", False))
+    pool_factor = int(config.get("pool_factor_override", _pool_factor(config)))
+    intermediate_batch_stride = 0
+    if cache:
+        intermediate_batch_stride = seq_len * num_v_heads * V * K
+    elif scatter_flat:
+        intermediate_batch_stride = pool_factor * num_v_heads * V * K
+
+    cosize_qk_bytes = 4 * ((seq_len - 1) * (K + 8) + K)
+    shared_bytes = 128 if seq_len == 1 else 1096 * seq_len + 128
+    kernel = _gdn_decode_bf16_ilp4.specialize(
+        SEQ_LEN=seq_len,
+        NUM_HEADS=int(config["num_heads"]),
+        NUM_V_HEADS=num_v_heads,
+        TILE_V=tile_v,
+        NUM_V_TILES=V // tile_v,
+        ROWS_PER_GROUP=tile_v // NUM_GROUPS,
+        ITERS_PER_GROUP=(tile_v // NUM_GROUPS) // ILP_ROWS,
+        POOL_FACTOR=pool_factor,
+        INTERMEDIATE_BATCH_STRIDE=intermediate_batch_stride,
+        INTERMEDIATE_DUMMY_ELEMENTS=0 if (cache or scatter_flat) else 1,
+        ACCEPTED_BATCH_STRIDE=1 if config.get("per_request_accepted_steps", False) else 0,
+        ACCEPTED_DUMMY_ELEMENTS=0 if config.get("per_request_accepted_steps", False) else 1,
+        SSM_BATCH_STRIDE=seq_len if scatter else 0,
+        SSM_DUMMY_ELEMENTS=0 if scatter else 1,
+        SHARED_BYTES=shared_bytes,
+        S_K_BYTE_OFFSET=cosize_qk_bytes,
+        S_GB_BYTE_OFFSET=2 * cosize_qk_bytes,
+        USE_QK_L2NORM=bool(config.get("use_qk_l2norm", True)),
+        DISABLE_STATE_UPDATE=bool(config.get("disable_state_update", False)),
+        CACHE_INTERMEDIATE_STATES=cache,
+        SAME_POOL=bool(config.get("same_pool", True)),
+        DISABLE_OUTPUT=bool(config.get("disable_output", False)),
+        PER_REQUEST_ACCEPTED_STEPS=bool(config.get("per_request_accepted_steps", False)),
+        PER_TOKEN_POOL_SCATTER=scatter,
+        PER_TOKEN_POOL_SCATTER_FLAT=scatter_flat,
+    )
+    return kernel.with_attr(
+        "tirx.kernel_launch_params", ["blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory"]
+    )
+
+
+def _allocate_pool(
+    pool_slots: int,
+    num_v_heads: int,
+    *,
+    padded: bool,
+    device: torch.device,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    padding_heads = 1 if padded else 0
+    backing = (
+        torch.randn(
+            (pool_slots, num_v_heads + padding_heads, V, K),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        * 0.05
+    )
+    return backing[:, :num_v_heads], backing
+
+
+def _clone_pool_layout(pool: torch.Tensor, *, padded: bool) -> tuple[torch.Tensor, torch.Tensor]:
+    pool_slots, num_v_heads = pool.shape[:2]
+    padding_heads = 1 if padded else 0
+    backing = torch.empty(
+        (pool_slots, num_v_heads + padding_heads, V, K), dtype=pool.dtype, device=pool.device
+    )
+    view = backing[:, :num_v_heads]
+    view.copy_(pool)
+    return view, backing
+
+
+def _make_qkv(
+    batch: int,
+    seq_len: int,
+    num_heads: int,
+    num_v_heads: int,
+    *,
+    packed: bool,
+    device: torch.device,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    if not packed:
+        q = (
+            torch.randn(
+                (batch, seq_len, num_heads, K),
+                dtype=torch.bfloat16,
+                device=device,
+                generator=generator,
+            )
+            * 0.05
+        )
+        k = torch.randn_like(q) * 0.05
+        v = (
+            torch.randn(
+                (batch, seq_len, num_v_heads, V),
+                dtype=torch.bfloat16,
+                device=device,
+                generator=generator,
+            )
+            * 0.05
+        )
+        return q, k, v, None
+
+    q_elements = seq_len * num_heads * K
+    k_elements = seq_len * num_heads * K
+    v_elements = seq_len * num_v_heads * V
+    row_elements = q_elements + k_elements + v_elements + 128
+    backing = (
+        torch.randn((batch, row_elements), dtype=torch.bfloat16, device=device, generator=generator)
+        * 0.05
+    )
+    q = backing.as_strided((batch, seq_len, num_heads, K), (row_elements, num_heads * K, K, 1), 0)
+    k = backing.as_strided(
+        (batch, seq_len, num_heads, K), (row_elements, num_heads * K, K, 1), q_elements
+    )
+    v = backing.as_strided(
+        (batch, seq_len, num_v_heads, V),
+        (row_elements, num_v_heads * V, V, 1),
+        q_elements + k_elements,
+    )
+    return q, k, v, backing
+
+
+def _device_from_config(config: dict[str, Any]) -> torch.device:
+    device = torch.device(config.get("device", "cuda:0"))
+    if device.type != "cuda" or not torch.cuda.is_available():
+        raise SkipTest("CUDA is required for BF16 ILP4 GDN decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"BF16 ILP4 GDN decode requires SM100, got {capability}")
+    return device
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Create deterministic, independently mutable TIRx and FlashInfer cases."""
+    config = dict(kwargs)
+    _require_supported_config(config)
+    device = _device_from_config(config)
+    batch = int(config["batch"])
+    seq_len = int(config["seq_len"])
+    num_heads = int(config["num_heads"])
+    num_v_heads = int(config["num_v_heads"])
+    padded_pool = bool(config.get("padded_pool", False))
+    same_pool = bool(config.get("same_pool", True))
+    scatter = bool(config.get("per_token_pool_scatter", False))
+    negative_read = bool(config.get("negative_read_index", False))
+    negative_write = bool(config.get("negative_write_index", False))
+    generator = torch.Generator(device=device)
+    generator.manual_seed(int(config.get("seed", 0)) + 20260812)
+
+    pool_factor = _pool_factor(config)
+    pool_slots = batch * pool_factor
+    initial_pool, initial_backing = _allocate_pool(
+        pool_slots, num_v_heads, padded=padded_pool, device=device, generator=generator
+    )
+    tirx_state, tirx_state_backing = _clone_pool_layout(initial_pool, padded=padded_pool)
+    source_state, source_state_backing = _clone_pool_layout(initial_pool, padded=padded_pool)
+
+    slot_offset = 1 if negative_read or negative_write else 0
+    read_indices = torch.arange(batch, dtype=torch.int32, device=device) + slot_offset
+    if negative_read:
+        read_indices[-1] = -1
+
+    scatter_indices: torch.Tensor | None = None
+    next_slot = slot_offset + batch
+    if scatter:
+        scatter_indices = torch.arange(
+            next_slot, next_slot + batch * seq_len, dtype=torch.int32, device=device
+        ).reshape(batch, seq_len)
+        next_slot += batch * seq_len
+    if same_pool:
+        write_indices = read_indices
+    else:
+        write_indices = torch.arange(next_slot, next_slot + batch, dtype=torch.int32, device=device)
+        if negative_write:
+            write_indices[-1] = -1
+
+    q, k, v, qkv_backing = _make_qkv(
+        batch,
+        seq_len,
+        num_heads,
+        num_v_heads,
+        packed=bool(config.get("packed_qkv", False)),
+        device=device,
+        generator=generator,
+    )
+    A_log = (
+        torch.randn((num_v_heads,), dtype=torch.float32, device=device, generator=generator) * 0.1
+    )
+    dt_bias = (
+        torch.randn((num_v_heads,), dtype=torch.float32, device=device, generator=generator) * 0.1
+    )
+    a = (
+        torch.randn(
+            (batch, seq_len, num_v_heads), dtype=torch.bfloat16, device=device, generator=generator
+        )
+        * 0.05
+    )
+    b_gate = torch.randn_like(a) * 0.05
+    output_initial = torch.randn(
+        (batch, seq_len, num_v_heads, V), dtype=torch.bfloat16, device=device, generator=generator
+    )
+    cache = bool(config.get("cache_intermediate_states", False))
+    if cache:
+        intermediate_initial = torch.randn(
+            (batch, seq_len, num_v_heads, V, K),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        tirx_intermediate = intermediate_initial.clone()
+        source_intermediate = intermediate_initial.clone()
+    else:
+        tirx_intermediate = torch.zeros((1,), dtype=torch.bfloat16, device=device)
+        source_intermediate = torch.zeros((1,), dtype=torch.bfloat16, device=device)
+
+    if config.get("per_request_accepted_steps", False):
+        accepted_values = tuple(int(value) for value in config.get("accepted_steps", (0,)))
+        if len(accepted_values) == 1:
+            accepted_values = accepted_values * batch
+        if len(accepted_values) != batch:
+            raise ValueError("accepted_steps must contain one value per batch row")
+        accepted_steps = torch.tensor(accepted_values, dtype=torch.int32, device=device)
+    else:
+        accepted_steps = torch.zeros((1,), dtype=torch.int32, device=device)
+    ssm_arg = (
+        scatter_indices
+        if scatter_indices is not None
+        else torch.zeros((1,), dtype=torch.int32, device=device)
+    )
+
+    return {
+        "config": config,
+        "pool_slots": pool_slots,
+        "initial_pool": initial_pool.clone(),
+        "initial_backing": initial_backing,
+        "tirx_state": tirx_state,
+        "tirx_state_backing": tirx_state_backing,
+        "source_state": source_state,
+        "source_state_backing": source_state_backing,
+        "read_indices": read_indices,
+        "write_indices": write_indices,
+        "accepted_steps": accepted_steps,
+        "ssm_state_indices": ssm_arg,
+        "q": q,
+        "k": k,
+        "v": v,
+        "qkv_backing": qkv_backing,
+        "qkv_snapshot": qkv_backing.clone() if qkv_backing is not None else None,
+        "A_log": A_log,
+        "dt_bias": dt_bias,
+        "a": a,
+        "b_gate": b_gate,
+        "tirx_output": output_initial.clone(),
+        "source_output": output_initial.clone(),
+        "tirx_intermediate": tirx_intermediate,
+        "source_intermediate": source_intermediate,
+    }
+
+
+@functools.cache
+def _load_frozen_oracle():
+    import flashinfer.gdn_kernels.gdn_decode_bf16_state as source_module
+
+    source_path = Path(source_module.__file__).resolve()
+    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
+        raise RuntimeError(
+            "GDN BF16 ILP4 oracle does not match the reviewed source: "
+            f"{source_path} sha256={digest}"
+        )
+    return source_module.gated_delta_rule_mtp
+
+
+@functools.cache
+def _compile_tirx(
+    seq_len: int,
+    num_heads: int,
+    num_v_heads: int,
+    tile_v: int,
+    pool_factor: int,
+    use_qk_l2norm: bool,
+    disable_state_update: bool,
+    cache_intermediate_states: bool,
+    same_pool: bool,
+    disable_output: bool,
+    per_request_accepted_steps: bool,
+    per_token_pool_scatter: bool,
+    padded_pool: bool,
+):
+    from tirx_kernels.runner import compile_kernel
+
+    config = {
+        "seq_len": seq_len,
+        "batch": 1,
+        "num_heads": num_heads,
+        "num_v_heads": num_v_heads,
+        "tile_v": tile_v,
+        "use_qk_l2norm": use_qk_l2norm,
+        "disable_state_update": disable_state_update,
+        "cache_intermediate_states": cache_intermediate_states,
+        "same_pool": same_pool,
+        "disable_output": disable_output,
+        "per_request_accepted_steps": per_request_accepted_steps,
+        "per_token_pool_scatter": per_token_pool_scatter,
+        "padded_pool": padded_pool,
+        "pool_factor_override": pool_factor,
+    }
+    return compile_kernel(get_kernel(**config))
+
+
+def _tirx_executable(case: dict[str, Any]):
+    config = case["config"]
+    return _compile_tirx(
+        int(config["seq_len"]),
+        int(config["num_heads"]),
+        int(config["num_v_heads"]),
+        int(config["tile_v"]),
+        _pool_factor(config),
+        bool(config.get("use_qk_l2norm", True)),
+        bool(config.get("disable_state_update", False)),
+        bool(config.get("cache_intermediate_states", False)),
+        bool(config.get("same_pool", True)),
+        bool(config.get("disable_output", False)),
+        bool(config.get("per_request_accepted_steps", False)),
+        bool(config.get("per_token_pool_scatter", False)),
+        bool(config.get("padded_pool", False)),
+    )
+
+
+def _storage_span(tensor: torch.Tensor, elements: int) -> torch.Tensor:
+    return tensor.as_strided((elements,), (1,))
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    config = case["config"]
+    state = case["tirx_state"]
+    q = case["q"]
+    k = case["k"]
+    v = case["v"]
+    batch = int(config["batch"])
+    cache = bool(config.get("cache_intermediate_states", False))
+    scatter = bool(config.get("per_token_pool_scatter", False))
+    scatter_flat = scatter and not bool(config.get("padded_pool", False))
+    if scatter_flat:
+        intermediate = _storage_span(state, int(state.stride(0)) * case["pool_slots"])
+    else:
+        intermediate = _storage_span(case["tirx_intermediate"], case["tirx_intermediate"].numel())
+    if not cache and not scatter_flat:
+        intermediate = intermediate[:1]
+    return (
+        _storage_span(state, int(state.stride(0)) * case["pool_slots"]),
+        intermediate,
+        case["A_log"],
+        case["a"].reshape(-1),
+        case["dt_bias"],
+        _storage_span(q, int(q.stride(0)) * (batch - 1) + int(q[0].numel())),
+        _storage_span(k, int(k.stride(0)) * (batch - 1) + int(k[0].numel())),
+        _storage_span(v, int(v.stride(0)) * (batch - 1) + int(v[0].numel())),
+        case["b_gate"].reshape(-1),
+        case["tirx_output"].reshape(-1),
+        case["read_indices"],
+        case["write_indices"],
+        case["accepted_steps"],
+        case["ssm_state_indices"].reshape(-1),
+        int(state.stride(0)),
+        int(q.stride(0)),
+        int(k.stride(0)),
+        int(v.stride(0)),
+        batch,
+    )
+
+
+def _run_reference(case: dict[str, Any]) -> torch.Tensor:
+    config = case["config"]
+    oracle = _load_frozen_oracle()
+    return oracle(
+        A_log=case["A_log"],
+        a=case["a"],
+        dt_bias=case["dt_bias"],
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=case["q"],
+        k=case["k"],
+        v=case["v"],
+        b=case["b_gate"],
+        initial_state_source=case["source_state"],
+        initial_state_indices=case["read_indices"],
+        output_state_indices=(
+            case["read_indices"] if bool(config.get("same_pool", True)) else case["write_indices"]
+        ),
+        intermediate_states_buffer=(
+            case["source_intermediate"]
+            if bool(config.get("cache_intermediate_states", False))
+            else None
+        ),
+        accepted_steps=(
+            case["accepted_steps"] if config.get("per_request_accepted_steps", False) else None
+        ),
+        ssm_state_indices=(
+            case["ssm_state_indices"] if config.get("per_token_pool_scatter", False) else None
+        ),
+        disable_state_update=bool(config.get("disable_state_update", False)),
+        use_qk_l2norm_in_kernel=bool(config.get("use_qk_l2norm", True)),
+        scale=SCALE,
+        output=case["source_output"],
+        disable_output=bool(config.get("disable_output", False)),
+        recovery_steps=0,
+    )
+
+
+def _assert_case_close(case: dict[str, Any]) -> None:
+    config = case["config"]
+    if bool(config.get("disable_output", False)):
+        torch.testing.assert_close(case["tirx_output"], case["source_output"], atol=0, rtol=0)
+    else:
+        torch.testing.assert_close(
+            case["tirx_output"].float(), case["source_output"].float(), atol=1.0e-3, rtol=5.0e-3
+        )
+    torch.testing.assert_close(
+        case["tirx_state"].float(), case["source_state"].float(), atol=2.0e-2, rtol=1.0e-2
+    )
+    if bool(config.get("cache_intermediate_states", False)):
+        torch.testing.assert_close(
+            case["tirx_intermediate"].float(),
+            case["source_intermediate"].float(),
+            atol=2.0e-2,
+            rtol=1.0e-2,
+        )
+    if case["qkv_backing"] is not None:
+        torch.testing.assert_close(case["qkv_backing"], case["qkv_snapshot"], atol=0, rtol=0)
+
+
+def run_test(**kwargs: Any) -> None:
+    case = prepare_data(**kwargs)
+    executable = _tirx_executable(case)
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["tirx_state"].device)
+    _run_reference(case)
+    torch.cuda.synchronize(case["tirx_state"].device)
+    _assert_case_close(case)
+
+
+def run_bench(
+    *,
+    warmup: int | None = None,
+    repeat: int | None = None,
+    timer: str | None = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    case = prepare_data(**kwargs)
+    executable = _tirx_executable(case)
+    args = _tirx_args(case)
+    executable(*args)
+    _run_reference(case)
+    torch.cuda.synchronize(case["tirx_state"].device)
+    _assert_case_close(case)
+
+    def source_builder():
+        for _ in range(2):
+            _run_reference(case)
+        torch.cuda.synchronize(case["source_state"].device)
+
+        def launch():
+            _run_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        references={"flashinfer_cutedsl": source_builder},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer's SM100 BF16 ILP4 GDN decode kernel to TIRx while preserving its CTA, warp, ILP4, shared-memory, and state-update structure
- cover the complete 48-workload production dispatch matrix for T=1/2/4/8
- add the reviewed kernel sketch and a source/IR no-tile-primitive lint across all 67 specializations

## Motivation

This adds a TIRx implementation of the BF16 ILP4 fallback path used by Qwen3-Next decode. The kernel tracks FlashInfer commit `f2e04400e330fb2debe0bf8730d9424a1d37927f` and supports dense caching, split and padded pools, accepted-step truncation, per-token scatter, packed QKV inputs, state-only execution, and optional Q/K normalization.

## Validation

- correctness: 67/67 configurations passed, with no failures or skips
- performance: 48/48 bench-suite workloads passed `flashinfer_cutedsl_us / tirx_us > 0.99`; minimum ratio was `1.037121880x`
- no-tile lint: source plus all 67 pre-dispatch specializations passed
- bench-suite import check passed
- `pre-commit run --from-ref upstream/main --to-ref HEAD` passed
