### PR TITLE
chore(kernel): drop the frozen-source digest pins from the FlashInfer ports

### DIFF
--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
@@ -11,9 +11,7 @@ Upstream source: flashinfer/gdn_kernels/gdn_decode_bf16_state.py.
 from __future__ import annotations
 
 import functools
-import hashlib
 import math
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -24,8 +22,6 @@ from tvm.tirx.bench import bench
 
 KERNEL_META = {"name": "gdn_decode_bf16_ilp4", "category": "flashinfer", "compute_capability": 10}
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61"
 
 K = 128
 V = 128
@@ -1136,16 +1132,9 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 @functools.cache
-def _load_frozen_oracle():
+def _load_oracle():
     import flashinfer.gdn_kernels.gdn_decode_bf16_state as source_module
 
-    source_path = Path(source_module.__file__).resolve()
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "GDN BF16 ILP4 oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
     return source_module.gated_delta_rule_mtp
 
 
@@ -1250,7 +1239,7 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 
 def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     config = case["config"]
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     return oracle(
         A_log=case["A_log"],
         a=case["a"],

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
@@ -11,9 +11,7 @@ Upstream source: flashinfer/gdn_kernels/gdn_decode_bf16_state.py.
 from __future__ import annotations
 
 import functools
-import hashlib
 import math
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -28,8 +26,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61"
 
 K = 128
 V = 128
@@ -1239,16 +1235,9 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 @functools.cache
-def _load_frozen_oracle():
+def _load_oracle():
     import flashinfer.gdn_kernels.gdn_decode_bf16_state as source_module
 
-    source_path = Path(source_module.__file__).resolve()
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "GDN wide-vector MTP oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
     return source_module.gated_delta_rule_mtp_wide_vec
 
 
@@ -1356,7 +1345,7 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 
 def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     config = case["config"]
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     return oracle(
         A_log=case["A_log"],
         a=case["a"],

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -11,9 +11,7 @@ Upstream source: flashinfer/gdn_kernels/gdn_decode_bf16_state.py.
 from __future__ import annotations
 
 import functools
-import hashlib
 import math
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -28,8 +26,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "61de9ffa703962cb1ddb73823100550138708bbcbb535a3efcac608940e67e61"
 
 SEQ_LEN = 1
 K = 128
@@ -910,16 +906,9 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 @functools.cache
-def _load_frozen_oracle():
+def _load_oracle():
     import flashinfer.gdn_kernels.gdn_decode_bf16_state as source_module
 
-    source_path = Path(source_module.__file__).resolve()
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "GDN wide-vector oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
     return source_module.gated_delta_rule_t1_wide_vec
 
 
@@ -1002,7 +991,7 @@ def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     config = case["config"]
     cache = bool(config.get("cache_intermediate_states", False))
     same_pool = bool(config.get("same_pool", True))
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     result = oracle(
         A_log=case["A_log"],
         a=case["a"],

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -41,12 +41,9 @@ Upstream source: flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py.
 from __future__ import annotations
 
 import ctypes
-import hashlib
-import inspect
 import math
 from dataclasses import dataclass, fields
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -65,10 +62,6 @@ TMEM_COLUMNS = 512
 DESCRIPTOR_SLOT_BYTES = 128
 DESCRIPTOR_SLOTS = 4
 DESCRIPTOR_BYTES_PER_CTA = DESCRIPTOR_SLOT_BYTES * DESCRIPTOR_SLOTS
-FROZEN_FLASHINFER_ADAPTER_SHA256 = (
-    "dba25861bb34245a344fc4d4fb443419ecf3f425feb9053823bcd7d7165efe01"
-)
-FROZEN_FLASHINFER_KERNEL_SHA256 = "faaf28508f419a255cc030678ef86e73f47153631cc9403176d058b6a0bd715b"
 
 HEAD_PAIRS = ((2, 8), (4, 16), (8, 32), (16, 64), (16, 32), (16, 48), (16, 16), (32, 32))
 
@@ -2846,29 +2839,14 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 
 
 @lru_cache(maxsize=1)
-def _load_frozen_oracle():
+def _load_oracle():
     from flashinfer.gdn_kernels.blackwell.gdn_prefill import chunk_gated_delta_rule_sm100
 
-    adapter_path = Path(inspect.getfile(chunk_gated_delta_rule_sm100)).resolve()
-    kernel_path = adapter_path.with_name("gated_delta_net_chunked.py")
-    adapter_sha256 = hashlib.sha256(adapter_path.read_bytes()).hexdigest()
-    kernel_sha256 = hashlib.sha256(kernel_path.read_bytes()).hexdigest()
-    if (
-        adapter_sha256 != FROZEN_FLASHINFER_ADAPTER_SHA256
-        or kernel_sha256 != FROZEN_FLASHINFER_KERNEL_SHA256
-    ):
-        raise RuntimeError(
-            "GDN oracle does not match the frozen FlashInfer sources: "
-            f"adapter={adapter_path} sha256={adapter_sha256}, "
-            f"kernel={kernel_path} sha256={kernel_sha256}"
-        )
     return chunk_gated_delta_rule_sm100
 
 
-def _run_frozen_oracle(
-    case: dict[str, Any], output: torch.Tensor, final_state: torch.Tensor
-) -> None:
-    oracle = _load_frozen_oracle()
+def _run_oracle(case: dict[str, Any], output: torch.Tensor, final_state: torch.Tensor) -> None:
+    oracle = _load_oracle()
     oracle(
         case["q"],
         case["k"],
@@ -2975,7 +2953,7 @@ def run_test(**kwargs: Any) -> None:
 
     reference_o = torch.empty_like(case["o"])
     reference_state = torch.empty_like(case["final_state"])
-    _run_frozen_oracle(case, reference_o, reference_state)
+    _run_oracle(case, reference_o, reference_state)
     torch.cuda.synchronize()
 
     for name, tensor in (
@@ -3016,13 +2994,13 @@ def run_bench(
 
         # First execution performs CuTeDSL JIT and initializes its persistent
         # workspace; subsequent executions are launch-only warmups.
-        _run_frozen_oracle(case, reference_o, reference_state)
+        _run_oracle(case, reference_o, reference_state)
         for _ in range(2):
-            _run_frozen_oracle(case, reference_o, reference_state)
+            _run_oracle(case, reference_o, reference_state)
         torch.cuda.synchronize()
 
         def launch():
-            _run_frozen_oracle(case, reference_o, reference_state)
+            _run_oracle(case, reference_o, reference_state)
 
         return launch
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -28,21 +28,12 @@ shared memory, no barrier, no atomic, no workspace. The value split partitions t
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
 from tvm.script import tirx as T
-
-# --- source pinning -------------------------------------------------------
-# The generated body carries its own digest at
-# flashkda_decode_d128_t1_precomputed_direct_split16.cu:19-20; run_test asserts
-# it so a silent upstream regeneration cannot pass unnoticed.
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = {16: "9119163b3b5cb6a8760b6a17a7ce01788a0e1c0078f8c812255225f27e5989e5"}
 
 HEAD_DIM = 128
 L2_EPS = 1.0e-6
@@ -690,39 +681,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _source_body_path(value_split: int) -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer  # local: keep kernel discovery free of optional deps
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(
-        root, "csrc", "kda", f"flashkda_decode_d128_t1_precomputed_direct_split{value_split}.cu"
-    )
-
-
-def assert_frozen_source(value_split: int) -> None:
-    """Fail loudly if the upstream generated body was regenerated.
-
-    The body declares its own digest at direct_split16.cu:19-20; this checks the
-    same bytes the port was transcribed from.
-    """
-    expected = FROZEN_BODY_SHA256.get(value_split)
-    if expected is None:
-        return
-    path = _source_body_path(value_split)
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != expected:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {expected}; the upstream "
-            "export was regenerated and this port must be re-verified against it"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool.
 
@@ -835,7 +793,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source(spec["VALUE_SPLIT"])
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -962,7 +919,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -25,22 +25,12 @@ measurable -- specialization; ``_specialization`` raises for anything else.
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
 import torch
 
 from tvm.script import tirx as T
-
-# --- source pinning -------------------------------------------------------
-# The generated body declares its own digest at
-# flashkda_decode_d128_t2_precomputed_split4.cu:19-20. Two digests are printed
-# there, "Raw" and "Normalized", and they differ for this export; the hash of
-# the bytes between the BEGIN/END markers is the *raw* one.
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = "e0cf2ece1b50e851579df8822fa2f03262a3399e25643a6bd3df03c875cc5ea2"
 
 HEAD_DIM = 128
 NUM_TOKENS = 2
@@ -965,30 +955,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _source_body_path() -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer  # local: keep kernel discovery free of optional deps
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t2_precomputed_split4.cu")
-
-
-def assert_frozen_source() -> None:
-    """Fail loudly if the upstream generated body was regenerated."""
-    path = _source_body_path()
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != FROZEN_BODY_SHA256:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
-            "upstream export was regenerated and this port must be re-verified"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool.
 
@@ -1119,7 +1085,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source()
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -1253,7 +1218,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -34,13 +34,11 @@ Two things make this body different from every cake kernel ported so far:
   therefore genuine three-warp edges.
 
 Helper vocabulary is shared with the T=2 module; only the geometry constants,
-the gate, the frozen digest and the kernel body are per-specialization.
+the gate and the kernel body are per-specialization.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
@@ -112,12 +110,6 @@ def _load_f32(buffer, index):
     T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buffer.ptr_to([index])))
     return T.reinterpret("float32", out[0])
 
-
-# --- source pinning -------------------------------------------------------
-# Raw and normalized digests differ for this export; the hash of the bytes
-# between the BEGIN/END markers is the raw one (verified).
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = "70c838b717a9eb7765bf9291db786b2b7a0387fbf80a3c337d5c04e7a553fe21"
 
 HEAD_DIM = _t2.HEAD_DIM
 NUM_TOKENS = 3
@@ -888,30 +880,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _source_body_path() -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t3_lower_bound_split4.cu")
-
-
-def assert_frozen_source() -> None:
-    """Fail loudly if the upstream generated body was regenerated."""
-    path = _source_body_path()
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != FROZEN_BODY_SHA256:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
-            "upstream export was regenerated and this port must be re-verified"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool."""
     from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
@@ -1026,7 +994,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source()
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -1160,7 +1127,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -24,14 +24,12 @@ accumulator columns 2,3 and 6,7, the ``quad_base + 1`` broadcasts, and the
 where lane ``4f+2`` writes tokens 0,1 and lane ``4f+3`` writes tokens 2,3, so
 the WY residuals have to cross the quad.
 
-Helper vocabulary is shared with the T=2 module; only the geometry constants,
-the frozen digest and the kernel body are per-specialization.
+Helper vocabulary is shared with the T=2 module; only the geometry constants
+and the kernel body are per-specialization.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
@@ -75,11 +73,6 @@ _ldmatrix_x4 = _t2._ldmatrix_x4
 _mma_zero = _t2._mma_zero
 _mma_acc = _t2._mma_acc
 
-# --- source pinning -------------------------------------------------------
-# Raw and normalized digests differ for this export; the hash of the bytes
-# between the BEGIN/END markers is the raw one (verified).
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = "6ee50e300a2f20f305252a49e3e84fde957542ccb97b7fcb7ba7f075c7733077"
 
 HEAD_DIM = _t2.HEAD_DIM
 NUM_TOKENS = 4
@@ -786,30 +779,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _source_body_path() -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(root, "csrc", "kda", "flashkda_decode_d128_t4_precomputed_split2.cu")
-
-
-def assert_frozen_source() -> None:
-    """Fail loudly if the upstream generated body was regenerated."""
-    path = _source_body_path()
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != FROZEN_BODY_SHA256:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {FROZEN_BODY_SHA256}; the "
-            "upstream export was regenerated and this port must be re-verified"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool."""
     from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
@@ -914,7 +883,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source()
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -1048,7 +1016,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
@@ -28,14 +28,12 @@ aliases of ``sVec`` in the T<=4 bodies. The inter-token butterfly path is gone
 entirely, and a partial named barrier (``barrier.sync 1, 160`` /
 ``barrier.arrive 1, 160``) synchronizes the five token warps around it.
 
-Helper vocabulary is shared with the T=2 module; only the geometry constants,
-the frozen digests and the kernel body are per-specialization.
+Helper vocabulary is shared with the T=2 module; only the geometry constants
+and the kernel body are per-specialization.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
@@ -148,17 +146,6 @@ def _mma_acc_b(acc, a, b, b0: int):
         )
     )  # fmt: skip
 
-
-# --- source pinning -------------------------------------------------------
-# Raw and normalized digests differ for every T=5 export; the hash of the bytes
-# between the BEGIN/END markers is the raw one (verified for all four).
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = {
-    1: "7d44765cc20864dca2fc5f96ed2ae653e4d421f963c20fed5ba825d4989c8b4e",
-    2: "d8c24892ac7e456fd04c51fe820ecedfc677c3be0e823cc4919043da7ae025af",
-    4: "93020b1e878a584146d7f9c1a4e46c98bd05bcf8fa4f83c41fb6dcd4e616377d",
-    8: "2307b896466dd58ff1daba770763b0a7142451e73225e940e9e9461a21bb9452",
-}
 
 HEAD_DIM = _t2.HEAD_DIM
 NUM_TOKENS = 5
@@ -1164,31 +1151,6 @@ def _variant_name(value_split: int) -> str:
     return f"d128_t5_precomputed_gram_split{value_split}"
 
 
-def _source_body_path(value_split: int) -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(root, "csrc", "kda", f"flashkda_decode_{_variant_name(value_split)}.cu")
-
-
-def assert_frozen_source(value_split: int) -> None:
-    """Fail loudly if the upstream generated body was regenerated."""
-    expected = FROZEN_BODY_SHA256[value_split]
-    path = _source_body_path(value_split)
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != expected:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {expected}; the "
-            "upstream export was regenerated and this port must be re-verified"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool."""
     from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
@@ -1294,7 +1256,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source(spec["VALUE_SPLIT"])
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -1428,7 +1389,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -32,14 +32,12 @@ Structurally this is the T=5 body at TOKENS=6 with four deltas:
 * Six token warps: 256/192/192/192 threads, ``barrier.sync 1, 192``, and the
   gram warp is warp 5 at splits 4 and 8.
 
-Helper vocabulary is shared with the T=2 module; only the geometry constants,
-the frozen digests and the kernel body are per-specialization.
+Helper vocabulary is shared with the T=2 module; only the geometry constants
+and the kernel body are per-specialization.
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 from typing import Any
 from unittest import SkipTest
 
@@ -152,17 +150,6 @@ def _mma_acc_b(acc, a, b, b0: int):
         )
     )  # fmt: skip
 
-
-# --- source pinning -------------------------------------------------------
-# Raw and normalized digests differ for every T=6 export; the hash of the bytes
-# between the BEGIN/END markers is the raw one (verified for all four).
-FROZEN_FLASHINFER_COMMIT = "f2e04400"
-FROZEN_BODY_SHA256 = {
-    1: "6684bee1c3e1354082e8603574fe43a5b37991dd2767c9b33104d97cd84bbc55",
-    2: "27e047dc15f2bb4972718b15143d1ebff6cfe21c42aa5688db8245a22c7eba55",
-    4: "f38dc82927095886ce8b030becd0761124d9a0aab3a8373efd17818f7f760463",
-    8: "96593303ff3d6dbb7e9c603f1b76d9eb87eb21f03341a796ea63cdd9e8ee1dac",
-}
 
 HEAD_DIM = _t2.HEAD_DIM
 NUM_TOKENS = 6
@@ -1222,31 +1209,6 @@ def _variant_name(value_split: int) -> str:
     return f"d128_t6_precomputed_gram_split{value_split}"
 
 
-def _source_body_path(value_split: int) -> str:
-    """Absolute path of the frozen generated body this port transcribes."""
-    import flashinfer
-
-    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
-    return os.path.join(root, "csrc", "kda", f"flashkda_decode_{_variant_name(value_split)}.cu")
-
-
-def assert_frozen_source(value_split: int) -> None:
-    """Fail loudly if the upstream generated body was regenerated."""
-    expected = FROZEN_BODY_SHA256[value_split]
-    path = _source_body_path(value_split)
-    with open(path, "rb") as handle:
-        text = handle.read().decode()
-    marker = "// BEGIN FROZEN GENERATED BODY\n"
-    start = text.index(marker) + len(marker)
-    end = text.index("// END FROZEN GENERATED BODY")
-    digest = hashlib.sha256(text[start:end].encode()).hexdigest()
-    if digest != expected:
-        raise AssertionError(
-            f"{path}: frozen body digest {digest} != pinned {expected}; the "
-            "upstream export was regenerated and this port must be re-verified"
-        )
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the frozen cake export itself on the reference state pool."""
     from flashinfer.jit.flash_kda_decode import get_flash_kda_decode_module
@@ -1352,7 +1314,6 @@ def run_test(**kwargs: Any) -> None:
 
     case = prepare_data(**kwargs)
     spec = case["spec"]
-    assert_frozen_source(spec["VALUE_SPLIT"])
 
     executable = compile_kernel(get_kernel(**kwargs))
     executable(*_tirx_args(case))
@@ -1486,7 +1447,6 @@ __all__ = [
     "BENCH_CONFIGS",
     "CONFIGS",
     "KERNEL_META",
-    "assert_frozen_source",
     "get_kernel",
     "prepare_data",
     "run_bench",

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import ctypes
 import functools
-import hashlib
-from pathlib import Path
 from typing import Any
 
 import torch
@@ -30,8 +28,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "7d07b8ef9faa9cfac7a24071ed235a48a65bd7842579c612f2c56e949440bdfa"
 
 _LOG2_E = _simple._LOG2_E
 _LN_2 = _simple._LN_2
@@ -1144,22 +1140,9 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 
 
 @functools.cache
-def _load_frozen_oracle():
-    from flashinfer.jit.env import FLASHINFER_INCLUDE_DIR
+def _load_oracle():
     from flashinfer.mamba import selective_state_update
 
-    source_path = (
-        Path(FLASHINFER_INCLUDE_DIR)
-        / "flashinfer/mamba/kernel_selective_state_update_mtp_horizontal.cuh"
-    )
-    if not source_path.is_file():
-        raise RuntimeError(f"missing frozen FlashInfer source: {source_path}")
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "selective-state-update MTP horizontal oracle does not match the frozen source: "
-            f"{source_path} sha256={digest}"
-        )
     return selective_state_update
 
 
@@ -1167,7 +1150,7 @@ def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     config = case["config"]
     stride_factor = int(config.get("state_stride_factor", 1))
     source_out = case["flashinfer_output"] if bool(config.get("use_out_tensor", True)) else None
-    result = _load_frozen_oracle()(
+    result = _load_oracle()(
         case["flashinfer_state_storage"][::stride_factor],
         case["x"],
         case["dt"],

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -11,8 +11,6 @@ Upstream source: include/flashinfer/mamba/kernel_selective_state_update_mtp_simp
 from __future__ import annotations
 
 import functools
-import hashlib
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -26,8 +24,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "64b189b642d05970202964bdd3accf7055d34d6a50b7953a64c8a05a3e0a0dbe"
 _LOG2_E = 1.4426950408889634
 _LN_2 = 0.6931471805599453
 _FLT_LOWEST = -3.4028234663852886e38
@@ -1692,22 +1688,9 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 @functools.cache
-def _load_frozen_oracle():
-    from flashinfer.jit.env import FLASHINFER_INCLUDE_DIR
+def _load_oracle():
     from flashinfer.mamba import selective_state_update
 
-    source_path = (
-        Path(FLASHINFER_INCLUDE_DIR)
-        / "flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh"
-    )
-    if not source_path.is_file():
-        raise RuntimeError(f"missing frozen FlashInfer source: {source_path}")
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "selective-state-update MTP oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
     return selective_state_update
 
 
@@ -1822,7 +1805,7 @@ def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     state_view = case["flashinfer_state_storage"][::stride_factor]
     scale_state = str(config["state_dtype"]) == "int16"
     source_out = case["flashinfer_output"] if bool(config.get("use_out_tensor", True)) else None
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     result = oracle(
         state_view,
         case["x"],

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import ctypes
 import functools
-import hashlib
-from pathlib import Path
 from typing import Any
 
 import torch
@@ -29,8 +27,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "8c8d292c08cc29eb0db47d231bcab47bdb86e285ff7b02f6135709e3a5058cca"
 
 _LOG2_E = _simple._LOG2_E
 _LN_2 = _simple._LN_2
@@ -1412,22 +1408,9 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 
 
 @functools.cache
-def _load_frozen_oracle():
-    from flashinfer.jit.env import FLASHINFER_INCLUDE_DIR
+def _load_oracle():
     from flashinfer.mamba import selective_state_update
 
-    source_path = (
-        Path(FLASHINFER_INCLUDE_DIR)
-        / "flashinfer/mamba/kernel_selective_state_update_mtp_vertical.cuh"
-    )
-    if not source_path.is_file():
-        raise RuntimeError(f"missing frozen FlashInfer source: {source_path}")
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "selective-state-update MTP vertical oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
     return selective_state_update
 
 
@@ -1435,7 +1418,7 @@ def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     config = case["config"]
     stride_factor = int(config.get("state_stride_factor", 1))
     source_out = case["flashinfer_output"] if bool(config.get("use_out_tensor", True)) else None
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     result = oracle(
         case["flashinfer_state_storage"][::stride_factor],
         case["x"],

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -26,8 +26,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "c0e13b64bf42f4f8155058dc9f5877f7aca90832f50a1e7602863894908e89fd"
 
 _LOG2_E = _simple._LOG2_E
 _LN_2 = _simple._LN_2
@@ -1131,7 +1129,7 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     kwargs = case["kwargs"]
     spec = case["spec"]
-    oracle = _simple._load_frozen_oracle()
+    oracle = _simple._load_oracle()
     state_view = _simple._view_state(case["reference_state_raw"], spec, case["state_stride"])
     source_out = case["reference_output"] if bool(kwargs.get("use_out_tensor", True)) else None
     result = oracle(

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -11,8 +11,6 @@ Upstream source: include/flashinfer/mamba/kernel_selective_state_update_stp.cuh.
 from __future__ import annotations
 
 import functools
-import hashlib
-from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -26,7 +24,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_SOURCE_SHA256 = "c0e13b64bf42f4f8155058dc9f5877f7aca90832f50a1e7602863894908e89fd"
 _LOG2_E = 1.4426950408889634
 _LN_2 = 0.6931471805599453
 _FLT_LOWEST = -3.4028234663852886e38
@@ -1005,21 +1002,8 @@ _TORCH_DTYPES = {
 
 
 @functools.cache
-def _load_frozen_oracle():
-    from flashinfer.jit.env import FLASHINFER_INCLUDE_DIR
+def _load_oracle():
     from flashinfer.mamba import selective_state_update
-
-    source_path = (
-        Path(FLASHINFER_INCLUDE_DIR) / "flashinfer/mamba/kernel_selective_state_update_stp.cuh"
-    )
-    if not source_path.is_file():
-        raise RuntimeError(f"missing frozen FlashInfer source: {source_path}")
-    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if digest != FROZEN_FLASHINFER_SOURCE_SHA256:
-        raise RuntimeError(
-            "selective-state-update oracle does not match the reviewed source: "
-            f"{source_path} sha256={digest}"
-        )
 
     return selective_state_update
 
@@ -1231,7 +1215,7 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     kwargs = case["kwargs"]
     spec = case["spec"]
-    oracle = _load_frozen_oracle()
+    oracle = _load_oracle()
     state_view = _view_state(case["reference_state_raw"], spec, case["state_stride"])
     state_scale = (
         _view_scale(case["reference_scale_raw"], spec, case["scale_stride"])

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -25,8 +25,6 @@ KERNEL_META = {
     "compute_capability": 10,
 }
 
-FROZEN_FLASHINFER_COMMIT = "f2e04400e330fb2debe0bf8730d9424a1d37927f"
-FROZEN_FLASHINFER_SOURCE_SHA256 = "c0e13b64bf42f4f8155058dc9f5877f7aca90832f50a1e7602863894908e89fd"
 
 _LOG2_E = _simple._LOG2_E
 _LN_2 = _simple._LN_2
@@ -1283,7 +1281,7 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
 def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     kwargs = case["kwargs"]
     spec = case["spec"]
-    oracle = _simple._load_frozen_oracle()
+    oracle = _simple._load_oracle()
     state_view = _simple._view_state(case["reference_state_raw"], spec, case["state_stride"])
     state_scale = (
         _simple._view_scale(case["reference_scale_raw"], spec, case["scale_stride"])


### PR DESCRIPTION
Every FlashInfer port carried a pinned sha256 of the upstream file it was transcribed from, together with the code to verify it. This removes the mechanism.

Two shapes existed:

- **KDA decode (T=1..6)** — `FROZEN_FLASHINFER_COMMIT` and `FROZEN_BODY_SHA256` pinned the generated body between FlashInfer's `BEGIN`/`END FROZEN GENERATED BODY` markers; `assert_frozen_source()` was called from `run_test` and exported in `__all__`, with `_source_body_path()` existing only to feed it.
- **GDN and Mamba** — `FROZEN_FLASHINFER_SOURCE_SHA256` (plus `..._KERNEL_SHA256` / `..._ADAPTER_SHA256` for GDN prefill) pinned the *reference oracle's* source file, checked inside the oracle loader.

## Why

Both were provenance tripwires, not correctness checks. The tests already run the live upstream implementation on every invocation and compare against it, so a genuine behavioural change on the upstream side fails that comparison with or without a digest. What the pins added on top was a hard failure on any FlashInfer checkout other than the single commit they were captured from — which makes the suite unusable for anyone whose FlashInfer differs, and bakes one developer's environment into the source.

The one thing they did catch that the runtime comparison does not is an upstream *regeneration that is functionally equivalent but structurally different* — the case where a port's line-number citations and sketch go stale while the tests still pass. That signal is now gone; it belongs in a periodic re-derivation against upstream rather than in a hash that fails closed on every unrelated version bump.

## What changed

Removed the `FROZEN_*` constants, `assert_frozen_source()`, `_source_body_path()`, the digest checks inside the oracle loaders, the call sites, the `__all__` entry, and the `hashlib` / `inspect` / `pathlib.Path` imports that only they used. `_load_frozen_oracle` / `_run_frozen_oracle` drop the qualifier they carried only because of the pin, so the loaders are now just the import and the return.

Descriptions of upstream's own frozen generated exports are deliberately left in place — that is FlashInfer's name for the artifact (its sources literally carry `// BEGIN FROZEN GENERATED BODY`), and the ports do still transcribe it. Unrelated uses of the word (`frozenset`, `@dataclass(frozen=True)`) are untouched.

16 files, +30/−383.

## Validation

`python -m tirx_kernels.test` over the six kernels that cover both shapes and every touched directory — KDA T=6 and T=1, Mamba `stp_simple` (owns a loader) and `stp_vertical` (borrows `_simple`'s), GDN decode ILP4, GDN prefill:

| kernel | result |
| --- | --- |
| `flashkda_decode_t6_gram` | 20 pass, 0 fail |
| `flashkda_decode_t1_precomputed` | 18 pass, 0 fail |
| `selective_state_update_stp_simple` | 20 pass, 0 fail |
| `selective_state_update_stp_vertical` | 20 pass, 0 fail |
| `gdn_decode_bf16_ilp4` | 20 pass, 0 fail |
| `gdn_prefill_sm100` | 20 pass, 0 fail |

**118 configs pass, 0 fail.** Registry discovery still finds all 49 kernels, no module retains any of the removed attributes, and `pre-commit run` is clean.