### PR TITLE
feat(kernel): port DeepEP V2 elastic dispatch (single-domain NVLink path)

### DIFF
--- a/.agents/sketch/deepep/dispatch.md
+++ b/.agents/sketch/deepep/dispatch.md
@@ -1,0 +1,829 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This design sketch documents a TIRx port of DeepEP's
+deep_ep/include/deep_ep/impls/dispatch.cuh (dispatch_impl, direct
+single-domain path) and deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
+(dispatch_copy_epilogue_impl). See NOTICE and licenses/ for upstream
+attribution.
+-->
+
+# DeepEP elastic dispatch (single-domain NVLink): coarse WASP pipeline sketch
+
+This file is a non-executable design sketch. It is not a Python module, a new
+IR, a builder API, or a mathematical reference implementation. Its purpose is
+to show the two CUDA kernels as:
+
+- an explicit runtime ABI and launch;
+- explicit GMEM, SMEM, and register tiles, including byte offsets;
+- the notify-warp / dispatch-warp role split and the source-order control flow;
+- primitive directional copies and primitive computation inside every role;
+- explicit synchronization edges: mbarriers, named barriers, NVLink barriers,
+  grid-wide barriers, and the PDL chaining edge;
+- hardware instruction selection stated per key operation.
+
+The implementation represented by this sketch is maintained in
+[`tirx_kernels/deepep/dispatch.py`](../../tirx_kernels/deepep/dispatch.py).
+That module is the source of truth.
+
+**In scope.** `dispatch_impl` instantiated with `kIsScaleupNVLink=true`
+(`team_t = ncclTeamTagLsa`), `kDoCPUSync=false`, `kReuseSlotIndices=false`,
+`kNumSFPacks=0` (bf16 tokens), `kNumScaleoutRanks=1`, non-expand mode; and
+`dispatch_copy_epilogue_impl` instantiated with `kDoExpand=false`,
+`kCachedMode=false`, `kDoZeroPadding=false`, `kNumScaleoutRanks=1`
+(`kDoCreateLinkedList=false`), `kNumSFPacks=0`. The two kernels form one
+PDL-chained pair, ported together.
+
+**Out of scope.** `hybrid_dispatch.cuh` / `hybrid_combine.cuh` (multi-node);
+every `not kIsScaleupNVLink` RDMA/GIN branch (compiled out in this
+specialization); FP8+SF input (`kNumSFPacks > 0`); cached-handle mode
+(`kReuseSlotIndices=true`, zero notify warps); `do_expand` / `do_zero_padding`
+layouts; `kDoCPUSync=true` host-workspace writes; `deterministic` sorting;
+`cumulative_local_expert_recv_stats` (nullptr in this port); combine kernels;
+tile (`Tx`) primitives.
+
+## Sanctioned substitutions (ABI adaptations, not algorithm changes)
+
+TIRx cannot express three source mechanisms literally. Each substitution below
+preserves the dataflow and synchronization semantics and is called out inline
+at every use site.
+
+1. **Peer pointer table for `NCCLGin` device-side translation.** In this
+   specialization `NCCLGin` is used only for `get_sym_ptr` (LSA translation),
+   `put_value` (`st.relaxed.sys`), and `red_add_rel_sys`. GIN/RDMA paths are
+   compiled out. The port replaces the device-side
+   `ncclGetLsaPointer(window, offset, rank)` with host-precomputed tables
+   `peer_ws_ptrs[8]` and `peer_buf_ptrs[8]` (int64, from
+   `ncclGetLsaDevicePointer`, csrc/kernels/backend/nccl.cu:141-152):
+   `remote(addr, dst) = peer_table[dst] + (addr - local_base)`. The
+   `nccl_dev_comm` / `nccl_window` / QP-mode plumbing (`comm::get_qp_mode`)
+   disappears with it.
+2. **Software grid barrier for `this_grid().sync()`.** TIRx has no
+   `%envreg`/cooperative-grid-sync PTX. Every `this_grid().sync()` site
+   becomes an arrive-and-spin software grid barrier on dedicated port-scratch
+   slots inside the aligned workspace tail (unused slack in
+   `WorkspaceLayout`'s 2 MB-aligned reservation): last-arriver releases via
+   `st.release.gpu`, others spin with `ld.acquire.gpu`. Arrive-before-proceed
+   semantics and the exact call sites are unchanged.
+3. **PDL via TIRx launch tags.** `cudaTriggerProgrammaticLaunchCompletion` /
+   `cudaGridDependencySynchronize` map to
+   `T.ptx.griddepcontrol.launch_dependents()` / `.wait()` plus the
+   `tirx.use_programtic_dependent_launch` kernel-launch tag (precedent:
+   `tirx_kernels/deepgemm/paged_mqa_logits_fp4.py`).
+
+Everything else — warp roles, counting and prefix-sum math, dedup and slot
+allocation, TMA load/store dataflow, barrier protocols, timeout policy — is a
+faithful transcription of the source.
+
+## Pipeline at a glance
+
+### Kernel 1: `dispatch_impl`
+
+| Warps | Role-local tile program | Main publication/reuse edges |
+| --- | --- | --- |
+| 0..3 (notify) | zero SMEM counts; per-token expert/rank counting with SMEM atomics and rank dedup; full-grid count reduction into workspace; SM 0: wait reduction, exchange counts with all peers (`st.relaxed.sys`), wait peer counts, per-expert reduce + align, warp 0/1 prefix sums | entry NVLink barrier (tag0) before everything; `red.gpu` grid reduction; peer count exchange through workspace recv area |
+| 4..(4+kNumDispatchWarps-1) (dispatch) | per-warp channel: strided loop over tokens; TMA-load token hidden into the warp's SMEM slot; write topk metadata; dedup ranks; global-atomic slot allocation; TMA-store the token slot into the destination rank's symmetric recv region | per-warp mbarrier for TMA load completion; `red.release.sys` slot counters; exit NVLink barrier (tag1) after TMA flush |
+| all | exit: TMA store flush, grid barrier, SM 0 runs NVLink barrier (tag1), PDL trigger, SM 0 cleans sender counters | grid barrier (software), NVLink barrier, `griddepcontrol.launch_dependents` |
+
+### Kernel 2: `dispatch_copy_epilogue_impl`
+
+| Warps | Role-local tile program | Main publication/reuse edges |
+| --- | --- | --- |
+| 0..(kNumWarps-1) | resolve `num_recv_tokens` from the on-GPU prefix sum; strided loop over received tokens: locate source rank via prefix walk, TMA-load the token slot from the local symmetric recv region, read/localize topk indices (dedup assert, master lane), store recv_topk_idx, TMA-store hidden to recv_x, store topk weights, write recv_src_metadata | `griddepcontrol.wait` at kernel entry (PDL edge); per-warp mbarrier for TMA load completion |
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+specialize(...)       # compile-time variant selection
+launch(...)           # compile-time launch topology and attributes
+tile(...)             # declare storage, dtype, logical shape, and placement
+view(...)             # change logical indexing without moving values
+slice(...)            # select a logical interval
+reg_tile(...)         # declare a role-local register tile
+```
+
+Copies always state their storage direction. `remote` marks a peer-GPU GMEM
+address formed through the sanctioned pointer-table substitution:
+
+```python
+copy_g2s(src, dst, completion=mb)   # global -> shared, TMA, mbarrier completion
+copy_s2g(src, dst)                  # shared -> global, TMA (dst may be remote)
+copy_g2r(src, dst)                  # global -> register (may carry .nc / volatile / acquire semantics)
+copy_s2r(src, dst)                  # shared -> register
+copy_r2s(src, dst)                  # register -> shared
+copy_r2g(src, dst)                  # register -> global (may be remote, may carry .relaxed.sys)
+```
+
+The complete computational vocabulary used below is:
+
+```python
+fill(dst, value)
+add(dst, lhs, rhs)
+sub(dst, lhs, rhs)
+mul(dst, lhs, rhs)
+div_floor(dst, lhs, rhs)
+align_up(dst, value, granularity)
+encode_positive(dst, value)        # -value - 1 (involution; 0 decodes to "not ready")
+is_ready(predicate, encoded)       # encode_positive(encoded) >= 0
+select(dst, predicate, true_value, false_value)
+bitwise_and / bitwise_or / bitwise_xor / shift_right
+atomic_add_block(dst, value)       # shared-memory atomic add
+atomic_add_gmem(dst, value)        # global atomic add, returns old
+shuffle_index(dst, src, source_lane)
+shuffle_up(dst, src, delta)
+ballot(dst, predicate)
+match_any(dst, value)
+bfind(dst, mask)                   # highest set bit; 31 - clz
+reduce_add(dst, value)             # warp reduce-add
+```
+
+`mbarrier_init`, `expect_tx`, `mbarrier_wait`, `named_barrier`,
+`tma_store_commit`, `tma_store_wait`, `tma_store_fence`, `grid_barrier`,
+`nvlink_barrier`, `pdl_trigger`, `pdl_wait`, `fence_proxy_async`,
+`red_global` (fire-and-forget global reduction, gpu/sys scope), `store_sys`
+(relaxed sys store), `load_sys` (acquire/volatile sys load), `clock`,
+`timeout_trap`, and stage/phase updates are schedule operations. Scalar
+address arithmetic, pointer offsets, and guards are shown directly; they do
+not hide copies, computation, role changes, or synchronization.
+
+There are deliberately no computational primitives named `dispatch`,
+`combine`, `notify`, `barrier_all`, `gin`, or `nccl`.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+variant = specialize(
+    kIsScaleupNVLink=True,            # team_t = ncclTeamTagLsa; RDMA branches dead
+    kDoCPUSync=False,
+    kReuseSlotIndices=False,          # non-cached: notify warps present
+    kNumSMs=...,                      # auto: get_theoretical_num_sms; 64 for e256/k6
+    kNumNotifyWarps=4,
+    kNumDispatchWarps=...,            # min((smem - 1536) // 14464, 28); 15 @ 232448 B
+    kNumRanks=8,                      # = kNumScaleupRanks; kNumScaleoutRanks = 1
+    kNumHiddenBytes=14336,            # hidden 7168 * sizeof(bf16)
+    kNumSFPacks=0,                    # bf16 mode: no scale factors
+    kNumMaxTokensPerRank=...,         # config: 128 / 1024 / 4096
+    kNumExperts=256, kNumTopk=6, kExpertAlignment=(1, 128),
+    kDoExpand=False, kCachedMode=False, kDoZeroPadding=False,
+    target="sm_100a",
+)
+# instruction_selection: none; extent: the template argument list of
+#   `dispatch_impl` / `dispatch_copy_epilogue_impl` for the direct path
+
+# Compile-time derived constants (no emitted code)
+kNumExpertsPerRank   = 32                       # kNumExperts / kNumRanks
+kNumNotifyThreads    = 128                      # kNumNotifyWarps * 32
+kNumNotifySmemBytes  = 1536                     # align(8 + 256, 128) * 4
+kTokenMetadataBytes  = 76                       # 6*4 topk idx + 6*4 weights + 4 src + 6*4 linked-list
+kTokenBytesGmem      = 14432                    # align(14336,32) + align(0,32) + align(76,32)=96
+kTokenBytesSmem      = 14464                    # kTokenBytesGmem + align(8,32) mbarrier
+kNumThreads          = (kNumNotifyWarps + kNumDispatchWarps) * 32   # 608 @ 15 warps
+kRecvRegionBytes     = kNumRanks * kNumMaxTokensPerRank * kTokenBytesGmem
+# Workspace byte offsets (layout.cuh; kNumMaxRanks=1024, kNumMaxExperts=2048)
+WS_BARRIER_COUNTER   = 0                        # u64; phase bit 0, sign bit 1
+WS_BARRIER_SIGNAL    = 8                        # i32[2]; slot phase at (2+phase)*4
+WS_NOTIFY_REDUCTION  = 16                       # i64[3072]
+WS_COUNT_SEND        = 24592                    # i64[3072]: rank counts [0:8), expert counts [8:264)
+WS_COUNT_RECV        = 49168                    # i64[3072]: peer-written, decoded-consumed
+WS_SENDER_COUNTER    = 73744                    # i32[1024]: per-dst-rank slot atomics
+WS_PORT_SCRATCH      = 12820528                 # port substitution 2: software grid-barrier slots,
+                                                # inside the 2 MB-aligned workspace reservation
+# instruction_selection: none; extent: compile-time constants only
+
+launch_config = launch(
+    grid=(kNumSMs, 1, 1),
+    cluster=(2 - kNumSMs % 2, 1, 1),            # 2 for even kNumSMs
+    block=(kNumThreads, 1, 1),
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=kNumSmemBytes,           # jit::device_runtime->get_num_smem_bytes()
+    programmatic_dependent_launch=True,
+)
+# instruction_selection: none; extent: static launch metadata;
+#   `__launch_bounds__(kNumThreads, 1)`; cudaLaunchKernelEx cluster + PDL attributes
+
+def dispatch_impl(
+    x,                  # bf16* [num_tokens, kNumHiddenBytes/2]
+    topk_idx,           # i64*  [num_tokens, kNumTopk]
+    topk_weights,       # f32*  [num_tokens, kNumTopk]
+    copied_topk_idx,    # i64*  [num_tokens, kNumTopk] (do_handle_copy)
+    psum_rank,          # i32*  [kNumRanks]             (out: inclusive prefix)
+    psum_expert,        # i32*  [kNumExpertsPerRank+1]  (out: exclusive prefix)
+    num_unaligned,      # i32*  [kNumExpertsPerRank]    (out: raw counts)
+    dst_slot_idx,       # i32*  [num_tokens, kNumTopk]  (out)
+    peer_ws_ptrs,       # i64*  [kNumRanks]  (substitution 1: peer workspace bases)
+    peer_buf_ptrs,      # i64*  [kNumRanks]  (substitution 1: peer recv-region bases)
+    buffer,             # u8*   local recv-region base (window_base + aligned workspace bytes)
+    workspace,          # u8*   local window base
+    num_tokens,         # i32   rank-local token count
+    rank_idx,           # i32   0..7
+):
+    sm_idx  = block_id()
+    thread_idx = thread_id()
+    warp = shuffle_index(thread_idx // 32, source_lane=0)
+    # instruction_selection: mov.u32 %tid.x, shr.u32, shfl.sync.idx.b32;
+    #   extent: warp-uniform scalar
+    lane = lane_id()
+    # instruction_selection: mov.s32 from %laneid; extent: scalar per thread
+
+    smem = tile("shared", "u8", [kNumSmemBytes], byte_offset=0, alignment=1024)
+
+    # -----------------------------------------------------------------------
+    # Entry NVLink barrier (tag0): no TMA flush, no start grid sync, end grid sync
+    # (comm.cuh: gpu_barrier<..., kDispatchTag0, false, false, true>)
+    # -----------------------------------------------------------------------
+    nvlink_barrier(workspace, peer_ws_ptrs, rank_idx, sm_idx, thread_idx,
+                   tag="dispatch0", flush=False)
+    # instruction_selection: red.release.sys.global.add.s32 (8 lanes of SM 0) +
+    #   atom.add.u64 counter + ld.acquire.sys spin on i32 signal;
+    #   extent: SM 0 only, one phase toggle
+    grid_barrier(workspace, WS_PORT_SCRATCH, site=0)
+    # instruction_selection (substitution 2): atom.add.s32 + st.release.gpu /
+    #   ld.acquire.gpu spin; extent: one arrive per SM; replaces this_grid().sync()
+
+    if warp < kNumNotifyWarps:
+        # ===================================================================
+        # NOTIFY ROLE: warps 0..3
+        # ===================================================================
+
+        rank_expert_count = view(smem, "i32", [384], byte_offset=0)
+        rank_count   = slice(rank_expert_count, 0, 8)
+        expert_count = slice(rank_expert_count, 8, 264)
+
+        # Clean initial counts (dispatch.cuh:87-89)
+        for i in range(384 // kNumNotifyThreads):
+            fill(rank_expert_count[i * kNumNotifyThreads + thread_idx], 0)
+        # instruction_selection: st.shared.s32; extent: 3-element vector loop per thread
+        named_barrier(idx=1, threads=kNumNotifyThreads)
+        # instruction_selection: bar.sync 1, 128; extent: all 128 notify threads
+
+        # Per-token counting (dispatch.cuh:94-107)
+        global_warp_idx = warp * kNumSMs + sm_idx
+        for i in range(global_warp_idx, num_tokens, kNumNotifyWarps * kNumSMs):
+            dst_expert = select(lane < kNumTopk,
+                                copy_g2r(topk_idx[i * kNumTopk + lane], reg_tile([], "i64")), -1)
+            # instruction_selection: ld.global.nc.s64 (__ldg) predicated on lane < 6;
+            #   extent: scalar per lane
+            if dst_expert >= 0:
+                atomic_add_block(expert_count[dst_expert], 1)
+                # instruction_selection: atom.shared.add.s32; extent: scalar, <= kNumTopk lanes
+            dst_rank = select(dst_expert >= 0, div_floor(dst_expert, kNumExpertsPerRank), -1)
+            # instruction_selection: s32 div by 32 -> shr.s32 5; extent: scalar
+            dup_mask = match_any(dst_rank)
+            # instruction_selection: match.any.sync.b32; extent: warp-wide
+            is_master = bfind(dup_mask) == lane
+            # instruction_selection: bfind.u32 + setp; extent: warp-wide deduplicate
+            if is_master and dst_rank >= 0:
+                atomic_add_block(rank_count[dst_rank], 1)
+                # instruction_selection: atom.shared.add.s32; extent: scalar, one lane per distinct rank
+        named_barrier(idx=1, threads=kNumNotifyThreads)
+        # instruction_selection: bar.sync 1, 128
+
+        # Full-grid reduction into workspace (dispatch.cuh:111-115)
+        for i in range(thread_idx, 8 + 256, kNumNotifyThreads):
+            red_global(workspace + WS_NOTIFY_REDUCTION + i * 8,
+                       (1 << 32) | rank_expert_count[i], scope="gpu", type="u64")
+            # instruction_selection: red.gpu.global.add.u64; extent: 2-3 per thread
+
+        # SM 0 completes the exchange (dispatch.cuh:118-257)
+        if sm_idx == 0:
+            # Wait all SMs' arrivals; decode; clean reduction slots (dispatch.cuh:121-147)
+            for i in range(thread_idx, 8 + 256, kNumNotifyThreads):
+                timeout_loop():
+                    status = copy_g2r(workspace + WS_NOTIFY_REDUCTION + i * 8,
+                                      reg_tile([], "i64"), semantic="volatile")
+                    # instruction_selection: ld.volatile.global.u64; extent: spin per slot
+                    if shift_right(status, 32) == kNumSMs:
+                        encoded = encode_positive(bitwise_and(status, 0xFFFFFFFF))
+                        # instruction_selection: s32 neg + sub (encode: -v-1); extent: scalar
+                        copy_r2s(encoded, rank_expert_count[i])
+                        copy_r2g(0, workspace + WS_NOTIFY_REDUCTION + i * 8, semantic="relaxed")
+                        # instruction_selection: st.global.u64 (plain); extent: scalar
+                        break
+                    on_timeout(): printf_and_trap(tag="notify-reduction")
+                    # instruction_selection: clock64 loop + trap; extent: 100 s budget
+            named_barrier(idx=1, threads=kNumNotifyThreads)
+            # instruction_selection: bar.sync 1, 128
+
+            # Publish rank counters to every peer (dispatch.cuh:152-158)
+            for i in range(thread_idx, kNumRanks, kNumNotifyThreads):
+                store_sys(remote(workspace + WS_COUNT_RECV + rank_idx * 8, dst=i, table=peer_ws_ptrs),
+                          rank_count[i])
+                # instruction_selection: st.relaxed.sys.global.u64; extent: 8 lanes, one per peer;
+                #   remote address = peer_ws_ptrs[i] + offset (substitution 1)
+            syncwarp()
+            # Publish per-expert counters, NVLink per-element form (dispatch.cuh:162-170)
+            for i in range(thread_idx, kNumExperts, kNumNotifyThreads):
+                idx = kNumExpertsPerRank * rank_idx + (i % kNumExpertsPerRank)
+                store_sys(remote(workspace + WS_COUNT_RECV + 8 * 8 + idx * 8,
+                                 dst=i // kNumExpertsPerRank, table=peer_ws_ptrs),
+                          expert_count[i])
+                # instruction_selection: st.relaxed.sys.global.u64; extent: 2 per thread
+            named_barrier(idx=1, threads=kNumNotifyThreads)
+            # instruction_selection: bar.sync 1, 128 (results rewrite smem below)
+
+            # Wait for every peer's counts; consume and clean (dispatch.cuh:184-201)
+            for i in range(thread_idx, 8 + 256, kNumNotifyThreads):
+                timeout_loop(start_clock=shared_clock):
+                    count = copy_g2r(workspace + WS_COUNT_RECV + i * 8,
+                                     reg_tile([], "i64"), semantic="volatile")
+                    # instruction_selection: ld.volatile.global.u64; extent: spin per slot
+                    decoded = encode_positive(count)
+                    if is_ready(decoded):
+                        copy_r2g(0, workspace + WS_COUNT_RECV + i * 8, semantic="relaxed")
+                        copy_r2s(decoded, rank_expert_count[i])
+                        break
+                    on_timeout(): printf_and_trap(tag="notify")
+            named_barrier(idx=1, threads=kNumNotifyThreads)
+            # instruction_selection: bar.sync 1, 128
+
+            # Per-expert reduce across source ranks + align (dispatch.cuh:205-220)
+            for i in range(thread_idx, kNumExpertsPerRank, kNumNotifyThreads):
+                total = fill(reg_tile([], "i32"), 0)
+                for j in range(kNumRanks):
+                    total = add(total, expert_count[j * kNumExpertsPerRank + i])
+                # instruction_selection: ld.shared.s32 + add.s32; extent: 8-term serial sum
+                copy_r2g(total, num_unaligned[i])
+                # instruction_selection: st.global.s32; extent: scalar
+                copy_r2s(align_up(total, kExpertAlignment), expert_count[i])
+                # instruction_selection: s32 round-up to kExpertAlignment; extent: scalar
+            named_barrier(idx=1, threads=kNumNotifyThreads)
+            # instruction_selection: bar.sync 1, 128
+
+            # (kDoCPUSync=false: the host-workspace write block at dispatch.cuh:224-230
+            #  is compiled out in this specialization)
+
+            # Prefix sums, one warp each (dispatch.cuh:234-257)
+            if warp == 0:
+                # Inclusive prefix over 8 rank counts -> psum_rank[0:8)
+                # (source do_psum: ceil_div(8 + 0, 32) = 1 iteration; warps 2..3 skip)
+                psum = fill(reg_tile([], "i32"), 0)
+                idx = lane
+                value = select(idx < kNumRanks, rank_count[idx], 0)
+                scan = add(psum, warp_inclusive_sum(value))
+                # instruction_selection: 5x (shfl.sync.up.b32 + predicated add.s32);
+                #   extent: 32-lane Hillis-Steele
+                if idx < kNumRanks:
+                    copy_r2g(scan, psum_rank[idx])
+                    # instruction_selection: st.global.s32; extent: 8 lanes
+            elif warp == 1:
+                # Exclusive prefix over 32 expert counts -> psum_expert[0:33)
+                # (source do_psum: ceil_div(32 + 1, 32) = 2 iterations)
+                psum = fill(reg_tile([], "i32"), 0)
+                for it in range(2):
+                    idx = it * 32 + lane
+                    value = select(0 <= idx - 1 < kNumExpertsPerRank, expert_count[idx - 1], 0)
+                    scan = add(psum, warp_inclusive_sum(value))
+                    # instruction_selection: 5x (shfl.sync.up.b32 + predicated add.s32)
+                    #   per iteration; extent: 32-lane Hillis-Steele, 2 iterations
+                    if idx < kNumExpertsPerRank + 1:
+                        copy_r2g(scan, psum_expert[idx])
+                        # instruction_selection: st.global.s32; extent: 33 lanes over 2 iterations
+                    psum = shuffle_index(scan, source_lane=31)
+                    # instruction_selection: shfl.sync.idx.b32 from lane 31; extent: warp-uniform
+
+    else:
+        # ===================================================================
+        # DISPATCH ROLE: warps 4..(4+kNumDispatchWarps-1), one channel each
+        # ===================================================================
+        dispatch_warp_idx = warp - kNumNotifyWarps
+
+        # Per-warp SMEM token buffer with trailing mbarrier (layout.cuh)
+        tma_buffer = view(smem, "u8", [kTokenBytesSmem],
+                          byte_offset=kNumNotifySmemBytes + dispatch_warp_idx * kTokenBytesSmem)
+        tma_hidden    = view(tma_buffer, "u8",  [14336], byte_offset=0)
+        tma_topk_idx  = view(tma_buffer, "i32", [6],     byte_offset=14336)
+        tma_topk_w    = view(tma_buffer, "f32", [6],     byte_offset=14336 + 24)
+        tma_src_idx   = view(tma_buffer, "i32", [1],     byte_offset=14336 + 48)
+        # (linked-list i32[6] @ +52 unused in this specialization)
+        tma_mbar      = view(tma_buffer, "u64", [1],     byte_offset=14432)
+
+        # Local recv region: [kNumRanks][kNumMaxTokensPerRank][kTokenBytesGmem]
+        # (dispatch.cuh:266-268; the RDMA send region at recv end is dead here)
+        recv_region = tile("gmem", "u8", [kRecvRegionBytes], base=buffer)
+
+        phase = fill(reg_tile([], "u32"), 0)
+        if elect_one():
+            mbarrier_init(tma_mbar, arrive_count=1)
+            # instruction_selection: mbarrier.init.shared::cta.b64 +
+            #   fence.mbarrier_init.release.cluster; extent: one elected lane
+        syncwarp()
+
+        token_start = dispatch_warp_idx * kNumSMs + sm_idx
+        token_stride = kNumDispatchWarps * kNumSMs
+        for token_idx in range(token_start, num_tokens, token_stride):
+
+            # Wait prior TMA store group fully drained (dispatch.cuh:284)
+            tma_store_wait(remaining=0)
+            # instruction_selection: cp.async.bulk.wait_group 0; extent: warp-wide
+            syncwarp()
+
+            # TMA-load the token's hidden bytes into SMEM (dispatch.cuh:288-291)
+            if elect_one():
+                copy_g2s(x + token_idx * kNumHiddenBytes, tma_hidden,
+                         completion=tma_mbar, num_bytes=kNumHiddenBytes)
+                # instruction_selection: cp.async.bulk.shared::cluster.global.
+                #   mbarrier::complete_tx::bytes.L2::cache_hint (evict-first);
+                #   extent: one 14336-byte 1-D bulk copy
+            syncwarp()
+
+            # (kNumSFPacks == 0: the SF cp.async block at dispatch.cuh:295-312
+            #  is compiled out)
+
+            # Load top-k into registers and SMEM metadata (dispatch.cuh:317-326)
+            stored_dst_rank = fill(reg_tile([], "i32"), -1)
+            if lane < kNumTopk:
+                raw_expert = copy_g2r(topk_idx[token_idx * kNumTopk + lane], reg_tile([], "i64"))
+                # instruction_selection: ld.global.nc.s64 (__ldg); extent: scalar per lane
+                dst_expert = i32(raw_expert)
+                stored_dst_rank = select(dst_expert >= 0,
+                                         div_floor(dst_expert, kNumExpertsPerRank), -1)
+                copy_r2s(dst_expert, tma_topk_idx[lane])
+                # instruction_selection: st.shared.s32; extent: scalar per lane
+                copy_r2s(copy_g2r(topk_weights[token_idx * kNumTopk + lane], reg_tile([], "f32")),
+                         tma_topk_w[lane])
+                # instruction_selection: ld.global.nc.f32 + st.shared.f32; extent: scalar per lane
+                copy_r2g(raw_expert, copied_topk_idx[token_idx * kNumTopk + lane])
+                # instruction_selection: st.global.s64; extent: scalar per lane
+            syncwarp()
+
+            # Source metadata; must be the last SMEM write before the fence (dispatch.cuh:331-333)
+            if elect_one():
+                copy_r2s(rank_idx * kNumMaxTokensPerRank + token_idx, tma_src_idx[0])
+                # instruction_selection: st.shared.s32; extent: one elected lane
+            fence_proxy_async()
+            # instruction_selection: fence.proxy.async.shared::cta; extent: warp-wide
+            syncwarp()
+
+            # Deduplicate destination ranks and allocate slots (dispatch.cuh:337-351,
+            # kReuseSlotIndices=false branch)
+            stored_slot = fill(reg_tile([], "i32"), -1)
+            dup_mask = match_any(stored_dst_rank)
+            # instruction_selection: match.any.sync.b32; extent: warp-wide
+            if bfind(dup_mask) == lane and stored_dst_rank >= 0:
+                stored_slot = atomic_add_gmem(workspace + WS_SENDER_COUNTER + stored_dst_rank * 4, 1)
+                # instruction_selection: atom.global.add.s32 (returns old);
+                #   extent: one lane per distinct destination rank
+            if lane < kNumTopk:
+                copy_r2g(select(stored_slot >= 0,
+                                rank_idx * kNumMaxTokensPerRank + stored_slot, -1),
+                         dst_slot_idx[token_idx * kNumTopk + lane])
+                # instruction_selection: st.global.s32; extent: scalar per lane
+            syncwarp()
+
+            # Publish expected bytes and wait TMA load arrival (dispatch.cuh:356-359)
+            if elect_one():
+                expect_tx(tma_mbar, kNumHiddenBytes)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared::cta.b64;
+                #   extent: one elected lane
+                mbarrier_wait(tma_mbar, phase)
+                # instruction_selection: mbarrier.try_wait.parity.shared::cta.b64 spin loop
+                #   (0x989680 suspend hint); extent: one elected lane, phase flips
+            syncwarp()
+
+            # (not kIsScaleupNVLink: the send-buffer TMA store at dispatch.cuh:364-369
+            #  is compiled out)
+
+            # TMA-store the whole token slot to the destination rank (dispatch.cuh:372-379)
+            dst_ptr = select(stored_slot >= 0,
+                             remote(buffer + rank_idx * (kNumMaxTokensPerRank * kTokenBytesGmem)
+                                    + stored_slot * kTokenBytesGmem,
+                                    dst=stored_dst_rank, table=peer_buf_ptrs),
+                             nullptr)
+            # instruction_selection (substitution 1): peer_buf_ptrs[dst] + offset;
+            #   extent: scalar address form
+            if dst_ptr != nullptr:
+                copy_s2g(tma_buffer, dst_ptr, num_bytes=kTokenBytesGmem)
+                # instruction_selection: cp.async.bulk.global.shared::cta.bulk_group.
+                #   L2::cache_hint (evict-normal); extent: one 14432-byte 1-D bulk copy,
+                #   issued by the lane holding a valid slot (source: any lane with
+                #   dst_ptr != nullptr issues it; per distinct dst rank one store)
+            tma_store_commit()
+            # instruction_selection: cp.async.bulk.commit_group; extent: warp-wide
+            syncwarp()
+
+            # (not kIsScaleupNVLink: the GIN put at dispatch.cuh:382-393 is compiled out)
+
+    # -----------------------------------------------------------------------
+    # Exit barrier (tag1): TMA flush + start grid sync, no end grid sync
+    # (comm.cuh: gpu_barrier<..., kDispatchTag1, true, true, false>)
+    # -----------------------------------------------------------------------
+    tma_store_commit()
+    tma_store_wait(remaining=0)
+    # instruction_selection: cp.async.bulk.commit_group + cp.async.bulk.wait_group 0;
+    #   extent: warp-wide, all warps
+    syncwarp()
+    grid_barrier(workspace, WS_PORT_SCRATCH, site=1)
+    # instruction_selection (substitution 2): replaces this_grid().sync()
+    nvlink_barrier(workspace, peer_ws_ptrs, rank_idx, sm_idx, thread_idx,
+                   tag="dispatch1", flush=True)
+    # instruction_selection: red.release.sys.global.add.s32 + ld.acquire.sys spin;
+    #   extent: SM 0 only, second phase toggle
+
+    # Chain the copy epilogue (dispatch.cuh:403)
+    pdl_trigger()
+    # instruction_selection: griddepcontrol.launch_dependents; extent: every CTA
+    #   (PDL completes when all CTAs trigger; SM 0 triggers after the barrier)
+
+    # Clean atomic sender counters (dispatch.cuh:406-408)
+    if sm_idx == 0 and thread_idx < kNumRanks:
+        copy_r2g(0, workspace + WS_SENDER_COUNTER + thread_idx * 4, semantic="relaxed")
+        # instruction_selection: st.global.s32 (plain); extent: 8 threads of SM 0
+
+
+# ===========================================================================
+# Kernel 2: dispatch_copy_epilogue_impl
+# ===========================================================================
+
+epilogue_variant = specialize(
+    kDoExpand=False, kCachedMode=False, kDoZeroPadding=False,
+    kNumSMs=...,                        # same as kernel 1
+    kNumChannels=1,                     # scaleout-only concept; fixed 1 here
+    kNumWarps=...,                      # min(smem // 14464, 32); 16 @ 232448 B
+    kNumScaleoutRanks=1, kNumScaleupRanks=8,
+    kNumHiddenBytes=14336, kNumSFPacks=0,
+    kNumMaxTokensPerRank=..., kNumExperts=256, kNumTopk=6, kExpertAlignment=(1, 128),
+)
+# instruction_selection: none; extent: template argument list
+
+epilogue_launch = launch(
+    grid=(kNumSMs, 1, 1),
+    cluster=(1, 1, 1),
+    block=(kNumWarps * 32, 1, 1),       # 512 @ 16 warps
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=kNumSmemBytes,
+    programmatic_dependent_launch=True, # waits on kernel 1's trigger
+)
+# instruction_selection: none; extent: static launch metadata;
+#   `__launch_bounds__(kNumWarps * 32, 1)`
+
+def dispatch_copy_epilogue_impl(
+    buffer,             # u8* local recv-region base
+    psum_rank,          # i32* [kNumRanks] inclusive prefix (from kernel 1)
+    psum_expert,        # i32* sliced [1:] (unused in non-expand; kept for ABI)
+    recv_x,             # bf16* [num_recv_alloc, kNumHiddenBytes/2]
+    recv_topk_idx,      # i64*  [num_recv_alloc, kNumTopk]
+    recv_topk_weights,  # f32*  [num_recv_alloc, kNumTopk]
+    recv_src_metadata,  # i32*  [num_recv_alloc, 2 + kNumTopk]
+    num_unaligned,      # i32*  (unused in non-expand; kept for ABI)
+    num_recv_tokens,    # i32   host value: kNumMaxTokensPerRank * kNumRanks (worst case)
+    rank_idx,           # i32   0..7
+):
+    sm_idx = block_id()
+    warp = shuffle_index(thread_id() // 32, source_lane=0)
+    lane = lane_id()
+    global_warp_idx = warp * kNumSMs + sm_idx
+
+    smem = tile("shared", "u8", [kNumSmemBytes], byte_offset=0, alignment=1024)
+    tma_buffer = view(smem, "u8", [kTokenBytesSmem],
+                      byte_offset=warp * kTokenBytesSmem)
+    tma_hidden    = view(tma_buffer, "u8",  [14336], byte_offset=0)
+    tma_topk_idx  = view(tma_buffer, "i32", [6],     byte_offset=14336)
+    tma_topk_w    = view(tma_buffer, "f32", [6],     byte_offset=14336 + 24)
+    tma_src_idx   = view(tma_buffer, "i32", [1],     byte_offset=14336 + 48)
+    tma_mbar      = view(tma_buffer, "u64", [1],     byte_offset=14432)
+
+    phase = fill(reg_tile([], "u32"), 0)
+    if elect_one():
+        mbarrier_init(tma_mbar, arrive_count=1)
+        # instruction_selection: mbarrier.init.shared::cta.b64 +
+        #   fence.mbarrier_init.release.cluster; extent: one elected lane
+    syncwarp()
+
+    # Block until kernel 1 finished and all data is visible (epilogue.cuh:60)
+    pdl_wait()
+    # instruction_selection: griddepcontrol.wait; extent: every CTA;
+    #   PDL edge: completes after all kernel-1 CTAs triggered (SM 0 triggers
+    #   post-barrier, so peer data is visible here)
+
+    # Worst-case host count -> read the real count from the GPU prefix (epilogue.cuh:63-64)
+    if num_recv_tokens == kNumMaxTokensPerRank * kNumRanks:
+        num_recv_tokens = copy_g2r(psum_rank[kNumRanks - 1], reg_tile([], "i32"))
+        # instruction_selection: ld.global.s32 (plain; post-PDL visibility);
+        #   extent: scalar per thread, warp-uniform value
+
+    # Per-warp strided loop over received tokens (epilogue.cuh:67-80)
+    current_rank = fill(reg_tile([], "i32"), -1)
+    rank_start = fill(reg_tile([], "i32"), 0)
+    rank_end = fill(reg_tile([], "i32"), 0)
+    for i in range(global_warp_idx, num_recv_tokens, kNumWarps * kNumSMs):
+        # Locate the source rank of received token i via the inclusive prefix
+        while i >= rank_end:
+            current_rank = add(current_rank, 1)
+            stored_lane = current_rank % 32
+            stored_psum = select(stored_lane == 0 and current_rank + lane < kNumRanks,
+                                 copy_g2r(psum_rank[current_rank + lane], reg_tile([], "i32")),
+                                 stored_psum)
+            # instruction_selection: ld.global.s32 predicated; extent: 32-lane
+            #   cooperative prefetch of the prefix array
+            rank_start = rank_end
+            rank_end = shuffle_index(stored_psum, source_lane=stored_lane)
+            # instruction_selection: shfl.sync.idx.b32; extent: warp-uniform scalar
+
+        token_addr = buffer + current_rank * (kNumMaxTokensPerRank * kTokenBytesGmem) \
+                     + (i - rank_start) * kTokenBytesGmem
+
+        # Drain prior TMA stores before reusing the SMEM slot (epilogue.cuh:84)
+        tma_store_wait(remaining=0)
+        # instruction_selection: cp.async.bulk.wait_group 0; extent: warp-wide
+        syncwarp()
+
+        # TMA-load the full token slot (hidden + metadata) (epilogue.cuh:89-93)
+        if elect_one():
+            copy_g2s(token_addr, tma_buffer, completion=tma_mbar, num_bytes=kTokenBytesGmem)
+            # instruction_selection: cp.async.bulk.shared::cluster.global.
+            #   mbarrier::complete_tx::bytes.L2::cache_hint (evict-first);
+            #   extent: one 14432-byte 1-D bulk copy
+            expect_tx(tma_mbar, kTokenBytesGmem)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared::cta.b64
+        syncwarp()
+
+        # Read target expert indices early, DIRECTLY FROM THE GMEM token slot,
+        # to tolerate TMA latency (epilogue.cuh:96-100: buffer_token is the GMEM
+        # token view, not the SMEM staging buffer; the SMEM copy is not yet
+        # guaranteed to have arrived)
+        dst_expert = select(lane < kNumTopk,
+                            copy_g2r(token_addr + 14336 + lane * 4, reg_tile([], "i32")), -1)
+        # instruction_selection: ld.global.s32 (plain; NO .nc — PDL visibility,
+        #   source comment "PDL is used, please do not use __ldg") predicated on
+        #   lane < 6; extent: scalar per lane
+        syncwarp()
+
+        # Validate, localize, and check per-token rank uniqueness (epilogue.cuh:104-109)
+        expert_start = kNumExpertsPerRank * rank_idx
+        expert_end = expert_start + kNumExpertsPerRank
+        in_range = expert_start <= dst_expert < expert_end
+        master_lane = bfind(ballot(in_range))
+        # instruction_selection: vote.sync.ballot.b32 + bfind.u32;
+        #   extent: warp-wide; highest set lane = master source top-k slot
+        dst_expert = select(in_range, dst_expert - expert_start, -1)
+        # device_assert: match_any(dst_expert) dedup holds (or dst_expert == -1)
+        # instruction_selection: match.any.sync.b32 + bfind.u32 (assert only)
+        if lane < kNumTopk:
+            copy_r2g(i64(dst_expert), recv_topk_idx[i * kNumTopk + lane])
+            # instruction_selection: st.global.s64; extent: scalar per lane
+        syncwarp()
+
+        # Non-expand destination index is the token ordinal (epilogue.cuh:114-116)
+        dst_tensor_idx = select(elect_one(), i, -1)
+        # instruction_selection: elect.sync; extent: one elected lane
+        syncwarp()
+
+        # Wait TMA arrival (epilogue.cuh:126-127)
+        if elect_one():
+            mbarrier_wait(tma_mbar, phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared::cta.b64 spin;
+            #   extent: one elected lane, phase flips
+        syncwarp()
+
+        # (kDoCreateLinkedList=false: linked-list block at epilogue.cuh:131-135 dead)
+
+        # TMA-store hidden to the output tensor (epilogue.cuh:138-142)
+        if elect_one():
+            copy_s2g(tma_hidden, recv_x + i * kNumHiddenBytes, num_bytes=kNumHiddenBytes)
+            # instruction_selection: cp.async.bulk.global.shared::cta.bulk_group.
+            #   L2::cache_hint (evict-normal); extent: one 14336-byte 1-D bulk copy
+            tma_store_commit()
+            # instruction_selection: cp.async.bulk.commit_group
+        syncwarp()
+
+        # (kNumSFPacks == 0: SF store block at epilogue.cuh:146-177 compiled out)
+
+        # Store top-k weights (epilogue.cuh:182-184)
+        if lane < kNumTopk:
+            copy_r2g(copy_s2r(tma_topk_w[lane], reg_tile([], "f32")),
+                     recv_topk_weights[i * kNumTopk + lane])
+            # instruction_selection: ld.shared.f32 + st.global.f32; extent: scalar per lane
+        syncwarp()
+
+        # Write source metadata, non-cached mode (epilogue.cuh:192-201)
+        if elect_one():
+            src_global = copy_s2r(tma_src_idx[0], reg_tile([], "i32"))
+            # instruction_selection: ld.shared.s32; extent: one elected lane
+            copy_r2g(src_global, recv_src_metadata[i * 8 + 0])
+            # instruction_selection: st.global.s32; extent: scalar
+            copy_r2g(current_rank * kNumTopk + master_lane, recv_src_metadata[i * 8 + 1])
+            # instruction_selection: st.global.s32; extent: scalar
+        syncwarp()
+
+    # (kDoCreateLinkedList=false: tail block at epilogue.cuh:212-229 dead)
+    # (kDoZeroPadding=false: zero-padding block at epilogue.cuh:232-322 dead)
+```
+
+## Kernel-specific tables
+
+### Workspace regions used by this specialization
+
+| region | byte offset | dtype | extent | writer -> consumer |
+| --- | --- | --- | --- | --- |
+| nvl_barrier_counter | 0 | u64 | 1 | every SM-0 thread-0 (atomicAdd) -> phase/sign reader |
+| nvl_barrier_signal[phase] | 8 + phase*4 | i32 | 2 | peers' `red.release.sys` -> local `ld.acquire.sys` spin |
+| notify_reduction | 16 | i64 | 8 + 256 used of 3072 | every SM's notify warps (`red.gpu`) -> SM 0 wait/decode/clean |
+| scaleup count recv area | 49168 | i64 | 8 rank + 256 expert | peers' `st.relaxed.sys` -> SM 0 wait/decode/clean |
+| sender counters | 73744 | i32 | 8 used of 1024 | dispatch warps `atom.add` -> SM 0 post-barrier cleanup |
+| port scratch (grid barrier) | 12820528 | i32 | 2 sites x (counter + flag) | substitution 2; inside the 2 MB-aligned reservation slack |
+| count send area | 24592 | i64 | unused | only written when `not kIsScaleupNVLink` |
+
+### Token slot layout (SMEM 14464 B / GMEM 14432 B)
+
+| field | offset | dtype | extent |
+| --- | --- | --- | --- |
+| hidden | 0 | bf16 | 7168 elems / 14336 B |
+| topk_idx | 14336 | i32 | 6 |
+| topk_weights | 14360 | f32 | 6 |
+| src_token_global_idx | 14384 | i32 | 1 |
+| linked_list_idx (dead) | 14388 | i32 | 6 |
+| pad | 14412..14431 | - | to 32 B |
+| mbarrier (SMEM only) | 14432 | u64 | 1 (+ 32 B pad to 14464) |
+
+### NVLink barrier state machine (comm.cuh:88-129)
+
+`status = counter & 3`; `phase = status & 1`; `sign = status >> 1`. SM 0's
+threads `red.release.sys.add` (`+1` when `sign==0`, `-1` when `sign==1`) into
+each peer's `signal[phase]`; then a CTA-local `__syncthreads()`
+(comm.cuh:107: `bar.sync 0` — orders the per-lane signal writes and the
+phase read before the counter increment) fires before thread 0 `atomicAdd`s
+the local counter and spins with `ld.acquire.sys` until
+`signal[phase] == (sign ? 0 : kNumRanks)`.
+Two toggling slots make the barrier self-cleaning across calls. The dispatch
+kernel uses it twice (tag0 entry, tag1 exit), so both phases are exercised per
+launch.
+
+### Software grid barrier (substitution 2)
+
+Each site owns `{counter: i32, flag: i32}` in the port-scratch area, zero at
+allocation. Every SM's thread 0 arrives with `atom.add(counter, 1)`; the
+arriver observing `old == kNumSMs - 1` resets the counter to 0 and issues
+`st.release.gpu(flag, generation)`; all other SMs spin
+`ld.acquire.gpu(flag) != generation`. `generation` is a per-site value that
+toggles once per completed barrier (tracked in the slot pair via a third word
+or derived from the flag's previous value). Semantics equal
+`this_grid().sync()` at the two source call sites (entry-barrier end,
+exit-barrier start).
+
+### TIRx module and benchmark contract
+
+- Module: `tirx_kernels/deepep/dispatch.py`; `get_kernel` returns the PrimFunc
+  pair; per-rank worker launches kernel 1 then kernel 2 on one stream with the
+  PDL launch attribute on both.
+- Rank-local inputs from `prepare_data`; symmetric window allocated per rank
+  via ctypes `ncclMemAlloc` + `ncclCommWindowRegister` +
+  `ncclGetLsaDevicePointer` on a raw `ncclComm_t` from
+  `deep_ep.utils.comm.get_nccl_comm_handle`.
+- Correctness: outputs and handle metadata compared rank-local against the
+  source `ElasticBuffer.dispatch` on identical inputs (bf16, do_cpu_sync=false,
+  non-cached, non-expand).
+- Benchmark: `tirx_kernels.bench_suite`, `num_gpus: 8`, `timer: kineto`; timed
+  scope is the two-kernel sequence on both sides (source:
+  `dispatch_impl` + `dispatch_copy_epilogue_impl`).
+
+### Static specialization boundary
+
+Fixed per config: `kNumSMs`, `kNumDispatchWarps`, `kNumWarps`,
+`kNumMaxTokensPerRank`, `kExpertAlignment`. Fixed for the whole port:
+`kNumRanks=8`, `kNumExperts=256`, `kNumTopk=6`, `kNumHiddenBytes=14336`,
+`kNumSFPacks=0`, `kNumNotifyWarps=4`, `kIsScaleupNVLink=true`,
+`kDoCPUSync=false`, `kReuseSlotIndices=false`, `kDoExpand=false`,
+`kCachedMode=false`, `kDoZeroPadding=false`, `kNumScaleoutRanks=1`.
+Everything outside this boundary is out of scope (see header).
+
+## Instruction-selection summary
+
+Placement, shape, and schedule select the instructions; the inline
+`instruction_selection` annotations carry the evidence. Expected families:
+
+| Primitive pattern | PTX family |
+| --- | --- |
+| full-token `copy_g2s(..., completion=mbar)` | `cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint` |
+| full-token `copy_s2g(smem, gmem/remote)` | `cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint` |
+| scalar `copy_g2r` of topk/weights/counts | `ld.global.nc.*` / `ld.volatile.global.*` / `ld.acquire.sys.*` |
+| `store_sys` to peer workspace | `st.relaxed.sys.global.u64` |
+| `red_global` count reduction | `red.gpu.global.add.u64` |
+| NVLink barrier arrive | `red.release.sys.global.add.s32` + `ld.acquire.sys` spin |
+| slot allocation | `atom.global.add.s32` (returns old) |
+| SMEM counting | `atom.shared.add.s32` |
+| dedup / master lane | `match.any.sync.b32` + `bfind.u32`; `vote.sync.ballot.b32` |
+| warp prefix sums | `shfl.sync.up.b32` chain (5 steps) + predicated adds |
+| mbarrier lifecycle | `mbarrier.init` / `mbarrier.arrive.expect_tx` / `mbarrier.try_wait.parity` |
+| TMA store ordering | `cp.async.bulk.commit_group` / `cp.async.bulk.wait_group` / `fence.proxy.async.shared::cta` |
+| named barrier | `bar.sync 1, 128` |
+| PDL chaining | `griddepcontrol.launch_dependents` / `griddepcontrol.wait` |
+| software grid barrier (substitution) | `atom.add.s32` + `st.release.gpu` / `ld.acquire.gpu` |
+| timeout policy | `clock64` deltas, `printf`, `trap` |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ point each port backs (`activation`, `quantization` — CuTe-DSL backend —,
 | `deepgemm_sm100_fp8_paged_mqa_logits`          | `paged_mqa_logits_fp8.py`          | Paged-KV MQA attention logits |
 | `deepgemm_sm100_tf32_hc_prenorm_gemm`          | `tf32_hc_prenorm_gemm.py`          | Prenorm GEMM |
 | `sm100_fp8_fp4_mega_moe`                       | `sm100_fp8_fp4_mega_moe.py`        | Fused MoE megakernel (MegaMoE) |
+
+`deepep/` — DeepEP ports:
+
+| Kernel            | Module        | What it is |
+| ----------------- | ------------- | ---------- |
+| `deepep_dispatch` | `dispatch.py` | V2 elastic dispatch, single-domain NVLink path (multi-GPU, 8 ranks) |
+
 ## Performance
 
 Per-workload numbers — our kernel time, every reference impl, and the

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "5f901d39",
-    "tirx-kernels": "c66267cb",
+    "tirx-kernels": "8bf3305d-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "2d1265da4c622e7f503c976d3881b0f0821b950e"
+    "tirx-kernels:tirx_kernels": "d8daf965756dcbad62048f746ce522def492b337"
   },
   "baselines": {
     "torch": {
@@ -246,6 +246,20 @@
         "tirx": 6103.611899999998,
         "cublas_nccl_cudagraph": 5984.332800000004,
         "cublasmp_split_p2p": 6148.8382999999985
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "deepep_dispatch",
+      "config": "t4096_h7168_e256_k6",
+      "label": "t4096_h7168_e256_k6",
+      "status": "ok",
+      "impls": {
+        "tirx": 638.0496999999966,
+        "deepep": 616.1591999999997
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '5f901d39', 'tirx-kernels': 'c66267cb', 'tirx-bench-ci': None}`
-- Workloads: 325 ok, 0 failed
+- Git:       `{'tir': '5f901d39', 'tirx-kernels': '8bf3305d-dirty', 'tirx-bench-ci': None}`
+- Workloads: 326 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -28,6 +28,12 @@ Grouped workloads show one row per config and one timing column per implementati
 | `tp1_m8192_n24576_k4096_fp16_dynamic` | tirx | 1066.3879 | cublas_nccl_cudagraph | 1034.9734 | 0.971 | cublasmp_split_p2p=1079.9175 |
 | `tp1_m8192_n51200_k5120_fp16_dynamic` | tirx | 2876.2938 | cublas_nccl_cudagraph | 2717.1455 | 0.945 | cublasmp_split_p2p=2772.5312 |
 | `tp1_m8192_n57344_k8192_fp16_dynamic` | tirx | 6103.6119 | cublas_nccl_cudagraph | 5984.3328 | 0.980 | cublasmp_split_p2p=6148.8383 |
+
+## deepep_dispatch
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `t4096_h7168_e256_k6` | tirx | 638.0497 | deepep | 616.1592 | 0.966 | — |
 
 ## deepgemm_sm100_fp4_mqa_logits
 

--- a/tirx_kernels/bench_suite/config/deepep/deepep_dispatch.yaml
+++ b/tirx_kernels/bench_suite/config/deepep/deepep_dispatch.yaml
@@ -1,0 +1,11 @@
+kernel: deepep_dispatch
+defaults:
+  num_gpus: 1
+  timer: kineto
+configs:
+  # Single-domain NVLink path needs the full 8-rank NVLink domain on this host
+  # (the ElasticBuffer reference only exists at world_size 8). Multi-GPU
+  # workloads stay out of the default sweep; run explicitly with --filter.
+  - config: t4096_h7168_e256_k6
+    default: false
+    num_gpus: 8

--- a/tirx_kernels/deepep/__init__.py
+++ b/tirx_kernels/deepep/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/deepep/dispatch.py
+++ b/tirx_kernels/deepep/dispatch.py
@@ -1,0 +1,1284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""DeepEP V2 elastic dispatch (single-domain NVLink path) ported to TIRx.
+
+Source: /home/bohanhou/kernel-libs/deepep
+  - deep_ep/include/deep_ep/impls/dispatch.cuh (`dispatch_impl`, direct path)
+  - deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
+    (`dispatch_copy_epilogue_impl`)
+
+Frozen sketch (source of the implementation plan):
+  `.agents/sketch/deepep/dispatch.md`
+
+Fixed specialization: bf16 tokens, num_sf_packs=0, non-cached, non-expand,
+do_cpu_sync=False, deterministic=False, num_scaleout_ranks==1,
+is_scaleup_nvlink=True.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tvm.ir.type import PointerType, PrimType
+from tvm.script import tirx as T
+
+from .utils._buffer import get_theoretical_num_sms
+
+KERNEL_META = {"name": "deepep_dispatch", "category": "deepep", "compute_capability": 10}
+
+# Correctness matrix. Every config runs the same source specialization
+# (bf16, non-cached, non-expand, do_cpu_sync=False) on `world_size` ranks.
+CONFIGS = [
+    {
+        "label": "t128_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 128,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    },
+    {
+        "label": "t4096_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 4096,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    },
+    {
+        "label": "t1024_h7168_e256_k6_masked",
+        "world_size": 8,
+        "num_tokens": 1024,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.3,
+    },
+    {
+        "label": "t1024_h7168_e256_k6_align128",
+        "world_size": 8,
+        "num_tokens": 1024,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 128,
+        "masked_ratio": 0.0,
+    },
+]
+
+# Benchmark-only matrix; the bench suite selects from these labels.
+BENCH_CONFIGS = [
+    {
+        "label": "t4096_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 4096,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    }
+]
+
+# ---------------------------------------------------------------------------
+# Specialization constants (frozen sketch: "Static specialization boundary")
+# ---------------------------------------------------------------------------
+
+NUM_RANKS = 8
+NUM_EXPERTS = 256
+NUM_TOPK = 6
+EXPERTS_PER_RANK = NUM_EXPERTS // NUM_RANKS
+HIDDEN_BYTES = 7168 * 2  # bf16
+NUM_NOTIFY_WARPS = 4
+NUM_NOTIFY_THREADS = NUM_NOTIFY_WARPS * 32
+
+SMEM_TOTAL = 232448  # max opt-in dynamic smem per block on SM100
+TOKEN_META_BYTES = 76
+TOKEN_BYTES_GMEM = 14432  # align(14336,32) + align(0,32) + align(76,32)
+TOKEN_BYTES_SMEM = 14464  # + align(8,32) mbarrier
+NOTIFY_SMEM_BYTES = 1536  # align(8 + 256, 128) * 4
+
+# layout::WorkspaceLayout byte offsets (common/layout.cuh)
+WS_BARRIER_COUNTER = 0
+WS_BARRIER_SIGNAL = 8
+WS_NOTIFY_REDUCTION = 16
+WS_COUNT_SEND = 24592
+WS_COUNT_RECV = 49168
+WS_SENDER_COUNTER = 73744
+WS_PORT_SCRATCH = 12_820_528  # software grid-barrier slots (sketch substitution 2)
+
+NUM_COUNT_SLOTS = NUM_RANKS + NUM_EXPERTS  # 264
+
+TIMEOUT_CYCLES = 200_000_000_000  # 100 s at ~2 GHz (comm.cuh: kNumOneSecCycles)
+
+_BULK_G2S_CHAIN = "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+_BULK_S2G_CHAIN = "cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint"
+_EVICT_FIRST = 0x12F0000000000000
+_EVICT_NORMAL = 0x1000000000000000
+
+
+def _gptr(base_u64, byte_off):
+    return T.reinterpret("handle", base_u64 + T.cast(byte_off, "uint64"))
+
+
+def _peer_u64(table, dst):
+    return T.cast(table[dst], "uint64")
+
+
+def _ld_volatile_u64(dst, addr):
+    return T.ptx.ld.volatile.global_.u64(dst, addr)
+
+
+def _ld_volatile_s64(dst, addr):
+    return T.ptx.ld.volatile.global_.s64(dst, addr)
+
+
+def _ld_acquire_sys_s32(dst, addr):
+    return T.ptx.ld.acquire.sys.global_.s32(dst, addr)
+
+
+def _ld_acquire_gpu_s32(dst, addr):
+    return T.ptx.ld.acquire.gpu.global_.s32(dst, addr)
+
+
+def _ld_acquire_gpu_u64(dst, addr):
+    return T.ptx.ld.acquire.gpu.global_.u64(dst, addr)
+
+
+def _shfl_idx(dst, src, src_lane):
+    return T.ptx.shfl_sync.idx.b32(
+        dst, src, T.cast(src_lane, "uint32"), T.uint32(31), T.uint32(0xFFFFFFFF)
+    )
+
+
+def _warp_inclusive_sum(value, lane):
+    # 5-step Hillis-Steele over the full warp (ptx.cuh:423-431)
+    result = value
+    for offset in (1, 2, 4, 8, 16):
+        tmp = T.alloc_local([1], "int32")
+        T.evaluate(
+            T.ptx.shfl_sync.up.b32(
+                tmp[0], result, T.uint32(offset), T.uint32(0), T.uint32(0xFFFFFFFF)
+            )
+        )
+        result = T.Select(lane >= offset, result + tmp[0], result)
+    return result
+
+
+def _launch_tags(cluster: int) -> list[str]:
+    tags = ["blockIdx.x"]
+    if cluster > 1:
+        tags.append("clusterCtaIdx.x")
+    tags += ["threadIdx.x", "tirx.use_programtic_dependent_launch", "tirx.use_dyn_shared_memory"]
+    return tags
+
+
+def _build_dispatch_kernel(
+    num_sms: int, num_max_tokens_per_rank: int, expert_alignment: int, num_ranks: int
+) -> Any:
+    """`dispatch_impl` for the direct single-domain path (frozen sketch kernel 1)."""
+
+    # Rank-count-dependent constants, closure-specialized per world size. The
+    # workspace byte offsets stay sized for 8 ranks, which is the worst case.
+    NUM_RANKS = num_ranks
+    EXPERTS_PER_RANK = NUM_EXPERTS // num_ranks
+    NUM_COUNT_SLOTS = NUM_RANKS + NUM_EXPERTS
+
+    num_dispatch_warps = min((SMEM_TOTAL - NOTIFY_SMEM_BYTES) // TOKEN_BYTES_SMEM, 28)
+    num_threads = (NUM_NOTIFY_WARPS + num_dispatch_warps) * 32
+    cluster = 2 - num_sms % 2
+    recv_region_bytes_per_rank = num_max_tokens_per_rank * TOKEN_BYTES_GMEM
+
+    @T.prim_func
+    def deepep_dispatch(
+        x_ptr: T.handle,
+        topk_idx_ptr: T.handle,
+        topk_weights_ptr: T.handle,
+        copied_topk_idx_ptr: T.handle,
+        psum_rank_ptr: T.handle,
+        psum_expert_ptr: T.handle,
+        num_unaligned_ptr: T.handle,
+        dst_slot_idx_ptr: T.handle,
+        peer_ws_ptrs_ptr: T.handle,
+        peer_buf_ptrs_ptr: T.handle,
+        workspace_addr: T.int64,
+        buffer_addr: T.int64,
+        num_tokens: T.int32,
+        rank_idx: T.int32,
+    ):
+        x = T.match_buffer(x_ptr, (num_tokens * HIDDEN_BYTES,), "uint8")
+        topk_idx = T.match_buffer(topk_idx_ptr, (num_tokens * NUM_TOPK,), "int64")
+        topk_weights = T.match_buffer(topk_weights_ptr, (num_tokens * NUM_TOPK,), "float32")
+        copied_topk_idx = T.match_buffer(copied_topk_idx_ptr, (num_tokens * NUM_TOPK,), "int64")
+        psum_rank = T.match_buffer(psum_rank_ptr, (NUM_RANKS,), "int32")
+        psum_expert = T.match_buffer(psum_expert_ptr, (EXPERTS_PER_RANK + 1,), "int32")
+        num_unaligned = T.match_buffer(num_unaligned_ptr, (EXPERTS_PER_RANK,), "int32")
+        dst_slot_idx = T.match_buffer(dst_slot_idx_ptr, (num_tokens * NUM_TOPK,), "int32")
+        peer_ws_ptrs = T.match_buffer(peer_ws_ptrs_ptr, (NUM_RANKS,), "int64")
+        peer_buf_ptrs = T.match_buffer(peer_buf_ptrs_ptr, (NUM_RANKS,), "int64")
+
+        T.device_entry()
+        T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+        smem = T.alloc_buffer([SMEM_TOTAL], "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": SMEM_TOTAL})
+
+        sm_idx = T.cta_id([num_sms])
+        if cluster > 1:
+            cta_in_cluster = T.cta_id_in_cluster([cluster])
+        thread_idx = T.thread_id([num_threads])
+        lane = T.lane_id([32])
+
+        # --- scalar helpers (module level: _gptr/_peer_u64/_ld_*/_shfl_idx) -
+        ws_u64 = T.cast(workspace_addr, "uint64")
+
+        # warp-uniform warp index (ptx.cuh: get_warp_idx)
+        warp_u32 = T.alloc_local([1], "uint32")
+        T.evaluate(_shfl_idx(warp_u32[0], thread_idx // 32, 0))
+        warp = T.cast(warp_u32[0], "int32")
+
+        # --- NVLink barrier (comm.cuh:88-129), SM 0 only --------------------
+        @T.inline
+        def nvlink_barrier(tag):
+            if sm_idx == 0:
+                counter_ptr = _gptr(ws_u64, WS_BARRIER_COUNTER)
+                cnt = T.alloc_local([1], "uint64")
+                T.evaluate(_ld_volatile_u64(cnt[0], counter_ptr))
+                status = T.cast(T.bitwise_and(cnt[0], T.uint64(3)), "int32")
+                phase = T.bitwise_and(status, 1)
+                sign = status // 2
+                if thread_idx < NUM_RANKS:
+                    delta = T.Select(sign == 0, T.int32(1), T.int32(-1))
+                    T.evaluate(
+                        T.ptx.red.release.sys.global_.add.s32(
+                            _gptr(
+                                _peer_u64(peer_ws_ptrs, thread_idx), WS_BARRIER_SIGNAL + phase * 4
+                            ),
+                            delta,
+                        )
+                    )
+                # comm.cuh:107 __syncthreads (SM 0's CTA only)
+                T.ptx.bar.sync(T.uint32(0), T.uint32(num_threads))
+                if thread_idx == 0:
+                    old = T.alloc_local([1], "uint64")
+                    T.evaluate(T.ptx.atom.global_.add.u64(old[0], counter_ptr, T.uint64(1)))
+                    target = T.Select(sign == 0, T.int32(NUM_RANKS), T.int32(0))
+                    sig = T.alloc_local([1], "int32")
+                    sig_ptr = _gptr(ws_u64, WS_BARRIER_SIGNAL + phase * 4)
+                    T.evaluate(_ld_acquire_sys_s32(sig[0], sig_ptr))
+                    start_clock = T.cuda.clock64()
+                    while sig[0] != target:
+                        if T.cuda.clock64() - start_clock >= T.uint64(TIMEOUT_CYCLES):
+                            T.cuda.printf(
+                                "DeepEP NVLink barrier timeout, tag: %d, nvl: %d, "
+                                "signal: %d, phase: %d, target: %d\n",
+                                T.int32(tag),
+                                rank_idx,
+                                sig[0],
+                                phase,
+                                target,
+                            )
+                            T.cuda.trap_when_assert_failed(False)
+                        T.evaluate(_ld_acquire_sys_s32(sig[0], sig_ptr))
+
+        # --- Software grid barrier (sketch substitution 2) ------------------
+        # Monotonic per-site u64 counter: every CTA's thread 0 adds 1, then
+        # spins until the counter crosses the next multiple of num_sms. No
+        # reset and no atomic-return ticket -> nothing for the compiler to
+        # mangle, and no reset race with straggler CTAs.
+        @T.inline
+        def grid_barrier(site):
+            counter_ptr = _gptr(ws_u64, WS_PORT_SCRATCH + site * 8)
+            if thread_idx == 0:
+                c0 = T.alloc_local([1], "uint64")
+                T.evaluate(_ld_acquire_gpu_u64(c0[0], counter_ptr))
+                target = (c0[0] // T.uint64(num_sms) + T.uint64(1)) * T.uint64(num_sms)
+                T.evaluate(T.ptx.red.release.gpu.global_.add.u64(counter_ptr, T.uint64(1)))
+                now = T.alloc_local([1], "uint64")
+                T.evaluate(_ld_acquire_gpu_u64(now[0], counter_ptr))
+                while now[0] < target:
+                    T.evaluate(_ld_acquire_gpu_u64(now[0], counter_ptr))
+            T.ptx.bar.sync(T.uint32(0), T.uint32(num_threads))
+
+        # -------------------------------------------------------------------
+        # Entry NVLink barrier (tag0) + end grid sync (dispatch.cuh:73-76)
+        # -------------------------------------------------------------------
+        # Reset the atomic sender counters up front (source resets them at
+        # kernel end; moved here after the mid-kernel reset race traced to
+        # the end-of-kernel cleanup). Every CTA allocates only after
+        # grid_barrier(0), which is gated behind this store on SM 0.
+        if sm_idx == 0 and thread_idx < NUM_RANKS:
+            T.evaluate(
+                T.ptx.st.global_.s32(_gptr(ws_u64, WS_SENDER_COUNTER + thread_idx * 4), T.int32(0))
+            )
+        nvlink_barrier(2)
+        grid_barrier(0)
+
+        if warp < NUM_NOTIFY_WARPS:
+            # =================================================================
+            # NOTIFY ROLE: warps 0..3 (dispatch.cuh:79-258)
+            # =================================================================
+            rank_expert_count = T.decl_buffer(
+                (384,),
+                "int32",
+                data=T.reinterpret(PointerType(PrimType("int32")), smem.ptr_to([0])),
+                scope="shared.dyn",
+            )
+
+            # Clean initial counts (dispatch.cuh:87-89)
+            for i in T.serial(0, 3):
+                rank_expert_count[i * NUM_NOTIFY_THREADS + thread_idx] = 0
+            T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+            # Per-token counting (dispatch.cuh:94-107)
+            atom_dst = T.alloc_local([1], "int32")
+            global_warp_idx = warp * num_sms + sm_idx
+            notify_stride = NUM_NOTIFY_WARPS * num_sms
+            notify_trips = T.max(
+                T.int32(0), (num_tokens - global_warp_idx + notify_stride - 1) // notify_stride
+            )
+            for notify_it in T.serial(0, notify_trips):
+                i = global_warp_idx + notify_it * notify_stride
+                e64 = T.alloc_local([1], "int64")
+                e64[0] = T.int64(-1)
+                if lane < NUM_TOPK:
+                    T.evaluate(
+                        T.ptx["ld.global.nc.s64"](e64[0], topk_idx.ptr_to([i * NUM_TOPK + lane]))
+                    )
+                dst_expert = T.cast(e64[0], "int32")
+                if dst_expert >= 0:
+                    T.evaluate(
+                        T.ptx.atom.shared.add.s32(
+                            atom_dst[0],
+                            rank_expert_count.ptr_to([NUM_RANKS + dst_expert]),
+                            T.int32(1),
+                        )
+                    )
+                dst_rank = T.Select(dst_expert >= 0, dst_expert // EXPERTS_PER_RANK, -1)
+                match_mask = T.alloc_local([1], "uint32")
+                T.evaluate(T.ptx.match.any.sync.b32(match_mask[0], dst_rank, T.uint32(0xFFFFFFFF)))
+                master = T.alloc_local([1], "uint32")
+                T.evaluate(T.ptx.bfind.u32(master[0], match_mask[0]))
+                if T.cast(master[0], "int32") == lane and dst_rank >= 0:
+                    T.evaluate(
+                        T.ptx.atom.shared.add.s32(
+                            atom_dst[0], rank_expert_count.ptr_to([dst_rank]), T.int32(1)
+                        )
+                    )
+            T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+            # Full-grid reduction into workspace (dispatch.cuh:111-115)
+            for _it in T.serial(
+                0, (NUM_COUNT_SLOTS - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS
+            ):
+                i = thread_idx + _it * NUM_NOTIFY_THREADS
+                T.evaluate(
+                    T.ptx.red.gpu.global_.add.u64(
+                        _gptr(ws_u64, WS_NOTIFY_REDUCTION + i * 8),
+                        (T.uint64(1) << T.uint64(32))
+                        | T.cast(T.cast(rank_expert_count[i], "uint32"), "uint64"),
+                    )
+                )
+
+            if sm_idx == 0:
+                # Wait all SMs, decode, clean (dispatch.cuh:121-147)
+                for _it in T.serial(
+                    0, (NUM_COUNT_SLOTS - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS
+                ):
+                    i = thread_idx + _it * NUM_NOTIFY_THREADS
+                    status = T.alloc_local([1], "uint64")
+                    T.evaluate(
+                        _ld_volatile_u64(status[0], _gptr(ws_u64, WS_NOTIFY_REDUCTION + i * 8))
+                    )
+                    start_clock = T.cuda.clock64()
+                    while T.cast(status[0] >> T.uint64(32), "int64") != T.int64(num_sms):
+                        if T.cuda.clock64() - start_clock >= T.uint64(TIMEOUT_CYCLES):
+                            T.cuda.printf(
+                                "DeepEP notify (GPU reduction) timeout, rank: %d, "
+                                "thread: %d, status: %d\n",
+                                rank_idx,
+                                thread_idx,
+                                T.cast(status[0], "int32"),
+                            )
+                            T.cuda.trap_when_assert_failed(False)
+                        T.evaluate(
+                            _ld_volatile_u64(status[0], _gptr(ws_u64, WS_NOTIFY_REDUCTION + i * 8))
+                        )
+                    total = T.cast(T.bitwise_and(status[0], T.uint64(0xFFFFFFFF)), "int64")
+                    encoded = T.cast(-total - 1, "int32")
+                    rank_expert_count[i] = encoded
+                    T.evaluate(
+                        T.ptx.st.global_.u64(
+                            _gptr(ws_u64, WS_NOTIFY_REDUCTION + i * 8), T.uint64(0)
+                        )
+                    )
+                T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+                # Publish rank counters to every peer (dispatch.cuh:152-158)
+                for _it in T.serial(
+                    0, (NUM_RANKS - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS
+                ):
+                    i = thread_idx + _it * NUM_NOTIFY_THREADS
+                    T.evaluate(
+                        T.ptx.st.relaxed.sys.global_.u64(
+                            _gptr(_peer_u64(peer_ws_ptrs, i), WS_COUNT_RECV + rank_idx * 8),
+                            T.cast(rank_expert_count[i], "uint64"),
+                        )
+                    )
+                T.cuda.warp_sync()
+
+                # Publish per-expert counters (dispatch.cuh:162-170)
+                for _it in T.serial(
+                    0, (NUM_EXPERTS - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS
+                ):
+                    i = thread_idx + _it * NUM_NOTIFY_THREADS
+                    idx = EXPERTS_PER_RANK * rank_idx + i % EXPERTS_PER_RANK
+                    T.evaluate(
+                        T.ptx.st.relaxed.sys.global_.u64(
+                            _gptr(
+                                _peer_u64(peer_ws_ptrs, i // EXPERTS_PER_RANK),
+                                WS_COUNT_RECV + NUM_RANKS * 8 + idx * 8,
+                            ),
+                            T.cast(rank_expert_count[NUM_RANKS + i], "uint64"),
+                        )
+                    )
+                T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+                # Wait for every peer's counts; consume and clean (dispatch.cuh:184-201)
+                start_clock = T.cuda.clock64()
+                for _it in T.serial(
+                    0, (NUM_COUNT_SLOTS - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS
+                ):
+                    i = thread_idx + _it * NUM_NOTIFY_THREADS
+                    count = T.alloc_local([1], "int64")
+                    T.evaluate(_ld_volatile_s64(count[0], _gptr(ws_u64, WS_COUNT_RECV + i * 8)))
+                    decoded = -count[0] - 1
+                    while decoded < 0:
+                        if T.cuda.clock64() - start_clock >= T.uint64(TIMEOUT_CYCLES):
+                            T.cuda.printf(
+                                "DeepEP notify timeout, rank: %d, thread: %d, count: %d\n",
+                                rank_idx,
+                                i,
+                                T.cast(count[0], "int32"),
+                            )
+                            T.cuda.trap_when_assert_failed(False)
+                        T.evaluate(
+                            T.ptx.ld.volatile.global_.s64(
+                                count[0], _gptr(ws_u64, WS_COUNT_RECV + i * 8)
+                            )
+                        )
+                        decoded = -count[0] - 1
+                    T.evaluate(
+                        T.ptx.st.global_.u64(_gptr(ws_u64, WS_COUNT_RECV + i * 8), T.uint64(0))
+                    )
+                    rank_expert_count[i] = T.cast(decoded, "int32")
+                T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+                # Per-expert reduce across source ranks + align (dispatch.cuh:205-220)
+                for _it in T.serial(
+                    0,
+                    (EXPERTS_PER_RANK - thread_idx + NUM_NOTIFY_THREADS - 1) // NUM_NOTIFY_THREADS,
+                ):
+                    i = thread_idx + _it * NUM_NOTIFY_THREADS
+                    total = T.alloc_local([1], "int32")
+                    total[0] = 0
+                    for j in T.serial(0, NUM_RANKS):
+                        total[0] = (
+                            total[0] + rank_expert_count[NUM_RANKS + j * EXPERTS_PER_RANK + i]
+                        )
+                    num_unaligned[i] = total[0]
+                    rank_expert_count[NUM_RANKS + i] = (
+                        (total[0] + expert_alignment - 1) // expert_alignment
+                    ) * expert_alignment
+                T.ptx.bar.sync(T.uint32(1), T.uint32(NUM_NOTIFY_THREADS))
+
+                # (kDoCPUSync=false: host-workspace write compiled out)
+
+                # Prefix sums, one warp each (dispatch.cuh:234-257)
+                if warp == 0:
+                    # Inclusive prefix over 8 rank counts -> psum_rank[0:8)
+                    value = T.Select(lane < NUM_RANKS, rank_expert_count[lane], 0)
+                    scan = _warp_inclusive_sum(value, lane)
+                    if lane < NUM_RANKS:
+                        psum_rank[lane] = scan
+                if warp == 1:
+                    # Exclusive prefix over the expert counts -> psum_expert[0:EPR+1)
+                    psum = T.alloc_local([1], "int32")
+                    psum[0] = 0
+                    for it in T.serial(0, (EXPERTS_PER_RANK + 1 + 31) // 32):
+                        idx = it * 32 + lane
+                        value = T.Select(
+                            idx >= 1 and idx - 1 < EXPERTS_PER_RANK,
+                            rank_expert_count[NUM_RANKS + idx - 1],
+                            0,
+                        )
+                        # Out-of-range lanes contribute 0; guard the smem read.
+                        if idx == 0 or idx > EXPERTS_PER_RANK:
+                            value = 0
+                        scan = psum[0] + _warp_inclusive_sum(value, lane)
+                        if idx < EXPERTS_PER_RANK + 1:
+                            psum_expert[idx] = scan
+                        carry = T.alloc_local([1], "uint32")
+                        T.evaluate(_shfl_idx(carry[0], scan, 31))
+                        psum[0] = T.cast(carry[0], "int32")
+
+        else:
+            # =================================================================
+            # DISPATCH ROLE: one channel per warp (dispatch.cuh:259-394)
+            # =================================================================
+            dispatch_warp_idx = warp - NUM_NOTIFY_WARPS
+            tok_off = NOTIFY_SMEM_BYTES + dispatch_warp_idx * TOKEN_BYTES_SMEM
+            tma_topk_idx = T.decl_buffer(
+                (NUM_TOPK,),
+                "int32",
+                data=T.reinterpret(PointerType(PrimType("int32")), smem.ptr_to([tok_off + 14336])),
+                scope="shared.dyn",
+            )
+            tma_topk_w = T.decl_buffer(
+                (NUM_TOPK,),
+                "float32",
+                data=T.reinterpret(
+                    PointerType(PrimType("float32")), smem.ptr_to([tok_off + 14360])
+                ),
+                scope="shared.dyn",
+            )
+            tma_src_idx = T.decl_buffer(
+                (1,),
+                "int32",
+                data=T.reinterpret(PointerType(PrimType("int32")), smem.ptr_to([tok_off + 14384])),
+                scope="shared.dyn",
+            )
+            tma_mbar = T.decl_buffer(
+                (1,),
+                "uint64",
+                data=T.reinterpret(PointerType(PrimType("uint64")), smem.ptr_to([tok_off + 14432])),
+                scope="shared.dyn",
+            )
+
+            phase = T.alloc_local([1], "uint32")
+            phase[0] = T.uint32(0)
+            if T.cuda.elect_sync():
+                T.evaluate(T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1)))
+                T.evaluate(T.ptx.fence.mbarrier_init.release.cluster())
+            T.cuda.warp_sync()
+
+            token_start = dispatch_warp_idx * num_sms + sm_idx
+            token_stride = num_dispatch_warps * num_sms
+            token_trips = T.max(
+                T.int32(0), (num_tokens - token_start + token_stride - 1) // token_stride
+            )
+            for token_it in T.serial(0, token_trips):
+                token_idx = token_start + token_it * token_stride
+                # Drain prior TMA stores' SMEM reads before reusing the slot.
+                # Deliberate relaxation vs dispatch.cuh:284 (full wait_group 0):
+                # `.read` only waits for the TMA engine to finish reading the
+                # SMEM source, letting the previous NVLink store overlap the
+                # next token's load. Peer visibility is unaffected — the exit
+                # path still does a full commit+wait_group(0) before the
+                # tag1 grid/NVLink barriers.
+                T.ptx.cp.async_.bulk.wait_group.read(0)
+                T.cuda.warp_sync()
+
+                # TMA-load the token's hidden bytes into SMEM (dispatch.cuh:288-291)
+                if T.cuda.elect_sync():
+                    T.evaluate(
+                        T.ptx[_BULK_G2S_CHAIN](
+                            smem.ptr_to([tok_off]),
+                            x.ptr_to([token_idx * HIDDEN_BYTES]),
+                            T.uint32(HIDDEN_BYTES),
+                            tma_mbar.ptr_to([0]),
+                            T.uint64(_EVICT_FIRST),
+                        )
+                    )
+                T.cuda.warp_sync()
+
+                # Load top-k into registers and SMEM metadata (dispatch.cuh:317-326)
+                stored_dst_rank = T.alloc_local([1], "int32")
+                stored_dst_rank[0] = -1
+                if lane < NUM_TOPK:
+                    raw = T.alloc_local([1], "int64")
+                    T.evaluate(
+                        T.ptx["ld.global.nc.s64"](
+                            raw[0], topk_idx.ptr_to([token_idx * NUM_TOPK + lane])
+                        )
+                    )
+                    dst_expert = T.cast(raw[0], "int32")
+                    stored_dst_rank[0] = T.Select(
+                        dst_expert >= 0, dst_expert // EXPERTS_PER_RANK, -1
+                    )
+                    tma_topk_idx[lane] = dst_expert
+                    w = T.alloc_local([1], "float32")
+                    T.evaluate(
+                        T.ptx["ld.global.nc.f32"](
+                            w[0], topk_weights.ptr_to([token_idx * NUM_TOPK + lane])
+                        )
+                    )
+                    tma_topk_w[lane] = w[0]
+                    copied_topk_idx[token_idx * NUM_TOPK + lane] = raw[0]
+                T.cuda.warp_sync()
+
+                # Source metadata; last SMEM write before the fence (dispatch.cuh:331-333)
+                if T.cuda.elect_sync():
+                    tma_src_idx[0] = rank_idx * num_max_tokens_per_rank + token_idx
+                T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
+                T.cuda.warp_sync()
+
+                # Deduplicate destination ranks and allocate slots (dispatch.cuh:337-351)
+                stored_slot = T.alloc_local([1], "int32")
+                stored_slot[0] = -1
+                match_mask = T.alloc_local([1], "uint32")
+                T.evaluate(
+                    T.ptx.match.any.sync.b32(
+                        match_mask[0], stored_dst_rank[0], T.uint32(0xFFFFFFFF)
+                    )
+                )
+                master = T.alloc_local([1], "uint32")
+                T.evaluate(T.ptx.bfind.u32(master[0], match_mask[0]))
+                if T.cast(master[0], "int32") == lane and stored_dst_rank[0] >= 0:
+                    T.evaluate(
+                        T.ptx.atom.global_.add.s32(
+                            stored_slot[0],
+                            _gptr(ws_u64, WS_SENDER_COUNTER + stored_dst_rank[0] * 4),
+                            T.int32(1),
+                        )
+                    )
+                if lane < NUM_TOPK:
+                    dst_slot_idx[token_idx * NUM_TOPK + lane] = T.Select(
+                        stored_slot[0] >= 0, rank_idx * num_max_tokens_per_rank + stored_slot[0], -1
+                    )
+                T.cuda.warp_sync()
+
+                # Publish expected bytes and wait TMA load arrival (dispatch.cuh:356-359)
+                if T.cuda.elect_sync():
+                    T.evaluate(
+                        T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                            tma_mbar.ptr_to([0]), T.uint32(HIDDEN_BYTES)
+                        )
+                    )
+                    T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), phase[0])
+                    phase[0] = phase[0] ^ T.uint32(1)
+                T.cuda.warp_sync()
+
+                # TMA-store the whole token slot to the destination rank (dispatch.cuh:372-379)
+                if stored_slot[0] >= 0:
+                    T.evaluate(
+                        T.ptx[_BULK_S2G_CHAIN](
+                            _gptr(
+                                _peer_u64(peer_buf_ptrs, stored_dst_rank[0]),
+                                rank_idx * recv_region_bytes_per_rank
+                                + stored_slot[0] * TOKEN_BYTES_GMEM,
+                            ),
+                            smem.ptr_to([tok_off]),
+                            T.uint32(TOKEN_BYTES_GMEM),
+                            T.uint64(_EVICT_NORMAL),
+                        )
+                    )
+                T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+                T.cuda.warp_sync()
+
+        # -------------------------------------------------------------------
+        # Exit barrier (tag1): TMA flush + start grid sync (dispatch.cuh:398-400)
+        # -------------------------------------------------------------------
+        T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+        T.ptx.cp.async_.bulk.wait_group(0)
+        T.cuda.warp_sync()
+        grid_barrier(1)
+        nvlink_barrier(3)
+
+        # Chain the copy epilogue (dispatch.cuh:403)
+        T.evaluate(T.ptx.griddepcontrol.launch_dependents())
+
+    return deepep_dispatch.with_attr("tirx.kernel_launch_params", _launch_tags(cluster))
+
+
+def _build_epilogue_kernel(
+    num_sms: int, num_max_tokens_per_rank: int, expert_alignment: int, num_ranks: int
+) -> Any:
+    """`dispatch_copy_epilogue_impl` (frozen sketch kernel 2)."""
+
+    NUM_RANKS = num_ranks
+    EXPERTS_PER_RANK = NUM_EXPERTS // num_ranks
+
+    num_warps = min(SMEM_TOTAL // TOKEN_BYTES_SMEM, 32)
+    num_threads = num_warps * 32
+    recv_region_bytes_per_rank = num_max_tokens_per_rank * TOKEN_BYTES_GMEM
+    num_recv_alloc = NUM_RANKS * num_max_tokens_per_rank
+
+    @T.prim_func
+    def deepep_dispatch_copy_epilogue(
+        buffer_addr: T.int64,
+        psum_rank_ptr: T.handle,
+        psum_expert_ptr: T.handle,
+        recv_x_ptr: T.handle,
+        recv_topk_idx_ptr: T.handle,
+        recv_topk_weights_ptr: T.handle,
+        recv_src_metadata_ptr: T.handle,
+        num_unaligned_ptr: T.handle,
+        num_recv_tokens: T.int32,
+        rank_idx: T.int32,
+    ):
+        psum_rank = T.match_buffer(psum_rank_ptr, (NUM_RANKS,), "int32")
+        psum_expert = T.match_buffer(psum_expert_ptr, (EXPERTS_PER_RANK,), "int32")
+        recv_x = T.match_buffer(recv_x_ptr, (num_recv_alloc * HIDDEN_BYTES,), "uint8")
+        recv_topk_idx = T.match_buffer(recv_topk_idx_ptr, (num_recv_alloc * NUM_TOPK,), "int64")
+        recv_topk_weights = T.match_buffer(
+            recv_topk_weights_ptr, (num_recv_alloc * NUM_TOPK,), "float32"
+        )
+        recv_src_metadata = T.match_buffer(
+            recv_src_metadata_ptr, (num_recv_alloc * (2 + NUM_TOPK),), "int32"
+        )
+        num_unaligned = T.match_buffer(num_unaligned_ptr, (EXPERTS_PER_RANK,), "int32")
+
+        T.device_entry()
+        T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+        smem = T.alloc_buffer([SMEM_TOTAL], "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": SMEM_TOTAL})
+
+        sm_idx = T.cta_id([num_sms])
+        thread_idx = T.thread_id([num_threads])
+        lane = T.lane_id([32])
+
+        buf_u64 = T.cast(buffer_addr, "uint64")
+
+        warp_u32 = T.alloc_local([1], "uint32")
+        T.evaluate(
+            T.ptx.shfl_sync.idx.b32(
+                warp_u32[0], thread_idx // 32, T.uint32(0), T.uint32(31), T.uint32(0xFFFFFFFF)
+            )
+        )
+        warp = T.cast(warp_u32[0], "int32")
+        global_warp_idx = warp * num_sms + sm_idx
+
+        tok_off = warp * TOKEN_BYTES_SMEM
+        tma_topk_w = T.decl_buffer(
+            (NUM_TOPK,),
+            "float32",
+            data=T.reinterpret(PointerType(PrimType("float32")), smem.ptr_to([tok_off + 14360])),
+            scope="shared.dyn",
+        )
+        tma_src_idx = T.decl_buffer(
+            (1,),
+            "int32",
+            data=T.reinterpret(PointerType(PrimType("int32")), smem.ptr_to([tok_off + 14384])),
+            scope="shared.dyn",
+        )
+        tma_mbar = T.decl_buffer(
+            (1,),
+            "uint64",
+            data=T.reinterpret(PointerType(PrimType("uint64")), smem.ptr_to([tok_off + 14432])),
+            scope="shared.dyn",
+        )
+
+        phase = T.alloc_local([1], "uint32")
+        phase[0] = T.uint32(0)
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1)))
+            T.evaluate(T.ptx.fence.mbarrier_init.release.cluster())
+        T.cuda.warp_sync()
+
+        # Block until kernel 1 finished and all data is visible (epilogue.cuh:60)
+        T.evaluate(T.ptx.griddepcontrol.wait())
+
+        # Worst-case host count -> read the real count from the GPU prefix (epilogue.cuh:63-64)
+        # Plain ld.global (no .nc): PDL visibility rule (epilogue.cuh:59).
+        num_recv_reg = T.alloc_local([1], "int32")
+        T.evaluate(T.ptx.ld.global_.s32(num_recv_reg[0], psum_rank.ptr_to([NUM_RANKS - 1])))
+        num_recv = T.Select(
+            num_recv_tokens == NUM_RANKS * num_max_tokens_per_rank, num_recv_reg[0], num_recv_tokens
+        )
+
+        # Per-warp strided loop over received tokens (epilogue.cuh:67-208)
+        current_rank = T.alloc_local([1], "int32")
+        rank_start = T.alloc_local([1], "int32")
+        rank_end = T.alloc_local([1], "int32")
+        stored_psum = T.alloc_local([1], "int32")
+        current_rank[0] = -1
+        rank_start[0] = 0
+        rank_end[0] = 0
+        stored_psum[0] = 0
+        epi_stride = num_warps * num_sms
+        epi_trips = T.max(T.int32(0), (num_recv - global_warp_idx + epi_stride - 1) // epi_stride)
+        for epi_it in T.serial(0, epi_trips):
+            i = global_warp_idx + epi_it * epi_stride
+            # Locate the source rank of received token i via the inclusive prefix
+            while i >= rank_end[0]:
+                current_rank[0] = current_rank[0] + 1
+                T.cuda.trap_when_assert_failed(current_rank[0] < NUM_RANKS)
+                stored_lane = current_rank[0] % 32
+                if stored_lane == 0 and current_rank[0] + lane < NUM_RANKS:
+                    # Plain ld.global (no .nc): PDL visibility rule (epilogue.cuh:59).
+                    T.evaluate(
+                        T.ptx.ld.global_.s32(
+                            stored_psum[0], psum_rank.ptr_to([current_rank[0] + lane])
+                        )
+                    )
+                rank_start[0] = rank_end[0]
+                shuffled = T.alloc_local([1], "uint32")
+                T.evaluate(
+                    T.ptx.shfl_sync.idx.b32(
+                        shuffled[0],
+                        stored_psum[0],
+                        T.cast(stored_lane, "uint32"),
+                        T.uint32(31),
+                        T.uint32(0xFFFFFFFF),
+                    )
+                )
+                rank_end[0] = T.cast(shuffled[0], "int32")
+
+            token_off = (
+                current_rank[0] * recv_region_bytes_per_rank
+                + (i - rank_start[0]) * TOKEN_BYTES_GMEM
+            )
+
+            # Drain prior TMA stores' SMEM reads before reusing the SMEM slot.
+            # Deliberate relaxation vs epilogue.cuh:84 (full wait_group 0):
+            # `.read` only waits for the TMA engine to finish reading the SMEM
+            # source, so the previous store's HBM write overlaps the next
+            # token's TMA load. End-of-kernel store drain semantics are
+            # unchanged (same as the source: no trailing full wait).
+            T.ptx.cp.async_.bulk.wait_group.read(0)
+            T.cuda.warp_sync()
+
+            # TMA-load the full token slot (hidden + metadata) (epilogue.cuh:89-93)
+            if T.cuda.elect_sync():
+                T.evaluate(
+                    T.ptx[_BULK_G2S_CHAIN](
+                        smem.ptr_to([tok_off]),
+                        _gptr(buf_u64, token_off),
+                        T.uint32(TOKEN_BYTES_GMEM),
+                        tma_mbar.ptr_to([0]),
+                        T.uint64(_EVICT_FIRST),
+                    )
+                )
+                T.evaluate(
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        tma_mbar.ptr_to([0]), T.uint32(TOKEN_BYTES_GMEM)
+                    )
+                )
+            T.cuda.warp_sync()
+
+            # Read target expert indices early, DIRECTLY FROM THE GMEM token slot,
+            # to tolerate TMA latency (epilogue.cuh:96-100; plain ld, no .nc)
+            dst_expert = T.alloc_local([1], "int32")
+            dst_expert[0] = -1
+            if lane < NUM_TOPK:
+                T.evaluate(
+                    T.ptx.ld.global_.s32(
+                        dst_expert[0], _gptr(buf_u64, token_off + 14336 + lane * 4)
+                    )
+                )
+            T.cuda.warp_sync()
+
+            # Validate, localize, and check per-token rank uniqueness (epilogue.cuh:104-109)
+            expert_start = EXPERTS_PER_RANK * rank_idx
+            in_range = (
+                dst_expert[0] >= expert_start and dst_expert[0] < expert_start + EXPERTS_PER_RANK
+            )
+            ballot = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.vote_sync.ballot.b32(ballot[0], in_range, T.uint32(0xFFFFFFFF)))
+            master_lane = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.bfind.u32(master_lane[0], ballot[0]))
+            dst_expert[0] = T.Select(in_range, dst_expert[0] - expert_start, -1)
+            dedup_mask = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.match.any.sync.b32(dedup_mask[0], dst_expert[0], T.uint32(0xFFFFFFFF)))
+            dedup_master = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.bfind.u32(dedup_master[0], dedup_mask[0]))
+            T.cuda.trap_when_assert_failed(
+                T.cast(dedup_master[0], "int32") == lane or dst_expert[0] == -1
+            )
+            if lane < NUM_TOPK:
+                recv_topk_idx[i * NUM_TOPK + lane] = T.cast(dst_expert[0], "int64")
+            T.cuda.warp_sync()
+
+            # Wait TMA arrival (epilogue.cuh:126-127)
+            if T.cuda.elect_sync():
+                T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), phase[0])
+                phase[0] = phase[0] ^ T.uint32(1)
+            T.cuda.warp_sync()
+
+            # TMA-store hidden to the output tensor (epilogue.cuh:138-142)
+            if T.cuda.elect_sync():
+                T.evaluate(
+                    T.ptx[_BULK_S2G_CHAIN](
+                        recv_x.ptr_to([i * HIDDEN_BYTES]),
+                        smem.ptr_to([tok_off]),
+                        T.uint32(HIDDEN_BYTES),
+                        T.uint64(_EVICT_NORMAL),
+                    )
+                )
+                T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+            T.cuda.warp_sync()
+
+            # Store top-k weights (epilogue.cuh:182-184)
+            if lane < NUM_TOPK:
+                recv_topk_weights[i * NUM_TOPK + lane] = tma_topk_w[lane]
+            T.cuda.warp_sync()
+
+            # Write source metadata, non-cached mode (epilogue.cuh:192-201)
+            if T.cuda.elect_sync():
+                recv_src_metadata[i * (2 + NUM_TOPK) + 0] = tma_src_idx[0]
+                recv_src_metadata[i * (2 + NUM_TOPK) + 1] = current_rank[0] * NUM_TOPK + T.cast(
+                    master_lane[0], "int32"
+                )
+            T.cuda.warp_sync()
+
+    return deepep_dispatch_copy_epilogue.with_attr("tirx.kernel_launch_params", _launch_tags(1))
+
+
+# ---------------------------------------------------------------------------
+# Module entries (tirx-kernels conventions)
+# ---------------------------------------------------------------------------
+
+
+def get_kernel(
+    world_size: int = NUM_RANKS,
+    num_tokens: int = 4096,
+    hidden: int = 7168,
+    num_experts: int = NUM_EXPERTS,
+    num_topk: int = NUM_TOPK,
+    expert_alignment: int = 1,
+    num_sms: int = 0,
+    **_: Any,
+) -> list[Any]:
+    """Return the dispatch kernel pair (main + copy epilogue), closure-specialized."""
+
+    if num_experts != NUM_EXPERTS or num_topk != NUM_TOPK:
+        raise ValueError("config is outside the ported specialization boundary")
+    if hidden * 2 != HIDDEN_BYTES:
+        raise ValueError("config is outside the ported specialization boundary")
+    if num_experts % world_size != 0:
+        raise ValueError(f"num_experts={num_experts} not divisible by world_size={world_size}")
+    if num_sms == 0:
+        num_sms = get_theoretical_num_sms(world_size, num_experts, num_topk)
+    # Source parity: the copy epilogue always launches with full device SMs
+    # (buffer.hpp "Launch copy kernels with full SMs": device_runtime->get_num_sms()),
+    # not the dispatch kernel's num_sms.
+    import torch
+
+    epilogue_num_sms = torch.cuda.get_device_properties(0).multi_processor_count
+    return [
+        _build_dispatch_kernel(num_sms, num_tokens, expert_alignment, world_size),
+        _build_epilogue_kernel(epilogue_num_sms, num_tokens, expert_alignment, world_size),
+    ]
+
+
+def prepare_data(
+    world_size: int,
+    num_tokens: int,
+    hidden: int,
+    num_experts: int,
+    num_topk: int,
+    expert_alignment: int = 1,
+    masked_ratio: float = 0.0,
+    seed: int = 42,
+    rank: int = 0,
+    **_: Any,
+) -> dict[str, Any]:
+    """Rank-local logical inputs, mirroring tests/elastic/test_ep.py data generation."""
+
+    import torch
+
+    device = torch.device("cuda", rank)
+    generator = torch.Generator(device=device).manual_seed(seed + rank)
+
+    # Variable per-rank token counts, same as the source test.
+    local_num_tokens = max(1, num_tokens - rank)
+
+    x = torch.randn(
+        (local_num_tokens, hidden), dtype=torch.bfloat16, device=device, generator=generator
+    )
+    scores = torch.randn(
+        (local_num_tokens, num_experts), dtype=torch.float32, device=device, generator=generator
+    )
+    topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
+    if masked_ratio > 0.0:
+        mask = (
+            torch.rand((local_num_tokens, num_topk), device=device, generator=generator)
+            < masked_ratio
+        )
+        topk_idx = topk_idx.masked_fill(mask, -1)
+
+    return {
+        "x": x,
+        "topk_idx": topk_idx,
+        "topk_weights": topk_weights,
+        "num_tokens": local_num_tokens,
+    }
+
+
+def _run_worker(
+    runtime: Any, modules: dict[str, Any], mode: str, kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Rank-local test/bench worker (see basic/allgather_gemm.py protocol)."""
+
+    import torch
+    import torch.distributed as dist
+
+    from .utils._buffer import SymmetricWindow
+
+    rank = runtime.rank
+    group = dist.group.WORLD
+    world_size = kwargs["world_size"]
+    num_tokens_max = kwargs["num_tokens"]
+    hidden = kwargs["hidden"]
+    num_experts = kwargs["num_experts"]
+    num_topk = kwargs["num_topk"]
+    expert_alignment = kwargs["expert_alignment"]
+    num_sms = kwargs["num_sms"]
+
+    data = prepare_data(**{k: v for k, v in kwargs.items() if k != "num_sms"}, rank=rank)
+    x, topk_idx, topk_weights = data["x"], data["topk_idx"], data["topk_weights"]
+    local_num_tokens = data["num_tokens"]
+
+    # The reference runtime needs GIN disabled on this host (verified in
+    # scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
+    import os
+
+    os.environ.setdefault("EP_DISABLE_GIN", "1")
+    import deep_ep
+
+    ref_buffer = deep_ep.ElasticBuffer(
+        group,
+        num_max_tokens_per_rank=num_tokens_max,
+        hidden=hidden,
+        num_topk=num_topk,
+        # Match the source perf test (tests/elastic/test_ep.py defaults).
+        prefer_overlap_with_compute=False,
+        explicitly_destroy=True,
+    )
+
+    # TIRx-side symmetric window + metadata tensors.
+    recv_region_bytes = world_size * num_tokens_max * TOKEN_BYTES_GMEM
+    window = SymmetricWindow(group, recv_region_bytes)
+    num_recv_alloc = world_size * num_tokens_max
+    device = torch.device("cuda", rank)
+    copied_topk_idx = torch.empty_like(topk_idx)
+    psum_rank = torch.empty(world_size, dtype=torch.int32, device=device)
+    psum_expert = torch.empty(num_experts // world_size + 1, dtype=torch.int32, device=device)
+    num_unaligned = torch.empty(num_experts // world_size, dtype=torch.int32, device=device)
+    dst_slot_idx = torch.empty((local_num_tokens, num_topk), dtype=torch.int32, device=device)
+    recv_x = torch.empty((num_recv_alloc, hidden), dtype=torch.bfloat16, device=device)
+    recv_topk_idx = torch.empty((num_recv_alloc, num_topk), dtype=torch.int64, device=device)
+    recv_topk_weights = torch.empty((num_recv_alloc, num_topk), dtype=torch.float32, device=device)
+    recv_src_metadata = torch.empty(
+        (num_recv_alloc, 2 + num_topk), dtype=torch.int32, device=device
+    )
+
+    dispatch_fn = modules["dispatch"].get_function("main")
+    epilogue_fn = modules["epilogue"].get_function("main")
+
+    # Flattened views matching the kernels' 1-D buffer declarations.
+    x_flat = x.view(torch.uint8).view(-1)
+    topk_idx_flat = topk_idx.view(-1)
+    topk_weights_flat = topk_weights.view(-1)
+    copied_topk_idx_flat = copied_topk_idx.view(-1)
+    dst_slot_idx_flat = dst_slot_idx.view(-1)
+    recv_x_flat = recv_x.view(torch.uint8).view(-1)
+    recv_topk_idx_flat = recv_topk_idx.view(-1)
+    recv_topk_weights_flat = recv_topk_weights.view(-1)
+    recv_src_metadata_flat = recv_src_metadata.view(-1)
+
+    def tirx_launch() -> None:
+        dispatch_fn(
+            x_flat,
+            topk_idx_flat,
+            topk_weights_flat,
+            copied_topk_idx_flat,
+            psum_rank,
+            psum_expert,
+            num_unaligned,
+            dst_slot_idx_flat,
+            window.peer_ws_ptrs,
+            window.peer_buf_ptrs,
+            window.base_ptr,
+            window.buffer_ptr,
+            local_num_tokens,
+            rank,
+        )
+        epilogue_fn(
+            window.buffer_ptr,
+            psum_rank,
+            psum_expert[1:],
+            recv_x_flat,
+            recv_topk_idx_flat,
+            recv_topk_weights_flat,
+            recv_src_metadata_flat,
+            num_unaligned,
+            num_recv_alloc,
+            rank,
+        )
+
+    def reference_launch():
+        return ref_buffer.dispatch(
+            x,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            num_max_tokens_per_rank=num_tokens_max,
+            num_experts=num_experts,
+            expert_alignment=expert_alignment,
+            num_sms=num_sms,
+            do_cpu_sync=False,
+        )
+
+    try:
+        if mode == "test":
+
+            def _launch_and_check() -> None:
+                with torch.cuda.stream(runtime.timing_stream):
+                    ref_recv_x, ref_recv_topk_idx, ref_recv_topk_weights, ref_handle, _ = (
+                        reference_launch()
+                    )
+                    tirx_launch()
+                runtime.device.sync(runtime.compute_stream)
+
+                num_recv_ref = int(ref_handle.psum_num_recv_tokens_per_scaleup_rank[-1].item())
+                num_recv_ours = int(psum_rank[-1].item())
+                assert num_recv_ref == num_recv_ours, (
+                    f"rank {rank}: num_recv_tokens {num_recv_ours} != reference {num_recv_ref}"
+                )
+                assert torch.equal(ref_handle.psum_num_recv_tokens_per_scaleup_rank, psum_rank), (
+                    f"rank {rank}: psum_num_recv_tokens_per_scaleup_rank mismatch"
+                )
+                assert torch.equal(ref_handle.psum_num_recv_tokens_per_expert, psum_expert[1:]), (
+                    f"rank {rank}: psum_num_recv_tokens_per_expert mismatch"
+                )
+                assert torch.equal(
+                    ref_handle.num_unaligned_recv_tokens_per_expert, num_unaligned
+                ), f"rank {rank}: num_unaligned_recv_tokens_per_expert mismatch"
+                assert torch.equal(copied_topk_idx, topk_idx), (
+                    f"rank {rank}: copied_topk_idx mismatch"
+                )
+
+                # The receive order inside each source-rank segment is atomic-order
+                # dependent in both implementations; compare up to permutation by
+                # sorting on the unique src_token_global_idx.
+                ref_meta = ref_handle.recv_src_metadata[:num_recv_ref]
+                ours_meta = recv_src_metadata[:num_recv_ours]
+                ref_order = torch.argsort(ref_meta[:, 0])
+                ours_order = torch.argsort(ours_meta[:, 0])
+                assert torch.equal(ref_meta[ref_order, 0], ours_meta[ours_order, 0]), (
+                    f"rank {rank}: src_token_global_idx set mismatch"
+                )
+                assert torch.equal(ref_meta[ref_order, 1], ours_meta[ours_order, 1]), (
+                    f"rank {rank}: recv_src_metadata[:, 1] mismatch"
+                )
+                assert torch.equal(ref_recv_x[:num_recv_ref][ref_order], recv_x[ours_order]), (
+                    f"rank {rank}: recv_x mismatch"
+                )
+                assert torch.equal(
+                    ref_recv_topk_idx[:num_recv_ref][ref_order], recv_topk_idx[ours_order]
+                ), f"rank {rank}: recv_topk_idx mismatch"
+                assert torch.equal(
+                    ref_recv_topk_weights[:num_recv_ref][ref_order], recv_topk_weights[ours_order]
+                ), f"rank {rank}: recv_topk_weights mismatch"
+
+            check_error = ""
+            try:
+                _launch_and_check()
+            except Exception as error:  # reported uniformly below
+                check_error = f"{type(error).__name__}: {error}"
+                print(f"[rank {rank}] CHECK FAILED: {check_error}", flush=True)
+            # Never diverge: a failed rank must not strand the others at the
+            # next collective.
+            status = torch.tensor([not check_error], dtype=torch.int32, device=device)
+            dist.all_reduce(status, op=dist.ReduceOp.MIN)
+            if not status.item():
+                raise AssertionError(f"deepep_dispatch check failed on some rank: {check_error}")
+            return {"status": "OK"}
+
+        # mode == "bench"
+        from tvm.tirx.bench import bench
+
+        def build_reference():
+            def launch() -> None:
+                reference_launch()
+
+            return launch
+
+        with torch.cuda.stream(runtime.timing_stream):
+            result = bench(
+                {"tirx": tirx_launch},
+                references={"deepep": build_reference},
+                timer="kineto",
+                rounds=kwargs.get("rounds", 1),
+                cooldown_s=kwargs.get("cooldown_s", 1.0),
+                distributed=runtime.bench_context(),
+            )
+        return {"status": "OK", **result}
+    finally:
+        window.destroy()
+        ref_buffer.destroy()
+
+
+def _resolve_num_sms(config: dict[str, Any]) -> int:
+    # prefer_overlap_with_compute=False mirrors the source perf test default
+    # (tests/elastic/test_ep.py), e.g. 64 SMs for e256/k6.
+    return get_theoretical_num_sms(
+        config["world_size"],
+        config["num_experts"],
+        config["num_topk"],
+        prefer_overlap_with_compute=False,
+    )
+
+
+def run_test(**config: Any) -> None:
+    """Correctness entry point used by the runner."""
+
+    from .utils._runtime import run_distributed
+
+    num_sms = _resolve_num_sms(config)
+    dispatch_kernel, epilogue_kernel = get_kernel(**config, num_sms=num_sms)
+    run_distributed(
+        {"dispatch": dispatch_kernel, "epilogue": epilogue_kernel},
+        world_size=config["world_size"],
+        worker=_run_worker,
+        mode="test",
+        worker_kwargs={**config, "num_sms": num_sms},
+    )
+
+
+def run_bench(
+    *args: Any,
+    warmup: Any = None,
+    repeat: Any = None,
+    timer: Any = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point used by the runner (kineto only, distributed)."""
+
+    from .utils._runtime import run_distributed
+
+    if timer is not None and timer != "kineto":
+        raise ValueError(f"deepep_dispatch is distributed and supports only kineto, got {timer}")
+    if warmup is not None or repeat is not None:
+        raise ValueError("kineto uses fixed iteration counts and rejects warmup/repeat overrides")
+    config = dict(kwargs)
+    if args:
+        raise TypeError(f"unexpected positional arguments: {args}")
+    num_sms = _resolve_num_sms(config)
+    dispatch_kernel, epilogue_kernel = get_kernel(**config, num_sms=num_sms)
+    return run_distributed(
+        {"dispatch": dispatch_kernel, "epilogue": epilogue_kernel},
+        world_size=config["world_size"],
+        worker=_run_worker,
+        mode="bench",
+        worker_kwargs={**config, "num_sms": num_sms, "rounds": rounds, "cooldown_s": cooldown_s},
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/deepep/utils/__init__.py
+++ b/tirx_kernels/deepep/utils/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/deepep/utils/_buffer.py
+++ b/tirx_kernels/deepep/utils/_buffer.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""NCCL symmetric-window allocation for the TIRx DeepEP kernels.
+
+The source kernels translate peer pointers through the NCCL device API
+(`NCCLGin`, common/handle.cuh). The TIRx port replaces that with
+host-precomputed peer base-pointer tables (sanctioned substitution 1 in
+`.agents/sketch/deepep_dispatch.md`), obtained here with the same host API
+the source backend uses (`ncclGetLsaDevicePointer`,
+csrc/kernels/backend/nccl.cu:141-152).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+import torch
+import torch.distributed as dist
+
+# DeepEP `layout::WorkspaceLayout::get_num_bytes()` (common/layout.cuh:43-80),
+# recomputed in Python; must stay in sync with the source.
+WORKSPACE_NUM_BYTES = (
+    16  # barrier counter + signals
+    + (1024 + 2048) * 8  # notify reduction workspace
+    + 1024 * 8 * 2  # scaleup rank send/recv counts
+    + 2048 * 8 * 2  # scaleup expert send/recv counts
+    + 1024 * 4  # scaleup atomic sender counters
+    + 1024 * 4 * 2  # scaleout rank send/recv counts
+    + 2048 * 4 * 2  # scaleout expert send/recv counts
+    + 1024 * 1024 * 8  # scaleout channel signaled tails
+    + 1024 * 1024 * 4  # channel scaleup tails
+    + 2 * 2 * 8  # PP send/recv counts
+    + (32 + 1) * 1024 * 4  # AGRS signals
+)
+assert WORKSPACE_NUM_BYTES == 12_820_528
+
+SYMMETRIC_ALIGNMENT = 2 * 1024 * 1024  # 2 MB (backend/symmetric.hpp:16)
+
+
+def align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+WORKSPACE_ALIGNED_BYTES = align_up(WORKSPACE_NUM_BYTES, SYMMETRIC_ALIGNMENT)
+
+_NCCL_WIN_STRICT_ORDERING = 0x02
+
+
+def _load_nccl() -> ctypes.CDLL:
+    """Resolve the libnccl instance already loaded by deep_ep / torch."""
+
+    candidates = [
+        None,  # already loaded symbols (deep_ep's _C links libnccl)
+        "/host-libs/libnccl.so.2",
+        "libnccl.so.2",
+    ]
+    for candidate in candidates:
+        try:
+            if candidate is None:
+                library = ctypes.CDLL(None)
+            else:
+                library = ctypes.CDLL(candidate, mode=os.RTLD_NOLOAD | os.RTLD_LOCAL)
+            if hasattr(library, "ncclGetLsaDevicePointer"):
+                return library
+        except OSError:
+            continue
+    raise RuntimeError("no loaded libnccl exports ncclGetLsaDevicePointer")
+
+
+def _check(result: int, call: str) -> None:
+    if result != 0:
+        raise RuntimeError(f"{call} failed with ncclResult_t={result}")
+
+
+class SymmetricWindow:
+    """One NCCL-registered symmetric window: [workspace | recv buffer]."""
+
+    def __init__(self, group: dist.ProcessGroup, num_buffer_bytes: int) -> None:
+        # Lazy import: optional reference dependency.
+        from deep_ep.utils.comm import get_nccl_comm_handle
+
+        self.group = group
+        self.rank = group.rank()
+        self.world_size = group.size()
+        # A dedicated communicator so window registration does not interact
+        # with the reference ElasticBuffer's comm state.
+        self._comm_handle = get_nccl_comm_handle(group, force_new_comm=True)
+        self._nccl = _load_nccl()
+
+        self.workspace_bytes = WORKSPACE_ALIGNED_BYTES
+        self.buffer_bytes = align_up(num_buffer_bytes, SYMMETRIC_ALIGNMENT)
+        self.total_bytes = self.workspace_bytes + self.buffer_bytes
+
+        comm = ctypes.c_void_p(self._comm_handle.get())
+
+        base = ctypes.c_void_p()
+        _check(
+            self._nccl.ncclMemAlloc(ctypes.byref(base), ctypes.c_size_t(self.total_bytes)),
+            "ncclMemAlloc",
+        )
+        self.base_ptr = int(base.value)
+        self.buffer_ptr = self.base_ptr + self.workspace_bytes
+
+        window = ctypes.c_void_p()
+        _check(
+            self._nccl.ncclCommWindowRegister(
+                comm,
+                base,
+                ctypes.c_size_t(self.total_bytes),
+                ctypes.byref(window),
+                ctypes.c_int(_NCCL_WIN_STRICT_ORDERING),
+            ),
+            "ncclCommWindowRegister",
+        )
+        self._window = window
+        self._comm = comm
+
+        # Workspace must start zeroed (barrier signals, counters, port scratch).
+        # Use the libcudart instance already loaded by torch (runtime API keeps
+        # the rank-local primary context current on this thread).
+        cudart = None
+        maps = open(f"/proc/{os.getpid()}/maps").read()
+        for line in maps.splitlines():
+            if "libcudart.so" in line:
+                cudart = ctypes.CDLL(line.split()[-1], mode=os.RTLD_NOLOAD | os.RTLD_LOCAL)
+                break
+        if cudart is None:
+            raise RuntimeError("no loaded libcudart found")
+        result = cudart.cudaMemset(
+            ctypes.c_void_p(self.base_ptr), 0, ctypes.c_size_t(self.workspace_bytes)
+        )
+        if result != 0:
+            raise RuntimeError(f"cudaMemset failed with cudaError_t={result}")
+
+        peer_ws = []
+        for peer in range(self.world_size):
+            ptr = ctypes.c_void_p()
+            _check(
+                self._nccl.ncclGetLsaDevicePointer(
+                    window, ctypes.c_int64(0), ctypes.c_int(peer), ctypes.byref(ptr)
+                ),
+                "ncclGetLsaDevicePointer",
+            )
+            peer_ws.append(int(ptr.value))
+        device = torch.device("cuda", self.rank)
+        self.peer_ws_ptrs = torch.tensor(peer_ws, dtype=torch.int64, device=device)
+        self.peer_buf_ptrs = torch.tensor(
+            [p + self.workspace_bytes for p in peer_ws], dtype=torch.int64, device=device
+        )
+
+    def destroy(self) -> None:
+        if self._window is not None:
+            _check(
+                self._nccl.ncclCommWindowDeregister(self._comm, self._window),
+                "ncclCommWindowDeregister",
+            )
+            self._window = None
+        if self.base_ptr:
+            _check(self._nccl.ncclMemFree(ctypes.c_void_p(self.base_ptr)), "ncclMemFree")
+            self.base_ptr = 0
+
+
+def get_theoretical_num_sms(
+    world_size: int, num_experts: int, num_topk: int, prefer_overlap_with_compute: bool = True
+) -> int:
+    """Reuse the source's own SM-count model without constructing an ElasticBuffer."""
+
+    from deep_ep.buffers.elastic import ElasticBuffer
+
+    class _FakeSelf:  # supports weakref (required by the semantic wrapper)
+        num_rdma_ranks = 1
+        num_scaleout_ranks = 1
+        prefer_overlap_with_compute = True
+
+        def __init__(self, world_size: int, prefer_overlap: bool) -> None:
+            self.num_ranks = world_size
+            self.num_scaleup_ranks = world_size
+            self.num_nvlink_ranks = world_size
+            self.prefer_overlap_with_compute = prefer_overlap
+
+    fake_self = _FakeSelf(world_size, prefer_overlap_with_compute)
+    return int(ElasticBuffer.get_theoretical_num_sms(fake_self, num_experts, num_topk))
+
+
+__all__ = [
+    "SYMMETRIC_ALIGNMENT",
+    "WORKSPACE_ALIGNED_BYTES",
+    "WORKSPACE_NUM_BYTES",
+    "SymmetricWindow",
+    "align_up",
+    "get_theoretical_num_sms",
+]

--- a/tirx_kernels/deepep/utils/_runtime.py
+++ b/tirx_kernels/deepep/utils/_runtime.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Rank-local distributed runtime support for DeepEP kernels.
+
+Trimmed from `tirx_kernels/basic/utils/_runtime.py`: keeps the spawn /
+FileStore / DistributedRuntime / DistributedBenchContext pattern, drops the
+NVSHMEM initialization and the GemmComm-specific library locks (DeepEP V2
+uses NCCL symmetric memory, not NVSHMEM).
+"""
+
+from __future__ import annotations
+
+import gc
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+from unittest import SkipTest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import tvm
+from tvm.tirx.bench import DistributedBenchContext
+
+_PROCESS_GROUP_TIMEOUT = timedelta(seconds=60)
+
+
+@dataclass
+class DistributedRuntime:
+    """Rank-local module state shared by DeepEP worker implementations."""
+
+    rank: int
+    world_size: int
+    device: Any
+    compute_stream: int
+    timing_stream: torch.cuda.ExternalStream
+
+    def barrier(self) -> None:
+        dist.barrier(device_ids=[self.rank])
+
+    def max_reduce(self, value: float) -> float:
+        reduced = torch.tensor(value, dtype=torch.float64, device=f"cuda:{self.rank}")
+        dist.all_reduce(reduced, op=dist.ReduceOp.MAX)
+        return float(reduced.item())
+
+    def bench_context(self) -> DistributedBenchContext:
+        return DistributedBenchContext(
+            rank=self.rank,
+            world_size=self.world_size,
+            barrier=self.barrier,
+            max_reduce=self.max_reduce,
+            stream=self.timing_stream,
+        )
+
+
+def require_sm100(world_size: int) -> None:
+    """Reject unsupported hosts before compiling or spawning workers."""
+
+    if not isinstance(world_size, int) or isinstance(world_size, bool) or world_size <= 0:
+        raise ValueError("world_size must be a positive integer")
+    device_count = torch.cuda.device_count()
+    if device_count < world_size:
+        raise SkipTest(f"requires {world_size} CUDA devices, found {device_count}")
+    for device_id in range(world_size):
+        major, _minor = torch.cuda.get_device_capability(device_id)
+        if major != 10:
+            raise SkipTest(f"device {device_id} has compute capability {major}, expected SM100")
+
+
+def _create_runtime(rank: int, world_size: int) -> DistributedRuntime:
+    torch.cuda.set_device(rank)
+    device = tvm.cuda(rank)
+    compute_stream = int(device.create_raw_stream())
+    device.set_raw_stream(compute_stream)
+    timing_stream = torch.cuda.ExternalStream(compute_stream, device=rank)
+    return DistributedRuntime(
+        rank=rank,
+        world_size=world_size,
+        device=device,
+        compute_stream=compute_stream,
+        timing_stream=timing_stream,
+    )
+
+
+def _cleanup_runtime(runtime: DistributedRuntime | None) -> None:
+    if runtime is None:
+        return
+    try:
+        runtime.device.sync(runtime.compute_stream)
+    except Exception:
+        pass
+    runtime.device.set_raw_stream(0)
+    runtime.device.free_raw_stream(runtime.compute_stream)
+
+
+def _rank_entry(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    library_paths: dict[str, str],
+    worker: Callable[[DistributedRuntime, dict[str, Any], str, dict[str, Any]], dict[str, Any]],
+    mode: str,
+    worker_kwargs: dict[str, Any],
+    result_queue: Any,
+) -> None:
+    runtime = None
+    modules: dict[str, Any] = {}
+    succeeded = False
+    result = None
+    try:
+        torch.cuda.set_device(rank)
+        dist.init_process_group(
+            backend="nccl",
+            init_method=init_method,
+            world_size=world_size,
+            rank=rank,
+            device_id=torch.device("cuda", rank),
+            timeout=_PROCESS_GROUP_TIMEOUT,
+        )
+        runtime = _create_runtime(rank, world_size)
+        modules = {name: tvm.runtime.load_module(path) for name, path in library_paths.items()}
+        result = worker(runtime, modules, mode, worker_kwargs)
+        runtime.barrier()
+        succeeded = True
+    finally:
+        if runtime is not None:
+            _cleanup_runtime(runtime)
+        modules.clear()
+        gc.collect()
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+    if succeeded and rank == 0:
+        result_queue.put(result)
+
+
+def run_distributed(
+    kernels: dict[str, Any],
+    *,
+    world_size: int,
+    worker: Callable[[DistributedRuntime, dict[str, Any], str, dict[str, Any]], dict[str, Any]],
+    mode: str,
+    worker_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Compile every kernel once in the parent, then run one rank-local worker per GPU."""
+
+    require_sm100(world_size)
+    if not callable(worker):
+        raise TypeError("worker must be callable")
+
+    with tempfile.TemporaryDirectory(prefix="tirx-deepep-") as tmpdir:
+        library_paths: dict[str, str] = {}
+        for name, func in kernels.items():
+            library_path = Path(tmpdir) / f"{name}.so"
+            executable = tvm.compile(
+                tvm.IRModule({"main": func}), target=tvm.target.Target("cuda"), tir_pipeline="tirx"
+            )
+            executable.export_library(str(library_path))
+            library_paths[name] = str(library_path)
+
+        context = mp.get_context("spawn")
+        result_queue = context.SimpleQueue()
+        # Every DeepEP workload is single-host. A unique FileStore avoids the
+        # bind-after-probe race of selecting a free TCP port before concurrent
+        # rank groups start listening on it.
+        init_method = f"file://{Path(tmpdir) / 'torch-distributed-init'}"
+        mp.spawn(
+            _rank_entry,
+            args=(
+                world_size,
+                init_method,
+                library_paths,
+                worker,
+                mode,
+                worker_kwargs,
+                result_queue,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+        result = result_queue.get()
+
+    if not isinstance(result, dict):
+        raise TypeError("distributed worker must return a result dictionary")
+    return result
+
+
+__all__ = ["DistributedRuntime", "require_sm100", "run_distributed"]


### PR DESCRIPTION
## What

Ports the two-kernel dispatch chain of DeepEP's V2 elastic buffer (`deep_ep.ElasticBuffer`) to TIRx:

- `dispatch_impl` on the direct single-domain NVLink path (LSA team, no RDMA)
- `dispatch_copy_epilogue_impl` chained behind it via programmatic dependent launch

New category package `tirx_kernels/deepep/` (`dispatch.py` + `utils/_buffer.py` symmetric-window helper + `utils/_runtime.py` distributed runner), bench-suite config, baseline row, README entry, and the frozen sketch at `.agents/sketch/deepep/dispatch.md`.

Fixed specialization: bf16 tokens, `num_sf_packs=0`, non-cached, non-expand, `do_cpu_sync=False`, deterministic=False, `num_scaleout_ranks=1`, NVLink LSA domain; 8 ranks.

## Deviations from the source (documented in the sketch notes)

- Software grid barrier: monotonic per-site u64 counter (`red.release` + `ld.acquire` spin) instead of the atomic-ticket idiom, which ptxas lowered incorrectly inside the full kernel (compare constant `0x1b` instead of `0x3f`).
- Sender-counter cleanup moved to kernel start, gated behind the entry grid barrier (removes the end-of-kernel reset race found at 4 ranks).
- Per-token TMA store waits relaxed to `cp.async.bulk.wait_group.read` so the previous store's HBM write overlaps the next token's TMA load.
- Copy epilogue launches with full device SMs, matching the source runtime (`buffer.hpp` passes `device_runtime->get_num_sms()`, not the dispatch `num_sms`).

## Correctness

`python -m tirx_kernels.test --kernel deepep_dispatch` compares tensor-by-tensor against `ElasticBuffer.dispatch` at 8 ranks over 4 configs (`t128`, `t4096`, `t1024` masked 0.3, `t1024` align128): recv_x, recv_topk_idx, recv_topk_weights, both psum arrays, unaligned counts, copied_topk_idx, and src metadata. Receive order inside each source-rank segment is atomic-order-dependent in both implementations, so outputs are compared up to permutation by `src_token_global_idx`. All configs pass, including on the latest upstream/main.

Requires 8 GPUs and a DeepEP checkout for the reference (`EP_DISABLE_GIN=1` on hosts without GIN).

## Performance

One bench-suite workload, `t4096_h7168_e256_k6` (`num_gpus: 8`, kineto), excluded from the default sweep like the other multi-GPU workloads; baseline row merged from a targeted run.

On the shared 8xB200 host the official source/tirx ratio measures ~0.97 (median across runs) with run-level spread 0.75-1.37 from tenant interference. Same-window kernel-level profiling shows dispatch at parity (558.0 vs 555.8 µs), and the epilogue token loop is instruction-equivalent to the reference JIT cubin in SASS — the only deltas favor ours (our `.read` wait avoids the reference's per-token `CCTL.IVALL`); NVRTC and nvcc produce byte-identical code for it. The residual delta is at the host's measurement noise floor.