### PR TITLE
docs(infra): complete the kernel and bench-suite file listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,110 +4,88 @@ High-performance GPU kernels written in [TIRx](https://github.com/apache/tvm).
 
 ## Kernels
 
-All kernels target `sm_100a`. Names are the registry names accepted by the
-`--kernel` CLI filters. Each category directory holds the kernels ported from
-one upstream project; `basic/` holds the native TIRx kernels with no single
+All kernels target `sm_100a`. **Kernel** is the registry name accepted by the
+`--kernel` CLI filters; **Module** is its source file, relative to the bucket
+directory under `tirx_kernels/`. Each bucket holds the kernels ported from one
 upstream project.
 
-`basic/` — native TIRx kernels:
+`basic/` — native TIRx kernels, with no single upstream project:
 
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `fp16_bf16_gemm` | fp16 / bf16 | Dense GEMM |
-| `nvfp4_gemm` | nvfp4 | Dense GEMM |
-| `rmsnorm` | fp16 / bf16 | RMSNorm |
-| `allgather_gemm` | fp16 | AllGather + GEMM (multi-GPU, NVSHMEM) |
-| `gemm_reduce_scatter` | fp16 | GEMM + ReduceScatter (multi-GPU, NVSHMEM) |
+| Kernel                | Module                   | What it is |
+| --------------------- | ------------------------ | ---------- |
+| `fp16_bf16_gemm`      | `fp16_bf16_gemm.py`      | Dense GEMM |
+| `nvfp4_gemm`          | `nvfp4_gemm.py`          | Dense GEMM |
+| `rmsnorm`             | `rmsnorm.py`             | RMSNorm |
+| `allgather_gemm`      | `allgather_gemm.py`      | AllGather + GEMM (multi-GPU, NVSHMEM) |
+| `gemm_reduce_scatter` | `gemm_reduce_scatter.py` | GEMM + ReduceScatter (multi-GPU, NVSHMEM) |
 
 `flashattention/` — Dao-AILab flash-attention ports:
 
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `flash_attention4` | bf16 | FlashAttention-4 |
-| `flash_attention_backward_sm100` | fp16 | Two-CTA FlashAttention backward (D=128); [schedule sketch](tirx_kernels/flashattention/flash_attention_backward_sm100_sketch.md) |
+| Kernel                           | Module                        | What it is |
+| -------------------------------- | ----------------------------- | ---------- |
+| `flash_attention4`               | `flash_attention4.py`         | FlashAttention-4 |
+| `flash_attention_backward_sm100` | `flash_attention_backward.py` | Two-CTA FlashAttention backward (D=128); [schedule sketch](tirx_kernels/flashattention/flash_attention_backward_sm100_sketch.md) |
 
 `flashinfer/` — FlashInfer ports, sub-bucketed by the FlashInfer Python entry
-point each port backs:
+point each port backs (`activation`, `quantization` — CuTe-DSL backend —,
+`mamba`, `kda`, `gdn_decode`, `gdn_prefill`, `gemm`):
 
-`flashinfer/activation/` — `flashinfer.activation`:
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `act_and_mul` | fp16 / bf16 | `silu_and_mul`, `gelu_and_mul`, `gelu_tanh_and_mul` (one templated kernel) |
-| `silu_and_mul_nvfp4_experts_quantize` | fp16 / bf16 → nvfp4 | SiLU*mul fused with per-expert NVFP4 quantization |
-
-`flashinfer/quantization/` — `flashinfer.quantization` (CuTe-DSL backend):
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `nvfp4_quantize` | fp16 / bf16 → nvfp4 | Block quantization, linear and swizzled SF layouts; also the `silu_and_mul` variant |
-| `nvfp4_quantize_per_token` | fp16 / bf16 → nvfp4 | Per-token-activation quantization |
-| `mxfp4_quantize` | fp16 / bf16 → mxfp4 | Block quantization with UE8M0 scales |
-| `mxfp8_quantize` | fp16 / bf16 → mxfp8 | Block quantization with UE8M0 scales |
-
-`flashinfer/mamba/` — `flashinfer.mamba.selective_state_update`, one port per
-`is_mtp` x `algorithm=` combination:
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `selective_state_update_stp_simple` | bf16 + fp32 | Single-token, `algorithm="simple"` |
-| `selective_state_update_stp_vertical` | bf16 + fp32 | Single-token, `algorithm="vertical"` |
-| `selective_state_update_stp_horizontal` | bf16 + fp32 | Single-token, `algorithm="horizontal"` |
-| `selective_state_update_mtp_simple` | bf16 + fp32 | Multi-token, `algorithm="simple"` |
-| `selective_state_update_mtp_vertical` | bf16 + fp32 | Multi-token, `algorithm="vertical"` |
-| `selective_state_update_mtp_horizontal` | bf16 + fp32 | Multi-token, `algorithm="horizontal"` |
-
-`flashinfer/kda/` — `flashinfer.kda`:
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `flashkda_bf16_fused_m128` | bf16 | Recurrent KDA prefill, M128 schedule |
-| `recurrent_kda_decode_one_warp` | bf16 | Recurrent KDA decode, one warp per CTA (T=1, `sequence_heads >= 128`) |
-| `recurrent_kda_decode_grouped` | bf16 | Recurrent KDA decode, grouped CTA (small-batch T=1 and all speculative T>1) |
-| `flashkda_decode_t1_precomputed` | bf16 | FlashKDA "cake" decode, T=1 precomputed gate |
-| `flashkda_decode_t2_precomputed` | bf16 | FlashKDA "cake" decode, T=2 precomputed gate (WY, tensor cores) |
-| `flashkda_decode_t3_lower_bound` | bf16 | FlashKDA "cake" decode, T=3 lower-bound gate computed in-kernel |
-| `flashkda_decode_t4_precomputed` | bf16 | FlashKDA "cake" decode, T=4 precomputed gate (WY, tensor cores) |
-| `flashkda_decode_t5_gram` | bf16 | FlashKDA "cake" decode, T=5 coefficient-Gram gate (tensor-core WY coefficients, all four value splits) |
-| `flashkda_decode_t6_gram` | bf16 | FlashKDA "cake" decode, T=6 coefficient-Gram gate (dynamic shared memory, all four value splits) |
-
-`flashinfer/gdn_prefill/` — `flashinfer.gdn_prefill`:
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `gdn_prefill_sm100` | fp16 | Gated Delta Net prefill |
-
-`flashinfer/gemm/` — `flashinfer.gemm`:
-
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `tinygemm2_sm100` | bf16 | TinyGEMM2 |
+| Kernel                                  | Module                                              | What it is |
+| --------------------------------------- | --------------------------------------------------- | ---------- |
+| `act_and_mul`                           | `activation/act_and_mul.py`                         | `silu_and_mul`, `gelu_and_mul`, `gelu_tanh_and_mul` (one templated kernel) |
+| `silu_and_mul_nvfp4_experts_quantize`   | `activation/silu_and_mul_nvfp4_experts_quantize.py` | SiLU*mul fused with per-expert NVFP4 quantization |
+| `nvfp4_quantize`                        | `quantization/nvfp4_quantize.py`                    | Block quantization, linear and swizzled SF layouts; also the `silu_and_mul` variant |
+| `nvfp4_quantize_per_token`              | `quantization/nvfp4_quantize_per_token.py`          | Per-token-activation quantization |
+| `mxfp4_quantize`                        | `quantization/mxfp4_quantize.py`                    | Block quantization with UE8M0 scales |
+| `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
+| `selective_state_update_stp_simple`     | `mamba/selective_state_update_stp_simple.py`        | Single-token, `algorithm="simple"` |
+| `selective_state_update_stp_vertical`   | `mamba/selective_state_update_stp_vertical.py`      | Single-token, `algorithm="vertical"` |
+| `selective_state_update_stp_horizontal` | `mamba/selective_state_update_stp_horizontal.py`    | Single-token, `algorithm="horizontal"` |
+| `selective_state_update_mtp_simple`     | `mamba/selective_state_update_mtp_simple.py`        | Multi-token, `algorithm="simple"` |
+| `selective_state_update_mtp_vertical`   | `mamba/selective_state_update_mtp_vertical.py`      | Multi-token, `algorithm="vertical"` |
+| `selective_state_update_mtp_horizontal` | `mamba/selective_state_update_mtp_horizontal.py`    | Multi-token, `algorithm="horizontal"` |
+| `flashkda_bf16_fused_m128`              | `kda/bf16_fused_m128.py`                            | Recurrent KDA prefill, M128 schedule |
+| `recurrent_kda_decode_one_warp`         | `kda/recurrent_kda_decode_one_warp.py`              | Recurrent KDA decode, one warp per CTA (T=1, `sequence_heads >= 128`) |
+| `recurrent_kda_decode_grouped`          | `kda/recurrent_kda_decode_grouped.py`               | Recurrent KDA decode, grouped CTA (small-batch T=1 and all speculative T>1) |
+| `flashkda_decode_t1_precomputed`        | `kda/flashkda_decode_t1_precomputed.py`             | FlashKDA "cake" decode, T=1 precomputed gate |
+| `flashkda_decode_t2_precomputed`        | `kda/flashkda_decode_t2_precomputed.py`             | FlashKDA "cake" decode, T=2 precomputed gate (WY, tensor cores) |
+| `flashkda_decode_t3_lower_bound`        | `kda/flashkda_decode_t3_lower_bound.py`             | FlashKDA "cake" decode, T=3 lower-bound gate computed in-kernel |
+| `flashkda_decode_t4_precomputed`        | `kda/flashkda_decode_t4_precomputed.py`             | FlashKDA "cake" decode, T=4 precomputed gate (WY, tensor cores) |
+| `flashkda_decode_t5_gram`               | `kda/flashkda_decode_t5_gram.py`                    | FlashKDA "cake" decode, T=5 coefficient-Gram gate (tensor-core WY coefficients, all four value splits) |
+| `flashkda_decode_t6_gram`               | `kda/flashkda_decode_t6_gram.py`                    | FlashKDA "cake" decode, T=6 coefficient-Gram gate (dynamic shared memory, all four value splits) |
+| `gdn_decode_bf16_ilp4`                  | `gdn_decode/gdn_decode_bf16_ilp4.py`                | Gated Delta Net decode, bf16 state, ILP4 fallback schedule (T=1/2/4/8) |
+| `gdn_decode_bf16_wide_vec_t1`           | `gdn_decode/gdn_decode_bf16_wide_vec_t1.py`         | Gated Delta Net decode, bf16 state, wide-vector single-token (T=1) |
+| `gdn_decode_bf16_wide_vec_mtp`          | `gdn_decode/gdn_decode_bf16_wide_vec_mtp.py`        | Gated Delta Net decode, bf16 state, wide-vector multi-token (T=2/4/8) |
+| `gdn_decode_fp32_mtp_warp`              | `gdn_decode/gdn_decode_fp32_mtp_warp.py`            | Gated Delta Net decode, fp32 state, multi-token warp schedule |
+| `gdn_prefill_sm100`                     | `gdn_prefill/gdn_prefill_sm100.py`                  | Gated Delta Net prefill |
+| `gdn_cp_prefill_sm100`                  | `gdn_prefill/gdn_cp_prefill_sm100.py`               | Gated Delta Net chunk-parallel prefill (T precompute, M/N precompute, chunk-state fixup, CP prefill) |
+| `tinygemm2_sm100`                       | `gemm/tinygemm2_sm100.py`                           | TinyGEMM2 |
 
 `flashmla/` — FlashMLA sparse attention ports:
 
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `sparse_flashmla_prefill_head64_phase1` | bf16 | Sparse prefill, 64 q-heads (phase 1) |
-| `sparse_flashmla_prefill_head128_phase1` | bf16 | Sparse prefill, 128 q-heads (phase 1) |
-| `sparse_flashmla_prefill_head128_small_topk_phase1` | bf16 | Sparse prefill, 128 q-heads, small top-k (phase 1) |
-| `flash_mla_sparse_fwd` | bf16 | Sparse forward |
+| Kernel                                              | Module                                        | What it is |
+| --------------------------------------------------- | --------------------------------------------- | ---------- |
+| `sparse_flashmla_prefill_head64_phase1`             | `sparse_prefill_head64_phase1.py`             | Sparse prefill, 64 q-heads (phase 1) |
+| `sparse_flashmla_prefill_head128_phase1`            | `sparse_prefill_head128_phase1.py`            | Sparse prefill, 128 q-heads (phase 1) |
+| `sparse_flashmla_prefill_head128_small_topk_phase1` | `sparse_prefill_head128_small_topk_phase1.py` | Sparse prefill, 128 q-heads, small top-k (phase 1) |
+| `sparse_flashmla_decode_head64`                     | `sparse_decode_head64.py`                     | Sparse decode, 64 q-heads (main + combine launch) |
+| `flash_mla_sparse_fwd`                              | `flash_mla_sparse_fwd.py`                     | Sparse forward |
 
 `deepgemm/` — DeepGEMM ports:
 
-| Kernel | dtype | What it is |
-| ------ | ----- | ---------- |
-| `deepgemm_sm100_fp8_gemm_1d1d` | fp8 + fp4 / bf16 | Dense blockwise-scaled GEMM |
-| `deepgemm_sm100_m_grouped_fp8_gemm_contiguous` | fp8 + fp4 / bf16 | M-grouped contiguous GEMM (incl. psum layout) |
-| `deepgemm_sm100_m_grouped_fp8_gemm_masked` | fp8 + fp4 / bf16 | M-grouped masked GEMM |
-| `deepgemm_sm100_k_grouped_fp8_gemm_contiguous` | fp8 / fp32 | K-grouped contiguous GEMM (wgrad, incl. psum layout) |
-| `deepgemm_sm100_fp8_bmm` | fp8 / bf16 + fp32 | Batched GEMM behind `fp8_einsum` |
-| `deepgemm_sm100_fp4_mqa_logits` | fp4 / bf16 | MQA attention logits |
-| `deepgemm_sm100_fp8_mqa_logits` | fp8 / bf16 | MQA attention logits |
-| `deepgemm_sm100_fp4_paged_mqa_logits` | fp4 / bf16 | Paged-KV MQA attention logits |
-| `deepgemm_sm100_fp8_paged_mqa_logits` | fp8 / bf16 | Paged-KV MQA attention logits |
-| `deepgemm_sm100_tf32_hc_prenorm_gemm` | tf32 / bf16 | Prenorm GEMM |
-| `sm100_fp8_fp4_mega_moe` | fp8 + fp4 | Fused MoE megakernel (MegaMoE) |
-
+| Kernel                                         | Module                             | What it is |
+| ---------------------------------------------- | ---------------------------------- | ---------- |
+| `deepgemm_sm100_fp8_gemm_1d1d`                 | `fp8_gemm_1d1d.py`                 | Dense blockwise-scaled GEMM |
+| `deepgemm_sm100_m_grouped_fp8_gemm_contiguous` | `m_grouped_fp8_gemm_contiguous.py` | M-grouped contiguous GEMM (incl. psum layout) |
+| `deepgemm_sm100_m_grouped_fp8_gemm_masked`     | `m_grouped_fp8_gemm_masked.py`     | M-grouped masked GEMM |
+| `deepgemm_sm100_k_grouped_fp8_gemm_contiguous` | `k_grouped_fp8_gemm_contiguous.py` | K-grouped contiguous GEMM (wgrad, incl. psum layout) |
+| `deepgemm_sm100_fp8_bmm`                       | `fp8_bmm.py`                       | Batched GEMM behind `fp8_einsum` |
+| `deepgemm_sm100_fp4_mqa_logits`                | `mqa_logits_fp4.py`                | MQA attention logits |
+| `deepgemm_sm100_fp8_mqa_logits`                | `mqa_logits_fp8.py`                | MQA attention logits |
+| `deepgemm_sm100_fp4_paged_mqa_logits`          | `paged_mqa_logits_fp4.py`          | Paged-KV MQA attention logits |
+| `deepgemm_sm100_fp8_paged_mqa_logits`          | `paged_mqa_logits_fp8.py`          | Paged-KV MQA attention logits |
+| `deepgemm_sm100_tf32_hc_prenorm_gemm`          | `tf32_hc_prenorm_gemm.py`          | Prenorm GEMM |
+| `sm100_fp8_fp4_mega_moe`                       | `sm100_fp8_fp4_mega_moe.py`        | Fused MoE megakernel (MegaMoE) |
 ## Performance
 
 Per-workload numbers — our kernel time, every reference impl, and the

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -106,9 +106,10 @@ are outside both timed closures. For this port, only the results emitted by
 
 | Kind | Files |
 |------|--------|
-| **Run** | `run.py`, `config/<bucket>/<kernel>.yaml` (one per kernel, per-config `default:` flag) |
+| **Run** | `__main__.py` (the `python -m tirx_kernels.bench_suite` entry point), `run.py`, `config/<bucket>/<kernel>.yaml` (one per kernel, per-config `default:` flag) |
 | **Pinned baseline (git)** | `baseline.json`, `baseline.md` |
-| **Promote / report** | `promote_baseline.py`, `ratio_diff.py`, `baseline_view.py` |
+| **Promote / report** | `promote_baseline.py`, `ratio_diff.py`, `baseline_view.py`, `impls.py` (impl-name classification shared by the reports) |
+| **Package** | `__init__.py` |
 
 Run artifacts (logs, `runs/*.json`, `reports/*`) live under `.bench-suite/` and are not committed.
 


### PR DESCRIPTION
## What

The README kernel tables listed **45 of the 51** registered kernels. Missing entirely:

| Kernel | Module |
| ------ | ------ |
| `gdn_decode_bf16_ilp4` | `flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py` |
| `gdn_decode_bf16_wide_vec_t1` | `flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py` |
| `gdn_decode_bf16_wide_vec_mtp` | `flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py` |
| `gdn_decode_fp32_mtp_warp` | `flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py` |
| `gdn_cp_prefill_sm100` | `flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py` |
| `sparse_flashmla_decode_head64` | `flashmla/sparse_decode_head64.py` |

The `flashinfer/gdn_decode/` bucket had no section at all, so four kernels had nowhere to be listed.

## How

- **One table per top-level bucket** (`basic/`, `flashattention/`, `flashinfer/`, `flashmla/`, `deepgemm/`) instead of eleven per-sub-bucket tables. Adding a kernel is now one row instead of a new section — which is how the four `gdn_decode` ports went missing.
- Replace the dtype column with a **Module** column, relative to the bucket directory. The registry name and the file name differ for most ports (`flashkda_bf16_fused_m128` → `kda/bf16_fused_m128.py`, `deepgemm_sm100_fp8_gemm_1d1d` → `fp8_gemm_1d1d.py`, `flash_attention_backward_sm100` → `flash_attention_backward.py`), so the name alone does not lead to the source.
- The FlashInfer sub-bucket → entry-point mapping that the per-sub-bucket headings carried is kept in the `flashinfer/` section heading. The 45 existing row descriptions are copied over unchanged.
- The bench-suite `Directory layout` table omitted `__main__.py`, `impls.py`, and `__init__.py`; every file in that directory is listed now.

## Verification

Docs only, no code changes. Checked mechanically against the registry: the 51 rows match exactly the 51 modules exposing `KERNEL_META`, in both directions, and every `Module` path resolves on disk. `pre-commit run --files README.md tirx_kernels/bench_suite/README.md` passes.