### PR TITLE
feat(kernel): port FlashInfer's FlashKDA cake T=6 coefficient-gram decode kernel

### DIFF
--- a/.agents/sketch/flashinfer/kda/flashkda_decode_t6_gram.md
+++ b/.agents/sketch/flashinfer/kda/flashkda_decode_t6_gram.md
@@ -1,0 +1,754 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashKDA cake T=6 coefficient-gram decode: coarse execution sketch
+
+**Non-executable.** This is the semantic execution skeleton, not runnable code.
+The source of truth for the implementation is
+`tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py`.
+
+Transcribed from four frozen generated exports, all with symbol
+`kernel_flashinfer_recurrent_kda_wy_vtile_short` (flashinfer-ai/flashinfer @
+`f2e04400`), 816 body lines each:
+
+- `csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split1.cu` — `S1:NNN`
+- `csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split2.cu` — `S2:NNN`, and
+  the default for a bare `:NNN`
+- `csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split4.cu` — `S4:NNN`
+- `csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split8.cu` — `S8:NNN`
+
+T=6 is the last variant the cake family exports. It shares one arm of the
+sm100a value-split policy with T=5 (`recurrent_kda.py:1181-1191` is a single
+`if num_tokens in (5, 6):`), so the split is shape-dependent, all four exports
+are production-reachable, and the split is a constexpr here as it was there.
+
+## What changed relative to the ported T=5 body
+
+Line numbering is **1:1 identical to T=5 through line 531**; the first
+insertion is the +6-line block at `:532-537`. Phase by phase:
+
+| phase | T=5 → T=6 |
+| --- | --- |
+| prologue | identical but for six array sizes `[5]→[6]` (`:172-177`) |
+| A preprocess | identical modulo T: `warp_0 < 6`, `ssm_idx[n*6 + …]`, nat clamp **`[0,5]`** |
+| C′ publish | identical modulo T: prefix loop 6, sVec k cols **0..5**, q cols **8..13** |
+| C″ gram | identical modulo the barrier count (**192**) and `GRAM_WARP` (**5** at splits 4/8) |
+| B gather | **byte-identical** — no T dependence |
+| D MMA | **byte-identical** — no T dependence |
+| E broadcasts + solve | **+6 lines**: token 5's broadcast is *elided* (below); solve depth 6; u redistribution 6 |
+| F outputs | **changed**: a **second** tail, and a new coefficient clamp (below) |
+| G publish `sU` | identical modulo T (12 stores) |
+| H recurrence | identical modulo T (6 tokens) |
+| the arena | **static → dynamic**: split1 needs 50560 B (below) |
+
+So four deltas carry the whole port. Everything else is the ported T=5
+skeleton re-parameterized by `T`.
+
+**Fixed specializations.**
+
+| knob | split1 | split2 | split4 | split8 |
+| --- | --- | --- | --- | --- |
+| `TOKENS` | 6 | 6 | 6 | 6 |
+| `GATE_KIND` | 0 (precomputed log-gate) | 0 | 0 | 0 |
+| `LAUNCH_THREADS` | **256** (8 warps) | **192** (6 warps) | 192 | 192 |
+| `ROWS_PER_CTA` | 128 | 64 | 32 | 16 |
+| `ROWS_PER_GROUP` | 8 | 8 | 8 | **2** |
+| `ROW_GROUPS` (B, H) | 16 | 8 | 4 | 8 |
+| `MMA_WARPS` (D–G) | 8 | 4 | 2 | **1** |
+| `GRAM_WARP` | 0 | 0 | **5** | **5** |
+| gram barrier shape | sync/arrive | sync/arrive | **all six sync** | sync/arrive |
+| `sU` publish barrier | `__syncwarp` | `__syncwarp` | `__syncwarp` | **`__syncthreads`, outer scope** |
+| `SMEM_TOTAL` | **50560** | 32640 | 23680 | 19200 |
+| grid | `(HV·1, N)` | `(HV·2, N)` | `(HV·4, N)` | `(HV·8, N)` |
+
+`HEAD_DIM = 128`, `DIRECT_PREFIX_CHECKPOINT = 0`, `BLOCK_CHECKPOINT_MMA = 0`,
+`NUM_MAIN_STAGES = 1`, `coefficient_gram = true`. `#define THREADS 256` is
+vestigial (`static_assert` at `binding_impl.cuh:40`); the real block size is
+`FLASHKDA_DECODE_LAUNCH_THREADS`, and `tokens=6` is what makes it 192 at
+splits 2/4/8 (`flash_kda_decode.py:115-136`).
+
+**Out of scope.** T ∈ {1,2,3,4,5} (ported separately); the sm103a T=6 policy
+(`recurrent_kda.py:1220-1225`), a separate three-band rule under which split4
+is unreachable — the port targets sm100a and replicates only `_current`.
+
+## Delta 1 — the arena is dynamic shared memory
+
+split1's `SMEM_TOTAL` is **50560 B**, past the 49152 B static ceiling every
+earlier cake port fit inside. The source has always been dynamic
+(`extern __shared__ __align__(1024) char smem_raw[]` at `:104`, sized by
+`cudaFuncSetAttribute(MaxDynamicSharedMemorySize, SMEM_TOTAL)`,
+`binding_impl.cuh:59-66`), so the port stops approximating it with a static
+buffer and allocates through `T.SMEMPool` **for all four splits** — uniform,
+and closer to the source than T=5's static arena was.
+
+Two things about this are not optional:
+
+- the kernel must declare `tirx.use_dyn_shared_memory` in
+  `tirx.kernel_launch_params`, or the launch reserves **zero** dynamic bytes
+  and every arena access faults at runtime — it is not a compile error;
+- the byte offsets and the 1024-byte alignment carry over unchanged, because
+  the swizzled `ldmatrix` addressing depends on both.
+
+Probed before this sketch was written: all four arenas compile, launch and
+round-trip data through the body's swizzled `st.shared.b16` + `ldmatrix`,
+while a 4 MB arena is rejected with a precise diagnostic.
+
+## Delta 2 — token 5's quad broadcast is elided
+
+The m16n8k16 accumulator map from T=5 holds for all six tokens: token `t`
+lives at lane `quad_base + t//2`, accumulator index `t%2`. For `t = 5` that
+source lane is `quad_base + 2` — which is exactly the lane that consumes it,
+since both consumers (the WY solve at `:539-559` and phase F's token-5 tail at
+`:651-667`) run under `lane_quad == 2`. So the generator does not shuffle:
+
+```
+ha_lo[5] = mma_acc[1];    ha_hi[5] = mma_acc[3];      // :533-534
+hc_lo[5] = mma_acc_c[1];  hc_hi[5] = mma_acc_c[3];    // :535-536
+```
+
+assigned **outside** the `lane_quad == 2` guard (every lane executes them; only
+lane_quad 2's values are meaningful). The broadcast count therefore stays at
+**20**, not 24 — confirmed in the PTX, which carries 33 `shfl.sync.idx.b32`
+total = 1 warp-uniform + 20 broadcasts + 12 u-redistribution.
+
+## Delta 3 — phase F has two tails, and token 4's row needs a clamp
+
+The pair structure is unchanged: `token0 = (lane_quad-2)*2`, `token1 = +1`, so
+`lane_quad == 2` writes tokens 0,1 and `lane_quad == 3` writes 2,3, with bases
+`hc_*[0..3]` (and the same dead `mma_acc` pre-init the port drops). Tokens 4
+and 5 have no partner lane, so **both tails run on `lane_quad == 2`**:
+
+- token 4 (`:629-650`), base `hc_*[4]`, coefficients `sR[24 + s]` — but
+  **clamped**: `coef4 = 0.0f` unless `s <= 4`. This is load-bearing.
+  `sR[29]` is (target 4, source 5), which the gram block never writes — the
+  gram guard is `source <= target`. It is in-region but uninitialized, so the
+  clamp is what keeps garbage out of the result. (The source's own dead
+  initializer at `:633` reads `sR[24+s]` unconditionally before the clamp
+  overwrites it; that read is harmless and the port drops it.)
+- token 5 (`:651-667`), base `hc_*[5]`, coefficients `sR[30 + s]` with **no**
+  clamp — target 5 accepts all six sources, so `sR[30..35]` are all live.
+
+Writer-lane stores: **8** on `lane_quad == 2` (tokens 0,1,4,5 × lo/hi), 4 on
+`lane_quad == 3`.
+
+**No out-of-region read at T=6.** Every `sSlot`/`sToken` index is < 6 and every
+`sR` index ≤ 35 < 36. This is not the T=3 hazard class, and unlike T=3 nothing
+needs predicating — only the source's own clamp reproducing.
+
+## Delta 4 — six token warps
+
+`barrier.sync 1, 192` / `barrier.arrive 1, 192` in every split, including
+split1's 256-thread launch, because the gram region is nested inside
+`if (warp_0 < 6)` (`:293` opens, `:409` closes) — split1's warps 6,7 never
+reach it. `GRAM_WARP` is `(flag) ? 5 : 0`, i.e. **0** at splits 1/2 and **5**
+at splits 4/8. split4 again hoists the wait unconditional across all six token
+warps and leaves its arrive arm dead (`else if (0)`) — its PTX carries **one**
+`barrier.*` where the others carry two.
+
+## Pipeline at a glance
+
+No warp specialization, no async pipeline: no `cp.async`, no mbarrier, no TMA,
+no atomics. The value split is a partition — CTA `(hv, value_tile)` owns
+`ROWS_PER_CTA` value rows and every CTA redundantly preprocesses its own
+`(n, hv)` tokens, which is why all four splits produce bit-identical results
+(measured: `max|Δ| = 0` on output and the whole state pool).
+
+| Role | Ownership | Publication/reuse edges |
+| --- | --- | --- |
+| CTA `(hv, value_tile, n)` | value head, sequence, `ROWS_PER_CTA` rows | independent |
+| warp `w < 6`, phases A and C′ | **token `w`** | publishes `sK`/`sD`/`sBeta`/`sSlot`/`sToken`/(warp 0)`sInit` across barrier #1; publishes `sGramA*` row `w` and `sVec` columns `w`, `8+w` across the named barrier to the gram warp; the same `sVec` columns reach every *other* MMA warp only across barrier #2, since those warps merely arrive at the named barrier (split4 excepted — there all six block on it) |
+| warp `GRAM_WARP` | **all 36 WY coefficient slots**: a 16×8×128 Gram product per side | consumes every token warp's `sGramA*` row and `sVec` column; publishes `sL`/`sR` across barrier #2 |
+| thread `tid`, `group < ROW_GROUPS` (B, H) | `ROWS_PER_GROUP` rows × 8 keys | gathers state into `hist` and stages it to `sState`; later writes all six tokens' checkpoints |
+| warp `w < MMA_WARPS` (D) | value rows `w·16 .. +15` | consumes all staged `sState` and all of `sVec` |
+| lane `lane_quad == 2` | the depth-6 WY solve, the `sU` publish, **and tokens 4 and 5's output** | the only lanes that load `v` |
+| lane `lane_quad >= 2` | tokens 0,1 on `4f+2`; 2,3 on `4f+3` | the only lanes that store `out` |
+
+Guards per split — at split1 the token guard is the live one (warps 6,7 skip
+A/C′/gram); at the other three the value guards are live and warp 5 is a
+token-only warp (it preprocesses token 5, joins the named barrier, and at
+splits 4/8 also runs the gram, but never gathers state, never issues the main
+MMA and never stores output):
+
+| guard | site | split1 | split2 | split4 | split8 |
+| --- | --- | --- | --- | --- | --- |
+| `warp_0 < 6` (A, C′, gram) | `:180`, `:293` | live (8 warps) | statically true | statically true | statically true |
+| `group < ROW_GROUPS` (B, H) | `:411`, `:798` | 16 of 16 | 8 of 12 | 4 of 12 | 8 of 12 |
+| `warp_0 < MMA_WARPS` (D–G) | `:448`, `:568`, `:671` | 8 of 8 | 4 of 6 | 2 of 6 | 1 of 6 |
+
+Dependency chain: preprocess → **CTA barrier** → sVec/sGramA publish →
+**named barrier** → gram MMA → state gather → **CTA barrier** → main MMA → WY
+solve → outputs → `sU` → **warp barrier** → recurrence and checkpoints.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute data:
+
+```python
+reg_tile(dtype, shape)                 # per-thread register array
+smem_pool()                            # T.SMEMPool -- the dynamic arena
+pool.alloc(bytes, align)               # the single shared allocation
+smem_view(name, offset, dtype, shape)  # a named region of that arena
+swz(byte_off)                          # byte_off ^ ((byte_off >> 7 & 7) << 4)
+widen(word)                            # one u32 -> two f32, as shl.b32 / and.b32
+```
+
+Data movement:
+
+```python
+copy_g2r(gmem_slice, reg)              # global -> register
+copy_r2g(reg, gmem_slice, pred=None)   # register -> global
+copy_r2s(reg, smem_slice)              # register -> shared
+copy_s2r(smem_slice, reg)              # shared -> register
+ldm(smem_addr, frag, trans=False)      # ldmatrix, one x4 group
+bcast(v, src_lane, 31, 0xFFFFFFFF)     # shfl.idx
+bfly(v, lane_xor, 31, 0xFFFFFFFF)      # shfl.bfly
+```
+
+Compute: `fill cast add sub mul fma exp rsqrt div dot mma`.
+Sync: `cta_sync()`, `warp_sync()`, `named_bar_sync(id, threads)`,
+`named_bar_arrive(id, threads)`.
+
+**Every shuffle is width-32 with a full member mask.** **`dot` is not a
+compound op**: each expands to an explicit FMA chain in a fixed association
+order.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+HEAD_DIM = 128
+TOKENS = 6
+VALUE_SPLIT   in (1, 2, 4, 8)                 # chosen by shape, constexpr here
+THREADS       = 256 if VALUE_SPLIT == 1 else 192
+ROWS_PER_CTA  = 128 // VALUE_SPLIT
+ROWS_PER_GROUP= 2 if VALUE_SPLIT == 8 else 8
+ROW_GROUPS    = ROWS_PER_CTA // ROWS_PER_GROUP
+MMA_WARPS     = ROWS_PER_CTA // 16
+GRAM_WARP     = 5 if VALUE_SPLIT in (4, 8) else 0
+
+grid  = (HV * VALUE_SPLIT, num_seqs)          # binding_impl.cuh:64
+block = (THREADS,)
+launch_params += ["tirx.use_dyn_shared_memory"]   # or the arena is 0 bytes
+
+# Runtime scalars: `scale`. `lower_bound` is 0.0 and A_log/dt_bias are 1-element
+# dummies -- GATE_KIND 0 never dereferences them (measured, not assumed).
+
+#                                                  s1 /    s2 /    s4 /    s8
+pool    = smem_pool()
+arena   = pool.alloc(SMEM_TOTAL, align=1024)               # 50560/32640/23680/19200
+sState0 = smem_view(arena, ..., bf16, [ROWS_PER_CTA, 64])  #     0/     0/    0/    0
+sState1 = smem_view(arena, ..., bf16, [ROWS_PER_CTA, 64])  # 16384/  8192/ 4096/ 2048
+sVec    = smem_view(arena, ..., bf16, [128, 16])           # 32768/ 16384/ 8192/ 4096
+sK      = smem_view(arena, ..., f32,  [6, 128])            # 36864/ 20480/12288/ 8192
+sD      = smem_view(arena, ..., f32,  [6, 128])            # 39936/ 23552/15360/11264
+sBeta   = smem_view(arena, ..., f32,  [6])                 # 43008/ 26624/18432/14336
+sSlot   = smem_view(arena, ..., i32,  [6])                 # 43032/ 26648/18456/14360
+sToken  = smem_view(arena, ..., i32,  [6])                 # 43056/ 26672/18480/14384
+sInit   = smem_view(arena, ..., i32,  [1])                 # 43080/ 26696/18504/14408
+sL      = smem_view(arena, ..., f32,  [6, 6])              # 43096/ 26712/18520/14424
+sR      = smem_view(arena, ..., f32,  [6, 6])              # 43240/ 26856/18664/14568
+sU      = smem_view(arena, ..., f32,  [6, ROWS_PER_CTA])   # 43384/ 27000/18808/14712
+sGramA0 = smem_view(arena, ..., bf16, [16, 64])            # 46464/ 28544/19584/15104
+sGramA1 = smem_view(arena, ..., bf16, [16, 64])            # 48512/ 30592/21632/17152
+
+# sVec keeps 16 columns; only 0..5 (k) and 8..13 (q) are ever written.
+# sGramA* rows 0..5 are written; 6..15 are read by ldmatrix and discarded.
+
+# ===========================================================================
+# Work decomposition and lane roles  (:100-178)
+# ===========================================================================
+work, n    = cta_id.x, cta_id.y
+value_tile = work % VALUE_SPLIT
+hv         = work // VALUE_SPLIT
+query_head = hv // HEAD_RATIO                # the body's only div.s32
+tid        = thread_id.x
+warp       = make_warp_uniform(tid // 32)    # == token index in A and C'
+# instruction_selection: shfl.sync.idx.b32 (lane 0, mask 0xFFFFFFFF); extent: scalar
+# Semantically the identity, and NOT droppable: it is the hint that lets ptxas
+# prove `warp_0 < 6` is warp-uniform. split1 is the geometry where that guard is
+# live, and without it phase A's reductions land in a WARPSYNC.COLLECTIVE retry
+# region -- the T=5 port paid for this and the fix is carried in from the start.
+lane, lane_quad, frag_row = tid % 32, lane % 4, lane // 4
+quad_base  = lane - lane_quad
+group, lane_group = tid // 16, tid % 16
+k_start, elem_start = lane_group * 8, lane * 4
+tile_row_base, owned_row_base = value_tile * ROWS_PER_CTA, group * ROWS_PER_GROUP
+
+# Register declarations (:161-177). Only the ha/hc/u arrays differ from T=5.
+r_q, r_k, r_d = (reg_tile(f32, [4]) for _ in range(3))
+ratio_scan    = reg_tile(f32, [4])                   # DEAD -- the butterfly path is gone
+r_state       = reg_tile(f32, [8])
+hist          = reg_tile(f32, [ROWS_PER_GROUP, 8])   # [8,8] / [2,8] at split8
+state_pack, state_frag, vec_frag = (reg_tile(u32, [4]) for _ in range(3))
+mma_acc, mma_acc_c = reg_tile(f32, [4]), reg_tile(f32, [4])
+ha_lo, ha_hi, hc_lo, hc_hi, u_lo, u_hi = (reg_tile(f32, [TOKENS]) for _ in range(6))
+
+token_base = load_i32(cu_seqlens[n])
+seq_len    = load_i32(cu_seqlens[n+1]) - token_base
+# instruction_selection: ld.global.nc.b32; extent: scalar (x2)
+# cu_seqlens must step by exactly 6; the body does not bound-check it. Padding
+# is signalled ONLY by ssm_state_indices < 0.
+
+# ===========================================================================
+# Phase A: token preprocess, warp <-> token  (:180-290)
+# ===========================================================================
+if warp < TOKENS:
+    token     = warp
+    active    = token < seq_len
+    token_pos = token_base + token if active else 0
+
+    copy_g2r(q[(token_pos*H + query_head)*128 + elem_start : +4], r_q)
+    copy_g2r(k[(token_pos*H + query_head)*128 + elem_start : +4], r_k)
+    copy_g2r(g[token_pos*GATE_TOKEN_STRIDE + hv*128 + elem_start : +4], r_d)
+    # instruction_selection: ld.global.nc.v2.b32 (one per tensor) + widen;
+    #                        extent: vector
+    # Four contiguous bf16 = 8 bytes = ONE v2.b32; each word splits into two f32
+    # by shl.b32 / and.b32.
+
+    q_sum = dot(r_q, r_q); k_sum = dot(r_k, r_k)
+    # instruction_selection: fma.rn.ftz.f32; extent: two 4-term chains (8 per
+    #                        body), each seeded with C = 0f00000000
+    # No `mul` at these sites, and the two chains are emitted INTERLEAVED,
+    # because the source accumulates both in one fused loop (:241-244).
+    for off in (16, 8, 4, 2, 1):
+        q_sum = add(q_sum, bfly(q_sum, off, 31, 0xFFFFFFFF))
+    for off in (16, 8, 4, 2, 1):
+        k_sum = add(k_sum, bfly(k_sum, off, 31, 0xFFFFFFFF))
+    # instruction_selection: shfl.sync.bfly.b32 + add.ftz.f32;
+    #                        extent: 5 rounds x 2 SEQUENTIAL reductions = 10 shfl
+    # `_warp_reduce_0` completes all five rounds (:245-249) before
+    # `_warp_reduce_1` starts (:250-254) -- the opposite of the dot chains above.
+
+    q_norm = mul(rsqrt(add(q_sum, 1e-6)), scale)
+    k_norm = rsqrt(add(k_sum, 1e-6))
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar (x2)
+    # `scale` folds into q only. FTZ throughout: the export is -use_fast_math.
+
+    for i in range(4):
+        r_q[i] = mul(r_q[i], q_norm)
+        r_k[i] = mul(r_k[i], k_norm)
+        r_d[i] = exp(r_d[i])
+        # instruction_selection: ex2.approx.ftz.f32; extent: scalar (x4)
+        # GATE_KIND 0: g arrives in log space; this is its only transcendental.
+
+    copy_r2s(r_k, sK[token, elem_start : +4])
+    copy_r2s(r_d, sD[token, elem_start : +4])
+    # instruction_selection: st.shared.v4.b32; extent: vector (one each)
+    # Four contiguous f32 per lane -> ONE 16-byte store per region, 2 in the
+    # phase. Issuing scalars here is a measurable regression, not a style choice.
+
+    if lane == 0:
+        raw_slot = load_i32(ssm_state_indices[n*6 + token])     # stride 6
+        copy_r2s(raw_slot if active else -1, sSlot[token])      # source order:
+        copy_r2s(token_pos, sToken[token])                     # sSlot, sToken,
+        copy_r2s(beta[token_pos*HV + hv], sBeta[token])        # then sBeta
+        # instruction_selection: ld.global.nc.b32 (ssm_state_indices)
+        #                        + ld.global.nc.b16 + cvt.f32.bf16 (beta)
+        #                        + st.shared.b32 x3; extent: scalar
+    if warp == 0 and lane == 0:
+        accepted  = clamp(load_i32(num_accepted_tokens[n]) - 1, 0, 5)   # [0,5]
+        init_slot = load_i32(ssm_state_indices[n*6 + accepted])
+        copy_r2s(0 if init_slot < 0 else init_slot, sInit[0])
+        # instruction_selection: ld.global.nc.b32 x2 + max.s32 x2 + min.s32
+        #                        + st.shared.b32; extent: scalar
+        # Two independent clamps emit two max.s32: `accepted < 0` (:280) and
+        # `initial_slot < 0` (:287).
+        # Both clamp arms are exercised: nat 0/1 agree, 6/13 agree, 1 and 6 differ.
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+
+# ===========================================================================
+# Phase C': gate prefix, sVec publish, sGramA publish  (:293-339)
+# ===========================================================================
+if warp < TOKENS:
+    token = warp
+    for i in range(4):
+        k_idx  = elem_start + i
+        prefix = 1.0
+        for p in range(TOKENS):
+            if token >= p:
+                prefix = mul(prefix, copy_s2r(sD[p, k_idx]))
+        # instruction_selection: ld.shared.b32 + mul.ftz.f32; extent: loop (<=6)
+        # SCALAR (24 in the phase): the walk is across tokens at a fixed key, so
+        # consecutive iterations are 512 B apart.
+
+        copy_r2s(cast(bf16, mul(prefix, r_k[i])), sVec[swz(k_idx*32 + token*2)])
+        copy_r2s(cast(bf16, mul(prefix, r_q[i])), sVec[swz(k_idx*32 + (8+token)*2)])
+        # instruction_selection: cvt.rn.bf16.f32 + st.shared.b16; extent: scalar
+        # The q column is 8+token; the generator's `c_col = 4 + token` at :311 is
+        # a dead store overwritten at :313, and the port drops it.
+
+        half = sGramA0 if k_idx < 64 else sGramA1
+        copy_r2s(cast(bf16, div(r_k[i], prefix)), half[swz(token*128 + (k_idx%64)*2)])
+        # instruction_selection: div.approx.ftz.f32 + cvt.rn.bf16.f32
+        #                        + st.shared.b16; extent: scalar (8 div per body)
+        # The gate-DEFLATED key. sVec holds the inflated one; their product is
+        # the T<=4 ratio factor, with both operands rounded to bf16 and a
+        # division the WY path never performed.
+
+# ===========================================================================
+# Phase C'': the coefficient Gram block  (:340-408)
+# ===========================================================================
+if warp < TOKENS:
+    if VALUE_SPLIT == 4:
+        named_bar_sync(1, TOKENS * 32)     # S4:340-343, all six token warps block
+        # instruction_selection: barrier.sync 1, 192; extent: 6 warps
+        is_gram = (warp == GRAM_WARP)
+    else:
+        is_gram = (warp == GRAM_WARP)
+        if not is_gram:
+            named_bar_arrive(1, TOKENS * 32)   # :406 -- publish and go
+            # instruction_selection: barrier.arrive 1, 192; extent: 6 warps
+
+    if is_gram:
+        if VALUE_SPLIT != 4:
+            named_bar_sync(1, TOKENS * 32)     # :343 -- wait for the other five
+            # instruction_selection: barrier.sync 1, 192; extent: 6 warps
+        gram_a, gram_b = reg_tile(u32, [4]), reg_tile(u32, [4])
+        gram_k_acc, gram_q_acc = reg_tile(f32, [4]), reg_tile(f32, [4])
+
+        for gram_half in range(2):                    # k 0..63 / 64..127
+            for gram_k in range(0, 64, 16):
+                a_addr = swz((lane % 16 * 64 + gram_k + lane // 16 * 8) * 2)
+                b_addr = swz(((gram_half*64 + gram_k + lane % 16) * 16
+                              + lane // 16 * 8) * 2)
+                ldm(sGramA0 if gram_half == 0 else sGramA1, a_addr, gram_a)
+                # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.shared.b16;
+                #                        extent: tile (8 per body)
+                ldm(sVec, b_addr, gram_b, trans=True)
+                # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16;
+                #                        extent: tile (8 per body)
+                # b_addr is phase D's sVec formula; frags [0],[1] are columns
+                # 0..7 (k side), [2],[3] are 8..15 (q side).
+
+                init = (gram_half == 0 and gram_k == 0)
+                mma(gram_k_acc, gram_a, gram_b[0:2], init=init)
+                mma(gram_q_acc, gram_a, gram_b[2:4], init=init)
+                # instruction_selection: mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32;
+                #                        extent: loop (2 x 4 x 2 = 16 issues)
+
+        # M index = SOURCE token, N index = TARGET token.
+        source = frag_row                 # 0..7, masked to < 6
+        target0, target1 = lane_quad*2, lane_quad*2 + 1
+        if source < TOKENS:
+            beta_source = copy_s2r(sBeta[source])
+            if source <  target0 and target0 < TOKENS:
+                copy_r2s(mul(beta_source, gram_k_acc[0]), sL[target0, source])
+            if source <  target1 and target1 < TOKENS:
+                copy_r2s(mul(beta_source, gram_k_acc[1]), sL[target1, source])
+            if source <= target0 and target0 < TOKENS:
+                copy_r2s(mul(beta_source, gram_q_acc[0]), sR[target0, source])
+            if source <= target1 and target1 < TOKENS:
+                copy_r2s(mul(beta_source, gram_q_acc[1]), sR[target1, source])
+            # instruction_selection: mul.ftz.f32 + st.shared.b32; extent: scalar (x4)
+            # Only acc[0],[1] are read; [2],[3] hold M rows 8..15. lane_quads 0..2
+            # cover targets 0..5 -- at T=6 lane_quad 2's SECOND target (5) is live
+            # too -- and lane_quad 3 (targets 6,7) is entirely masked out.
+            # sL gets 15 live entries (strict lower), sR gets 21 (lower + diagonal).
+
+# ===========================================================================
+# Phase B: gather the initial checkpoint  (:410-446)  -- byte-identical to T=5
+# ===========================================================================
+if group < ROW_GROUPS:
+    init_slot = copy_s2r(sInit[0])
+    for row_local in range(ROWS_PER_GROUP):
+        value_row_local = owned_row_base + row_local        # CTA-local, sState
+        value_row       = tile_row_base + value_row_local   # global, `state`
+        copy_g2r(state[init_slot*STATE_SLOT_STRIDE + hv*128*128
+                       + value_row*128 + k_start : +8], state_pack)
+        # instruction_selection: ld.global.v4.b32 (no .nc -- state is written
+        #                        later in this kernel); extent: vector (8; 2 at split8)
+        for i in range(8):
+            hist[row_local*8 + i] = widen(state_pack)[i]
+        # instruction_selection: shl.b32 / and.b32; extent: scalar
+        half, k_off = (sState0, k_start) if lane_group < 8 else (sState1, k_start - 64)
+        copy_r2s(state_pack, half[swz(value_row_local*128 + k_off*2)])
+        # instruction_selection: st.shared.v4.b32; extent: vector (16; 4 at split8)
+        # An if/ELSE selecting the destination half (:438-442), NOT a guard:
+        # lanes 8..15 stage keys 64..127 into sState1.
+
+cta_sync()
+# instruction_selection: bar.sync 0; extent: CTA
+# Orders sState and sL/sR -- and, at splits 1, 2 and 8, sVec: `barrier.arrive`
+# releases but ACQUIRES NOTHING, so every MMA warp except the gram warp first
+# synchronizes with the other token warps here. At split4 all six token warps
+# block on the named barrier, so sVec is already visible.
+
+# ===========================================================================
+# Phase D: the main MMA chain  (:448-490)  -- byte-identical to T=5
+# ===========================================================================
+if warp < MMA_WARPS:
+    for state_half in range(2):
+        for mma_k in range(0, 64, 16):
+            ldm(sVec, swz(((state_half*64 + mma_k + lane % 16)*16
+                           + lane // 16 * 8) * 2), vec_frag, trans=True)
+            # instruction_selection: ldmatrix...x4.trans.shared.b16; extent: tile (8)
+            ldm(sState0 if state_half == 0 else sState1,
+                swz(((warp*16 + lane % 16)*64 + (mma_k + lane // 16 * 8)) * 2),
+                state_frag)
+            # instruction_selection: ldmatrix...x4.shared.b16; extent: tile (8)
+            init = (state_half == 0 and mma_k == 0)
+            mma(mma_acc,   state_frag, vec_frag[0:2], init=init)   # columns 0..7
+            mma(mma_acc_c, state_frag, vec_frag[2:4], init=init)   # columns 8..15
+            # instruction_selection: mma.sync.aligned.m16n8k16...; extent: loop (16)
+            # Two issues per step: the k side needs sVec columns 0..5 and the q
+            # side 8..13, which no single n=8 tile covers.
+
+# ===========================================================================
+# Phase E: quad broadcasts and the WY solve  (:491-566)
+# ===========================================================================
+if warp < MMA_WARPS:
+    # Source emission order (:491-530), then the elided token-5 reads.
+    for t in range(4):
+        ha_lo[t] = bcast(mma_acc[t % 2],     quad_base + t // 2, 31, 0xFFFFFFFF)
+    for t in range(4):
+        ha_hi[t] = bcast(mma_acc[2 + t % 2], quad_base + t // 2, 31, 0xFFFFFFFF)
+    ha_lo[4] = bcast(mma_acc[0], quad_base + 2, 31, 0xFFFFFFFF)
+    ha_hi[4] = bcast(mma_acc[2], quad_base + 2, 31, 0xFFFFFFFF)
+    for t in range(5):
+        hc_lo[t] = bcast(mma_acc_c[t % 2],     quad_base + t // 2, 31, 0xFFFFFFFF)
+    for t in range(5):
+        hc_hi[t] = bcast(mma_acc_c[2 + t % 2], quad_base + t // 2, 31, 0xFFFFFFFF)
+    # instruction_selection: shfl.sync.idx.b32; extent: loop (20 per body)
+
+    ha_lo[5], ha_hi[5] = mma_acc[1],   mma_acc[3]        # :533-534, NO shuffle
+    hc_lo[5], hc_hi[5] = mma_acc_c[1], mma_acc_c[3]      # :535-536
+    # instruction_selection: none -- register moves, folded away
+    # Token 5's source lane IS quad_base + 2, the only lane that consumes it, so
+    # the source reads the local registers. Assigned outside the lane_quad == 2
+    # guard: every lane executes them, only lane_quad 2's values are meaningful.
+
+    if lane_quad == 2:
+        row_lo, row_hi = warp*16 + frag_row, warp*16 + frag_row + 8
+        for t in range(TOKENS):                       # depth 6
+            base = (copy_s2r(sToken[t]) * HV + hv) * 128
+            solved_lo = sub(cast(f32, v[base + tile_row_base + row_lo]), ha_lo[t])
+            solved_hi = sub(cast(f32, v[base + tile_row_base + row_hi]), ha_hi[t])
+            # instruction_selection: ld.global.nc.b16 + cvt.f32.bf16 + sub.ftz.f32;
+            #                        extent: scalar (12 v loads in the phase)
+            for p in range(TOKENS):
+                if p < t:
+                    coef = copy_s2r(sL[t, p])
+                    solved_lo = sub(solved_lo, mul(coef, u_lo[p]))
+                    solved_hi = sub(solved_hi, mul(coef, u_hi[p]))
+            # instruction_selection: ld.shared.{b32,v2.b32,v4.b32} (the 15 live
+            #                        sL entries are read as a mixed scalar/vector
+            #                        set) + mul.ftz.f32 + sub.ftz.f32;
+            #                        extent: loop (15 live (t,p) pairs)
+            u_lo[t], u_hi[t] = solved_lo, solved_hi
+
+    for t in range(TOKENS):
+        u_lo[t] = bcast(u_lo[t], quad_base + 2, 31, 0xFFFFFFFF)
+        u_hi[t] = bcast(u_hi[t], quad_base + 2, 31, 0xFFFFFFFF)
+    # instruction_selection: shfl.sync.idx.b32; extent: loop (12 per body)
+    # The solve runs on lane_quad == 2 but lane_quad == 3 also writes output.
+
+# ===========================================================================
+# Phase F: the outputs  (:568-670)
+# ===========================================================================
+if warp < MMA_WARPS and lane_quad >= 2:
+    token0, token1 = (lane_quad - 2) * 2, (lane_quad - 2) * 2 + 1
+    row_lo_f, row_hi_f = warp*16 + frag_row, warp*16 + frag_row + 8
+    # `tile_row_base` is folded into the store BASE below, exactly as the
+    # merged T=5 port does: the source stores to `global_row_lo =
+    # tile_row_base + value_row_lo_1` (:606-607). Dropping it is invisible at
+    # split1 -- `value_tile = work & 0` folds it to 0 -- and silently wrong at
+    # splits 2/4/8, where every value tile would write head rows [0, ROWS).
+    # STATIC indices under a lane_quad branch, as the source does -- indexing
+    # hc_* by a runtime token would spill the register array to local memory.
+    out0_lo, out1_lo, out0_hi, out1_hi = hc_lo[0], hc_lo[1], hc_hi[0], hc_hi[1]
+    if lane_quad == 3:
+        out0_lo, out1_lo, out0_hi, out1_hi = hc_lo[2], hc_lo[3], hc_hi[2], hc_hi[3]
+
+    for s in range(TOKENS):
+        coef0 = copy_s2r(sR[token0, s]) if token0 >= s else 0.0
+        coef1 = copy_s2r(sR[token1, s]) if token1 >= s else 0.0
+        # instruction_selection: ld.shared.b32; extent: scalar (masked)
+        out0_lo = fma(coef0, u_lo[s], out0_lo);  out1_lo = fma(coef1, u_lo[s], out1_lo)
+        out0_hi = fma(coef0, u_hi[s], out0_hi);  out1_hi = fma(coef1, u_hi[s], out1_hi)
+        # instruction_selection: fma.rn.ftz.f32; extent: loop (6 x 4 = 24)
+
+    for (token, lo, hi) in ((token0, out0_lo, out0_hi), (token1, out1_lo, out1_hi)):
+        slot = copy_s2r(sSlot[token])
+        base = (copy_s2r(sToken[token])*HV + hv)*128 + tile_row_base
+        copy_r2g(cast(bf16, lo) if slot >= 0 else 0.0, out[base + row_lo_f])
+        copy_r2g(cast(bf16, hi) if slot >= 0 else 0.0, out[base + row_hi_f])
+        # instruction_selection: cvt.rn.bf16.f32 + st.global.b16; extent: scalar
+        # A padded row writes an EXPLICIT zero -- it is not skipped.
+
+    if lane_quad == 2:                        # BOTH tails live here at T=6
+        out4_lo, out4_hi = hc_lo[4], hc_hi[4]
+        for s in range(TOKENS):
+            coef4 = copy_s2r(sR[4, s]) if s <= 4 else 0.0
+            # instruction_selection: ld.shared.v2.b32 + ld.shared.v4.b32
+            #                        (sR[24..29] in one pair of loads);
+            #                        extent: vector
+            # Row 4 of sR is contiguous, so the whole six-entry row is loaded --
+            # INCLUDING sR[29] -- and the clamp discards element 5 afterwards.
+            # That clamp is load-bearing: sR[29] = (target 4, source 5) is never
+            # written by the gram block, whose predicate is `source <= target`.
+            # The source's own unconditional read at :633 is dead; the port
+            # drops it and keeps the clamp.
+            out4_lo = fma(coef4, u_lo[s], out4_lo)
+            out4_hi = fma(coef4, u_hi[s], out4_hi)
+        store token 4 exactly as above (same `... + tile_row_base` base),
+            predicated on sSlot[4]
+
+        out5_lo, out5_hi = hc_lo[5], hc_hi[5]
+        for s in range(TOKENS):
+            coef5 = copy_s2r(sR[5, s])        # NO clamp: target 5 accepts all six
+            # instruction_selection: ld.shared.v4.b32 + ld.shared.v2.b32
+            #                        (sR[30..35]); extent: vector
+            out5_lo = fma(coef5, u_lo[s], out5_lo)
+            out5_hi = fma(coef5, u_hi[s], out5_hi)
+        store token 5 exactly as above (same `... + tile_row_base` base),
+            predicated on sSlot[5]
+        # instruction_selection: fma.rn.ftz.f32 + cvt.rn.bf16.f32
+        #                        + st.global.b16, plus 6 scalar ld.shared.b32 for
+        #                        the tails' sSlot[4]/sToken[4]/sSlot[5]/sToken[5];
+        #                        extent: 24 fma, 8 stores
+        # Both tails' coefficient rows vectorize. At T=5 only one tail existed
+        # and the sketch there called it "the only sR read in the body that
+        # vectorizes"; at T=6 both do, while the masked pair loop above still
+        # cannot.
+    # No out-of-region read anywhere: sSlot/sToken indices < 6, sR indices <= 35.
+
+# ===========================================================================
+# Phase G: publish sU  (:671-684)
+# ===========================================================================
+if warp < MMA_WARPS:
+    if lane_quad == 2:
+        for t in range(TOKENS):
+            copy_r2s(u_lo[t], sU[t, warp*16 + frag_row])
+            copy_r2s(u_hi[t], sU[t, warp*16 + frag_row + 8])
+            # instruction_selection: st.shared.b32; extent: scalar (12 per body)
+    if VALUE_SPLIT != 8:
+        warp_sync()        # :681-683, INSIDE the guard
+        # instruction_selection: bar.warp.sync -1; extent: warp
+        # Warp w produces rows [16w, 16w+16), exactly what its own groups consume.
+
+if VALUE_SPLIT == 8:
+    cta_sync()             # S8:682-684, at OUTER scope -- all 192 threads
+    # instruction_selection: bar.sync 0; extent: CTA
+    # NOTE THE NESTING: split8's `warp_0 < 1` guard CLOSES at S8:681. One MMA
+    # warp produces sU for eight consuming groups, so the barrier must be
+    # unguarded; keeping it inside would hang the kernel.
+
+# ===========================================================================
+# Phase H: FP32 recurrence and checkpoints  (:798-834)
+# ===========================================================================
+if group < ROW_GROUPS:
+    for t in range(TOKENS):
+        slot_t = copy_s2r(sSlot[t]);  beta_t = copy_s2r(sBeta[t])
+        sd_t, sk_t = copy_s2r(sD[t, k_start:+8]), copy_s2r(sK[t, k_start:+8])
+        # instruction_selection: ld.shared.v4.b32 x4 (2 per region); extent: vector
+        # Hoisted OUT of the row loop -- invariant across rows. 44 static v4 at
+        # .loc 812 = 4 per token x 2*TOKENS-1 = 11 replications, the same nvcc
+        # tail duplication the T=5 export shows (9 there).
+
+        # The store predicate is hoisted out of the row loop and the loop
+        # duplicated -- the shape nvcc produces for the source's per-row
+        # `if (slot_t >= 0)` (:818). Keeping the branch per row costs DRAM
+        # utilisation at the largest split1 shapes; the T=5 port measured it.
+        if slot_t >= 0:
+            for row_local in range(ROWS_PER_GROUP):
+                row_h  = owned_row_base + row_local
+                update = mul(copy_s2r(sU[t, row_h]), beta_t)
+                for i in range(8):
+                    hist[row_local*8 + i] = fma(hist[row_local*8 + i], sd_t[i],
+                                                mul(update, sk_t[i]))
+                # instruction_selection: mul.ftz.f32 + fma.rn.ftz.f32;
+                #                        extent: loop (6 x ROWS_PER_GROUP x 8)
+                # `hist*sD + (sU*beta)*sK`: the compiler contracts the FIRST
+                # product and rounds update*sK.
+                copy_r2g(pack_bf16x2(hist[row_local]),
+                         state[slot_t*STATE_SLOT_STRIDE + hv*128*128
+                               + (tile_row_base + row_h)*128 + k_start])
+                # instruction_selection: cvt.rn.bf16x2.f32 x4 + st.global.v4.b32;
+                #                        extent: vector (48 stores; 12 at split8)
+        else:
+            for row_local in range(ROWS_PER_GROUP):   # advance, store nothing
+                same recurrence, no store
+```
+
+## Instruction-selection summary
+
+Counted from the exported `--source-in-ptx` bodies with `ptx_census.py`
+(comment-, brace- and predicate-aware) and attributed with
+`ptx_phase_census.py` via `.loc`, restricted to the body file — `__shfl_sync`
+and the bf16 conversions carry header line numbers and are only attributable
+through `inlined_at`.
+
+| form | s1 | s2 | s4 | s8 | where |
+| --- | --- | --- | --- | --- | --- |
+| `mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32` | 32 | 32 | 32 | 32 | 16 gram + 16 main |
+| `ldmatrix...x4.shared.b16` | 16 | 16 | 16 | 16 | 8 gram (A) + 8 main (sState) |
+| `ldmatrix...x4.trans.shared.b16` | 16 | 16 | 16 | 16 | 8 gram (sVec) + 8 main (sVec) |
+| `shfl.sync.idx.b32` | 33 | 33 | 33 | 33 | 1 warp-uniform + **20** broadcasts + **12** u |
+| `shfl.sync.bfly.b32` | 10 | 10 | 10 | 10 | phase A's two L2 reductions |
+| `div.approx.ftz.f32` | 8 | 8 | 8 | 8 | `k / prefix`, 4 elements x 2 halves |
+| `ex2.approx.ftz.f32` | 4 | 4 | 4 | 4 | the gate, phase A |
+| `rsqrt.approx.ftz.f32` | 2 | 2 | 2 | 2 | the q and k L2 norms |
+| `bar.sync 0` | 2 | 2 | 2 | **3** | split8 replaces the warp barrier |
+| `bar.warp.sync` | 1 | 1 | 1 | **0** | ditto |
+| `barrier.sync/arrive 1, 192` | 2 | 2 | **1** | 2 | split4's arrive arm is dead |
+| `st.shared.b16` | 16 | 16 | 16 | 16 | 4 sVec-k + 4 sVec-q + 8 sGramA |
+| `st.shared.v4.b32` | 18 | 18 | 18 | **6** | 2 phase-A sK/sD + phase-B staging |
+| `st.shared.b32` | 20 | 20 | 20 | 20 | 4 phase-A scalars + 4 gram sL/sR + 12 sU |
+| `ld.shared.b32` | 57 | 57 | 57 | 57 | 24 in C′ (gate prefix), 17 in F (sR/sSlot/sToken), 11 in H, 2 in E, 1 sInit (`:292`), 1 in the gram block, 1 hoisted `sBeta[5]` with no `.loc` |
+| `ld.shared.v4.b32` | 60 | 60 | 60 | **49** | 55 in H (44 sD/sK hoisted per token + 11 sU), 3 in E, 2 in F |
+| `ld.shared.v2.b32` | 29 | 29 | 29 | **18** | 22 in H (sU peel), 4 in E (sToken/sL), 3 in F |
+| `fma.rn.ftz.f32` | 760 | 760 | 760 | **226** | phase H dominates; 48 in F, 8 in A's dot chains |
+| `mul.ftz.f32` | 867 | 867 | 867 | **275** | phase H dominates; C′'s prefix walk, E's solve, 4 in the gram result map |
+| `ld.global.nc.v2.b32` | 3 | 3 | 3 | 3 | phase A's q, k and g slices |
+| `ld.global.v4.b32` | 8 | 8 | 8 | **2** | phase B, one per owned row |
+| `st.global.b16` | 14 | 14 | 14 | 14 | phase F outputs, scalar |
+| `st.global.v4.b32` | 48 | 48 | 48 | **12** | phase H checkpoints (6 tokens x rows) |
+| `cvt.rn.bf16x2.f32` | 192 | 192 | 192 | **48** | phase H packing |
+
+Per-phase totals for split2, out of **3553** counted body instructions:
+prologue 197, A 123, C′ 265, gram 127, B 211, D 93, E 175, F 291,
+**H 1969**. The `BLOCK_CHECKPOINT_MMA` block contributes 0 — eliminated,
+not merely unexecuted. Phase H is **55%** of the body; the gram block is
+3.6%. (3553 is `ptx_census.py`'s counted-instruction figure; its
+*statement line* count for the same body is 5112 and includes `.loc`
+directives, declarations and labels.)
+
+Splits 1, 2 and 4 share `ROWS_PER_GROUP = 8` and therefore identical
+key-operation mixes apart from split4's missing `barrier.arrive`; their full
+bodies differ only in address arithmetic (**3430 / 3553 / 3551** counted
+instructions, split1 folding `value_tile` to 0). split8 has **1721**, and
+differs only where `ROWS_PER_GROUP` does.
+
+## Live/dead inventory
+
+Live at T=6 that was dead at T≤4 (and stays live from T=5): `mma_acc_c`,
+`vec_frag[2],[3]`, `hc_*`, `sGramA0/1`, the named barrier. Newly live at T=6
+versus T=5: `ha_*[5]`/`hc_*[5]` (via the elided broadcast), sVec columns 5 and
+13, `sGramA*` row 5, `sL` row 5 / `sR` row 5, and lane_quad 2's second gram
+target.
+
+Still dead: `ratio_scan[4]`; sVec columns 6,7,14,15; `sGramA*` rows 6..15;
+`gram_*_acc[2],[3]`; the whole `BLOCK_CHECKPOINT_MMA` block; the three
+`elem_start < 128` guards (`:194`, `:260`, `:294`) and the `r_q/r_k/r_d`
+zero-init at `:188-193` that precedes the first of them, plus
+`gate_a = 1.0f` (`:259`); and phase F's `token0 < 6` / `token1 < 6` guards
+(`:610`, `:619`), statically true under `lane_quad >= 2` because token0 is
+0 or 2 and token1 is 1 or 3 — this is exactly the guard that is LIVE at T=3
+and that forced the predication that sibling needed. All of these carry
+zero instructions in every export.
+
+**Uninitialized-but-in-region reads are safe.** Both `ldmatrix` sites read full
+16-row / 16-column tiles, touching `sGramA*` rows 6..15 and `sVec` columns
+6,7,14,15 that nobody writes; those land in MMA outputs that no broadcast ever
+selects (`m16n8k16` columns are independent). The one place an uninitialized
+value could reach a result is `sR[29]` in phase F's token-4 tail, and the
+source clamps it — which the port reproduces rather than predicating away.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ point each port backs:
 | `flashkda_decode_t3_lower_bound` | bf16 | FlashKDA "cake" decode, T=3 lower-bound gate computed in-kernel |
 | `flashkda_decode_t4_precomputed` | bf16 | FlashKDA "cake" decode, T=4 precomputed gate (WY, tensor cores) |
 | `flashkda_decode_t5_gram` | bf16 | FlashKDA "cake" decode, T=5 coefficient-Gram gate (tensor-core WY coefficients, all four value splits) |
+| `flashkda_decode_t6_gram` | bf16 | FlashKDA "cake" decode, T=6 coefficient-Gram gate (dynamic shared memory, all four value splits) |
 
 `flashinfer/gdn_prefill/` — `flashinfer.gdn_prefill`:
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "ea0950ab",
-    "tirx-kernels": "61f08633",
+    "tirx-kernels": "8166f465",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "736afe707c184d6025b9662b25e12d6a9b20f312"
+    "tirx-kernels:tirx_kernels": "77f6ea21865a2a95fcdefa23ed6fc59f979ce8cf"
   },
   "baselines": {
     "torch": {
@@ -2311,6 +2311,202 @@
       "impls": {
         "tirx": 14.163372720071113,
         "flashinfer_cake": 16.052781192062394
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv12h12_b64_s1",
+      "label": "hv12h12_b64_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 40.5521320751403,
+        "flashinfer_cake": 42.673299305884
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv12h12_b8_s4",
+      "label": "hv12h12_b8_s4",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.615648386630369,
+        "flashinfer_cake": 16.384643510863956
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv16h16_b2_s8",
+      "label": "hv16h16_b2_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.26483245403878,
+        "flashinfer_cake": 8.809267001413495
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv16h16_b5_s4",
+      "label": "hv16h16_b5_s4",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.045094567892448,
+        "flashinfer_cake": 15.577077671005771
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv16h16_b64_s1",
+      "label": "hv16h16_b64_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 50.32821562431621,
+        "flashinfer_cake": 53.056791933355655
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv16h16_b8_s2",
+      "label": "hv16h16_b8_s2",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.60759211461361,
+        "flashinfer_cake": 12.131849202161726
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b128_s1",
+      "label": "hv32h16_b128_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 176.96006420089253,
+        "flashinfer_cake": 179.937822178715
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b16_s1",
+      "label": "hv32h16_b16_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 27.768000909471162,
+        "flashinfer_cake": 29.509279309002515
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b1_s8",
+      "label": "hv32h16_b1_s8",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.435627763992436,
+        "flashinfer_cake": 9.314902195755867
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b2_s2",
+      "label": "hv32h16_b2_s2",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.667163230824096,
+        "flashinfer_cake": 9.626263705886325
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b32_s1",
+      "label": "hv32h16_b32_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 48.977497779910045,
+        "flashinfer_cake": 52.20792178219764
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b3_s4",
+      "label": "hv32h16_b3_s4",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.536727618229927,
+        "flashinfer_cake": 16.372589466273045
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b64_s1",
+      "label": "hv32h16_b64_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 91.65201766854545,
+        "flashinfer_cake": 92.83441768126445
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashkda_decode_t6_gram",
+      "config": "hv32h16_b8_s1",
+      "label": "hv32h16_b8_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.283695022425709,
+        "flashinfer_cake": 17.01846355341056
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '61f08633', 'tirx-bench-ci': None}`
-- Workloads: 306 ok, 0 failed
+- Git:       `{'tir': 'ea0950ab', 'tirx-kernels': '8166f465', 'tirx-bench-ci': None}`
+- Workloads: 320 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -270,6 +270,25 @@ Grouped workloads show one row per config and one timing column per implementati
 | `hv32h16_b3_s4` | tirx | 8.7830 | flashinfer_cake | 10.1928 | 1.161 | — |
 | `hv32h16_b64_s1` | tirx | 81.5038 | flashinfer_cake | 83.4040 | 1.023 | — |
 | `hv32h16_b8_s1` | tirx | 14.1634 | flashinfer_cake | 16.0528 | 1.133 | — |
+
+## flashkda_decode_t6_gram
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hv12h12_b64_s1` | tirx | 40.5521 | flashinfer_cake | 42.6733 | 1.052 | — |
+| `hv12h12_b8_s4` | tirx | 14.6156 | flashinfer_cake | 16.3846 | 1.121 | — |
+| `hv16h16_b2_s8` | tirx | 7.2648 | flashinfer_cake | 8.8093 | 1.213 | — |
+| `hv16h16_b5_s4` | tirx | 14.0451 | flashinfer_cake | 15.5771 | 1.109 | — |
+| `hv16h16_b64_s1` | tirx | 50.3282 | flashinfer_cake | 53.0568 | 1.054 | — |
+| `hv16h16_b8_s2` | tirx | 10.6076 | flashinfer_cake | 12.1318 | 1.144 | — |
+| `hv32h16_b128_s1` | tirx | 176.9601 | flashinfer_cake | 179.9378 | 1.017 | — |
+| `hv32h16_b16_s1` | tirx | 27.7680 | flashinfer_cake | 29.5093 | 1.063 | — |
+| `hv32h16_b1_s8` | tirx | 7.4356 | flashinfer_cake | 9.3149 | 1.253 | — |
+| `hv32h16_b2_s2` | tirx | 8.6672 | flashinfer_cake | 9.6263 | 1.111 | — |
+| `hv32h16_b32_s1` | tirx | 48.9775 | flashinfer_cake | 52.2079 | 1.066 | — |
+| `hv32h16_b3_s4` | tirx | 14.5367 | flashinfer_cake | 16.3726 | 1.126 | — |
+| `hv32h16_b64_s1` | tirx | 91.6520 | flashinfer_cake | 92.8344 | 1.013 | — |
+| `hv32h16_b8_s1` | tirx | 15.2837 | flashinfer_cake | 17.0185 | 1.114 | — |
 
 ## fp16_bf16_gemm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t6_gram.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/kda/flashkda_decode_t6_gram.yaml
@@ -1,0 +1,42 @@
+# FlashKDA "cake" T=6 coefficient-gram decode, against the frozen FlashInfer
+# exports it is ported from. This is the last variant in the cake family.
+#
+# T=6 shares one arm of the sm100a value-split policy with T=5
+# (recurrent_kda.py:1181-1191 is a single `if num_tokens in (5, 6):`), so the
+# split is chosen by shape here too: with W = num_seqs * num_value_heads and S
+# SMs the policy returns 8 for W <= 3S/8, 2 for W <= S/2, 4 for W <= 3S/4, 2
+# again for W <= 3S/2, and 1 above that. The split4 band sits *between* two
+# split2 bands, so it is not monotonic in W. All four exports are reachable,
+# all four are ported, and .porting/.../verify_dispatch.py asserts the split
+# each row selects by feeding its real tensors into FlashInfer's own selector.
+#
+# Coverage matters more here than at T=5: upstream's only T=6 GPU test is the
+# (6, 8) matrix row, which selects split1, so splits 2/4/8 have no upstream
+# correctness coverage at all -- the rows below and the port's forced-split
+# CONFIGS are what exercise them.
+#
+#   hv32h16_b{8,16,32,64,128}_s1   parity with FlashInfer's own T=6 export bench,
+#                                  which pins split1 for exactly these five shapes
+#   hv32h16_b{1,2,3}_s{8,2,4}      small batch walks the first three bands
+#                                  (W = 32, 64, 96) at the same head count
+#   hv16h16_b{2,5,8,64}            the non-GQA head count; b8 (W = 128) lands in
+#                                  the SECOND split2 band, above the split4 island
+#   hv12h12_b{8,64}                Kimi K3's TP8 per-rank head count (W = 96, 768)
+#
+# Split coverage over the 14 rows: split1 x7, split2 x2, split4 x3, split8 x2.
+kernel: flashkda_decode_t6_gram
+configs:
+  - {config: hv32h16_b8_s1, default: true}
+  - {config: hv32h16_b16_s1, default: true}
+  - {config: hv32h16_b32_s1, default: true}
+  - {config: hv32h16_b64_s1, default: true}
+  - {config: hv32h16_b128_s1, default: true}
+  - {config: hv32h16_b1_s8, default: true}
+  - {config: hv32h16_b2_s2, default: true}
+  - {config: hv32h16_b3_s4, default: true}
+  - {config: hv16h16_b2_s8, default: true}
+  - {config: hv16h16_b5_s4, default: true}
+  - {config: hv16h16_b8_s2, default: true}
+  - {config: hv16h16_b64_s1, default: true}
+  - {config: hv12h12_b8_s4, default: true}
+  - {config: hv12h12_b64_s1, default: true}

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -1,0 +1,938 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400),
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx port of FlashInfer's FlashKDA "cake" T=6 coefficient-gram decode kernel.
+
+Source: ``csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split{1,2,4,8}.cu``,
+symbol ``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- the T=6 member of
+the same ``coefficient_gram`` generator family as the ported T=6 sibling, and
+the last cake variant upstream exports.
+
+Dispatch reaches these bodies whenever ``num_tokens == 6`` with
+``num_spec_tokens == 5`` and a precomputed log-space gate. T=6 and T=6 share
+one arm of the sm100a value-split policy (``recurrent_kda.py:1181-1191``), so
+the split is shape-dependent here too and all four exports are in scope.
+
+Structurally this is the T=6 body at TOKENS=6 with four deltas:
+
+* **The arena is dynamic shared memory.** split1 needs 50560 B, past the
+  49152 B static ceiling every earlier cake port used, so all four splits
+  allocate through ``T.SMEMPool`` -- which is also what the source does
+  (``extern __shared__ __align__(1024)`` plus ``cudaFuncSetAttribute``).
+* **Token 5's quad broadcast is elided.** The ``(quad_base + t//2, acc[t%2])``
+  map holds for all six tokens, but token 5's source lane is ``quad_base + 2``
+  -- the only lane that consumes it -- so the source reads the local registers
+  instead and the broadcast count stays at 20.
+* **Phase F gained a second tail.** ``lane_quad == 2`` now writes tokens 0, 1,
+  4 and 5; token 4's coefficient row needs a clamp because ``sR[29]`` (target
+  4, source 5) is never written by the gram block.
+* Six token warps: 256/192/192/192 threads, ``barrier.sync 1, 192``, and the
+  gram warp is warp 5 at splits 4 and 8.
+
+Helper vocabulary is shared with the T=2 module; only the geometry constants,
+the frozen digests and the kernel body are per-specialization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from unittest import SkipTest
+
+import torch
+
+from tvm.script import tirx as T
+
+from . import flashkda_decode_t2_precomputed as _t2
+
+# Shared helper vocabulary (identical PTX forms, identical swizzle -- verified
+# against this body's exports too; see .porting/.../toolchain_notes.md).
+_ptx_un = _t2._ptx_un
+_ptx_bin = _t2._ptx_bin
+_ptx_ter = _t2._ptx_ter
+_mul = _t2._mul
+_add = _t2._add
+_sub = _t2._sub
+_fma = _t2._fma
+_rsqrt = _t2._rsqrt
+_expf = _t2._expf
+_shfl_bfly = _t2._shfl_bfly
+_shfl_idx = _t2._shfl_idx
+_load_i32 = _t2._load_i32
+_load_bf16_f32 = _t2._load_bf16_f32
+_widen_lo = _t2._widen_lo
+_widen_hi = _t2._widen_hi
+_load_u32x2 = _t2._load_u32x2
+_load_u32x4 = _t2._load_u32x4
+_store_u32x4 = _t2._store_u32x4
+_pack_bf16x2 = _t2._pack_bf16x2
+_store_f32_as_bf16 = _t2._store_f32_as_bf16
+_swz = _t2._swz
+_st_shared_f32 = _t2._st_shared_f32
+_ld_shared_f32 = _t2._ld_shared_f32
+_st_shared_i32 = _t2._st_shared_i32
+_ld_shared_i32 = _t2._ld_shared_i32
+_ld_shared_f32x4 = _t2._ld_shared_f32x4
+_st_shared_u32x4 = _t2._st_shared_u32x4
+_st_shared_b16 = _t2._st_shared_b16
+_ldmatrix_x4 = _t2._ldmatrix_x4
+_mma_zero = _t2._mma_zero
+_mma_acc = _t2._mma_acc
+
+
+def _div(a, b):
+    """``div.approx.ftz.f32`` -- the lowering nvcc picks for ``k / prefix``.
+
+    Read off the exported PTX (8 of them in the sVec/sGramA publish, none of
+    the rcp+mul or full-range forms); -use_fast_math selects the approximate line.
+    """
+    return _ptx_bin("div.approx.ftz.f32", a, b)
+
+
+def _make_warp_uniform(value):
+    """``shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF`` -- the source's :36-39.
+
+    Semantically the identity (every lane of a warp already holds the same
+    ``tid / 32``), which is why the ported T<=4 siblings spell it ``tid // 32``
+    and drop the instruction. It is NOT droppable here: it is the hint that lets
+    ptxas prove ``warp_0 < 5`` is warp-uniform. Without it, at split1 -- the only
+    geometry where that guard is live -- ptxas cannot assume the shuffles inside
+    phase A are collectively executed and wraps them in a
+    ``WARPSYNC.COLLECTIVE``/``ENDCOLLECTIVE`` retry region with a back-edge over
+    most of the kernel: 14 WARPSYNC, 10 ENDCOLLECTIVE and 10 duplicate
+    register-operand ``SHFL.BFLY`` against the export's zero.
+    """
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.idx.b32(
+            out[0], T.reinterpret("uint32", value), T.uint32(0), T.uint32(31), T.uint32(0xFFFFFFFF)
+        )
+    )
+    return T.reinterpret("int32", out[0])
+
+
+def _named_bar_sync(bar_id: int, threads: int):
+    """``barrier.sync <id>, <count>`` -- blocks until `count` threads arrive."""
+    T.evaluate(T.ptx["barrier.sync"](bar_id, threads))
+
+
+def _named_bar_arrive(bar_id: int, threads: int):
+    """``barrier.arrive <id>, <count>`` -- releases, does NOT block or acquire."""
+    T.evaluate(T.ptx["barrier.arrive"](bar_id, threads))
+
+
+def _mma_zero_b(acc, a, b, b0: int):
+    """``mma.sync...m16n8k16`` with an explicit zero C, B taken at ``b[b0:b0+2]``.
+
+    The gram block issues two products from one pair of ``ldmatrix`` results, so
+    unlike the shared helper this one has to select the B half.
+    """
+    T.evaluate(
+        T.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+            acc[0], acc[1], acc[2], acc[3],
+            a[0], a[1], a[2], a[3],
+            b[b0], b[b0 + 1],
+            *_t2._MMA_ZERO_C,
+        )
+    )  # fmt: skip
+
+
+def _mma_acc_b(acc, a, b, b0: int):
+    """Same, accumulating: C aliases D, matching the source's `+f` tied registers."""
+    T.evaluate(
+        T.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+            acc[0], acc[1], acc[2], acc[3],
+            a[0], a[1], a[2], a[3],
+            b[b0], b[b0 + 1],
+            acc[0], acc[1], acc[2], acc[3],
+        )
+    )  # fmt: skip
+
+
+# --- source pinning -------------------------------------------------------
+# Raw and normalized digests differ for every T=6 export; the hash of the bytes
+# between the BEGIN/END markers is the raw one (verified for all four).
+FROZEN_FLASHINFER_COMMIT = "f2e04400"
+FROZEN_BODY_SHA256 = {
+    1: "6684bee1c3e1354082e8603574fe43a5b37991dd2767c9b33104d97cd84bbc55",
+    2: "27e047dc15f2bb4972718b15143d1ebff6cfe21c42aa5688db8245a22c7eba55",
+    4: "f38dc82927095886ce8b030becd0761124d9a0aab3a8373efd17818f7f760463",
+    8: "96593303ff3d6dbb7e9c603f1b76d9eb87eb21f03341a796ea63cdd9e8ee1dac",
+}
+
+HEAD_DIM = _t2.HEAD_DIM
+NUM_TOKENS = 6
+L2_EPS = _t2.L2_EPS
+LOG2_E = _t2.LOG2_E
+
+# Per-split geometry, transcribed from the four bodies' `#define` blocks and
+# their guard expressions (`.cu:45-88`, `:143-166`, `:180`, `:411`, `:448`,
+# `:652`). `threads` is FLASHKDA_DECODE_LAUNCH_THREADS (the `#define THREADS
+# 256` in every body is vestigial -- it only feeds a static_assert in
+# binding_impl.cuh:40); it is derived upstream by
+# `max(tokens, value_rows/16, ((value_rows/rows_per_group)+1)/2) * 32`
+# with rows_per_group = 2 only for gram+split8 (flash_kda_decode.py:115-134).
+_SPLIT_GEOMETRY: dict[int, dict[str, int]] = {
+    1: {
+        "threads": 256,  # 8 warps
+        "rows_per_cta": 128,
+        "mma_warps": 8,
+        "row_groups": 16,
+        "rows_per_group": 8,
+        "gram_warp": 0,
+        "gram_sync_all": 0,
+        "su_sync_cta": 0,
+        "smem_total": 50560,
+        "off_sstate0": 0,
+        "off_sstate1": 16384,
+        "off_svec": 32768,
+        "off_sk": 36864,
+        "off_sd": 39936,
+        "off_sbeta": 43008,
+        "off_sslot": 43032,
+        "off_stoken": 43056,
+        "off_sinit": 43080,
+        "off_sl": 43096,
+        "off_sr": 43240,
+        "off_su": 43384,
+        "off_sgrama0": 46464,
+        "off_sgrama1": 48512,
+    },
+    2: {
+        "threads": 192,  # 6 warps
+        "rows_per_cta": 64,
+        "mma_warps": 4,
+        "row_groups": 8,
+        "rows_per_group": 8,
+        "gram_warp": 0,
+        "gram_sync_all": 0,
+        "su_sync_cta": 0,
+        "smem_total": 32640,
+        "off_sstate0": 0,
+        "off_sstate1": 8192,
+        "off_svec": 16384,
+        "off_sk": 20480,
+        "off_sd": 23552,
+        "off_sbeta": 26624,
+        "off_sslot": 26648,
+        "off_stoken": 26672,
+        "off_sinit": 26696,
+        "off_sl": 26712,
+        "off_sr": 26856,
+        "off_su": 27000,
+        "off_sgrama0": 28544,
+        "off_sgrama1": 30592,
+    },
+    4: {
+        "threads": 192,  # 6 warps
+        "rows_per_cta": 32,
+        "mma_warps": 2,
+        "row_groups": 4,
+        "rows_per_group": 8,
+        "gram_warp": 5,
+        "gram_sync_all": 1,
+        "su_sync_cta": 0,
+        "smem_total": 23680,
+        "off_sstate0": 0,
+        "off_sstate1": 4096,
+        "off_svec": 8192,
+        "off_sk": 12288,
+        "off_sd": 15360,
+        "off_sbeta": 18432,
+        "off_sslot": 18456,
+        "off_stoken": 18480,
+        "off_sinit": 18504,
+        "off_sl": 18520,
+        "off_sr": 18664,
+        "off_su": 18808,
+        "off_sgrama0": 19584,
+        "off_sgrama1": 21632,
+    },
+    8: {
+        "threads": 192,  # 6 warps
+        "rows_per_cta": 16,
+        "mma_warps": 1,
+        "row_groups": 8,
+        "rows_per_group": 2,
+        "gram_warp": 5,
+        "gram_sync_all": 0,
+        "su_sync_cta": 1,
+        "smem_total": 19200,
+        "off_sstate0": 0,
+        "off_sstate1": 2048,
+        "off_svec": 4096,
+        "off_sk": 8192,
+        "off_sd": 11264,
+        "off_sbeta": 14336,
+        "off_sslot": 14360,
+        "off_stoken": 14384,
+        "off_sinit": 14408,
+        "off_sl": 14424,
+        "off_sr": 14568,
+        "off_su": 14712,
+        "off_sgrama0": 15104,
+        "off_sgrama1": 17152,
+    },
+}
+
+K_PER_THREAD = 8
+
+
+def _case(label: str, **overrides: Any) -> dict[str, Any]:
+    """One config row. Defaults mirror FlashInfer's T=6 export bench."""
+    config: dict[str, Any] = {
+        "label": label,
+        "num_seqs": 8,
+        "num_heads": 16,
+        "num_value_heads": 32,
+        "pool_slack": 6,
+        "padded_seqs": 0,
+        "slot_stride_pad": 0,
+        "gate_token_stride_pad": 0,
+        "accepted": None,
+        "scale": None,
+        "sm_count": None,
+        "seed": 20260816,
+    }
+    config.update(overrides)
+    return config
+
+
+# The T=6 split moves with shape: with W = num_seqs * num_value_heads and S SMs
+# the bands are W <= 3S/8 -> 8, W <= S/2 -> 2, W <= 3S/4 -> 4, W <= 3S/2 -> 2,
+# else 1 (recurrent_kda.py:1181-1191). Every label names the split its shape
+# actually selects on a 148-SM B200, and verify_dispatch.py asserts that
+# against the real selector. The five hv32h16 rows are FlashInfer's own T=6
+# export-bench matrix (all split1); the rest exist to cover the other three
+# exports, which are equally reachable in production.
+BENCH_CONFIGS = [
+    # FlashInfer's own T=6 export bench (W = 256..4096, all split1).
+    _case("hv32h16_b8_s1", num_seqs=8),
+    _case("hv32h16_b16_s1", num_seqs=16),
+    _case("hv32h16_b32_s1", num_seqs=32),
+    _case("hv32h16_b64_s1", num_seqs=64),
+    _case("hv32h16_b128_s1", num_seqs=128),
+    # Small batch at HV=32 walks the first three bands (W = 32, 64, 96).
+    _case("hv32h16_b1_s8", num_seqs=1),
+    _case("hv32h16_b2_s2", num_seqs=2),
+    _case("hv32h16_b3_s4", num_seqs=3),
+    # HV == H == 16: W = 32, 80, 128, 1024 -- note b8 lands in the *second*
+    # split2 band, the one above the split4 island.
+    _case("hv16h16_b2_s8", num_seqs=2, num_value_heads=16),
+    _case("hv16h16_b5_s4", num_seqs=5, num_value_heads=16),
+    _case("hv16h16_b8_s2", num_seqs=8, num_value_heads=16),
+    _case("hv16h16_b64_s1", num_seqs=64, num_value_heads=16),
+    # Kimi K3 TP8 per-rank head count (W = 96, 768).
+    _case("hv12h12_b8_s4", num_seqs=8, num_heads=12, num_value_heads=12),
+    _case("hv12h12_b64_s1", num_seqs=64, num_heads=12, num_value_heads=12),
+]
+
+CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
+    # nat selects the initial checkpoint slot as ssm_idx[n*6 + clamp(nat-1, 0, 5)];
+    # the upstream matrix row sweeps 0/1/6/13, covering both clamp arms (.cu:280-286).
+    _case("hv32h16_b8_nat0", num_seqs=8, accepted="zeros"),
+    _case("hv32h16_b8_nat6", num_seqs=8, accepted="sixes"),
+    _case("hv32h16_b8_nat13", num_seqs=8, accepted="thirteens"),
+    _case("hv32h16_b8_natmix", num_seqs=8, accepted="mixed"),
+    _case("hv32h16_b8_padded", num_seqs=8, padded_seqs=2),
+    _case("hv32h16_b8_strided", num_seqs=8, slot_stride_pad=8),
+    _case("hv32h16_b8_gstride", num_seqs=8, gate_token_stride_pad=8),
+    _case("hv32h16_b8_scale", num_seqs=8, scale=0.05),
+    _case("hv64h16_b8_s1", num_seqs=8, num_value_heads=64),
+    # Forced splits at one fixed shape (W = 256), via the SM count the policy
+    # reads: the same tensors must give the same answer through all four
+    # exports. Unlike T=5, upstream has NO forced-split test at T=6 -- its only
+    # T=6 GPU coverage is the (6, 8) matrix row, which is split1 -- so these
+    # rows and characterize_source.py are the whole story for splits 2/4/8.
+    _case("hv32h16_b8_force_s8", num_seqs=8, sm_count=683),
+    _case("hv32h16_b8_force_s2", num_seqs=8, sm_count=512),
+    _case("hv32h16_b8_force_s4", num_seqs=8, sm_count=342),
+    # Selector knife edges on a 148-SM part: W = 222 -> split2, W = 224 -> split1.
+    _case("hv16h16_b13_edge_s2", num_seqs=13, num_value_heads=16, sm_count=148),
+    _case("hv16h16_b14_edge_s1", num_seqs=14, num_value_heads=16, sm_count=148),
+]
+
+KERNEL_META = {
+    "name": "flashkda_decode_t6_gram",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+
+def _sm_count(kwargs: dict[str, Any]) -> int:
+    """SM count driving the split policy; overridable for deterministic tests."""
+    override = kwargs.get("sm_count")
+    if override is not None:
+        return int(override)
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA is required to resolve the FlashKDA decode value split")
+    device = kwargs.get("device", "cuda")
+    return int(torch.cuda.get_device_properties(device).multi_processor_count)
+
+
+def _select_value_split(work: int, sm_count: int) -> int:
+    """Reproduce ``_select_flash_kda_decode_value_split_current`` for T = 6.
+
+    recurrent_kda.py:1181-1191. `work` is `num_seqs * num_value_heads`. Note the
+    split4 island sits *between* two split2 bands, so this is not monotonic.
+    """
+    three_wave_ctas = 3 * sm_count
+    if 8 * work <= three_wave_ctas:
+        return 8
+    if 2 * work <= sm_count:
+        return 2
+    if 4 * work <= three_wave_ctas:
+        return 4
+    if 2 * work <= three_wave_ctas:
+        return 2
+    return 1
+
+
+def _specialization(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Derive the constexpr set, mirroring the source host dispatch."""
+    num_seqs = int(kwargs["num_seqs"])
+    num_heads = int(kwargs["num_heads"])
+    num_value_heads = int(kwargs["num_value_heads"])
+    slot_stride_pad = int(kwargs.get("slot_stride_pad", 0))
+    gate_token_stride_pad = int(kwargs.get("gate_token_stride_pad", 0))
+    pool_slack = int(kwargs.get("pool_slack", 6))
+
+    if num_value_heads % num_heads != 0 or num_value_heads < num_heads:
+        raise ValueError("num_value_heads must be a multiple of num_heads and >= it")
+    if not 0 < num_seqs <= 65535:
+        raise ValueError("num_seqs must fit grid.y (binding_common.cuh:284-287)")
+    if slot_stride_pad % 8 != 0:
+        raise ValueError("state slot stride padding must stay 8-element aligned")
+    if gate_token_stride_pad % 4 != 0:
+        raise ValueError("gate token stride padding must stay 4-element aligned")
+
+    value_split = _select_value_split(num_seqs * num_value_heads, _sm_count(kwargs))
+    geometry = _SPLIT_GEOMETRY[value_split]
+
+    total_tokens = num_seqs * NUM_TOKENS
+    slot_stride = num_value_heads * HEAD_DIM * HEAD_DIM + slot_stride_pad
+    gate_token_stride = num_value_heads * HEAD_DIM + gate_token_stride_pad
+    state_slots = total_tokens + pool_slack
+    spec = {
+        "NUM_SEQS": num_seqs,
+        "NUM_HEADS": num_heads,
+        "NUM_VALUE_HEADS": num_value_heads,
+        "HEAD_RATIO": num_value_heads // num_heads,
+        "VALUE_SPLIT": value_split,
+        "STATE_SLOT_STRIDE": slot_stride,
+        "GATE_TOKEN_STRIDE": gate_token_stride,
+        "Q_ELEMENTS": total_tokens * num_heads * HEAD_DIM,
+        "V_ELEMENTS": total_tokens * num_value_heads * HEAD_DIM,
+        "GATE_ELEMENTS": total_tokens * gate_token_stride,
+        "BETA_ELEMENTS": total_tokens * num_value_heads,
+        "STATE_ELEMENTS": state_slots * slot_stride,
+        "CU_SEQLENS_ELEMENTS": num_seqs + 1,
+        "STATE_INDEX_ELEMENTS": total_tokens,
+        "NAT_ELEMENTS": num_seqs,
+    }
+    spec.update({key.upper(): value for key, value in geometry.items()})
+    return spec
+
+
+# TIRX_TRANSCRIBE_START flashkda_decode_t6_gram
+
+
+@T.jit
+def _flashkda_decode_t6_gram(
+    q_h: T.handle,
+    k_h: T.handle,
+    v_h: T.handle,
+    g_h: T.handle,
+    beta_h: T.handle,
+    state_h: T.handle,
+    out_h: T.handle,
+    cu_seqlens_h: T.handle,
+    ssm_state_indices_h: T.handle,
+    num_accepted_tokens_h: T.handle,
+    scale: T.float32,
+    *,
+    NUM_SEQS: T.constexpr,
+    NUM_HEADS: T.constexpr,
+    NUM_VALUE_HEADS: T.constexpr,
+    HEAD_RATIO: T.constexpr,
+    VALUE_SPLIT: T.constexpr,
+    STATE_SLOT_STRIDE: T.constexpr,
+    GATE_TOKEN_STRIDE: T.constexpr,
+    Q_ELEMENTS: T.constexpr,
+    V_ELEMENTS: T.constexpr,
+    GATE_ELEMENTS: T.constexpr,
+    BETA_ELEMENTS: T.constexpr,
+    STATE_ELEMENTS: T.constexpr,
+    CU_SEQLENS_ELEMENTS: T.constexpr,
+    STATE_INDEX_ELEMENTS: T.constexpr,
+    NAT_ELEMENTS: T.constexpr,
+    THREADS: T.constexpr,
+    ROWS_PER_CTA: T.constexpr,
+    MMA_WARPS: T.constexpr,
+    ROW_GROUPS: T.constexpr,
+    ROWS_PER_GROUP: T.constexpr,
+    GRAM_WARP: T.constexpr,
+    GRAM_SYNC_ALL: T.constexpr,
+    SU_SYNC_CTA: T.constexpr,
+    SMEM_TOTAL: T.constexpr,
+    OFF_SSTATE0: T.constexpr,
+    OFF_SSTATE1: T.constexpr,
+    OFF_SVEC: T.constexpr,
+    OFF_SK: T.constexpr,
+    OFF_SD: T.constexpr,
+    OFF_SBETA: T.constexpr,
+    OFF_SSLOT: T.constexpr,
+    OFF_STOKEN: T.constexpr,
+    OFF_SINIT: T.constexpr,
+    OFF_SL: T.constexpr,
+    OFF_SR: T.constexpr,
+    OFF_SU: T.constexpr,
+    OFF_SGRAMA0: T.constexpr,
+    OFF_SGRAMA1: T.constexpr,
+):
+    """FlashKDA "cake" T=6 coefficient-gram decode; 5 token warps.
+
+    Scaffold only -- the body is written in the kernel-sketch stage, from the
+    reviewer-approved sketch at
+    `.agents/sketch/flashinfer/kda/flashkda_decode_t6_gram.md`. Bare `:NNN`
+    references in the transcribed body are into
+    `flashkda_decode_d128_t6_precomputed_gram_split2.cu` unless a split is named.
+    """
+    q = T.match_buffer(q_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    k = T.match_buffer(k_h, (Q_ELEMENTS,), "bfloat16", scope="global")
+    v = T.match_buffer(v_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    g = T.match_buffer(g_h, (GATE_ELEMENTS,), "bfloat16", scope="global")
+    beta = T.match_buffer(beta_h, (BETA_ELEMENTS,), "bfloat16", scope="global")
+    state = T.match_buffer(state_h, (STATE_ELEMENTS,), "bfloat16", scope="global")
+    out = T.match_buffer(out_h, (V_ELEMENTS,), "bfloat16", scope="global")
+    cu = T.match_buffer(cu_seqlens_h, (CU_SEQLENS_ELEMENTS,), "int32", scope="global")
+    ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
+    nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
+    T.device_entry()
+    # TRANSCRIBE: the frozen body goes here (kernel-sketch stage).
+
+
+def get_kernel(**kwargs: Any):
+    """Return the specialized FlashKDA cake T=6 gram decode PrimFunc."""
+    kernel = _flashkda_decode_t6_gram.specialize(**_specialization(kwargs))
+    return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+_NAT_PATTERNS = {None: None, "zeros": 0, "ones": 1, "sixes": 6, "thirteens": 13}
+
+
+def _accepted_tensor(kind: Any, num_seqs: int, device: str) -> torch.Tensor:
+    """num_accepted_tokens per case; the kernel clamps nat-1 into [0, 5]."""
+    if kind is None:
+        return torch.ones(num_seqs, device=device, dtype=torch.int32)
+    if kind == "mixed":
+        # The upstream T=6 matrix test's sweep, tiled to the batch size.
+        pattern = torch.tensor([0, 1, 6, 13, 5, 0, 1, 6], dtype=torch.int32)
+        reps = (num_seqs + pattern.numel() - 1) // pattern.numel()
+        return pattern.repeat(reps)[:num_seqs].to(device)
+    if kind in _NAT_PATTERNS:
+        return torch.full((num_seqs,), _NAT_PATTERNS[kind], device=device, dtype=torch.int32)
+    raise ValueError(f"unknown accepted-token pattern {kind!r}")
+
+
+def prepare_data(**kwargs: Any) -> dict[str, Any]:
+    """Build one deterministic case with independent TIRx / reference state.
+
+    Same recipe as the ported T=2/T=4 siblings at T=6: packed [1, N*5, ...]
+    bf16, a log-space gate (GATE_KIND 0 -- the kernel applies exp()),
+    pre-sigmoided beta, flat [N*5] slot indices with slot 0 never a target.
+    """
+    device = kwargs.get("device", "cuda")
+    if not torch.cuda.is_available() or torch.device(device).type != "cuda":
+        raise SkipTest("CUDA is required for FlashKDA cake T=6 decode")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] != 10:
+        raise SkipTest(f"FlashKDA cake decode targets compute capability 10.x, got {capability}")
+
+    spec = _specialization({**kwargs, "device": device})
+    num_seqs = spec["NUM_SEQS"]
+    num_heads = spec["NUM_HEADS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    gate_token_stride = spec["GATE_TOKEN_STRIDE"]
+    total_tokens = num_seqs * NUM_TOKENS
+    state_slots = spec["STATE_ELEMENTS"] // slot_stride
+    padded_seqs = int(kwargs.get("padded_seqs", 0))
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(int(kwargs["seed"]))
+
+    def randn(*shape: int, dtype=torch.bfloat16, gain: float = 1.0):
+        raw = torch.randn(shape, device=device, dtype=torch.float32, generator=gen)
+        return (gain * raw).to(dtype)
+
+    q = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    k = randn(1, total_tokens, num_heads, HEAD_DIM, gain=0.5)
+    v = randn(1, total_tokens, num_value_heads, HEAD_DIM, gain=0.5)
+    # GATE_KIND == 0: g holds the per-K log-gate; the kernel applies exp().
+    gate_logits = torch.randn(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        device=device,
+        dtype=torch.float32,
+        generator=gen,
+    )
+    g_dense = torch.nn.functional.logsigmoid(gate_logits).to(torch.bfloat16)
+    g_raw = torch.zeros((total_tokens * gate_token_stride,), device=device, dtype=torch.bfloat16)
+    g = g_raw.as_strided(
+        (1, total_tokens, num_value_heads, HEAD_DIM),
+        (total_tokens * gate_token_stride, gate_token_stride, HEAD_DIM, 1),
+    )
+    g.copy_(g_dense)
+    beta = torch.sigmoid(randn(1, total_tokens, num_value_heads, dtype=torch.float32, gain=0.5)).to(
+        torch.bfloat16
+    )
+
+    cu_seqlens = torch.arange(0, total_tokens + 1, NUM_TOKENS, device=device, dtype=torch.int32)
+    # Slot 0 is deliberately never a checkpoint target (upstream bench recipe).
+    slots = torch.arange(1, total_tokens + 1, device=device, dtype=torch.int32).reshape(
+        num_seqs, NUM_TOKENS
+    )
+    if padded_seqs:
+        slots[num_seqs - padded_seqs :, :] = -1
+    ssm_state_indices = slots.contiguous().view(-1)
+    num_accepted_tokens = _accepted_tensor(kwargs.get("accepted"), num_seqs, device)
+
+    def make_state_pool() -> tuple[torch.Tensor, torch.Tensor]:
+        raw = randn(state_slots * slot_stride, gain=0.01)
+        view = raw.as_strided(
+            (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+        return raw, view
+
+    tirx_state_raw, tirx_state = make_state_pool()
+    reference_state_raw = tirx_state_raw.clone()
+    reference_state = reference_state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    initial_state_raw = tirx_state_raw.clone()
+
+    tirx_out = torch.empty(
+        (1, total_tokens, num_value_heads, HEAD_DIM), device=device, dtype=torch.bfloat16
+    )
+
+    scale = kwargs.get("scale")
+    return {
+        "spec": spec,
+        "config": dict(kwargs),
+        "device": device,
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": g,
+        "g_raw": g_raw,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": ssm_state_indices,
+        "ssm_state_indices_2d": slots,
+        "num_accepted_tokens": num_accepted_tokens,
+        "tirx_state_raw": tirx_state_raw,
+        "tirx_state": tirx_state,
+        "reference_state_raw": reference_state_raw,
+        "reference_state": reference_state,
+        "initial_state_raw": initial_state_raw,
+        "tirx_out": tirx_out,
+        "scale": float(scale) if scale is not None else HEAD_DIM**-0.5,
+    }
+
+
+def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        case["q"].reshape(-1),
+        case["k"].reshape(-1),
+        case["v"].reshape(-1),
+        case["g_raw"],
+        case["beta"].reshape(-1),
+        case["tirx_state_raw"],
+        case["tirx_out"].reshape(-1),
+        case["cu_seqlens"],
+        case["ssm_state_indices"],
+        case["num_accepted_tokens"],
+        float(case["scale"]),
+    )
+
+
+def _variant_name(value_split: int) -> str:
+    return f"d128_t6_precomputed_gram_split{value_split}"
+
+
+def _source_body_path(value_split: int) -> str:
+    """Absolute path of the frozen generated body this port transcribes."""
+    import flashinfer
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    return os.path.join(root, "csrc", "kda", f"flashkda_decode_{_variant_name(value_split)}.cu")
+
+
+def assert_frozen_source(value_split: int) -> None:
+    """Fail loudly if the upstream generated body was regenerated."""
+    expected = FROZEN_BODY_SHA256[value_split]
+    path = _source_body_path(value_split)
+    with open(path, "rb") as handle:
+        text = handle.read().decode()
+    marker = "// BEGIN FROZEN GENERATED BODY\n"
+    start = text.index(marker) + len(marker)
+    end = text.index("// END FROZEN GENERATED BODY")
+    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
+    if digest != expected:
+        raise AssertionError(
+            f"{path}: frozen body digest {digest} != pinned {expected}; the "
+            "upstream export was regenerated and this port must be re-verified"
+        )
+
+
+def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
+    """Run the frozen cake export itself on the reference state pool."""
+    from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
+
+    device = case["device"]
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        target = "sm100f" if torch.version.cuda and torch.version.cuda >= "12.9" else "sm100a"
+    elif (major, minor) == (10, 3):
+        target = "sm100f"  # non-direct variants are never built for sm103a
+    else:
+        raise SkipTest(f"no FlashKDA cake export for compute capability {major}.{minor}")
+
+    module = get_flash_kda_decode_module(_variant_name(case["spec"]["VALUE_SPLIT"]), target)
+    reference_out = torch.empty_like(case["tirx_out"])
+    dummy_f32 = torch.ones(1, device=device, dtype=torch.float32)
+
+    module.run(
+        case["q"], case["k"], case["v"], case["g"], case["beta"],
+        dummy_f32, dummy_f32,
+        case["reference_state"], reference_out,
+        case["cu_seqlens"], case["ssm_state_indices"], case["num_accepted_tokens"],
+        float(case["scale"]), 0.0,
+        int(torch.cuda.current_stream(device).cuda_stream),
+    )  # fmt: skip
+    torch.cuda.synchronize(device)
+    return reference_out
+
+
+def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent FP32 oracle of the T=6 delta rule (sequential form)."""
+    spec = case["spec"]
+    num_seqs = spec["NUM_SEQS"]
+    num_value_heads = spec["NUM_VALUE_HEADS"]
+    head_ratio = spec["HEAD_RATIO"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+
+    q = case["q"][0].float()
+    k = case["k"][0].float()
+    v = case["v"][0].float()
+    g = case["g"][0].float()
+    beta = case["beta"][0].float()
+    slots2d = case["ssm_state_indices_2d"]
+    nat = case["num_accepted_tokens"]
+
+    state_raw = case["initial_state_raw"].clone()
+    state_slots = state_raw.numel() // slot_stride
+    state = state_raw.as_strided(
+        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
+        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+    )
+    out = torch.zeros(
+        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
+        device=case["device"],
+        dtype=torch.float32,
+    )
+
+    scale = float(case["scale"])
+    for n in range(num_seqs):
+        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
+        init_slot = int(slots2d[n, accepted].item())
+        if init_slot < 0:
+            init_slot = 0
+        for hv in range(num_value_heads):
+            h = hv // head_ratio
+            # FP32 carry across all tokens; only the checkpoint store rounds.
+            s = state[init_slot, hv].float()
+            for t in range(NUM_TOKENS):
+                row = n * NUM_TOKENS + t
+                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
+                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
+                gamma = torch.exp(g[row, hv])
+
+                decayed = s * gamma.unsqueeze(0)
+                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
+                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
+                out[row, hv] = s @ qn
+
+                slot = int(slots2d[n, t].item())
+                if slot >= 0:
+                    state[slot, hv] = s.to(torch.bfloat16)
+                else:
+                    out[row, hv] = 0.0
+
+    return out.to(torch.bfloat16).unsqueeze(0), state_raw
+
+
+# The port replicates the source's MMA chain, swizzle and association orders, so
+# it should agree with the frozen export to within bf16 rounding.
+_RTOL = 2.0**-8
+_ATOL = 2.0e-3
+# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
+# operands to bf16 -- and at T=6 the WY coefficients themselves come from a
+# bf16 Gram product of `k / prefix`, so this band is wider than the T<=4 one and
+# is re-measured at the correctness gate rather than inherited.
+_ORACLE_RTOL = 2.0**-5
+_ORACLE_ATOL = 6.0e-3
+
+
+def run_test(**kwargs: Any) -> None:
+    """Validate one config against the frozen export and an independent oracle."""
+    from tirx_kernels.runner import compile_kernel
+
+    case = prepare_data(**kwargs)
+    spec = case["spec"]
+    assert_frozen_source(spec["VALUE_SPLIT"])
+
+    executable = compile_kernel(get_kernel(**kwargs))
+    executable(*_tirx_args(case))
+    torch.cuda.synchronize(case["device"])
+
+    tirx_out = case["tirx_out"]
+    tirx_state = case["tirx_state_raw"].clone()
+
+    # 1. the frozen cake export itself, on an independent state pool
+    reference_out = _flashinfer_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        reference_out.float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"output vs flashinfer cake export (split {spec['VALUE_SPLIT']})\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        case["reference_state_raw"].float(),
+        rtol=_RTOL,
+        atol=_ATOL,
+        msg=lambda m: f"state vs flashinfer cake export (split {spec['VALUE_SPLIT']})\n{m}",
+    )
+
+    # 2. an independent FP32 oracle of the same recurrence
+    oracle_out, oracle_state = _torch_reference(case)
+    torch.testing.assert_close(
+        tirx_out.float(),
+        oracle_out.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"output vs FP32 oracle\n{m}",
+    )
+    torch.testing.assert_close(
+        tirx_state.float(),
+        oracle_state.float(),
+        rtol=_ORACLE_RTOL,
+        atol=_ORACLE_ATOL,
+        msg=lambda m: f"state vs FP32 oracle\n{m}",
+    )
+
+    # 3. invariants the tolerances cannot express
+    num_seqs = spec["NUM_SEQS"]
+    slot_stride = spec["STATE_SLOT_STRIDE"]
+    payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM
+    slots2d = case["ssm_state_indices_2d"]
+    initial = case["initial_state_raw"]
+
+    touched: set[int] = set()
+    for seq in range(num_seqs):
+        for t in range(NUM_TOKENS):
+            slot = int(slots2d[seq, t])
+            row = seq * NUM_TOKENS + t
+            if slot < 0:
+                # A padded row writes explicit zeros, so this is exact.
+                assert tirx_out[0, row].abs().max().item() == 0.0, (
+                    f"padded row {seq} token {t} must have a zeroed output"
+                )
+            else:
+                touched.add(slot)
+    n_slots = initial.numel() // slot_stride
+    for slot in range(min(n_slots, num_seqs * NUM_TOKENS + 2)):
+        if slot in touched:
+            continue
+        lo, hi = slot * slot_stride, (slot + 1) * slot_stride
+        assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+            f"untouched state slot {slot} was modified"
+        )
+    if slot_stride > payload:
+        for slot in sorted(touched)[:4]:
+            lo = slot * slot_stride + payload
+            hi = (slot + 1) * slot_stride
+            assert torch.equal(initial[lo:hi], tirx_state[lo:hi]), (
+                f"inter-slot padding after slot {slot} was modified"
+            )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Time the port against the frozen cake export on identical inputs."""
+    rounds = int(kwargs.pop("rounds", 5))
+    cooldown_s = float(kwargs.pop("cooldown_s", 1.0))
+    from tirx_kernels.runner import compile_kernel
+    from tvm.tirx.bench import bench
+
+    case = prepare_data(**kwargs)
+    executable = compile_kernel(get_kernel(**kwargs))
+    args = _tirx_args(case)
+
+    # Validate once, outside the timed region. Both sides mutate their own state
+    # pool in place, so this also proves the pools stayed independent.
+    executable(*args)
+    reference_out = _flashinfer_reference(case)
+    torch.cuda.synchronize(case["device"])
+    torch.testing.assert_close(
+        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+    )
+    torch.testing.assert_close(
+        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
+    )
+
+    def flashinfer_builder():
+        # The nvcc JIT build and warmup both happen here, outside the timing.
+        for _ in range(2):
+            _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+
+        def launch():
+            _flashinfer_reference(case)
+
+        return launch
+
+    return bench(
+        {"tirx": lambda: executable(*args)},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashinfer_cake": flashinfer_builder},
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "assert_frozen_source",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -8,15 +8,15 @@
 
 Source: ``csrc/kda/flashkda_decode_d128_t6_precomputed_gram_split{1,2,4,8}.cu``,
 symbol ``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- the T=6 member of
-the same ``coefficient_gram`` generator family as the ported T=6 sibling, and
+the same ``coefficient_gram`` generator family as the ported T=5 sibling, and
 the last cake variant upstream exports.
 
 Dispatch reaches these bodies whenever ``num_tokens == 6`` with
-``num_spec_tokens == 5`` and a precomputed log-space gate. T=6 and T=6 share
+``num_spec_tokens == 5`` and a precomputed log-space gate. T=5 and T=6 share
 one arm of the sm100a value-split policy (``recurrent_kda.py:1181-1191``), so
 the split is shape-dependent here too and all four exports are in scope.
 
-Structurally this is the T=6 body at TOKENS=6 with four deltas:
+Structurally this is the T=5 body at TOKENS=6 with four deltas:
 
 * **The arena is dynamic shared memory.** split1 needs 50560 B, past the
   49152 B static ceiling every earlier cake port used, so all four splits
@@ -99,7 +99,7 @@ def _make_warp_uniform(value):
     Semantically the identity (every lane of a warp already holds the same
     ``tid / 32``), which is why the ported T<=4 siblings spell it ``tid // 32``
     and drop the instruction. It is NOT droppable here: it is the hint that lets
-    ptxas prove ``warp_0 < 5`` is warp-uniform. Without it, at split1 -- the only
+    ptxas prove ``warp_0 < 6`` is warp-uniform. Without it, at split1 -- the only
     geometry where that guard is live -- ptxas cannot assume the shuffles inside
     phase A are collectively executed and wraps them in a
     ``WARPSYNC.COLLECTIVE``/``ENDCOLLECTIVE`` retry region with a back-edge over
@@ -171,7 +171,7 @@ LOG2_E = _t2.LOG2_E
 
 # Per-split geometry, transcribed from the four bodies' `#define` blocks and
 # their guard expressions (`.cu:45-88`, `:143-166`, `:180`, `:411`, `:448`,
-# `:652`). `threads` is FLASHKDA_DECODE_LAUNCH_THREADS (the `#define THREADS
+# `:671`, `:681-684`). `threads` is FLASHKDA_DECODE_LAUNCH_THREADS (the `#define THREADS
 # 256` in every body is vestigial -- it only feeds a static_assert in
 # binding_impl.cuh:40); it is derived upstream by
 # `max(tokens, value_rows/16, ((value_rows/rows_per_group)+1)/2) * 32`
@@ -494,7 +494,7 @@ def _flashkda_decode_t6_gram(
     OFF_SGRAMA0: T.constexpr,
     OFF_SGRAMA1: T.constexpr,
 ):
-    """FlashKDA "cake" T=6 coefficient-gram decode; 5 token warps.
+    """FlashKDA "cake" T=6 coefficient-gram decode; 6 token warps.
 
     Scaffold only -- the body is written in the kernel-sketch stage, from the
     reviewer-approved sketch at
@@ -514,6 +514,13 @@ def _flashkda_decode_t6_gram(
     nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
     T.device_entry()
     # TRANSCRIBE: the frozen body goes here (kernel-sketch stage).
+
+
+# The dynamic-shared arena is only backed at launch when the kernel asks for
+# it; without this tag the launch reserves zero bytes and every arena access
+# faults at runtime (.porting/flashkda_decode_t6_gram/probe_dyn_smem.py). The
+# grid is 2-D (binding_impl.cuh:64).
+LAUNCH_TAGS = ("blockIdx.x", "blockIdx.y", "threadIdx.x", "tirx.use_dyn_shared_memory")
 
 
 def get_kernel(**kwargs: Any):
@@ -542,9 +549,9 @@ def _accepted_tensor(kind: Any, num_seqs: int, device: str) -> torch.Tensor:
 def prepare_data(**kwargs: Any) -> dict[str, Any]:
     """Build one deterministic case with independent TIRx / reference state.
 
-    Same recipe as the ported T=2/T=4 siblings at T=6: packed [1, N*5, ...]
+    Same recipe as the ported T=2/T=4 siblings at T=6: packed [1, N*6, ...]
     bf16, a log-space gate (GATE_KIND 0 -- the kernel applies exp()),
-    pre-sigmoided beta, flat [N*5] slot indices with slot 0 never a target.
+    pre-sigmoided beta, flat [N*6] slot indices with slot 0 never a target.
     """
     device = kwargs.get("device", "cuda")
     if not torch.cuda.is_available() or torch.device(device).type != "cuda":

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -513,7 +513,556 @@ def _flashkda_decode_t6_gram(
     ssm_idx = T.match_buffer(ssm_state_indices_h, (STATE_INDEX_ELEMENTS,), "int32", scope="global")
     nat = T.match_buffer(num_accepted_tokens_h, (NAT_ELEMENTS,), "int32", scope="global")
     T.device_entry()
-    # TRANSCRIBE: the frozen body goes here (kernel-sketch stage).
+
+    # The source declares `extern __shared__ __align__(1024) char smem_raw[]`
+    # and sizes it with cudaFuncSetAttribute (binding_impl.cuh:59-66). At T=6 the
+    # port has to do the same rather than declare a static buffer: split1 needs
+    # 50560 B, past the 49152 B ceiling the T<=5 ports fit inside. The pool
+    # arena carries the same byte offsets at the same 1024-byte alignment, which
+    # is what the swizzled ldmatrix addressing depends on. `get_kernel` adds
+    # `tirx.use_dyn_shared_memory` to the launch params; without it the launch
+    # reserves zero bytes and every access below faults.
+    pool = T.SMEMPool()
+    arena = pool.alloc((SMEM_TOTAL,), "uint8", align=1024)
+    pool.commit()
+
+    # --- work decomposition and lane roles (:142-178) ----------------------
+    work, n = T.cta_id([NUM_VALUE_HEADS * VALUE_SPLIT, NUM_SEQS])
+    tid = T.thread_id([THREADS])
+    value_tile: T.int32 = work % VALUE_SPLIT
+    hv: T.int32 = work // VALUE_SPLIT
+    query_head: T.int32 = hv // HEAD_RATIO
+    warp: T.int32 = _make_warp_uniform(tid // 32)  # == token index in A and C'
+    lane: T.int32 = tid % 32
+    lane_quad: T.int32 = lane % 4
+    frag_row: T.int32 = lane // 4
+    quad_base: T.int32 = lane - lane_quad
+    group: T.int32 = tid // 16
+    lane_group: T.int32 = tid % 16
+    k_start: T.int32 = lane_group * 8
+    elem_start: T.int32 = lane * 4
+    tile_row_base: T.int32 = value_tile * ROWS_PER_CTA
+    owned_row_base: T.int32 = group * ROWS_PER_GROUP
+    token_base: T.int32 = _load_i32(cu, n)
+    seq_len: T.int32 = _load_i32(cu, n + 1) - token_base
+
+    r_q = T.alloc_local((4,), "float32")
+    r_k = T.alloc_local((4,), "float32")
+    r_d = T.alloc_local((4,), "float32")
+
+    # =======================================================================
+    # Phase A: token preprocess, warp <-> token  (:180-290)
+    # =======================================================================
+    # Identical to the ported T=4 phase A apart from the token count, the
+    # ssm_state_indices stride and the nat clamp ceiling.
+    if warp < NUM_TOKENS:
+        token: T.int32 = warp
+        active_token = token < seq_len
+        token_pos: T.int32 = T.if_then_else(active_token, token_base + token, 0)
+        qk_base: T.int32 = (token_pos * NUM_HEADS + query_head) * HEAD_DIM + elem_start
+        gate_base: T.int32 = token_pos * GATE_TOKEN_STRIDE + hv * HEAD_DIM + elem_start
+
+        q_words = _load_u32x2(q, qk_base)
+        k_words = _load_u32x2(k, qk_base)
+        g_words = _load_u32x2(g, gate_base)
+        for pair in T.unroll(2):
+            r_q[2 * pair] = _widen_lo(q_words[pair])
+            r_q[2 * pair + 1] = _widen_hi(q_words[pair])
+            r_k[2 * pair] = _widen_lo(k_words[pair])
+            r_k[2 * pair + 1] = _widen_hi(k_words[pair])
+            r_d[2 * pair] = _widen_lo(g_words[pair])
+            r_d[2 * pair + 1] = _widen_hi(g_words[pair])
+
+        # Index-ordered accumulation (:241-244); the first term has a zero addend
+        # and the two chains interleave, because the source fuses them in one loop.
+        q_sq: T.float32 = _fma(
+            r_q[3],
+            r_q[3],
+            _fma(r_q[2], r_q[2], _fma(r_q[1], r_q[1], _fma(r_q[0], r_q[0], T.float32(0.0)))),
+        )
+        k_sq: T.float32 = _fma(
+            r_k[3],
+            r_k[3],
+            _fma(r_k[2], r_k[2], _fma(r_k[1], r_k[1], _fma(r_k[0], r_k[0], T.float32(0.0)))),
+        )
+        # Two sequential full-warp butterflies, not interleaved (:245-254).
+        for off in T.unroll(5):
+            q_sq = _add(q_sq, _shfl_bfly(q_sq, 16 >> off))
+        for off in T.unroll(5):
+            k_sq = _add(k_sq, _shfl_bfly(k_sq, 16 >> off))
+        q_norm: T.float32 = _mul(_rsqrt(_add(q_sq, T.float32(L2_EPS))), scale)
+        k_norm: T.float32 = _rsqrt(_add(k_sq, T.float32(L2_EPS)))
+
+        # GATE_KIND == 0: `g` already holds log(gamma), so one exp per element.
+        k_pub = T.alloc_local((4,), "uint32")
+        d_pub = T.alloc_local((4,), "uint32")
+        for i in T.unroll(4):
+            r_q[i] = _mul(r_q[i], q_norm)
+            r_k[i] = _mul(r_k[i], k_norm)
+            r_d[i] = _expf(r_d[i])
+            k_pub[i] = T.reinterpret("uint32", r_k[i])
+            d_pub[i] = T.reinterpret("uint32", r_d[i])
+        # Four contiguous f32 per lane: one 16-byte shared store each, not four
+        # scalar ones (:269-270 lower to 2 st.shared.v4.b32).
+        _st_shared_u32x4(arena, OFF_SK + (token * HEAD_DIM + elem_start) * 4, k_pub)
+        _st_shared_u32x4(arena, OFF_SD + (token * HEAD_DIM + elem_start) * 4, d_pub)
+
+        if lane == 0:
+            raw_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + token)
+            _st_shared_i32(arena, OFF_SSLOT + token * 4, T.if_then_else(active_token, raw_slot, -1))
+            _st_shared_i32(arena, OFF_STOKEN + token * 4, token_pos)
+            _st_shared_f32(
+                arena, OFF_SBETA + token * 4, _load_bf16_f32(beta, token_pos * NUM_VALUE_HEADS + hv)
+            )
+            if token == 0:
+                # nat picks the initial checkpoint slot; at T=5 the clamp ceiling
+                # is 4 and both edges are reachable (:279-287).
+                accepted: T.int32 = T.min(T.max(_load_i32(nat, n) - 1, 0), NUM_TOKENS - 1)
+                initial_slot: T.int32 = _load_i32(ssm_idx, n * NUM_TOKENS + accepted)
+                _st_shared_i32(arena, OFF_SINIT, T.max(initial_slot, 0))
+
+    T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase C': sVec columns and the gram operand  (:293-339)
+    # =======================================================================
+    # Runs BEFORE the state gather at T=5 -- the reverse of the T=4 order.
+    if warp < NUM_TOKENS:
+        token_c: T.int32 = warp
+        for i in T.unroll(4):
+            k_idx: T.int32 = elem_start + i
+            prefix: T.float32 = T.float32(1.0)
+            # Scalar loads: the walk is across tokens at a fixed key, so
+            # consecutive iterations are 512 B apart (:296-302).
+            for j in T.unroll(NUM_TOKENS):
+                if token_c >= j:
+                    prefix = _mul(
+                        prefix, _ld_shared_f32(arena, OFF_SD + (j * HEAD_DIM + k_idx) * 4)
+                    )
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + token_c * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_k[i]), dtype="uint16"),
+            )
+            # The q column is 8 + token at T=5, not 4 + token: the generator
+            # emits `c_col = 4 + token` and immediately overrides it (:311-314).
+            _st_shared_b16(
+                arena,
+                OFF_SVEC + _swz(k_idx * 32 + (8 + token_c) * 2),
+                _ptx_un("cvt.rn.bf16.f32", _mul(prefix, r_q[i]), dtype="uint16"),
+            )
+            # The gate-DEFLATED key, the operand that makes the Gram product come
+            # out as T<=4's ratio_scan factor. div.approx.ftz.f32 per the PTX.
+            deflated = _ptx_un("cvt.rn.bf16.f32", _div(r_k[i], prefix), dtype="uint16")
+            if k_idx < 64:
+                _st_shared_b16(arena, OFF_SGRAMA0 + _swz(token_c * 128 + k_idx * 2), deflated)
+            else:
+                _st_shared_b16(
+                    arena, OFF_SGRAMA1 + _swz(token_c * 128 + (k_idx - 64) * 2), deflated
+                )
+
+    # =======================================================================
+    # Phase C'': the coefficient Gram block  (:340-408)  -- new at T=5
+    # =======================================================================
+    # One warp forms both token x token Gram products on tensor cores, replacing
+    # T<=4's inter-token butterfly path entirely. The barrier is partial: only
+    # the five token warps take part, which is why its count is 160 in every
+    # split, including split1's 256-thread launch.
+    if warp < NUM_TOKENS:
+        if GRAM_SYNC_ALL == 1:
+            # split4 hoists the wait out of the branch: all five token warps
+            # block, and the arrive arm below is `else if (0)` -- dead (S4:340-344).
+            _named_bar_sync(1, NUM_TOKENS * 32)
+        if warp == GRAM_WARP:
+            if GRAM_SYNC_ALL == 0:
+                _named_bar_sync(1, NUM_TOKENS * 32)
+            gram_a = T.alloc_local((4,), "uint32", align=4)
+            gram_b = T.alloc_local((4,), "uint32", align=4)
+            gram_k_acc = T.alloc_local((4,), "float32", align=4)
+            gram_q_acc = T.alloc_local((4,), "float32", align=4)
+            for gram_half in T.unroll(2):
+                for gram_step in T.unroll(4):
+                    gram_k: T.int32 = gram_step * 16
+                    global_gram_k: T.int32 = gram_half * 64 + gram_k
+                    a_off: T.int32 = (lane % 16 * 64 + (gram_k + lane // 16 * 8)) * 2
+                    if gram_half == 0:
+                        _ldmatrix_x4(arena, OFF_SGRAMA0 + _swz(a_off), gram_a, False)
+                    else:
+                        _ldmatrix_x4(arena, OFF_SGRAMA1 + _swz(a_off), gram_a, False)
+                    # Same sVec address formula as phase D's operand (:360-361
+                    # vs :454-455); frags 0,1 are columns 0..7 (the k side) and
+                    # 2,3 are columns 8..15 (the q side).
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SVEC + _swz(((global_gram_k + lane % 16) * 16 + lane // 16 * 8) * 2),
+                        gram_b,
+                        True,
+                    )
+                    if gram_half == 0 and gram_step == 0:
+                        _mma_zero_b(gram_k_acc, gram_a, gram_b, 0)
+                        _mma_zero_b(gram_q_acc, gram_a, gram_b, 2)
+                    else:
+                        _mma_acc_b(gram_k_acc, gram_a, gram_b, 0)
+                        _mma_acc_b(gram_q_acc, gram_a, gram_b, 2)
+
+            # The transpose of T<=4's roles: the MMA M index is the SOURCE token
+            # and the N index (the sVec column) is the TARGET (:387-404). Only
+            # acc[0],[1] are read -- acc[2],[3] hold M rows 8..15, past the five
+            # real tokens.
+            source_token: T.int32 = frag_row
+            target0: T.int32 = lane_quad * 2
+            target1: T.int32 = target0 + 1
+            if source_token < NUM_TOKENS:
+                beta_source: T.float32 = _ld_shared_f32(arena, OFF_SBETA + source_token * 4)
+                if source_token < target0 and target0 < NUM_TOKENS:
+                    _st_shared_f32(
+                        arena,
+                        OFF_SL + (target0 * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, gram_k_acc[0]),
+                    )
+                if source_token < target1 and target1 < NUM_TOKENS:
+                    _st_shared_f32(
+                        arena,
+                        OFF_SL + (target1 * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, gram_k_acc[1]),
+                    )
+                if source_token <= target0 and target0 < NUM_TOKENS:
+                    _st_shared_f32(
+                        arena,
+                        OFF_SR + (target0 * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, gram_q_acc[0]),
+                    )
+                if source_token <= target1 and target1 < NUM_TOKENS:
+                    _st_shared_f32(
+                        arena,
+                        OFF_SR + (target1 * NUM_TOKENS + source_token) * 4,
+                        _mul(beta_source, gram_q_acc[1]),
+                    )
+        else:
+            if GRAM_SYNC_ALL == 0:
+                _named_bar_arrive(1, NUM_TOKENS * 32)
+
+    # =======================================================================
+    # Phase B: state gather and sState stage  (:410-446)
+    # =======================================================================
+    init_slot: T.int32 = _ld_shared_i32(arena, OFF_SINIT)
+    head_base = T.cast(init_slot, "int64") * T.cast(STATE_SLOT_STRIDE, "int64") + T.cast(
+        hv * HEAD_DIM * HEAD_DIM, "int64"
+    )
+    hist = T.alloc_local((ROWS_PER_GROUP * 8,), "float32")
+    if group < ROW_GROUPS:
+        for row_local in T.unroll(ROWS_PER_GROUP):
+            # Two distinct indices: row_l is CTA-local and addresses sState;
+            # tile_row_base + row_l is the global row of `state` (:414-415).
+            row_l: T.int32 = owned_row_base + row_local
+            pack = _load_u32x4(
+                state, head_base + T.cast((tile_row_base + row_l) * HEAD_DIM + k_start, "int64")
+            )
+            for pr in T.unroll(4):
+                hist[row_local * 8 + 2 * pr] = _widen_lo(pack[pr])
+                hist[row_local * 8 + 2 * pr + 1] = _widen_hi(pack[pr])
+            # An if/ELSE selecting the destination half, not a guard: lanes 8..15
+            # stage keys 64..127 into sState1 (:438-442). The bf16 bits go to
+            # shared unmodified; the swizzle is on the byte offset.
+            if lane_group < 8:
+                _st_shared_u32x4(arena, OFF_SSTATE0 + _swz(row_l * 128 + k_start * 2), pack)
+            else:
+                _st_shared_u32x4(arena, OFF_SSTATE1 + _swz(row_l * 128 + (k_start - 64) * 2), pack)
+
+    T.cuda.cta_sync()
+    # Besides sState and sL/sR, this is the sVec publish edge for every MMA warp
+    # except the gram warp: `barrier.arrive` releases but does not acquire, so an
+    # arriving token warp has synchronized with the others only here.
+
+    # =======================================================================
+    # Phase D: the MMA chain, warp <-> 16 value rows  (:448-490)
+    # =======================================================================
+    # Two issues per step at T=5: the k side needs sVec columns 0..4 and the q
+    # side 8..12, which no single n=8 tile covers. `mma_acc_c` and
+    # `vec_frag[2],[3]` were dead at every T <= 4.
+    acc = T.alloc_local((4,), "float32", align=4)
+    acc_c = T.alloc_local((4,), "float32", align=4)
+    if warp < MMA_WARPS:
+        vec_frag = T.alloc_local((4,), "uint32", align=4)
+        state_frag = T.alloc_local((4,), "uint32", align=4)
+        for state_half in T.unroll(2):
+            for mma_step in T.unroll(4):
+                mma_k: T.int32 = mma_step * 16
+                global_k: T.int32 = state_half * 64 + mma_k
+                _ldmatrix_x4(
+                    arena,
+                    OFF_SVEC + _swz((global_k + lane % 16) * 32 + lane // 16 * 16),
+                    vec_frag,
+                    True,
+                )
+                if state_half == 0:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE0
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                else:
+                    _ldmatrix_x4(
+                        arena,
+                        OFF_SSTATE1
+                        + _swz((warp * 16 + lane % 16) * 128 + (mma_k + lane // 16 * 8) * 2),
+                        state_frag,
+                        False,
+                    )
+                if state_half == 0 and mma_step == 0:
+                    _mma_zero_b(acc, state_frag, vec_frag, 0)
+                    _mma_zero_b(acc_c, state_frag, vec_frag, 2)
+                else:
+                    _mma_acc_b(acc, state_frag, vec_frag, 0)
+                    _mma_acc_b(acc_c, state_frag, vec_frag, 2)
+
+    # =======================================================================
+    # Phase E: quad broadcast and the WY forward substitution  (:491-566)
+    # =======================================================================
+    u_lo = T.alloc_local((NUM_TOKENS,), "float32")
+    u_hi = T.alloc_local((NUM_TOKENS,), "float32")
+    # hc_* is declared out here because phase F consumes it from its own block;
+    # ha_* never leaves phase E.
+    hc_lo = T.alloc_local((NUM_TOKENS,), "float32")
+    hc_hi = T.alloc_local((NUM_TOKENS,), "float32")
+    if warp < MMA_WARPS:
+        # 20 broadcasts in the source's emission order (:491-531). m16n8k16 puts
+        # columns 2q, 2q+1 of row frag_row in lane quad_base+q's acc[0],[1] and
+        # rows +8 in acc[2],[3], so token t lives at (quad_base + t//2, t%2).
+        # ha_* is the k side (the solve), hc_* the q side (the outputs).
+        ha_lo = T.alloc_local((NUM_TOKENS,), "float32")
+        ha_hi = T.alloc_local((NUM_TOKENS,), "float32")
+        for t in T.unroll(4):
+            ha_lo[t] = _shfl_idx(acc[t % 2], quad_base + t // 2)
+        for t in T.unroll(4):
+            ha_hi[t] = _shfl_idx(acc[2 + t % 2], quad_base + t // 2)
+        ha_lo[4] = _shfl_idx(acc[0], quad_base + 2)
+        ha_hi[4] = _shfl_idx(acc[2], quad_base + 2)
+        for t in T.unroll(NUM_TOKENS - 1):
+            hc_lo[t] = _shfl_idx(acc_c[t % 2], quad_base + t // 2)
+        for t in T.unroll(NUM_TOKENS - 1):
+            hc_hi[t] = _shfl_idx(acc_c[2 + t % 2], quad_base + t // 2)
+
+        # Token 5 needs NO shuffle (:532-537). The (quad_base + t//2, acc[t%2])
+        # map puts it on lane quad_base + 2 -- which is the only lane that
+        # consumes it, since both the solve below and phase F's token-5 tail run
+        # under `lane_quad == 2`. So the source reads the local registers, and
+        # the broadcast count stays at 20 rather than 24. These four assignments
+        # sit OUTSIDE the `lane_quad == 2` guard: every lane executes them, only
+        # lane_quad 2's values are meaningful.
+        ha_lo[NUM_TOKENS - 1] = acc[1]
+        ha_hi[NUM_TOKENS - 1] = acc[3]
+        hc_lo[NUM_TOKENS - 1] = acc_c[1]
+        hc_hi[NUM_TOKENS - 1] = acc_c[3]
+
+        if lane_quad == 2:
+            row_lo: T.int32 = warp * 16 + frag_row
+            row_hi: T.int32 = row_lo + 8
+            for t in T.unroll(NUM_TOKENS):
+                base_t: T.int32 = (
+                    _ld_shared_i32(arena, OFF_STOKEN + t * 4) * NUM_VALUE_HEADS + hv
+                ) * HEAD_DIM
+                solved_lo: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_lo), ha_lo[t]
+                )
+                solved_hi: T.float32 = _sub(
+                    _load_bf16_f32(v, base_t + tile_row_base + row_hi), ha_hi[t]
+                )
+                for prev in T.unroll(NUM_TOKENS):
+                    if prev < t:
+                        lts: T.float32 = _ld_shared_f32(arena, OFF_SL + (t * NUM_TOKENS + prev) * 4)
+                        solved_lo = _sub(solved_lo, _mul(lts, u_lo[prev]))
+                        solved_hi = _sub(solved_hi, _mul(lts, u_hi[prev]))
+                u_lo[t] = solved_lo
+                u_hi[t] = solved_hi
+
+        # The solve runs on lane_quad == 2 but lane_quad == 3 also writes output,
+        # so the residuals cross the quad (:554-560).
+        for t in T.unroll(NUM_TOKENS):
+            u_lo[t] = _shfl_idx(u_lo[t], quad_base + 2)
+            u_hi[t] = _shfl_idx(u_hi[t], quad_base + 2)
+
+    # =======================================================================
+    # Phase F: the outputs  (:568-670)
+    # =======================================================================
+    # The bases come from hc_* (the q-side MMA), not from acc: the source
+    # assigns acc[0..3] and then unconditionally overwrites (:567-582). The
+    # lane_quad == 3 remap uses STATIC indices, as the source does -- indexing
+    # hc_* by a runtime token would spill the register array to local memory.
+    if warp < MMA_WARPS and lane_quad >= 2:
+        token0: T.int32 = (lane_quad - 2) * 2
+        token1: T.int32 = token0 + 1
+        row_lo_f: T.int32 = warp * 16 + frag_row
+        row_hi_f: T.int32 = row_lo_f + 8
+        out0_lo: T.float32 = hc_lo[0]
+        out1_lo: T.float32 = hc_lo[1]
+        out0_hi: T.float32 = hc_hi[0]
+        out1_hi: T.float32 = hc_hi[1]
+        if lane_quad == 3:
+            out0_lo = hc_lo[2]
+            out1_lo = hc_lo[3]
+            out0_hi = hc_hi[2]
+            out1_hi = hc_hi[3]
+        for src in T.unroll(NUM_TOKENS):
+            residual_lo: T.float32 = u_lo[src]
+            residual_hi: T.float32 = u_hi[src]
+            coef0: T.float32 = T.float32(0.0)
+            coef1: T.float32 = T.float32(0.0)
+            # The masked-out coefficient is a real zero-operand fma, not a
+            # skipped iteration (:585-594).
+            if token0 >= src:
+                coef0 = _ld_shared_f32(arena, OFF_SR + (token0 * NUM_TOKENS + src) * 4)
+            if token1 >= src:
+                coef1 = _ld_shared_f32(arena, OFF_SR + (token1 * NUM_TOKENS + src) * 4)
+            out0_lo = _fma(coef0, residual_lo, out0_lo)
+            out1_lo = _fma(coef1, residual_lo, out1_lo)
+            out0_hi = _fma(coef0, residual_hi, out0_hi)
+            out1_hi = _fma(coef1, residual_hi, out1_hi)
+
+        for half in T.unroll(2):
+            token_o: T.int32 = T.if_then_else(half == 0, token0, token1)
+            o_lo: T.float32 = T.if_then_else(half == 0, out0_lo, out1_lo)
+            o_hi: T.float32 = T.if_then_else(half == 0, out0_hi, out1_hi)
+            active_o = _ld_shared_i32(arena, OFF_SSLOT + token_o * 4) >= 0
+            base_o: T.int32 = (
+                _ld_shared_i32(arena, OFF_STOKEN + token_o * 4) * NUM_VALUE_HEADS + hv
+            ) * HEAD_DIM + tile_row_base
+            # A padded row writes EXPLICIT zeros; the upstream test asserts them
+            # bit-exactly, so this is not an "unwritten" path.
+            _store_f32_as_bf16(out, base_o + row_lo_f, o_lo, active_o)
+            _store_f32_as_bf16(out, base_o + row_hi_f, o_hi, active_o)
+            _store_f32_as_bf16(out, base_o + row_lo_f, T.float32(0.0), T.Not(active_o))
+            _store_f32_as_bf16(out, base_o + row_hi_f, T.float32(0.0), T.Not(active_o))
+
+        # Tokens 4 and 5 have no partner lane, so lane_quad == 2 writes BOTH
+        # tails at T=6 (:628-668) -- eight output stores against quad 3's four.
+        if lane_quad == 2:
+            # Token 4 (:629-650). Its coefficient row is CLAMPED: sR[29] is
+            # (target 4, source 5), which the gram block never writes -- its
+            # predicate is `source <= target` -- so it is in-region but
+            # uninitialized, and only the `src <= 4` mask keeps it out of the
+            # result. The source's unconditional read at :633 is dead.
+            out4_lo: T.float32 = hc_lo[NUM_TOKENS - 2]
+            out4_hi: T.float32 = hc_hi[NUM_TOKENS - 2]
+            for src4 in T.unroll(NUM_TOKENS):
+                coef4: T.float32 = T.float32(0.0)
+                if src4 <= NUM_TOKENS - 2:
+                    coef4 = _ld_shared_f32(
+                        arena, OFF_SR + ((NUM_TOKENS - 2) * NUM_TOKENS + src4) * 4
+                    )
+                out4_lo = _fma(coef4, u_lo[src4], out4_lo)
+                out4_hi = _fma(coef4, u_hi[src4], out4_hi)
+            active4 = _ld_shared_i32(arena, OFF_SSLOT + (NUM_TOKENS - 2) * 4) >= 0
+            base4: T.int32 = (
+                _ld_shared_i32(arena, OFF_STOKEN + (NUM_TOKENS - 2) * 4) * NUM_VALUE_HEADS + hv
+            ) * HEAD_DIM + tile_row_base
+            _store_f32_as_bf16(out, base4 + row_lo_f, out4_lo, active4)
+            _store_f32_as_bf16(out, base4 + row_hi_f, out4_hi, active4)
+            _store_f32_as_bf16(out, base4 + row_lo_f, T.float32(0.0), T.Not(active4))
+            _store_f32_as_bf16(out, base4 + row_hi_f, T.float32(0.0), T.Not(active4))
+
+            # Token 5 (:651-667). No clamp: the last target accepts every
+            # source, so sR[30..35] are all live.
+            out5_lo: T.float32 = hc_lo[NUM_TOKENS - 1]
+            out5_hi: T.float32 = hc_hi[NUM_TOKENS - 1]
+            for src5 in T.unroll(NUM_TOKENS):
+                coef5: T.float32 = _ld_shared_f32(
+                    arena, OFF_SR + ((NUM_TOKENS - 1) * NUM_TOKENS + src5) * 4
+                )
+                out5_lo = _fma(coef5, u_lo[src5], out5_lo)
+                out5_hi = _fma(coef5, u_hi[src5], out5_hi)
+            active5 = _ld_shared_i32(arena, OFF_SSLOT + (NUM_TOKENS - 1) * 4) >= 0
+            base5: T.int32 = (
+                _ld_shared_i32(arena, OFF_STOKEN + (NUM_TOKENS - 1) * 4) * NUM_VALUE_HEADS + hv
+            ) * HEAD_DIM + tile_row_base
+            _store_f32_as_bf16(out, base5 + row_lo_f, out5_lo, active5)
+            _store_f32_as_bf16(out, base5 + row_hi_f, out5_hi, active5)
+            _store_f32_as_bf16(out, base5 + row_lo_f, T.float32(0.0), T.Not(active5))
+            _store_f32_as_bf16(out, base5 + row_hi_f, T.float32(0.0), T.Not(active5))
+
+    # =======================================================================
+    # Phase G: publish sU  (:671-684)
+    # =======================================================================
+    if warp < MMA_WARPS:
+        if lane_quad == 2:
+            row_lo_g: T.int32 = warp * 16 + frag_row
+            for t in T.unroll(NUM_TOKENS):
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g) * 4, u_lo[t])
+                _st_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_lo_g + 8) * 4, u_hi[t])
+        if SU_SYNC_CTA == 0:
+            # Warp w produces rows [16w, 16w+16), exactly the rows its own groups
+            # consume in phase H, so a warp barrier suffices (:651-653).
+            T.cuda.warp_sync()
+    if SU_SYNC_CTA == 1:
+        # split8 has ONE MMA warp producing sU for eight consuming groups, so the
+        # generator emits a CTA barrier -- and it sits OUTSIDE the warp guard
+        # (S8:651 closes it, S8:652-654 follows). Keeping it inside would have
+        # one warp of five arrive at a CTA barrier and the kernel would hang.
+        T.cuda.cta_sync()
+
+    # =======================================================================
+    # Phase H: recurrence and checkpoints  (:798-834)
+    # =======================================================================
+    words_w = T.alloc_local((4,), "uint32")
+    sd_t = T.alloc_local((8,), "float32")
+    sk_t = T.alloc_local((8,), "float32")
+    if group < ROW_GROUPS:
+        for t in T.unroll(NUM_TOKENS):
+            slot_t: T.int32 = _ld_shared_i32(arena, OFF_SSLOT + t * 4)
+            beta_t: T.float32 = _ld_shared_f32(arena, OFF_SBETA + t * 4)
+            # The gate and key slices depend only on (t, k_start), not on the
+            # row, so they are hoisted out of the row loop as two 16-byte reads
+            # each rather than reloaded per key (:782).
+            _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start) * 4, sd_t, 0)
+            _ld_shared_f32x4(arena, OFF_SD + (t * HEAD_DIM + k_start + 4) * 4, sd_t, 4)
+            _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start) * 4, sk_t, 0)
+            _ld_shared_f32x4(arena, OFF_SK + (t * HEAD_DIM + k_start + 4) * 4, sk_t, 4)
+            # The store predicate is hoisted OUT of the row loop and the loop
+            # duplicated, which is the shape nvcc produces for the source's
+            # per-row `if (slot_t >= 0)` (:788): its phase H appears 2*TOKENS-1
+            # times in the export's SASS, against a single copy when the branch
+            # stays inside. Keeping the branch per row costs DRAM utilisation at
+            # the largest split1 shapes -- the stores cannot be issued as densely.
+            # The recurrence itself is identical in both arms: it advances
+            # unconditionally, in FP32, so token t+1 consumes the un-rounded
+            # token-t state rather than the bf16 checkpoint.
+            if slot_t >= 0:
+                for row_local in T.unroll(ROWS_PER_GROUP):
+                    row_h: T.int32 = owned_row_base + row_local
+                    update: T.float32 = _mul(
+                        _ld_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_h) * 4), beta_t
+                    )
+                    for i in T.unroll(8):
+                        # `hist*sD + update*sK` (:782): the compiler contracts the
+                        # FIRST product and rounds update*sK.
+                        hist[row_local * 8 + i] = _fma(
+                            hist[row_local * 8 + i], sd_t[i], _mul(update, sk_t[i])
+                        )
+                    for pr in T.unroll(4):
+                        words_w[pr] = _pack_bf16x2(
+                            hist[row_local * 8 + 2 * pr + 1], hist[row_local * 8 + 2 * pr]
+                        )
+                    _store_u32x4(
+                        state,
+                        T.cast(slot_t, "int64") * T.cast(STATE_SLOT_STRIDE, "int64")
+                        + T.cast(
+                            hv * HEAD_DIM * HEAD_DIM + (tile_row_base + row_h) * HEAD_DIM + k_start,
+                            "int64",
+                        ),
+                        words_w,
+                    )
+            else:
+                for row_local_p in T.unroll(ROWS_PER_GROUP):
+                    row_p: T.int32 = owned_row_base + row_local_p
+                    update_p: T.float32 = _mul(
+                        _ld_shared_f32(arena, OFF_SU + (t * ROWS_PER_CTA + row_p) * 4), beta_t
+                    )
+                    for i in T.unroll(8):
+                        hist[row_local_p * 8 + i] = _fma(
+                            hist[row_local_p * 8 + i], sd_t[i], _mul(update_p, sk_t[i])
+                        )
 
 
 # The dynamic-shared arena is only backed at launch when the kernel asks for


### PR DESCRIPTION
Ports FlashInfer's `d128_t6_precomputed_gram_split{1,2,4,8}` (flashinfer @ `f2e04400`, symbol `kernel_flashinfer_recurrent_kda_wy_vtile_short`) to TIRx as `flashkda_decode_t6_gram`. This is the last variant the cake family exports — with T=1, 2, 3, 4 and 5 already merged, the family is now complete.

T=6 shares one arm of the sm100a value-split policy with T=5 (`recurrent_kda.py:1181-1191` is a single `if num_tokens in (5, 6):`), so the split is shape-dependent, all four exports are production-reachable, and the split stays a constexpr.

## What is new relative to the T=5 sibling

The bodies are line-for-line identical through `:531`; four deltas carry the port.

- **The arena is dynamic shared memory.** split1 needs **50560 B**, past the 49152 B static ceiling every earlier cake port fit inside, so all four splits allocate through `T.SMEMPool` — which is also what the source does (`extern __shared__ __align__(1024)` sized by `cudaFuncSetAttribute`). The kernel must declare `tirx.use_dyn_shared_memory` in its launch params; without it the launch reserves zero bytes and every arena access faults at runtime, which is not a compile error. A probe run before any body was written confirms all four arenas round-trip data through the body's swizzled `st.shared.b16` + `ldmatrix`, and that a 4 MB arena is refused.
- **Token 5's quad broadcast is elided.** The `(quad_base + t//2, acc[t%2])` map holds for all six tokens, but token 5's source lane is `quad_base + 2` — the only lane that consumes it, since both the WY solve and phase F's token-5 tail run under `lane_quad == 2` — so the source reads the local registers. The broadcast count stays at 20, not 24.
- **Phase F grew a second tail.** `lane_quad == 2` now writes tokens 0, 1, 4 and 5 (eight stores against `lane_quad == 3`'s four). Token 4's coefficient row is **clamped** to `source <= 4`: `sR[29]` is (target 4, source 5), which the gram block never writes because its predicate is `source <= target`. It is in-region but uninitialized, and the clamp is what keeps it out of the result — the port reproduces the clamp rather than predicating the read away. Token 5 needs no clamp; `sR[30..35]` are all live.
- **Six token warps**: 256/192/192/192 threads, `barrier.sync/arrive 1, 192` in every split (including split1's 256-thread launch, because the gram region is nested inside `if (warp_0 < 6)`), and the gram warp is warp 5 at splits 4 and 8.

Design sketch: `.agents/sketch/flashinfer/kda/flashkda_decode_t6_gram.md`.

## Validation

**Correctness — 28/28**, against the frozen export through its own ABI (tight band) and an independent FP32 oracle, plus invariants the tolerances cannot express (padded rows exactly zero, untouched slots byte-identical, inter-slot padding intact).

Coverage: all four splits both by natural shape and by forced `sm_count`; both `nat` clamp arms (0/1/6/13 and a mixed pattern); padded sequences; padded state-slot and gate-token strides; a non-default scale; GQA ratio 4; and the selector knife edge.

This coverage matters more here than at T=5: **upstream's only T=6 GPU test is the `(6, 8)` matrix row, which selects split1**. Splits 2, 4 and 8 have no upstream correctness coverage at all, so the four-way agreement checked by `characterize_source.py` (all four exports produce bit-identical output and state on identical inputs) and the port's forced-split rows are the whole story for them. Dispatch is verified in both directions, including T=6's own five published boundary points and 18 refused near-miss contracts.

**Performance — 14/14 above the gate**, one complete `bench_suite` run, minimum **1.013x**:

| shape | split | ratio | | shape | split | ratio |
| --- | --- | --- | --- | --- | --- | --- |
| `hv32h16_b64_s1` | 1 | 1.013 | | `hv32h16_b8_s1` | 1 | 1.114 |
| `hv32h16_b128_s1` | 1 | 1.017 | | `hv16h16_b5_s4` | 4 | 1.109 |
| `hv12h12_b64_s1` | 1 | 1.052 | | `hv32h16_b2_s2` | 2 | 1.111 |
| `hv16h16_b64_s1` | 1 | 1.054 | | `hv12h12_b8_s4` | 4 | 1.121 |
| `hv32h16_b16_s1` | 1 | 1.063 | | `hv32h16_b3_s4` | 4 | 1.126 |
| `hv32h16_b32_s1` | 1 | 1.066 | | `hv16h16_b8_s2` | 2 | 1.144 |
| `hv16h16_b2_s8` | 8 | 1.213 | | `hv32h16_b1_s8` | 8 | 1.253 |

The five `hv32h16` split1 rows mirror FlashInfer's own T=6 export bench; the rest cover the other three exports. Split coverage is 7/2/3/2. Baseline 306 → 320 rows; no existing row changed.

Both findings the T=5 port paid for — reproducing `make_warp_uniform` (the hint that lets ptxas prove the token guard is warp-uniform) and hoisting phase H's checkpoint predicate out of the row loop to match the `2*TOKENS-1 = 11` replication the export shows — were applied from the first transcription, so the large split1 shapes that needed two rounds of tuning at T=5 cleared the gate on the first measurement here.