### PR TITLE
fix: enforce low-level IR contracts in kernel tests

### DIFF
--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -429,6 +429,30 @@ weaken cross-stream ordering.
 Validate transaction counts, ring wrap, completion visibility, and deadlock
 freedom before profiling wait stalls and tail-dominated shapes.
 
+## Keep multimem participants alive through kernel exit
+
+**Symptoms:** `illegal_instruction`, `unspecified_launch_failure`, `multimem_early_exit`, `distributed_flake`
+
+A host barrier after launch cannot keep a rank's device workers alive while
+peer ranks are still issuing `multimem.ld_reduce`.  Give every persistent
+worker its own symmetric exit flag, release-increment the multicast flag after
+all local multimem users finish, and acquire-wait on the local flag until every
+rank arrives before releasing device resources or exiting the kernel.
+
+Keep this barrier outside the tile protocol: first complete the local CTA or
+cluster drain, then perform the system-scope rank rendezvous, then deallocate
+TMEM and exit.  A single flag per rank is insufficient when independently
+scheduled persistent workers can finish at different times; index the flags by
+the physical worker or SM identity used by the grid.
+
+The missing exit rendezvous presented as two different asynchronous CUDA
+faults at two different TP4 shapes across two full correctness matrices, while
+standalone reruns passed.  Adding the per-worker device barrier passed 200
+non-blocking relaunches across both failing shapes, the complete 16-shape
+TP1/TP4 matrix, and a 1402-configuration full suite.  Launch blocking is a
+localization tool here, not a fix: it passed 200 relaunches but does not prove
+the cross-rank kernel-exit invariant.
+
 ## Size swizzles and fragments physically
 
 **Symptoms:** `smem_bank_conflict`, `register_spill`, `slow_epilogue`
@@ -463,6 +487,27 @@ Sweep neighboring budgets on representative single-wave and multi-wave shapes.
 Re-run the sweep after changing descriptor placement, fragment width, or other
 live ranges. Record realized allocation and dynamic local traffic, not only the
 requested cap.
