### PR TITLE
fix(kernel): add DeepEP upstream attribution to the deepep port headers

### DIFF
--- a/.agents/sketch/deepep/combine.md
+++ b/.agents/sketch/deepep/combine.md
@@ -1,23 +1,10 @@
 <!--
-Copyright (c) 2026 The TIRx Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This design sketch documents a TIRx port of DeepEP's
-deep_ep/include/deep_ep/impls/combine.cuh (combine_impl, direct
-single-domain path) and deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
-(combine_reduce_epilogue_impl). See NOTICE and licenses/ for upstream
-attribution.
+This file is a design sketch for a TIRx port of code from DeepEP
+(https://github.com/deepseek-ai/DeepEP @ 01dc3aa), Copyright (c) 2025 DeepSeek.
+It documents deep_ep/include/deep_ep/impls/combine.cuh and
+   deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh; see NOTICE and licenses/ for upstream attribution.
+SPDX-License-Identifier: Apache-2.0 AND MIT
+SPDX-FileCopyrightText: Copyright TIRx authors
 -->
 
 # DeepEP elastic combine (single-domain NVLink): coarse WASP pipeline sketch

--- a/.agents/sketch/deepep/dispatch.md
+++ b/.agents/sketch/deepep/dispatch.md
@@ -1,23 +1,10 @@
 <!--
-Copyright (c) 2026 The TIRx Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This design sketch documents a TIRx port of DeepEP's
-deep_ep/include/deep_ep/impls/dispatch.cuh (dispatch_impl, direct
-single-domain path) and deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
-(dispatch_copy_epilogue_impl). See NOTICE and licenses/ for upstream
-attribution.
+This file is a design sketch for a TIRx port of code from DeepEP
+(https://github.com/deepseek-ai/DeepEP @ 01dc3aa), Copyright (c) 2025 DeepSeek.
+It documents deep_ep/include/deep_ep/impls/dispatch.cuh and
+   deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh; see NOTICE and licenses/ for upstream attribution.
+SPDX-License-Identifier: Apache-2.0 AND MIT
+SPDX-FileCopyrightText: Copyright TIRx authors
 -->
 
 # DeepEP elastic dispatch (single-domain NVLink): coarse WASP pipeline sketch

--- a/NOTICE
+++ b/NOTICE
@@ -8,5 +8,11 @@ FlashInfer
 Copyright 2025-2026 NVIDIA
 Copyright 2023-2026 FlashInfer community (https://flashinfer.ai/)
 
+This product includes modified software from DeepEP
+(https://github.com/deepseek-ai/DeepEP):
+
+DeepEP
+Copyright (c) 2025 DeepSeek
+
 Additional third-party copyright notices and license terms are provided in
 the LICENSE file and the licenses/ directory.

--- a/licenses/LICENSE.deepep.txt
+++ b/licenses/LICENSE.deepep.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 DeepSeek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -64,6 +64,11 @@ PORT_BUCKETS = {
         "https://github.com/deepseek-ai/DeepGEMM",
         "Apache-2.0 AND MIT",
     ),
+    "tirx_kernels/deepep/": (
+        "DeepEP",
+        "https://github.com/deepseek-ai/DeepEP",
+        "Apache-2.0 AND MIT",
+    ),
     "tirx_kernels/flashmla/": (
         "FlashMLA",
         "https://github.com/deepseek-ai/FlashMLA",
@@ -103,6 +108,8 @@ FILE_OVERRIDES = {
 
 # Native modules inside port buckets — package markers and our own harnesses.
 PORT_DIR_EXCEPTIONS = {
+    "tirx_kernels/deepep/utils/_buffer.py",
+    "tirx_kernels/deepep/utils/_runtime.py",
     "tirx_kernels/flashinfer/utils/_flashkda_bench.py",
     "tirx_kernels/flashmla/utils/_flashmla_bench.py",
     "tirx_kernels/flashmla/utils/_trtllm_gen_bench.py",

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
+# This file is a TIRx port of code from DeepEP
+# (https://github.com/deepseek-ai/DeepEP @ 01dc3aa), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 """DeepEP V2 elastic combine (single-domain NVLink path) ported to TIRx.

--- a/tirx_kernels/deepep/dispatch.py
+++ b/tirx_kernels/deepep/dispatch.py
@@ -1,4 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
+# This file is a TIRx port of code from DeepEP
+# (https://github.com/deepseek-ai/DeepEP @ 01dc3aa), Copyright (c) 2025 DeepSeek
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 """DeepEP V2 elastic dispatch (single-domain NVLink path) ported to TIRx.


### PR DESCRIPTION
DeepEP is MIT-licensed (Copyright (c) 2025 DeepSeek), so the two ported kernel modules and their design sketches should carry the repo's port header shape (citation + upstream copyright + `SPDX-License-Identifier: Apache-2.0 AND MIT`) — the same convention the DeepGEMM and FlashMLA ports already use. The port files from #55/#56 currently carry only the plain two-line TIRx header.

- `tirx_kernels/deepep/{dispatch,combine}.py` and `.agents/sketch/deepep/{dispatch,combine}.md` get the DeepEP port header (pinned at `deepseek-ai/DeepEP @ 01dc3aa`).
- `licenses/LICENSE.deepep.txt` holds the verbatim upstream MIT license text.
- `NOTICE` gains a DeepEP entry alongside FlashInfer.
- `tests/lint/check_license_headers.py` registers the `tirx_kernels/deepep/` port bucket (DeepEP, `Apache-2.0 AND MIT`) and excepts the bucket's own harness modules (`utils/_buffer.py`, `utils/_runtime.py` — native TIRx code, not ports).

`python tests/lint/check_license_headers.py` passes on all tracked files, its `--self-test` passes (13 cases), and pre-commit is clean.