### PR TITLE
Fix persistent stage reuse synchronization

### DIFF
--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
@@ -1556,6 +1556,10 @@ def build_kernel(spec: GemmSpec):
                                 T.cast(tr_phase, "uint32"),
                                 T.uint32(TRY_WAIT_TICKS),
                             )
+                        # The prior logical task may still read this stage through tcgen05's
+                        # async proxy.  Complete that handoff before generic-proxy transpose
+                        # stores reuse the same shared bytes.
+                        T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
                         if tr_k % sfa_stages_per_load == 0:
                             for c in T.unroll(0, num_sfa_chunks):
                                 base = c * NUM_UTCCP_ALIGNED_ELEMS

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -487,9 +487,6 @@ def _make_low_level_kernel(
                                     T.ptx.cp("async", "bulk", "commit_group", "")
                         else:
                             T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
-                            # Match the steady-state epilogue rendezvous: every WG0 waiter
-                            # must consume this generation before warp 0 can commit the next.
-                            T.ptx.bar(T.uint32(0), T.uint32(128), "", "sync", "")
                         last_valid = 1
                         last_s_q_idx = wg0_s_q_idx
                         last_outer_loop_phase = wg0_outer_loop_phase

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -487,6 +487,9 @@ def _make_low_level_kernel(
                                     T.ptx.cp("async", "bulk", "commit_group", "")
                         else:
                             T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
+                            # Match the steady-state epilogue rendezvous: every WG0 waiter
+                            # must consume this generation before warp 0 can commit the next.
+                            T.ptx.bar(T.uint32(0), T.uint32(128), "", "sync", "")
                         last_valid = 1
                         last_s_q_idx = wg0_s_q_idx
                         last_outer_loop_phase = wg0_outer_loop_phase

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -324,6 +324,7 @@ def _make_low_level_kernel(
                 bar_valid_coord_scales_empty_buf = T.decl_buffer((4,), "uint64", data=pool_buf.data, elem_offset=27803, scope="shared.dyn", align=8)
                 buffer_8 = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27807, scope="shared.dyn", align=8)
                 bar_clc_empty_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27808, scope="shared.dyn", align=8)
+                bar_tQ_consumed_buf = T.decl_buffer((1,), "uint64", data=pool_buf.data, elem_offset=27809, scope="shared.dyn", align=8)
                 clc_response = T.decl_buffer((4,), "uint32", data=pool_buf.data, elem_offset=55620, scope="shared.dyn", align=16)
                 tmem_start_addr = T.decl_buffer((1,), "uint32", data=pool_buf.data, elem_offset=55624, scope="shared.dyn", align=4)
                 with T.attr({"tirx.dyn_smem_bytes": T.int64(222500)}):
@@ -365,6 +366,9 @@ def _make_low_level_kernel(
                             T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer_8[i])), T.uint32(1), "init", "shared", "b64", "")
                         for i in T.unroll(1):
                             T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_clc_empty_buf[i])), T.uint32(539), "init", "shared", "b64", "")
+                        # One elected arrival from each WG0 warp in both CTAs.
+                        for i in T.unroll(1):
+                            T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(bar_tQ_consumed_buf[i])), T.uint32(8), "init", "shared", "b64", "")
                         T.ptx.fence("mbarrier_init", "release", "cluster", "")
                 else:
                     if warp_idx == 2:
