### PR TITLE
Fix recurrent KDA one-warp output store ordering

### DIFF
--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -519,6 +519,24 @@ showed the barriers contributed nothing and the fast-math swap was an
 instruction-selection divergence that the parity contract forbids. Change one
 thing per measurement.
 
+## Measure elided warp synchronization as a scheduling constraint
+
+**Symptoms:** `warp_sync_schedule_shift`, `small_shape_regression`, `bar_warp_elided`
+
+A converged full-mask `bar.warp.sync` may remain in PTX while ptxas emits no
+`BAR.WARP` instruction. That does not make the source change performance
+neutral: the ordering constraint can still reschedule surrounding instructions
+differently for each specialization.
+
+One B200 `sm_100a` one-warp decode sweep added exactly one PTX
+`bar.warp.sync`, emitted no SASS barrier, and kept registers and spills
+unchanged. Cold-L2 time nevertheless moved by +2.07%, -0.76%, and -1.17%
+across its small, medium, and large default shapes; both benchmark orderings
+agreed. Treat the movement as specialization-specific scheduling, not as a
+fixed barrier latency. Inspect PTX, SASS, and resources for every affected
+shape, then A/B the complete dispatch matrix even when the machine barrier is
+elided.
+
 ## Predict the cross-shape ordering before measuring
 
 **Symptoms:** `hypothesis_not_falsifiable`, `placement_search`, `gate_flapping`

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -515,6 +515,7 @@ def _recurrent_kda_decode_one_warp(
             (batch_idx * NUM_VALUE_HEADS + value_head_idx) * HEAD_DIM + v_offset + tidx,
             T.uint16(0),
         )
+    T.cuda.warp_sync()
 
     # --- initial-state slot (recurrent_kda.py:257-272) ----------------------
     init_raw_slot: T.int32 = _load_i32(ssm_state_indices, batch_idx * NUM_TOKENS)


### PR DESCRIPTION
## Summary

- order the one-warp decode output prefill before the later active-result stores with a warp-scoped synchronization edge
- record the measured instruction-selection behavior of an elided `bar.warp.sync`

## Root cause

The prologue zero-fills output rows from lanes `0..TILE_ROWS-1`. The token loop later writes the same output bytes from different lanes selected by `k_lane == j`. The one-warp CTA had no happens-before edge between those stores, so their final order was undefined even though normal numerical runs usually observed the intended active result.

`T.cuda.warp_sync()` is the narrowest synchronization primitive that orders all participating lanes without introducing a CTA-wide barrier.

## Performance

Measured on an idle NVIDIA B200 with driver 595.58.03 and CUDA 13.2. Each variant/config used ten cold-L2 Proton rounds with both baseline-first and patched-first orderings.

| Default config | Baseline | With warp sync | Change |
| --- | ---: | ---: | ---: |
| `hv16_b8_tr8_lb` | 5.2290 ms | 5.3373 ms | +108.2 us / +2.07% |
| `hv12_b64_tr16_lb` | 12.8482 ms | 12.7510 ms | -97.2 us / -0.76% |
| `hv16_b128_tr16_lb` | 26.8257 ms | 26.5113 ms | -314.4 us / -1.17% |

The generated PTX adds one `bar.warp.sync`; ptxas emits no SASS `BAR.WARP`, and register/spill counts are unchanged. The remaining movement is specialization-specific scheduling rather than a fixed machine-barrier latency.

## Validation

- `python -m ruff check tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py`
- `python -m ruff format --check tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py`
- `CUDA_VISIBLE_DEVICES=2 PYTHONPATH=/home/hongyij/tir/python python -m tirx_kernels.test --kernel recurrent_kda_decode_one_warp --config <config>` for all three default configs above: 3/3 passed
- external `tirx_tools` canonical full-launch case (`prepare_recurrent_kda_one_warp_case`): Synccheck clean (2048/2048 tasks), Racecheck clean (2048/2048 tasks), NumSim clean (zero mismatches and diagnostics)