+
+## Adapt row grouping when a fixup grid cannot fill one wave
+
+**Symptoms:** `low_wave_count`, `low_dram_throughput`, `latency_bound_fixup`, `small_grid`
+
+A bandwidth-looking fixup can instead be launch-latency-bound when grouping
+several independent rows into each CTA leaves too few blocks to occupy the SMs.
+Choose the largest supported row group that still launches roughly one wave:
+retain the wider group when the state count already provides enough blocks,
+then fall back through smaller groups only for underfilled shapes.  Keep the
+grouping decision derived from the state count and device SM count rather than
+special-casing a named shape.
+
+One B200 fixup launched 32 blocks, only 0.11 waves per SM, while using 0.66% of
+peak DRAM throughput.  Reducing its group from four rows to one raised the grid
+to 128 blocks; the generated row-one kernel used 255 registers, 512 bytes of
+shared memory, and no spills.  On the same physical GPU over 15 rounds, time
+improved from 54.641 us to 53.665 us, a 1.0182 before/current ratio.  The wider
+group remained selected for shapes with sufficient parallel states, all ten
+correctness configurations passed, and the complete affected bench matrix
+cleared its 0.99 ratio gate.
 
 ## Declare the block shape the reference declares
 

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -197,6 +197,27 @@ def derive_config(
 
 ld_reduce_8xfp16 = '\n__forceinline__ __device__ void ld_reduce_8_fp16(void* src_addr, void* dst_addr) {\n    int4* source = (int4*) nvshmemx_mc_ptr(NVSHMEM_TEAM_WORLD, src_addr);\n    int4* dest = (int4*) dst_addr;\n    constexpr int UNROLL = 1;\n    union {\n        uint16_t u2[8 * UNROLL];\n        uint64_t u8[2 * UNROLL];\n    };\n    for (int u = 0; u < UNROLL; u++) {\n        asm("multimem.ld_reduce.global.add.v8.f16 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"\n            : "=h"(u2[8 * u]), "=h"(u2[8 * u + 1]), "=h"(u2[8 * u + 2]), "=h"(u2[8 * u + 3]), "=h"(u2[8 * u + 4]), "=h"(u2[8 * u + 5]), "=h"(u2[8 * u + 6]), "=h"(u2[8 * u + 7])\n            : "l"(source + u));\n    }\n    for (int u = 0; u < UNROLL; u++) {\n        asm("st.global.v2.b64 [%0], {%1, %2};" ::"l"(dest + u), "l"(u8[2 * u]),\n            "l"(u8[2 * u + 1]));\n    }\n}\n'
 semaphore_notify_remote = "\n__forceinline__ __device__ uint64_t semaphore_notify_remote(int32_t signal_rank, uint64_t* addr, uint64_t signal_value) {\n    auto dst_addr = reinterpret_cast<unsigned long long*>(nvshmem_ptr(addr, signal_rank));\n    return atomicAdd_system(dst_addr, signal_value);\n}\n"
+exit_barrier_arrive_and_wait = """
+__forceinline__ __device__ void exit_barrier_arrive_and_wait(
+        uint32_t* flags, int32_t worker_idx, int32_t expected) {
+    uint32_t* flag = flags + worker_idx;
+    auto mc_flag = reinterpret_cast<uint32_t*>(
+        nvshmemx_mc_ptr(NVSHMEM_TEAM_WORLD, flag));
+    asm volatile(
+        "multimem.red.release.sys.global.add.u32 [%0], 1;"
+        :
+        : "l"(mc_flag)
+        : "memory");
+    uint32_t value;
+    do {
+        asm volatile(
+            "ld.global.acquire.sys.b32 %0, [%1];"
+            : "=r"(value)
+            : "l"(flag)
+            : "memory");
+    } while (value != static_cast<uint32_t>(expected));
+}
+"""
 enqueue_remote = """
 __forceinline__ __device__ void enqueue_remote(
         int32_t* task_types, int32_t* task_idxs, int32_t* tail, int32_t mask,
@@ -564,6 +585,7 @@ def test_mma_ss_tma_2sm_persistent(
     rs_task_idxs: Tx.Buffer((CAPACITY, 2), "int32"),
     rs_head: Tx.Buffer((1,), "int32"),
     rs_tail: Tx.Buffer((1,), "int32"),
+    exit_barrier: Tx.Buffer((SM_NUMBER,), "uint32"),
 ):
     A_tensor_map: Tx.let[Tx.handle("tensormap")] = Tx.tvm_stack_alloca("tensormap", 1)
     B_tensor_map: Tx.let[Tx.handle("tensormap")] = Tx.tvm_stack_alloca("tensormap", 1)
@@ -994,6 +1016,15 @@ def test_mma_ss_tma_2sm_persistent(
     # Synchronize every local and peer-CTA TMEM user before collective deallocation.
     Tx.ptx.barrier.cluster.arrive()
     Tx.ptx.barrier.cluster.wait()
+    if WORLD_SIZE > 1:
+        if tid == 0:
+            Tx.cuda.func_call(
+                "exit_barrier_arrive_and_wait",
+                exit_barrier.ptr_to([bx]),
+                Tx.int32(0),
+                Tx.int32(WORLD_SIZE),
+                source_code=exit_barrier_arrive_and_wait,
+            )
     if (wg_id == 0) & (warp_id == 0):
         Tx.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
         Tx.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
@@ -1143,6 +1174,7 @@ class _Case:
     rs_task_idxs: Any
     rs_head: Any
     rs_tail: Any
+    exit_barrier: Any
     gemm_out_torch: torch.Tensor
     semaphore_torch: torch.Tensor
     gemm_types_torch: torch.Tensor
@@ -1151,6 +1183,7 @@ class _Case:
     rs_types_torch: torch.Tensor
     rs_head_torch: torch.Tensor
     rs_tail_torch: torch.Tensor
+    exit_barrier_torch: torch.Tensor
     initial_queues: tuple[torch.Tensor, ...]
 
     def reset(self) -> None:
@@ -1176,6 +1209,7 @@ class _Case:
         torch_view(self.rs_task_idxs).copy_(rs_indices)
         self.rs_head_torch.copy_(rs_heads)
         self.rs_tail_torch.copy_(rs_tails)
+        self.exit_barrier_torch.zero_()
         self.semaphore_torch.zero_()
         self.gemm_out_torch.fill_(float("nan"))
         self.out.fill_(float("nan"))
@@ -1198,6 +1232,7 @@ class _Case:
             self.rs_task_idxs,
             self.rs_head,
             self.rs_tail,
+            self.exit_barrier,
         )
 
     def assert_terminal_state(self) -> None:
@@ -1216,6 +1251,11 @@ class _Case:
         torch.testing.assert_close(
             self.semaphore_torch,
             torch.full_like(self.semaphore_torch, self.config.completion_count),
+        )
+        expected_exit_count = self.config.world_size if self.config.world_size > 1 else 0
+        torch.testing.assert_close(
+            self.exit_barrier_torch,
+            torch.full_like(self.exit_barrier_torch, expected_exit_count),
         )
         if torch.isnan(self.gemm_out_torch).any() or torch.isnan(self.out).any():
             raise AssertionError("GemmRS output contains an uncovered tile")
@@ -1236,6 +1276,8 @@ def _allocate_case(
     rs_task_idxs = symmetric_empty(runtime, (CAPACITY, TASK_IDX_LEN), "int32")
     rs_head = symmetric_empty(runtime, (1,), "int32")
     rs_tail = symmetric_empty(runtime, (1,), "int32")
+    exit_barrier = symmetric_empty(runtime, (SM_NUMBER,), "uint32")
+    exit_barrier_torch = torch_view(exit_barrier)
     initial_queues = tuple(
         torch.from_numpy(array[runtime.rank].copy()).to(device) for array in queue_state
     )
@@ -1256,6 +1298,7 @@ def _allocate_case(
         rs_task_idxs=rs_task_idxs,
         rs_head=rs_head,
         rs_tail=rs_tail,
+        exit_barrier=exit_barrier,
         gemm_out_torch=torch_view(gemm_out),
         semaphore_torch=torch_view(semaphore),
         gemm_types_torch=torch_view(gemm_task_types),
@@ -1264,10 +1307,12 @@ def _allocate_case(
         rs_types_torch=torch_view(rs_task_types),
         rs_head_torch=torch_view(rs_head),
         rs_tail_torch=torch_view(rs_tail),
+        exit_barrier_torch=exit_barrier_torch,
         initial_queues=initial_queues,
     )
     if config.world_size > 1:
         require_nvls_multicast(runtime, case.gemm_out_torch)
+        require_nvls_multicast(runtime, exit_barrier_torch)
     with torch.cuda.stream(runtime.timing_stream):
         case.reset()
     runtime.timing_stream.synchronize()

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
@@ -120,6 +120,10 @@ def _uceil(x, d):
     return T.cast((T.cast(x, "uint32") + T.uint32(d - 1)) // T.uint32(d), "int32")
 
 
+def _load_grouped_layout(dst, grouped_layout, index):
+    return T.ptx.ld.global_.s32(dst, grouped_layout.ptr_to([index]))
+
+
 def _udiv(x, d):
     """Exact division of a known non-negative value; see `_uceil`."""
     return T.cast(T.cast(x, "uint32") // T.cast(d, "uint32"), "int32")
@@ -695,7 +699,7 @@ def build_kernel(spec: GemmSpec):
                     ld_nmb = num_m_blocks
                     if is_k_grouped_psum:
                         while ld_grp < num_groups:
-                            ld_nxtk = grouped_layout[ld_grp]
+                            _load_grouped_layout(ld_nxtk, grouped_layout, ld_grp)
                             ld_last = (_uceil(ld_kend, k_alignment)) * k_alignment
                             ld_psum = ld_nxtk - ld_last
                             ld_kend = ld_nxtk
@@ -704,18 +708,18 @@ def build_kernel(spec: GemmSpec):
                             ld_grp = ld_grp + 1
                     else:
                         while ld_grp < num_groups:
-                            ld_psum = grouped_layout[ld_grp]
+                            _load_grouped_layout(ld_psum, grouped_layout, ld_grp)
                             if ld_psum > 0:
                                 break
                             ld_grp = ld_grp + 1
                         ld_nxt = ld_grp + 1
                         while ld_nxt < num_groups:
-                            ld_nxtk = grouped_layout[ld_nxt]
+                            _load_grouped_layout(ld_nxtk, grouped_layout, ld_nxt)
                             if ld_nxtk > 0:
                                 break
                             ld_nxt = ld_nxt + 1
                 elif is_m_grouped_psum:
-                    ld_psum = grouped_layout[0]
+                    _load_grouped_layout(ld_psum, grouped_layout, 0)
                     ld_nmb = _uceil(ld_psum, block_m)
                 else:
                     ld_psum = 0
@@ -731,7 +735,8 @@ def build_kernel(spec: GemmSpec):
                                 ld_valid = 0
                                 ld_done = 1
                             else:
-                                ld_nmb = _uceil(grouped_layout[ld_grp], block_m)
+                                _load_grouped_layout(ld_nmb, grouped_layout, ld_grp)
+                                ld_nmb = _uceil(ld_nmb, block_m)
                                 if ld_nb < (ld_cum + ld_nmb) * num_n_blocks:
                                     ld_done = 1
                                 else:
@@ -748,7 +753,7 @@ def build_kernel(spec: GemmSpec):
                                     ld_done = 1
                                 else:
                                     ld_last = (_uceil(ld_psum, block_m)) * block_m
-                                    ld_psum = grouped_layout[ld_grp]
+                                    _load_grouped_layout(ld_psum, grouped_layout, ld_grp)
                                     ld_cum = ld_cum + ld_nmb
                                     ld_nmb = _uceil(ld_psum - ld_last, block_m)
                     elif is_k_grouped:
@@ -766,7 +771,7 @@ def build_kernel(spec: GemmSpec):
                                 if is_k_grouped_psum:
                                     ld_grp = ld_grp + 1
                                     while ld_grp < num_groups:
-                                        ld_nxtk = grouped_layout[ld_grp]
+                                        _load_grouped_layout(ld_nxtk, grouped_layout, ld_grp)
                                         ld_last = (_uceil(ld_kend, k_alignment)) * k_alignment
                                         ld_psum = ld_nxtk - ld_last
                                         ld_kend = ld_nxtk
@@ -779,7 +784,7 @@ def build_kernel(spec: GemmSpec):
                                     ld_nxt = ld_nxt + 1
                                     ld_psum = ld_nxtk
                                     while ld_nxt < num_groups:
-                                        ld_nxtk = grouped_layout[ld_nxt]
+                                        _load_grouped_layout(ld_nxtk, grouped_layout, ld_nxt)
                                         if ld_nxtk > 0:
                                             break
                                         ld_nxt = ld_nxt + 1
@@ -826,7 +831,8 @@ def build_kernel(spec: GemmSpec):
                         if is_m_grouped_contiguous:
                             # Non-psum contiguous: the expert is a per-row id.
                             expert: T.int32
-                            expert = T.max(0, grouped_layout[m_idx])
+                            _load_grouped_layout(expert, grouped_layout, m_idx)
+                            expert = T.max(0, expert)
                             if major_b_is_k:
                                 n_idx = expert * eff_n + n_idx
                             else:
@@ -1056,7 +1062,7 @@ def build_kernel(spec: GemmSpec):
                     mma_nmb = num_m_blocks
                     if is_k_grouped_psum:
                         while mma_grp < num_groups:
-                            mma_nxtk = grouped_layout[mma_grp]
+                            _load_grouped_layout(mma_nxtk, grouped_layout, mma_grp)
                             mma_last = (_uceil(mma_kend, k_alignment)) * k_alignment
                             mma_psum = mma_nxtk - mma_last
                             mma_kend = mma_nxtk
@@ -1065,18 +1071,18 @@ def build_kernel(spec: GemmSpec):
                             mma_grp = mma_grp + 1
                     else:
                         while mma_grp < num_groups:
-                            mma_psum = grouped_layout[mma_grp]
+                            _load_grouped_layout(mma_psum, grouped_layout, mma_grp)
                             if mma_psum > 0:
                                 break
                             mma_grp = mma_grp + 1
                         mma_nxt = mma_grp + 1
                         while mma_nxt < num_groups:
-                            mma_nxtk = grouped_layout[mma_nxt]
+                            _load_grouped_layout(mma_nxtk, grouped_layout, mma_nxt)
                             if mma_nxtk > 0:
                                 break
                             mma_nxt = mma_nxt + 1
                 elif is_m_grouped_psum:
-                    mma_psum = grouped_layout[0]
+                    _load_grouped_layout(mma_psum, grouped_layout, 0)
                     mma_nmb = _uceil(mma_psum, block_m)
                 else:
                     mma_psum = 0
@@ -1093,7 +1099,8 @@ def build_kernel(spec: GemmSpec):
                                 mma_valid = 0
                                 mma_done = 1
                             else:
-                                mma_nmb = _uceil(grouped_layout[mma_grp], block_m)
+                                _load_grouped_layout(mma_nmb, grouped_layout, mma_grp)
+                                mma_nmb = _uceil(mma_nmb, block_m)
                                 if mma_nb < (mma_cum + mma_nmb) * num_n_blocks:
                                     mma_done = 1
                                 else:
@@ -1110,7 +1117,7 @@ def build_kernel(spec: GemmSpec):
                                     mma_done = 1
                                 else:
                                     mma_last = (_uceil(mma_psum, block_m)) * block_m
-                                    mma_psum = grouped_layout[mma_grp]
+                                    _load_grouped_layout(mma_psum, grouped_layout, mma_grp)
                                     mma_cum = mma_cum + mma_nmb
                                     mma_nmb = _uceil(mma_psum - mma_last, block_m)
                     elif is_k_grouped:
@@ -1127,7 +1134,7 @@ def build_kernel(spec: GemmSpec):
                                 if is_k_grouped_psum:
                                     mma_grp = mma_grp + 1
                                     while mma_grp < num_groups:
-                                        mma_nxtk = grouped_layout[mma_grp]
+                                        _load_grouped_layout(mma_nxtk, grouped_layout, mma_grp)
                                         mma_last = (_uceil(mma_kend, k_alignment)) * k_alignment
                                         mma_psum = mma_nxtk - mma_last
                                         mma_kend = mma_nxtk
@@ -1140,7 +1147,7 @@ def build_kernel(spec: GemmSpec):
                                     mma_nxt = mma_nxt + 1
                                     mma_psum = mma_nxtk
                                     while mma_nxt < num_groups:
-                                        mma_nxtk = grouped_layout[mma_nxt]
+                                        _load_grouped_layout(mma_nxtk, grouped_layout, mma_nxt)
                                         if mma_nxtk > 0:
                                             break
                                         mma_nxt = mma_nxt + 1
@@ -1443,7 +1450,7 @@ def build_kernel(spec: GemmSpec):
                 tr_nmb = num_m_blocks
                 if is_k_grouped_psum:
                     while tr_grp < num_groups:
-                        tr_nxtk = grouped_layout[tr_grp]
+                        _load_grouped_layout(tr_nxtk, grouped_layout, tr_grp)
                         tr_last = (_uceil(tr_kend, k_alignment)) * k_alignment
                         tr_psum = tr_nxtk - tr_last
                         tr_kend = tr_nxtk
@@ -1452,18 +1459,18 @@ def build_kernel(spec: GemmSpec):
                         tr_grp = tr_grp + 1
                 else:
                     while tr_grp < num_groups:
-                        tr_psum = grouped_layout[tr_grp]
+                        _load_grouped_layout(tr_psum, grouped_layout, tr_grp)
                         if tr_psum > 0:
                             break
                         tr_grp = tr_grp + 1
                     tr_nxt = tr_grp + 1
                     while tr_nxt < num_groups:
-                        tr_nxtk = grouped_layout[tr_nxt]
+                        _load_grouped_layout(tr_nxtk, grouped_layout, tr_nxt)
                         if tr_nxtk > 0:
                             break
                         tr_nxt = tr_nxt + 1
             elif is_m_grouped_psum:
-                tr_psum = grouped_layout[0]
+                _load_grouped_layout(tr_psum, grouped_layout, 0)
                 tr_nmb = _uceil(tr_psum, block_m)
             else:
                 tr_psum = 0
@@ -1480,7 +1487,8 @@ def build_kernel(spec: GemmSpec):
                             tr_valid = 0
                             tr_done = 1
                         else:
-                            tr_nmb = _uceil(grouped_layout[tr_grp], block_m)
+                            _load_grouped_layout(tr_nmb, grouped_layout, tr_grp)
+                            tr_nmb = _uceil(tr_nmb, block_m)
                             if tr_nb < (tr_cum + tr_nmb) * num_n_blocks:
                                 tr_done = 1
                             else:
@@ -1497,7 +1505,7 @@ def build_kernel(spec: GemmSpec):
                                 tr_done = 1
                             else:
                                 tr_last = (_uceil(tr_psum, block_m)) * block_m
-                                tr_psum = grouped_layout[tr_grp]
+                                _load_grouped_layout(tr_psum, grouped_layout, tr_grp)
                                 tr_cum = tr_cum + tr_nmb
                                 tr_nmb = _uceil(tr_psum - tr_last, block_m)
                 elif is_k_grouped:
@@ -1514,7 +1522,7 @@ def build_kernel(spec: GemmSpec):
                             if is_k_grouped_psum:
                                 tr_grp = tr_grp + 1
                                 while tr_grp < num_groups:
-                                    tr_nxtk = grouped_layout[tr_grp]
+                                    _load_grouped_layout(tr_nxtk, grouped_layout, tr_grp)
                                     tr_last = (_uceil(tr_kend, k_alignment)) * k_alignment
                                     tr_psum = tr_nxtk - tr_last
                                     tr_kend = tr_nxtk
@@ -1527,7 +1535,7 @@ def build_kernel(spec: GemmSpec):
                                 tr_nxt = tr_nxt + 1
                                 tr_psum = tr_nxtk
                                 while tr_nxt < num_groups:
-                                    tr_nxtk = grouped_layout[tr_nxt]
+                                    _load_grouped_layout(tr_nxtk, grouped_layout, tr_nxt)
                                     if tr_nxtk > 0:
                                         break
                                     tr_nxt = tr_nxt + 1
@@ -1564,19 +1572,35 @@ def build_kernel(spec: GemmSpec):
                             for c in T.unroll(0, num_sfa_chunks):
                                 base = c * NUM_UTCCP_ALIGNED_ELEMS
                                 for i in T.unroll(0, 4):
-                                    sf_vals[i] = smem_sfa[tr_stage, base + i * 32 + lane_idx]
+                                    T.ptx.ld.shared.u32(
+                                        sf_vals[i],
+                                        smem_sfa.ptr_to([tr_stage, base + i * 32 + lane_idx]),
+                                    )
                                 T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
-                                for i in T.unroll(0, 4):
-                                    smem_sfa[tr_stage, base + lane_idx * 4 + i] = sf_vals[i]
+                                T.ptx.st.shared.v4.u32(
+                                    smem_sfa.ptr_to([tr_stage, base + lane_idx * 4]),
+                                    sf_vals[0],
+                                    sf_vals[1],
+                                    sf_vals[2],
+                                    sf_vals[3],
+                                )
                             T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
                         if tr_k % sfb_stages_per_load == 0:
                             for c in T.unroll(0, num_sfb_chunks):
                                 base = c * NUM_UTCCP_ALIGNED_ELEMS
                                 for i in T.unroll(0, 4):
-                                    sf_vals[i] = smem_sfb[tr_stage, base + i * 32 + lane_idx]
+                                    T.ptx.ld.shared.u32(
+                                        sf_vals[i],
+                                        smem_sfb.ptr_to([tr_stage, base + i * 32 + lane_idx]),
+                                    )
                                 T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
-                                for i in T.unroll(0, 4):
-                                    smem_sfb[tr_stage, base + lane_idx * 4 + i] = sf_vals[i]
+                                T.ptx.st.shared.v4.u32(
+                                    smem_sfb.ptr_to([tr_stage, base + lane_idx * 4]),
+                                    sf_vals[0],
+                                    sf_vals[1],
+                                    sf_vals[2],
+                                    sf_vals[3],
+                                )
                             T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
                         # `arrive(0u)` passes a destination CTA rank, not a count:
                         # every thread arrives on the leader CTA's barrier copy.
@@ -1626,7 +1650,7 @@ def build_kernel(spec: GemmSpec):
                 ep_nmb = num_m_blocks
                 if is_k_grouped_psum:
                     while ep_grp < num_groups:
-                        ep_nxtk = grouped_layout[ep_grp]
+                        _load_grouped_layout(ep_nxtk, grouped_layout, ep_grp)
                         ep_last = (_uceil(ep_kend, k_alignment)) * k_alignment
                         ep_psum = ep_nxtk - ep_last
                         ep_kend = ep_nxtk
@@ -1635,18 +1659,18 @@ def build_kernel(spec: GemmSpec):
                         ep_grp = ep_grp + 1
                 else:
                     while ep_grp < num_groups:
-                        ep_psum = grouped_layout[ep_grp]
+                        _load_grouped_layout(ep_psum, grouped_layout, ep_grp)
                         if ep_psum > 0:
                             break
                         ep_grp = ep_grp + 1
                     ep_nxt = ep_grp + 1
                     while ep_nxt < num_groups:
-                        ep_nxtk = grouped_layout[ep_nxt]
+                        _load_grouped_layout(ep_nxtk, grouped_layout, ep_nxt)
                         if ep_nxtk > 0:
                             break
                         ep_nxt = ep_nxt + 1
             elif is_m_grouped_psum:
-                ep_psum = grouped_layout[0]
+                _load_grouped_layout(ep_psum, grouped_layout, 0)
                 ep_nmb = _uceil(ep_psum, block_m)
             else:
                 ep_psum = 0
@@ -1665,7 +1689,8 @@ def build_kernel(spec: GemmSpec):
                             ep_valid = 0
                             ep_done = 1
                         else:
-                            ep_nmb = _uceil(grouped_layout[ep_grp], block_m)
+                            _load_grouped_layout(ep_nmb, grouped_layout, ep_grp)
+                            ep_nmb = _uceil(ep_nmb, block_m)
                             if ep_nb < (ep_cum + ep_nmb) * num_n_blocks:
                                 ep_done = 1
                             else:
@@ -1682,7 +1707,7 @@ def build_kernel(spec: GemmSpec):
                                 ep_done = 1
                             else:
                                 ep_last = (_uceil(ep_psum, block_m)) * block_m
-                                ep_psum = grouped_layout[ep_grp]
+                                _load_grouped_layout(ep_psum, grouped_layout, ep_grp)
                                 ep_cum = ep_cum + ep_nmb
                                 ep_nmb = _uceil(ep_psum - ep_last, block_m)
                 elif is_k_grouped:
@@ -1699,7 +1724,7 @@ def build_kernel(spec: GemmSpec):
                             if is_k_grouped_psum:
                                 ep_grp = ep_grp + 1
                                 while ep_grp < num_groups:
-                                    ep_nxtk = grouped_layout[ep_grp]
+                                    _load_grouped_layout(ep_nxtk, grouped_layout, ep_grp)
                                     ep_last = (_uceil(ep_kend, k_alignment)) * k_alignment
                                     ep_psum = ep_nxtk - ep_last
                                     ep_kend = ep_nxtk
@@ -1712,7 +1737,7 @@ def build_kernel(spec: GemmSpec):
                                 ep_nxt = ep_nxt + 1
                                 ep_psum = ep_nxtk
                                 while ep_nxt < num_groups:
-                                    ep_nxtk = grouped_layout[ep_nxt]
+                                    _load_grouped_layout(ep_nxtk, grouped_layout, ep_nxt)
                                     if ep_nxtk > 0:
                                         break
                                     ep_nxt = ep_nxt + 1
@@ -1952,8 +1977,13 @@ def build_kernel(spec: GemmSpec):
                                             )
                                         )
                                         T.ptx.tcgen05.wait__ld.sync.aligned()
-                                        for j in T.unroll(0, 4):
-                                            smem_cd_u32[cd_word + j] = values[j]
+                                        T.ptx.st.shared.v4.u32(
+                                            smem_cd_u32.ptr_to([cd_word]),
+                                            values[0],
+                                            values[1],
+                                            values[2],
+                                            values[3],
+                                        )
                                     else:
                                         T.evaluate(
                                             T.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
@@ -1972,8 +2002,13 @@ def build_kernel(spec: GemmSpec):
                                                 T.reinterpret("float32", values[2 * j + 1]),
                                                 T.reinterpret("float32", values[2 * j]),
                                             )
-                                        for j in T.unroll(0, 4):
-                                            smem_cd_u32[cd_word + j] = packed[j]
+                                        T.ptx.st.shared.v4.u32(
+                                            smem_cd_u32.ptr_to([cd_word]),
+                                            packed[0],
+                                            packed[1],
+                                            packed[2],
+                                            packed[3],
+                                        )
 
                                 if w == num_m_waves - 1 and st == num_stores - 1:
                                     T.ptx.tcgen05.fence__before_thread_sync()

--- a/tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py
+++ b/tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py
@@ -283,6 +283,7 @@ def check_correctness(
                 intermediate_hidden=intermediate_hidden,
                 num_experts=num_experts,
                 num_topk=num_topk,
+                num_shared_experts=num_shared_experts,
                 activation_clamp=activation_clamp,
                 fast_math=fast_math,
             ),
@@ -365,6 +366,7 @@ def prepare_bench(
     intermediate_hidden=512,
     num_experts=8,
     num_topk=2,
+    num_shared_experts=0,
     activation_clamp=10.0,
     fast_math=1,
 ):
@@ -379,6 +381,7 @@ def prepare_bench(
         intermediate_hidden=intermediate_hidden,
         num_experts=num_experts,
         num_topk=num_topk,
+        num_shared_experts=num_shared_experts,
         activation_clamp=activation_clamp,
         fast_math=fast_math,
     )

--- a/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
+++ b/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
@@ -19,7 +19,6 @@ scope (fast-math reciprocal, E4M3 scale factors, no 4over6 refinement).
 from typing import Any
 
 from tirx_kernels.runner import bench
-from tvm.ir.type import PointerType, PrimType
 from tvm.script import tirx as T
 
 KERNEL_META = {
@@ -244,20 +243,8 @@ def get_kernel(dtype: str, n_experts: int, m: int, k: int, mask_mode: str = "ran
         if use_silu_and_mul != 0:
             actual_cols = cols_per_row * 2
 
-        x64 = T.alloc_local([4], "uint64")
-        y64 = T.alloc_local([4], "uint64")
-        xw = T.decl_buffer(
-            [8],
-            "uint32",
-            data=T.reinterpret(PointerType(PrimType("uint32")), T.address_of(x64[0])),
-            scope="local",
-        )
-        yw = T.decl_buffer(
-            [8],
-            "uint32",
-            data=T.reinterpret(PointerType(PrimType("uint32")), T.address_of(y64[0])),
-            scope="local",
-        )
+        xw = T.alloc_local([8], "uint32")
+        yw = T.alloc_local([8], "uint32")
         packed = T.alloc_local([1], "uint32")
         e_tmp = T.alloc_local([1], "float32")
         r_tmp = T.alloc_local([1], "float32")
@@ -277,24 +264,42 @@ def get_kernel(dtype: str, n_experts: int, m: int, k: int, mask_mode: str = "ran
             row_idx_in_expert = row_idx - expert_idx * m_rows
 
             if use_mask:
-                if row_idx_in_expert >= mask[expert_idx]:
+                mask_rows: T.int32
+                T.ptx.ld.global_.s32(mask_rows, mask.ptr_to([expert_idx]))
+                if row_idx_in_expert >= mask_rows:
                     break
 
             in_offset = T.cast(row_idx, "int64") * actual_cols + col_idx
-            T.ptx.ld.global_.v4.b64(
-                x64[0],
-                x64[1],
-                x64[2],
-                x64[3],
+            T.ptx.ld.global_.v4.b32(
+                xw[0],
+                xw[1],
+                xw[2],
+                xw[3],
                 T.address_of(input_global[in_offset * ELTS_PER_THREAD]),
             )
+            T.ptx.ld.global_.v4.b32(
+                xw[4],
+                xw[5],
+                xw[6],
+                xw[7],
+                T.address_of(input_global[in_offset * ELTS_PER_THREAD + 8]),
+            )
             if use_silu_and_mul != 0:
-                T.ptx.ld.global_.v4.b64(
-                    y64[0],
-                    y64[1],
-                    y64[2],
-                    y64[3],
+                T.ptx.ld.global_.v4.b32(
+                    yw[0],
+                    yw[1],
+                    yw[2],
+                    yw[3],
                     T.address_of(input_global[(in_offset + cols_per_row) * ELTS_PER_THREAD]),
+                )
+                T.ptx.ld.global_.v4.b32(
+                    yw[4],
+                    yw[5],
+                    yw[6],
+                    yw[7],
+                    T.address_of(
+                        input_global[(in_offset + cols_per_row) * ELTS_PER_THREAD + 8]
+                    ),
                 )
                 # silu_and_mul (utils:1142-1166): fp32 silu*mul per element,
                 # rounded back to DTYPE pairs in place.
@@ -322,7 +327,7 @@ def get_kernel(dtype: str, n_experts: int, m: int, k: int, mask_mode: str = "ran
             # SFScale select (branch-lowered in the source).
             sfscale_val: T.f32 = T.float32(1.0)
             if T.reinterpret("uint64", T.address_of(sf_scale[0])) != T.uint64(0):
-                sfscale_val = sf_scale[expert_idx]
+                T.ptx.ld.global_.f32(sfscale_val, sf_scale.ptr_to([expert_idx]))
 
             # SF swizzled output address (utils:1096-1140 + quantization.cuh:706-714).
             num_cols_padded = (

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -392,6 +392,57 @@ def _device_chunk_bound(seq_idx, total, chunk_size):
     return clipped + (total - clipped) // chunk_size
 
 
+def _load_global_s32(dst, address):
+    return T.ptx.ld.global_.nc.b32(dst, address)
+
+
+def _load_global_f32(dst, address):
+    return T.ptx.ld.global_.nc.f32(dst, address)
+
+
+def _store_global_f32(address, value):
+    return T.ptx.st.global_.f32(address, value)
+
+
+def _load_shared_f32(dst, address):
+    return T.ptx.ld.shared.f32(dst, address)
+
+
+def _store_shared_f32(address, value):
+    return T.ptx.st.shared.f32(address, value)
+
+
+@T.inline
+def _load_global_as_f32(values, value_index, source, source_index, SOURCE_DTYPE):
+    if SOURCE_DTYPE == "float32":
+        T.ptx.ld.global_.f32(values[value_index], source.ptr_to([source_index]))
+    else:
+        bits = T.alloc_local((1,), "uint16")
+        T.ptx.ld.global_.b16(bits[0], source.ptr_to([source_index]))
+        values[value_index] = T.cast(T.reinterpret(SOURCE_DTYPE, bits[0]), "float32")
+
+
+def _store_global_from_f32(output, output_index, value, OUTPUT_DTYPE):
+    if OUTPUT_DTYPE == "float32":
+        return T.ptx.st.global_.f32(output.ptr_to([output_index]), value)
+    return T.ptx.st.global_.b16(
+        output.ptr_to([output_index]), T.reinterpret("uint16", T.cast(value, OUTPUT_DTYPE))
+    )
+
+
+@T.inline
+def _load_sequence_bounds(cu_seqlens, seq_idx, bounds, CU_DTYPE):
+    if CU_DTYPE == "int32":
+        T.ptx.ld.global_.nc.b32(bounds[0], cu_seqlens.ptr_to([seq_idx]))
+        T.ptx.ld.global_.nc.b32(bounds[1], cu_seqlens.ptr_to([seq_idx + 1]))
+    else:
+        raw = T.alloc_local((2,), "int64")
+        T.ptx.ld.global_.nc.b64(raw[0], cu_seqlens.ptr_to([seq_idx]))
+        T.ptx.ld.global_.nc.b64(raw[1], cu_seqlens.ptr_to([seq_idx + 1]))
+        bounds[0] = T.cast(raw[0], "int32")
+        bounds[1] = T.cast(raw[1], "int32")
+
+
 def _lg2_approx_ftz(value):
     result = T.alloc_local((1,), "float32")
     T.evaluate(T.ptx.lg2.approx.ftz.f32(result[0], value))
@@ -612,12 +663,21 @@ def _t_store_t_fragment(
         )
         output_lo: T.float32 = 0.0
         output_hi: T.float32 = 0.0
+        beta_value: T.float32
         if row < valid_len and col < valid_len:
-            output_lo = -beta_storage[col] * inverse_lo
+            _load_shared_f32(beta_value, beta_storage.ptr_to([col]))
+            output_lo = -beta_value * inverse_lo
         if row < valid_len and col + 1 < valid_len:
-            output_hi = -beta_storage[col + 1] * inverse_hi
-        t[t_base + col * T_BLOCK + row] = T.cast(output_lo, IO_DTYPE)
-        t[t_base + (col + 1) * T_BLOCK + row] = T.cast(output_hi, IO_DTYPE)
+            _load_shared_f32(beta_value, beta_storage.ptr_to([col + 1]))
+            output_hi = -beta_value * inverse_hi
+        T.ptx.st.global_.b16(
+            t.ptr_to([t_base + col * T_BLOCK + row]),
+            T.reinterpret("uint16", T.cast(output_lo, IO_DTYPE)),
+        )
+        T.ptx.st.global_.b16(
+            t.ptr_to([t_base + (col + 1) * T_BLOCK + row]),
+            T.reinterpret("uint16", T.cast(output_hi, IO_DTYPE)),
+        )
 
 
 @T.inline
@@ -1180,19 +1240,24 @@ def _fixup_load_initial_to_tmem(tmem_base, initial_state, base, thread, ROWS, ST
     if ROWS == 128:
         for sub in range(4):
             for i in T.unroll(32):
-                values[sub * 32 + i] = T.cast(
-                    initial_state[base + T.cast(thread, "int64") * D_HEAD + sub * 32 + i], "float32"
+                _load_global_as_f32(
+                    values,
+                    sub * 32 + i,
+                    initial_state,
+                    base + T.cast(thread, "int64") * D_HEAD + sub * 32 + i,
+                    STATE_DTYPE,
                 )
     else:
         local_row: T.int32 = (thread >> 5) * 16 + (thread & 15)
         col_base: T.int32 = thread & 16
         for sub in range(4):
             for i in T.unroll(16):
-                values[sub * 16 + i] = T.cast(
-                    initial_state[
-                        base + T.cast(local_row, "int64") * D_HEAD + col_base + sub * 32 + i
-                    ],
-                    "float32",
+                _load_global_as_f32(
+                    values,
+                    sub * 16 + i,
+                    initial_state,
+                    base + T.cast(local_row, "int64") * D_HEAD + col_base + sub * 32 + i,
+                    STATE_DTYPE,
                 )
     _fixup_tmem_st(tmem_base, _FIXUP_TMEM_ACC_COL, thread, words, ROWS)
 
@@ -1969,8 +2034,10 @@ def _t_precompute_sm100(
     state_head: T.int32 = bx % STATE_HEADS
     block_in_seq: T.int32 = bx // STATE_HEADS
     k_head: T.int32 = state_head * K_HEADS // STATE_HEADS
-    seq_start: T.int32 = T.cast(cu_seqlens[seq_idx], "int32")
-    seq_end: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+    sequence_bounds = T.alloc_local((2,), "int32")
+    _load_sequence_bounds(cu_seqlens, seq_idx, sequence_bounds, CU_DTYPE)
+    seq_start: T.int32 = sequence_bounds[0]
+    seq_end: T.int32 = sequence_bounds[1]
     seq_len: T.int32 = seq_end - seq_start
     num_blocks: T.int32 = (seq_len + T_BLOCK - 1) // T_BLOCK
 
@@ -2020,8 +2087,11 @@ def _t_precompute_sm100(
                 beta_row: T.int32 = lane + beta_half * 32
                 beta_value: T.float32 = 0.0
                 if beta_row < valid_len:
-                    beta_value = beta[(token_start + beta_row) * STATE_HEADS + state_head]
-                beta_storage[beta_row] = beta_value
+                    _load_global_f32(
+                        beta_value,
+                        beta.ptr_to([(token_start + beta_row) * STATE_HEADS + state_head]),
+                    )
+                _store_shared_f32(beta_storage.ptr_to([beta_row]), beta_value)
             T.ptx.fence.proxy.async_.shared__cta()
             _mn_opt_commit(smem_addr, 16, 0, 1)
 
@@ -2065,7 +2135,9 @@ def _t_precompute_sm100(
                 )
                 value_kk: T.float32 = 0.0
                 if row_kk > col_kk:
-                    value_kk = kk_acc[n_group * 8 + element] * beta_storage[row_kk]
+                    beta_value: T.float32
+                    _load_shared_f32(beta_value, beta_storage.ptr_to([row_kk]))
+                    value_kk = kk_acc[n_group * 8 + element] * beta_value
                 kk_acc[n_group * 8 + element] = value_kk
             for pair in T.unroll(4):
                 packed_kk[pair] = _t_pack_f16x2(
@@ -2210,8 +2282,10 @@ def _mn_precompute_sm100(
     chunk_in_seq: T.int32 = bx // STATE_HEADS
     k_head: T.int32 = state_head * K_HEADS // STATE_HEADS
     v_head: T.int32 = state_head * V_HEADS // STATE_HEADS
-    seq_start: T.int32 = T.cast(cu_seqlens[seq_idx], "int32")
-    seq_end: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+    sequence_bounds = T.alloc_local((2,), "int32")
+    _load_sequence_bounds(cu_seqlens, seq_idx, sequence_bounds, CU_DTYPE)
+    seq_start: T.int32 = sequence_bounds[0]
+    seq_end: T.int32 = sequence_bounds[1]
     seq_len: T.int32 = seq_end - seq_start
     num_chunks: T.int32 = (seq_len + CP_CHUNK_LEN - 1) // CP_CHUNK_LEN
     valid_chunk: T.int32 = T.cast(chunk_in_seq < num_chunks, "int32")
@@ -2918,11 +2992,12 @@ def _fixup_sm100(
     STATE_POOL: T.constexpr,
     TOTAL_CP_CHUNKS: T.constexpr,
     CP_CHUNK_LEN: T.constexpr,
+    ROWS_PER_CTA: T.constexpr,
     NEEDS_INITIAL_STATE: T.constexpr,
     STORE_FINAL_STATE: T.constexpr,
     USE_STATE_INDICES: T.constexpr,
 ):
-    """Source SIMT4 fixup: one thread owns one column and four rows."""
+    """Source SIMT fixup: one thread owns one column and a small row group."""
     transfer = T.match_buffer(
         transfer_h, (TOTAL_CP_CHUNKS * STATE_HEADS * D_HEAD * D_HEAD,), "float32", scope="global"
     )
@@ -2950,16 +3025,18 @@ def _fixup_sm100(
     T.attr({"tirx.launch_bounds_min_blocks_per_sm": 2})
     # TIRX_TRANSCRIBE_START cp_delta_rule_fixup_sm100
 
-    row_ctas = T.meta_var(D_HEAD // 4)
+    row_ctas = T.meta_var(D_HEAD // ROWS_PER_CTA)
     block = T.cta_id([NUM_SEQUENCES * STATE_HEADS * row_ctas])
     col = T.thread_id([T_THREADS])
     row_cta: T.int32 = block % row_ctas
     head_seq: T.int32 = block // row_ctas
     state_head: T.int32 = head_seq % STATE_HEADS
     seq_idx: T.int32 = head_seq // STATE_HEADS
-    row_start: T.int32 = row_cta * 4
-    seq_start: T.int32 = T.cast(cu_seqlens[seq_idx], "int32")
-    seq_end: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+    row_start: T.int32 = row_cta * ROWS_PER_CTA
+    sequence_bounds = T.alloc_local((2,), "int32")
+    _load_sequence_bounds(cu_seqlens, seq_idx, sequence_bounds, CU_DTYPE)
+    seq_start: T.int32 = sequence_bounds[0]
+    seq_end: T.int32 = sequence_bounds[1]
     seq_len: T.int32 = seq_end - seq_start
     num_chunks: T.int32 = (seq_len + CP_CHUNK_LEN - 1) // CP_CHUNK_LEN
     chunk_start: T.int32 = _device_chunk_bound(seq_idx, seq_start, CP_CHUNK_LEN)
@@ -2969,77 +3046,105 @@ def _fixup_sm100(
         gap_end = _device_chunk_bound(seq_idx + 1, seq_end, CP_CHUNK_LEN)
     state_slot: T.int32 = seq_idx
     if USE_STATE_INDICES:
-        state_slot = state_indices[seq_idx]
+        _load_global_s32(state_slot, state_indices.ptr_to([seq_idx]))
 
-    shared_state = T.alloc_buffer((4 * D_HEAD,), "float32", scope="shared", align=128)
+    shared_state = T.alloc_buffer(
+        (ROWS_PER_CTA * D_HEAD,), "float32", scope="shared", align=128
+    )
     T.ptx.setmaxnreg.inc.sync.aligned.u32(256)
     T.cuda.cta_sync()
     if num_chunks > 0:
         start: T.int32 = 0
         if NEEDS_INITIAL_STATE:
-            for local_row in T.unroll(4):
-                initial_value: T.float32 = T.cast(
-                    initial_state[
-                        ((state_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
-                        * D_HEAD
-                        + col
-                    ],
-                    "float32",
-                )
-                shared_state[local_row * D_HEAD + col] = initial_value
-                initial_state_workspace[
-                    ((seq_idx * STATE_HEADS + state_head) * D_HEAD + row_start + local_row) * D_HEAD
+            initial_values = T.alloc_local((ROWS_PER_CTA,), "float32")
+            for local_row in T.unroll(ROWS_PER_CTA):
+                initial_index: T.int32 = (
+                    ((state_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
+                    * D_HEAD
                     + col
-                ] = initial_value
+                )
+                _load_global_as_f32(
+                    initial_values,
+                    local_row,
+                    initial_state,
+                    initial_index,
+                    STATE_DTYPE,
+                )
+                _store_shared_f32(
+                    shared_state.ptr_to([local_row * D_HEAD + col]), initial_values[local_row]
+                )
+                workspace_index: T.int32 = (
+                    ((seq_idx * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
+                    * D_HEAD
+                    + col
+                )
+                _store_global_f32(
+                    initial_state_workspace.ptr_to([workspace_index]), initial_values[local_row]
+                )
         else:
             start = 1
             first_slot: T.int32 = chunk_start
-            for local_row in T.unroll(4):
-                first_value: T.float32 = local_state[
+            for local_row in T.unroll(ROWS_PER_CTA):
+                first_index: T.int32 = (
                     ((first_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
                     * D_HEAD
                     + col
-                ]
-                shared_state[local_row * D_HEAD + col] = first_value
-                fixed_state[
+                )
+                first_value: T.float32
+                _load_global_f32(first_value, local_state.ptr_to([first_index]))
+                _store_shared_f32(
+                    shared_state.ptr_to([local_row * D_HEAD + col]), first_value
+                )
+                fixed_index: T.int32 = (
                     ((first_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
                     * D_HEAD
                     + col
-                ] = first_value
+                )
+                _store_global_f32(fixed_state.ptr_to([fixed_index]), first_value)
         T.cuda.cta_sync()
 
-        accum: T.float32[4]
-        accum_next: T.float32[4]
+        accum = T.alloc_local((ROWS_PER_CTA,), "float32")
+        accum_next = T.alloc_local((ROWS_PER_CTA,), "float32")
         m_values: T.float32[16]
         m_next: T.float32[16]
         if start < num_chunks:
             first_work_slot: T.int32 = chunk_start + start
-            for local_row in T.unroll(4):
-                accum[local_row] = local_state[
+            for local_row in T.unroll(ROWS_PER_CTA):
+                first_work_index: T.int32 = (
                     ((first_work_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
                     * D_HEAD
                     + col
-                ]
+                )
+                _load_global_f32(accum[local_row], local_state.ptr_to([first_work_index]))
             for inner in T.unroll(16):
-                m_values[inner] = transfer[
+                transfer_index: T.int32 = (
                     ((first_work_slot * STATE_HEADS + state_head) * D_HEAD + inner) * D_HEAD + col
-                ]
+                )
+                _load_global_f32(m_values[inner], transfer.ptr_to([transfer_index]))
 
         for chunk in T.serial(start, num_chunks):
             cp_slot: T.int32 = chunk_start + chunk
             next_chunk: T.int32 = chunk + 1
             for k_tile in T.unroll(7):
                 for inner in T.unroll(16):
-                    m_next[inner] = transfer[
+                    transfer_next_index: T.int32 = (
                         ((cp_slot * STATE_HEADS + state_head) * D_HEAD + (k_tile + 1) * 16 + inner)
                         * D_HEAD
                         + col
-                    ]
-                for local_row in T.unroll(4):
+                    )
+                    _load_global_f32(m_next[inner], transfer.ptr_to([transfer_next_index]))
+                for local_row in T.unroll(ROWS_PER_CTA):
                     for inner in T.unroll(16):
+                        shared_value_main: T.float32
+                        _load_shared_f32(
+                            shared_value_main,
+                            shared_state.ptr_to(
+                                [local_row * D_HEAD + k_tile * 16 + inner]
+                            ),
+                        )
                         T.ptx.fma.rn.f32(
                             accum[local_row],
-                            shared_state[local_row * D_HEAD + k_tile * 16 + inner],
+                            shared_value_main,
                             m_values[inner],
                             accum[local_row],
                         )
@@ -3048,52 +3153,72 @@ def _fixup_sm100(
 
             if next_chunk < num_chunks:
                 next_slot: T.int32 = chunk_start + next_chunk
-                for local_row in T.unroll(4):
-                    accum_next[local_row] = local_state[
+                for local_row in T.unroll(ROWS_PER_CTA):
+                    next_state_index: T.int32 = (
                         ((next_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
                         * D_HEAD
                         + col
-                    ]
+                    )
+                    _load_global_f32(
+                        accum_next[local_row], local_state.ptr_to([next_state_index])
+                    )
                 for inner in T.unroll(16):
-                    m_next[inner] = transfer[
+                    next_transfer_index: T.int32 = (
                         ((next_slot * STATE_HEADS + state_head) * D_HEAD + inner) * D_HEAD + col
-                    ]
-            for local_row in T.unroll(4):
+                    )
+                    _load_global_f32(m_next[inner], transfer.ptr_to([next_transfer_index]))
+            for local_row in T.unroll(ROWS_PER_CTA):
                 for inner in T.unroll(16):
+                    shared_value_tail: T.float32
+                    _load_shared_f32(
+                        shared_value_tail,
+                        shared_state.ptr_to([local_row * D_HEAD + 112 + inner]),
+                    )
                     T.ptx.fma.rn.f32(
                         accum[local_row],
-                        shared_state[local_row * D_HEAD + 112 + inner],
+                        shared_value_tail,
                         m_values[inner],
                         accum[local_row],
                     )
             T.cuda.cta_sync()
-            for local_row in T.unroll(4):
-                shared_state[local_row * D_HEAD + col] = accum[local_row]
-                fixed_state[
+            for local_row in T.unroll(ROWS_PER_CTA):
+                _store_shared_f32(
+                    shared_state.ptr_to([local_row * D_HEAD + col]), accum[local_row]
+                )
+                fixed_index: T.int32 = (
                     ((cp_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row) * D_HEAD
                     + col
-                ] = accum[local_row]
+                )
+                _store_global_f32(fixed_state.ptr_to([fixed_index]), accum[local_row])
             T.cuda.cta_sync()
             if next_chunk < num_chunks:
-                for local_row in T.unroll(4):
+                for local_row in T.unroll(ROWS_PER_CTA):
                     accum[local_row] = accum_next[local_row]
                 for inner in T.unroll(16):
                     m_values[inner] = m_next[inner]
 
         if STORE_FINAL_STATE:
-            for local_row in T.unroll(4):
-                final_state[
+            for local_row in T.unroll(ROWS_PER_CTA):
+                final_index: T.int32 = (
                     ((state_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row)
                     * D_HEAD
                     + col
-                ] = T.cast(shared_state[local_row * D_HEAD + col], STATE_DTYPE)
+                )
+                final_value: T.float32
+                _load_shared_f32(
+                    final_value, shared_state.ptr_to([local_row * D_HEAD + col])
+                )
+                _store_global_from_f32(
+                    final_state, final_index, final_value, STATE_DTYPE
+                )
 
     for gap_slot in T.serial(gap_start, gap_end):
-        for local_row in T.unroll(4):
-            fixed_state[
+        for local_row in T.unroll(ROWS_PER_CTA):
+            gap_index: T.int32 = (
                 ((gap_slot * STATE_HEADS + state_head) * D_HEAD + row_start + local_row) * D_HEAD
                 + col
-            ] = T.float32(0.0)
+            )
+            _store_global_f32(fixed_state.ptr_to([gap_index]), T.float32(0.0))
 
 
 @T.jit
@@ -3175,8 +3300,10 @@ def _fixup_utcmma_sm100(
     state_head: T.int32 = head_seq % STATE_HEADS
     seq_idx: T.int32 = head_seq // STATE_HEADS
     row_start: T.int32 = row_cta * ROWS
-    seq_start: T.int32 = T.cast(cu_seqlens[seq_idx], "int32")
-    seq_end: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+    sequence_bounds = T.alloc_local((2,), "int32")
+    _load_sequence_bounds(cu_seqlens, seq_idx, sequence_bounds, CU_DTYPE)
+    seq_start: T.int32 = sequence_bounds[0]
+    seq_end: T.int32 = sequence_bounds[1]
     seq_len: T.int32 = seq_end - seq_start
     num_chunks: T.int32 = (seq_len + CP_CHUNK_LEN - 1) // CP_CHUNK_LEN
     chunk_start: T.int32 = _device_chunk_bound(seq_idx, seq_start, CP_CHUNK_LEN)
@@ -3184,7 +3311,7 @@ def _fixup_utcmma_sm100(
     num_iters: T.int32 = num_chunks - start
     state_slot: T.int32 = seq_idx
     if USE_STATE_INDICES:
-        state_slot = state_indices[seq_idx]
+        _load_global_s32(state_slot, state_indices.ptr_to([seq_idx]))
 
     pool = T.SMEMPool()
     smem_raw = pool.alloc((SMEM_TOTAL,), "uint8", align=1024)
@@ -3434,8 +3561,10 @@ def _prefill_sm100(
     lane: T.int32 = thread & 31
     state_head: T.int32 = bx % STATE_HEADS
     chunk_in_seq: T.int32 = bx // STATE_HEADS
-    seq_start: T.int32 = T.cast(cu_seqlens[seq_idx], "int32")
-    seq_end: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+    sequence_bounds = T.alloc_local((2,), "int32")
+    _load_sequence_bounds(cu_seqlens, seq_idx, sequence_bounds, CU_DTYPE)
+    seq_start: T.int32 = sequence_bounds[0]
+    seq_end: T.int32 = sequence_bounds[1]
     seq_len: T.int32 = seq_end - seq_start
     num_cp_chunks: T.int32 = (seq_len + CP_CHUNK_LEN - 1) // CP_CHUNK_LEN
     chunk_len: T.int32 = 0
@@ -5007,6 +5136,14 @@ def _fixup_kind(cfg: GDNCPPrefillSM100Config, num_sms: int) -> str:
     return "fixup_utcmma128"
 
 
+def _fixup_simt_rows(cfg: GDNCPPrefillSM100Config, num_sms: int) -> int:
+    parallel_states = cfg.num_sequences * cfg.state_heads
+    for rows_per_cta in (4, 2, 1):
+        if parallel_states * (D_HEAD // rows_per_cta) >= num_sms:
+            return rows_per_cta
+    return 1
+
+
 def _specialization(cfg: GDNCPPrefillSM100Config, device: str = "cuda") -> dict[str, Any]:
     del device
     from tirx_kernels.runner import hardware_num_sms
@@ -5036,6 +5173,7 @@ def _specialization(cfg: GDNCPPrefillSM100Config, device: str = "cuda") -> dict[
         "STORE_FINAL_STATE": cfg.store_final_state,
         "USE_STATE_INDICES": cfg.indexed_state,
         "FIXUP_KIND": _fixup_kind(cfg, num_sms),
+        "FIXUP_SIMT_ROWS": _fixup_simt_rows(cfg, num_sms),
     }
 
 
@@ -5117,7 +5255,9 @@ def get_kernel(**kwargs: Any) -> dict[str, Any]:
     return {
         "t_precompute": t_kernel,
         "mn_precompute": mn_kernel,
-        "fixup_simt_row4": _fixup_sm100.specialize(**fixup_common),
+        "fixup_simt_row4": _fixup_sm100.specialize(
+            **fixup_common, ROWS_PER_CTA=spec["FIXUP_SIMT_ROWS"]
+        ),
         "fixup_utcmma64": _fixup_utcmma_sm100.specialize(
             **fixup_common,
             ROWS=64,

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -216,7 +216,9 @@ def _tinygemm2_sm100(
         smem_wt_addr_c: T.uint32 = smem_addr_c + T.uint32(WT_OFF)
         smem_act_addr_c: T.uint32 = smem_addr_c + T.uint32(act_off)
         if tid < 16:
-            smem_bias[tid] = d_bias[mib_c + tid]
+            bias_bits: T.uint16
+            T.ptx.ld.global_.b16(bias_bits, d_bias.ptr_to([mib_c + tid]))
+            T.ptx.st.shared.b16(smem_bias.ptr_to([tid]), bias_bits)
 
         accum = T.alloc_local((4,), "float32", align=4)
         for z in T.unroll(4):
@@ -309,8 +311,11 @@ def _tinygemm2_sm100(
 
             tm: T.int32 = mib_c + lane // 4
             tn: T.int32 = ni_c + 2 * (lane % 4)
-            bias_lo: T.float32 = T.cast(smem_bias[lane // 4], "float32")
-            bias_hi: T.float32 = T.cast(smem_bias[lane // 4 + 8], "float32")
+            bias_bits = T.alloc_local((2,), "uint16")
+            T.ptx.ld.shared.b16(bias_bits[0], smem_bias.ptr_to([lane // 4]))
+            T.ptx.ld.shared.b16(bias_bits[1], smem_bias.ptr_to([lane // 4 + 8]))
+            bias_lo: T.float32 = T.cast(T.reinterpret("bfloat16", bias_bits[0]), "float32")
+            bias_hi: T.float32 = T.cast(T.reinterpret("bfloat16", bias_bits[1]), "float32")
             out_frag = T.alloc_local((4,), "float32", align=4)
             T.ptx["add.ftz.f32"](out_frag[0], accum[0], bias_lo)
             T.ptx["add.ftz.f32"](out_frag[1], accum[1], bias_lo)
@@ -321,16 +326,28 @@ def _tinygemm2_sm100(
 
             if tn < b_N:
                 if tm < a_M:
-                    c_output[out_base] = T.cast(out_frag[0], "bfloat16")
+                    T.ptx.st.global_.b16(
+                        c_output.ptr_to([out_base]),
+                        T.reinterpret("uint16", T.cast(out_frag[0], "bfloat16")),
+                    )
             if tn + 1 < b_N:
                 if tm < a_M:
-                    c_output[out_next] = T.cast(out_frag[1], "bfloat16")
+                    T.ptx.st.global_.b16(
+                        c_output.ptr_to([out_next]),
+                        T.reinterpret("uint16", T.cast(out_frag[1], "bfloat16")),
+                    )
             if tn < b_N:
                 if tm + 8 < a_M:
-                    c_output[out_base + 8] = T.cast(out_frag[2], "bfloat16")
+                    T.ptx.st.global_.b16(
+                        c_output.ptr_to([out_base + 8]),
+                        T.reinterpret("uint16", T.cast(out_frag[2], "bfloat16")),
+                    )
             if tn + 1 < b_N:
                 if tm + 8 < a_M:
-                    c_output[out_next + 8] = T.cast(out_frag[3], "bfloat16")
+                    T.ptx.st.global_.b16(
+                        c_output.ptr_to([out_next + 8]),
+                        T.reinterpret("uint16", T.cast(out_frag[3], "bfloat16")),
+                    )
 
     elif 4 <= warp and warp <= 7:
         k_loops_w: T.int32 = T.truncdiv(c_K + 1023, 1024)

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -40,6 +40,8 @@ _log2 = _simple._log2
 _div = _simple._div
 _global_load_u16 = _simple._global_load_u16
 _global_load_u32 = _simple._global_load_u32
+_global_load_s64 = _simple._global_load_s64
+_global_load_index_s64 = _simple._global_load_index_s64
 _shared_load_u16 = _simple._shared_load_u16
 _shared_load_u32 = _simple._shared_load_u32
 _bf16_to_f32 = _simple._bf16_to_f32
@@ -266,6 +268,7 @@ def _role_update_horizontal(
     DSTATE_PAD,
     STATE_DTYPE,
     WEIGHT_DTYPE,
+    INDEX_DTYPE,
     STATE_BYTES,
     ELEMS_PER_TILE_MEMBER,
     PAIRS_PER_TILE_MEMBER,
@@ -290,11 +293,11 @@ def _role_update_horizontal(
 ):
     random_seed: T.int64 = 0
     if PHILOX_ROUNDS > 0 and not IS_PAD:
-        random_seed = rand_seed[0]
+        random_seed = _global_load_s64(rand_seed, 0)
 
     icache_idx: T.int64 = state_batch
     if HAS_INTERMEDIATE_STATES and not IS_PAD:
-        icache_idx = T.cast(intermediate_indices[batch_i], "int64")
+        icache_idx = _global_load_index_s64(intermediate_indices, batch_i, INDEX_DTYPE)
 
     a_value: T.float32 = T.reinterpret("float32", _global_load_u32(matrix_a, head))
     d_value: T.float32 = 0.0
@@ -848,6 +851,7 @@ def _selective_state_update_mtp_horizontal(
                 DSTATE_PAD=DSTATE_PAD,
                 STATE_DTYPE=STATE_DTYPE,
                 WEIGHT_DTYPE=WEIGHT_DTYPE,
+                INDEX_DTYPE=INDEX_DTYPE,
                 STATE_BYTES=STATE_BYTES,
                 ELEMS_PER_TILE_MEMBER=ELEMS_PER_TILE_MEMBER,
                 PAIRS_PER_TILE_MEMBER=PAIRS_PER_TILE_MEMBER,

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -129,6 +129,24 @@ def _global_load_u32(buffer, index):
     return out[0]
 
 
+def _global_load_s32(buffer, index):
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.s32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_s64(buffer, index):
+    out = T.alloc_local((1,), "int64")
+    T.evaluate(T.ptx.ld.global_.s64(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_index_s64(buffer, index, dtype):
+    if dtype == "int32":
+        return T.cast(_global_load_s32(buffer, index), "int64")
+    return _global_load_s64(buffer, index)
+
+
 def _shared_load_u16(buffer, index):
     out = T.alloc_local((1,), "uint16")
     T.evaluate(T.ptx.ld.shared.b16(out[0], buffer.ptr_to([index])))
@@ -139,6 +157,16 @@ def _shared_load_u32(buffer, index):
     out = T.alloc_local((1,), "uint32")
     T.evaluate(T.ptx.ld.shared.b32(out[0], buffer.ptr_to([index])))
     return out[0]
+
+
+def _shared_load_s64(buffer, index):
+    out = T.alloc_local((1,), "int64")
+    T.evaluate(T.ptx.ld.shared.b64(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _shared_store_s64(buffer, index, value):
+    T.evaluate(T.ptx.st.shared.b64(buffer.ptr_to([index]), value))
 
 
 def _bf16_to_f32(bits):
@@ -552,24 +580,27 @@ def _selective_state_update_mtp_simple(
     bos: T.int32 = 0
     seq_len: T.int32 = NTOKENS
     if HAS_CU_SEQLENS:
-        bos = T.cast(cu_seqlens[seq_idx], "int32")
-        eos: T.int32 = T.cast(cu_seqlens[seq_idx + 1], "int32")
+        bos = T.cast(_global_load_index_s64(cu_seqlens, seq_idx, CU_SEQLENS_DTYPE), "int32")
+        eos: T.int32 = T.cast(
+            _global_load_index_s64(cu_seqlens, seq_idx + 1, CU_SEQLENS_DTYPE), "int32"
+        )
         seq_len = eos - bos
 
     if seq_len > 0:
         init_token_idx: T.int32 = 0
         if HAS_NUM_ACCEPTED_TOKENS:
-            accepted: T.int32 = T.cast(num_accepted_tokens[seq_idx], "int32")
+            accepted: T.int32 = T.cast(
+                _global_load_index_s64(num_accepted_tokens, seq_idx, ACCEPTED_DTYPE), "int32"
+            )
             init_token_idx = T.if_then_else(accepted > 1, accepted - 1, 0)
 
         state_batch: T.int64
         if HAS_STATE_INDICES:
-            state_batch = T.cast(
-                state_indices[
-                    T.cast(seq_idx, "int64") * state_indices_stride_batch
-                    + T.cast(init_token_idx, "int64") * state_indices_stride_t
-                ],
-                "int64",
+            state_batch = _global_load_index_s64(
+                state_indices,
+                T.cast(seq_idx, "int64") * state_indices_stride_batch
+                + T.cast(init_token_idx, "int64") * state_indices_stride_t,
+                INDEX_DTYPE,
             )
         else:
             state_batch = T.cast(seq_idx, "int64")
@@ -753,23 +784,24 @@ def _selective_state_update_mtp_simple(
                 dst_slot: T.int64 = -1
                 if not IS_PAD and step < seq_len:
                     if HAS_DST_INDICES:
-                        dst_index: T.int64 = T.cast(
-                            dst_indices[
-                                T.cast(seq_idx, "int64") * dst_indices_stride_batch
-                                + T.cast(step, "int64") * dst_indices_stride_t
-                            ],
-                            "int64",
+                        dst_index: T.int64 = _global_load_index_s64(
+                            dst_indices,
+                            T.cast(seq_idx, "int64") * dst_indices_stride_batch
+                            + T.cast(step, "int64") * dst_indices_stride_t,
+                            INDEX_DTYPE,
                         )
                         if dst_index != T.cast(pad_slot_id, "int64"):
                             dst_slot = dst_index
                     elif HAS_INTERMEDIATE_STATES:
                         intermediate_index: T.int64 = state_batch
                         if HAS_INTERMEDIATE_INDICES:
-                            intermediate_index = T.cast(intermediate_indices[seq_idx], "int64")
+                            intermediate_index = _global_load_index_s64(
+                                intermediate_indices, seq_idx, INDEX_DTYPE
+                            )
                         dst_slot = intermediate_index * T.cast(cache_steps, "int64") + step
                     elif step == seq_len - 1 and update_state != 0:
                         dst_slot = state_batch
-                s_dst_slots[step] = dst_slot
+                _shared_store_s64(s_dst_slots, step, dst_slot)
 
             T.ptx.cp.async_.commit_group()
             T.ptx.cp.async_.wait_group(0)
@@ -777,7 +809,7 @@ def _selective_state_update_mtp_simple(
 
             random_seed: T.int64 = 0
             if PHILOX_ROUNDS > 0:
-                random_seed = rand_seed[0]
+                random_seed = _global_load_s64(rand_seed, 0)
 
             member: T.int32 = lane % 8
             row_group: T.int32 = lane // 8
@@ -849,7 +881,7 @@ def _selective_state_update_mtp_simple(
                 out_step: T.int32 = 0
                 for step in T.serial(NTOKENS):
                     if step < seq_len:
-                        dst_slot: T.int64 = s_dst_slots[step]
+                        dst_slot: T.int64 = _shared_load_s64(s_dst_slots, step)
                         dt_value: T.float32 = T.reinterpret(
                             "float32", _shared_load_u32(s_dt, dt_step)
                         )

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -42,6 +42,8 @@ _mul_lo_s32 = _simple._mul_lo_s32
 _add_s32 = _simple._add_s32
 _global_load_u16 = _simple._global_load_u16
 _global_load_u32 = _simple._global_load_u32
+_global_load_s64 = _simple._global_load_s64
+_global_load_index_s64 = _simple._global_load_index_s64
 _shared_load_u16 = _simple._shared_load_u16
 _shared_load_u32 = _simple._shared_load_u32
 _bf16_to_f32 = _simple._bf16_to_f32
@@ -502,6 +504,7 @@ def _role_update_state(
     NUM_PASSES,
     STATE_DTYPE,
     WEIGHT_DTYPE,
+    INDEX_DTYPE,
     STATE_BYTES,
     STATE_VALUES_PER_THREAD,
     HAS_INTERMEDIATE_STATES,
@@ -522,10 +525,10 @@ def _role_update_state(
 ):
     random_seed: T.int64 = 0
     if PHILOX_ROUNDS > 0 and not IS_PAD:
-        random_seed = rand_seed[0]
+        random_seed = _global_load_s64(rand_seed, 0)
     icache_idx: T.int64 = state_batch
     if HAS_INTERMEDIATE_STATES and not IS_PAD:
-        icache_idx = T.cast(intermediate_indices[batch_i], "int64")
+        icache_idx = _global_load_index_s64(intermediate_indices, batch_i, INDEX_DTYPE)
 
     a_value: T.float32 = T.reinterpret("float32", _global_load_u32(matrix_a, head))
     d_value: T.float32 = 0.0
@@ -1099,6 +1102,7 @@ def _selective_state_update_mtp_vertical(
                     NUM_PASSES=NUM_PASSES,
                     STATE_DTYPE=STATE_DTYPE,
                     WEIGHT_DTYPE=WEIGHT_DTYPE,
+                    INDEX_DTYPE=INDEX_DTYPE,
                     STATE_BYTES=STATE_BYTES,
                     STATE_VALUES_PER_THREAD=STATE_VALUES_PER_THREAD,
                     HAS_INTERMEDIATE_STATES=HAS_INTERMEDIATE_STATES,

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -641,7 +641,7 @@ def _selective_state_update_stp_horizontal(
 
     random_seed: T.int64 = 0
     if PHILOX_ROUNDS > 0:
-        random_seed = rand_seed[0]
+        random_seed = _global_load_s64(rand_seed, 0)
 
     batch_i, head = T.cta_id([BATCH, NHEADS])
     raw_lane, warp = T.thread_id([32, NUM_WARPS])

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -129,6 +129,24 @@ def _global_load_u32(buffer, index):
     return out[0]
 
 
+def _global_load_s32(buffer, index):
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.s32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_s64(buffer, index):
+    out = T.alloc_local((1,), "int64")
+    T.evaluate(T.ptx.ld.global_.s64(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def _global_load_index_s64(buffer, index, dtype):
+    if dtype == "int32":
+        return T.cast(_global_load_s32(buffer, index), "int64")
+    return _global_load_s64(buffer, index)
+
+
 def _shared_load_u16(buffer, index):
     out = T.alloc_local((1,), "uint16")
     T.evaluate(T.ptx.ld.shared.b16(out[0], buffer.ptr_to([index])))
@@ -467,7 +485,7 @@ def _selective_state_update_stp_simple(
 
     random_seed: T.int64 = 0
     if PHILOX_ROUNDS > 0 and not SCALE_STATE:
-        random_seed = rand_seed[0]
+        random_seed = _global_load_s64(rand_seed, 0)
 
     batch_i, head, dim_tile = T.cta_id([BATCH, NHEADS, dim_tiles_runtime])
     lane_axis, warp = T.thread_id([32, 4])
@@ -478,12 +496,16 @@ def _selective_state_update_stp_simple(
 
     state_batch: T.int64
     if HAS_STATE_INDICES:
-        state_batch = T.cast(state_indices[batch_i * state_indices_stride_batch], "int64")
+        state_batch = _global_load_index_s64(
+            state_indices, batch_i * state_indices_stride_batch, INDEX_DTYPE
+        )
     else:
         state_batch = T.cast(batch_i, "int64")
     dst_state_batch: T.int64
     if HAS_DST_INDICES:
-        dst_state_batch = T.cast(dst_indices[batch_i * dst_indices_stride_batch], "int64")
+        dst_state_batch = _global_load_index_s64(
+            dst_indices, batch_i * dst_indices_stride_batch, INDEX_DTYPE
+        )
     else:
         dst_state_batch = state_batch
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -46,6 +46,7 @@ _mul_hi_u32 = _simple._mul_hi_u32
 _mul_lo_s32 = _simple._mul_lo_s32
 _add_s32 = _simple._add_s32
 _lane_mask = _simple._lane_mask
+_global_load_s64 = _simple._global_load_s64
 _shared_load_u16 = _simple._shared_load_u16
 _shared_load_u32 = _simple._shared_load_u32
 _bf16_to_f32 = _simple._bf16_to_f32
@@ -726,7 +727,7 @@ def _selective_state_update_stp_vertical(
 
     random_seed: T.int64 = 0
     if PHILOX_ROUNDS > 0 and not SCALE_STATE:
-        random_seed = rand_seed[0]
+        random_seed = _global_load_s64(rand_seed, 0)
 
     batch_i, head = T.cta_id([BATCH, NHEADS])
     lane_axis, warp = T.thread_id([32, 5])

--- a/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
+++ b/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
@@ -189,11 +189,11 @@ def get_kernel(
         lane = T.truncmod(tx, T.int32(32))
         warp = T.truncdiv(tx, T.int32(32))
         if lane == 0:
-            red_buf[warp] = warp_amax
+            T.ptx.st.shared.f32(red_buf.ptr_to([warp]), warp_amax)
         T.ptx.bar.sync(T.uint32(0), T.uint32(_PER_TOKEN_THREADS))
         block_val: T.float32 = T.float32(0.0)
         if lane < _PER_TOKEN_WARPS:
-            block_val = red_buf[lane]
+            T.ptx.ld.shared.f32(block_val, red_buf.ptr_to([lane]))
         row_amax = warp_reduce_max(block_val)
 
         gs_inv = ld_global_f32(gsi, 0)
@@ -208,7 +208,7 @@ def get_kernel(
             encode_scale = rcp_approx_ftz(token_scale)
 
         if tx == 0:
-            pts_out[row_idx] = token_scale
+            T.ptx.st.global_.f32(pts_out.ptr_to([row_idx]), token_scale)
         T.ptx.bar.sync(T.uint32(0), T.uint32(_PER_TOKEN_THREADS))
 
         # Pass 2: quantize with the row encode scale (kernel:846-875).

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -25,6 +25,7 @@ from types import ModuleType
 from typing import Any, Protocol, runtime_checkable
 
 import tvm
+from tirx_kernels.low_level_ir import check_low_level_ir
 
 DEFAULT_BENCH_ROUNDS = 5
 DEFAULT_BENCH_COOLDOWN_S = 0.0
@@ -557,7 +558,8 @@ def compile_kernel(func):
 def run_kernel_test(kernel_name: str, config: dict[str, Any], *, registry=None):
     """Run a kernel's correctness test.
 
-    Delegates to ``mod.run_test(**params)``.
+    Validates the public pre-lowering IR, then delegates to
+    ``mod.run_test(**params)``.
     """
     if registry is None:
         from tirx_kernels.registry import discover_kernels
@@ -566,6 +568,7 @@ def run_kernel_test(kernel_name: str, config: dict[str, Any], *, registry=None):
 
     mod = registry[kernel_name]
     params = {k: v for k, v in config.items() if k != "label"}
+    check_low_level_ir(mod.get_kernel(**params))
     mod.run_test(**params)
 
 


### PR DESCRIPTION
## Summary

- validate every public kernel's pre-lowering IR with the existing low-level contract checker before running its correctness test
- make the affected kernels express global/shared accesses with contract-safe low-level operations, propagate MegaMoE shared-expert configuration, and add the missing GemmRS device-side exit rendezvous
- preserve GDN fixup performance with SM-aware SIMT row grouping and record the measured reusable guidance

## Validation

- full correctness sweep: **1402 passed, 0 failed, 0 skipped**
- post-rebase overlap checks:
  - `gdn_cp_prefill_sm100`: **10/10 passed**
  - single-GPU shared-expert `sm100_fp8_fp4_mega_moe`: **9/9 passed**, including the 8192-token shape
- 33-workload bench suite, 2x B200, 5 rounds, no interference retries: all workloads clear the 0.99 before/current gate after same-physical-GPU reruns for card-sensitive rows; minimum ratio **0.993779**
- post-rebase GDN same-GPU 15-round A/B versus `origin/main`:
  - q16/v16 long shape: **0.997058**
  - q16/v64 initial+final shape: **0.998430**
  - q1 fixup shape: **1.018408**
- `ruff check` on changed Python files
- `git diff --check`
