### PR TITLE
feat(kernel): port flashinfer radix top-k single-CTA kernel to TIRx

### DIFF
--- a/.agents/sketch/flashinfer/topk/radix_topk_single_cta.md
+++ b/.agents/sketch/flashinfer/topk/radix_topk_single_cta.md
@@ -1,0 +1,911 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of FlashInfer's
+include/flashinfer/topk.cuh RadixTopKKernel_Unified, restricted to the
+SINGLE_CTA=true specialization the host launchers select when one CTA
+can stage a whole row in shared memory.
+-->
+
+# radix_topk_single_cta SM100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/flashinfer/topk/radix_topk_single_cta.py`](../../../../tirx_kernels/flashinfer/topk/radix_topk_single_cta.py).
+That TIRx module is the authoritative implementation.
+
+The instantiations are `DTYPE in {f32, f16, bf16}` x `MODE in {Basic,
+PageTableTransform, RaggedTransform}` x `DETERMINISTIC in {false, true}` x
+`VEC_SIZE in {4,2,1}` (f32) / `{8,4,2,1}` (f16, bf16), each mirroring one
+`RadixTopKKernel_Unified<1024, VEC_SIZE, true, DETERMINISTIC, MODE, DType,
+int32_t>` template instantiation. `IdType` is always `int32_t` (`csrc/topk.cu`).
+`num_rows`, `length`, `k`, and the derived `chunk_size` / grid / dynamic-smem
+size are static per config, exactly like the per-launch values
+`RadixTopKMultiCTA` (:2172), `RadixTopKPageTableTransformMultiCTA` (:1939) and
+`RadixTopKRaggedTransformMultiCTA` (:2055) compute at every call.
+
+The accepted target is SM100/B200. Out of scope, because the source itself
+routes them elsewhere: `SINGLE_CTA=false` (the cross-CTA `RadixRowState`
+barrier/histogram protocol), per-row `top_k_arr` (`csrc/topk.cu` always passes
+`nullptr`), and the FilteredTopK / cluster algorithms that `TopKDispatch`
+(:3446) selects for other shapes, tie-break modes, and `dsa_graph_safe`.
+Tile (`Tx`) primitives are out of scope everywhere.
+
+Because `ctas_per_group == 1`, `group_id == blockIdx.x`, `cta_in_group == 0`,
+`chunk_start == 0`, `actual_chunk_size == length`, and every
+`AdvanceRadixGroupBarrier` / `RadixGroupResetStateLastCTA` /
+`state->histogram` / `det_scratch` reference is compile-time dead
+(`state == nullptr`). The sketch shows only what survives.
+
+## Pipeline at a glance
+
+| Warps | Role-local program | Publication/reuse edges |
+| --- | --- | --- |
+| all 32 warps (uniform) | Every thread of CTA `blockIdx.x` runs the same single-role program: persistent row loop; per-row header loads; mode trivial-branch early-out; block-strided vectorized row load + monotone key flip into `s_ordered`; `NUM_ROUNDS` radix rounds over `s_hist`/`s_suffix`; block-strided gt/eq count with a warp shuffle reduction; one collect pass; mode epilogue. | all edges are CTA-internal: `s_ordered` published once per row by the load loop, re-read by every round, the counting pass and the collect pass; `s_hist`/`s_suffix`/`s_scalars` are republished each round. Every publication point is one `bar.sync 0`. |
+
+There is no warp specialization, no producer/consumer split, no mbarrier, no
+async copy and no cluster. The only cross-thread mechanisms are `bar.sync 0`,
+shared-memory atomics, and one warp shuffle reduction (plus the deterministic
+collect's block scan, which is itself shuffle + shared based).
+
+`s_hist` and `s_suffix` are deliberately aliased to two different roles inside
+one row iteration: during the rounds they are the 256-bin histogram and its
+suffix sum; after the rounds `s_suffix[0]`/`s_suffix[1]` become the row-wide
+gt/eq accumulators, and during collect `s_hist[0..4]` become the collect
+counters. The source does the same by macro (:908-910, :1029-1033) and by direct
+reuse of `suffix_sum[0..1]` as the gt/eq accumulators (:782-786, :825-827).
+
+## Primitive vocabulary
+
+Structural operations declare placement without moving data:
+
+```python
+specialize(...)        # compile-time variant selection
+launch(...)            # compile-time launch topology and attributes
+raw_shared(...)        # the one dynamic shared allocation
+static_shared(...)     # a separate static __shared__ object (deterministic collect only)
+view(...)              # typed view at a fixed byte offset in that allocation
+reg_tile(...)          # per-thread register tile
+```
+
+Copies state their direction and width:
+
+```python
+copy_g2r_v(src_addr, dst_bits)      # one VEC_SIZE*sizeof(DType)-byte global -> register load
+copy_g2r_scalar(src_addr, dst)      # one scalar global -> register load
+copy_r2s(src, dst_slot)             # one register -> shared store
+copy_s2r(src_slot, dst)             # one shared -> register load
+copy_r2g_scalar(src, dst_addr)      # one scalar register -> global store
+```
+
+The compute vocabulary is deliberately primitive:
+
+```python
+to_ordered(dst, bits)     # monotone float bits -> unsigned key (RadixTopKTraits::ToOrdered)
+from_ordered(dst, key)    # inverse (RadixTopKTraits::FromOrdered)
+and_(dst, a, b); or_(dst, a, b); xor_(dst, a, b); not_(dst, a)
+shr(dst, a, n); shl(dst, a, n)
+add(dst, a, b); sub(dst, a, b); min_(dst, a, b); max_(dst, a, b)
+cmp_eq/cmp_gt/cmp_ge/cmp_lt(pred, a, b)
+select(dst, pred, a, b)
+move(dst, src)
+```
+
+Schedule and cross-thread operations:
+
+```python
+thread_id(...); cta_id(...)
+barrier()                        # CTA barrier
+atomic_add_shared(dst, slot, v)  # shared-memory read-modify-write returning the old value
+shfl_down(dst, src, delta)       # warp shuffle
+block_exclusive_sum(dst, src)            # CTA-wide exclusive scan (cub BlockScan, RAKING_MEMOIZE)
+block_exclusive_sum_pair(dst2, src2)     # the same scan over a (gt, eq) pair
+```
+
+Address expressions, loop bounds, and guards are shown directly; they do not
+hide copies, computation, role changes, or synchronization.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+variant = specialize(DTYPE=("f32", "f16", "bf16"),
+                     MODE=("Basic", "PageTableTransform", "RaggedTransform"),
+                     DETERMINISTIC=(False, True),
+                     VEC_SIZE=(8, 4, 2, 1),
+                     target="sm_100a")
+# instruction_selection: none; extent: compile-time instantiations
+
+BLOCK      = 1024                      # BLOCK_THREADS (:2177)
+RADIX      = 256
+OBITS      = 32 if DTYPE == "f32" else 16          # sizeof(OrderedType)*8
+NUM_ROUNDS = OBITS // 8                            # 4 (f32) | 2 (f16, bf16)
+OBYTES     = OBITS // 8                            # 4 | 2
+
+# Launcher arithmetic, replicated at specialization time
+# (Basic :2177-2213; PageTable :1946-1980; Ragged :2063-2097; smem budget :43-59):
+#   VEC_SIZE      = 1 if (MODE != Basic and row_starts) else gcd(16 // sizeof(DType), LENGTH)
+#   avail         = max_smem_optin - 2080 - (8512 if DETERMINISTIC else 0)
+#   max_chunk     = max(round_down(avail // OBYTES, VEC_SIZE), VEC_SIZE * BLOCK)
+#   ctas_per_grp  = ceil_div(LENGTH, max_chunk)          == 1 in this specialization
+#   CHUNK         = min(round_up(LENGTH, VEC_SIZE), max_chunk)  == LENGTH
+#   NUM_GROUPS    = max(1, min(num_sms, NUM_ROWS))
+# `aligned_size` (:608) is not a compile-time value in general: it derives from
+# `actual_chunk_size`, which is `stride` (static) only in Basic mode and the
+# per-row runtime `lengths[row_idx]` (:1235) in the other two modes.  It is
+# therefore computed inside the row loop, not here.
+
+FIXED_BYTES = 2080                     # round_up(4*(256+256+5), 16) (:1194-1200)
+SMEM_BYTES  = FIXED_BYTES + CHUNK * OBYTES
+
+launch_config = launch(
+    grid=(NUM_GROUPS, 1, 1),
+    block=(BLOCK, 1, 1),
+    dynamic_smem_bytes=SMEM_BYTES,     # cudaFuncSetAttribute + cudaLaunchKernel (:2255-2259)
+    launch_bounds=BLOCK,               # __launch_bounds__(1024)
+)
+# instruction_selection: none; extent: static launch metadata
+
+# ===========================================================================
+# Shared storage: one dynamic allocation carved by hand (:1192-1201)
+# ===========================================================================
+
+smem      = raw_shared(dtype="u8", bytes=SMEM_BYTES, alignment=16)
+s_hist    = view(smem[0:1024],    dtype="u32", shape=(256,))   # local_histogram
+s_suffix  = view(smem[1024:2048], dtype="u32", shape=(256,))   # suffix_sum
+s_scalars = view(smem[2048:2068], dtype="u32", shape=(5,))     # prefix, rem_k, bucket, rem_k', out_ctr
+s_ordered = view(smem[2080:SMEM_BYTES], dtype="u32" if OBYTES == 4 else "u16",
+                 shape=(CHUNK,))                               # shared_ordered, 16B-aligned base
+# instruction_selection: none; extent: static shared layout (PTX confirms the +2080 base)
+
+# A second, *static* shared object exists only when DETERMINISTIC (:1095-1102):
+#   union DeterministicCollectScanTempStorage {
+#       cub::BlockScan<uint32_t,  1024, RAKING_MEMOIZE>::TempStorage scalar;
+#       cub::BlockScan<CountPair, 1024, RAKING_MEMOIZE>::TempStorage pair;
+#   } __shared__ scan_temp_storage;
+if DETERMINISTIC:
+    s_scan_temp = static_shared(bytes=8480, alignment=16)
+    # lifetime: the whole RadixCollectIndicesDeterministic body -- the scan and both
+    #   emit loops.  Disjoint from the dynamic arena, so a DETERMINISTIC config's
+    #   total shared footprint is SMEM_BYTES + 8480.  The launcher pre-pays for it by
+    #   subtracting 2 * sizeof(ScalarBlockScan::TempStorage) == 8512 from the chunk
+    #   budget (:43-52), which is why the deterministic single-CTA domain is smaller.
+# instruction_selection: none; extent: `.shared .align 16 .b8 ...scan_temp_storage[8480]`,
+#   present in every DETERMINISTIC=true entry and absent from the others
+
+def radix_topk_single_cta(
+        input,                  # DType [NUM_ROWS, LENGTH]
+        output_indices,         # int32 [NUM_ROWS, K]
+        output_values,          # DType [NUM_ROWS, K]; Basic only
+        aux_data,               # int32; PageTable: src_page_table, Ragged: offsets
+        lengths,                # int32 [NUM_ROWS]; non-Basic only
+        row_starts,             # int32 [NUM_ROWS] | null; non-Basic only
+        page_table_row_starts,  # int32 [NUM_ROWS] | null; PageTable only
+        row_to_batch,           # int32 [NUM_ROWS] | null; PageTable only
+        aux_stride,             # int64; PageTable only
+        ):
+    group_id = cta_id(axis="x", extent=NUM_GROUPS)
+    # instruction_selection: mov.u32 %ctaid.x; extent: scalar per thread
+    tx = thread_id(extent=BLOCK, dtype="uint32")
+    # instruction_selection: mov.u32 %tid.x; extent: scalar per thread
+
+    total_iterations = ceil_div(NUM_ROWS, NUM_GROUPS)          # (:1213-1214)
+
+    # =======================================================================
+    # Persistent row loop (:1218-1220)
+    # =======================================================================
+    for it in range(total_iterations):                         # static trip count
+        row_idx = group_id + it * NUM_GROUPS
+        cmp_ge(p_done, row_idx, NUM_ROWS)
+        # instruction_selection: setp.ge.u32; extent: scalar
+        if p_done: break
+        # instruction_selection: bra; extent: loop exit predicate
+
+        # ---- per-row header (:1221-1247) ----------------------------------
+        if MODE == "Basic":
+            row_start = 0
+            page_start = 0
+            length = LENGTH                                    # stride
+            k = K                                              # top_k_arr is null
+        else:
+            if row_starts is not null:
+                copy_g2r_scalar(row_starts + row_idx, row_start)
+                # instruction_selection: ld.global.b32; extent: one scalar load
+            else:
+                move(row_start, 0)
+            if MODE == "PageTableTransform" and page_table_row_starts is not null:
+                copy_g2r_scalar(page_table_row_starts + row_idx, page_start)
+                # instruction_selection: ld.global.b32; extent: one scalar load
+            else:
+                move(page_start, row_start)
+            copy_g2r_scalar(lengths + row_idx, length)
+            # instruction_selection: ld.global.b32; extent: one scalar load
+            k = K
+        row_input   = input + row_idx * LENGTH + row_start      # (:1227)
+        row_output  = output_indices + row_idx * K              # (:1240)
+        # instruction_selection: address family (mul.wide.u32 / mul.wide.s32 / mul.lo.s32,
+        #   cvt.u64.u32, cvt.u32.u64, shl.b64, add.s64, add.s32; cvta.to.global.u64 is
+        #   also emitted here inside the row loop, not only in the entry block);
+        #   extent: per row iteration
+
+        # ---- mode trivial early-out (:1243-1307) --------------------------
+        if MODE == "Basic":
+            cmp_ge(p_all, k, length)
+            # instruction_selection: setp.ge.u32; extent: scalar
+            if p_all:                                          # k >= length: identity output
+                i = tx
+                while i < length:
+                    cmp_lt(p_in, i, k)
+                    # instruction_selection: setp.lt.u32; extent: scalar per iteration
+                    if p_in:
+                        copy_r2g_scalar(i, row_output + i)
+                        # instruction_selection: st.global.b32; extent: one scalar store
+                        copy_g2r_scalar(input + row_idx * LENGTH + i, v_raw)
+                        # instruction_selection: ld.global.b32 (f32) | ld.global.b16 (f16, bf16); extent: one scalar load
+                        copy_r2g_scalar(v_raw, output_values + row_idx * K + i)
+                        # instruction_selection: st.global.b32 (f32) | st.global.b16 (f16, bf16); extent: one scalar store
+                    i = i + BLOCK
+                continue                                       # next row
+        elif MODE == "PageTableTransform":
+            if row_to_batch is not null:
+                copy_g2r_scalar(row_to_batch + row_idx, batch_idx)
+                # instruction_selection: ld.global.b32; extent: one scalar load
+            else:
+                move(batch_idx, row_idx)
+            src_page_entry = aux_data + batch_idx * aux_stride
+            # instruction_selection: cvt.u64.u32 + mul.lo.s64 + add.s64 (:1271 -- aux_stride is a
+            #   runtime int64_t); extent: address arithmetic
+            cmp_le(p_short, length, K)
+            # instruction_selection: setp.le.u32; extent: scalar
+            if p_short:
+                i = tx
+                while i < K:
+                    cmp_lt(p_in, i, length)
+                    # instruction_selection: setp.lt.u32; extent: scalar per iteration
+                    if p_in:
+                        copy_g2r_scalar(src_page_entry + page_start + i, page_id)
+                        # instruction_selection: ld.global.b32; extent: one scalar load
+                    else:
+                        move(page_id, -1)
+                        # instruction_selection: selp.b32; extent: scalar
+                    copy_r2g_scalar(page_id, row_output + i)
+                    # instruction_selection: st.global.b32; extent: one scalar store
+                    i = i + BLOCK
+                continue
+        else:  # RaggedTransform
+            copy_g2r_scalar(aux_data + row_idx, offset)
+            # instruction_selection: ld.global.b32; extent: one scalar load
+            cmp_le(p_short, length, K)
+            # instruction_selection: setp.le.u32; extent: scalar
+            if p_short:
+                i = tx
+                while i < K:
+                    cmp_lt(p_in, i, length)
+                    # instruction_selection: setp.lt.u32; extent: scalar per iteration
+                    add(val, i, offset)
+                    # instruction_selection: add.s32; extent: scalar
+                    select(out_id, p_in, val, -1)
+                    # instruction_selection: selp.b32; extent: scalar
+                    copy_r2g_scalar(out_id, row_output + i)
+                    # instruction_selection: st.global.b32; extent: one scalar store
+                    i = i + BLOCK
+                continue
+
+        # =====================================================================
+        # Stage 1: stage the row into shared memory as monotone keys
+        # LoadToSharedOrdered (:605-623); chunk_start == 0, actual_chunk_size == length
+        # =====================================================================
+        aligned = length // VEC_SIZE * VEC_SIZE                # aligned_size (:608)
+        # instruction_selection: and.b32 with ~(VEC_SIZE-1) (VEC_SIZE is a power of two);
+        #   constant-folded in Basic mode where `length == stride` is static, a real
+        #   instruction in PageTable/Ragged where `length` came from lengths[row_idx]
+
+        i = tx * VEC_SIZE
+        while i < aligned:                                     # #pragma unroll 2
+            # instruction_selection: none; extent: loop control (setp.lt.u32/bra), unroll hint 2
+            bits = reg_tile("b32" if DTYPE == "f32" else "b16", [VEC_SIZE])
+            copy_g2r_v(row_input + i, bits)
+            # instruction_selection: ld.global.v4.b32 (VEC_SIZE*sizeof(DType) == 16) |
+            #   ld.global.v2.b32 | ld.global.b32 | ld.global.b16 for the narrower vec widths;
+            #   extent: one vector load per iteration
+            for j in static_range(VEC_SIZE):
+                to_ordered(key[j], bits[j])
+                # instruction_selection: setp.gt.s32 + selp.b32(0x80000000, -1) + xor.b32 (f32) |
+                #   setp.gt.s16 + selp.b16(0x8000, -1) + xor.b16 (f16, bf16);
+                #   extent: three scalar instructions per element, VEC_SIZE per iteration
+                copy_r2s(key[j], s_ordered[i + j])
+                # instruction_selection: st.shared.b32 (f32) | st.shared.b16 (f16, bf16), which the
+                #   compiler coalesces to st.shared.v4.b32 / st.shared.v2.b32 when the VEC_SIZE
+                #   group is contiguous; extent: one shared store per element
+            i = i + BLOCK * VEC_SIZE
+
+        i = aligned + tx
+        while i < length:                                      # scalar tail (:619-621)
+            # instruction_selection: none; extent: loop control.  Statically dead only in
+            #   Basic mode when LENGTH % VEC_SIZE == 0; live in PageTable/Ragged, where the
+            #   per-row runtime `length` can leave a remainder (PTX: `.loc 2 608 and.b32 ...,-4`
+            #   and a live `.loc 2 619/620` ld.global.b32 + st.shared.b32 pair in the PageTable
+            #   body; x7 in the Basic body, where `stride` is also a runtime kernel argument)
+            copy_g2r_scalar(row_input + i, bits_s)
+            # instruction_selection: ld.global.b32 (f32) | ld.global.b16 (f16, bf16); extent: one scalar load
+            to_ordered(key_s, bits_s)
+            # instruction_selection: setp.gt.s32/s16 + selp.b32/b16 + xor.b32/b16; extent: three scalar
+            copy_r2s(key_s, s_ordered[i])
+            # instruction_selection: st.shared.b32 | st.shared.b16; extent: one shared store
+            i = i + BLOCK
+
+        barrier()
+        # instruction_selection: bar.sync 0; extent: one CTA-wide publication of s_ordered,
+        #   closing LoadToSharedOrdered (:622)
+
+        # =====================================================================
+        # Stage 2: NUM_ROUNDS of 8-bit radix select
+        # RadixSelectFromSharedMemory (:669-777).  Note the scalar init below runs
+        # *after* the load barrier, and is closed by its own barrier (:677).
+        # =====================================================================
+        if tx == 0:                                            # (:669-676)
+            move(s_scalars[0], 0)                              # prefix_cache
+            move(s_scalars[1], k)                              # remaining_k_cache
+            # instruction_selection: st.shared.v2.b32 [smem+2048], {0, k} (the two adjacent
+            #   u32 scalars are written as one 64-bit store); extent: one paired shared store
+            move(s_scalars[4], 0)                              # shared_output_counter
+            # instruction_selection: st.shared.b32; extent: one scalar store
+        barrier()
+        # instruction_selection: bar.sync 0; extent: CTA-wide, scalar caches published (:677)
+
+        rnd = 0
+        while rnd < NUM_ROUNDS:                                # rolled loop (:690)
+            # instruction_selection: add.s32 + setp.ne.b32 back-edge; extent: loop control.
+            #   NVCC keeps this loop rolled -- every round-body .loc appears exactly once
+            #   and the whole kernel has 28 bar.sync, which only the rolled form allows.
+            shift = OBITS - (rnd + 1) * 8                      # (:692), runtime
+            # instruction_selection: shl.b32 + sub.s32; extent: two scalar per round
+            mask  = 0 if rnd == 0 else (~0 << (OBITS - rnd * 8))  # (:714-717), runtime
+            # instruction_selection: sub.s32 + shl.b32 + selp.b32, hoisted by NVCC into the
+            #   round-body preheader (`.loc 2 0`); extent: three scalar per round.  With the
+            #   loop rolled the mask is a runtime value in every round, including rnd == 0.
+            copy_s2r((s_scalars[0], s_scalars[1]), (prefix, remaining_k))
+            # instruction_selection: ld.shared.b64 [smem+2048] + mov.b64 unpack (the two adjacent
+            #   u32 scalars are read as one 64-bit shared load); extent: one 64-bit shared load per round
+
+            b = tx
+            while b < RADIX:                                   # clear the histogram (:704-706)
+                move(s_hist[b], 0)
+                # instruction_selection: st.shared.b32 (no vector coalescing: the whole kernel
+                #   emits one st.shared.v4.b32 and it belongs to the key staging at :615);
+                #   extent: one shared store per iteration
+                b = b + BLOCK
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, histogram cleared
+
+            i = tx
+            while i < length:                                  # #pragma unroll 2 (:709-722)
+                # instruction_selection: none; extent: loop control (setp.lt.u32/bra), unroll hint 2
+                copy_s2r(s_ordered[i], key)
+                # instruction_selection: ld.shared.b32 (f32) | ld.shared.b16 (f16, bf16); extent: one shared load
+                and_(masked, key, mask)
+                # instruction_selection: and.b32 | and.b16 (:718) applied on every round -- the
+                #   rolled loop leaves `mask` a runtime `selp.b32` result, so there is no
+                #   rnd == 0 fold; extent: scalar
+                cmp_eq(p_match, masked, prefix)
+                # instruction_selection: setp.eq.b32 | setp.eq.b16; extent: scalar
+                if p_match:
+                    shr(bucket, key, shift)
+                    and_(bucket, bucket, 0xFF)
+                    # instruction_selection: shr.u32 + and.b32; extent: two scalar
+                    atomic_add_shared(_, s_hist[bucket], 1)
+                    # instruction_selection: atom.shared.add.u32; extent: one per matching element
+                i = i + BLOCK
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, histogram complete
+
+            b = tx
+            while b < RADIX:                                   # single-CTA copy (:743-745)
+                copy_s2r(s_hist[b], h)
+                # instruction_selection: ld.shared.b32; extent: one shared load per iteration
+                copy_r2s(h, s_suffix[b])
+                # instruction_selection: st.shared.b32; extent: one shared store per iteration
+                b = b + BLOCK
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, s_suffix seeded
+
+            # RadixSuffixSum (:389-406), called at :750: 8 doubling steps, two barriers each
+            for stride in static_range([1, 2, 4, 8, 16, 32, 64, 128]):
+                cmp_lt(p_lane, tx, RADIX)
+                # instruction_selection: setp.lt.u32; extent: scalar
+                move(val, 0)
+                if p_lane:
+                    copy_s2r(s_suffix[tx], val)
+                    # instruction_selection: ld.shared.b32; extent: one shared load
+                    cmp_lt(p_pair, tx + stride, RADIX)
+                    # instruction_selection: setp.lt.u32; extent: scalar
+                    if p_pair:
+                        copy_s2r(s_suffix[tx + stride], rhs)
+                        # instruction_selection: ld.shared.b32; extent: one shared load
+                        add(val, val, rhs)
+                        # instruction_selection: add.s32; extent: scalar
+                barrier()
+                # instruction_selection: bar.sync 0; extent: CTA-wide, read phase closed
+                if p_lane:
+                    copy_r2s(val, s_suffix[tx])
+                    # instruction_selection: st.shared.b32; extent: one shared store
+                barrier()
+                # instruction_selection: bar.sync 0; extent: CTA-wide, write phase closed
+
+            # Threshold bucket (:752-766)
+            if tx == 0:
+                move(s_scalars[2], 0)
+                move(s_scalars[3], remaining_k)
+                # instruction_selection: st.shared.v2.b32 [smem+2056] (:755); extent: one paired shared store
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide
+            cmp_lt(p_lane, tx, RADIX)
+            # instruction_selection: setp.lt.u32; extent: scalar
+            if p_lane:
+                copy_s2r(s_suffix[tx], count_ge)
+                # instruction_selection: ld.shared.b32; extent: one shared load
+                move(count_gt, 0)
+                cmp_lt(p_next, tx + 1, RADIX)
+                # instruction_selection: setp.lt.u32; extent: scalar
+                if p_next:
+                    copy_s2r(s_suffix[tx + 1], count_gt)
+                    # instruction_selection: ld.shared.b32; extent: one shared load
+                cmp_ge(p_a, count_ge, remaining_k)
+                cmp_lt(p_b, count_gt, remaining_k)
+                # instruction_selection: setp.ge.u32 + setp.lt.u32; extent: two scalar
+                if p_a and p_b:
+                    move(s_scalars[2], tx)
+                    sub(rk, remaining_k, count_gt)
+                    # instruction_selection: sub.s32; extent: scalar
+                    move(s_scalars[3], rk)
+                    # instruction_selection: st.shared.v2.b32 [smem+2056] (:764); extent: one paired
+                    #   shared store by the single winner lane
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, bucket published
+
+            if tx == 0:                                        # (:770-772)
+                copy_s2r((s_scalars[2], s_scalars[3]), (bucket, rk))
+                # instruction_selection: ld.shared.v2.b32 [smem+2056] (:771); extent: one paired shared load
+                shl(hi, bucket, shift)
+                or_(new_prefix, prefix, hi)
+                # instruction_selection: shl.b32 + or.b32; extent: two scalar
+                move(s_scalars[0], new_prefix)
+                move(s_scalars[1], rk)
+                # instruction_selection: st.shared.v2.b32 [smem+2048] (:772); extent: one paired shared store
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, round state published (:774)
+            rnd = rnd + 1
+
+        copy_s2r(s_scalars[0], pivot)                          # ordered_pivot (:777)
+        # instruction_selection: ld.shared.b32 (f32) | ld.shared.b16 + cvt.u16.u32 (f16, bf16);
+        #   extent: one shared load
+
+        # =====================================================================
+        # Stage 3: row-wide counts of key > pivot (and == pivot when needed)
+        # (:776-830).  TRACK_EQ_COUNT == DETERMINISTIC.
+        # =====================================================================
+        if tx == 0:                                            # (:782-786)
+            if not DETERMINISTIC:
+                move(s_suffix[0], 0)
+                # instruction_selection: st.shared.b32 (:783); extent: one scalar store
+            else:
+                move(s_suffix[0], 0)
+                move(s_suffix[1], 0)
+                # instruction_selection: st.shared.v2.b32 [smem+1024] (:785); extent: one paired shared store
+        barrier()
+        # instruction_selection: bar.sync 0; extent: CTA-wide, accumulators cleared
+
+        move(my_gt, 0)
+        move(my_eq, 0)
+        i = tx
+        while i < length:                                      # #pragma unroll 2 (:789-801)
+            # instruction_selection: none; extent: loop control, unroll hint 2
+            copy_s2r(s_ordered[i], key)
+            # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+            cmp_gt(p_gt, key, pivot)
+            # instruction_selection: setp.gt.u32 | setp.gt.u16; extent: scalar
+            add(my_gt, my_gt, p_gt)
+            # instruction_selection: selp.b32 + add.s32; extent: two scalar
+            if DETERMINISTIC:
+                cmp_eq(p_eq, key, pivot)
+                # instruction_selection: setp.eq.b32 | setp.eq.b16; extent: scalar
+                add(my_eq, my_eq, p_eq)
+                # instruction_selection: selp.b32 + add.s32; extent: two scalar
+            i = i + BLOCK
+
+        for delta in static_range([16, 8, 4, 2, 1]):           # warp reduction (:804-810)
+            shfl_down(peer, my_gt, delta)
+            # instruction_selection: shfl.sync.down.b32 %r|%p, %r, delta, 31, -1; extent: one per step
+            add(my_gt, my_gt, peer)
+            # instruction_selection: add.s32; extent: scalar
+            if DETERMINISTIC:
+                shfl_down(peer_eq, my_eq, delta)
+                # instruction_selection: shfl.sync.down.b32; extent: one per step
+                add(my_eq, my_eq, peer_eq)
+                # instruction_selection: add.s32; extent: scalar
+
+        lane = tx % 32
+        # instruction_selection: and.b32 (tx & 31); extent: scalar
+        if lane == 0 and my_gt > 0:
+            atomic_add_shared(_, s_suffix[0], my_gt)
+            # instruction_selection: atom.shared.add.u32; extent: one per warp leader
+        if DETERMINISTIC and lane == 0 and my_eq > 0:
+            atomic_add_shared(_, s_suffix[1], my_eq)
+            # instruction_selection: atom.shared.add.u32; extent: one per warp leader
+        barrier()
+        # instruction_selection: bar.sync 0; extent: CTA-wide, counts published
+        copy_s2r(s_suffix[0], gt_count)
+        # instruction_selection: ld.shared.b32; extent: one scalar load
+        if DETERMINISTIC:
+            copy_s2r(s_suffix[1], eq_count)
+            # instruction_selection: ld.shared.b32; extent: one scalar load
+
+        # =====================================================================
+        # Stage 3b: epilogue-scope aux recompute, per row, BEFORE the collect.
+        # The source opens the mode epilogue scope at :1343 / :1372 and computes
+        # these once per row; only then does it call collect_indices(...).  They are
+        # second, distinct reads from the ones the trivial branch made at :1270-1271
+        # and :1290, and both pairs survive into the PTX.
+        # =====================================================================
+        if MODE == "PageTableTransform":                       # (:1344-1345)
+            if row_to_batch is not null:
+                copy_g2r_scalar(row_to_batch + row_idx, batch_idx)
+                # instruction_selection: ld.global.b32 (:1344); extent: one scalar load per row
+            else:
+                move(batch_idx, row_idx)
+            src_page_entry = aux_data + batch_idx * aux_stride
+            # instruction_selection: cvt.u64.u32 + mul.lo.s64 + add.s64 (:1345 -- aux_stride is a
+            #   runtime int64_t); extent: address arithmetic, once per row
+        elif MODE == "RaggedTransform":                        # (:1373)
+            copy_g2r_scalar(aux_data + row_idx, offset)
+            # instruction_selection: ld.global.b32 (:1373); extent: one scalar load per row
+
+        # =====================================================================
+        # Stage 4a: non-deterministic collect (:901-968), DETERMINISTIC == False
+        # s_hist[0] = local_offset_gt, s_hist[1] = global_base_gt
+        # =====================================================================
+        if not DETERMINISTIC:
+            if tx == 0:
+                move(s_hist[0], 0)
+                # instruction_selection: st.shared.b32; extent: one scalar store
+                if gt_count > 0:
+                    atomic_add_shared(base, s_scalars[4], gt_count)
+                    # instruction_selection: atom.shared.add.u32; extent: one per CTA
+                    move(s_hist[1], base)
+                    # instruction_selection: st.shared.b32; extent: one scalar store
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, collect base published (:923)
+
+            i = tx
+            while i < length:                                  # pass 1: key > pivot (:927-937)
+                # instruction_selection: none; extent: loop control, unroll hint 2
+                copy_s2r(s_ordered[i], key)
+                # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                cmp_gt(p_gt, key, pivot)
+                # instruction_selection: setp.gt.u32 | setp.gt.u16; extent: scalar
+                if p_gt:
+                    atomic_add_shared(local_pos, s_hist[0], 1)
+                    # instruction_selection: atom.shared.add.u32; extent: one per emitted element
+                    copy_s2r(s_hist[1], global_base_gt)
+                    # instruction_selection: ld.shared.b32 [smem+4] (:932); extent: one shared load per
+                    #   emitted element -- the source re-reads global_base_gt inside the loop rather
+                    #   than hoisting it, and the PTX keeps one per unrolled body
+                    add(pos, global_base_gt, local_pos)
+                    # instruction_selection: add.s32; extent: scalar
+                    EMIT(i, key, pos)                          # mode epilogue below
+                i = i + BLOCK
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, gt pass closed before the eq pass (:944)
+
+            i = tx
+            while i < length:                                  # pass 2: key == pivot (:950-965)
+                # instruction_selection: none; extent: loop control, unroll hint 2
+                copy_s2r(s_ordered[i], key)
+                # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                cmp_eq(p_eq, key, pivot)
+                # instruction_selection: setp.eq.b32 | setp.eq.b16; extent: scalar
+                if p_eq:
+                    atomic_add_shared(pos, s_scalars[4], 1)
+                    # instruction_selection: atom.shared.add.u32; extent: one per candidate
+                    cmp_lt(p_room, pos, k)
+                    # instruction_selection: setp.lt.s32; extent: scalar
+                    if p_room:
+                        EMIT(i, pivot, pos)
+                i = i + BLOCK
+
+        # =====================================================================
+        # Stage 4b: deterministic collect (:1017-1136), DETERMINISTIC == True
+        # Single-CTA degenerates to a block-local scheme: gt entries occupy
+        # [0, gt_count) and eq entries fill [gt_count, k).
+        # =====================================================================
+        else:
+            if tx == 0:
+                move(s_hist[0], 0)                             # gt prefix  == 0
+                move(s_hist[1], 0)                             # eq prefix  == 0
+                move(s_hist[2], gt_count)                      # row total gt
+                sub(need, k, gt_count)
+                max_(need, need, 0)
+                # instruction_selection: sub.s32 + max.u32 (the source writes the ternary
+                #   `(k > gt) ? (k - gt) : 0`); extent: two scalar
+                move(s_hist[3], need)                          # eq needed
+                move(s_hist[4], 0)
+                # instruction_selection: st.shared.v4.b32 [smem] over s_hist[0..3] (:1041) +
+                #   st.shared.b32 for s_hist[4] (:1042); extent: one 128-bit and one scalar store
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide, collect plan published
+            copy_s2r((s_hist[0], s_hist[1], s_hist[2], s_hist[3]),
+                     (gt_output_base, _eq_prefix, eq_output_base, eq_emit_limit))
+            # instruction_selection: ld.shared.v4.b32 {..},[smem] (:1046 + :1085); extent: one
+            #   128-bit shared load covering local_histogram[0..3] -- it carries
+            #   s_cta_local_gt_prefix as well as the eq plan
+            sub(gt_emit_limit, k, gt_output_base)
+            max_(gt_emit_limit, gt_emit_limit, 0)
+            # instruction_selection: max.u32 + sub.s32 (:1086-1087, the source's
+            #   `(k > base) ? (k - base) : 0`); extent: two scalar.  base is 0 in this
+            #   specialization but the source still computes it, and so does the PTX.
+
+            if eq_emit_limit == 0:
+                # DeterministicThreadStridedCollect (:256-286): gt-only fast path
+                move(my_sel, 0)
+                i = tx
+                while i < length:
+                    copy_s2r(s_ordered[i], key)
+                    # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                    cmp_gt(p_gt, key, pivot)
+                    # instruction_selection: setp.gt.u32 | setp.gt.u16; extent: scalar
+                    add(my_sel, my_sel, p_gt)
+                    # instruction_selection: selp.b32 + add.s32; extent: two scalar
+                    i = i + BLOCK
+                block_exclusive_sum(my_prefix, my_sel)
+                # instruction_selection: cub BlockScan RAKING_MEMOIZE ExclusiveSum: 5
+                #   shfl.sync.up.b32 (warp_scan_shfl.cuh:179) plus st.shared.v2.b32 /
+                #   ld.shared.v2.b32 raking traffic through s_scan_temp and bar.sync 0
+                #   (block_scan_raking.cuh:165/325/341);
+                #   extent: one CTA-wide exclusive scan
+                cmp_gt(p_any, my_sel, 0)
+                cmp_lt(p_room, my_prefix, gt_emit_limit)
+                # instruction_selection: setp.gt.u32 + setp.lt.u32; extent: two scalar
+                if p_any and p_room:
+                    move(emit_pos, my_prefix)
+                    add(emit_end, my_prefix, my_sel)
+                    min_(emit_end, emit_end, gt_emit_limit)
+                    # instruction_selection: add.s32 + min.u32; extent: two scalar
+                    i = tx
+                    while i < length:
+                        copy_s2r(s_ordered[i], key)
+                        # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                        cmp_gt(p_gt, key, pivot)
+                        # instruction_selection: setp.gt.u32 | setp.gt.u16; extent: scalar
+                        if p_gt:
+                            EMIT(i, key, gt_output_base + emit_pos)
+                            add(emit_pos, emit_pos, 1)
+                            # instruction_selection: add.s32; extent: scalar
+                            cmp_eq(p_full, emit_pos, emit_end)
+                            # instruction_selection: setp.eq.b32; extent: scalar
+                            if p_full: break
+                            # instruction_selection: bra; extent: early exit
+                        i = i + BLOCK
+                barrier()
+                # instruction_selection: bar.sync 0; extent: CTA-wide, collect closed
+            else:
+                # Paired gt/eq scan (:1113-1135)
+                move(my_gt_sel, 0)
+                move(my_eq_sel, 0)
+                i = tx
+                while i < length:
+                    copy_s2r(s_ordered[i], key)
+                    # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                    cmp_gt(p_gt, key, pivot)
+                    cmp_eq(p_eq, key, pivot)
+                    # instruction_selection: setp.gt.u32/u16 + setp.eq.b32/b16; extent: two scalar
+                    add(my_gt_sel, my_gt_sel, p_gt)
+                    add(my_eq_sel, my_eq_sel, p_eq)
+                    # instruction_selection: selp.b32 x2 + add.s32 x2; extent: four scalar
+                    i = i + BLOCK
+                block_exclusive_sum_pair((gt_prefix, eq_prefix), (my_gt_sel, my_eq_sel))
+                # instruction_selection: cub BlockScan RAKING_MEMOIZE ExclusiveScan over the
+                #   (gt, eq) pair: 12 shfl.sync.up.b32 (util_ptx.cuh:98) plus st.shared.v2.b32 /
+                #   ld.shared.v2.b32 raking traffic through s_scan_temp and bar.sync 0;
+                #   extent: one CTA-wide exclusive pair scan.  Both scan variants are compiled
+                #   into every DETERMINISTIC entry, so the two sites together account for the
+                #   17 shfl.sync.up.b32 in the count table.
+                move(pos_gt, gt_prefix)
+                move(pos_eq, eq_prefix)
+                i = tx
+                while i < length:
+                    copy_s2r(s_ordered[i], key)
+                    # instruction_selection: ld.shared.b32 | ld.shared.b16; extent: one shared load
+                    cmp_gt(p_gt, key, pivot)
+                    cmp_lt(p_gt_room, pos_gt, gt_emit_limit)
+                    # instruction_selection: setp.gt.u32/u16 + setp.lt.u32; extent: two scalar
+                    if p_gt and p_gt_room:
+                        EMIT(i, key, gt_output_base + pos_gt)
+                        add(pos_gt, pos_gt, 1)
+                        # instruction_selection: add.s32; extent: scalar
+                    else:
+                        cmp_eq(p_eq, key, pivot)
+                        cmp_lt(p_eq_room, pos_eq, eq_emit_limit)
+                        # instruction_selection: setp.eq.b32/b16 + setp.lt.u32; extent: two scalar
+                        if p_eq and p_eq_room:
+                            EMIT(i, key, eq_output_base + pos_eq)
+                            add(pos_eq, pos_eq, 1)
+                            # instruction_selection: add.s32; extent: scalar
+                    i = i + BLOCK
+                barrier()
+                # instruction_selection: bar.sync 0; extent: CTA-wide, collect closed
+
+        # =====================================================================
+        # Stage 5: PageTable second pass (:1352-1358); Basic and Ragged emit
+        # their final value inside EMIT.  `src_page_entry` was computed in Stage 3b.
+        # =====================================================================
+        if MODE == "PageTableTransform":
+            barrier()
+            # instruction_selection: bar.sync 0 (:1353); extent: CTA-wide, raw indices published
+            i = tx
+            while i < k:
+                copy_g2r_scalar(row_output + i, idx)
+                # instruction_selection: ld.global.b32; extent: one scalar load
+                copy_g2r_scalar(src_page_entry + page_start + idx, page_id)
+                # instruction_selection: ld.global.b32; extent: one scalar gather load
+                copy_r2g_scalar(page_id, row_output + i)
+                # instruction_selection: st.global.b32; extent: one scalar store
+                i = i + BLOCK
+
+# ===========================================================================
+# EMIT: the mode epilogue the collect passes call per selected element
+# (:1336-1372).  `pos` is the output slot, `i` the row-local index.
+# ===========================================================================
+
+def EMIT_Basic(i, key, pos):
+    copy_r2g_scalar(i, row_output + pos)
+    # instruction_selection: st.global.b32; extent: one scalar store
+    from_ordered(bits, key)
+    # instruction_selection: setp.gt.s32 + selp.b32(-1, 0x80000000) + xor.b32 (f32) |
+    #   setp.gt.s16 + selp.b16(-1, 0x8000) + xor.b16 (f16, bf16); extent: three scalar
+    copy_r2g_scalar(bits, output_values + row_idx * K + pos)
+    # instruction_selection: st.global.b32 (f32) | st.global.b16 (f16, bf16); extent: one scalar store
+
+def EMIT_PageTableTransform(i, key, pos):
+    copy_r2g_scalar(i, row_output + pos)                # raw index; gathered in stage 5
+    # instruction_selection: st.global.b32; extent: one scalar store
+
+def EMIT_RaggedTransform(i, key, pos):   # `offset` was loaded once per row in Stage 3b
+    add(val, i, offset)
+    # instruction_selection: add.s32; extent: scalar
+    copy_r2g_scalar(val, row_output + pos)
+    # instruction_selection: st.global.b32; extent: one scalar store
+```
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `DTYPE` | static per config | selects `OrderedType` (u32/u16), `NUM_ROUNDS` (4/2), the 32-bit vs 16-bit `to_ordered`/compare/shared-access opcode family, and `16 / sizeof(DType)` in the vec dispatch |
+| `MODE` | static per config | selects the per-row header, the trivial branch, `EMIT`, and whether stage 5 exists |
+| `DETERMINISTIC` | static per config | selects the collect path, whether eq counts are tracked, whether the 8480-byte static `scan_temp_storage` exists, and the launcher's matching 8512-byte smem headroom (hence `max_chunk` and the single-CTA domain) |
+| `VEC_SIZE` | static per config | selects the load width; the scalar tail loop is statically dead only in Basic mode when `LENGTH % VEC_SIZE == 0`, and stays live in PageTable/Ragged |
+| `SINGLE_CTA = true` | static (launcher decision) | removes `RadixRowState`, `det_scratch`, every group barrier, the triple-buffer global histogram and the trailing state reset |
+| `NUM_ROWS`, `LENGTH`, `K` | static per config | `CHUNK == LENGTH`, `SMEM_BYTES`, `NUM_GROUPS`, `total_iterations` constant-fold. `aligned_size` folds only in Basic mode; in PageTable/Ragged it is derived per row from the runtime `lengths[row_idx]` |
+| `row_starts` / `page_table_row_starts` / `row_to_batch` non-null | static per config (runtime pointer in the source) | selects the header loads; a non-null `row_starts` also forces `VEC_SIZE == 1` in the non-Basic launchers |
+| `top_k_arr` | always null | Basic mode's per-row k branch is dead; `k == K` for every row |
+| dynamic smem size | static per config | requested through the `tirx.use_dyn_shared_memory` launch tag, mirroring `cudaFuncSetAttribute(..., MaxDynamicSharedMemorySize, SMEM_BYTES)` |
+| unroll hints | static | the load loop, the histogram loop, the count loop and both non-deterministic collect passes carry the source's `#pragma unroll 2`, which NVCC turns into three emitted bodies each; the 8 suffix-sum doubling steps, the VEC_SIZE inner loop and the 5 shuffle steps are fully unrolled; the `NUM_ROUNDS` round loop stays **rolled** |
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "radix_topk_single_cta", "category": "flashinfer",
+  "compute_capability": 10}`.
+- The kernel is expressed entirely in plain TIRx: `T.SMEMPool` arena with the
+  source's byte offsets, explicit `while` block-strided loops, register
+  buffers, and native `T.ptx.*` forms for the key operations
+  (`bar.sync`, `atom.shared.add.u32`, `shfl.sync.down.b32`, the vector global
+  loads, the shared loads/stores). No `Tx` tile primitives and no
+  `T.cuda.func_call` anywhere in the pre-dispatch IR.
+- `get_kernel(dtype, mode, num_rows, length, k, deterministic, row_starts,
+  page_table_row_starts, row_to_batch)` returns the specialized primfunc;
+  `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, `run_bench` follow the
+  repository contract.
+- The timed implementation is named `tirx`; the reference is the FlashInfer
+  source kernel itself, launched through the raw `topk` FFI module with
+  preallocated outputs and `FLASHINFER_TOPK_ALGO=multi_cta` pinning
+  `TopKDispatch` to this kernel. Allocation, module build and validation stay
+  outside timing.
+- Correctness compares against that same source launch: exact positional
+  equality for `DETERMINISTIC` configs, and set equality of the selected
+  indices/values otherwise, because both sides leave the non-deterministic
+  collect order unspecified.
+
+## Instruction selection is a lowering consequence
+
+The sketch never requests a hardware instruction beyond the shared atomics, the
+warp shuffle, and the CTA barrier. The families below follow from storage
+direction, shape, dtype and schedule. PTX names are taken from a fresh
+line-info export of the exact source instantiations
+(`.porting/radix_topk_single_cta/ptx/instantiate.cu`, explicit instantiation of
+`RadixTopKKernel_Unified<1024, VEC, true, DET, MODE, DType, int32_t>`) built
+with the production JIT flags
+`nvcc -ptx -lineinfo -std=c++17 -use_fast_math -O3 -DNDEBUG -arch=compute_100a`
+plus the FlashInfer `-D` set; they are audit evidence, not operands.
+
+| Primitive/schedule pattern | PTX family (fresh SM100a export) |
+| --- | --- |
+| vectorized row load (`vec_t::cast_load`, VEC_SIZE*sizeof(DType) == 16) | `ld.global.v4.b32` |
+| scalar tail / header / gather loads | `ld.global.b32`, `ld.global.b16` (16-bit dtypes) |
+| `to_ordered` f32 | `setp.gt.s32` + `selp.b32 -2147483648, -1` + `xor.b32` |
+| `to_ordered` f16/bf16 | `setp.gt.s16` + `selp.b16 -32768, -1` + `xor.b16` |
+| `from_ordered` f32 / f16 / bf16 | the same triple with the `selp` operands swapped (`-1, -2147483648`) |
+| stage into `s_ordered` | `st.shared.b32` / `st.shared.b16`, coalesced to `st.shared.v4.b32` / `st.shared.v2.b32` for contiguous VEC groups |
+| histogram clear / seed / scalar publication | `st.shared.b32`, coalesced to `st.shared.v4.b32` / `st.shared.v2.b32` |
+| histogram bump, gt/eq accumulate, collect counters | `atom.shared.add.u32` |
+| shared reads of keys, histogram, suffix sum, scalars | `ld.shared.b32`, `ld.shared.b16`, `ld.shared.b64` (the paired `prefix`/`remaining_k` read), `ld.shared.v2.b32`, `ld.shared.v4.b32` (the deterministic collect plan) |
+| every publication point | `bar.sync 0` |
+| gt/eq warp reduction | `shfl.sync.down.b32 %r|%p, %r, {16,8,4,2,1}, 31, -1` |
+| deterministic block scan (cub `BlockScan`, `BLOCK_SCAN_RAKING_MEMOIZE`) | `shfl.sync.up.b32` + `st.shared.v2.b32` / `ld.shared.v2.b32` raking + `bar.sync 0` |
+| predicate arithmetic on counts | `setp.{gt,ge,lt,le,eq,ne}.{u32,s32,u16,s16,b32,b16}` + `selp.b32` + `add.s32` |
+| bucket extraction | `shr.u32` + `and.b32` (no `bfe` in the export) |
+| index/value stores | `st.global.b32`, `st.global.b16` (16-bit values) |
+| address arithmetic | `mul.wide.u32`, `mul.wide.s32`, `mul.lo.s32`, `cvt.u64.u32`, `cvt.u32.u64`, `shl.b64`, `add.s64`, `add.s32`, `shl.b32`, `cvta.to.global.u64` (emitted inside the row loop too, not only in the entry block). `mul.lo.s64` appears only in PageTableTransform, twice per body (`:1271`, `:1345`), for the runtime `int64_t aux_stride` multiply. |
+
+Static PTX opcode counts per exported instantiation (whole kernel body; the
+round loop stays rolled, so each round body appears once, and every `#pragma unroll 2`
+loop emits three bodies):
+
+| Family | f32 vec4 Basic | f32 vec4 Basic det | f16 vec8 Basic | f32 vec1 Basic | f32 vec4 PageTable | f32 vec4 PageTable det | f32 vec4 Ragged | f32 vec4 Ragged det |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `ld.global.v4.b32` | 3 | 3 | 3 | 0 | 3 | 3 | 3 | 3 |
+| `ld.global.b32` | 9 | 9 | 1 | 12 | 27 | 27 | 5 | 5 |
+| `ld.global.b16` | 0 | 0 | 8 | 0 | 0 | 0 | 0 | 0 |
+| `st.global.b32` | 14 | 32 | 7 | 14 | 20 | 17 | 21 | 18 |
+| `st.global.b16` | 0 | 0 | 7 | 0 | 0 | 0 | 0 | 0 |
+| `ld.shared.b32` | 36 | 98 | 23 | 36 | 36 | 92 | 36 | 92 |
+| `ld.shared.b16` | 0 | 0 | 13 | 0 | 0 | 0 | 0 | 0 |
+| `ld.shared.b64` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
+| `ld.shared.v2.b32` | 1 | 34 | 1 | 1 | 1 | 34 | 1 | 34 |
+| `ld.shared.v4.b32` | 0 | 1 | 0 | 0 | 0 | 1 | 0 | 1 |
+| `st.shared.b32` | 29 | 60 | 14 | 24 | 23 | 54 | 23 | 54 |
+| `st.shared.b16` | 0 | 0 | 23 | 0 | 0 | 0 | 0 | 0 |
+| `st.shared.v2.b32` | 4 | 38 | 4 | 4 | 4 | 38 | 4 | 38 |
+| `st.shared.v4.b32` | 1 | 2 | 1 | 0 | 1 | 2 | 1 | 2 |
+| `atom.shared.add.u32` | 11 | 5 | 11 | 11 | 11 | 5 | 11 | 5 |
+| `bar.sync` | 28 | 33 | 28 | 28 | 29 | 34 | 28 | 33 |
+| `shfl.sync.down.b32` | 5 | 10 | 5 | 5 | 5 | 10 | 5 | 10 |
+| `shfl.sync.up.b32` | 0 | 17 | 0 | 0 | 0 | 17 | 0 | 17 |
+| `xor.b32` | 23 | 31 | 0 | 14 | 13 | 13 | 13 | 13 |
+| `xor.b16` | 0 | 0 | 35 | 0 | 0 | 0 | 0 | 0 |
+| `mul.wide.u32` | 12 | 14 | 12 | 12 | 10 | 13 | 9 | 11 |
+| `mul.wide.s32` | 6 | 15 | 12 | 6 | 6 | 3 | 6 | 3 |
+| `mul.lo.s32` | 3 | 8 | 3 | 3 | 3 | 7 | 3 | 5 |
+| `cvta.to.global.u64` | 5 | 8 | 6 | 5 | 7 | 11 | 5 | 7 |
+| `max.u32` | 4 | 3 | 4 | 4 | 0 | 3 | 0 | 3 |
+| `min.u32` | 1 | 2 | 1 | 1 | 1 | 2 | 1 | 2 |
+| `mov.b64` | 2 | 2 | 2 | 2 | 2 | 2 | 3 | 3 |
+
+The `atom.shared.add.u32` count drops from 11 to 5 with `DETERMINISTIC` because
+the deterministic collect replaces both atomic-driven passes with the block
+scans, which contribute the 17 `shfl.sync.up.b32` (12 from the pair scan via
+`util_ptx.cuh:98`, 5 from the scalar gt-only scan via `warp_scan_shfl.cuh:179`
+-- both variants are compiled into the same kernel) and the paired
+`st.shared.v2.b32`/`ld.shared.v2.b32` raking traffic instead. The extra
+`bar.sync` in PageTable mode is the barrier before the in-place page gather.
+The single `ld.shared.b64` in every entry is the paired `prefix_cache` /
+`remaining_k_cache` read at the head of each round; the single
+`ld.shared.v4.b32` in every deterministic entry is the collect-plan read of
+`local_histogram[0..3]`. `xor.b32` is 0 for the 16-bit dtypes: all 35 monotone
+key flips there are `xor.b16`. bf16 entries are identical to the f16 entries
+apart from the source-level dtype; every opcode matches exactly.

