### PR TITLE
feat(kernel): port DeepEP V2 elastic combine (single-domain NVLink path)

### DIFF
--- a/.agents/sketch/deepep/combine.md
+++ b/.agents/sketch/deepep/combine.md
@@ -1,0 +1,650 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This design sketch documents a TIRx port of DeepEP's
+deep_ep/include/deep_ep/impls/combine.cuh (combine_impl, direct
+single-domain path) and deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
+(combine_reduce_epilogue_impl). See NOTICE and licenses/ for upstream
+attribution.
+-->
+
+# DeepEP elastic combine (single-domain NVLink): coarse WASP pipeline sketch
+
+This file is a non-executable design sketch. It is not a Python module, a new
+IR, a builder API, or a mathematical reference implementation. Its purpose is
+to show the two CUDA kernels as:
+
+- an explicit runtime ABI and launch;
+- explicit GMEM, SMEM, and register tiles, including byte offsets;
+- the uniform copy-warp (kernel 1) and reduce-warp (kernel 2) role structure
+  and the source-order control flow;
+- primitive directional copies and primitive computation inside every role;
+- explicit synchronization edges: mbarriers, NVLink barriers, grid-wide
+  barriers, and the PDL chaining edge;
+- hardware instruction selection stated per key operation.
+
+The implementation represented by this sketch is maintained in
+[`tirx_kernels/deepep/combine.py`](../../tirx_kernels/deepep/combine.py).
+That module is the source of truth.
+
+**In scope.** `combine_impl` instantiated with `kIsScaleupNVLink=true`
+(`team_t = ncclTeamTagLsa`), `kUseExpandedLayout=false`,
+`kAllowMultipleReduction=true`, `kNumScaleoutRanks=1` — the backward partner of
+the non-expand dispatch port; and `combine_reduce_epilogue_impl` instantiated
+with the same booleans and `kNumScaleoutRanks=1`. Derived:
+`kUseRankLayout=false` (8 ranks > 6 top-k), `kNumTokensInLayout=kNumTopk=6`,
+`kDoExpandedSend=false`. The two kernels form one PDL-chained pair, ported
+together.
+
+**Out of scope.** `hybrid_combine.cuh` (multi-node); every RDMA/GIN `gin.put`
+branch (dead in this specialization: `nvlink_bypass` is always true inside the
+LSA domain); `kUseExpandedLayout=true` (the kernel-1 local-reduction branch at
+combine.cuh:144-176 and the expanded-send loop at combine.cuh:177-213 require
+it; both are dead here); `bias_0`/`bias_1` (nullptr; the `add_bias` prologue in
+`combine_reduce` is dead); FP8/SF variants; `do_cpu_sync` host-count paths;
+linked-list/channel metadata (scaleout-only); tile (`Tx`) primitives.
+
+## Multiple-reduction semantics (why dedup-by-rank is correct)
+
+The dispatch kernel dedups by destination rank (dispatch.cuh:344: only the
+master lane of each rank group allocates a sender-counter slot; the torch
+reference does the same, refs.py:67 `.any(dim=1)`), so each (token, rank)
+group produces exactly ONE received token, no matter how many of the token's
+experts live on that rank. `src_metadata[i][1]` written by the dispatch
+epilogue is `src_rank * kNumTopk + m`, where `m` is that group's MASTER
+(highest) top-k lane — the group's unique identity. Every remote rank-buffer
+slot is therefore written exactly once; there is no same-slot race. The
+caller-side expert computation is expected to produce rank-group pre-reduced
+outputs: `x[i]` already holds the sum of this rank group's expert outputs
+(tests build it as the masked in-order accumulate over this rank's lanes).
+Kernel 2 then dedups by dst rank (each group contributes once, through its
+master lane's rank buffer) and sums the groups. The `no_local_reduce` path is
+the only reachable path in this specialization (combine.cuh:126-127:
+`not kUseExpandedLayout` is constant-true).
+
+## Sanctioned substitutions (ABI adaptations, not algorithm changes)
+
+Same three substitutions as the dispatch port (see
+[dispatch.md](dispatch.md) "Sanctioned substitutions"), restated where used:
+
+1. **Peer pointer table for `NCCLGin` device-side translation.** Here
+   `NCCLGin` is used only for `get_sym_ptr` (LSA translation) and
+   `red_add_rel_sys` (barrier signals); `is_nvlink_accessible<Lsa>` is
+   constant-true and `put` is dead. The port replaces
+   `ncclGetLsaPointer(window, offset, rank)` with host-precomputed tables
+   `peer_ws_ptrs[8]` and `peer_buf_ptrs[8]` (int64):
+   `remote(addr, dst) = peer_table[dst] + (addr - local_base)`.
+2. **Software grid barrier for `this_grid().sync()`.** Every grid-sync site in
+   `comm::gpu_barrier` becomes the dispatch port's monotonic per-site u64
+   counter on dedicated port-scratch workspace slots (arrive via
+   `red.release.gpu`, spin via `ld.acquire.gpu`, no reset). Arrive-before-
+   proceed semantics and call sites are unchanged.
+3. **PDL via TIRx launch tags.** `cudaGridDependencySynchronize` in kernel 2
+   maps to `T.ptx.griddepcontrol.wait()` plus the
+   `tirx.use_programtic_dependent_launch` kernel-launch tag. Kernel 1 contains
+   **no** `cudaTriggerProgrammaticLaunchCompletion` (unlike dispatch kernel 1;
+   zero `griddepcontrol` instructions in the kernel-1 PTX): the PDL wait
+   releases at kernel-1 completion (implicit trigger), so kernel 1 emits no
+   `griddepcontrol.launch_dependents`.
+
+Everything else — warp rotation, contiguous token chunking, TMA load/store
+dataflow, the direct NVLink weights store, barrier protocols, dedup/slot
+computation, and both reduce dtype paths — is a faithful transcription of the
+source.
+
+## Pipeline at a glance
+
+### Kernel 1: `combine_impl`
+
+| Warps | Role-local tile program | Main publication/reuse edges |
+| --- | --- | --- |
+| 0..15 (uniform copy role, rotated by `rank_idx`) | contiguous token chunks (`ceil_div(num_reduced, 64*16)` per warp): read `src_metadata[i][0..1]` (`__ldg`); elect-one TMA-load `x[i]` hidden into the warp's SMEM slot; mbarrier wait; TMA-store hidden into the source rank's rank buffer `src_topk_idx`, slot `src_token_idx` (remote, via peer table); commit; write this token's 6 top-k weights into the same remote slot via direct `st.b32` | per-warp mbarrier for TMA load completion; per-token `tma_store_wait` before SMEM slot reuse; entry NVLink barrier (tag0, kCombineTag0=4) before everything |
+| all | exit: TMA flush (commit + wait), grid barrier, SM 0 runs NVLink barrier (tag1, kCombineTag1=5); no PDL trigger | software grid barrier (substitution 2), NVLink barrier |
+
+### Kernel 2: `combine_reduce_epilogue_impl`
+
+| Warps | Role-local tile program | Main publication/reuse edges |
+| --- | --- | --- |
+| 0..15 x 148 SMs (uniform reduce role) | `griddepcontrol.wait`; strided loop over local output tokens: read `combined_topk_idx` (plain ld, post-PDL visibility), compute dst ranks, dedup by rank, `compute_topk_slots`; `combine_reduce` over <= 6 rank buffers: 7 hidden chunks x (4 x int4 `.nc` gez-predicated loads per valid slot; bf16 `hadd` bypass when <= 2 valid slots, else fp32 `add.rn.f32.bf16` accumulate + `cvt.rn.bf16x2.f32`); first chunk drains prior TMA store; `tma_store_fence`; elect-one TMA-store the reduced token to `combined_x`; write `combined_topk_weights` from the master lane's rank-buffer weights slot | PDL edge from kernel 1; per-token `tma_store_wait` before SMEM slot reuse; no mbarrier (kernel 2 only TMA-stores FROM smem) |
+
+## Primitive vocabulary
+
+Structural operations and copy directions are the same as in
+[dispatch.md](dispatch.md) ("Primitive vocabulary"):
+
+```python
+specialize(...)       # compile-time variant selection
+launch(...)           # compile-time launch topology and attributes
+tile(...) / view(...) / slice(...) / reg_tile(...)
+copy_g2s(src, dst, completion=mb)   # global -> shared, TMA, mbarrier completion
+copy_s2g(src, dst)                  # shared -> global, TMA (dst may be remote)
+copy_g2r(src, dst)                  # global -> register (may carry .nc / acquire semantics)
+copy_s2r(src, dst)                  # shared -> register
+copy_r2s(src, dst)                  # register -> shared
+copy_r2g(src, dst)                  # register -> global (may be remote)
+fill / add / sub / mul / div_floor / align_up / select
+bitwise_and / shift_right
+shuffle_index(dst, src, source_lane)
+ballot(dst, predicate)
+match_any(dst, value)
+bfind(dst, mask)                    # highest set bit; 31 - clz
+ffs(dst, mask)                      # lowest set bit index + 1; 0 when mask == 0
+```
+
+Computation additions for the reduce body:
+
+```python
+vec_g2r_16B(src, predicate)         # one gez-predicated int4 (16 B) vector load per lane
+add_bf162(dst, lhs, rhs)            # pairwise bf16x2 adds on int4-views (hadd path)
+accum_bf16_f32(dst_f32x2, src_bf16) # fused bf16 -> f32 convert-and-add, per scalar
+cast_f32_bf162(dst, src)            # float2 -> bf162 round-to-nearest pair cast
+```
+
+`mbarrier_init`, `expect_tx`, `mbarrier_wait`, `tma_store_commit`,
+`tma_store_wait`, `tma_store_fence`, `grid_barrier`, `nvlink_barrier`,
+`pdl_wait`, `syncwarp`, `named_barrier`, `red_global`, `clock`, `timeout_trap`
+are schedule operations, as in the dispatch sketch. Scalar address arithmetic,
+pointer offsets, and guards are shown directly; they do not hide copies,
+computation, role changes, or synchronization.
+
+There are deliberately no computational primitives named `dispatch`, `combine`,
+`reduce_all`, `barrier_all`, `gin`, or `nccl`.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+k1_variant = specialize(
+    kIsScaleupNVLink=True,              # team_t = ncclTeamTagLsa; RDMA branches dead
+    kUseExpandedLayout=False,           # non-expand dispatch handle (do_expand=false)
+    kAllowMultipleReduction=True,       # test/default recipe (reduce_in_local)
+    kNumSMs=...,                        # auto: get_theoretical_num_sms; 64 for e256/k6
+    kNumWarps=16,                       # min(kNumSmemBytes // 14432, 32)
+    kNumRanks=8,                        # = kNumScaleupRanks; kNumScaleoutRanks = 1
+    kHidden=7168,                       # bf16; kNumHiddenBytes = 14336
+    kNumMaxTokensPerRank=...,           # config: 128 / 1024 / 4096
+    kNumExperts=256, kNumTopk=6,
+    target="sm_100a",
+)
+k2_variant = specialize(
+    kUseExpandedLayout=False, kAllowMultipleReduction=True,
+    kNumSMs=...,                        # FULL device SMs: 148 on B200
+                                        # (buffer.hpp: launch_combine_reduce_epilogue
+                                        #  passes device_runtime->get_num_sms())
+    kNumWarps=16,                       # min(kNumSmemBytes // 14336, 32)
+    kNumScaleoutRanks=1, kNumScaleupRanks=8,
+    kHidden=7168, kNumMaxTokensPerRank=...,
+    kNumExperts=256, kNumTopk=6,
+    target="sm_100a",
+)
+# instruction_selection: none; extent: the template argument lists of
+#   combine_impl / combine_reduce_epilogue_impl for the direct path
+
+# Compile-time derived constants (no emitted code)
+kNumExpertsPerRank   = 32               # kNumExperts / kNumRanks
+kUseRankLayout       = False            # kAllowMultipleReduction and kNumRanks <= kNumTopk -> 8 <= 6 is False
+kNumTokensInLayout   = 6                # = kNumTopk when not kUseRankLayout
+kCombineTokenBytes   = 14400            # align(14336,32) + align(0,32) + align(6*4+6*4,32)
+kCombineTokenSmem    = 14432            # + align(8,32) mbarrier area (kernel 1 only)
+kOutputTokenBytes    = 14336            # TokenLayout(14336, 0, 0, false): flat hidden
+kHiddenVec           = 896              # 14336 / sizeof(int4)
+kUnrollFactor        = 4                # get_max_unroll_factor<896, 4>: 896 % (32*4) == 0
+kHiddenChunks        = 7                # 896 / (4*32)
+kNumSmemBytes        = 232448           # max opt-in dynamic smem per block on SM100
+kRecvRegionBytes     = kNumTokensInLayout * kNumMaxTokensPerRank * kCombineTokenBytes
+# Workspace byte offsets (subset of dispatch.md's table; barrier-only usage)
+WS_BARRIER_COUNTER   = 0                # u64; phase bit 0, sign bit 1
+WS_BARRIER_SIGNAL    = 8                # i32[2]; slot phase at (2+phase)*4
+WS_PORT_SCRATCH      = 12820528         # substitution 2: software grid-barrier slots
+# Barrier tags (comm.cuh:18-21)
+kCombineTag0         = 4                # entry barrier
+kCombineTag1         = 5                # exit barrier
+# instruction_selection: none; extent: compile-time constants only
+
+k1_launch = launch(
+    grid=(kNumSMs, 1, 1),
+    cluster=(2 - kNumSMs % 2, 1, 1),    # 2 for even kNumSMs (combine.hpp:173-174)
+    block=(kNumWarps * 32, 1, 1),       # 512
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=kNumSmemBytes,
+    cooperative=True,                   # source only, for this_grid().sync();
+                                        # realized via substitution 2
+    programmatic_dependent_launch=False,
+)
+# instruction_selection: none; extent: static launch metadata;
+#   `__launch_bounds__(512, 1)`; cudaLaunchKernelEx cluster attribute
+
+k2_launch = launch(
+    grid=(kNumSMs_k2, 1, 1),            # kNumSMs_k2 = full device SM count (148)
+    cluster=(1, 1, 1),
+    block=(kNumWarps * 32, 1, 1),       # 512
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=kNumSmemBytes,
+    programmatic_dependent_launch=True, # waits on kernel 1 completion (implicit trigger)
+)
+# instruction_selection: none; extent: static launch metadata;
+#   `__launch_bounds__(512, 1)`
+
+# ---------------------------------------------------------------------------
+# Shared barrier helpers (identical to dispatch.md; restated for tags 4/5)
+# ---------------------------------------------------------------------------
+
+def nvlink_barrier(workspace, peer_ws_ptrs, rank_idx, sm_idx, thread_idx, tag):
+    # comm.cuh:88-129 nvlink_barrier_wo_local_sync; SM 0 only
+    if sm_idx == 0:
+        status = copy_g2r(workspace + WS_BARRIER_COUNTER, reg_tile([], "u64")) & 3
+        # instruction_selection: ld.global.b32 (plain C++ deref of the counter's
+        #   low word; comm.cuh:98) + bitwise; extent: SM 0
+        phase, sign = status & 1, status >> 1
+        if thread_idx < kNumRanks:
+            red_global(remote(peer_ws_ptrs, workspace, thread_idx)
+                           + WS_BARRIER_SIGNAL + phase * 4,
+                       select(sign == 0, 1, -1), scope="sys", type="s32")
+            # instruction_selection: red.release.sys.global.add.s32;
+            #   extent: 8 lanes of SM 0
+        named_barrier(idx=0, threads=kNumWarps * 32)
+        # instruction_selection: bar.sync 0, 512 (__syncthreads)
+        if thread_idx == 0:
+            atomic_add_gmem(workspace + WS_BARRIER_COUNTER, 1)
+            # instruction_selection: atom.add.u64; extent: scalar
+            target = select(sign == 0, kNumRanks, 0)
+            timeout_loop():
+                if copy_g2r(workspace + WS_BARRIER_SIGNAL + phase * 4,
+                            reg_tile([], "i32"), semantic="acquire_sys") == target:
+                    break
+                # instruction_selection: ld.acquire.sys.L1::no_allocate.global.u32
+                #   spin (ptx::ld_acquire_sys); extent: SM 0 thread 0;
+                #   timeout_trap on kNumTimeoutCycles
+
+def grid_barrier(workspace, site):
+    # substitution 2 for this_grid().sync(): monotonic per-site u64 counter
+    counter = workspace + WS_PORT_SCRATCH + site * 8
+    if thread_idx == 0:
+        c0 = copy_g2r(counter, reg_tile([], "u64"), semantic="acquire_gpu")
+        target = (c0 // kNumSMs_grid + 1) * kNumSMs_grid
+        red_global(counter, 1, scope="gpu", type="u64")
+        # instruction_selection: red.release.gpu.global.add.u64; extent: one per CTA
+        while copy_g2r(counter, reg_tile([], "u64"), semantic="acquire_gpu") < target:
+            pass
+        # instruction_selection: ld.acquire.gpu.u64 spin; extent: CTA thread 0
+    named_barrier(idx=0, threads=kNumWarps * 32)
+    # instruction_selection: bar.sync 0, 512
+
+# ===========================================================================
+# Kernel 1: combine_impl
+# ===========================================================================
+
+def combine_impl(
+    x,                  # bf16* [num_reduced_tokens, kHidden]     (expert outputs)
+    topk_weights,       # f32*  [num_reduced_tokens, kNumTopk]
+    src_metadata,       # i32*  [num_reduced_tokens, 2 + kNumTopk]
+    psum_rank,          # i32*  [kNumRanks] (dispatch's inclusive prefix)
+    peer_ws_ptrs,       # i64*  [kNumRanks]  (substitution 1)
+    peer_buf_ptrs,      # i64*  [kNumRanks]  (substitution 1)
+    buffer,             # u8*   local combine recv-region base (6 rank buffers)
+    workspace,          # u8*   local window base
+    num_reduced_tokens, # i32   host value: kNumMaxTokensPerRank * kNumRanks (worst case)
+    rank_idx,           # i32   0..7
+):
+    sm_idx = block_id()
+    thread_idx = thread_id()
+    # Rotated warp index (combine.cuh:39): staggers per-rank channel usage
+    warp = (shuffle_index(thread_idx // 32, source_lane=0) + rank_idx) % kNumWarps
+    # instruction_selection: mov.u32 %tid.x, shr.u32, shfl.sync.idx.b32,
+    #   add + rem (by 16 -> and); extent: warp-uniform scalar
+    lane = lane_id()
+    global_warp_idx = warp * kNumSMs + sm_idx
+
+    # Real received-token count from the GPU prefix (combine.cuh:45-46);
+    # kernel 1 has no PDL edge, so `__ldg` is legal here
+    if num_reduced_tokens == kNumMaxTokensPerRank * kNumRanks:
+        num_reduced_tokens = copy_g2r(psum_rank[kNumRanks - 1], reg_tile([], "i32"),
+                                      semantic="nc")
+        # instruction_selection: ld.global.nc.s32 (__ldg); extent: warp-uniform
+
+    smem = tile("shared", "u8", [kNumSmemBytes], byte_offset=0, alignment=1024)
+    tma_buffer = view(smem, "u8", [kCombineTokenSmem],
+                      byte_offset=warp * kCombineTokenSmem)
+    tma_hidden = view(tma_buffer, "u8", [14336], byte_offset=0)
+    tma_mbar   = view(tma_buffer, "u64", [1], byte_offset=kCombineTokenBytes)  # @14400
+
+    phase = fill(reg_tile([], "u32"), 0)
+    if elect_one():
+        mbarrier_init(tma_mbar, arrive_count=1)
+        # instruction_selection: mbarrier.init.shared::cta.b64 +
+        #   fence.mbarrier_init.release.cluster; extent: one elected lane
+    syncwarp()
+
+    # (kDoExpandedSend=false: topk_weights==nullptr assert at combine.cuh:68-69 dead)
+
+    # Entry barrier (combine.cuh:77-80):
+    # gpu_barrier<kCombineTag0, kFlushStores=false, kSyncAtStart=false, kSyncAtEnd=true>
+    nvlink_barrier(workspace, peer_ws_ptrs, rank_idx, sm_idx, thread_idx,
+                   tag=kCombineTag0)
+    grid_barrier(workspace, site=0)     # kSyncAtEnd=true (substitution 2)
+
+    # Contiguous token chunks per warp (combine.cuh:83-85: NOT a strided loop)
+    num_tokens_per_warp = ceil_div(num_reduced_tokens, kNumSMs * kNumWarps)
+    token_start = num_tokens_per_warp * global_warp_idx
+    token_end = min(token_start + num_tokens_per_warp, num_reduced_tokens)
+    for i in range(token_start, token_end):
+        # Source routing indices (combine.cuh:88-92)
+        src_token_idx = copy_g2r(src_metadata[i * 8 + 0], reg_tile([], "i32"),
+                                 semantic="nc") % kNumMaxTokensPerRank
+        # instruction_selection: ld.global.nc.s32 (__ldg) + rem; extent: per thread
+        src_rank_topk = copy_g2r(src_metadata[i * 8 + 1], reg_tile([], "i32"),
+                                 semantic="nc")
+        # instruction_selection: ld.global.nc.s32 (__ldg); extent: per thread
+        src_rank_idx = div_floor(src_rank_topk, kNumTopk)
+        src_topk_idx = src_rank_topk % kNumTopk
+        # instruction_selection: s32 div/mod by 6; extent: scalar
+
+        # nvlink_bypass = is_nvlink_accessible<Lsa>(src_rank_idx): constant-true here;
+        # master slot is on the SOURCE rank's combine recv region (combine.cuh:96-106)
+        master_slot = remote(peer_buf_ptrs, buffer, src_rank_idx) \
+                      + (src_topk_idx * kNumMaxTokensPerRank + src_token_idx) \
+                        * kCombineTokenBytes
+
+        # (kUseExpandedLayout=false: stored_topk_slot_idx reads at
+        #  combine.cuh:115-119 dead; reduce_valid_mask empty;
+        #  no_local_reduce = true (combine.cuh:125-127), always the simple path)
+        if elect_one():
+            # Drain the previous token's TMA store before reusing the SMEM slot
+            # (combine.cuh:136, inside the elected lane in source order)
+            tma_store_wait(remaining=0)
+            # instruction_selection: cp.async.bulk.wait_group 0;
+            #   extent: one elected lane
+            copy_g2s(x + i * 14336, tma_hidden, completion=tma_mbar, num_bytes=14336)
+            # instruction_selection: cp.async.bulk.shared::cluster.global.
+            #   mbarrier::complete_tx::bytes.L2::cache_hint (evict-first);
+            #   extent: one 14336-byte 1-D bulk copy
+            expect_tx(tma_mbar, 14336)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared::cta.b64
+            mbarrier_wait(tma_mbar, phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared::cta.b64 spin;
+            #   extent: one elected lane, phase flips
+            copy_s2g(tma_hidden, master_slot, num_bytes=14336)
+            # instruction_selection: cp.async.bulk.global.shared::cta.bulk_group.
+            #   L2::cache_hint (evict-normal); extent: one 14336-byte 1-D bulk copy
+            #   to a PEER (NVLink) address
+            tma_store_commit()
+            # instruction_selection: cp.async.bulk.commit_group;
+            #   extent: one elected lane
+        syncwarp()
+
+        # (kAllowMultipleReduction local-reduce branch combine.cuh:144-176: dead,
+        #  requires kUseExpandedLayout; expanded-send loop combine.cuh:177-213: dead)
+
+        # Write this token's top-k weights into the same remote slot (combine.cuh:216-226)
+        if lane < kNumTopk:
+            w = copy_g2r(topk_weights[i * kNumTopk + lane], reg_tile([], "f32"),
+                         semantic="nc")
+            # instruction_selection: ld.global.nc.f32 (__ldg) predicated lane < 6;
+            #   extent: scalar per lane
+            copy_r2g(w, master_slot + 14360 + lane * 4)
+            # instruction_selection: st.b32 (generic space; the peer address is
+            #   runtime-computed, so NVCC cannot prove .global; f32 payload
+            #   carried as b32; TIRx's handle-typed peer pointer lowers to
+            #   st.global.b32, a same-address refinement); extent: <= 6 lanes
+        syncwarp()
+
+        # (nvlink_bypass constant-true: RDMA send block combine.cuh:230-236 dead)
+
+    # Exit barrier (combine.cuh:239-242):
+    # gpu_barrier<kCombineTag1, kFlushStores=true, kSyncAtStart=true, kSyncAtEnd=false>
+    tma_store_commit()
+    # instruction_selection: cp.async.bulk.commit_group; extent: per thread (kFlushStores)
+    tma_store_wait(remaining=0)
+    # instruction_selection: cp.async.bulk.wait_group 0; extent: per thread
+    syncwarp()
+    grid_barrier(workspace, site=1)     # kSyncAtStart=true (substitution 2)
+    nvlink_barrier(workspace, peer_ws_ptrs, rank_idx, sm_idx, thread_idx,
+                   tag=kCombineTag1)
+    # kSyncAtEnd=false: non-SM-0 CTAs proceed; kernel 1 carries no PDL trigger,
+    # so kernel 2's griddepcontrol.wait releases at kernel-1 completion
+
+# ===========================================================================
+# Kernel 2: combine_reduce_epilogue_impl
+# ===========================================================================
+
+def combine_reduce_epilogue_impl(
+    combined_x,             # bf16* [num_combined_tokens, kHidden]  (out)
+    combined_topk_weights,  # f32*  [num_combined_tokens, kNumTopk] (out)
+    combined_topk_idx,      # i64*  [num_combined_tokens, kNumTopk] (original top-k)
+    buffer,                 # u8*   local combine recv-region base (6 rank buffers)
+    num_combined_tokens,    # i32   host-known local token count
+    rank_idx,               # i32   0..7 (scaleup_rank_idx; scaleout is 0)
+):
+    sm_idx = block_id()
+    warp = shuffle_index(thread_id() // 32, source_lane=0)
+    lane = lane_id()
+    global_warp_idx = warp * kNumSMs_k2 + sm_idx
+    # (epilogue.cuh:39 comment: warp-major index concentrates the last wave on SMs)
+
+    smem = tile("shared", "u8", [kNumSmemBytes], byte_offset=0, alignment=1024)
+    tma_buffer = view(smem, "u8", [kOutputTokenBytes],
+                      byte_offset=warp * kOutputTokenBytes)
+    # (BufferLayout<false>: no mbarrier — kernel 2 never TMA-loads into smem)
+
+    # Block until kernel 1 finished and all peer data are visible (epilogue.cuh:59)
+    pdl_wait()
+    # instruction_selection: griddepcontrol.wait; extent: every CTA;
+    #   PDL edge: completes at kernel-1 completion (no explicit trigger)
+
+    for token_idx in range(global_warp_idx, num_combined_tokens,
+                           kNumWarps * kNumSMs_k2):
+        # Dst expert/rank per top-k lane (epilogue.cuh:66-71; plain ld, NOT __ldg:
+        # "PDL is used, please do not use __ldg"; the i64 -> int truncation reads
+        # only the little-endian low word)
+        dst_expert = select(lane < kNumTopk,
+                            i32(copy_g2r(combined_topk_idx[token_idx * kNumTopk + lane],
+                                         reg_tile([], "i32"))), -1)
+        # instruction_selection: ld.global.b32 (plain; low word of the i64 entry,
+        #   no explicit conversion emitted) predicated lane < 6;
+        #   extent: scalar per lane
+        dst_rank = select(dst_expert >= 0, div_floor(dst_expert, kNumExpertsPerRank), -1)
+        # instruction_selection: s32 div by 32 -> shr.s32 5; extent: scalar
+        syncwarp()
+
+        # Dedup on dst rank (epilogue.cuh:82-84 else-branch, scaleout == 1):
+        # each rank group contributes once, through its master lane
+        is_group_master = (bfind(match_any(dst_rank)) == lane)
+        # instruction_selection: match.any.sync.b32 + bfind.u32 + setp;
+        #   extent: warp-wide (ptx::deduplicate)
+        reduce_valid_mask = ballot(is_group_master and dst_rank >= 0)
+        # instruction_selection: vote.sync.ballot.b32; extent: warp-wide
+
+        # Sort valid top-k slots to front (combine_utils.cuh:43-53; fetch = identity
+        # because kUseRankLayout=false: the slot index IS the rank-buffer index)
+        topk_slot_idx = reg_tile([kNumTokensInLayout], "i32")
+        mask = reduce_valid_mask
+        for k in range(kNumTokensInLayout):         # #pragma unroll
+            lowest = ffs(mask) - 1
+            topk_slot_idx[k] = select(lowest >= 0, lowest, -1)
+            # instruction_selection: ffs.b32 + select; extent: warp-uniform;
+            #   exchange is identity here (epilogue.cuh:93, kUseRankLayout=false)
+            mask = bitwise_and(mask, mask - 1)
+
+        # ------------------------------------------------------------------
+        # combine_reduce<896, 4, 6, 6> (combine_utils.cuh:57-170):
+        # sum the valid rank buffers' token slots into the smem staging buffer
+        # ------------------------------------------------------------------
+        # enable_hadd_bypass (utils.cuh:68-70): no bias in this specialization, so
+        # the path selector is exactly (topk_slot_idx[2] < 0), i.e. <= 2 valid slots
+        hadd_bypass = topk_slot_idx[2] < 0
+
+        if hadd_bypass:
+            # --- bf16 hadd path (utils.cuh:73-110) ---
+            for c in range(kHiddenChunks):          # #pragma unroll 1 (serial)
+                # 4 x int4 gez-predicated reads per slot (slots 0 and 1)
+                values_0 = reg_tile([kUnrollFactor], "int4")
+                values_1 = reg_tile([kUnrollFactor], "int4")
+                base_0 = buffer + (topk_slot_idx[0] * kNumMaxTokensPerRank + token_idx) \
+                                  * kCombineTokenBytes
+                base_1 = buffer + (topk_slot_idx[1] * kNumMaxTokensPerRank + token_idx) \
+                                  * kCombineTokenBytes
+                for j in range(kUnrollFactor):      # #pragma unroll
+                    values_0[j] = vec_g2r_16B(
+                        base_0 + (c * 128 + j * 32 + lane) * 16, predicate=topk_slot_idx[0])
+                    values_1[j] = vec_g2r_16B(
+                        base_1 + (c * 128 + j * 32 + lane) * 16, predicate=topk_slot_idx[1])
+                # instruction_selection: setp.ge.s32 + @p
+                #   ld.L1::no_allocate.L2::cache_hint.global.nc.v4.s32 (evict-first),
+                #   zero-filled when the predicate is false (ptx::ldg_with_gez_pred);
+                #   extent: 4 x 16 B per slot per lane per chunk, LOCAL window
+                #   addresses; slot -1 computes a wraparound address never loaded
+                if c == 0:
+                    # Drain the previous token's TMA store before reusing smem
+                    # (utils.cuh:96-98 wait_buffer_func)
+                    tma_store_wait(remaining=0)
+                    # instruction_selection: cp.async.bulk.wait_group 0;
+                    #   extent: warp-wide
+                    syncwarp()
+                for j in range(kUnrollFactor):      # #pragma unroll
+                    values_0[j] = add_bf162(values_0[j], values_1[j])
+                    # instruction_selection: add.bf16x2 x4 per int4 (PTX omits the
+                    #   default .rn), 16 per chunk; extent: 4 x int4 per lane
+                    copy_r2s(values_0[j], tma_buffer + (c * 128 + j * 32 + lane) * 16)
+                    # instruction_selection: st.shared.v4.b32; extent: 16 B per lane
+        else:
+            # --- fp32 accumulate path (utils.cuh:111-168) ---
+            for c in range(kHiddenChunks):          # #pragma unroll 1 (serial)
+                reduced = fill(reg_tile([kUnrollFactor * 4], "f32x2"), 0.0)
+                # (bias_0/bias_1 == nullptr: add_bias prologue utils.cuh:129-130 dead)
+                for k in range(kNumTokensInLayout): # #pragma unroll
+                    # (k >= kNumExpectedTopk(6) never true: no early break, utils.cuh:134)
+                    base_k = buffer + (topk_slot_idx[k] * kNumMaxTokensPerRank
+                                       + token_idx) * kCombineTokenBytes
+                    values = reg_tile([kUnrollFactor], "int4")
+                    for j in range(kUnrollFactor):  # #pragma unroll
+                        values[j] = vec_g2r_16B(
+                            base_k + (c * 128 + j * 32 + lane) * 16,
+                            predicate=topk_slot_idx[k])
+                    # instruction_selection: setp.ge.s32 + @p
+                    #   ld.L1::no_allocate.L2::cache_hint.global.nc.v4.s32
+                    #   (evict-first); extent: 4 x 16 B per slot per lane per chunk
+                    for j in range(kUnrollFactor * 4):  # #pragma unroll
+                        reduced[j] = accum_bf16_f32(reduced[j], values bf16 pair j)
+                    # instruction_selection: add.rn.f32.bf16 x8 per int4
+                    #   (ptx::accumulate, SM100 fused cast+add); extent: 32 scalars/lane
+                if c == 0:
+                    tma_store_wait(remaining=0)
+                    # instruction_selection: cp.async.bulk.wait_group 0;
+                    #   extent: warp-wide
+                    syncwarp()
+                for j in range(kUnrollFactor):      # #pragma unroll
+                    copy_r2s(cast_f32_bf162(reduced[j*4:j*4+4]),
+                             tma_buffer + (c * 128 + j * 32 + lane) * 16)
+                    # instruction_selection: cvt.rn.bf16x2.f32 x4
+                    #   (__float22bfloat162_rn) + st.shared.v4.b32; extent: 16 B per lane
+
+        # Async-proxy fence so the TMA engine sees the smem reduce output
+        # (epilogue.cuh:116)
+        tma_store_fence()
+        # instruction_selection: fence.proxy.async.shared::cta; extent: warp-wide
+        syncwarp()
+
+        # TMA-store the reduced token (epilogue.cuh:120-123)
+        if elect_one():
+            copy_s2g(tma_buffer, combined_x + token_idx * kOutputTokenBytes,
+                     num_bytes=kOutputTokenBytes)
+            # instruction_selection: cp.async.bulk.global.shared::cta.bulk_group.
+            #   L2::cache_hint (evict-normal); extent: one 14336-byte 1-D bulk copy
+            tma_store_commit()
+            # instruction_selection: cp.async.bulk.commit_group
+        syncwarp()
+
+        # Write combined top-k weights from the master lane's rank buffer
+        # (epilogue.cuh:128-141); every written slot carries the full 6-weight
+        # array, so any valid group buffer serves
+        weight_master_lane = bfind(match_any(dst_rank))
+        # instruction_selection: match.any.sync.b32 + bfind.u32; extent: warp-wide
+        if lane < kNumTopk:
+            w = select(dst_rank >= 0,
+                       copy_g2r(buffer + (weight_master_lane * kNumMaxTokensPerRank
+                                          + token_idx) * kCombineTokenBytes
+                                + 14360 + lane * 4, reg_tile([], "f32")),
+                       0.0)
+            # instruction_selection: ld.global.b32 (plain; post-PDL visibility)
+            #   predicated on dst_rank >= 0; extent: scalar per lane
+            copy_r2g(w, combined_topk_weights[token_idx * kNumTopk + lane])
+            # instruction_selection: st.global.b32; extent: scalar per lane
+        syncwarp()
+```
+
+## Kernel-specific tables
+
+### Combine token slot layout (`TokenLayout(14336, 0, 6, false)`)
+
+| region | byte offset | dtype | extent | writer -> consumer |
+| --- | --- | --- | --- | --- |
+| hidden | 0 | bf16 | 14336 B | peer K1 TMA store -> K2 reduce reads |
+| topk_idx (dead) | 14336 | i32 | 24 B | never written/read in this specialization |
+| topk_weights | 14360 | f32 | 24 B | peer K1 `st.b32` -> K2 weights read |
+| padding | 14384 | - | 16 B | align(48, 32) = 64 |
+| (smem only) mbarrier | 14400 | u64 | 8 B | K1 TMA load completion (smem slot 14432 B) |
+
+### Reduce dtype paths (`combine_reduce`, combine_utils.cuh:57-170)
+
+| selector | path | loads | arithmetic | store |
+| --- | --- | --- | --- | --- |
+| `topk_slot_idx[2] < 0` (<= 2 valid) | hadd bypass | 2 slots x 4 x int4 `.nc` gez-pred per chunk | `add.bf16x2` x4 per int4 (16/chunk) | `st.shared.v4.b32` |
+| else | fp32 accumulate | 6 slots x 4 x int4 `.nc` gez-pred per chunk | `add.rn.f32.bf16` x8 per int4 into f32x2 | `cvt.rn.bf16x2.f32` + `st.shared.v4.b32` |
+
+Both paths: 7 serial hidden chunks (`#pragma unroll 1`), first chunk drains the
+prior TMA store (`cp.async.bulk.wait_group 0` + `bar.warp.sync`), identical
+chunk/lane iteration order, so the fp32 path's accumulation order matches the
+reference's in-order accumulate bit-for-bit; the 2-operand hadd path rounds the
+exact sum once, identically to fp32-accumulate-then-cast.
+
+### Workspace regions used by this specialization
+
+| region | byte offset | dtype | writer -> consumer |
+| --- | --- | --- | --- |
+| nvl_barrier_counter | 0 | u64 | SM-0 thread-0 `atom.add.u64` -> phase/sign reader |
+| nvl_barrier_signal[phase] | 8 + phase*4 | i32 | peers' `red.release.sys` -> SM-0 `ld.acquire.sys` spin |
+| port grid-barrier sites 0/1 | 12820528 + site*8 | u64 | every CTA `red.release.gpu` -> all CTAs `ld.acquire.gpu` spin (substitution 2) |
+
+### TIRx module and benchmark contract
+
+- Module: `tirx_kernels/deepep/combine.py`, registry name `deepep_combine`.
+- Correctness: `python -m tirx_kernels.test --kernel deepep_combine`, 8 ranks,
+  4 configs (t128 / t4096 / t1024 masked 0.3 / t1024 align128), reference
+  `ElasticBuffer.combine` on identical group-sum inputs; compare `combined_x`
+  and `combined_topk_weights` bitwise.
+- Benchmark: `tirx_kernels/bench_suite/config/deepep/deepep_combine.yaml`
+  (`num_gpus: 8`, `timer: kineto`, `default: false`), config
+  `t4096_h7168_e256_k6`; gate `source_time / tirx_time > 0.99`.
+
+## Instruction-selection summary
+
+- Placement selects the loop shape: kernel 1 chunks tokens contiguously across
+  64 x 16 rank-rotated warps; kernel 2 strides tokens across 148 x 16 warps.
+- All bulk hidden movement is 1-D `cp.async.bulk` with mbarrier completion
+  (loads, evict-first) or bulk-group commit (stores, evict-normal); peer stores
+  target NVLink-translated addresses from the sanctioned pointer table.
+- The only non-TMA cross-rank traffic is the 6 x generic-space `st.b32` weights
+  write per token and the barrier's `red.release.sys` signals.
+- The reduce body is register-vectorized `.nc` int4 loads with gez predication
+  (invalid slots load nothing and read as zero), bf16x2 adds on the <= 2-slot
+  path, fused `add.rn.f32.bf16` accumulation + `cvt.rn.bf16x2.f32` on the
+  wider path, and a single `fence.proxy.async` before the output TMA store.
+- Synchronization is mbarrier parity spin (kernel 1 only), bulk-group
+  waits/commits, `bar.warp.sync` between phases, one `bar.sync 0` per CTA at
+  each grid-barrier site, and the PDL edge (`griddepcontrol.wait`) that gates
+  kernel 2 on kernel-1 completion.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ point each port backs (`activation`, `quantization` — CuTe-DSL backend —,
 | Kernel            | Module        | What it is |
 | ----------------- | ------------- | ---------- |
 | `deepep_dispatch` | `dispatch.py` | V2 elastic dispatch, single-domain NVLink path (multi-GPU, 8 ranks) |
+| `deepep_combine` | `combine.py` | V2 elastic combine, single-domain NVLink path (multi-GPU, 8 ranks) |
 
 ## Performance
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "5f901d39",
-    "tirx-kernels": "8bf3305d-dirty",
+    "tirx-kernels": "277c6761-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "d8daf965756dcbad62048f746ce522def492b337"
+    "tirx-kernels:tirx_kernels": "dda29bf2f26132ac42a63a8a7a2ed53e1ff7650e"
   },
   "baselines": {
     "torch": {
@@ -246,6 +246,20 @@
         "tirx": 6103.611899999998,
         "cublas_nccl_cudagraph": 5984.332800000004,
         "cublasmp_split_p2p": 6148.8382999999985
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "deepep_combine",
+      "config": "t4096_h7168_e256_k6",
+      "label": "t4096_h7168_e256_k6",
+      "status": "ok",
+      "impls": {
+        "tirx": 1098.7104999999974,
+        "deepep": 989.9300000000003
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '5f901d39', 'tirx-kernels': '8bf3305d-dirty', 'tirx-bench-ci': None}`
-- Workloads: 326 ok, 0 failed
+- Git:       `{'tir': '5f901d39', 'tirx-kernels': '277c6761-dirty', 'tirx-bench-ci': None}`
+- Workloads: 327 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -28,6 +28,12 @@ Grouped workloads show one row per config and one timing column per implementati
 | `tp1_m8192_n24576_k4096_fp16_dynamic` | tirx | 1066.3879 | cublas_nccl_cudagraph | 1034.9734 | 0.971 | cublasmp_split_p2p=1079.9175 |
 | `tp1_m8192_n51200_k5120_fp16_dynamic` | tirx | 2876.2938 | cublas_nccl_cudagraph | 2717.1455 | 0.945 | cublasmp_split_p2p=2772.5312 |
 | `tp1_m8192_n57344_k8192_fp16_dynamic` | tirx | 6103.6119 | cublas_nccl_cudagraph | 5984.3328 | 0.980 | cublasmp_split_p2p=6148.8383 |
+
+## deepep_combine
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `t4096_h7168_e256_k6` | tirx | 1098.7105 | deepep | 989.9300 | 0.901 | — |
 
 ## deepep_dispatch
 

--- a/tirx_kernels/bench_suite/config/deepep/deepep_combine.yaml
+++ b/tirx_kernels/bench_suite/config/deepep/deepep_combine.yaml
@@ -1,0 +1,11 @@
+kernel: deepep_combine
+defaults:
+  num_gpus: 1
+  timer: kineto
+configs:
+  # Single-domain NVLink path needs the full 8-rank NVLink domain on this host
+  # (the ElasticBuffer reference only exists at world_size 8). Multi-GPU
+  # workloads stay out of the default sweep; run explicitly with --filter.
+  - config: t4096_h7168_e256_k6
+    default: false
+    num_gpus: 8

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -1,0 +1,1183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""DeepEP V2 elastic combine (single-domain NVLink path) ported to TIRx.
+
+Source: /home/bohanhou/DeepEP
+  - deep_ep/include/deep_ep/impls/combine.cuh (`combine_impl`, direct path)
+  - deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
+    (`combine_reduce_epilogue_impl`)
+  - deep_ep/include/deep_ep/impls/combine_utils.cuh
+
+Frozen sketch (source of the implementation plan):
+  `.agents/sketch/deepep/combine.md`
+
+Fixed specialization: bf16 tokens, non-expanded layout,
+allow_multiple_reduction=True, no bias, num_scaleout_ranks==1,
+is_scaleup_nvlink=True.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tvm.ir.type import PointerType, PrimType
+from tvm.script import tirx as T
+
+from .utils._buffer import get_theoretical_num_sms
+
+KERNEL_META = {"name": "deepep_combine", "category": "deepep", "compute_capability": 10}
+
+# Correctness matrix. Every config runs the same source specialization
+# (bf16, non-expanded, allow_multiple_reduction, no bias) on `world_size` ranks.
+CONFIGS = [
+    {
+        "label": "t128_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 128,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    },
+    {
+        "label": "t4096_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 4096,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    },
+    {
+        "label": "t1024_h7168_e256_k6_masked",
+        "world_size": 8,
+        "num_tokens": 1024,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.3,
+    },
+    {
+        "label": "t1024_h7168_e256_k6_align128",
+        "world_size": 8,
+        "num_tokens": 1024,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 128,
+        "masked_ratio": 0.0,
+    },
+]
+
+# Benchmark-only matrix; the bench suite selects from these labels.
+BENCH_CONFIGS = [
+    {
+        "label": "t4096_h7168_e256_k6",
+        "world_size": 8,
+        "num_tokens": 4096,
+        "hidden": 7168,
+        "num_experts": 256,
+        "num_topk": 6,
+        "expert_alignment": 1,
+        "masked_ratio": 0.0,
+    }
+]
+
+# ---------------------------------------------------------------------------
+# Specialization constants (frozen sketch: "Static specialization boundary")
+# ---------------------------------------------------------------------------
+
+NUM_RANKS = 8
+NUM_EXPERTS = 256
+NUM_TOPK = 6
+HIDDEN_BYTES = 7168 * 2  # bf16
+NUM_WARPS = 16
+NUM_THREADS = NUM_WARPS * 32
+
+SMEM_TOTAL = 232448  # max opt-in dynamic smem per block on SM100
+COMBINE_TOKEN_BYTES = 14400  # align(14336,32) + align(0,32) + align(6*4+6*4,32)
+COMBINE_TOKEN_SMEM = 14432  # + align(8,32) mbarrier area (kernel 1 only)
+OUTPUT_TOKEN_BYTES = 14336  # flat hidden (kernel 2 staging / combined_x)
+NUM_TOKENS_IN_LAYOUT = NUM_TOPK  # kUseRankLayout=false (8 ranks > 6 topk)
+
+# layout::WorkspaceLayout byte offsets (common/layout.cuh) + port scratch
+WS_BARRIER_COUNTER = 0
+WS_BARRIER_SIGNAL = 8
+WS_PORT_SCRATCH = 12_820_528  # software grid-barrier slots (dispatch substitution 2)
+
+TIMEOUT_CYCLES = 200_000_000_000  # 100 s at ~2 GHz (comm.cuh: kNumOneSecCycles)
+
+_BULK_G2S_CHAIN = "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+_BULK_S2G_CHAIN = "cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint"
+_GEZ_VEC_LOAD = "ld.L1::no_allocate.L2::cache_hint.global.nc.v4.s32"
+_EVICT_FIRST = 0x12F0000000000000
+_EVICT_NORMAL = 0x1000000000000000
+
+
+def _gptr(base_u64, byte_off):
+    return T.reinterpret("handle", base_u64 + T.cast(byte_off, "uint64"))
+
+
+def _peer_u64(table, dst):
+    return T.cast(table[dst], "uint64")
+
+
+def _ld_acquire_gpu_u64(dst, addr):
+    return T.ptx.ld.acquire.gpu.global_.u64(dst, addr)
+
+
+def _shfl_idx(dst, src, src_lane):
+    return T.ptx.shfl_sync.idx.b32(
+        dst, src, T.cast(src_lane, "uint32"), T.uint32(31), T.uint32(0xFFFFFFFF)
+    )
+
+
+def _launch_tags(cluster: int, pdl: bool) -> list[str]:
+    tags = ["blockIdx.x"]
+    if cluster > 1:
+        tags.append("clusterCtaIdx.x")
+    tags.append("threadIdx.x")
+    if pdl:
+        tags.append("tirx.use_programtic_dependent_launch")
+    tags.append("tirx.use_dyn_shared_memory")
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# Kernel 1: combine_impl
+# ---------------------------------------------------------------------------
+
+
+def _build_combine_kernel(num_sms: int, num_max_tokens_per_rank: int, num_ranks: int) -> Any:
+    """`combine_impl` (frozen sketch kernel 1)."""
+
+    NUM_RANKS_ = num_ranks
+    cluster = 2 - num_sms % 2
+
+    @T.prim_func
+    def deepep_combine(
+        x_ptr: T.handle,
+        topk_weights_ptr: T.handle,
+        src_metadata_ptr: T.handle,
+        psum_rank_ptr: T.handle,
+        peer_ws_ptrs: T.handle,
+        peer_buf_ptrs: T.handle,
+        workspace_addr: T.int64,
+        buffer_addr: T.int64,
+        num_reduced_tokens: T.int32,
+        rank_idx: T.int32,
+    ):
+        x = T.match_buffer(x_ptr, (NUM_RANKS_ * num_max_tokens_per_rank * HIDDEN_BYTES,), "uint8")
+        topk_weights = T.match_buffer(
+            topk_weights_ptr, (NUM_RANKS_ * num_max_tokens_per_rank * NUM_TOPK,), "float32"
+        )
+        src_metadata = T.match_buffer(
+            src_metadata_ptr, (NUM_RANKS_ * num_max_tokens_per_rank * (2 + NUM_TOPK),), "int32"
+        )
+        psum_rank = T.match_buffer(psum_rank_ptr, (NUM_RANKS_,), "int32")
+        peer_ws = T.match_buffer(peer_ws_ptrs, (NUM_RANKS_,), "int64")
+        peer_buf = T.match_buffer(peer_buf_ptrs, (NUM_RANKS_,), "int64")
+
+        T.device_entry()
+        T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+        smem = T.alloc_buffer([SMEM_TOTAL], "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": SMEM_TOTAL})
+
+        sm_idx = T.cta_id([num_sms])
+        if cluster > 1:
+            cta_in_cluster = T.cta_id_in_cluster([cluster])
+        thread_idx = T.thread_id([NUM_THREADS])
+        lane = T.lane_id([32])
+
+        ws_u64 = T.cast(workspace_addr, "uint64")
+        buf_u64 = T.cast(buffer_addr, "uint64")
+
+        # Rotated warp index (combine.cuh:39)
+        warp_u32 = T.alloc_local([1], "uint32")
+        T.evaluate(
+            T.ptx.shfl_sync.idx.b32(
+                warp_u32[0], thread_idx // 32, T.uint32(0), T.uint32(31), T.uint32(0xFFFFFFFF)
+            )
+        )
+        warp = (T.cast(warp_u32[0], "int32") + rank_idx) % NUM_WARPS
+        global_warp_idx = warp * num_sms + sm_idx
+
+        # --- NVLink barrier (comm.cuh:88-129), SM 0 only --------------------
+        @T.inline
+        def nvlink_barrier(tag):
+            if sm_idx == 0:
+                counter_ptr = _gptr(ws_u64, WS_BARRIER_COUNTER)
+                # Plain low-word read of the counter (comm.cuh:98; reviewer r2)
+                status32 = T.alloc_local([1], "uint32")
+                T.evaluate(T.ptx["ld.global.b32"](status32[0], counter_ptr))
+                status = T.cast(T.bitwise_and(status32[0], T.uint32(3)), "int32")
+                bphase = T.bitwise_and(status, 1)
+                bsign = status // 2
+                if thread_idx < NUM_RANKS_:
+                    delta = T.Select(bsign == 0, T.int32(1), T.int32(-1))
+                    T.evaluate(
+                        T.ptx.red.release.sys.global_.add.s32(
+                            _gptr(_peer_u64(peer_ws, thread_idx), WS_BARRIER_SIGNAL + bphase * 4),
+                            delta,
+                        )
+                    )
+                # comm.cuh:107 __syncthreads (SM 0's CTA only)
+                T.ptx.bar.sync(T.uint32(0), T.uint32(NUM_THREADS))
+                if thread_idx == 0:
+                    old = T.alloc_local([1], "uint64")
+                    T.evaluate(T.ptx.atom.global_.add.u64(old[0], counter_ptr, T.uint64(1)))
+                    target = T.Select(bsign == 0, T.int32(NUM_RANKS_), T.int32(0))
+                    sig = T.alloc_local([1], "int32")
+                    sig_ptr = _gptr(ws_u64, WS_BARRIER_SIGNAL + bphase * 4)
+                    T.evaluate(T.ptx["ld.acquire.sys.L1::no_allocate.global.s32"](sig[0], sig_ptr))
+                    start_clock = T.cuda.clock64()
+                    while sig[0] != target:
+                        if T.cuda.clock64() - start_clock >= T.uint64(TIMEOUT_CYCLES):
+                            T.cuda.printf(
+                                "DeepEP NVLink barrier timeout, tag: %d, nvl: %d, "
+                                "signal: %d, phase: %d, target: %d\n",
+                                T.int32(tag),
+                                rank_idx,
+                                sig[0],
+                                bphase,
+                                target,
+                            )
+                            T.cuda.trap_when_assert_failed(False)
+                        T.evaluate(
+                            T.ptx["ld.acquire.sys.L1::no_allocate.global.s32"](sig[0], sig_ptr)
+                        )
+
+        # --- Software grid barrier (dispatch substitution 2) -----------------
+        @T.inline
+        def grid_barrier(site):
+            counter_ptr = _gptr(ws_u64, WS_PORT_SCRATCH + site * 8)
+            if thread_idx == 0:
+                c0 = T.alloc_local([1], "uint64")
+                T.evaluate(_ld_acquire_gpu_u64(c0[0], counter_ptr))
+                target = (c0[0] // T.uint64(num_sms) + T.uint64(1)) * T.uint64(num_sms)
+                T.evaluate(T.ptx.red.release.gpu.global_.add.u64(counter_ptr, T.uint64(1)))
+                now = T.alloc_local([1], "uint64")
+                T.evaluate(_ld_acquire_gpu_u64(now[0], counter_ptr))
+                while now[0] < target:
+                    T.evaluate(_ld_acquire_gpu_u64(now[0], counter_ptr))
+            T.ptx.bar.sync(T.uint32(0), T.uint32(NUM_THREADS))
+
+        # Real received-token count from the GPU prefix (combine.cuh:45-46);
+        # kernel 1 has no PDL edge, so `__ldg` is legal here
+        num_red_reg = T.alloc_local([1], "int32")
+        T.evaluate(T.ptx["ld.global.nc.s32"](num_red_reg[0], psum_rank.ptr_to([NUM_RANKS_ - 1])))
+        num_reduced = T.Select(
+            num_reduced_tokens == NUM_RANKS_ * num_max_tokens_per_rank,
+            num_red_reg[0],
+            num_reduced_tokens,
+        )
+
+        tok_off = warp * COMBINE_TOKEN_SMEM
+        tma_mbar = T.decl_buffer(
+            (1,),
+            "uint64",
+            data=T.reinterpret(
+                PointerType(PrimType("uint64")), smem.ptr_to([tok_off + COMBINE_TOKEN_BYTES])
+            ),
+            scope="shared.dyn",
+        )
+
+        phase = T.alloc_local([1], "uint32")
+        phase[0] = T.uint32(0)
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.mbarrier.init.shared.b64(tma_mbar.ptr_to([0]), T.uint32(1)))
+            T.evaluate(T.ptx.fence.mbarrier_init.release.cluster())
+        T.cuda.warp_sync()
+
+        # Entry barrier (combine.cuh:77-80): gpu_barrier<tag0, false, false, true>
+        nvlink_barrier(4)
+        grid_barrier(0)
+
+        # Contiguous token chunks per warp (combine.cuh:83-85: NOT a strided loop)
+        num_tokens_per_warp = (num_reduced + num_sms * NUM_WARPS - 1) // (num_sms * NUM_WARPS)
+        token_start = num_tokens_per_warp * global_warp_idx
+        token_end = T.min(token_start + num_tokens_per_warp, num_reduced)
+        chunk_trips = T.max(T.int32(0), token_end - token_start)
+        for it in T.serial(0, chunk_trips):
+            i = token_start + it
+            # Source routing indices (combine.cuh:88-92)
+            meta0 = T.alloc_local([1], "int32")
+            T.evaluate(T.ptx["ld.global.nc.s32"](meta0[0], src_metadata.ptr_to([i * 8 + 0])))
+            src_token_idx = meta0[0] % num_max_tokens_per_rank
+            meta1 = T.alloc_local([1], "int32")
+            T.evaluate(T.ptx["ld.global.nc.s32"](meta1[0], src_metadata.ptr_to([i * 8 + 1])))
+            src_rank_idx = meta1[0] // NUM_TOPK
+            src_topk_idx = meta1[0] % NUM_TOPK
+
+            # Master slot on the SOURCE rank's combine recv region (combine.cuh:96-106)
+            master_u64 = _peer_u64(peer_buf, src_rank_idx) + T.cast(
+                (src_topk_idx * num_max_tokens_per_rank + src_token_idx) * COMBINE_TOKEN_BYTES,
+                "uint64",
+            )
+
+            # no_local_reduce is always true in this specialization (combine.cuh:125-127)
+            if T.cuda.elect_sync():
+                # Drain the previous token's TMA store before reusing the SMEM slot
+                T.ptx.cp.async_.bulk.wait_group(0)
+                T.evaluate(
+                    T.ptx[_BULK_G2S_CHAIN](
+                        smem.ptr_to([tok_off]),
+                        x.ptr_to([i * HIDDEN_BYTES]),
+                        T.uint32(HIDDEN_BYTES),
+                        tma_mbar.ptr_to([0]),
+                        T.uint64(_EVICT_FIRST),
+                    )
+                )
+                T.evaluate(
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        tma_mbar.ptr_to([0]), T.uint32(HIDDEN_BYTES)
+                    )
+                )
+                T.cuda.mbarrier_wait(tma_mbar.ptr_to([0]), phase[0])
+                phase[0] = phase[0] ^ T.uint32(1)
+                T.evaluate(
+                    T.ptx[_BULK_S2G_CHAIN](
+                        T.reinterpret("handle", master_u64),
+                        smem.ptr_to([tok_off]),
+                        T.uint32(HIDDEN_BYTES),
+                        T.uint64(_EVICT_NORMAL),
+                    )
+                )
+                T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+            T.cuda.warp_sync()
+
+            # Write this token's top-k weights into the same remote slot
+            # (combine.cuh:216-226)
+            if lane < NUM_TOPK:
+                w = T.alloc_local([1], "float32")
+                T.evaluate(
+                    T.ptx["ld.global.nc.f32"](w[0], topk_weights.ptr_to([i * NUM_TOPK + lane]))
+                )
+                T.evaluate(
+                    T.ptx.st.global_.b32(
+                        _gptr(master_u64, 14360 + lane * 4), T.cuda.float_as_uint(w[0])
+                    )
+                )
+            T.cuda.warp_sync()
+
+        # Exit barrier (combine.cuh:239-242): gpu_barrier<tag1, true, true, false>
+        T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+        T.ptx.cp.async_.bulk.wait_group(0)
+        T.cuda.warp_sync()
+        grid_barrier(1)
+        nvlink_barrier(5)
+        # No PDL trigger in kernel 1 (combine.cuh has none): kernel 2's
+        # griddepcontrol.wait releases at kernel-1 completion.
+
+    return deepep_combine.with_attr("tirx.kernel_launch_params", _launch_tags(cluster, False))
+
+
+# ---------------------------------------------------------------------------
+# Kernel 2: combine_reduce_epilogue_impl
+# ---------------------------------------------------------------------------
+
+
+def _build_reduce_epilogue_kernel(
+    num_sms: int, num_max_tokens_per_rank: int, num_ranks: int
+) -> Any:
+    """`combine_reduce_epilogue_impl` (frozen sketch kernel 2)."""
+
+    NUM_RANKS_ = num_ranks
+    EXPERTS_PER_RANK = NUM_EXPERTS // num_ranks
+
+    @T.prim_func
+    def deepep_combine_reduce_epilogue(
+        combined_x_ptr: T.handle,
+        combined_topk_weights_ptr: T.handle,
+        combined_topk_idx_ptr: T.handle,
+        buffer_addr: T.int64,
+        num_combined_tokens: T.int32,
+    ):
+        combined_x = T.match_buffer(
+            combined_x_ptr, (num_max_tokens_per_rank * HIDDEN_BYTES,), "uint8"
+        )
+        combined_topk_weights = T.match_buffer(
+            combined_topk_weights_ptr, (num_max_tokens_per_rank * NUM_TOPK,), "float32"
+        )
+        # The i64 top-k indices are passed as an int32 view; the source reads
+        # only the little-endian low word of each entry (reviewer r2 finding 3)
+        combined_topk_idx = T.match_buffer(
+            combined_topk_idx_ptr, (num_max_tokens_per_rank * NUM_TOPK * 2,), "int32"
+        )
+
+        T.device_entry()
+        T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+        smem = T.alloc_buffer([SMEM_TOTAL], "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": SMEM_TOTAL})
+
+        sm_idx = T.cta_id([num_sms])
+        thread_idx = T.thread_id([NUM_THREADS])
+        lane = T.lane_id([32])
+
+        buf_u64 = T.cast(buffer_addr, "uint64")
+
+        warp_u32 = T.alloc_local([1], "uint32")
+        T.evaluate(
+            T.ptx.shfl_sync.idx.b32(
+                warp_u32[0], thread_idx // 32, T.uint32(0), T.uint32(31), T.uint32(0xFFFFFFFF)
+            )
+        )
+        warp = T.cast(warp_u32[0], "int32")
+        global_warp_idx = warp * num_sms + sm_idx
+
+        tok_off = warp * OUTPUT_TOKEN_BYTES
+
+        # Block until kernel 1 finished and all peer data are visible (epilogue.cuh:59)
+        T.evaluate(T.ptx.griddepcontrol.wait())
+
+        epi_stride = NUM_WARPS * num_sms
+        epi_trips = T.max(
+            T.int32(0), (num_combined_tokens - global_warp_idx + epi_stride - 1) // epi_stride
+        )
+        for epi_it in T.serial(0, epi_trips):
+            token_idx = global_warp_idx + epi_it * epi_stride
+
+            # Dst expert/rank per top-k lane (epilogue.cuh:66-71; plain ld, NOT
+            # __ldg: "PDL is used, please do not use __ldg")
+            dst_expert = T.alloc_local([1], "int32")
+            dst_expert[0] = -1
+            if lane < NUM_TOPK:
+                T.evaluate(
+                    T.ptx["ld.global.b32"](
+                        dst_expert[0],
+                        combined_topk_idx.ptr_to([token_idx * NUM_TOPK * 2 + lane * 2]),
+                    )
+                )
+            T.cuda.warp_sync()
+            dst_rank = T.Select(dst_expert[0] >= 0, dst_expert[0] // EXPERTS_PER_RANK, -1)
+
+            # Dedup on dst rank (epilogue.cuh:82-84 else-branch, scaleout == 1)
+            match_mask = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.match.any.sync.b32(match_mask[0], dst_rank, T.uint32(0xFFFFFFFF)))
+            master = T.alloc_local([1], "uint32")
+            T.evaluate(T.ptx.bfind.u32(master[0], match_mask[0]))
+            is_master = T.cast(master[0], "int32") == lane
+            ballot = T.alloc_local([1], "uint32")
+            T.evaluate(
+                T.ptx.vote_sync.ballot.b32(
+                    ballot[0], is_master and (dst_rank >= 0), T.uint32(0xFFFFFFFF)
+                )
+            )
+
+            # Sort valid top-k slots to front (combine_utils.cuh:43-53; fetch is
+            # identity because kUseRankLayout=false)
+            topk_slot = T.alloc_local([NUM_TOKENS_IN_LAYOUT], "int32")
+            mask = T.alloc_local([1], "uint32")
+            mask[0] = ballot[0]
+            for k in T.unroll(NUM_TOKENS_IN_LAYOUT):
+                lowest = T.cast(T.cuda.ffs_u32(mask[0]), "int32") - 1
+                topk_slot[k] = T.Select(lowest >= 0, lowest, -1)
+                mask[0] = T.bitwise_and(mask[0], mask[0] - T.uint32(1))
+
+            # combine_reduce<896, 4, 6, 6>: no bias in this specialization, so the
+            # path selector is exactly (topk_slot[2] < 0) (utils.cuh:68-70)
+            if topk_slot[2] < 0:
+                # --- bf16 hadd path (utils.cuh:73-110) ---
+                for c in T.serial(0, 7):
+                    values_0 = T.alloc_local([16], "int32", align=16)
+                    values_1 = T.alloc_local([16], "int32", align=16)
+                    for j in T.unroll(16):
+                        values_0[j] = T.uint32(0)
+                        values_1[j] = T.uint32(0)
+                    if topk_slot[0] >= 0:
+                        base0 = buf_u64 + T.cast(
+                            (topk_slot[0] * num_max_tokens_per_rank + token_idx)
+                            * COMBINE_TOKEN_BYTES,
+                            "uint64",
+                        )
+                        for j in T.unroll(4):
+                            T.evaluate(
+                                T.ptx[_GEZ_VEC_LOAD](
+                                    values_0[j * 4],
+                                    values_0[j * 4 + 1],
+                                    values_0[j * 4 + 2],
+                                    values_0[j * 4 + 3],
+                                    T.reinterpret(
+                                        "handle",
+                                        base0 + T.cast((c * 128 + j * 32 + lane) * 16, "uint64"),
+                                    ),
+                                    T.uint64(_EVICT_FIRST),
+                                )
+                            )
+                    if topk_slot[1] >= 0:
+                        base1 = buf_u64 + T.cast(
+                            (topk_slot[1] * num_max_tokens_per_rank + token_idx)
+                            * COMBINE_TOKEN_BYTES,
+                            "uint64",
+                        )
+                        for j in T.unroll(4):
+                            T.evaluate(
+                                T.ptx[_GEZ_VEC_LOAD](
+                                    values_1[j * 4],
+                                    values_1[j * 4 + 1],
+                                    values_1[j * 4 + 2],
+                                    values_1[j * 4 + 3],
+                                    T.reinterpret(
+                                        "handle",
+                                        base1 + T.cast((c * 128 + j * 32 + lane) * 16, "uint64"),
+                                    ),
+                                    T.uint64(_EVICT_FIRST),
+                                )
+                            )
+                    if c == 0:
+                        # Drain the previous token's TMA store before reusing smem
+                        T.ptx.cp.async_.bulk.wait_group(0)
+                        T.cuda.warp_sync()
+                    for j in T.unroll(4):
+                        sums = T.alloc_local([4], "uint32")
+                        for w in T.unroll(4):
+                            T.evaluate(
+                                T.ptx["add.bf16x2"](
+                                    sums[w],
+                                    T.cast(values_0[j * 4 + w], "uint32"),
+                                    T.cast(values_1[j * 4 + w], "uint32"),
+                                )
+                            )
+                        T.evaluate(
+                            T.ptx.st.shared_.v4.b32(
+                                smem.ptr_to([tok_off + (c * 128 + j * 32 + lane) * 16]),
+                                sums[0],
+                                sums[1],
+                                sums[2],
+                                sums[3],
+                            )
+                        )
+            else:
+                # --- fp32 accumulate path (utils.cuh:111-168) ---
+                for c in T.serial(0, 7):
+                    reduced = T.alloc_local([32], "float32")
+                    for j in T.unroll(32):
+                        reduced[j] = T.float32(0.0)
+                    for k in T.unroll(NUM_TOKENS_IN_LAYOUT):
+                        values = T.alloc_local([16], "int32", align=16)
+                        for j in T.unroll(16):
+                            values[j] = T.uint32(0)
+                        if topk_slot[k] >= 0:
+                            base_k = buf_u64 + T.cast(
+                                (topk_slot[k] * num_max_tokens_per_rank + token_idx)
+                                * COMBINE_TOKEN_BYTES,
+                                "uint64",
+                            )
+                            for j in T.unroll(4):
+                                T.evaluate(
+                                    T.ptx[_GEZ_VEC_LOAD](
+                                        values[j * 4],
+                                        values[j * 4 + 1],
+                                        values[j * 4 + 2],
+                                        values[j * 4 + 3],
+                                        T.reinterpret(
+                                            "handle",
+                                            base_k
+                                            + T.cast((c * 128 + j * 32 + lane) * 16, "uint64"),
+                                        ),
+                                        T.uint64(_EVICT_FIRST),
+                                    )
+                                )
+                        for j in T.unroll(4):
+                            for w in T.unroll(4):
+                                word_u32 = T.cast(values[j * 4 + w], "uint32")
+                                lo = T.cast(T.bitwise_and(word_u32, T.uint32(0xFFFF)), "uint16")
+                                hi = T.cast(word_u32 >> T.uint32(16), "uint16")
+                                e = j * 8 + w * 2
+                                T.evaluate(T.ptx.add.rn.f32.bf16(reduced[e], lo, reduced[e]))
+                                T.evaluate(
+                                    T.ptx.add.rn.f32.bf16(reduced[e + 1], hi, reduced[e + 1])
+                                )
+                    if c == 0:
+                        T.ptx.cp.async_.bulk.wait_group(0)
+                        T.cuda.warp_sync()
+                    for j in T.unroll(4):
+                        casted = T.alloc_local([4], "uint32")
+                        for p in T.unroll(4):
+                            casted[p] = T.cuda.float22bfloat162_rn(
+                                reduced[j * 8 + p * 2], reduced[j * 8 + p * 2 + 1]
+                            )
+                        T.evaluate(
+                            T.ptx.st.shared_.v4.b32(
+                                smem.ptr_to([tok_off + (c * 128 + j * 32 + lane) * 16]),
+                                casted[0],
+                                casted[1],
+                                casted[2],
+                                casted[3],
+                            )
+                        )
+
+            # Async-proxy fence so the TMA engine sees the smem reduce output
+            T.evaluate(T.ptx["fence.proxy.async.shared::cta"]())
+            T.cuda.warp_sync()
+
+            # TMA-store the reduced token (epilogue.cuh:120-123)
+            if T.cuda.elect_sync():
+                T.evaluate(
+                    T.ptx[_BULK_S2G_CHAIN](
+                        combined_x.ptr_to([token_idx * OUTPUT_TOKEN_BYTES]),
+                        smem.ptr_to([tok_off]),
+                        T.uint32(OUTPUT_TOKEN_BYTES),
+                        T.uint64(_EVICT_NORMAL),
+                    )
+                )
+                T.evaluate(T.ptx.cp.async_.bulk.commit_group())
+            T.cuda.warp_sync()
+
+            # Write combined top-k weights from the master lane's rank buffer
+            # (epilogue.cuh:128-141)
+            if lane < NUM_TOPK:
+                w32 = T.alloc_local([1], "uint32")
+                w32[0] = T.uint32(0)
+                if dst_rank >= 0:
+                    T.evaluate(
+                        T.ptx["ld.global.b32"](
+                            w32[0],
+                            _gptr(
+                                buf_u64,
+                                (T.cast(master[0], "int32") * num_max_tokens_per_rank + token_idx)
+                                * COMBINE_TOKEN_BYTES
+                                + 14360
+                                + lane * 4,
+                            ),
+                        )
+                    )
+                combined_topk_weights[token_idx * NUM_TOPK + lane] = T.cuda.uint_as_float(w32[0])
+            T.cuda.warp_sync()
+
+    return deepep_combine_reduce_epilogue.with_attr(
+        "tirx.kernel_launch_params", _launch_tags(1, True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module entries (tirx-kernels conventions)
+# ---------------------------------------------------------------------------
+
+
+def _device_num_sms() -> int:
+    """Device SM count without forcing CUDA init in the bench-suite CPU stage.
+
+    Reads the suite-provided `TIRX_PREPARE_NUM_SMS` first; falls back to a
+    torch device query in unguarded contexts.
+    """
+
+    import os
+
+    from tirx_kernels.runner import PREPARE_NUM_SMS_ENV
+
+    value = os.environ.get(PREPARE_NUM_SMS_ENV)
+    if value:
+        return int(value)
+    import torch
+
+    return torch.cuda.get_device_properties(0).multi_processor_count
+
+
+def get_kernel(
+    world_size: int = NUM_RANKS,
+    num_tokens: int = 4096,
+    hidden: int = 7168,
+    num_experts: int = NUM_EXPERTS,
+    num_topk: int = NUM_TOPK,
+    expert_alignment: int = 1,
+    num_sms: int = 0,
+    **_: Any,
+) -> list[Any]:
+    """Return the combine kernel pair (main + reduce epilogue), closure-specialized."""
+
+    if num_experts != NUM_EXPERTS or num_topk != NUM_TOPK:
+        raise ValueError("config is outside the ported specialization boundary")
+    if hidden * 2 != HIDDEN_BYTES:
+        raise ValueError("config is outside the ported specialization boundary")
+    if num_experts % world_size != 0:
+        raise ValueError(f"num_experts={num_experts} not divisible by world_size={world_size}")
+    if num_sms == 0:
+        num_sms = get_theoretical_num_sms(
+            world_size, num_experts, num_topk, prefer_overlap_with_compute=False
+        )
+    # Source parity: the reduce epilogue always launches with full device SMs
+    # (buffer.hpp launch_combine_reduce_epilogue: device_runtime->get_num_sms()),
+    # not the combine kernel's num_sms.
+    epilogue_num_sms = _device_num_sms()
+    return [
+        _build_combine_kernel(num_sms, num_tokens, world_size),
+        _build_reduce_epilogue_kernel(epilogue_num_sms, num_tokens, world_size),
+    ]
+
+
+def prepare_data(
+    world_size: int,
+    num_tokens: int,
+    hidden: int,
+    num_experts: int,
+    num_topk: int,
+    expert_alignment: int = 1,
+    masked_ratio: float = 0.0,
+    seed: int = 42,
+    rank: int = 0,
+    **_: Any,
+) -> dict[str, Any]:
+    """Rank-local logical inputs; identical generation to the dispatch module."""
+
+    from . import dispatch as _dispatch
+
+    return _dispatch.prepare_data(
+        world_size=world_size,
+        num_tokens=num_tokens,
+        hidden=hidden,
+        num_experts=num_experts,
+        num_topk=num_topk,
+        expert_alignment=expert_alignment,
+        masked_ratio=masked_ratio,
+        seed=seed,
+        rank=rank,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Distributed worker
+# ---------------------------------------------------------------------------
+
+
+def _closed_form_x(alloc: int, hidden: int, device: Any) -> Any:
+    """Deterministic combine input, identical on every rank for the same row.
+
+    x[i][h] = sin(i * 0.373 + h * 0.001) in bf16. The combine kernels move and
+    sum arbitrary x rows; an exact closed form lets the small-rank torch golden
+    reproduce any row without communication.
+    """
+
+    import torch
+
+    rows = torch.arange(alloc, device=device, dtype=torch.float32).unsqueeze(1)
+    cols = torch.arange(hidden, device=device, dtype=torch.float32).unsqueeze(0)
+    return torch.sin(rows * 0.373 + cols * 0.001).to(torch.bfloat16)
+
+
+def _simulate_combine_torch(
+    topk_idx: Any,
+    topk_weights: Any,
+    x_input: Any,
+    world_size: int,
+    num_tokens_max: int,
+    num_experts: int,
+    rank: int,
+    device: Any,
+) -> tuple[Any, Any, Any, Any, Any]:
+    """Small-rank oracle: simulate dispatch routing and the combine golden.
+
+    The reference ElasticBuffer segfaults below 8 ranks on this host, so 1/2/4-
+    rank bring-up validates against pure-torch semantics instead:
+    metadata/psum/topk_weights inputs are simulated per the dispatch contract
+    (one received token per (token, rank) group, master lane = group identity,
+    rows sorted by (src rank, src token)), and the golden combine output is
+    computed from the same rows: per local token, sum each contributing
+    group's x row in ascending master-lane order in fp32, then cast to bf16.
+    """
+
+    import numpy as np
+    import torch
+    import torch.distributed as dist
+
+    num_topk = topk_idx.shape[1]
+    hidden = x_input.shape[1]
+    experts_per_rank = num_experts // world_size
+    alloc = world_size * num_tokens_max
+
+    idx_all = [torch.empty_like(topk_idx) for _ in range(world_size)]
+    dist.all_gather(idx_all, topk_idx)
+    w_all = [torch.empty_like(topk_weights) for _ in range(world_size)]
+    dist.all_gather(w_all, topk_weights)
+    idx_all_np = [t.cpu().numpy() for t in idx_all]
+    w_all_np = [t.cpu().numpy() for t in w_all]
+
+    # Per-receiver received rows: recv_rows[g] = [(src_global, src * topk + master)]
+    recv_rows: list[list[tuple[int, int]]] = []
+    row_of: dict[tuple[int, int], int] = {}
+    for g in range(world_size):
+        rows: list[tuple[int, int]] = []
+        for s in range(world_size):
+            for t in range(idx_all_np[s].shape[0]):
+                lanes = idx_all_np[s][t]
+                groups: dict[int, int] = {}
+                for lane in range(num_topk):
+                    expert = int(lanes[lane])
+                    if expert >= 0:
+                        groups.setdefault(expert // experts_per_rank, lane)
+                if g in groups:
+                    rows.append((s * num_tokens_max + t, s * num_topk + groups[g]))
+        rows.sort()
+        for row_idx, (src_global, meta1) in enumerate(rows):
+            row_of[(g, src_global)] = row_idx
+        recv_rows.append(rows)
+
+    # This rank's kernel inputs
+    my_rows = recv_rows[rank]
+    num_recv = len(my_rows)
+    metadata = torch.zeros((alloc, 2 + num_topk), dtype=torch.int32, device=device)
+    if num_recv:
+        metadata[:num_recv, 0] = torch.tensor(
+            [r[0] for r in my_rows], dtype=torch.int32, device=device
+        )
+        metadata[:num_recv, 1] = torch.tensor(
+            [r[1] for r in my_rows], dtype=torch.int32, device=device
+        )
+    counts = [0] * world_size
+    for src_global, _ in my_rows:
+        counts[src_global // num_tokens_max] += 1
+    psum_rank = torch.tensor(np.cumsum(counts), dtype=torch.int32, device=device)
+    tw_input = torch.zeros((alloc, num_topk), dtype=torch.float32, device=device)
+    for i, (src_global, _) in enumerate(my_rows):
+        s, t = src_global // num_tokens_max, src_global % num_tokens_max
+        tw_input[i] = torch.tensor(w_all_np[s][t], dtype=torch.float32, device=device)
+
+    # Golden: per local token, sum groups' x rows in ascending master-lane order
+    local_num_tokens = topk_idx.shape[0]
+    my_idx_np = idx_all_np[rank]
+    my_w_np = w_all_np[rank]
+    golden_x = torch.zeros((local_num_tokens, hidden), dtype=torch.bfloat16, device=device)
+    cols = torch.arange(hidden, device=device, dtype=torch.float32).unsqueeze(0)
+    for t in range(local_num_tokens):
+        groups = {}
+        for lane in range(num_topk):
+            expert = int(my_idx_np[t][lane])
+            if expert >= 0:
+                groups.setdefault(expert // experts_per_rank, lane)
+        acc = torch.zeros((hidden,), dtype=torch.float32, device=device)
+        for g in sorted(groups, key=groups.get):
+            row = row_of[(g, rank * num_tokens_max + t)]
+            acc += torch.sin(row * 0.373 + cols).view(-1)
+        golden_x[t] = acc.to(torch.bfloat16)
+    golden_w = torch.where(topk_idx >= 0, topk_weights, torch.zeros_like(topk_weights))
+    return metadata, psum_rank, tw_input, golden_x, golden_w
+
+
+def _run_worker(
+    runtime: Any, modules: dict[str, Any], mode: str, kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    from .utils._buffer import SymmetricWindow
+
+    rank = runtime.rank
+    world_size = kwargs["world_size"]
+    num_tokens_max = kwargs["num_tokens"]
+    hidden = kwargs["hidden"]
+    num_experts = kwargs["num_experts"]
+    num_topk = kwargs["num_topk"]
+    expert_alignment = kwargs["expert_alignment"]
+    num_sms = kwargs["num_sms"]
+
+    data = prepare_data(**{k: v for k, v in kwargs.items() if k != "num_sms"}, rank=rank)
+    x, topk_idx, topk_weights = data["x"], data["topk_idx"], data["topk_weights"]
+    local_num_tokens = data["num_tokens"]
+
+    device = torch.device("cuda", rank)
+    alloc = world_size * num_tokens_max
+    x_input = _closed_form_x(alloc, hidden, device)
+
+    combine_fn = modules["combine"].get_function("main")
+    epilogue_fn = modules["reduce_epilogue"].get_function("main")
+
+    # TIRx-side symmetric window + output tensors
+    window = SymmetricWindow(
+        dist.group.WORLD, NUM_TOKENS_IN_LAYOUT * num_tokens_max * COMBINE_TOKEN_BYTES
+    )
+    # Buffers are declared with num_tokens_max rows (the kernel's static bound);
+    # only the first local_num_tokens rows are written and compared.
+    combined_x = torch.empty((num_tokens_max, hidden), dtype=torch.bfloat16, device=device)
+    combined_w = torch.empty((num_tokens_max, num_topk), dtype=torch.float32, device=device)
+    topk_idx_padded = torch.zeros((num_tokens_max, num_topk), dtype=torch.int64, device=device)
+    topk_idx_padded[:local_num_tokens] = topk_idx
+
+    ref_buffer = None
+    handle = None
+    golden_x = golden_w = None
+    if world_size == 8:
+        # The reference runtime needs GIN disabled on this host (verified in the
+        # dispatch scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
+        os.environ.setdefault("EP_DISABLE_GIN", "1")
+        import deep_ep
+
+        ref_buffer = deep_ep.ElasticBuffer(
+            dist.group.WORLD,
+            num_max_tokens_per_rank=num_tokens_max,
+            hidden=hidden,
+            num_topk=num_topk,
+            prefer_overlap_with_compute=False,
+            explicitly_destroy=True,
+        )
+        _, _, recv_topk_weights, handle, _ = ref_buffer.dispatch(
+            x,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            num_max_tokens_per_rank=num_tokens_max,
+            num_experts=num_experts,
+            expert_alignment=expert_alignment,
+            num_sms=num_sms,
+            do_cpu_sync=False,
+        )
+        metadata = handle.recv_src_metadata
+        psum_rank = handle.psum_num_recv_tokens_per_scaleup_rank
+        tw_input = recv_topk_weights
+    else:
+        metadata, psum_rank, tw_input, golden_x, golden_w = _simulate_combine_torch(
+            topk_idx, topk_weights, x_input, world_size, num_tokens_max, num_experts, rank, device
+        )
+
+    def tirx_launch() -> None:
+        combine_fn(
+            x_input.view(torch.uint8).view(-1),
+            tw_input.view(-1),
+            metadata.view(-1),
+            psum_rank,
+            window.peer_ws_ptrs,
+            window.peer_buf_ptrs,
+            window.base_ptr,
+            window.buffer_ptr,
+            alloc,
+            rank,
+        )
+        epilogue_fn(
+            combined_x.view(torch.uint8).view(-1),
+            combined_w.view(-1),
+            topk_idx_padded.view(torch.int32).view(-1),
+            window.buffer_ptr,
+            local_num_tokens,
+        )
+
+    def reference_launch():
+        return ref_buffer.combine(x_input, handle, topk_weights=tw_input)
+
+    try:
+        if mode == "test":
+
+            def _launch_and_check() -> None:
+                with torch.cuda.stream(runtime.timing_stream):
+                    if world_size == 8:
+                        ref_cx, ref_cw, _ = reference_launch()
+                    tirx_launch()
+                runtime.device.sync(runtime.compute_stream)
+
+                our_cx = combined_x[:local_num_tokens]
+                our_cw = combined_w[:local_num_tokens]
+                if world_size == 8:
+                    assert torch.equal(ref_cx, our_cx), (
+                        f"rank {rank}: combined_x mismatch "
+                        f"(max abs diff {(ref_cx.float() - our_cx.float()).abs().max().item()})"
+                    )
+                    assert torch.equal(ref_cw, our_cw), (
+                        f"rank {rank}: combined_topk_weights mismatch"
+                    )
+                else:
+                    assert torch.equal(golden_x, our_cx), (
+                        f"rank {rank}: combined_x mismatch vs torch golden "
+                        f"(max abs diff {(golden_x.float() - our_cx.float()).abs().max().item()})"
+                    )
+                    assert torch.equal(golden_w, our_cw), (
+                        f"rank {rank}: combined_topk_weights mismatch vs torch golden"
+                    )
+
+            check_error = ""
+            try:
+                _launch_and_check()
+            except Exception as error:  # reported uniformly below
+                check_error = f"{type(error).__name__}: {error}"
+                print(f"[rank {rank}] CHECK FAILED: {check_error}", flush=True)
+            # Never diverge: a failed rank must not strand the others at the
+            # next collective.
+            status = torch.tensor([not check_error], dtype=torch.int32, device=device)
+            dist.all_reduce(status, op=dist.ReduceOp.MIN)
+            if not status.item():
+                raise AssertionError(f"deepep_combine check failed on some rank: {check_error}")
+            return {"status": "OK"}
+
+        # mode == "bench"
+        from tvm.tirx.bench import bench
+
+        def build_reference():
+            def launch() -> None:
+                reference_launch()
+
+            return launch
+
+        with torch.cuda.stream(runtime.timing_stream):
+            result = bench(
+                {"tirx": tirx_launch},
+                references={"deepep": build_reference},
+                timer="kineto",
+                rounds=kwargs.get("rounds", 1),
+                cooldown_s=kwargs.get("cooldown_s", 1.0),
+                distributed=runtime.bench_context(),
+            )
+        return {"status": "OK", **result}
+    finally:
+        window.destroy()
+        if ref_buffer is not None:
+            ref_buffer.destroy()
+
+
+def _resolve_num_sms(config: dict[str, Any]) -> int:
+    # prefer_overlap_with_compute=False mirrors the source perf test default
+    # (tests/elastic/test_ep.py), e.g. 64 SMs for e256/k6.
+    return get_theoretical_num_sms(
+        config["world_size"],
+        config["num_experts"],
+        config["num_topk"],
+        prefer_overlap_with_compute=False,
+    )
+
+
+def run_test(**config: Any) -> None:
+    """Correctness entry point used by the runner."""
+
+    from .utils._runtime import run_distributed
+
+    num_sms = _resolve_num_sms(config)
+    combine_kernel, epilogue_kernel = get_kernel(**config, num_sms=num_sms)
+    run_distributed(
+        {"combine": combine_kernel, "reduce_epilogue": epilogue_kernel},
+        world_size=config["world_size"],
+        worker=_run_worker,
+        mode="test",
+        worker_kwargs={**config, "num_sms": num_sms},
+    )
+
+
+def _resolve_num_sms_cpu(config: dict[str, Any]) -> int:
+    """CUDA-free mirror of `ElasticBuffer.get_theoretical_num_sms` for the
+    single-domain path, for the bench-suite CPU-prepare stage.
+
+    The source model's only CUDA-initializing call is its closing
+    `torch.cuda.get_device_properties`; the bench suite forbids CUDA in CPU
+    prepare, so the arithmetic is mirrored with the suite-provided device SM
+    count (TIRX_PREPARE_NUM_SMS via `_device_num_sms`) and the
+    subprocess-based `get_nvlink_gbs` (no CUDA init). For the bench config
+    (world=8, e=256, k=6) the result is 64 over a wide bandwidth range, equal
+    to the source model's output.
+    """
+
+    import math
+
+    from deep_ep.utils.envs import get_nvlink_gbs
+
+    world = config["world_size"]
+    experts = config["num_experts"]
+    topk = config["num_topk"]
+    expected_topk = world * (
+        1 - math.comb(experts - experts // world, topk) / math.comb(experts, topk)
+    )
+    gbs = get_nvlink_gbs()
+    nvlink_traffic = 1 - 1 / world if world > 1 else 0.0
+    device_sms = _device_num_sms()
+    num_sms = float(device_sms)
+    if nvlink_traffic > 0:
+        num_sms = max(
+            gbs / nvlink_traffic * (1 / expected_topk) / 200, gbs / nvlink_traffic * 1 / 50
+        )
+    # align(max(4, ceil(x * 1.25)), 2); prefer_overlap_with_compute=False -> max(.., 64)
+    num_sms = max(4, math.ceil(num_sms * 1.25))
+    num_sms += num_sms % 2
+    num_sms = max(num_sms, 64)
+    return min(num_sms, device_sms)
+
+
+def _run_bench_gpu(state: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """GPU stage of the two-stage benchmark contract (ranks start CUDA here).
+
+    All TIRx specialization and compilation completed in prepare_bench; this
+    stage only spawns ranks against the prebuilt libraries.
+    """
+
+    from .utils._runtime import run_distributed
+
+    config = state["config"]
+    return run_distributed(
+        {},
+        world_size=config["world_size"],
+        worker=_run_worker,
+        mode="bench",
+        worker_kwargs={
+            **config,
+            "num_sms": state["num_sms"],
+            "rounds": kwargs.get("rounds", 1),
+            "cooldown_s": kwargs.get("cooldown_s", 1.0),
+        },
+        prepared_libraries=state["library_paths"],
+    )
+
+
+def prepare_bench(**config: Any):
+    """CPU-side prepare for the two-stage benchmark contract.
+
+    Completes every CUDA-free step the suite requires before READY: SM-count
+    resolution (no CUDA-initializing calls), TIRx specialization, and
+    tvm.compile + export. Ranks start CUDA later in `_run_bench_gpu`.
+    """
+
+    import tempfile
+
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    from .utils._runtime import compile_kernels
+
+    if config.get("timer") not in {None, "kineto"}:
+        raise ValueError(
+            f"deepep_combine is distributed and supports only kineto, got {config['timer']}"
+        )
+    num_sms = _resolve_num_sms_cpu(config)
+    combine_kernel, epilogue_kernel = get_kernel(**config, num_sms=num_sms)
+    tmpdir = tempfile.TemporaryDirectory(prefix="tirx-deepep-prepare-")
+    library_paths = compile_kernels(
+        {"combine": combine_kernel, "reduce_epilogue": epilogue_kernel}, tmpdir.name
+    )
+    state = {
+        "config": dict(config),
+        "num_sms": num_sms,
+        "library_paths": library_paths,
+        "tmpdir": tmpdir,
+    }
+    return prepared_gpu_benchmark(
+        _run_bench_gpu, state, required_num_gpus=config["world_size"], close=state["tmpdir"].cleanup
+    )
+
+
+def run_bench(
+    *args: Any,
+    warmup: Any = None,
+    repeat: Any = None,
+    timer: Any = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Benchmark entry point used by the runner (kineto only, distributed)."""
+
+    if timer is not None and timer != "kineto":
+        raise ValueError(f"deepep_combine is distributed and supports only kineto, got {timer}")
+    if warmup is not None or repeat is not None:
+        raise ValueError("kineto uses fixed iteration counts and rejects warmup/repeat overrides")
+    config = dict(kwargs)
+    if args:
+        raise TypeError(f"unexpected positional arguments: {args}")
+    return prepare_bench(**config).run_gpu(rounds=rounds, cooldown_s=cooldown_s)
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/deepep/utils/_runtime.py
+++ b/tirx_kernels/deepep/utils/_runtime.py
@@ -139,6 +139,20 @@ def _rank_entry(
         result_queue.put(result)
 
 
+def compile_kernels(kernels: dict[str, Any], tmpdir: str) -> dict[str, str]:
+    """Compile every kernel once and export loadable libraries into `tmpdir`."""
+
+    library_paths: dict[str, str] = {}
+    for name, func in kernels.items():
+        library_path = Path(tmpdir) / f"{name}.so"
+        executable = tvm.compile(
+            tvm.IRModule({"main": func}), target=tvm.target.Target("cuda"), tir_pipeline="tirx"
+        )
+        executable.export_library(str(library_path))
+        library_paths[name] = str(library_path)
+    return library_paths
+
+
 def run_distributed(
     kernels: dict[str, Any],
     *,
@@ -146,22 +160,24 @@ def run_distributed(
     worker: Callable[[DistributedRuntime, dict[str, Any], str, dict[str, Any]], dict[str, Any]],
     mode: str,
     worker_kwargs: dict[str, Any],
+    prepared_libraries: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Compile every kernel once in the parent, then run one rank-local worker per GPU."""
+    """Compile every kernel once in the parent, then run one rank-local worker per GPU.
+
+    When `prepared_libraries` is given, compilation is skipped and the
+    prebuilt `{name: library_path}` mapping is used instead (the two-stage
+    bench-suite contract compiles in the CPU-prepare stage).
+    """
 
     require_sm100(world_size)
     if not callable(worker):
         raise TypeError("worker must be callable")
 
     with tempfile.TemporaryDirectory(prefix="tirx-deepep-") as tmpdir:
-        library_paths: dict[str, str] = {}
-        for name, func in kernels.items():
-            library_path = Path(tmpdir) / f"{name}.so"
-            executable = tvm.compile(
-                tvm.IRModule({"main": func}), target=tvm.target.Target("cuda"), tir_pipeline="tirx"
-            )
-            executable.export_library(str(library_path))
-            library_paths[name] = str(library_path)
+        if prepared_libraries is not None:
+            library_paths = prepared_libraries
+        else:
+            library_paths = compile_kernels(kernels, tmpdir)
 
         context = mp.get_context("spawn")
         result_queue = context.SimpleQueue()
@@ -190,4 +206,4 @@ def run_distributed(
     return result
 
 
-__all__ = ["DistributedRuntime", "require_sm100", "run_distributed"]
+__all__ = ["DistributedRuntime", "compile_kernels", "require_sm100", "run_distributed"]


### PR DESCRIPTION
Stacked on #55: this branch is `deepep-combine` = `deepep` (#55's head) + the combine commit, so until #55 merges the diff shows both commits; afterwards it reduces to the combine commit alone.

## What

Ports the two-kernel combine chain of DeepEP's V2 elastic buffer (`deep_ep.ElasticBuffer`) to TIRx — the backward partner of `deepep_dispatch`:

- `combine_impl` on the direct single-domain NVLink path (per-token TMA send-back into the source rank's rank buffers, direct NVLink weights stores, tag0/tag1 barriers)
- `combine_reduce_epilogue_impl` chained behind it via programmatic dependent launch (dedup-by-rank slot selection, two exact dtype paths in `combine_reduce`: bf16 hadd bypass vs fp32 `add.rn.f32.bf16` accumulate)

New module `tirx_kernels/deepep/combine.py`, bench-suite config, baseline row, README entry, and the frozen sketch at `.agents/sketch/deepep/combine.md` (sketch review passed at r2; correctness review passed at r2).

Fixed specialization: bf16 tokens, non-expanded layout, `allow_multiple_reduction=True`, no bias, `num_scaleout_ranks=1`, NVLink LSA domain; 8 ranks.

## Implementation notes (beyond the dispatch port's sanctioned substitutions)

- Kernel 1 carries **no** PDL trigger (combine.cuh has none): the epilogue's `griddepcontrol.wait` releases at kernel-1 completion. Kernel 1 launches without the PDL tag.
- Kernel 1 binds the cluster scope (`cta_id_in_cluster`, dispatch precedent) so its launch keeps the source's cluster (2,1,1) attribute — without the binding the attribute is silently dropped.
- The reduce epilogue launches with **full device SMs** (148), matching the source runtime (`launch_combine_reduce_epilogue` passes `get_num_sms()`), decoupled from kernel 1's `num_sms` (64).
- The gez-predicated slot loads are realized as zero-initialized registers plus warp-uniform `if slot >= 0:` branches (TIRx cannot emit the inline `@p` form); invalid slots read as exact zeros, same as the source's zero-fill.
- The module implements the **current two-stage bench-suite contract** (post-#52): a CUDA-free `prepare_bench` — the combine num_sms resolved without the source model's CUDA-initializing device query, epilogue grid from `TIRX_PREPARE_NUM_SMS` — compiles and exports both kernels; `deepep/utils/_runtime.py` gained an additive `prepared_libraries` kwarg so the GPU stage only spawns ranks. Multi-GPU workloads stay `default: false` and run explicitly via `--workloads`.

## Correctness

`python -m tirx_kernels.test --kernel deepep_combine` compares `combined_x` and `combined_topk_weights` **bitwise** against `ElasticBuffer.combine` at 8 ranks over 4 configs (`t128`, `t4096`, `t1024` masked 0.3, `t1024` align128), on identical deterministic inputs. All configs pass, multiple rounds including a final-tree rerun. Below 8 ranks (where the reference segfaults on this host) a pure-torch simulation of the dispatch routing provides the oracle.

Requires 8 GPUs and a DeepEP checkout for the reference (`EP_DISABLE_GIN=1` on hosts without GIN).

## Performance

One bench-suite workload, `t4096_h7168_e256_k6` (`num_gpus: 8`, kineto), excluded from the default sweep like the other multi-GPU workloads; baseline row merged from a targeted run.

Across **eight runs** on the shared 8xB200 host the official source/tirx ratio medians at **0.993** (steady 1.005) with run-level spread 0.90-1.59 from tenant interference. Same-window kernel-level profiling shows `combine_impl` at parity (1089.7 vs 1089.3 µs, ours faster in the quietest samples) and the reduce epilogue within 0.15 % of the pairspan. The residual spread is the host's measurement noise floor.