### PR TITLE
fix(kernels): use unaligned sync for split-site role barriers

### DIFF
--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -2342,7 +2342,7 @@ def _mn_precompute_sm100(
             )
     elif warp <= 3:
         T.ptx.setmaxnreg.inc.sync.aligned.u32(216)
-        T.ptx.bar.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg0: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg0, T.address_of(tmem_holding[0]))
         cg0_thread: T.int32 = tid
@@ -2401,7 +2401,7 @@ def _mn_precompute_sm100(
 
     elif warp <= 7:
         T.ptx.setmaxnreg.inc.sync.aligned.u32(216)
-        T.ptx.bar.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg1: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg1, T.address_of(tmem_holding[0]))
         cg1_thread: T.int32 = tid & 127
@@ -2464,7 +2464,7 @@ def _mn_precompute_sm100(
             )
 
     elif warp == 8:
-        T.ptx.bar.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_transfer: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_transfer, T.address_of(tmem_holding[0]))
         _mn_opt_consumer_wait(smem_addr, 208, 0, 1)
@@ -2521,7 +2521,7 @@ def _mn_precompute_sm100(
             _mn_opt_mma_commit(_mn_opt_empty_addr(smem_addr, 24, block, 3))
 
     elif warp == 11:
-        T.ptx.bar.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(MN_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_state: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_state, T.address_of(tmem_holding[0]))
         _mn_opt_consumer_wait(smem_addr, 224, 0, 1)
@@ -3636,7 +3636,7 @@ def _prefill_sm100(
     # CG0: transform the precomputed T tile and materialize gated QK.
     if warp <= 3:
         T.ptx.setmaxnreg.inc.sync.aligned.u32(224)
-        T.ptx.bar.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg0: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg0, T.address_of(tmem_holding[0]))
         gate_index_cg0: T.int32 = 0
@@ -3743,7 +3743,7 @@ def _prefill_sm100(
             T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_holding[0]), T.uint32(PREFILL_OPT_TMEM_COLUMNS)
             )
-        T.ptx.bar.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg1: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg1, T.address_of(tmem_holding[0]))
         v_index_cg1: T.int32 = 0
@@ -4096,7 +4096,7 @@ def _prefill_sm100(
     # Issuer and load roles are mutually exclusive with CG1, matching source.
     elif warp == 8:
         T.ptx.setmaxnreg.dec.sync.aligned.u32(24)
-        T.ptx.bar.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_i0: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_i0, T.address_of(tmem_holding[0]))
         acc_index_i0: T.int32 = 0
@@ -4140,7 +4140,7 @@ def _prefill_sm100(
 
     elif warp == 10:
         T.ptx.setmaxnreg.dec.sync.aligned.u32(24)
-        T.ptx.bar.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(PREFILL_OPT_TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_i1: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_i1, T.address_of(tmem_holding[0]))
         cg1_producer_i1: T.int32 = 0

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -1439,7 +1439,7 @@ def _kernel(
     if warp <= 3:
         smem_addr_cg0: T.uint32 = T.cuda.cvta_generic_to_shared(smem_raw.ptr_to([0]))
         T.ptx.setmaxnreg.inc.sync.aligned.u32(224)
-        T.ptx.bar.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg0: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg0, T.address_of(tmem_holding[0]))
         gate_consumer_index_cg0: T.int32 = 0
@@ -1741,7 +1741,7 @@ def _kernel(
             T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
                 T.address_of(tmem_holding[0]), T.uint32(TMEM_COLUMNS)
             )
-        T.ptx.bar.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_cg1: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_cg1, T.address_of(tmem_holding[0]))
         v_consumer_index_cg1: T.int32 = 0
@@ -2092,7 +2092,7 @@ def _kernel(
     elif warp == 8:
         smem_addr_issuer0: T.uint32 = T.cuda.cvta_generic_to_shared(smem_raw.ptr_to([0]))
         T.ptx.setmaxnreg.dec.sync.aligned.u32(24)
-        T.ptx.bar.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_issuer0: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_issuer0, T.address_of(tmem_holding[0]))
         cg0_producer_index_i0: T.int32 = 0
@@ -2209,7 +2209,7 @@ def _kernel(
     elif warp == 10:
         smem_addr_issuer1: T.uint32 = T.cuda.cvta_generic_to_shared(smem_raw.ptr_to([0]))
         T.ptx.setmaxnreg.dec.sync.aligned.u32(24)
-        T.ptx.bar.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
+        T.ptx.barrier.sync(T.uint32(TMEM_ALLOC_BARRIER), T.uint32(320))
         tmem_base_issuer1: T.int32
         T.ptx.ld.volatile.shared.s32(tmem_base_issuer1, T.address_of(tmem_holding[0]))
         cg1_producer_count_i1: T.int32 = 0

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -288,7 +288,7 @@ def _tinygemm2_sm100(
             accum_bits[2],
             accum_bits[3],
         )
-        T.ptx.bar.sync(T.uint32(2), T.uint32(THREADS))
+        T.ptx.barrier.sync(T.uint32(2), T.uint32(THREADS))
 
         if warp == 0:
             part_bits = T.alloc_local((12,), "uint32", align=4)
@@ -384,7 +384,7 @@ def _tinygemm2_sm100(
                     T.uint32(consumed_off) + dstage_w * T.uint32(8),
                     dphase_w ^ T.uint32(1),
                 )
-        T.ptx.bar.sync(T.uint32(2), T.uint32(THREADS))
+        T.ptx.barrier.sync(T.uint32(2), T.uint32(THREADS))
 
     elif 8 <= warp and warp <= 11:
         k_loops_a: T.int32 = T.truncdiv(c_K + 1023, 1024)
@@ -425,7 +425,7 @@ def _tinygemm2_sm100(
                     T.uint32(consumed_off) + dstage_a * T.uint32(8),
                     dphase_a ^ T.uint32(1),
                 )
-        T.ptx.bar.sync(T.uint32(2), T.uint32(THREADS))
+        T.ptx.barrier.sync(T.uint32(2), T.uint32(THREADS))
 
 
 def get_kernel(


### PR DESCRIPTION
The GDN prefill and CP-prefill TMEM allocation barriers and tinygemm2's role barrier 2 are each completed by threads arriving from distinct static role branches. `bar.sync` is `barrier.sync.aligned`, whose PTX contract requires the whole participant set to execute one static barrier instruction ("all threads in CTA will execute the same barrier instruction"; divergent use is undefined). These fifteen rendezvous are respelled as the unaligned `barrier.sync` form. Barrier ids, arrival counts, participants, and ordering are unchanged.

Barriers completed from a single static site keep the aligned spelling, including CP-prefill's invalid-chunk teardown rendezvous: its guard is CTA-uniform (chunk validity derives from the CTA id and `cu_seqlens`), so all 320 participants reach the one call site and the aligned contract holds.

Found by TIRx Synccheck's aligned-sync origin check; each site was flagged as a completed named-barrier generation with aligned blocking syncs from multiple static TIR sites. Validated by the tirx-tools canonical synccheck and racecheck gates for all three kernels (all phases clean).