@@ -409,6 +413,9 @@ def _make_low_level_kernel(
                                 buffer_18 = T.decl_scalar(T.bfloat16, data=q_smem_tma.data, elem_offset=0, scope="shared.dyn")
                                 T.ptx.cp(T.cuda.cvta_generic_to_shared(T.address_of(buffer_18)), T.reinterpret(T.handle().ty, T.address_of(q_tma_tensormap)), 0, block_idx % 2 * 64, 0, 0, wg0_job_block_idx // 2, T.cuda.cvta_generic_to_shared(T.reinterpret(T.handle().ty, buffer_17)), T.uint64(1364590687093260288), "async", "bulk", "tensor", "5d", "shared::cluster", "global", "", "mbarrier::complete_tx::bytes", "", "cta_group::2", "L2::cache_hint", "")
                                 if cta_idx == 0:
+                                    # Do not republish tQ-full until both CTAs consumed its prior phase.
+                                    if last_valid != 0:
+                                        T.cuda.mbarrier_wait(T.address_of(bar_tQ_consumed_buf[0]), T.bitwise_xor(last_outer_loop_phase, 0))
                                     T.ptx.mbarrier(T.cuda.cvta_generic_to_shared(T.address_of(buffer[0])), T.uint32(131072), "arrive", "expect_tx", "", "", "shared", "b64", "")
                                     T.cuda.mbarrier_wait(T.address_of(buffer[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
                                     T.cuda.mbarrier_wait(T.address_of(buffer_1[0]), T.bitwise_xor(T.bitwise_xor(wg0_outer_loop_phase, 1), 0))
@@ -443,6 +450,10 @@ def _make_low_level_kernel(
                                 if epi_k == 0:
                                     T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(T.bitwise_xor(last_outer_loop_phase, 1), 0))
                                     T.ptx.fence("proxy", "async", "shared::cta", "")
+                                    if T.cuda.elect_sync():
+                                        buffer_22: T.uint32
+                                        T.ptx.mapa(buffer_22, T.cuda.cvta_generic_to_shared(T.address_of(bar_tQ_consumed_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                        T.ptx.mbarrier(buffer_22, "arrive", "", "", "shared::cluster", "b64", "")
                                 if epi_k == 3:
                                     buffer_17: T.uint32
                                     T.ptx.mapa(buffer_17, T.cuda.cvta_generic_to_shared(T.address_of(bar_tOut_empty_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
@@ -487,6 +498,10 @@ def _make_low_level_kernel(
                                     T.ptx.cp("async", "bulk", "commit_group", "")
                         else:
                             T.cuda.mbarrier_wait(T.address_of(buffer_2[0]), T.bitwise_xor(wg0_outer_loop_phase, 0))
+                            if T.cuda.elect_sync():
+                                buffer_13: T.uint32
+                                T.ptx.mapa(buffer_13, T.cuda.cvta_generic_to_shared(T.address_of(bar_tQ_consumed_buf[0])), T.uint32(0), "shared::cluster", "u32", "")
+                                T.ptx.mbarrier(buffer_13, "arrive", "", "", "shared::cluster", "b64", "")
                         last_valid = 1
                         last_s_q_idx = wg0_s_q_idx
                         last_outer_loop_phase = wg0_outer_loop_phase


### PR DESCRIPTION
## Summary

- complete the async-to-generic proxy handoff before the persistent grouped-FP8 transposer reuses scale-factor shared storage
- pair FlashMLA's multicast tQ-full barrier with an explicit cross-CTA consumed barrier so a later phase cannot overtake lagging waiters

## Root causes

The grouped-FP8 kernel waited for the logical task's mbarrier generation, but then reused the same shared stage through generic-proxy transpose stores while the preceding `tcgen05.cp` could still read it through the async proxy. The proxy fence establishes that ownership transfer before reuse.

FlashMLA publishes each tQ phase from CTA0 but all four WG0 warps in both CTAs consume it. Under task stealing, CTA0 warp 0 could publish the next phase before a lagging warp observed the prior parity. The new consumed mbarrier receives one elected arrival from each of those eight warps; CTA0 waits for that exact consumption event before republishing tQ-full.

## Review correction

An earlier attempt added an unconditional `bar.sync 0, 128` after the first wait. That was wrong: it imposed an extra named-barrier generation and can deadlock shapes whose dynamic participation does not match that assumption. Commit `edfa724` explicitly reverts it; the effective source diff contains no added `bar.sync`. The replacement models the actual full/empty ownership contract instead of forcing warpgroup lockstep.

## Verification

Checker before -> after:

- grouped-FP8 Racecheck: `error` with one `read_write` overlap plus 64 audited scale-padding reviews -> `review` with only those 64 padding findings; 16/16 tasks complete
- FlashMLA forced cluster-0 task-steal Synccheck: one generation-lap `fixed_sync_protocol_error` -> zero findings and zero advisories; 32/32 selected warps complete, with only the intentional 32/64 subset classification remaining `incomplete`
- FlashMLA task-steal Racecheck: zero findings; independent NumPy/NumSim oracle passes
- FlashMLA full-launch Synccheck and Racecheck remain clean

Corpus runs against the effective diff:

- NumSim: 48 passed
- Racecheck: 46 passed
- Synccheck: 45 ordinary/full-launch cases passed; the one deselected downstream test intentionally asserts the now-fixed FlashMLA source blocker
- Ruff: passed

B200 GPU correctness:

- `deepgemm_sm100_fp8_gemm_1d1d`: 20/20 configurations passed using its referenced DeepGEMM `559d79fb` oracle
- FlashMLA boundary shapes passed: `s_q/topk` = `1/64`, `2/128`, `3/256`, and `5/1280`; these include attention sink, dynamic top-k length, and injected invalid-index paths
- FlashMLA production matrix passed 3/3: `s_q=4096`, `topk=1280`, `s_kv` in `{8192, 32768, 65536}`
- Compute Sanitizer Synccheck: 0 errors for `s_q=1, topk=64` and for CLC-active `s_q=128, topk=64`

## Downstream note

When the wiki/tooling repository repins this commit, replace its old FlashMLA source-blocker assertion with zero-finding assertions while retaining the deliberate subset-incomplete classification. The existing normal full-launch case should remain clean.