--- a/tests/lint/check_radix_topk_single_cta_no_tile.py
+++ b/tests/lint/check_radix_topk_single_cta_no_tile.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every radix top-k single-CTA specialization.
+
+Scans the kernel module and the shared instruction-level helpers it imports,
+then every pre-dispatch specialization built from ``CONFIGS``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import tvm
+from tirx_kernels.flashinfer.topk import radix_topk_single_cta as target
+from tvm.tirx.stmt_functor import StmtExprVisitor
+
+REPO = Path(__file__).resolve().parents[2]
+TARGETS = (
+    REPO / "tirx_kernels/flashinfer/topk/radix_topk_single_cta.py",
+    REPO / "tirx_kernels/flashinfer/utils/topk_radix.py",
+)
+
+_TILE_OPS = {
+    "add",
+    "binary_chain",
+    "binary_reduce",
+    "cast",
+    "compose_op",
+    "copy",
+    "copy_async",
+    "exp",
+    "exp2",
+    "fdiv",
+    "fill",
+    "fma",
+    "gemm",
+    "gemm_async",
+    "max",
+    "maximum",
+    "memset",
+    "min",
+    "minimum",
+    "mul",
+    "permute_layout",
+    "reciprocal",
+    "reduce_negate",
+    "select",
+    "silu",
+    "sqrt",
+    "sub",
+    "sum",
+    "unary_reduce",
+    "zero",
+}
+_SCOPES = {"thread", "warp", "wg", "warpgroup", "cta", "cluster"}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    path: str
+    detail: str
+
+
+def _qualified_name(node: ast.AST, aliases: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Name):
+        return aliases.get(node.id, node.id)
+    if isinstance(node, ast.Attribute):
+        base = _qualified_name(node.value, aliases)
+        return f"{base}.{node.attr}" if base else None
+    return None
+
+
+def _is_plain_cast(call: ast.Call) -> bool:
+    """Recognize ordinary expression ``T.cast(value, "dtype")`` calls."""
+    return (
+        len(call.args) == 2
+        and not call.keywords
+        and isinstance(call.args[1], ast.Constant)
+        and isinstance(call.args[1].value, str)
+    )
+
+
+def _tile_call_reason(name: str | None, call: ast.Call) -> str | None:
+    if name is None:
+        return None
+    parts = name.split(".")
+    leaf = parts[-1]
+    if leaf == "TilePrimitiveCall" or ".tile." in name:
+        return f"explicit tile primitive call {name}"
+    if "tile_primitive" in parts and leaf not in {"SwizzleMode", "sf_smem_layout"}:
+        return f"tile-primitive helper call {name}"
+
+    # TIRx script exposes both direct and execution-scope tile APIs.  Cast has
+    # a scalar overload, which is legal when its second argument is a dtype.
+    script_root = parts[0] in {"T", "Tx", "tirx"}
+    scoped = len(parts) >= 3 and parts[-2] in _SCOPES
+    direct = len(parts) == 2
+    if script_root and (direct or scoped) and leaf in _TILE_OPS:
+        if leaf == "cast" and _is_plain_cast(call):
+            return None
+        return f"TIRx tile API call {name}"
+    return None
+
+
+class _FunctionScanner(ast.NodeVisitor):
+    def __init__(
+        self,
+        source: str,
+        aliases: dict[str, str],
+        function_names: set[str],
+        function: str,
+        target: Path,
+    ) -> None:
+        self.source = source
+        self.target = target
+        self.aliases = dict(aliases)
+        self.function_names = function_names
+        self.function = function
+        self.findings: list[Finding] = []
+        self.calls: list[tuple[str, ast.Call]] = []
+
+    def _path(self, node: ast.AST) -> str:
+        return f"{self.target.relative_to(REPO)}:{node.lineno}:{node.col_offset + 1}"
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        value_name = _qualified_name(node.value, self.aliases)
+        if value_name is not None:
+            for assignment in node.targets:
+                if isinstance(assignment, ast.Name):
+                    self.aliases[assignment.id] = value_name
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and isinstance(node.target, ast.Name):
+            value_name = _qualified_name(node.value, self.aliases)
+            if value_name is not None:
+                self.aliases[node.target.id] = value_name
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        name = _qualified_name(node.func, self.aliases)
+        reason = _tile_call_reason(name, node)
+        if reason is not None:
+            self.findings.append(Finding("source", self._path(node), reason))
+
+        local_name = name.rsplit(".", 1)[-1] if name else None
+        if local_name in self.function_names:
+            self.calls.append((local_name, node))
+
+        for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+                if argument.value.startswith("tirx.tile."):
+                    self.findings.append(
+                        Finding(
+                            "source",
+                            self._path(argument),
+                            f"dynamic tile operator name {argument.value!r}",
+                        )
+                    )
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Nested function bodies are scanned by their own scanner.
+        if node.name != self.function:
+            return
+        self.generic_visit(node)
+
+
+def _source_findings_for(target: Path) -> list[Finding]:
+    source = target.read_text()
+    tree = ast.parse(source, filename=str(target))
+    aliases: dict[str, str] = {}
+    functions = {
+        node.name for node in tree.body if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for item in node.names:
+                aliases[item.asname or item.name.split(".")[0]] = item.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for item in node.names:
+                aliases[item.asname or item.name] = f"{module}.{item.name}"
+        elif isinstance(node, ast.Assign):
+            name = _qualified_name(node.value, aliases)
+            if name is not None:
+                for assignment in node.targets:
+                    if isinstance(assignment, ast.Name):
+                        aliases[assignment.id] = name
+
+    scans: dict[str, _FunctionScanner] = {}
+    findings: list[Finding] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        scanner = _FunctionScanner(source, aliases, functions, node.name, target)
+        scanner.visit(node)
+        scans[node.name] = scanner
+        findings.extend(scanner.findings)
+
+    # Propagate taint through local wrappers so both the primitive and every
+    # wrapper call site are visible in diagnostics.
+    tainted = {name for name, scanner in scans.items() if scanner.findings}
+    changed = True
+    while changed:
+        changed = False
+        for name, scanner in scans.items():
+            if name in tainted:
+                continue
+            if any(callee in tainted for callee, _ in scanner.calls):
+                tainted.add(name)
+                changed = True
+
+    for name, scanner in scans.items():
+        for callee, call in scanner.calls:
+            if callee in tainted:
+                findings.append(
+                    Finding(
+                        "source",
+                        scanner._path(call),
+                        f"wrapper {name} calls tile-tainted helper {callee}",
+                    )
+                )
+    return findings
+
+
+def _source_findings() -> list[Finding]:
+    findings: list[Finding] = []
+    for target_path in TARGETS:
+        findings.extend(_source_findings_for(target_path))
+    return findings
+
+
+class _IRScanner(StmtExprVisitor):
+    def __init__(self, specialization: str) -> None:
+        super().__init__()
+        self.specialization = specialization
+        self.findings: list[Finding] = []
+
+    def _record(self, node: Any, detail: str) -> None:
+        span = getattr(node, "span", None)
+        suffix = f" span={span}" if span is not None else ""
+        self.findings.append(Finding("IR", self.specialization, detail + suffix))
+
+    def visit_op_call_(self, op: Any) -> None:
+        op_name = getattr(getattr(op, "op", None), "name", "<unknown>")
+        self._record(op, f"TilePrimitiveCall op={op_name}")
+        super().visit_op_call_(op)
+
+    def visit_call_(self, call: tvm.ir.Call) -> None:
+        op = getattr(call, "op", None)
+        op_name = getattr(op, "name", None)
+        category = op.get_attr("TIRxOpCategory") if isinstance(op, tvm.ir.Op) else None
+        if op_name is not None and op_name.startswith("tirx.tile."):
+            self._record(call, f"forbidden operator {op_name}")
+        elif category == "tile_primitive":
+            self._record(call, f"operator {op_name} has TIRxOpCategory=tile_primitive")
+        super().visit_call_(call)
+
+
+def _ir_findings() -> list[Finding]:
+    findings: list[Finding] = []
+    for config in target.CONFIGS:
+        label = str(config["label"])
+        kernel = target.get_kernel(**config)
+        scanner = _IRScanner(f"CONFIGS[{label!r}]")
+        scanner(kernel.body)
+        findings.extend(scanner.findings)
+    return findings
+
+
+def main() -> int:
+    findings = _source_findings() + _ir_findings()
+    if findings:
+        for finding in findings:
+            print(f"ERROR [{finding.kind}] {finding.path}: {finding.detail}")
+        print(f"\n{len(findings)} tile-primitive violation(s).")
+        return 1
+    print(
+        f"PASS: {len(TARGETS)} source file(s) and all "
+        f"{len(target.CONFIGS)} pre-dispatch specializations contain no tile primitive"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tirx_kernels/bench_suite/config/flashinfer/quantization/mxfp4_quantize.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/quantization/mxfp4_quantize.yaml
@@ -2,12 +2,6 @@
 # base plus small and large 128x4 shapes; the rest stay benchable on request.
 kernel: mxfp4_quantize
 selection_rationale: The linear 4096 square anchors the base layout; small and large 128x4 rows bound the alternate scale-layout work range.
-defaults:
-  # Wider timing windows than the do_bench_proton defaults (25ms/100ms):
-  # these kernels are 2-100us and memory-bound, so longer windows average out
-  # mid-window clock wobble on the shared machine.
-  warmup: 50
-  repeat: 300
 configs:
   - {config: fp16_linear_m4096_k4096, default: true, selection_role: medium}
   - {config: bf16_linear_m4096_k4096, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/quantization/mxfp8_quantize.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/quantization/mxfp8_quantize.yaml
@@ -2,12 +2,6 @@
 # base plus small and large 128x4 shapes; the rest stay benchable on request.
 kernel: mxfp8_quantize
 selection_rationale: The linear 4096 square anchors the base layout; small and large 128x4 rows bound the alternate scale-layout work range.
-defaults:
-  # Wider timing windows than the do_bench_proton defaults (25ms/100ms):
-  # these kernels are 2-100us and memory-bound, so longer windows average out
-  # mid-window clock wobble on the shared machine.
-  warmup: 50
-  repeat: 300
 configs:
   - {config: fp16_linear_m4096_k4096, default: true, selection_role: medium}
   - {config: bf16_linear_m4096_k4096, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/quantization/nvfp4_quantize.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/quantization/nvfp4_quantize.yaml
@@ -2,12 +2,6 @@
 # base plus small and large 128x4 shapes; the rest stay benchable on request.
 kernel: nvfp4_quantize
 selection_rationale: The linear 4096 square anchors the base layout; small and large 128x4 rows bound the alternate scale-layout work range.
-defaults:
-  # Wider timing windows than the do_bench_proton defaults (25ms/100ms):
-  # these kernels are 2-100us and memory-bound, so longer windows average out
-  # mid-window clock wobble on the shared machine.
-  warmup: 50
-  repeat: 300
 configs:
   - {config: fp16_linear_m4096_k4096, default: true, selection_role: medium}
   - {config: bf16_linear_m4096_k4096, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/quantization/nvfp4_quantize_per_token.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/quantization/nvfp4_quantize_per_token.yaml
@@ -2,12 +2,6 @@
 # base plus small and large 128x4 shapes; the rest stay benchable on request.
 kernel: nvfp4_quantize_per_token
 selection_rationale: The linear 4096 square anchors the base layout; small and large 128x4 rows bound the per-token alternate scale-layout work range.
-defaults:
-  # Wider timing windows than the do_bench_proton defaults (25ms/100ms):
-  # these kernels are 2-100us and memory-bound, so longer windows average out
-  # mid-window clock wobble on the shared machine.
-  warmup: 50
-  repeat: 300
 configs:
   - {config: fp16_linear_m4096_k4096, default: true, selection_role: medium}
   - {config: bf16_linear_m4096_k4096, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/topk/radix_topk_single_cta.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/topk/radix_topk_single_cta.yaml
@@ -1,0 +1,64 @@
+# Every config the SINGLE_CTA dispatch domain reaches: all 18
+# dtype x mode x deterministic cells at three shape/topology regimes each
+# (small, mid-size multi-row, and the largest chunk the shared-memory budget
+# still keeps on one CTA per row).  The performance gate requires every entry
+# here to beat 0.99x the FlashInfer source, so the list is the full domain
+# rather than a curated subset; the three `default: true` rows are only the
+# representatives carried into the repository-wide default sweep.
+kernel: radix_topk_single_cta
+selection_rationale: The fp32 Basic column is the base dispatch; 8x8192 anchors the small single-CTA shape, 64x32768 the mid-range where the grid still fits one row per SM, and 256x57592 the largest chunk the smem budget allows with rows restriding the grid.
+configs:
+  - {config: f32_basic_r8_l8192_k256, default: true, selection_role: small}
+  - {config: f32_basic_r64_l32768_k512, default: true, selection_role: medium}
+  - {config: f32_basic_r256_l57592_k1024_maxchunk, default: true, selection_role: large}
+  - {config: f32_basic_det_r8_l8192_k256, default: false}
+  - {config: f32_basic_det_r64_l32768_k512, default: false}
+  - {config: f32_basic_det_r256_l55464_k1024_maxchunk, default: false}
+  - {config: f32_pt_r8_l8192_k256, default: false}
+  - {config: f32_pt_r64_l32768_k512, default: false}
+  - {config: f32_pt_r256_l57592_k1024_maxchunk, default: false}
+  - {config: f32_pt_det_r8_l8192_k256, default: false}
+  - {config: f32_pt_det_r64_l32768_k512, default: false}
+  - {config: f32_pt_det_r256_l55464_k1024_maxchunk, default: false}
+  - {config: f32_rag_r8_l8192_k256, default: false}
+  - {config: f32_rag_r64_l32768_k512, default: false}
+  - {config: f32_rag_r256_l57592_k1024_maxchunk, default: false}
+  - {config: f32_rag_det_r8_l8192_k256, default: false}
+  - {config: f32_rag_det_r64_l32768_k512, default: false}
+  - {config: f32_rag_det_r256_l55464_k1024_maxchunk, default: false}
+  - {config: f16_basic_r8_l8192_k256, default: false}
+  - {config: f16_basic_r64_l32768_k512, default: false}
+  - {config: f16_basic_r256_l115184_k1024_maxchunk, default: false}
+  - {config: f16_basic_det_r8_l8192_k256, default: false}
+  - {config: f16_basic_det_r64_l32768_k512, default: false}
+  - {config: f16_basic_det_r256_l110928_k1024_maxchunk, default: false}
+  - {config: f16_pt_r8_l8192_k256, default: false}
+  - {config: f16_pt_r64_l32768_k512, default: false}
+  - {config: f16_pt_r256_l115184_k1024_maxchunk, default: false}
+  - {config: f16_pt_det_r8_l8192_k256, default: false}
+  - {config: f16_pt_det_r64_l32768_k512, default: false}
+  - {config: f16_pt_det_r256_l110928_k1024_maxchunk, default: false}
+  - {config: f16_rag_r8_l8192_k256, default: false}
+  - {config: f16_rag_r64_l32768_k512, default: false}
+  - {config: f16_rag_r256_l115184_k1024_maxchunk, default: false}
+  - {config: f16_rag_det_r8_l8192_k256, default: false}
+  - {config: f16_rag_det_r64_l32768_k512, default: false}
+  - {config: f16_rag_det_r256_l110928_k1024_maxchunk, default: false}
+  - {config: bf16_basic_r8_l8192_k256, default: false}
+  - {config: bf16_basic_r64_l32768_k512, default: false}
+  - {config: bf16_basic_r256_l115184_k1024_maxchunk, default: false}
+  - {config: bf16_basic_det_r8_l8192_k256, default: false}
+  - {config: bf16_basic_det_r64_l32768_k512, default: false}
+  - {config: bf16_basic_det_r256_l110928_k1024_maxchunk, default: false}
+  - {config: bf16_pt_r8_l8192_k256, default: false}
+  - {config: bf16_pt_r64_l32768_k512, default: false}
+  - {config: bf16_pt_r256_l115184_k1024_maxchunk, default: false}
+  - {config: bf16_pt_det_r8_l8192_k256, default: false}
+  - {config: bf16_pt_det_r64_l32768_k512, default: false}
+  - {config: bf16_pt_det_r256_l110928_k1024_maxchunk, default: false}
+  - {config: bf16_rag_r8_l8192_k256, default: false}
+  - {config: bf16_rag_r64_l32768_k512, default: false}
+  - {config: bf16_rag_r256_l115184_k1024_maxchunk, default: false}
+  - {config: bf16_rag_det_r8_l8192_k256, default: false}
+  - {config: bf16_rag_det_r64_l32768_k512, default: false}
+  - {config: bf16_rag_det_r256_l110928_k1024_maxchunk, default: false}

--- a/tirx_kernels/flashinfer/topk/__init__.py
+++ b/tirx_kernels/flashinfer/topk/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Ports of the kernels behind ``flashinfer.topk``."""

--- a/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
@@ -1,0 +1,1418 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer radix top-k single-CTA port.
+
+Ports ``RadixTopKKernel_Unified<1024, VEC_SIZE, SINGLE_CTA=true, DETERMINISTIC,
+MODE, DType, int32_t>`` (``include/flashinfer/topk.cuh:1170``) together with the
+device helpers it inlines: ``LoadToSharedOrdered`` (:602),
+``RadixSelectFindPivot`` (:851) / ``RadixSelectFromSharedMemory`` (:655),
+``RadixSuffixSum`` (:389), ``RadixCollectIndices`` (:901),
+``RadixCollectIndicesDeterministic`` (:1017),
+``DeterministicThreadStridedCollect`` (:256) and ``RadixTopKTraits``
+(``include/flashinfer/topk_common.cuh``).  Host launchers:
+``RadixTopKMultiCTA`` (:2172), ``RadixTopKPageTableTransformMultiCTA`` (:1939),
+``RadixTopKRaggedTransformMultiCTA`` (:2055); bindings ``csrc/topk.cu``;
+Python entries ``flashinfer.top_k`` / ``flashinfer.top_k_page_table_transform``
+/ ``flashinfer.top_k_ragged_transform`` (``flashinfer/topk.py``).
+
+One 1024-thread CTA owns a whole row: the row is staged into dynamic shared
+memory as monotone ordered integers, an 8-bit radix select walks 4 (fp32) or 2
+(fp16/bf16) rounds of a 256-bin shared histogram plus suffix sum to the exact
+k-th value, and a single collect pass emits the winners through a
+mode-specific epilogue.  Grid is persistent: ``min(num_sms, num_rows)`` CTAs
+stride over the rows.
+
+In-scope specialization: the ``SINGLE_CTA=true`` template, i.e. every shape the
+launchers map onto one CTA per row (``ceil_div(length, max_chunk_elements) ==
+1``).  All three epilogue modes, both collect paths, fp32/fp16/bf16, every
+reachable ``VEC_SIZE``, and the runtime ``row_starts`` /
+``page_table_row_starts`` / ``row_to_batch`` branches are covered.  Out of
+scope: per-row ``top_k_arr`` (``csrc/topk.cu`` always passes ``nullptr``), the
+multi-CTA cross-group protocol, and the FilteredTopK and cluster algorithms
+that ``TopKDispatch`` selects for other shapes.
+"""
+
+import math
+import os
+from typing import Any
+
+from tirx_kernels.flashinfer.utils.topk_radix import (
+    atom_shared_add_u32,
+    bar_sync,
+    from_ordered_u16,
+    from_ordered_u32,
+    ld_shared_pair_u32,
+    ld_shared_quad_u32,
+    ld_shared_u16,
+    ld_shared_u32,
+    ld_shared_u64,
+    shfl_down_u32,
+    st_global_u16,
+    st_global_u32,
+    st_shared_pair_u32,
+    st_shared_quad_u32,
+    st_shared_u16,
+    st_shared_u32,
+    to_ordered_u16,
+    to_ordered_u32,
+    u64_hi,
+    u64_lo,
+    warp_inclusive_sum_u32,
+)
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {"name": "radix_topk_single_cta", "category": "flashinfer", "compute_capability": 10}
+
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+
+# ---------------------------------------------------------------------------
+# Source constants (topk.cuh:2172-2270 launcher, :1192-1201 smem layout).
+# ---------------------------------------------------------------------------
+BLOCK_THREADS = 1024
+RADIX = 256
+RADIX_BITS = 8
+NUM_SCALARS_SINGLE_CTA = 5  # prefix, remaining_k, found_bucket, found_rk, out_counter
+
+# fixed_smem_size = sizeof(uint32_t) * (RADIX + RADIX + 5), 16B aligned (:1194-1200)
+_FIXED_SMEM_BYTES = 4 * (RADIX + RADIX + NUM_SCALARS_SINGLE_CTA)
+_FIXED_SMEM_ALIGNED = (_FIXED_SMEM_BYTES + 15) // 16 * 16
+
+# sizeof(cub::BlockScan<uint32_t, 1024, BLOCK_SCAN_RAKING_MEMOIZE>::TempStorage),
+# doubled into RADIX_TOPK_LAUNCH_SMEM_HEADROOM (topk.cuh:46-52).  The launcher
+# reserves it only when `deterministic` is set, which shrinks the chunk budget
+# and therefore the single-CTA shape domain.
+_DET_BLOCK_SCAN_TEMP_BYTES = 4256
+_DET_LAUNCH_HEADROOM = 2 * _DET_BLOCK_SCAN_TEMP_BYTES
+
+# cudaDevAttrMaxSharedMemoryPerBlockOptin on the accepted SM100 target (B200).
+# Kept as a compile-profile constant so module import and CPU prepare never
+# touch CUDA; `run_test` cross-checks it against the live device.
+DEFAULT_MAX_SMEM_OPTIN = 232448
+PREPARE_MAX_SMEM_OPTIN_ENV = "TIRX_PREPARE_MAX_SMEM_OPTIN"
+
+DTYPES = ("float32", "float16", "bfloat16")
+MODES = ("basic", "page_table", "ragged")
+
+_TIE_BREAK_NONE = 0
+_SOURCE_ALGO_ENV = "FLASHINFER_TOPK_ALGO"
+_SOURCE_ALGO_VALUE = "multi_cta"
+
+
+def hardware_max_smem_optin(default: int = DEFAULT_MAX_SMEM_OPTIN) -> int:
+    """Compile-profile ``cudaDevAttrMaxSharedMemoryPerBlockOptin``."""
+    configured = os.environ.get(PREPARE_MAX_SMEM_OPTIN_ENV)
+    if configured is not None:
+        value = int(configured)
+        if value < 1:
+            raise ValueError(f"{PREPARE_MAX_SMEM_OPTIN_ENV} must be positive, got {value}")
+        return value
+    return default
+
+
+def ordered_dtype(dtype: str) -> str:
+    """``RadixTopKTraits<DType>::OrderedType`` (topk_common.cuh:26/53/79)."""
+    return "uint32" if dtype == "float32" else "uint16"
+
+
+def ordered_bytes(dtype: str) -> int:
+    return 4 if dtype == "float32" else 2
+
+
+def dtype_bytes(dtype: str) -> int:
+    return 4 if dtype == "float32" else 2
+
+
+def num_rounds(dtype: str) -> int:
+    return ordered_bytes(dtype) * 8 // RADIX_BITS
+
+
+def vec_size(dtype: str, length: int, scalar_addressing: bool = False) -> int:
+    """Launcher vec-size dispatch (topk.cuh:2179, :1947, :2064).
+
+    ``scalar_addressing`` mirrors the ``row_starts != nullptr`` clause the
+    page-table and ragged launchers apply before the gcd.
+    """
+    if scalar_addressing:
+        return 1
+    return math.gcd(16 // dtype_bytes(dtype), length)
+
+
+def max_chunk_elements(
+    dtype: str, length: int, deterministic: bool, scalar_addressing: bool
+) -> int:
+    """``max_chunk_elements`` after round-down and the min-chunk floor (:2199-2203)."""
+    headroom = _DET_LAUNCH_HEADROOM if deterministic else 0
+    available = hardware_max_smem_optin() - _FIXED_SMEM_ALIGNED - headroom
+    if available <= 0:
+        raise ValueError("no shared memory available for the ordered chunk")
+    vec = vec_size(dtype, length, scalar_addressing)
+    chunk = (available // ordered_bytes(dtype)) // vec * vec
+    return max(chunk, vec * BLOCK_THREADS)
+
+
+def launch_plan(
+    dtype: str,
+    mode: str,
+    length: int,
+    num_rows: int,
+    deterministic: bool,
+    scalar_addressing: bool = False,
+    num_sms: int | None = None,
+) -> dict[str, Any]:
+    """Replicate the host launcher's chunk/grid/smem arithmetic (:2179-2231)."""
+    if num_sms is None:
+        from tirx_kernels.runner import hardware_num_sms
+
+        num_sms = hardware_num_sms()
+    vec = vec_size(dtype, length, scalar_addressing)
+    max_chunk = max_chunk_elements(dtype, length, deterministic, scalar_addressing)
+    ctas_per_group = (length + max_chunk - 1) // max_chunk
+    chunk = (length + ctas_per_group - 1) // ctas_per_group
+    chunk = (chunk + vec - 1) // vec * vec
+    chunk = min(chunk, max_chunk)
+    num_groups = min(num_sms // ctas_per_group, num_rows)
+    if num_groups == 0:
+        num_groups = 1
+    return {
+        "vec_size": vec,
+        "max_chunk_elements": max_chunk,
+        "ctas_per_group": ctas_per_group,
+        "chunk_size": chunk,
+        "single_cta": ctas_per_group == 1,
+        "num_groups": num_groups,
+        "grid": num_groups * ctas_per_group,
+        "smem_bytes": _FIXED_SMEM_ALIGNED + chunk * ordered_bytes(dtype),
+        "num_rounds": num_rounds(dtype),
+    }
+
+
+def _validate(
+    dtype: str,
+    mode: str,
+    num_rows: int,
+    length: int,
+    k: int,
+    deterministic: bool,
+    scalar_addressing: bool,
+) -> dict[str, Any]:
+    if dtype not in DTYPES:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+    if mode not in MODES:
+        raise ValueError(f"Unsupported mode: {mode}")
+    if num_rows < 1 or length < 1 or k < 1:
+        raise ValueError(f"num_rows={num_rows}, length={length}, k={k} must be positive")
+    if k > length:
+        raise ValueError(f"k={k} exceeds length={length}")
+    plan = launch_plan(dtype, mode, length, num_rows, deterministic, scalar_addressing)
+    if not plan["single_cta"]:
+        raise ValueError(
+            f"({dtype}, len={length}, det={deterministic}) needs "
+            f"{plan['ctas_per_group']} CTAs per row: outside the SINGLE_CTA dispatch domain"
+        )
+    return plan
+
+
+def page_table_batch(num_rows: int, row_to_batch: bool) -> int:
+    """Rows map identity->batch unless ``row_to_batch`` folds them onto fewer."""
+    return max(1, num_rows // 2) if row_to_batch else num_rows
+
+
+def aux_elements(mode: str, num_rows: int, length: int, row_to_batch: bool) -> int:
+    """Elements of the mode-specific ``aux_data`` buffer."""
+    if mode == "page_table":
+        return page_table_batch(num_rows, row_to_batch) * length
+    if mode == "ragged":
+        return num_rows
+    return 1
+
+
+def _ld_global_bits(buf, elem_index, is32):
+    """One scalar element's raw bits (``ld.global.b32`` | ``ld.global.b16``)."""
+    if is32:
+        out = T.alloc_local((1,), "uint32")
+        T.evaluate(T.ptx.ld.global_.b32(out[0], buf.ptr_to([elem_index])))
+        return out[0]
+    out16 = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(out16[0], buf.ptr_to([elem_index])))
+    return out16[0]
+
+
+def _ld_global_words(buf, elem_index, load_bytes):
+    """One vector load of ``load_bytes`` bytes, returned as 32-bit words."""
+    if load_bytes == 16:
+        w = T.alloc_local((4,), "uint32", align=16)
+        T.evaluate(T.ptx["ld.global.v4.b32"](w[0], w[1], w[2], w[3], buf.ptr_to([elem_index])))
+        return [w[0], w[1], w[2], w[3]]
+    if load_bytes == 8:
+        w = T.alloc_local((2,), "uint32", align=8)
+        T.evaluate(T.ptx["ld.global.v2.b32"](w[0], w[1], buf.ptr_to([elem_index])))
+        return [w[0], w[1]]
+    w = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.b32(w[0], buf.ptr_to([elem_index])))
+    return [w[0]]
+
+
+def _stage_vector(buf, s_ordered, row_in, i, vec, load_bytes, is32, to_ordered, st_key):
+    """LoadToSharedOrdered's vector body (:612-617): one vector load, then
+    ``VEC_SIZE`` monotone key conversions and shared stores."""
+    base = row_in + T.cast(i, "int64")
+    if load_bytes == 2:
+        bits = _ld_global_bits(buf, base, False)
+        st_key(s_ordered, i, to_ordered(bits))
+        return
+    words = _ld_global_words(buf, base, load_bytes)
+    if is32:
+        for j in range(vec):
+            st_key(s_ordered, i + j, to_ordered(words[j]))
+    else:
+        for m in range(len(words)):
+            lo = T.cast(T.bitwise_and(words[m], T.uint32(0xFFFF)), "uint16")
+            hi = T.cast(T.shift_right(words[m], T.uint32(16)), "uint16")
+            st_key(s_ordered, i + m * 2, to_ordered(lo))
+            st_key(s_ordered, i + m * 2 + 1, to_ordered(hi))
+
+
+def _emit(out_idx, out_val, row_out, i, key, pos, offset, basic, ragged, is32, dtype):
+    """The mode epilogue the collect passes call per selected element (:1339-1375)."""
+    slot = row_out + T.cast(pos, "int64")
+    if basic:
+        st_global_u32(out_idx, slot, T.reinterpret("uint32", i))
+        if is32:
+            st_global_u32(out_val, slot, from_ordered_u32(key))
+        else:
+            st_global_u16(out_val, slot, from_ordered_u16(T.cast(key, "uint16")))
+    elif ragged:
+        st_global_u32(out_idx, slot, T.reinterpret("uint32", i + offset))
+    else:
+        st_global_u32(out_idx, slot, T.reinterpret("uint32", i))
+
+
+# ---------------------------------------------------------------------------
+# Target entry.
+# ---------------------------------------------------------------------------
+RAKING_THREADS = 32
+RAKING_SEGMENT = BLOCK_THREADS // RAKING_THREADS  # 32
+RAKING_STRIDE = RAKING_SEGMENT + 1  # cub BlockRakingLayout segment padding
+RAKING_ELEMENTS = RAKING_THREADS * RAKING_STRIDE  # 1056
+
+
+def _raking_offset(tx):
+    """cub ``BlockRakingLayout::PlacementPtr``: ``tid + tid / SEGMENT_LENGTH``."""
+    return tx + T.shift_right(tx, T.int32(5))
+
+
+def scan_scratch_elements(deterministic: bool) -> int:
+    """uint32 slots for the collect scan scratch (0 when non-deterministic)."""
+    return RAKING_ELEMENTS * 2 if deterministic else 0
+
+
+def get_kernel(
+    dtype: str = "float32",
+    mode: str = "basic",
+    num_rows: int = 16,
+    length: int = 32000,
+    k: int = 256,
+    deterministic: bool = False,
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    **kwargs,
+):
+    """Return the TIRx specialization for one launcher dispatch cell."""
+    scalar_addressing = row_starts and mode != "basic"
+    plan = _validate(dtype, mode, num_rows, length, k, deterministic, scalar_addressing)
+    ordered = ordered_dtype(dtype)
+    is32 = ordered == "uint32"
+    obits = 32 if is32 else 16
+    rounds = num_rounds(dtype)
+    vec = plan["vec_size"]
+    chunk = plan["chunk_size"]
+    grid = plan["grid"]
+    load_bytes = vec * dtype_bytes(dtype)
+    aux_elems = aux_elements(mode, num_rows, length, row_to_batch)
+    scan_elems = scan_scratch_elements(deterministic)
+    basic = mode == "basic"
+    page_table = mode == "page_table"
+    ragged = mode == "ragged"
+    # Basic mode's `length` is the static kernel stride, so `k >= length` folds.
+    basic_trivial = basic and k >= length
+
+    def to_ordered(bits):
+        return to_ordered_u32(bits) if is32 else to_ordered_u16(bits)
+
+    def from_ordered(key):
+        return from_ordered_u32(key) if is32 else from_ordered_u16(key)
+
+    def ld_key(buf, i):
+        return ld_shared_u32(buf, i) if is32 else ld_shared_u16(buf, i)
+
+    def st_key(buf, i, v):
+        st_shared_u32(buf, i, v) if is32 else st_shared_u16(buf, i, v)
+
+    @T.prim_func
+    def radix_topk_single_cta(
+        input_h: T.handle,
+        output_indices_h: T.handle,
+        output_values_h: T.handle,
+        aux_data_h: T.handle,
+        lengths_h: T.handle,
+        row_starts_h: T.handle,
+        page_table_row_starts_h: T.handle,
+        row_to_batch_h: T.handle,
+        aux_stride: T.int64,
+    ):
+        T.func_attr({"global_symbol": "radix_topk_single_cta"})
+        inp = T.match_buffer(input_h, (num_rows * length,), dtype, scope="global")
+        out_idx = T.match_buffer(output_indices_h, (num_rows * k,), "int32", scope="global")
+        out_val = T.match_buffer(output_values_h, (num_rows * k,), dtype, scope="global")
+        aux = T.match_buffer(aux_data_h, (aux_elems,), "int32", scope="global")
+        lengths_g = T.match_buffer(lengths_h, (num_rows,), "int32", scope="global")
+        row_starts_g = T.match_buffer(row_starts_h, (num_rows,), "int32", scope="global")
+        pt_starts_g = T.match_buffer(page_table_row_starts_h, (num_rows,), "int32", scope="global")
+        row_to_batch_g = T.match_buffer(row_to_batch_h, (num_rows,), "int32", scope="global")
+        T.device_entry()
+
+        group_id = T.cta_id([grid])
+        tx = T.thread_id([BLOCK_THREADS])
+
+        pool = T.SMEMPool()
+        s_hist = pool.alloc((RADIX,), "uint32")
+        s_suffix = pool.alloc((RADIX,), "uint32")
+        s_scalars = pool.alloc((NUM_SCALARS_SINGLE_CTA,), "uint32")
+        s_ordered = pool.alloc((chunk,), ordered, align=16)
+        if deterministic:
+            s_scan = pool.alloc((scan_elems,), "uint32", align=16)
+        pool.commit()
+
+        # --- persistent row loop (:1218-1220) -----------------------------
+        row_idx: T.int32 = group_id
+        while row_idx < num_rows:
+            # --- per-row header (:1221-1247) ------------------------------
+            row_start: T.int32 = T.int32(0)
+            page_start: T.int32 = T.int32(0)
+            row_len: T.int32 = T.int32(length)
+            if not basic:
+                if row_starts:
+                    row_start = row_starts_g[row_idx]
+                if page_table:
+                    if page_table_row_starts:
+                        page_start = pt_starts_g[row_idx]
+                    else:
+                        page_start = row_start
+                row_len = lengths_g[row_idx]
+            row_in: T.int64 = T.cast(row_idx, "int64") * T.int64(length) + T.cast(
+                row_start, "int64"
+            )
+            row_out: T.int64 = T.cast(row_idx, "int64") * T.int64(k)
+
+            # --- mode trivial early-out (:1243-1307) ----------------------
+            take_main: T.int32 = T.int32(1)
+            if basic:
+                if basic_trivial:
+                    take_main = T.int32(0)
+                    for i0 in T.serial(tx, row_len, step=BLOCK_THREADS):
+                        if i0 < k:
+                            out_idx[row_out + T.cast(i0, "int64")] = i0
+                            out_val[row_out + T.cast(i0, "int64")] = inp[
+                                T.cast(row_idx, "int64") * T.int64(length) + T.cast(i0, "int64")
+                            ]
+            batch_idx: T.int32 = row_idx
+            offset: T.int32 = T.int32(0)
+            if page_table:
+                if row_to_batch:
+                    batch_idx = row_to_batch_g[row_idx]
+                if row_len <= k:
+                    take_main = T.int32(0)
+                    src0: T.int64 = T.cast(batch_idx, "int64") * aux_stride
+                    for i1 in T.serial(tx, k, step=BLOCK_THREADS):
+                        page_id: T.int32 = T.int32(-1)
+                        if i1 < row_len:
+                            page_id = aux[src0 + T.cast(page_start + i1, "int64")]
+                        out_idx[row_out + T.cast(i1, "int64")] = page_id
+            if ragged:
+                offset = aux[T.cast(row_idx, "int64")]
+                if row_len <= k:
+                    take_main = T.int32(0)
+                    for i2 in T.serial(tx, k, step=BLOCK_THREADS):
+                        val2: T.int32 = T.int32(-1)
+                        if i2 < row_len:
+                            val2 = i2 + offset
+                        out_idx[row_out + T.cast(i2, "int64")] = val2
+
+            if take_main == 1:
+                # === Stage 1: stage the row as monotone keys (:605-623) ====
+                aligned: T.int32 = T.truncdiv(row_len, T.int32(vec)) * T.int32(vec)
+                for iv in T.serial(tx * vec, aligned, step=BLOCK_THREADS * vec, unroll=2):
+                    _stage_vector(
+                        inp, s_ordered, row_in, iv, vec, load_bytes, is32, to_ordered, st_key
+                    )
+                for it_tail in T.serial(aligned + tx, row_len, step=BLOCK_THREADS):
+                    st_key(
+                        s_ordered,
+                        it_tail,
+                        to_ordered(_ld_global_bits(inp, row_in + T.cast(it_tail, "int64"), is32)),
+                    )
+                bar_sync()
+
+                # scalar caches (:669-677)
+                if tx == 0:
+                    st_shared_pair_u32(s_scalars, 0, T.uint32(0), T.uint32(k))
+                    st_shared_u32(s_scalars, 4, T.uint32(0))
+                bar_sync()
+
+                # === Stage 2: NUM_ROUNDS radix-select rounds (:690-774) ====
+                for rnd in T.serial(0, rounds):
+                    shift: T.int32 = T.int32(obits) - (rnd + 1) * 8
+                    mask: T.uint32 = T.uint32(0)
+                    if rnd != 0:
+                        mask = T.shift_left(
+                            T.uint32(0xFFFFFFFF), T.cast(T.int32(obits) - rnd * 8, "uint32")
+                        )
+                    packed: T.uint64 = ld_shared_u64(s_scalars, 0)
+                    prefix: T.uint32 = u64_lo(packed)
+                    remaining_k: T.uint32 = u64_hi(packed)
+
+                    for bh in T.serial(tx, RADIX, step=BLOCK_THREADS):
+                        st_shared_u32(s_hist, bh, T.uint32(0))
+                    bar_sync()
+
+                    for ih in T.serial(tx, row_len, step=BLOCK_THREADS, unroll=2):
+                        key: T.uint32 = T.cast(ld_key(s_ordered, ih), "uint32")
+                        if T.bitwise_and(key, mask) == prefix:
+                            bucket: T.uint32 = T.bitwise_and(
+                                T.shift_right(key, T.cast(shift, "uint32")), T.uint32(0xFF)
+                            )
+                            T.evaluate(
+                                atom_shared_add_u32(s_hist, T.cast(bucket, "int32"), T.uint32(1))
+                            )
+                    bar_sync()
+
+                    for bs in T.serial(tx, RADIX, step=BLOCK_THREADS):
+                        st_shared_u32(s_suffix, bs, ld_shared_u32(s_hist, bs))
+                    bar_sync()
+
+                    # RadixSuffixSum (:389-406)
+                    for step in T.unroll(8):
+                        stride: T.int32 = T.shift_left(T.int32(1), step)
+                        acc: T.uint32 = T.uint32(0)
+                        if tx < RADIX:
+                            acc = ld_shared_u32(s_suffix, tx)
+                            if tx + stride < RADIX:
+                                acc = acc + ld_shared_u32(s_suffix, tx + stride)
+                        bar_sync()
+                        if tx < RADIX:
+                            st_shared_u32(s_suffix, tx, acc)
+                        bar_sync()
+
+                    # threshold bucket (:753-767)
+                    if tx == 0:
+                        st_shared_pair_u32(s_scalars, 2, T.uint32(0), remaining_k)
+                    bar_sync()
+                    if tx < RADIX:
+                        count_ge: T.uint32 = ld_shared_u32(s_suffix, tx)
+                        count_gt: T.uint32 = T.uint32(0)
+                        if tx + 1 < RADIX:
+                            count_gt = ld_shared_u32(s_suffix, tx + 1)
+                        if count_ge >= remaining_k:
+                            if count_gt < remaining_k:
+                                st_shared_pair_u32(
+                                    s_scalars, 2, T.cast(tx, "uint32"), remaining_k - count_gt
+                                )
+                    bar_sync()
+                    if tx == 0:
+                        found = ld_shared_pair_u32(s_scalars, 2)
+                        st_shared_pair_u32(
+                            s_scalars,
+                            0,
+                            T.bitwise_or(prefix, T.shift_left(found[0], T.cast(shift, "uint32"))),
+                            found[1],
+                        )
+                    bar_sync()
+
+                pivot: T.uint32 = ld_shared_u32(s_scalars, 0)
+                if not is32:
+                    pivot = T.bitwise_and(pivot, T.uint32(0xFFFF))
+
+                # === Stage 3: row-wide gt (and eq) counts (:782-830) =======
+                if tx == 0:
+                    if deterministic:
+                        st_shared_pair_u32(s_suffix, 0, T.uint32(0), T.uint32(0))
+                    else:
+                        st_shared_u32(s_suffix, 0, T.uint32(0))
+                bar_sync()
+                my_gt: T.uint32 = T.uint32(0)
+                my_eq: T.uint32 = T.uint32(0)
+                for ic in T.serial(tx, row_len, step=BLOCK_THREADS, unroll=2):
+                    key2: T.uint32 = T.cast(ld_key(s_ordered, ic), "uint32")
+                    if key2 > pivot:
+                        my_gt = my_gt + T.uint32(1)
+                    if deterministic:
+                        if key2 == pivot:
+                            my_eq = my_eq + T.uint32(1)
+                for step in T.unroll(5):
+                    delta: T.int32 = T.shift_right(T.int32(16), step)
+                    my_gt = my_gt + shfl_down_u32(my_gt, delta)
+                    if deterministic:
+                        my_eq = my_eq + shfl_down_u32(my_eq, delta)
+                lane: T.int32 = T.bitwise_and(tx, T.int32(31))
+                if lane == 0:
+                    if my_gt > T.uint32(0):
+                        T.evaluate(atom_shared_add_u32(s_suffix, 0, my_gt))
+                    if deterministic:
+                        if my_eq > T.uint32(0):
+                            T.evaluate(atom_shared_add_u32(s_suffix, 1, my_eq))
+                bar_sync()
+                gt_count: T.uint32 = ld_shared_u32(s_suffix, 0)
+
+                # === Stage 3b: epilogue-scope aux, per row (:1344-1345, :1373)
+                src_base: T.int64 = T.int64(0)
+                if page_table:
+                    if row_to_batch:
+                        batch_idx = row_to_batch_g[row_idx]
+                    src_base = T.cast(batch_idx, "int64") * aux_stride
+                if ragged:
+                    offset = aux[T.cast(row_idx, "int64")]
+
+                if not deterministic:
+                    # === Stage 4a: non-deterministic collect (:906-963) ====
+                    if tx == 0:
+                        st_shared_u32(s_hist, 0, T.uint32(0))
+                        if gt_count > T.uint32(0):
+                            st_shared_u32(s_hist, 1, atom_shared_add_u32(s_scalars, 4, gt_count))
+                    bar_sync()
+                    for i in T.serial(tx, row_len, step=BLOCK_THREADS, unroll=2):
+                        key3: T.uint32 = T.cast(ld_key(s_ordered, i), "uint32")
+                        if key3 > pivot:
+                            local_pos: T.uint32 = atom_shared_add_u32(s_hist, 0, T.uint32(1))
+                            pos: T.int32 = T.cast(ld_shared_u32(s_hist, 1) + local_pos, "int32")
+                            _emit(
+                                out_idx,
+                                out_val,
+                                row_out,
+                                i,
+                                key3,
+                                pos,
+                                offset,
+                                basic,
+                                ragged,
+                                is32,
+                                dtype,
+                            )
+                    bar_sync()
+                    for i in T.serial(tx, row_len, step=BLOCK_THREADS, unroll=2):
+                        key4: T.uint32 = T.cast(ld_key(s_ordered, i), "uint32")
+                        if key4 == pivot:
+                            pos2: T.int32 = T.cast(
+                                atom_shared_add_u32(s_scalars, 4, T.uint32(1)), "int32"
+                            )
+                            if pos2 < k:
+                                _emit(
+                                    out_idx,
+                                    out_val,
+                                    row_out,
+                                    i,
+                                    pivot,
+                                    pos2,
+                                    offset,
+                                    basic,
+                                    ragged,
+                                    is32,
+                                    dtype,
+                                )
+                else:
+                    # === Stage 4b: deterministic collect (:1023-1138) ======
+                    eq_count: T.uint32 = ld_shared_u32(s_suffix, 1)
+                    if tx == 0:
+                        need: T.uint32 = T.uint32(0)
+                        if T.uint32(k) > gt_count:
+                            need = T.uint32(k) - gt_count
+                        st_shared_quad_u32(s_hist, 0, T.uint32(0), T.uint32(0), gt_count, need)
+                        st_shared_u32(s_hist, 4, T.uint32(0))
+                    bar_sync()
+                    plan = ld_shared_quad_u32(s_hist, 0)
+                    gt_base: T.uint32 = plan[0]
+                    eq_base: T.uint32 = plan[2]
+                    eq_limit: T.uint32 = plan[3]
+                    gt_limit: T.uint32 = T.uint32(0)
+                    if T.uint32(k) > gt_base:
+                        gt_limit = T.uint32(k) - gt_base
+
+                    if eq_limit == T.uint32(0):
+                        sel: T.uint32 = T.uint32(0)
+                        for id1 in T.serial(tx, row_len, step=BLOCK_THREADS):
+                            key5: T.uint32 = T.cast(ld_key(s_ordered, id1), "uint32")
+                            if key5 > pivot:
+                                sel = sel + T.uint32(1)
+                        # cub BLOCK_SCAN_RAKING_MEMOIZE exclusive sum (:268-270):
+                        # place into the padded raking grid, one warp serially
+                        # reduces its 32-element segment while memoizing it in
+                        # registers, a warp shuffle scan runs over the segment
+                        # totals, then the same warp scatters the prefixes back.
+                        rake_off: T.int32 = _raking_offset(tx)
+                        st_shared_u32(s_scan, rake_off, sel)
+                        bar_sync()
+                        if tx < RAKING_THREADS:
+                            rake_base: T.int32 = tx * RAKING_STRIDE
+                            cache = T.alloc_local((RAKING_SEGMENT,), "uint32")
+                            total: T.uint32 = T.uint32(0)
+                            for j in T.unroll(RAKING_SEGMENT):
+                                cache[j] = ld_shared_u32(s_scan, rake_base + j)
+                                total = total + cache[j]
+                            run: T.uint32 = warp_inclusive_sum_u32(total, tx) - total
+                            for j in T.unroll(RAKING_SEGMENT):
+                                st_shared_u32(s_scan, rake_base + j, run)
+                                run = run + cache[j]
+                        bar_sync()
+                        pre: T.uint32 = ld_shared_u32(s_scan, rake_off)
+                        if sel > T.uint32(0):
+                            if pre < gt_limit:
+                                emit_pos: T.uint32 = pre
+                                emit_end: T.uint32 = pre + sel
+                                if emit_end > gt_limit:
+                                    emit_end = gt_limit
+                                done: T.int32 = 0
+                                for id3 in T.serial(tx, row_len, step=BLOCK_THREADS):
+                                    if done == 0:
+                                        key6: T.uint32 = T.cast(ld_key(s_ordered, id3), "uint32")
+                                        if key6 > pivot:
+                                            _emit(
+                                                out_idx,
+                                                out_val,
+                                                row_out,
+                                                id3,
+                                                key6,
+                                                T.cast(gt_base + emit_pos, "int32"),
+                                                offset,
+                                                basic,
+                                                ragged,
+                                                is32,
+                                                dtype,
+                                            )
+                                            emit_pos = emit_pos + T.uint32(1)
+                                            if emit_pos == emit_end:
+                                                done = 1
+                        bar_sync()
+                    else:
+                        sel_gt: T.uint32 = T.uint32(0)
+                        sel_eq: T.uint32 = T.uint32(0)
+                        for id4 in T.serial(tx, row_len, step=BLOCK_THREADS):
+                            key7: T.uint32 = T.cast(ld_key(s_ordered, id4), "uint32")
+                            if key7 > pivot:
+                                sel_gt = sel_gt + T.uint32(1)
+                            if key7 == pivot:
+                                sel_eq = sel_eq + T.uint32(1)
+                        # The same raking scan over the {gt, eq} pair (:1122-1125).
+                        rake_off2: T.int32 = _raking_offset(tx) * 2
+                        st_shared_pair_u32(s_scan, rake_off2, sel_gt, sel_eq)
+                        bar_sync()
+                        if tx < RAKING_THREADS:
+                            rake_base2: T.int32 = tx * RAKING_STRIDE * 2
+                            cache_gt = T.alloc_local((RAKING_SEGMENT,), "uint32")
+                            cache_eq = T.alloc_local((RAKING_SEGMENT,), "uint32")
+                            total_gt: T.uint32 = T.uint32(0)
+                            total_eq: T.uint32 = T.uint32(0)
+                            for j in T.unroll(RAKING_SEGMENT):
+                                seg = ld_shared_pair_u32(s_scan, rake_base2 + j * 2)
+                                cache_gt[j] = seg[0]
+                                cache_eq[j] = seg[1]
+                                total_gt = total_gt + cache_gt[j]
+                                total_eq = total_eq + cache_eq[j]
+                            run_gt: T.uint32 = warp_inclusive_sum_u32(total_gt, tx) - total_gt
+                            run_eq: T.uint32 = warp_inclusive_sum_u32(total_eq, tx) - total_eq
+                            for j in T.unroll(RAKING_SEGMENT):
+                                st_shared_pair_u32(s_scan, rake_base2 + j * 2, run_gt, run_eq)
+                                run_gt = run_gt + cache_gt[j]
+                                run_eq = run_eq + cache_eq[j]
+                        bar_sync()
+                        seg_out = ld_shared_pair_u32(s_scan, rake_off2)
+                        cur_gt: T.uint32 = seg_out[0]
+                        cur_eq: T.uint32 = seg_out[1]
+                        i = tx
+                        while i < row_len:
+                            key8: T.uint32 = T.cast(ld_key(s_ordered, i), "uint32")
+                            emitted: T.int32 = 0
+                            if key8 > pivot:
+                                if cur_gt < gt_limit:
+                                    _emit(
+                                        out_idx,
+                                        out_val,
+                                        row_out,
+                                        i,
+                                        key8,
+                                        T.cast(gt_base + cur_gt, "int32"),
+                                        offset,
+                                        basic,
+                                        ragged,
+                                        is32,
+                                        dtype,
+                                    )
+                                    cur_gt = cur_gt + T.uint32(1)
+                                    emitted = 1
+                            if emitted == 0:
+                                if key8 == pivot:
+                                    if cur_eq < eq_limit:
+                                        _emit(
+                                            out_idx,
+                                            out_val,
+                                            row_out,
+                                            i,
+                                            key8,
+                                            T.cast(eq_base + cur_eq, "int32"),
+                                            offset,
+                                            basic,
+                                            ragged,
+                                            is32,
+                                            dtype,
+                                        )
+                                        cur_eq = cur_eq + T.uint32(1)
+                            i = i + BLOCK_THREADS
+                        bar_sync()
+
+                # === Stage 5: PageTable in-place gather (:1352-1358) =======
+                if page_table:
+                    bar_sync()
+                    for ig in T.serial(tx, k, step=BLOCK_THREADS):
+                        gidx: T.int32 = out_idx[row_out + T.cast(ig, "int64")]
+                        out_idx[row_out + T.cast(ig, "int64")] = aux[
+                            src_base + T.cast(page_start + gidx, "int64")
+                        ]
+
+            row_idx = row_idx + grid
+
+    return radix_topk_single_cta.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+# ---------------------------------------------------------------------------
+# Config matrix: every launcher dispatch cell reachable with one CTA per row.
+# ---------------------------------------------------------------------------
+_DT_TAG = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+_MODE_TAG = {"basic": "basic", "page_table": "pt", "ragged": "rag"}
+
+
+def _cfg(
+    dtype: str,
+    mode: str,
+    num_rows: int,
+    length: int,
+    k: int,
+    deterministic: bool = False,
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    tag: str = "",
+) -> dict[str, Any]:
+    label = f"{_DT_TAG[dtype]}_{_MODE_TAG[mode]}"
+    if deterministic:
+        label += "_det"
+    label += f"_r{num_rows}_l{length}_k{k}"
+    if row_starts:
+        label += "_rs"
+    if page_table_row_starts:
+        label += "_pts"
+    if row_to_batch:
+        label += "_r2b"
+    if trivial:
+        label += "_trivial"
+    if tag:
+        label += f"_{tag}"
+    return {
+        "label": label,
+        "dtype": dtype,
+        "mode": mode,
+        "num_rows": num_rows,
+        "length": length,
+        "k": k,
+        "deterministic": deterministic,
+        "row_starts": row_starts,
+        "page_table_row_starts": page_table_row_starts,
+        "row_to_batch": row_to_batch,
+        "trivial": trivial,
+    }
+
+
+def _max_single_cta_length(dtype: str, deterministic: bool) -> int:
+    """Largest ``length`` the launcher still maps onto one CTA per row."""
+    headroom = _DET_LAUNCH_HEADROOM if deterministic else 0
+    available = hardware_max_smem_optin() - _FIXED_SMEM_ALIGNED - headroom
+    best = available // ordered_bytes(dtype)
+    # Walk down to the first length whose own gcd-derived vec size keeps it
+    # inside its own max_chunk_elements (the launcher recomputes both).
+    for candidate in range(best, best - 64, -1):
+        if candidate < 1:
+            break
+        if candidate <= max_chunk_elements(dtype, candidate, deterministic, False):
+            return candidate
+    raise RuntimeError("no single-CTA length found")
+
+
+def _vec_lengths(dtype: str, deterministic: bool) -> list[tuple[int, int]]:
+    """One small length per reachable VEC_SIZE, as ``(vec, length)``."""
+    widest = 16 // dtype_bytes(dtype)
+    out: list[tuple[int, int]] = []
+    vec = widest
+    while vec >= 1:
+        if vec == widest:
+            length = 32768
+        elif vec == 1:
+            length = 32001
+        else:
+            length = 32768 + vec  # gcd(widest, 32768 + vec) == vec
+        assert vec_size(dtype, length) == vec, (dtype, vec, length)
+        out.append((vec, length))
+        vec //= 2
+    return out
+
+
+def _build_configs() -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    for dtype in DTYPES:
+        for mode in MODES:
+            for deterministic in (False, True):
+                # VEC_SIZE dispatch: every reachable instantiation.
+                for vec, length in _vec_lengths(dtype, deterministic):
+                    configs.append(
+                        _cfg(dtype, mode, 8, length, 256, deterministic, tag=f"vec{vec}")
+                    )
+                # Largest chunk the smem budget still keeps on one CTA.
+                big = _max_single_cta_length(dtype, deterministic)
+                configs.append(_cfg(dtype, mode, 4, big, 256, deterministic, tag="maxchunk"))
+                # k sweep inside one shape.
+                for k in (64, 512, 1024):
+                    configs.append(_cfg(dtype, mode, 8, 32768, k, deterministic))
+                # Launch topology: single row, below num_sms, above num_sms.
+                for rows in (1, 64, 256):
+                    configs.append(_cfg(dtype, mode, rows, 32768, 256, deterministic))
+                # Trivial early-out branch (k >= length / length <= top_k).
+                configs.append(_cfg(dtype, mode, 8, 2048, 2048, deterministic, trivial=True))
+                # Runtime pointer branches.
+                if mode == "page_table":
+                    configs.append(_cfg(dtype, mode, 8, 32768, 256, deterministic, row_starts=True))
+                    configs.append(
+                        _cfg(
+                            dtype,
+                            mode,
+                            8,
+                            32768,
+                            256,
+                            deterministic,
+                            row_starts=True,
+                            page_table_row_starts=True,
+                        )
+                    )
+                    configs.append(
+                        _cfg(dtype, mode, 8, 32768, 256, deterministic, row_to_batch=True)
+                    )
+                elif mode == "ragged":
+                    configs.append(_cfg(dtype, mode, 8, 32768, 256, deterministic, row_starts=True))
+    return configs
+
+
+CONFIGS = _build_configs()
+
+
+def _build_bench_configs() -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    for dtype in DTYPES:
+        for mode in MODES:
+            for deterministic in (False, True):
+                configs.append(_cfg(dtype, mode, 8, 8192, 256, deterministic))
+                configs.append(_cfg(dtype, mode, 64, 32768, 512, deterministic))
+                configs.append(
+                    _cfg(
+                        dtype,
+                        mode,
+                        256,
+                        _max_single_cta_length(dtype, deterministic),
+                        1024,
+                        deterministic,
+                        tag="maxchunk",
+                    )
+                )
+    return configs
+
+
+BENCH_CONFIGS = _build_bench_configs()
+
+
+# ---------------------------------------------------------------------------
+# Data preparation and the FlashInfer reference path.
+# ---------------------------------------------------------------------------
+def _torch_dtype(dtype: str):
+    import torch
+
+    return {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def prepare_data(
+    dtype: str = "float32",
+    mode: str = "basic",
+    num_rows: int = 16,
+    length: int = 32000,
+    k: int = 256,
+    deterministic: bool = False,
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    **kwargs,
+):
+    """Logical inputs for one config.
+
+    Scores follow the source benchmark's ``random`` pattern: seeded fp32 normals
+    cast to the target dtype.  Ties are expected and wanted -- fp16 has only
+    63487 distinct finite values while this kernel's single-CTA domain reaches
+    115184 elements per row, so a tie-free input does not exist at the large
+    shapes, and ties are what exercise the ``== pivot`` collect pass.  See
+    ``_compare`` for the tie-robust correctness criterion.
+    """
+    import torch
+
+    device = "cuda"
+    rows = num_rows
+    generator = torch.Generator(device=device).manual_seed(1234)
+    scores = torch.randn(rows, length, dtype=torch.float32, device=device, generator=generator)
+    scores = scores.to(_torch_dtype(dtype)).contiguous()
+
+    data: dict[str, Any] = {"scores": scores}
+    if mode != "basic":
+        if trivial:
+            lengths = torch.full((rows,), min(k, length), dtype=torch.int32, device=device)
+        else:
+            lengths = torch.full((rows,), length, dtype=torch.int32, device=device)
+        if row_starts:
+            # Non-zero row starts shrink the usable span; keep k <= span.
+            starts = torch.arange(rows, dtype=torch.int32, device=device) % 8
+            lengths = torch.clamp(lengths - starts, min=k)
+            data["row_starts"] = starts
+        data["lengths"] = lengths
+    if mode == "page_table":
+        batch = page_table_batch(rows, row_to_batch)
+        if row_to_batch:
+            data["row_to_batch"] = (
+                torch.arange(rows, dtype=torch.int32, device=device) % batch
+            ).contiguous()
+        # Injective page ids (batch-major) so a returned page id inverts back to
+        # the row-local index the kernel selected: id == batch * length + slot.
+        data["src_page_table"] = (
+            torch.arange(batch * length, dtype=torch.int32, device=device)
+            .reshape(batch, length)
+            .contiguous()
+        )
+        data["page_table_batch"] = batch
+        if page_table_row_starts:
+            data["page_table_row_starts"] = (
+                torch.arange(rows, dtype=torch.int32, device=device) % 4
+            ).contiguous()
+    if mode == "ragged":
+        data["offsets"] = (
+            torch.arange(rows, dtype=torch.int32, device=device) * length
+        ).contiguous()
+    return data
+
+
+def _source_module():
+    """Raw FlashInfer topk FFI module (no allocating Python wrapper)."""
+    from flashinfer.jit.topk import gen_topk_module
+
+    return gen_topk_module().build_and_load()
+
+
+def _pin_source_algo() -> None:
+    """Force ``TopKDispatch`` onto the radix path this port targets."""
+    os.environ[_SOURCE_ALGO_ENV] = _SOURCE_ALGO_VALUE
+
+
+def _row_states_buffer():
+    import torch
+
+    return torch.zeros(1024 * 1024, dtype=torch.uint8, device="cuda")
+
+
+def run_reference(config: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]) -> None:
+    """One launch of the FlashInfer source kernel with preallocated outputs."""
+    import torch
+
+    _pin_source_algo()
+    module = _source_module()
+    mode = config["mode"]
+    k = config["k"]
+    det = config["deterministic"]
+    row_states = outputs["row_states"]
+    if mode == "basic":
+        module.radix_topk(
+            data["scores"],
+            outputs["indices"],
+            outputs["values"],
+            row_states,
+            k,
+            False,  # sorted_output
+            det,
+            _TIE_BREAK_NONE,
+            False,  # dsa_graph_safe
+        )
+    elif mode == "page_table":
+        module.radix_topk_page_table_transform(
+            data["scores"],
+            outputs["indices"],
+            data["src_page_table"],
+            data.get("row_to_batch"),
+            data["lengths"],
+            row_states,
+            k,
+            det,
+            _TIE_BREAK_NONE,
+            False,
+            data.get("row_starts"),
+            data.get("page_table_row_starts"),
+        )
+    else:
+        module.radix_topk_ragged_transform(
+            data["scores"],
+            outputs["indices"],
+            data["offsets"],
+            data["lengths"],
+            row_states,
+            k,
+            det,
+            _TIE_BREAK_NONE,
+            False,
+            data.get("row_starts"),
+        )
+    torch.cuda.synchronize()
+
+
+def build_reference_launch(config: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]):
+    """Resolve the module and bind every argument once; return a bare launch.
+
+    The timed closure must enqueue exactly one kernel and nothing else -- no env
+    writes, no module lookup, no host synchronize.
+    """
+    _pin_source_algo()
+    module = _source_module()
+    mode = config["mode"]
+    k = config["k"]
+    det = config["deterministic"]
+    row_states = outputs["row_states"]
+    scores = data["scores"]
+    indices = outputs["indices"]
+    if mode == "basic":
+        values = outputs["values"]
+        fn = module.radix_topk
+        args = (scores, indices, values, row_states, k, False, det, _TIE_BREAK_NONE, False)
+    elif mode == "page_table":
+        fn = module.radix_topk_page_table_transform
+        args = (
+            scores,
+            indices,
+            data["src_page_table"],
+            data.get("row_to_batch"),
+            data["lengths"],
+            row_states,
+            k,
+            det,
+            _TIE_BREAK_NONE,
+            False,
+            data.get("row_starts"),
+            data.get("page_table_row_starts"),
+        )
+    else:
+        fn = module.radix_topk_ragged_transform
+        args = (
+            scores,
+            indices,
+            data["offsets"],
+            data["lengths"],
+            row_states,
+            k,
+            det,
+            _TIE_BREAK_NONE,
+            False,
+            data.get("row_starts"),
+        )
+    return lambda: fn(*args)
+
+
+def _alloc_outputs(config: dict[str, Any]):
+    import torch
+
+    rows = config["num_rows"]
+    k = config["k"]
+    return {
+        "indices": torch.empty(rows, k, dtype=torch.int32, device="cuda"),
+        "values": torch.empty(rows, k, dtype=_torch_dtype(config["dtype"]), device="cuda"),
+        "row_states": _row_states_buffer(),
+    }
+
+
+def _assert_device_matches_compile_profile() -> None:
+    import torch
+
+    optin = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).shared_memory_per_block_optin
+    expected = hardware_max_smem_optin()
+    if optin != expected:
+        raise AssertionError(
+            f"device optin shared memory {optin} != compile profile {expected}; "
+            "the single-CTA dispatch domain would differ from the configured matrix"
+        )
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against the FlashInfer source."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    try:
+        import flashinfer  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"flashinfer unavailable: {exc}") from exc
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    cfg = _normalize_config(config)
+    _assert_device_matches_compile_profile()
+    _validate(
+        cfg["dtype"],
+        cfg["mode"],
+        cfg["num_rows"],
+        cfg["length"],
+        cfg["k"],
+        cfg["deterministic"],
+        cfg["row_starts"] and cfg["mode"] != "basic",
+    )
+
+    data = prepare_data(**cfg)
+    ref_out = _alloc_outputs(cfg)
+    run_reference(cfg, data, ref_out)
+
+    assert_reference_is_top_k(cfg, data, ref_out)
+
+    ex = compile_kernel(get_kernel(**cfg))
+    tirx_out = _alloc_outputs(cfg)
+    _launch_tirx(ex, cfg, data, tirx_out)
+    torch.cuda.synchronize()
+
+    _compare(cfg, data, ref_out, tirx_out)
+
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    cfg = {
+        "dtype": "float32",
+        "mode": "basic",
+        "num_rows": 16,
+        "length": 32000,
+        "k": 256,
+        "deterministic": False,
+        "row_starts": False,
+        "page_table_row_starts": False,
+        "row_to_batch": False,
+        "trivial": False,
+    }
+    cfg.update({key: value for key, value in config.items() if key != "label"})
+    return cfg
+
+
+def build_tirx_args(cfg: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]):
+    """Materialize the flat launch ABI once, outside any timed region.
+
+    Every tensor the kernel reads must exist before the launch closure is built:
+    allocating placeholders inside the closure would launch extra fill kernels
+    that a per-kernel timer attributes to this kernel.
+    """
+    import torch
+
+    rows = cfg["num_rows"]
+    length = cfg["length"]
+    empty_i32 = torch.zeros(rows, dtype=torch.int32, device="cuda")
+    aux = data.get("src_page_table")
+    if aux is None:
+        aux = data.get("offsets")
+    if aux is None:
+        aux = torch.zeros(1, dtype=torch.int32, device="cuda")
+    lengths = data.get("lengths")
+    if lengths is None:
+        lengths = torch.full((rows,), length, dtype=torch.int32, device="cuda")
+    aux_stride = int(aux.stride(0)) if aux.dim() == 2 else 0
+    expected_aux = aux_elements(cfg["mode"], rows, length, cfg["row_to_batch"])
+    assert aux.numel() == expected_aux, (aux.numel(), expected_aux)
+    return (
+        data["scores"].view(-1),
+        outputs["indices"].view(-1),
+        outputs["values"].view(-1),
+        aux.reshape(-1),
+        lengths,
+        data.get("row_starts", empty_i32),
+        data.get("page_table_row_starts", empty_i32),
+        data.get("row_to_batch", empty_i32),
+        aux_stride,
+    )
+
+
+def _launch_tirx(ex, cfg: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]) -> None:
+    ex(*build_tirx_args(cfg, data, outputs))
+
+
+def _row_local_indices(cfg: dict[str, Any], data: dict[str, Any], out_indices):
+    """Map one launch's raw output back to row-local score offsets.
+
+    Basic returns the index directly; Ragged adds a per-row offset; PageTable
+    returns an injective page id (``batch * length + slot``).  ``-1`` marks the
+    padding the trivial branches write when a row is shorter than ``k``.
+    """
+    import torch
+
+    rows = cfg["num_rows"]
+    length = cfg["length"]
+    idx = out_indices.to(torch.int64)
+    pad = idx < 0
+    if cfg["mode"] == "ragged":
+        idx = idx - data["offsets"].to(torch.int64).unsqueeze(-1)
+    elif cfg["mode"] == "page_table":
+        row_to_batch = data.get("row_to_batch")
+        if row_to_batch is None:
+            batch = torch.arange(rows, dtype=torch.int64, device=idx.device)
+        else:
+            batch = row_to_batch.to(torch.int64)
+        idx = idx - batch.unsqueeze(-1) * length
+        pt_starts = data.get("page_table_row_starts")
+        if pt_starts is None:
+            pt_starts = data.get("row_starts")
+        if pt_starts is not None:
+            idx = idx - pt_starts.to(torch.int64).unsqueeze(-1)
+    return idx, pad
+
+
+def _selected_values(cfg: dict[str, Any], data: dict[str, Any], out_indices):
+    """Sorted-descending scores of the selected elements, padding removed."""
+    import torch
+
+    idx, pad = _row_local_indices(cfg, data, out_indices)
+    row_starts = data.get("row_starts")
+    if row_starts is not None:
+        idx = idx + row_starts.to(torch.int64).unsqueeze(-1)
+    scores = data["scores"].to(torch.float32)
+    safe = idx.clamp_(0, scores.size(1) - 1)
+    vals = torch.gather(scores, 1, safe)
+    # Padding slots carry no score; sort them to the bottom deterministically.
+    vals = torch.where(pad, torch.full_like(vals, float("-inf")), vals)
+    return torch.sort(vals, dim=-1, descending=True).values
+
+
+def _compare(
+    cfg: dict[str, Any], data: dict[str, Any], ref: dict[str, Any], got: dict[str, Any]
+) -> None:
+    """Compare a TIRx launch against the FlashInfer launch.
+
+    Ties make the selected *index set* ambiguous, so the criterion is the
+    multiset of selected score values, which every valid top-k shares.  For
+    deterministic configs both sides run the same fixed-order collect, so the
+    raw outputs must additionally match element for element.
+    """
+    import torch
+
+    if cfg["deterministic"]:
+        torch.testing.assert_close(got["indices"], ref["indices"], rtol=0, atol=0)
+        if cfg["mode"] == "basic":
+            torch.testing.assert_close(got["values"], ref["values"], rtol=0, atol=0)
+        return
+
+    ref_vals = _selected_values(cfg, data, ref["indices"])
+    got_vals = _selected_values(cfg, data, got["indices"])
+    torch.testing.assert_close(got_vals, ref_vals, rtol=0, atol=0)
+    if cfg["mode"] == "basic":
+        ref_out = torch.sort(ref["values"].to(torch.float32), dim=-1, descending=True).values
+        got_out = torch.sort(got["values"].to(torch.float32), dim=-1, descending=True).values
+        torch.testing.assert_close(got_out, ref_out, rtol=0, atol=0)
+        # The emitted values must be the scores at the emitted indices.
+        torch.testing.assert_close(got_out, got_vals, rtol=0, atol=0)
+
+
+def assert_reference_is_top_k(
+    cfg: dict[str, Any], data: dict[str, Any], ref: dict[str, Any]
+) -> None:
+    """Independent oracle on the reference launch itself (tie-robust)."""
+    import torch
+
+    if cfg["trivial"]:
+        return
+    scores = data["scores"].to(torch.float32)
+    row_starts = data.get("row_starts")
+    lengths = data.get("lengths")
+    if row_starts is None and lengths is None:
+        window = scores
+    else:
+        rows, length, k = cfg["num_rows"], cfg["length"], cfg["k"]
+        starts = (
+            torch.zeros(rows, dtype=torch.int64, device=scores.device)
+            if row_starts is None
+            else row_starts.to(torch.int64)
+        )
+        lens = (
+            torch.full((rows,), length, dtype=torch.int64, device=scores.device)
+            if lengths is None
+            else lengths.to(torch.int64)
+        )
+        cols = torch.arange(length, device=scores.device).unsqueeze(0)
+        inside = (cols >= starts.unsqueeze(-1)) & (cols < (starts + lens).unsqueeze(-1))
+        window = torch.where(inside, scores, torch.full_like(scores, float("-inf")))
+        del k
+    expect = torch.topk(window, cfg["k"], dim=-1).values
+    expect = torch.sort(expect, dim=-1, descending=True).values
+    actual = _selected_values(cfg, data, ref["indices"])
+    torch.testing.assert_close(actual, expect, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+# ---------------------------------------------------------------------------
+def prepare_bench(**kwargs: Any):
+    """Specialize and compile before the workload receives a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    cfg = _normalize_config(kwargs)
+    state = {"config": cfg, "executable": compile_kernel(get_kernel(**cfg))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    """Kernel-only comparison against the FlashInfer source launch."""
+    cfg = dict(prepared["config"])
+    ex = prepared["executable"]
+
+    data = prepare_data(**cfg)
+    tirx_out = _alloc_outputs(cfg)
+    tirx_args = build_tirx_args(cfg, data, tirx_out)
+
+    def tirx_launch():
+        ex(*tirx_args)
+
+    def build_reference():
+        ref_out = _alloc_outputs(cfg)
+        return build_reference_launch(cfg, data, ref_out)
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )

--- a/tirx_kernels/flashinfer/utils/topk_radix.py
+++ b/tirx_kernels/flashinfer/utils/topk_radix.py
@@ -1,0 +1,176 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Instruction-level helpers for the FlashInfer radix top-k ports.
+
+Covers the monotone float->unsigned key mapping of ``RadixTopKTraits``
+(``include/flashinfer/topk_common.cuh``) and the shared-memory, warp-shuffle and
+barrier primitives ``RadixTopKKernel_Unified`` and its device helpers use
+(``include/flashinfer/topk.cuh``).
+"""
+
+from tvm.script import tirx as T
+
+WARP_SIZE = 32
+FULL_MASK = 0xFFFFFFFF
+
+
+# --- barriers ---------------------------------------------------------------
+def bar_sync():
+    """``bar.sync 0`` -- the plain CTA barrier ``__syncthreads()`` lowers to."""
+    T.evaluate(T.ptx.bar.sync(T.uint32(0)))
+
+
+# --- shared memory ----------------------------------------------------------
+def ld_shared_u32(buffer, index):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def st_shared_u32(buffer, index, value):
+    T.evaluate(T.ptx.st.shared.b32(buffer.ptr_to([index]), value))
+
+
+def ld_shared_u16(buffer, index):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.shared.b16(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def st_shared_u16(buffer, index, value):
+    T.evaluate(T.ptx.st.shared.b16(buffer.ptr_to([index]), value))
+
+
+def ld_shared_u64(buffer, index):
+    """``ld.shared.b64`` -- reads two adjacent u32 scalars as one 64-bit access."""
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx["ld.shared.b64"](out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def u64_lo(value):
+    return T.cast(T.bitwise_and(value, T.uint64(0xFFFFFFFF)), "uint32")
+
+
+def u64_hi(value):
+    return T.cast(T.shift_right(value, T.uint64(32)), "uint32")
+
+
+def ld_shared_pair_u32(buffer, index):
+    """``ld.shared.v2.b32``; returns the 2-element register pair."""
+    out = T.alloc_local((2,), "uint32", align=8)
+    T.evaluate(T.ptx["ld.shared.v2.b32"](out[0], out[1], buffer.ptr_to([index])))
+    return out
+
+
+def st_shared_pair_u32(buffer, index, v0, v1):
+    """``st.shared.v2.b32``."""
+    T.evaluate(T.ptx["st.shared.v2.b32"](buffer.ptr_to([index]), v0, v1))
+
+
+def ld_shared_quad_u32(buffer, index):
+    """``ld.shared.v4.b32``; returns the 4-element register quad."""
+    out = T.alloc_local((4,), "uint32", align=16)
+    T.evaluate(T.ptx["ld.shared.v4.b32"](out[0], out[1], out[2], out[3], buffer.ptr_to([index])))
+    return out
+
+
+def st_shared_quad_u32(buffer, index, v0, v1, v2, v3):
+    """``st.shared.v4.b32``."""
+    T.evaluate(T.ptx["st.shared.v4.b32"](buffer.ptr_to([index]), v0, v1, v2, v3))
+
+
+def atom_shared_add_u32(buffer, index, value):
+    """``atom.shared.add.u32``; returns the value held before the addition."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.atom.shared.add.u32(out[0], buffer.ptr_to([index]), value))
+    return out[0]
+
+
+# --- warp shuffles ----------------------------------------------------------
+def shfl_down_u32(value, delta):
+    """``shfl.sync.down.b32 d, a, delta, 31, -1`` (the ``__shfl_down_sync`` form)."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.down.b32(out[0], value, T.uint32(delta), T.uint32(31), T.uint32(FULL_MASK))
+    )
+    return out[0]
+
+
+def shfl_up_u32(value, delta):
+    """``shfl.sync.up.b32 d, a, delta, 0, -1`` (cub's warp-scan form)."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.up.b32(out[0], value, T.uint32(delta), T.uint32(0), T.uint32(FULL_MASK))
+    )
+    return out[0]
+
+
+# --- monotone key mapping ---------------------------------------------------
+# RadixTopKTraits<float>::ToOrdered  (topk_common.cuh:35-39)
+#   (bits & 0x80000000) ? ~bits : (bits ^ 0x80000000)
+# nvcc lowers this to setp.gt.s32 + selp.b32(0x80000000, -1) + xor.b32.
+def to_ordered_u32(bits):
+    signed = T.reinterpret("int32", bits)
+    mask = T.if_then_else(signed > T.int32(-1), T.uint32(0x80000000), T.uint32(0xFFFFFFFF))
+    return T.bitwise_xor(mask, bits)
+
+
+# RadixTopKTraits<float>::FromOrdered (topk_common.cuh:41-44)
+#   (ordered & 0x80000000) ? (ordered ^ 0x80000000) : ~ordered
+def from_ordered_u32(ordered):
+    signed = T.reinterpret("int32", ordered)
+    mask = T.if_then_else(signed > T.int32(-1), T.uint32(0xFFFFFFFF), T.uint32(0x80000000))
+    return T.bitwise_xor(mask, ordered)
+
+
+# RadixTopKTraits<half|nv_bfloat16>::ToOrdered (topk_common.cuh:61-64, :87-90)
+def to_ordered_u16(bits):
+    signed = T.reinterpret("int16", bits)
+    mask = T.if_then_else(signed > T.int16(-1), T.uint16(0x8000), T.uint16(0xFFFF))
+    return T.bitwise_xor(mask, bits)
+
+
+# RadixTopKTraits<half|nv_bfloat16>::FromOrdered (topk_common.cuh:66-69, :92-95)
+def from_ordered_u16(ordered):
+    signed = T.reinterpret("int16", ordered)
+    mask = T.if_then_else(signed > T.int16(-1), T.uint16(0xFFFF), T.uint16(0x8000))
+    return T.bitwise_xor(mask, ordered)
+
+
+# --- global memory ----------------------------------------------------------
+def st_global_u32(buffer, index, value):
+    T.evaluate(T.ptx.st.global_.b32(buffer.ptr_to([index]), value))
+
+
+def st_global_u16(buffer, index, value):
+    T.evaluate(T.ptx.st.global_.b16(buffer.ptr_to([index]), value))
+
+
+def ld_global_u32(buffer, index):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def ld_global_u16(buffer, index):
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.b16(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def warp_inclusive_sum_u32(value, lane):
+    """cub ``WarpScanShfl`` inclusive sum: five ``shfl.sync.up.b32`` steps.
+
+    The source uses the shuffle's own out-predicate to guard the add; the
+    equivalent lane compare is used here because the TIRx wrapper does not
+    expose the ``d|p`` destination form.
+    """
+    acc = value
+    for step in range(5):
+        peer = shfl_up_u32(acc, 1 << step)
+        acc = T.if_then_else(lane >= T.int32(1 << step), acc + peer, acc)
+    return acc


### PR DESCRIPTION
## Summary

Ports FlashInfer's radix top-k kernel to TIRx as `radix_topk_single_cta`, restricted to the `SINGLE_CTA=true` specialization the host launchers select when one CTA can stage a whole row in shared memory.

Source: `RadixTopKKernel_Unified<1024, VEC_SIZE, true, DETERMINISTIC, MODE, DType, int32_t>`, `include/flashinfer/topk.cuh:1170`, flashinfer @ `f2e04400`.

One 1024-thread CTA owns a whole row: the row is staged into dynamic shared memory as monotone ordered integers, an 8-bit radix select walks 4 (fp32) or 2 (fp16/bf16) rounds of a 256-bin shared histogram plus suffix sum to the exact k-th value, and a single collect pass emits the winners through a mode-specific epilogue. The grid is persistent — `min(num_sms, num_rows)` CTAs stride the rows.

## Scope

The full `SINGLE_CTA` dispatch domain, not a curated subset:

- all three epilogue modes (Basic / PageTableTransform / RaggedTransform)
- both collect paths (`DETERMINISTIC` on and off)
- fp32 / fp16 / bf16
- every reachable `VEC_SIZE` (4/2/1 for fp32, 8/4/2/1 for the 16-bit types)
- the runtime `row_starts` / `page_table_row_starts` / `row_to_batch` branches
- the three trivial early-outs, and all three launch-topology regimes

Out of scope, because the source routes them elsewhere: per-row `top_k_arr` (`csrc/topk.cu` always passes `nullptr`), the multi-CTA cross-group protocol, and the FilteredTopK / SM100 cluster algorithms.

cub has no TIRx equivalent, so `BlockScan<..., BLOCK_SCAN_RAKING_MEMOIZE>` is reimplemented in plain TIRx: 32 raking threads, 32-element segments, stride-33 padded grid, register memoize, 5-step `shfl.sync.up.b32` warp scan, two `bar.sync 0`.

## Correctness

**234/234 `CONFIGS` pass.** The reference on every case is the FlashInfer kernel itself, reached through the raw `topk` FFI module with `FLASHINFER_TOPK_ALGO=multi_cta` pinning `TopKDispatch` to the radix path, with every config asserted in-domain by the replicated launcher arithmetic.

Criterion:
- deterministic configs — exact positional equality of the raw outputs;
- non-deterministic configs — equality of the multiset of selected score values.

The second is not laziness: fp16 has only 63487 distinct finite values while this kernel's single-CTA domain reaches 115184 elements per row, so ties are unavoidable by construction and the selected *index set* is genuinely ambiguous. The value multiset is shared by every valid top-k. An independent `torch.topk` oracle additionally checks the reference launch itself.

`tests/lint/check_radix_topk_single_cta_no_tile.py` asserts no tile primitives in the two source files or in any of the 234 pre-dispatch specializations.

## Performance — **not yet at the gate**

Measured with `python -m tirx_kernels.bench_suite` over all 54 bench configs, central 25ms/100ms budgets. Ratio is `flashinfer / tirx`, so >1 means the port is faster.

| | ratio |
|---|---|
| median | **1.086x** |
| best (`bf16_basic_r64_l32768_k512`) | **1.209x** |
| worst (`f32_basic_det_r256_l55464_k1024_maxchunk`) | **0.976x** |

52 of 54 recorded shapes clear 0.99. **One shape does not**: `f32_basic_det_r256_l55464_k1024_maxchunk`, improved from 0.9729x to **0.9759x** by the `perf(kernel)` commit but still under the gate. The next-worst four are the same family (256-row maxchunk / deterministic), so this looks like a real pattern in the deterministic largest-chunk path rather than noise.

One further shape, `bf16_rag_r64_l32768_k512`, is missing from that run — bench-suite repeatedly hit `INTERFERED ... intruders` on a shared machine and correctly refused to record a contended measurement. Standalone it measures 17.20µs vs 19.21µs (1.117x), but that is a diagnostic number, not gate evidence.

So this is **not** a finished performance story: the deterministic maxchunk shape needs work and the matrix needs one clean end-to-end run.

Two known optimization leads, both already identified against the generated code:
1. TVM emits `#pragma unroll 1` on some strided loops where the source carries `#pragma unroll 2` (the five hottest are already converted to `T.serial(..., unroll=2)`).
2. Staging shared stores are scalar `st.shared.b32`; the source coalesces one group into `st.shared.v4.b32`. Opaque inline asm blocks the merge, so it needs requesting explicitly — `st_shared_quad_u32` already exists for it.

## Second commit

`chore(infra)` removes an identical `defaults: {warmup: 50, repeat: 300}` block from the four quantization bench configs. These are millisecond budgets, not iteration counts, so the block tripled the measurement window over the central defaults with no measured justification.

This is **independent of the port** and touches kernels I did not author — happy to split it into its own PR. Note the pinned `baseline.json` numbers for those four kernels were recorded under the wider windows and may shift slightly on their next run.



## Update: partial performance work

A third commit closes part of the gap on the deterministic largest-chunk family. Diagnosis (NCU as diagnostic only; every accept/reject decision came from bench_suite):

- The port already executed **fewer** thread-instructions than the source (1.271B vs 1.283B) and fewer shared wavefronts (5.67M vs 5.91M) with identical shared-atomic counts, so the deficit was never work volume.
- It was stalls, and specifically branch reconvergence: `BSSY` stall samples 768 vs the source's 433. `T.if_then_else` in the monotone key flip was lowering to a real if/else where the source emits a predicated `selp.b32`, and several conditions were nested where the source uses `&&`.

Result on that shape: **0.9729x -> 0.9759x**. Still short of 0.99x, so the gate stays open.

Two findings worth recording for whoever continues:

1. **Predicated `@p` stores are the wrong tool for the collect emits.** They are the textbook fix for a guarded store, but here only `k` of `row_len` elements are selected, so ~98% of lanes are inactive and a predicated store still issues for every lane -- it cost ~8%. Reverted.
2. **The remaining lead** is the deterministic pair-emit loop, whose two top stall sites are the same construct. Worth checking whether the scan result and the emit-loop guards can be kept entirely in registers.

Correctness is unaffected: 234/234 CONFIGS still pass, and the no-tile lint passes over all 234 pre-dispatch specializations.