### PR TITLE
docs(infra): fix fast-math attribution, add launch-bounds numbers in instruction-selection DB

### DIFF
--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -30,6 +30,11 @@ When the reference pins an instruction, use the exact PTX operation: non-FTZ
 `.approx.ftz` only where the reference uses it. Plain TIRx remains appropriate
 for integer and index math.
 
+Global fast-math off-switches exist for both TVM CUDA compile paths
+(`TVM_CUDA_NVCC_NO_FAST_MATH=1` for nvcc, `--ftz=false` via
+`TVM_CUDA_NVRTC_EXTRA_OPTS` for NVRTC), but prefer per-op pinning: it holds
+regardless of compile defaults and documents intent at the use site.
+
 Confirm with denormal inputs and an instruction-by-instruction PTX comparison.
 
 ## E3: Match launch bounds

--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -35,6 +35,16 @@ Global fast-math off-switches exist for both TVM CUDA compile paths
 `TVM_CUDA_NVRTC_EXTRA_OPTS` for NVRTC), but prefer per-op pinning: it holds
 regardless of compile defaults and documents intent at the use site.
 
+The direction is a property of the reference, not of the family, and both
+families are registered in the PTX table, so the `.ftz` forms are always an
+explicit choice. Two siblings ported from a tile-DSL reference emit no `.ftz` at
+all and needed non-FTZ helpers to defeat the fast-math build; a third, whose
+reference is plain CUDA operators compiled with fast math, emits 108
+`fma.rn.ftz.f32`, 69 `mul.ftz.f32`, 53 `add.ftz.f32`, 4 `sub.ftz.f32` and no
+plain-`.f32` arithmetic at all. Inheriting a sibling's arithmetic helpers is a
+silent divergence in either direction; read the reference's own PTX census
+first.
+
 Confirm with denormal inputs and an instruction-by-instruction PTX comparison.
 
 ## E3: Match launch bounds

--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -18,9 +18,12 @@ Confirm by counting instructions in the corresponding PTX/SASS basic block. A
 
 **Symptoms:** `bitwise_mismatch`, `denormal_mismatch`, `unexpected_ftz`, `select_lowered_as_branch`
 
-Fast-math defaults can add `.ftz`, approximate division, or change a compare and
-select into different control flow. This causes bitwise mismatches on denormals
-and may perturb scheduling even when normal values agree.
+Two independent mechanisms share one fix. Fast-math defaults (e.g. nvcc
+`--use_fast_math`) add `.ftz` to float arithmetic and make division
+approximate, causing bitwise mismatches on denormals. Independently, a float
+compare/select whose PTX form is unpinned lets the codegen choose whether
+`setp` carries `.ftz` and lets ptxas choose between `selp` and a branch; that
+perturbs instruction shape and scheduling even when normal values agree.
 
 When the reference pins an instruction, use the exact PTX operation: non-FTZ
 `mul.f32`/`add.f32`, `div.rn.f32`, or explicit `setp` plus `selp`. Retain
@@ -34,9 +37,13 @@ Confirm with denormal inputs and an instruction-by-instruction PTX comparison.
 **Symptoms:** `register_spill`, `register_budget_mismatch`, `local_memory_traffic`, `low_occupancy`
 
 `tirx.launch_bounds_min_blocks_per_sm` becomes the second CUDA
-`__launch_bounds__` argument and imposes a hard ptxas register budget. A value
-chosen from theoretical occupancy can starve a kernel whose reference uses more
-registers, producing STL/LDL or global rescheduling.
+`__launch_bounds__` argument and imposes a hard ptxas register budget: roughly
+65536 registers divided by (threads per CTA times the bound), rounded down to
+the allocation granularity. A value chosen from theoretical occupancy can
+starve a kernel whose reference uses more registers, producing STL/LDL or
+global rescheduling. One measured 512-thread quantization kernel was capped at
+32 registers with a bound of 4 while its reference ran at about 50; a bound of
+2 restored parity.
 
 Set the bound from the reference kernel's realized occupancy target. Compare
 resource usage, achieved occupancy, and dynamic local-memory traffic on both


### PR DESCRIPTION
Two corrections/additions to the tirx-instruction-selection DB, both from measured perf-gate work behind the quantization kernel ports:

**E2 (Pin floating-point instructions): attribution fix.** The entry currently lumps three effects under fast-math defaults, including changing a compare/select into different control flow. The selp-vs-branch choice is a ptxas heuristic and is independent of `--use_fast_math`. Rewritten as two independent mechanisms sharing one fix: fast math covers `.ftz` / approximate division (bitwise mismatches on denormals), while an unpinned float compare/select lets codegen choose the `setp` flag and lets ptxas choose between `selp` and a branch (instruction-shape perturbation even when values agree). Symptom tags unchanged.

**E3 (Match launch bounds): add the essential numbers.** States the register-budget formula (65536 registers / (threads per CTA x bound), rounded down to allocation granularity) and the measured case behind the entry: a 512-thread quantization kernel capped at 32 registers with a bound of 4 while its reference ran at about 50; a bound of 2 restored parity. This makes the gap recognizable from `cuobjdump -res-usage` output alone.

Follows the skill's curation rules: symptom rows untouched, no paths/line numbers/run IDs, only measured mechanisms.