### PR TITLE
test: pin upstream correctness references

### DIFF
--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -1036,3 +1036,38 @@ only the single-GPU sweep.
 
 Compile and export in prepare, spawn ranks in `run_gpu`, and make any
 shared launcher accept prebuilt libraries so the GPU stage never compiles.
+
+## Guard CUDA enum constants by toolkit version
+
+**Symptoms:** `unsupported_swizzle_enum`, `valid_driver_enum_rejected`, `descriptor_creation_failure`
+
+CUDA driver enum constants are C/C++ identifiers, not preprocessor macros, so
+`#ifdef CU_TENSOR_MAP_SWIZZLE_*` is always false even when `cuda.h` declares the
+enumerator. Guard toolkit-specific cases with `CUDA_VERSION` instead. On the
+SM100 target stack, the 128B atom swizzles are present in every inspected CUDA
+12.8 through 13.2 header, so `CUDA_VERSION >= 12080` admits values 4-6 while
+preserving builds against older headers.
+
+Do not change a kernel's shared-memory layout to work around this runtime
+validation failure. With the enum checks compiled under the version guard, a
+GDN prefill case that previously rejected swizzle value 4 passed unchanged;
+an NVSHMEM all-gather case passed against the same rebuilt runtime, confirming
+that the fix belongs to descriptor validation rather than kernel lowering.
+
+## Lower specialized global accesses explicitly
+
+**Symptoms:** `low_level_ir_contract_failure`, `config_specific_buffer_load`, `config_specific_buffer_store`
+
+TIRx configuration specialization can hide raw global `BufferLoad` and
+`BufferStore` nodes from the commonly exercised shape while leaving them in a
+less frequent branch. The low-level contract intentionally rejects those nodes:
+express the access with the kernel's typed `ld.global` / `st.global` helper and
+preserve signed values through bit reinterpretation rather than conversion.
+
+Configuration-wide inspection exposed this in 82 radix-top-k configurations
+and all four DeepEP combine configurations. Replacing only the raw accesses
+with existing typed PTX helpers left zero violations across the complete
+234-config radix and four-config DeepEP matrices; all 86 previously rejected
+configurations then passed their upstream oracles under a 16-worker run.
+Inspect every public configuration after specialization; validating only one
+default `get_kernel()` result is insufficient.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tools/cpusim/examples/bench_gen/
 # bench-suite run artifacts (pinned baselines live under tirx_kernels/bench_suite/)
 /.bench-suite/
 /.tir-bench/
+/.reference-deps/
 
 # /file-bug skill backlog — transient per-machine bug folders
 /bugs/

--- a/README.md
+++ b/README.md
@@ -113,24 +113,36 @@ pip install -e .
 
 ### External dependencies
 
-These are **not on PyPI** and must be installed/available separately. They are
-imported lazily, so `import tirx_kernels` and kernel discovery work without
-them — they are only needed to actually compile/run a kernel:
+Correctness uses the original upstream implementations. Install the exact,
+mutually compatible revisions from the repository lock:
+
+```bash
+python scripts/install_reference_dependencies.py
+```
+
+[`reference-dependencies.json`](reference-dependencies.json) is the single
+source of truth for reference revisions and the shared CUTLASS DSL version.
+The same command installs the pinned pytest/xdist runner. `torch` and `tvm.tirx`
+remain externally managed runtime/compiler dependencies.
 
 | Dependency       | Needed by                          | Notes                                                  |
 | ---------------- | ---------------------------------- | ------------------------------------------------------ |
 | `tvm.tirx`       | all kernels (compile + run)        | The TIRx compiler. Put it on `PYTHONPATH`, e.g. `/path/to/tir/python`. |
 | `torch`          | all kernels                        | CUDA build matching your GPU.                          |
-| `deep_gemm`      | FP8 GEMM and `deepgemm_*` baselines | Used for optimized reference kernels. |
-| `flashinfer`     | `nvfp4_gemm` data/baseline | Used for nvfp4 quantization and reference impls. |
-| `flash-attn` + CUTLASS DSL | `flash_attention_backward_sm100` data/baseline | Current SM100 forward/backward reference. |
-| `flash_kda`      | `flashkda_bf16_fused_m128` baseline | Uses the installed package; results record its package, source, extension, and CUTLASS provenance when available. |
-| `sglang` (+ CUTLASS DSL) | `deepgemm_sm100_fp8_paged_mqa_logits` reference | `sglang_cutedsl` reference; checkout on `PYTHONPATH`. |
+| `deep_gemm`      | FP8 GEMM and `deepgemm_*` baselines | Used for optimized reference kernels and the MegaMoE timer. |
+| `flashinfer`     | `nvfp4_gemm` baseline | Used for reference implementations. |
+| `flash-attn` + CUTLASS DSL | `flash_attention_backward_sm100` baseline | Current SM100 forward/backward reference. |
+| `sglang` (+ CUTLASS DSL) | `deepgemm_sm100_fp8_paged_mqa_logits` reference | Optional `sglang_cutedsl` benchmark reference. |
 | `flash_mla`      | `sparse_flashmla_*` / `flash_mla_sparse_fwd` baselines | Reference impls. |
+| `deep_ep`        | `deepep_*` correctness and baselines | Reference implementation. |
+| `flash_kda`      | `flashkda_*` optional baselines | Raw FlashKDA benchmark peer. |
 | NVSHMEM          | `allgather_gemm`, `gemm_reduce_scatter` | Required to compile/run the GemmComm kernels. |
 
-The bench_suite **default sweep** hard-requires several of these (a missing
-reference fails the whole sweep) — see
+Correctness tests import and run these upstream implementations. The bench suite
+does not launch or time benchmark reference implementations by default (kernel
+data-preparation helpers may still import their upstream package). Pass
+`--with-references` to enable reference launches; a missing enabled reference
+fails its workload. See
 [`tirx_kernels/bench_suite/README.md`](tirx_kernels/bench_suite/README.md)
 for the prerequisites and workarounds.
 
@@ -143,12 +155,11 @@ for the prerequisites and workarounds.
 python -m tirx_kernels.registry --format json
 
 # Run correctness tests (optionally filter by kernel / config label)
-python -m tirx_kernels.test
-python -m tirx_kernels.test --kernel fp16_bf16_gemm
-python -m tirx_kernels.test --kernel fp16_bf16_gemm --config bf16_1024x1024x1024
+pytest -n 16 tests/test_correctness.py
 
 # Benchmark
 python -m tirx_kernels.bench --kernel nvfp4_gemm
+python -m tirx_kernels.bench --kernel nvfp4_gemm --with-references
 
 # Pre-commit regression benchmark sweep (see tirx_kernels/bench_suite/README.md)
 python -m tirx_kernels.bench_suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ license-files = ["LICENSE", "NOTICE", "licenses/*.txt"]
 # tvm, torch, triton are runtime dependencies managed externally (not on PyPI)
 dependencies = ["pyyaml>=6.0"]
 
+[tool.pytest.ini_options]
+addopts = "-n 16"
+testpaths = ["tests"]
+
 [tool.setuptools.packages.find]
 include = ["tirx_kernels*"]
 

--- a/reference-dependencies.json
+++ b/reference-dependencies.json
@@ -1,0 +1,73 @@
+{
+  "schema": 1,
+  "python_requirements": [
+    "nvidia-cutlass-dsl[cu13]==4.6.2",
+    "nvidia-cuda-cccl==13.2.75",
+    "quack-kernels==0.6.4"
+  ],
+  "test_requirements": [
+    "pytest==9.0.2",
+    "pytest-xdist==3.8.0"
+  ],
+  "sources": [
+    {
+      "name": "deep-gemm",
+      "import_name": "deep_gemm",
+      "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+      "revision": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+      "install_subdirectory": ".",
+      "source_links": [
+        {
+          "source": "third-party/cutlass/include/cutlass",
+          "target": "deep_gemm/include/cutlass"
+        },
+        {
+          "source": "third-party/cutlass/include/cute",
+          "target": "deep_gemm/include/cute"
+        }
+      ]
+    },
+    {
+      "name": "flashinfer",
+      "import_name": "flashinfer",
+      "url": "https://github.com/flashinfer-ai/flashinfer.git",
+      "revision": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+      "install_subdirectory": "."
+    },
+    {
+      "name": "flash-attention",
+      "import_name": "flash_attn.cute",
+      "url": "https://github.com/Dao-AILab/flash-attention.git",
+      "revision": "0251105a2fb19d2957484b7f023cd8c115286ced",
+      "install_subdirectory": "flash_attn/cute"
+    },
+    {
+      "name": "flash-mla",
+      "import_name": "flash_mla",
+      "url": "https://github.com/deepseek-ai/FlashMLA.git",
+      "revision": "9241ae3ef9bac614dd25e45e507e089f888280e0",
+      "install_subdirectory": "."
+    },
+    {
+      "name": "deep-ep",
+      "import_name": "deep_ep",
+      "url": "https://github.com/deepseek-ai/DeepEP.git",
+      "revision": "01dc3aaac82068020353dce2c302e38153c0bfaa",
+      "install_subdirectory": "."
+    },
+    {
+      "name": "sglang",
+      "import_name": "sglang",
+      "url": "https://github.com/sgl-project/sglang.git",
+      "revision": "c7c03ec53b1e664c2d415db4f02e43f86661f31d",
+      "install_subdirectory": "python"
+    },
+    {
+      "name": "flash-kda",
+      "import_name": "flash_kda",
+      "url": "https://github.com/MoonshotAI/FlashKDA.git",
+      "revision": "1ce47ea3bb22c84eb9cc665028399cf35e8ffb0b",
+      "install_subdirectory": "."
+    }
+  ]
+}

--- a/scripts/install_reference_dependencies.py
+++ b/scripts/install_reference_dependencies.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Install exact correctness references and their test runner dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError, distribution, version
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LOCK_PATH = REPO_ROOT / "reference-dependencies.json"
+DEFAULT_SOURCE_ROOT = REPO_ROOT / ".reference-deps"
+
+
+def run(*command: str, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    shown = " ".join(command)
+    print(f"+ {shown}", flush=True)
+    subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def output(*command: str, cwd: Path | None = None) -> str:
+    return subprocess.check_output(command, cwd=cwd, text=True).strip()
+
+
+def load_lock() -> dict[str, Any]:
+    lock = json.loads(LOCK_PATH.read_text())
+    if lock.get("schema") != 1:
+        raise RuntimeError(f"unsupported reference dependency schema: {lock.get('schema')!r}")
+    return lock
+
+
+def checkout_source(source: dict[str, str], source_root: Path) -> Path:
+    checkout = source_root / source["name"]
+    revision = source["revision"]
+    if not checkout.exists():
+        run("git", "clone", "--filter=blob:none", source["url"], str(checkout))
+    elif not (checkout / ".git").exists():
+        raise RuntimeError(f"reference source path is not a git checkout: {checkout}")
+
+    try:
+        output("git", "rev-parse", "--verify", "HEAD", cwd=checkout)
+        has_head = True
+    except subprocess.CalledProcessError:
+        has_head = False
+    materialized = any(path.name != ".git" for path in checkout.iterdir())
+    if has_head and materialized and output(
+        "git",
+        "status",
+        "--porcelain",
+        "--untracked-files=no",
+        "--ignore-submodules=untracked",
+        cwd=checkout,
+    ):
+        raise RuntimeError(f"reference source checkout has local changes: {checkout}")
+    origin = output("git", "remote", "get-url", "origin", cwd=checkout)
+    if origin.rstrip("/").removesuffix(".git") != source["url"].rstrip("/").removesuffix(".git"):
+        raise RuntimeError(f"unexpected origin for {checkout}: {origin}")
+
+    try:
+        output("git", "cat-file", "-e", f"{revision}^{{commit}}", cwd=checkout)
+    except subprocess.CalledProcessError:
+        run("git", "fetch", "--filter=blob:none", "origin", revision, cwd=checkout)
+    run("git", "checkout", "--detach", revision, cwd=checkout)
+    run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
+    actual = output("git", "rev-parse", "HEAD", cwd=checkout)
+    if actual != revision:
+        raise RuntimeError(f"{source['name']} resolved to {actual}, expected {revision}")
+    return checkout
+
+
+def source_build_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    cccl = distribution("nvidia-cuda-cccl")
+    utility = next(
+        (
+            Path(file.locate())
+            for file in cccl.files or ()
+            if str(file).endswith("cuda/std/utility")
+        ),
+        None,
+    )
+    if utility is None:
+        raise RuntimeError("nvidia-cuda-cccl does not contain cuda/std/utility")
+    cccl_include = str(utility.parents[2])
+    existing = env.get("CPLUS_INCLUDE_PATH")
+    env["CPLUS_INCLUDE_PATH"] = (
+        f"{cccl_include}{os.pathsep}{existing}" if existing else cccl_include
+    )
+    return env
+
+
+def materialize_source_links(source: dict[str, Any], checkout: Path) -> None:
+    for link in source.get("source_links", []):
+        source_path = (checkout / link["source"]).resolve(strict=True)
+        target_path = checkout / link["target"]
+        if target_path.is_symlink() and target_path.resolve() == source_path:
+            continue
+        if target_path.exists() or target_path.is_symlink():
+            raise RuntimeError(f"reference install link has unexpected target: {target_path}")
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        relative_source = os.path.relpath(source_path, target_path.parent)
+        target_path.symlink_to(relative_source, target_is_directory=True)
+
+
+def import_paths(import_name: str) -> list[Path]:
+    spec = importlib.util.find_spec(import_name)
+    if spec is None:
+        return []
+    paths = []
+    if spec.origin not in (None, "built-in"):
+        paths.append(Path(spec.origin).resolve())
+    paths.extend(Path(path).resolve() for path in spec.submodule_search_locations or ())
+    return paths
+
+
+def import_uses_checkout(source: dict[str, str], checkout: Path) -> bool:
+    install_path = (checkout / source["install_subdirectory"]).resolve()
+    return any(
+        path.is_relative_to(install_path) for path in import_paths(source["import_name"])
+    )
+
+
+def install(lock: dict[str, Any], source_root: Path) -> None:
+    requirements = lock["python_requirements"]
+    run(sys.executable, "-m", "pip", "install", "--upgrade", *lock["test_requirements"])
+    run(sys.executable, "-m", "pip", "install", "--upgrade", "--no-deps", *requirements)
+    build_env = source_build_environment()
+    source_root.mkdir(parents=True, exist_ok=True)
+    for source in lock["sources"]:
+        checkout = checkout_source(source, source_root)
+        materialize_source_links(source, checkout)
+        if import_uses_checkout(source, checkout):
+            print(f"{source['name']} already imports from its pinned checkout", flush=True)
+            continue
+        install_path = checkout / source["install_subdirectory"]
+        run(
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--no-build-isolation",
+            "--editable",
+            str(install_path),
+            env=build_env,
+        )
+
+
+def check(lock: dict[str, Any], source_root: Path) -> None:
+    failures: list[str] = []
+    for requirement in [*lock["python_requirements"], *lock["test_requirements"]]:
+        package, expected = requirement.split("==", 1)
+        package = package.split("[", 1)[0]
+        try:
+            actual = version(package)
+        except PackageNotFoundError:
+            failures.append(f"{package} is not installed")
+            continue
+        if actual != expected:
+            failures.append(f"{package}=={actual}, expected {expected}")
+
+    for source in lock["sources"]:
+        checkout = source_root / source["name"]
+        if not (checkout / ".git").exists():
+            failures.append(f"missing checkout: {checkout}")
+            continue
+        actual = output("git", "rev-parse", "HEAD", cwd=checkout)
+        if actual != source["revision"]:
+            failures.append(f"{source['name']} checkout is {actual}, expected {source['revision']}")
+        try:
+            materialize_source_links(source, checkout)
+        except (FileNotFoundError, RuntimeError) as error:
+            failures.append(str(error))
+        resolved_import_paths = import_paths(source["import_name"])
+        if not resolved_import_paths:
+            failures.append(f"cannot find import {source['import_name']!r}")
+            continue
+        install_path = (checkout / source["install_subdirectory"]).resolve()
+        if not any(path.is_relative_to(install_path) for path in resolved_import_paths):
+            rendered = ", ".join(str(path) for path in resolved_import_paths)
+            failures.append(
+                f"import {source['import_name']!r} resolves outside {install_path}: {rendered}"
+            )
+
+    if failures:
+        raise RuntimeError("reference dependency check failed:\n- " + "\n- ".join(failures))
+    print(f"Reference dependencies match {LOCK_PATH.name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=DEFAULT_SOURCE_ROOT,
+        help=f"checkout directory (default: {DEFAULT_SOURCE_ROOT})",
+    )
+    parser.add_argument("--check", action="store_true", help="verify the installed lock only")
+    args = parser.parse_args()
+    lock = load_lock()
+    source_root = args.source_root.resolve()
+    if not args.check:
+        install(lock, source_root)
+        run(
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--check",
+            "--source-root",
+            str(source_root),
+        )
+        return
+    check(lock, source_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+from __future__ import annotations
+
+import fcntl
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tirx_kernels.registry import discover_kernels
+
+
+def _correctness_cases() -> list[Any]:
+    cases = []
+    for kernel_name, module in sorted(discover_kernels().items()):
+        labels = [config.get("label", "default") for config in module.CONFIGS]
+        if len(labels) != len(set(labels)):
+            raise RuntimeError(f"correctness config labels are not unique for {kernel_name}")
+        for config, label in zip(module.CONFIGS, labels, strict=True):
+            required_devices = int(
+                config.get("num_processes", config.get("world_size", 1))
+            )
+            cases.append(
+                pytest.param(
+                    kernel_name,
+                    label,
+                    required_devices,
+                    id=f"{kernel_name}[{label}]",
+                )
+            )
+    return cases
+
+
+def _visible_gpu_memory() -> list[tuple[str, int]]:
+    output = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-gpu=index,uuid,memory.free",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+    )
+    rows = []
+    for line in output.splitlines():
+        index, uuid, free_memory = (field.strip() for field in line.split(","))
+        rows.append((index, uuid, int(free_memory)))
+
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is None:
+        visible = {index for index, _uuid, _free_memory in rows}
+    else:
+        visible = {token.strip() for token in configured.split(",") if token.strip()}
+    return [
+        (uuid if uuid in visible else index, free_memory)
+        for index, uuid, free_memory in rows
+        if index in visible or uuid in visible
+    ]
+
+
+def _try_lock(path: Path):
+    handle = path.open("a+")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        return None
+    return handle
+
+
+@contextmanager
+def _reserve_gpus(test_run_uid: str, count: int):
+    lock_root = Path("/tmp") / f"tirx-correctness-{test_run_uid}"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
+
+    selected: list[str] = []
+    slot_handles = []
+    while not selected:
+        with (lock_root / "allocator.lock").open("a+") as allocator:
+            fcntl.flock(allocator, fcntl.LOCK_EX)
+            gpu_memory = sorted(_visible_gpu_memory(), key=lambda item: item[1], reverse=True)
+            if not gpu_memory:
+                raise RuntimeError("no CUDA GPU is visible to correctness tests")
+            if count > len(gpu_memory):
+                raise RuntimeError(
+                    f"correctness case requires {count} GPUs, "
+                    f"but only {len(gpu_memory)} are visible"
+                )
+            slots_per_gpu = max(1, math.ceil(worker_count / len(gpu_memory)))
+            for gpu, _free_memory in gpu_memory:
+                for slot in range(slots_per_gpu):
+                    slot_handle = _try_lock(lock_root / f"gpu-{gpu}-slot-{slot}.lock")
+                    if slot_handle is not None:
+                        selected.append(gpu)
+                        slot_handles.append(slot_handle)
+                        break
+                if len(selected) == count:
+                    break
+            if len(selected) != count:
+                selected.clear()
+                for slot_handle in slot_handles:
+                    slot_handle.close()
+                slot_handles.clear()
+        if not selected:
+            time.sleep(0.1)
+
+    try:
+        yield selected
+    finally:
+        for slot_handle in slot_handles:
+            slot_handle.close()
+
+
+def _last_json_object(output: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    for offset in range(len(output) - 1, -1, -1):
+        if output[offset] != "{":
+            continue
+        try:
+            payload, end = decoder.raw_decode(output[offset:])
+        except json.JSONDecodeError:
+            continue
+        if not output[offset + end :].strip() and isinstance(payload, dict):
+            return payload
+    raise AssertionError(f"correctness child did not emit JSON:\n{output[-12000:]}")
+
+
+@pytest.mark.parametrize(
+    ("kernel_name", "config_label", "required_devices"), _correctness_cases()
+)
+def test_kernel_correctness(
+    kernel_name: str, config_label: str, required_devices: int, testrun_uid: str
+) -> None:
+    with _reserve_gpus(testrun_uid, required_devices) as selected_gpus:
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(selected_gpus)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tirx_kernels.test",
+                "--json",
+                "--kernel",
+                kernel_name,
+                "--config",
+                config_label,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+    payload = _last_json_object(completed.stdout)
+    assert completed.returncode == 0, completed.stdout[-12000:] + completed.stderr[-12000:]
+    assert payload["passed"] == 1, payload
+    assert payload["failed"] == 0, payload
+    assert payload["skipped"] == 0, payload

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -95,21 +95,35 @@ def _reserve_gpus(test_run_uid: str, count: int):
                     f"correctness case requires {count} GPUs, "
                     f"but only {len(gpu_memory)} are visible"
                 )
-            slots_per_gpu = max(1, math.ceil(worker_count / len(gpu_memory)))
-            for gpu, _free_memory in gpu_memory:
+            # Any four visible GPUs can absorb all xdist workers, while free
+            # cards remain eligible to take work from cards occupied externally.
+            active_gpu_target = min(4, len(gpu_memory))
+            slots_per_gpu = math.ceil(worker_count / active_gpu_target)
+            candidates = []
+            for gpu, free_memory in gpu_memory:
+                active_slots = 0
+                candidate_handle = None
                 for slot in range(slots_per_gpu):
                     slot_handle = _try_lock(lock_root / f"gpu-{gpu}-slot-{slot}.lock")
-                    if slot_handle is not None:
-                        selected.append(gpu)
-                        slot_handles.append(slot_handle)
-                        break
-                if len(selected) == count:
-                    break
-            if len(selected) != count:
-                selected.clear()
-                for slot_handle in slot_handles:
-                    slot_handle.close()
-                slot_handles.clear()
+                    if slot_handle is None:
+                        active_slots += 1
+                    elif candidate_handle is None:
+                        candidate_handle = slot_handle
+                    else:
+                        slot_handle.close()
+                if candidate_handle is not None:
+                    candidates.append(
+                        (free_memory // (active_slots + 1), free_memory, gpu, candidate_handle)
+                    )
+
+            candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            if len(candidates) >= count:
+                for _score, _free_memory, gpu, slot_handle in candidates[:count]:
+                    selected.append(gpu)
+                    slot_handles.append(slot_handle)
+                candidates = candidates[count:]
+            for _score, _free_memory, _gpu, slot_handle in candidates:
+                slot_handle.close()
         if not selected:
             time.sleep(0.1)
 

--- a/tirx_kernels/basic/allgather_gemm.py
+++ b/tirx_kernels/basic/allgather_gemm.py
@@ -1315,37 +1315,41 @@ def _run_worker(
     if mode != "bench":
         raise ValueError(f"unsupported distributed worker mode {mode!r}")
 
-    from tirx_kernels.runner import bench
+    from tirx_kernels.runner import bench, external_references_enabled
 
     def prepare() -> None:
         case.reset()
         case.prepare()
 
-    baselines = create_baseline_suite(
-        runtime,
-        data,
-        workload="allgather_gemm",
-        M=kwargs["M"],
-        N=kwargs["N"],
-        K=kwargs["K"],
-        world_size=kwargs["world_size"],
-    )
+    baselines = None
+    if external_references_enabled():
+        baselines = create_baseline_suite(
+            runtime,
+            data,
+            workload="allgather_gemm",
+            M=kwargs["M"],
+            N=kwargs["N"],
+            K=kwargs["K"],
+            world_size=kwargs["world_size"],
+        )
     try:
         result = bench(
             {"tirx": case.launch},
-            references=baselines.references(),
+            references=baselines.references() if baselines is not None else None,
             timer=kwargs.get("timer", "kineto"),
             rounds=kwargs.get("rounds", 1),
             cooldown_s=kwargs.get("cooldown_s", 1.0),
             distributed=runtime.bench_context(),
             prepare={"tirx": prepare},
         )
-        result["baseline_metadata"] = baselines.metadata()
-        result["ratio_definition"] = "baseline_us / tirx_us"
-        result["ratios"] = baseline_ratios(result)
+        if baselines is not None:
+            result["baseline_metadata"] = baselines.metadata()
+            result["ratio_definition"] = "baseline_us / tirx_us"
+            result["ratios"] = baseline_ratios(result)
         return {"status": "OK", **result}
     finally:
-        baselines.close()
+        if baselines is not None:
+            baselines.close()
 
 
 def run_test(

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -1371,43 +1371,49 @@ def _run_worker(
     if mode != "bench":
         raise ValueError(f"unsupported distributed worker mode {mode!r}")
 
-    from tirx_kernels.runner import bench
+    from tirx_kernels.runner import bench, external_references_enabled
 
     def prepare() -> None:
         case.reset()
         case.prepare()
 
-    baselines = create_baseline_suite(
-        runtime,
-        data,
-        workload="gemm_reduce_scatter",
-        M=config.M,
-        N=config.N,
-        K=config.total_k,
-        world_size=config.world_size,
-    )
+    baselines = None
+    if external_references_enabled():
+        baselines = create_baseline_suite(
+            runtime,
+            data,
+            workload="gemm_reduce_scatter",
+            M=config.M,
+            N=config.N,
+            K=config.total_k,
+            world_size=config.world_size,
+        )
     try:
         result = bench(
             {"tirx": case.launch},
-            references=baselines.references(),
+            references=baselines.references() if baselines is not None else None,
             timer=kwargs.get("timer", "kineto"),
             rounds=kwargs.get("rounds", 1),
             cooldown_s=kwargs.get("cooldown_s", 1.0),
             distributed=runtime.bench_context(),
             prepare={"tirx": prepare},
         )
-        result["baseline_metadata"] = baselines.metadata()
-        result["ratio_definition"] = "baseline_us / tirx_us"
-        result["ratios"] = baseline_ratios(result, tirx="tirx")
-        result["performance_gate"] = {
-            "required_ratio": "> 1",
-            "passed": all(
-                ratio > 1 for name, ratio in result["ratios"].items() if name.startswith("cublas")
-            ),
-        }
+        if baselines is not None:
+            result["baseline_metadata"] = baselines.metadata()
+            result["ratio_definition"] = "baseline_us / tirx_us"
+            result["ratios"] = baseline_ratios(result, tirx="tirx")
+            result["performance_gate"] = {
+                "required_ratio": "> 1",
+                "passed": all(
+                    ratio > 1
+                    for name, ratio in result["ratios"].items()
+                    if name.startswith("cublas")
+                ),
+            }
         return {"status": "OK", **result}
     finally:
-        baselines.close()
+        if baselines is not None:
+            baselines.close()
 
 
 def run_test(

--- a/tirx_kernels/basic/nvfp4_gemm.py
+++ b/tirx_kernels/basic/nvfp4_gemm.py
@@ -1113,13 +1113,14 @@ def _flashinfer_tuned_choice(
 # kernel time -> honest ~parity (verified 0.996 vs event 4.11).
 def prepare_bench(M=1024, N=1024, K=1024, **kwargs):
     """Compile TIRx and the device-independent cuBLASLt extension before READY."""
-    from tirx_kernels.runner import prepared_gpu_benchmark
+    from tirx_kernels.runner import external_references_enabled, prepared_gpu_benchmark
 
     state = {
         "config": {"M": M, "N": N, "K": K, **kwargs},
         "executable": _compile_executable(M, N, K),
-        "cublaslt_extension": _load_cublaslt_nvfp4_ext(),
     }
+    if external_references_enabled():
+        state["cublaslt_extension"] = _load_cublaslt_nvfp4_ext()
     return prepared_gpu_benchmark(run_gpu, state)
 
 
@@ -1127,6 +1128,8 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, **kwargs):
     """Benchmark."""
     import flashinfer
     import torch
+
+    from tirx_kernels.runner import external_references_enabled
 
     config_kwargs = {**prepared["config"], **kwargs}
     M = config_kwargs.pop("M")
@@ -1231,24 +1234,28 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, **kwargs):
             A_fp4, B_fp4, A_sf, B_sf, alpha_value, out_cublaslt, M, N, K
         )
 
-    # FlashInfer is a required reference for this benchmark. Prepare and
-    # validate its tuned launch before entering bench() so a bad/missing cache
-    # fails the workload instead of being downgraded to an optional baseline
-    # construction error.
-    flashinfer_run = _flashinfer()
-    # Load the file and install the exact-M mapper once, outside all timer
-    # calls. Timed FlashInfer launches then perform only an in-memory cache
-    # lookup and the selected kernel launch.
-    with flashinfer.autotune(False, **flashinfer_context_kwargs):
+    if external_references_enabled():
+        # Prepare and validate the tuned reference launch before entering bench().
+        flashinfer_run = _flashinfer()
+        # Keep the exact-M mapper installed while timing FlashInfer.
+        with flashinfer.autotune(False, **flashinfer_context_kwargs):
+            result = bench(
+                funcs,
+                warmup=warmup,
+                repeat=repeat,
+                timer=timer,
+                references={
+                    "flashinfer": lambda: flashinfer_run,
+                    "cublaslt_nvfp4": _cublaslt,
+                },
+                **config_kwargs,
+            )
+    else:
         result = bench(
             funcs,
             warmup=warmup,
             repeat=repeat,
             timer=timer,
-            references={
-                "flashinfer": lambda: flashinfer_run,
-                "cublaslt_nvfp4": _cublaslt,
-            },
             **config_kwargs,
         )
     result["metadata"] = {**result.get("metadata", {}), **metadata}

--- a/tirx_kernels/bench/__main__.py
+++ b/tirx_kernels/bench/__main__.py
@@ -382,6 +382,11 @@ def main():
         "activity span, 'megamoe' = DeepGEMM bench_kineto protocol for MegaMoE",
     )
     parser.add_argument(
+        "--with-references",
+        action="store_true",
+        help="Run and time external reference implementations (off by default)",
+    )
+    parser.add_argument(
         "--rounds",
         type=int,
         default=None,
@@ -402,6 +407,10 @@ def main():
 
     if args.json or args.json_file:
         os.environ["TIRX_BENCH_JSON"] = "1"
+
+    from tirx_kernels.runner import set_external_references_enabled
+
+    set_external_references_enabled(args.with_references)
 
     if args.prepared_control_fd is not None:
         sys.exit(_prepared_child_main(args, child_started=child_started))

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -22,6 +22,7 @@ small/medium/large selection.
 ```bash
 cd /path/to/tirx-kernels
 pip install -e .
+python scripts/install_reference_dependencies.py
 
 export TVM_PATH=/path/to/tvm
 export PYTHONPATH="${TVM_PATH}/python"
@@ -33,21 +34,19 @@ Entry point: `python -m tirx_kernels.bench_suite` (same flags as `run.py`).
 
 ### Default-sweep prerequisites
 
-Every row benches our kernel **and all of its reference impls**; a reference
-that fails to build is recorded as a baseline error and **fails the workload**
-(which fail-fasts the whole sweep). The host requires:
+By default every row benches only the TIRx implementation. Pass
+`--with-references` to run and time all configured reference implementations;
+an enabled reference that fails to build fails the workload. The host requires:
 
 - a CUDA 13.2-aligned Python stack, including PyTorch, `cuda-toolkit`, NVRTC,
   and extensions rebuilt against that PyTorch ABI;
-- **SGLang** on `PYTHONPATH` (plus its CUTLASS DSL) for the fp8 paged MQA
-  reference rows.
+- the revisions installed from the repository's `reference-dependencies.json`
+  for correctness and reference-enabled benchmark rows.
 
-Explicit GemmComm workloads additionally require NVSHMEM and absolute
-runtime-library locks:
-`TIRX_NCCL_LIBRARY`, `TIRX_CUBLAS_LIBRARY`, `TIRX_CUBLASMP_LIBRARY`, and
-`TIRX_NVSHMEM_LIBRARY`. `NVSHMEM_HOME` points to the development installation
-used while compiling the TIRx kernels. These locks affect only the spawned
-GemmComm rank workers.
+Explicit GemmComm workloads require NVSHMEM plus `TIRX_NCCL_LIBRARY` and
+`TIRX_NVSHMEM_LIBRARY`. Reference-enabled runs additionally require
+`TIRX_CUBLAS_LIBRARY` and `TIRX_CUBLASMP_LIBRARY`. `NVSHMEM_HOME` points to the
+development installation used while compiling the TIRx kernels.
 
 Import-check the kernels selected by the current workload file without
 preparing, compiling, or using a GPU:
@@ -58,17 +57,12 @@ python -m tirx_kernels.bench_suite --check-imports
 
 ### SGLang FP8 paged MQA exploration
 
-The `sglang_cutedsl` reference is required wherever it appears — the fp8 paged
-MQA rows of the default sweep as well as this exploration sweep (see
-"Default-sweep prerequisites" above). To run the 80-shape SM100 comparison
-against SGLang's current production picker, expose a matching SGLang checkout
-and install the CUTLASS DSL version required by that checkout:
+The `sglang_cutedsl` reference is enabled only by `--with-references`. To run
+the 80-shape SM100 comparison against the locked SGLang production picker:
 
 ```bash
-export SGLANG_PATH=/path/to/sglang
-export PYTHONPATH="${SGLANG_PATH}/python:${PYTHONPATH}"
-
-python -m tirx_kernels.bench_suite --filter deepgemm_sm100_fp8_paged_mqa_logits \
+python -m tirx_kernels.bench_suite --with-references \
+  --filter deepgemm_sm100_fp8_paged_mqa_logits \
   --workloads <(python -c "import yaml,sys; from tirx_kernels.bench_suite import run; \
 yaml.safe_dump({'workloads': run.load_kernel_configs('deepgemm_sm100_fp8_paged_mqa_logits')}, sys.stdout)")
 ```
@@ -135,7 +129,7 @@ Run artifacts (logs, `runs/*.json`, `reports/*`) live under `.bench-suite/` and 
    foreign GPU occupancy changes. The initial occupancy snapshot starts alongside
    the first CPU prepares; assignment remains blocked until that snapshot is complete.
 4. **Measurement semantics stay in the GPU stage.** Each child benches our kernel
-   and every reference implementation, retaining the original implementation
+   and, with `--with-references`, every reference implementation, retaining the original implementation
    order, correctness/reference setup, timer, warmup/repeat, five rounds, 1.0s
    cooldown before every implementation/round, raw samples, and arithmetic mean.
 5. **Fail fast**: the first workload/subprocess `FAIL` stops new scheduling,
@@ -147,9 +141,9 @@ Run artifacts (logs, `runs/*.json`, `reports/*`) live under `.bench-suite/` and 
    assigned card. Every interference retry records the workload, attempt,
    intruder PIDs, and `retry_in_place: true`; retried results otherwise follow
    the ordinary measurement path.
-6. **Ratio regression report** compares current ref/ours ratio vs the pinned
-   `baseline.json` ratio (computed from its ours + ref impls). Promote a run over
-   the baseline with `promote_baseline.py`.
+6. **Ratio regression report** is generated only by `--with-references` and
+   compares current ref/ours ratio vs the pinned `baseline.json` ratio. Only a
+   reference-enabled run can be promoted with `promote_baseline.py`.
 
 ## Baseline files (git-tracked)
 
@@ -165,7 +159,7 @@ Promote through `promote_baseline.py` only (never bare `cp`).
 ### Daily: kernel iteration
 
 ```bash
-python -m tirx_kernels.bench_suite
+python -m tirx_kernels.bench_suite --with-references
 python tirx_kernels/bench_suite/promote_baseline.py \
   .bench-suite/runs/<id>.json --merge
 ```
@@ -177,7 +171,7 @@ in the run JSON.
 ### Refresh the pinned baseline (rare)
 
 ```bash
-python -m tirx_kernels.bench_suite
+python -m tirx_kernels.bench_suite --with-references
 python tirx_kernels/bench_suite/promote_baseline.py .bench-suite/runs/<id>.json
 ```
 
@@ -188,6 +182,7 @@ workloads do not remain in `baseline.json`. For a targeted update,
 arithmetic mean of all five samples; no samples are trimmed or silently dropped.
 
 Spot-check one workload: `python -m tirx_kernels.bench --kernel ... --config ... --rounds 5`
+(add `--with-references` for the source comparisons).
 
 ## Workload fields
 

--- a/tirx_kernels/bench_suite/promote_baseline.py
+++ b/tirx_kernels/bench_suite/promote_baseline.py
@@ -24,6 +24,14 @@ def _result_key(row: dict) -> tuple[str, str]:
     return row["kernel"], row.get("label") or row["config"]
 
 
+def _require_reference_run(doc: dict) -> None:
+    if doc.get("references_enabled") is not True:
+        raise ValueError(
+            "reference-disabled runs cannot update the reference-ratio baseline; "
+            "rerun the suite with --with-references"
+        )
+
+
 def slim_baseline_row(row: dict) -> dict:
     """Drop per-run metadata; keep only checked-in baseline fields."""
     agg = row.get("aggregated") or {}
@@ -38,7 +46,7 @@ def slim_baseline_row(row: dict) -> dict:
 
 
 def slim_baseline_doc(doc: dict) -> dict:
-    out = {k: v for k, v in doc.items() if k != "results"}
+    out = {k: v for k, v in doc.items() if k not in {"results", "references_enabled"}}
     out["results"] = sorted(
         [slim_baseline_row(r) for r in doc.get("results") or []], key=_result_key
     )
@@ -55,6 +63,7 @@ def merge_baseline(run_json: Path, baseline_path: Path) -> int:
     If ``baseline_path`` does not exist yet, the slimmed run is written as a
     fresh baseline."""
     run = json.loads(run_json.read_text())
+    _require_reference_run(run)
     if not baseline_path.exists():
         _write_baseline(baseline_path, run)
         print(f"[promote] merge: no existing baseline, wrote {baseline_path.relative_to(HERE)}")
@@ -135,6 +144,7 @@ def main() -> None:
                 sys.exit(1)
         else:
             run = json.loads(args.run_json.read_text())
+            _require_reference_run(run)
             _write_baseline(baseline_path, run)
             print(f"[promote] {args.run_json} -> {baseline_path.relative_to(HERE)}")
 

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -792,7 +792,12 @@ class _PreparedAttempt:
 
 
 def _prepared_child_command(
-    workload: dict, *, control_fd: int, rounds: int, cooldown: float
+    workload: dict,
+    *,
+    control_fd: int,
+    rounds: int,
+    cooldown: float,
+    with_references: bool,
 ) -> list[str]:
     command = [
         sys.executable,
@@ -817,6 +822,8 @@ def _prepared_child_command(
         command += ["--repeat", str(workload["repeat"])]
     if workload.get("timer") is not None:
         command += ["--timer", workload["timer"]]
+    if with_references:
+        command.append("--with-references")
     return command
 
 
@@ -828,6 +835,7 @@ def _spawn_prepared_attempt(
     rounds: int,
     cooldown: float,
     compile_profile: dict,
+    with_references: bool,
 ) -> _PreparedAttempt:
     """Spawn a GPU-unbound child that immediately begins CPU prepare."""
     parent_control, child_control = socket.socketpair()
@@ -855,7 +863,11 @@ def _spawn_prepared_attempt(
     cache_dir.mkdir(parents=True, exist_ok=True)
     env["TIRX_BENCH_CACHE_DIR"] = str(cache_dir)
     command = _prepared_child_command(
-        workload, control_fd=child_control.fileno(), rounds=rounds, cooldown=cooldown
+        workload,
+        control_fd=child_control.fileno(),
+        rounds=rounds,
+        cooldown=cooldown,
+        with_references=with_references,
     )
     process_started = time.time()
     try:
@@ -1261,6 +1273,7 @@ def write_run(
     stamp: str,
     results: list[dict],
     label: str | None,
+    references_enabled: bool,
     probe: dict | None = None,
     pipeline: dict | None = None,
 ) -> Path:
@@ -1269,9 +1282,10 @@ def write_run(
     payload = {
         "timestamp": stamp,
         "label": label,
+        "references_enabled": references_enabled,
         "git": collect_repo_git(),
         "kernel_tree": collect_kernel_fingerprint(),
-        "baselines": collect_baseline_provenance(),
+        "baselines": collect_baseline_provenance() if references_enabled else {},
         "probe": probe or {},
         "pipeline": pipeline or {},
         "results": results,
@@ -1447,7 +1461,9 @@ def load_baseline(path=None):
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 
-def _finalize_bench_record(row: dict, *, rounds: int, cooldown: float) -> None:
+def _finalize_bench_record(
+    row: dict, *, rounds: int, cooldown: float, references_enabled: bool
+) -> None:
     """Validate in-bench round samples and write aggregated impl times (microseconds)."""
     required_fields = ("round_samples", "errors", "timer", "benchmark_protocol")
     missing_fields = [field for field in required_fields if field not in row]
@@ -1503,6 +1519,15 @@ def _finalize_bench_record(row: dict, *, rounds: int, cooldown: float) -> None:
         row["status"] = "FAIL"
         row["error"] = "bench result field 'round_samples' must be a non-empty mapping"
         return
+    if not references_enabled:
+        external_impls = [name for name in samples if name not in our_impls(samples)]
+        if external_impls:
+            row["status"] = "FAIL"
+            row["error"] = (
+                "reference-disabled benchmark reported external implementation(s): "
+                f"{external_impls}"
+            )
+            return
     bad = {
         impl: len(vals) if isinstance(vals, list) else type(vals).__name__
         for impl, vals in samples.items()
@@ -1565,6 +1590,7 @@ def run_scheduled_jobs(
     rounds: int,
     cooldown: float,
     compile_profile: dict,
+    with_references: bool,
     max_prepare_processes: int | None = None,
     ready_backlog: int | None = None,
 ) -> tuple[list[dict], list[dict[str, Any]], dict]:
@@ -1681,6 +1707,7 @@ def run_scheduled_jobs(
                 rounds=rounds,
                 cooldown=cooldown,
                 compile_profile=compile_profile,
+                with_references=with_references,
             )
             active[item.control.fileno()] = item
             log(f"[bench-suite] {now_iso()} prepare pid={item.process.pid} START {item.label}")
@@ -1876,7 +1903,12 @@ def run_scheduled_jobs(
                         if status in ("SKIP", "FAIL"):
                             record.update(result)
                         else:
-                            _finalize_bench_record(result, rounds=rounds, cooldown=cooldown)
+                            _finalize_bench_record(
+                                result,
+                                rounds=rounds,
+                                cooldown=cooldown,
+                                references_enabled=with_references,
+                            )
                             record.update(result)
                         record.setdefault("label", item.workload["config"])
                         record["finished_at"] = now_iso()
@@ -2005,6 +2037,11 @@ def main() -> None:
         help="Free-form label for this run (default: git short sha)",
     )
     ap.add_argument("--no-report", action="store_true", help="Skip regression report generation")
+    ap.add_argument(
+        "--with-references",
+        action="store_true",
+        help="Run and benchmark external reference implementations (off by default)",
+    )
     ap.add_argument(
         "--no-probe",
         action="store_true",
@@ -2227,6 +2264,7 @@ def main() -> None:
         rounds=args.rounds,
         cooldown=args.cooldown,
         compile_profile=compile_profile,
+        with_references=args.with_references,
         max_prepare_processes=args.max_prepare_processes,
         ready_backlog=args.ready_backlog,
     )
@@ -2243,7 +2281,15 @@ def main() -> None:
 
     results.sort(key=lambda r: (r["kernel"], r.get("label") or r.get("config")))
     probe_meta = {"enabled": not args.no_probe, "usable": sorted(usable), "failed": probe_failures}
-    run_path = write_run(out_dir, stamp, results, label, probe=probe_meta, pipeline=pipeline_meta)
+    run_path = write_run(
+        out_dir,
+        stamp,
+        results,
+        label,
+        args.with_references,
+        probe=probe_meta,
+        pipeline=pipeline_meta,
+    )
     current = json.loads(run_path.read_text())
 
     latest = out_dir / "latest.json"
@@ -2266,6 +2312,13 @@ def main() -> None:
         sys.exit(1)
 
     if args.no_report:
+        return
+
+    if not args.with_references:
+        print(
+            "[bench-suite] references are disabled; skipping the reference-ratio "
+            "regression report (rerun with --with-references to compare ratios)"
+        )
         return
 
     # Single pinned baseline (baseline.json). Promote a fresh run over it via

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -125,7 +125,9 @@ def _gptr(base_u64, byte_off):
 
 
 def _peer_u64(table, dst):
-    return T.cast(table[dst], "uint64")
+    value = T.alloc_local([1], "uint64")
+    T.evaluate(T.ptx.ld.global_.b64(value[0], table.ptr_to([dst])))
+    return value[0]
 
 
 def _ld_acquire_gpu_u64(dst, addr):
@@ -648,7 +650,11 @@ def _build_reduce_epilogue_kernel(
                             ),
                         )
                     )
-                combined_topk_weights[token_idx * NUM_TOPK + lane] = T.cuda.uint_as_float(w32[0])
+                T.evaluate(
+                    T.ptx.st.global_.b32(
+                        combined_topk_weights.ptr_to([token_idx * NUM_TOPK + lane]), w32[0]
+                    )
+                )
             T.cuda.warp_sync()
 
     return deepep_combine_reduce_epilogue.with_attr(

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -867,6 +867,8 @@ def _run_worker(
     import torch
     import torch.distributed as dist
 
+    from tirx_kernels.runner import external_references_enabled
+
     from .utils._buffer import SymmetricWindow
 
     rank = runtime.rank
@@ -903,7 +905,8 @@ def _run_worker(
     ref_buffer = None
     handle = None
     golden_x = golden_w = None
-    if world_size == 8:
+    with_references = mode == "test" or external_references_enabled()
+    if world_size == 8 and with_references:
         # The reference runtime needs GIN disabled on this host (verified in the
         # dispatch scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
         os.environ.setdefault("EP_DISABLE_GIN", "1")
@@ -957,6 +960,7 @@ def _run_worker(
         )
 
     def reference_launch():
+        assert ref_buffer is not None and handle is not None
         return ref_buffer.combine(x_input, handle, topk_weights=tw_input)
 
     try:
@@ -1014,7 +1018,7 @@ def _run_worker(
         with torch.cuda.stream(runtime.timing_stream):
             result = bench(
                 {"tirx": tirx_launch},
-                references={"deepep": build_reference},
+                references={"deepep": build_reference} if ref_buffer is not None else None,
                 timer="kineto",
                 rounds=kwargs.get("rounds", 1),
                 cooldown_s=kwargs.get("cooldown_s", 1.0),

--- a/tirx_kernels/deepep/dispatch.py
+++ b/tirx_kernels/deepep/dispatch.py
@@ -1079,6 +1079,8 @@ def _run_worker(
     import torch
     import torch.distributed as dist
 
+    from tirx_kernels.runner import external_references_enabled
+
     from .utils._buffer import SymmetricWindow
 
     rank = runtime.rank
@@ -1095,22 +1097,25 @@ def _run_worker(
     x, topk_idx, topk_weights = data["x"], data["topk_idx"], data["topk_weights"]
     local_num_tokens = data["num_tokens"]
 
-    # The reference runtime needs GIN disabled on this host (verified in
-    # scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
-    import os
+    with_references = mode == "test" or external_references_enabled()
+    ref_buffer = None
+    if with_references:
+        # The reference runtime needs GIN disabled on this host (verified in
+        # scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
+        import os
 
-    os.environ.setdefault("EP_DISABLE_GIN", "1")
-    import deep_ep
+        os.environ.setdefault("EP_DISABLE_GIN", "1")
+        import deep_ep
 
-    ref_buffer = deep_ep.ElasticBuffer(
-        group,
-        num_max_tokens_per_rank=num_tokens_max,
-        hidden=hidden,
-        num_topk=num_topk,
-        # Match the source perf test (tests/elastic/test_ep.py defaults).
-        prefer_overlap_with_compute=False,
-        explicitly_destroy=True,
-    )
+        ref_buffer = deep_ep.ElasticBuffer(
+            group,
+            num_max_tokens_per_rank=num_tokens_max,
+            hidden=hidden,
+            num_topk=num_topk,
+            # Match the source perf test (tests/elastic/test_ep.py defaults).
+            prefer_overlap_with_compute=False,
+            explicitly_destroy=True,
+        )
 
     # TIRx-side symmetric window + metadata tensors.
     recv_region_bytes = world_size * num_tokens_max * TOKEN_BYTES_GMEM
@@ -1174,6 +1179,7 @@ def _run_worker(
         )
 
     def reference_launch():
+        assert ref_buffer is not None
         return ref_buffer.dispatch(
             x,
             topk_idx=topk_idx,
@@ -1263,7 +1269,7 @@ def _run_worker(
         with torch.cuda.stream(runtime.timing_stream):
             result = bench(
                 {"tirx": tirx_launch},
-                references={"deepep": build_reference},
+                references={"deepep": build_reference} if with_references else None,
                 timer="kineto",
                 rounds=kwargs.get("rounds", 1),
                 cooldown_s=kwargs.get("cooldown_s", 1.0),
@@ -1272,7 +1278,8 @@ def _run_worker(
         return {"status": "OK", **result}
     finally:
         window.destroy()
-        ref_buffer.destroy()
+        if ref_buffer is not None:
+            ref_buffer.destroy()
 
 
 def _resolve_num_sms(config: dict[str, Any]) -> int:

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/data.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/data.py
@@ -452,7 +452,11 @@ def _run_worker(
             f"{torch.cuda.device_count()} CUDA devices are visible"
         )
 
-    from tirx_kernels.runner import bind_cuda_assignment, validate_current_cuda_assignment
+    from tirx_kernels.runner import (
+        bind_cuda_assignment,
+        external_references_enabled,
+        validate_current_cuda_assignment,
+    )
 
     bind_cuda_assignment((physical_device_index,), (physical_device_uuid,))
     deep_gemm, source = load_deep_gemm_mega()
@@ -518,6 +522,8 @@ def _run_worker(
         if mode == "bench":
             from tirx_kernels.runner import bench
 
+            with_references = external_references_enabled()
+
             # bench()'s proton/event/cudagraph_proton timers are single-process:
             # each rank derives n_warmup/n_repeat from its own per-call estimate
             # with no cross-rank sync, so a cross-rank mega_moe kernel (in-kernel
@@ -535,7 +541,9 @@ def _run_worker(
                         "deadlock the cross-rank kernel collectives"
                     )
 
-            dg_case = create_case(deep_gemm, config, group, rank_idx, num_ranks)
+            dg_case = None
+            if with_references:
+                dg_case = create_case(deep_gemm, config, group, rank_idx, num_ranks)
             tirx_case = create_case(deep_gemm, config, group, rank_idx, num_ranks)
             deepgemm_stats = None
             tirx_stats = None
@@ -543,17 +551,22 @@ def _run_worker(
                 initial_stats = torch.zeros(
                     config.num_experts_per_rank, dtype=torch.int32, device="cuda"
                 )
-                deepgemm_stats = initial_stats.clone()
+                if with_references:
+                    deepgemm_stats = initial_stats.clone()
                 tirx_stats = initial_stats.clone()
                 tirx_case.cumulative_local_expert_recv_stats = tirx_stats
-            _copy_inputs_into_symm_buffer(dg_case)
+            if dg_case is not None:
+                _copy_inputs_into_symm_buffer(dg_case)
             _copy_inputs_into_symm_buffer(tirx_case)
-            y_deepgemm = torch.empty(
-                (config.num_tokens, config.hidden), dtype=torch.bfloat16, device="cuda"
-            )
+            y_deepgemm = None
+            if with_references:
+                y_deepgemm = torch.empty(
+                    (config.num_tokens, config.hidden), dtype=torch.bfloat16, device="cuda"
+                )
             tirx_invocation = _prepare_tirx_invocation(tirx_case)
 
             def deepgemm_step() -> None:
+                assert dg_case is not None and y_deepgemm is not None
                 dg_case.deep_gemm.fp8_fp4_mega_moe(
                     y_deepgemm,
                     dg_case.transformed_l1_weights,
@@ -571,17 +584,21 @@ def _run_worker(
 
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
-            deepgemm_step()
-            if torch.distributed.is_initialized():
-                torch.distributed.barrier()
+            if with_references:
+                deepgemm_step()
+                if torch.distributed.is_initialized():
+                    torch.distributed.barrier()
             tirx_step()
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
-            deepgemm_max_abs_diff = _max_abs_diff(tirx_invocation.y, y_deepgemm)
-            if deepgemm_max_abs_diff != 0.0:
-                raise AssertionError(f"TIRx diff={deepgemm_max_abs_diff}")
-            if timer == "megamoe" and not torch.equal(tirx_stats, deepgemm_stats):
-                raise AssertionError("TIRx cumulative expert stats differ from DeepGEMM")
+            deepgemm_max_abs_diff = None
+            if with_references:
+                assert y_deepgemm is not None
+                deepgemm_max_abs_diff = _max_abs_diff(tirx_invocation.y, y_deepgemm)
+                if deepgemm_max_abs_diff != 0.0:
+                    raise AssertionError(f"TIRx diff={deepgemm_max_abs_diff}")
+                if timer == "megamoe" and not torch.equal(tirx_stats, deepgemm_stats):
+                    raise AssertionError("TIRx cumulative expert stats differ from DeepGEMM")
 
             if timer == "megamoe":
                 if warmup is not None or repeat is not None:
@@ -592,6 +609,7 @@ def _run_worker(
 
                 def deepgemm_megamoe_step() -> None:
                     nonlocal y_deepgemm
+                    assert dg_case is not None
                     _copy_inputs_into_symm_buffer(dg_case)
                     y_deepgemm = torch.empty(
                         (config.num_tokens, config.hidden), dtype=torch.bfloat16, device="cuda"
@@ -613,9 +631,14 @@ def _run_worker(
                 from deep_gemm.testing import bench_kineto
 
                 validate_current_cuda_assignment("before DeepGEMM MegaMoE timing", restore=True)
+                funcs = {"tirx": tirx_megamoe_step}
+                kernel_names = {"tirx": "mega_moe_kernel"}
+                if with_references:
+                    funcs["deepgemm"] = deepgemm_megamoe_step
+                    kernel_names["deepgemm"] = "sm100_fp8_fp4_mega_moe_impl"
                 bench_result = _bench_megamoe_mode(
-                    {"tirx": tirx_megamoe_step, "deepgemm": deepgemm_megamoe_step},
-                    {"tirx": "mega_moe_kernel", "deepgemm": "sm100_fp8_fp4_mega_moe_impl"},
+                    funcs,
+                    kernel_names,
                     bench_kineto,
                     torch.distributed.barrier,
                     reset_between_implementations,
@@ -636,19 +659,22 @@ def _run_worker(
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
             impls = bench_result["impls"]
-            missing = {"deepgemm", "tirx"} - set(impls)
+            expected_impls = {"tirx", "deepgemm"} if with_references else {"tirx"}
+            missing = expected_impls - set(impls)
             if missing:
                 raise RuntimeError(f"Benchmark did not report timings for: {sorted(missing)}")
-            return {
+            result = {
                 "status": "OK",
                 "reference_source": source,
-                "deepgemm_max_abs_diff": deepgemm_max_abs_diff,
-                "impls": {"deepgemm": float(impls["deepgemm"]), "tirx": float(impls["tirx"])},
+                "impls": {name: float(impls[name]) for name in sorted(expected_impls)},
                 "round_samples": bench_result.get("round_samples", {}),
                 "errors": bench_result["errors"],
                 "timer": bench_result.get("timer"),
                 "benchmark_protocol": bench_result.get("benchmark_protocol", {}),
             }
+            if deepgemm_max_abs_diff is not None:
+                result["deepgemm_max_abs_diff"] = deepgemm_max_abs_diff
+            return result
 
         raise ValueError(f"Unsupported mode: {mode}")
     finally:

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -2007,7 +2007,7 @@ def _make_sglang_cutedsl_runner(data: dict[str, Any]) -> Any:
             "use context_pattern='sglang_fixed' or 'sglang_ragged'"
         )
 
-    from sglang.jit_kernel.dsa.cutedsl_paged_mqa_logits import (
+    from sglang.kernels.ops.attention.dsa.cutedsl_paged_mqa_logits import (
         CuteDSLPagedMQALogitsRunner,
         pick_dsl_expand,
     )
@@ -2318,7 +2318,7 @@ def prepare_bench(**kwargs: Any):
 
 def run_gpu(prepared, **kwargs: Any) -> dict[str, Any]:
     kwargs = {**prepared["config"], **kwargs}
-    from tirx_kernels.runner import bench
+    from tirx_kernels.runner import bench, external_references_enabled
 
     # Tiny (~8-11µs) paged kernel: event timing is launch-jitter-noisy (sporadic
     # 10-13% ratio spread) and ~2x inflated by launch overhead. timer=None inherits the
@@ -2340,16 +2340,22 @@ def run_gpu(prepared, **kwargs: Any) -> dict[str, Any]:
     # page-by-page and is prohibitively slow for SGLang's 131K-context sweep.
     data = _prepare_data(config, compute_reference=False)
     invocation = _prepare_tirx_invocation(data, executable=tirx_executable)
-    deepgemm_logits = _run_deepgemm_paged_mqa(data, clean_logits=False)
-    tirx_logits = _run_tirx_invocation(data, invocation)
-    torch.cuda.synchronize()
-    max_diff = _assert_valid_correct(data, tirx_logits, deepgemm_logits, name="TIRx vs DeepGEMM")
-    torch.cuda.empty_cache()
+    deepgemm_logits = None
+    max_diff = None
+    if external_references_enabled():
+        deepgemm_logits = _run_deepgemm_paged_mqa(data, clean_logits=False)
+        tirx_logits = _run_tirx_invocation(data, invocation)
+        torch.cuda.synchronize()
+        max_diff = _assert_valid_correct(
+            data, tirx_logits, deepgemm_logits, name="TIRx vs DeepGEMM"
+        )
+        torch.cuda.empty_cache()
 
     def _deepgemm():
         return lambda: _run_deepgemm_paged_mqa(data, clean_logits=False)
 
     def _sglang_cutedsl():
+        assert deepgemm_logits is not None
         cutedsl_runner = _make_sglang_cutedsl_runner(data)
         cutedsl_logits = cutedsl_runner()
         torch.cuda.synchronize()
@@ -2367,7 +2373,8 @@ def run_gpu(prepared, **kwargs: Any) -> dict[str, Any]:
         cooldown_s=_cooldown_s,
         references={"deepgemm": _deepgemm, "sglang_cutedsl": _sglang_cutedsl},
     )
-    result["max_diff"] = max_diff
+    if max_diff is not None:
+        result["max_diff"] = max_diff
     return result
 
 

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -4,9 +4,13 @@
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 import ctypes
+import importlib
+import sys
+import types
 from dataclasses import asdict, dataclass
 from functools import cache
 from importlib.util import find_spec
+from pathlib import Path
 from typing import Any
 from unittest import SkipTest
 
@@ -1999,6 +2003,38 @@ def _sglang_cutedsl_available() -> bool:
     return find_spec("sglang") is not None and find_spec("cutlass") is not None
 
 
+@cache
+def _load_sglang_cutedsl_reference() -> tuple[Any, Any]:
+    """Load SGLang's kernel modules without initializing its unrelated frontend."""
+    spec = find_spec("sglang")
+    if spec is None or not spec.submodule_search_locations:
+        raise ImportError("cannot find the pinned SGLang source checkout")
+    root = Path(next(iter(spec.submodule_search_locations)))
+
+    package_paths = {
+        "sglang": root,
+        "sglang.kernels": root / "kernels",
+        "sglang.kernels.ops": root / "kernels" / "ops",
+        "sglang.kernels.ops.attention": root / "kernels" / "ops" / "attention",
+        "sglang.kernels.ops.attention.dsa": root / "kernels" / "ops" / "attention" / "dsa",
+        "sglang.srt": root / "srt",
+    }
+    for name, path in package_paths.items():
+        package = types.ModuleType(name)
+        package.__package__ = name
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+
+    utils = types.ModuleType("sglang.srt.utils")
+    utils.is_sm100_supported = lambda: torch.cuda.get_device_capability()[0] == 10
+    sys.modules[utils.__name__] = utils
+
+    module = importlib.import_module(
+        "sglang.kernels.ops.attention.dsa.cutedsl_paged_mqa_logits"
+    )
+    return module.CuteDSLPagedMQALogitsRunner, module.pick_dsl_expand
+
+
 def _make_sglang_cutedsl_runner(data: dict[str, Any]) -> Any:
     config: PagedMQALogitsFP8Config = data["config"]
     if config.context_pattern == "random_2d" and config.next_n > 1:
@@ -2007,10 +2043,7 @@ def _make_sglang_cutedsl_runner(data: dict[str, Any]) -> Any:
             "use context_pattern='sglang_fixed' or 'sglang_ragged'"
         )
 
-    from sglang.kernels.ops.attention.dsa.cutedsl_paged_mqa_logits import (
-        CuteDSLPagedMQALogitsRunner,
-        pick_dsl_expand,
-    )
+    CuteDSLPagedMQALogitsRunner, pick_dsl_expand = _load_sglang_cutedsl_reference()
 
     expand_factor, atom = pick_dsl_expand(
         config.next_n,

--- a/tirx_kernels/flashattention/flash_attention_backward.py
+++ b/tirx_kernels/flashattention/flash_attention_backward.py
@@ -1981,7 +1981,13 @@ def get_kernel(
 
 
 def _prepare_official_workload(
-    batch_size: int, seq_len: int, num_heads: int, head_dim: int, is_causal: bool
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    head_dim: int,
+    is_causal: bool,
+    *,
+    compute_backward_reference: bool = True,
 ):
     """Create saved forward tensors and the current FA4 backward reference."""
     from flash_attn.cute.interface import _flash_attn_bwd, _flash_attn_fwd
@@ -1997,8 +2003,19 @@ def _prepare_official_workload(
         out, lse = _flash_attn_fwd(
             q=q, k=k, v=v, softmax_scale=scale, causal=is_causal, return_lse=True
         )[:2]
-        expected = _flash_attn_bwd(
-            q=q, k=k, v=v, out=out, dout=dout, lse=lse, softmax_scale=scale, causal=is_causal
+        expected = (
+            _flash_attn_bwd(
+                q=q,
+                k=k,
+                v=v,
+                out=out,
+                dout=dout,
+                lse=lse,
+                softmax_scale=scale,
+                causal=is_causal,
+            )
+            if compute_backward_reference
+            else None
         )
     data = {
         "Q": q,
@@ -2078,7 +2095,14 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, **kwargs):
     num_heads = config.pop("num_heads")
     head_dim = config.pop("head_dim")
     is_causal = config.pop("is_causal")
-    data, _ = _prepare_official_workload(batch_size, seq_len, num_heads, head_dim, is_causal)
+    data, _ = _prepare_official_workload(
+        batch_size,
+        seq_len,
+        num_heads,
+        head_dim,
+        is_causal,
+        compute_backward_reference=False,
+    )
     candidate = setup(
         data, batch_size, num_heads, seq_len, head_dim, executables=prepared["executables"]
     )

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
@@ -1339,12 +1339,11 @@ def run_gpu(
     case = prepare_data(**kwargs)
     executable = prepared["executable"]
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize(case["tirx_state"].device)
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize(case["tirx_state"].device)
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize(case["source_state"].device)

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
@@ -1446,12 +1446,11 @@ def run_gpu(
     case = prepare_data(**kwargs)
     executable = prepared["executable"]
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize(case["tirx_state"].device)
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize(case["tirx_state"].device)
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize(case["source_state"].device)

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -1093,12 +1093,11 @@ def run_gpu(
     case = prepare_data(**kwargs)
     executable = prepared["executable"]
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py
@@ -17,8 +17,8 @@ from unittest import SkipTest
 
 import torch
 
+from tirx_kernels.runner import bench
 from tvm.script import tirx as T
-from tvm.tirx.bench import bench
 
 KERNEL_META = {
     "name": "gdn_decode_fp32_mtp_warp",
@@ -1943,12 +1943,11 @@ def run_gpu(
     case = prepare_data(**kwargs)
     executable = prepared["executable"]
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize(case["tirx_state"].device)
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize(case["tirx_state"].device)
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize(case["source_state"].device)

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -5592,7 +5592,7 @@ def run_gpu(
 ) -> dict[str, Any]:
     """Benchmark the prepared four-launch chain against the source chain."""
     kwargs = {**prepared["config"], **kwargs}
-    from tvm.tirx.bench import bench
+    from tirx_kernels.runner import bench
 
     case = prepare_data(**kwargs)
     executable = prepared["executable"]

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -658,7 +658,7 @@ def run_gpu(
     cooldown_s: float = 1.0,
 ) -> dict[str, Any]:
     _require_sm100()
-    from tirx_kernels.runner import bench
+    from tirx_kernels.runner import bench, external_references_enabled
 
     B, O, K = prepared["B"], prepared["O"], prepared["K"]
     stage = prepared["stage"]
@@ -666,12 +666,13 @@ def run_gpu(
     case = prepare_data(B, O, K)
     args = _tirx_args(case)
 
-    reference_out = torch.zeros_like(case["out"])
-    _run_flashinfer(case, stage, False, reference_out)
-    executable(*args)
-    torch.cuda.synchronize()
-    if not torch.equal(case["out"], reference_out):
-        raise AssertionError("TinyGEMM2 benchmark preflight failed bitwise validation")
+    if external_references_enabled():
+        reference_out = torch.zeros_like(case["out"])
+        _run_flashinfer(case, stage, False, reference_out)
+        executable(*args)
+        torch.cuda.synchronize()
+        if not torch.equal(case["out"], reference_out):
+            raise AssertionError("TinyGEMM2 benchmark preflight failed bitwise validation")
 
     def _flashinfer_builder():
         output = torch.empty_like(case["out"])

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -891,19 +891,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the two pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -1191,19 +1191,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -1100,19 +1100,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -989,19 +989,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
@@ -1361,19 +1361,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -1419,19 +1419,20 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region. Both sides mutate their own state
-    # pool in place, so this also proves the pools stayed independent.
-    executable(*args)
-    reference_out = _flashinfer_reference(case)
-    torch.cuda.synchronize(case["device"])
-    torch.testing.assert_close(
-        case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
-    )
-    torch.testing.assert_close(
-        case["tirx_state_raw"].float(), case["reference_state_raw"].float(), rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once outside the timed region. Both sides mutate independent state pools.
+        executable(*args)
+        reference_out = _flashinfer_reference(case)
+        torch.cuda.synchronize(case["device"])
+        torch.testing.assert_close(
+            case["tirx_out"].float(), reference_out.float(), rtol=_RTOL, atol=_ATOL
+        )
+        torch.testing.assert_close(
+            case["tirx_state_raw"].float(),
+            case["reference_state_raw"].float(),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
         # The nvcc JIT build and warmup both happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -1249,19 +1249,17 @@ def run_gpu(
     spec = case["spec"]
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region.  Both implementations update
-    # their own state-pool clone in place, so repeated timed launches let the
-    # values drift; the work per launch is identical either way.
-    executable(*args)
-    shape = (1, spec["Q_TOTAL"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
-    flashinfer_out = _flashinfer_reference(case).reshape(shape)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
-    torch.testing.assert_close(
-        case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once before the reference enters the timed region. Both
+        # implementations update independent state-pool clones in place.
+        executable(*args)
+        shape = (1, spec["Q_TOTAL"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
+        flashinfer_out = _flashinfer_reference(case).reshape(shape)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
+        torch.testing.assert_close(
+            case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
+        )
         # Heavy import, CuTe JIT and warmup all happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -1012,18 +1012,17 @@ def run_gpu(
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
 
-    # Validate once, outside the timed region.
-    executable(*args)
-    spec = case["spec"]
-    shape = (1, spec["NUM_SEQS"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
-    flashinfer_out = _flashinfer_reference(case).reshape(shape)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
-    torch.testing.assert_close(
-        case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
-    )
-
     def flashinfer_builder():
+        # Validate once before the reference enters the timed region.
+        executable(*args)
+        spec = case["spec"]
+        shape = (1, spec["NUM_SEQS"], spec["NUM_VALUE_HEADS"], HEAD_DIM)
+        flashinfer_out = _flashinfer_reference(case).reshape(shape)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
+        torch.testing.assert_close(
+            case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
+        )
         # Heavy import, CuTe JIT and warmup all happen here, outside the timing.
         for _ in range(2):
             _flashinfer_reference(case)

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -1247,12 +1247,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _simple._assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _simple._assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -1976,12 +1976,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -1517,12 +1517,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _simple._assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _simple._assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -1198,12 +1198,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _simple._assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _simple._assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -1371,12 +1371,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -1357,12 +1357,11 @@ def run_gpu(
 
     case = prepare_data(**kwargs)
     args = _tirx_args(case)
-    executable(*args)
-    _run_reference(case)
-    torch.cuda.synchronize()
-    _simple._assert_case_close(case)
-
     def source_builder():
+        executable(*args)
+        _run_reference(case)
+        torch.cuda.synchronize()
+        _simple._assert_case_close(case)
         for _ in range(2):
             _run_reference(case)
         torch.cuda.synchronize()

--- a/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
@@ -44,6 +44,7 @@ from tirx_kernels.flashinfer.utils.topk_radix import (
     bar_sync,
     from_ordered_u16,
     from_ordered_u32,
+    ld_global_u32,
     ld_shared_pair_u32,
     ld_shared_quad_u32,
     ld_shared_u16,
@@ -398,13 +399,15 @@ def get_kernel(
             row_len: T.int32 = T.int32(length)
             if not basic:
                 if row_starts:
-                    row_start = row_starts_g[row_idx]
+                    row_start = T.reinterpret("int32", ld_global_u32(row_starts_g, row_idx))
                 if page_table:
                     if page_table_row_starts:
-                        page_start = pt_starts_g[row_idx]
+                        page_start = T.reinterpret(
+                            "int32", ld_global_u32(pt_starts_g, row_idx)
+                        )
                     else:
                         page_start = row_start
-                row_len = lengths_g[row_idx]
+                row_len = T.reinterpret("int32", ld_global_u32(lengths_g, row_idx))
             row_in: T.int64 = T.cast(row_idx, "int64") * T.int64(length) + T.cast(
                 row_start, "int64"
             )
@@ -417,32 +420,57 @@ def get_kernel(
                     take_main = T.int32(0)
                     for i0 in T.serial(tx, row_len, step=BLOCK_THREADS):
                         if i0 < k:
-                            out_idx[row_out + T.cast(i0, "int64")] = i0
-                            out_val[row_out + T.cast(i0, "int64")] = inp[
-                                T.cast(row_idx, "int64") * T.int64(length) + T.cast(i0, "int64")
-                            ]
+                            slot0: T.int64 = row_out + T.cast(i0, "int64")
+                            st_global_u32(out_idx, slot0, T.reinterpret("uint32", i0))
+                            bits0 = _ld_global_bits(
+                                inp,
+                                T.cast(row_idx, "int64") * T.int64(length)
+                                + T.cast(i0, "int64"),
+                                is32,
+                            )
+                            if is32:
+                                st_global_u32(out_val, slot0, bits0)
+                            else:
+                                st_global_u16(out_val, slot0, bits0)
             batch_idx: T.int32 = row_idx
             offset: T.int32 = T.int32(0)
             if page_table:
                 if row_to_batch:
-                    batch_idx = row_to_batch_g[row_idx]
+                    batch_idx = T.reinterpret(
+                        "int32", ld_global_u32(row_to_batch_g, row_idx)
+                    )
                 if row_len <= k:
                     take_main = T.int32(0)
                     src0: T.int64 = T.cast(batch_idx, "int64") * aux_stride
                     for i1 in T.serial(tx, k, step=BLOCK_THREADS):
                         page_id: T.int32 = T.int32(-1)
                         if i1 < row_len:
-                            page_id = aux[src0 + T.cast(page_start + i1, "int64")]
-                        out_idx[row_out + T.cast(i1, "int64")] = page_id
+                            page_id = T.reinterpret(
+                                "int32",
+                                ld_global_u32(
+                                    aux, src0 + T.cast(page_start + i1, "int64")
+                                ),
+                            )
+                        st_global_u32(
+                            out_idx,
+                            row_out + T.cast(i1, "int64"),
+                            T.reinterpret("uint32", page_id),
+                        )
             if ragged:
-                offset = aux[T.cast(row_idx, "int64")]
+                offset = T.reinterpret(
+                    "int32", ld_global_u32(aux, T.cast(row_idx, "int64"))
+                )
                 if row_len <= k:
                     take_main = T.int32(0)
                     for i2 in T.serial(tx, k, step=BLOCK_THREADS):
                         val2: T.int32 = T.int32(-1)
                         if i2 < row_len:
                             val2 = i2 + offset
-                        out_idx[row_out + T.cast(i2, "int64")] = val2
+                        st_global_u32(
+                            out_idx,
+                            row_out + T.cast(i2, "int64"),
+                            T.reinterpret("uint32", val2),
+                        )
 
             if take_main == 1:
                 # === Stage 1: stage the row as monotone keys (:605-623) ====
@@ -573,10 +601,14 @@ def get_kernel(
                 src_base: T.int64 = T.int64(0)
                 if page_table:
                     if row_to_batch:
-                        batch_idx = row_to_batch_g[row_idx]
+                        batch_idx = T.reinterpret(
+                            "int32", ld_global_u32(row_to_batch_g, row_idx)
+                        )
                     src_base = T.cast(batch_idx, "int64") * aux_stride
                 if ragged:
-                    offset = aux[T.cast(row_idx, "int64")]
+                    offset = T.reinterpret(
+                        "int32", ld_global_u32(aux, T.cast(row_idx, "int64"))
+                    )
 
                 if not deterministic:
                     # === Stage 4a: non-deterministic collect (:906-963) ====
@@ -777,10 +809,14 @@ def get_kernel(
                 if page_table:
                     bar_sync()
                     for ig in T.serial(tx, k, step=BLOCK_THREADS):
-                        gidx: T.int32 = out_idx[row_out + T.cast(ig, "int64")]
-                        out_idx[row_out + T.cast(ig, "int64")] = aux[
-                            src_base + T.cast(page_start + gidx, "int64")
-                        ]
+                        out_slot: T.int64 = row_out + T.cast(ig, "int64")
+                        gidx: T.int32 = T.reinterpret(
+                            "int32", ld_global_u32(out_idx, out_slot)
+                        )
+                        gathered: T.uint32 = ld_global_u32(
+                            aux, src_base + T.cast(page_start + gidx, "int64")
+                        )
+                        st_global_u32(out_idx, out_slot, gathered)
 
             row_idx = row_idx + grid
 

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -33,6 +33,22 @@ PREPARE_NUM_SMS_ENV = "TIRX_PREPARE_NUM_SMS"
 PREPARE_CUDA_ARCH_ENV = "TIRX_PREPARE_CUDA_ARCH"
 TVM_FFI_DISABLE_TORCH_C_DLPACK_ENV = "TVM_FFI_DISABLE_TORCH_C_DLPACK"
 TVM_COMPILE_FORCE_FALLBACK_ENV = "TVM_COMPILE_FORCE_FALLBACK"
+_EXTERNAL_REFERENCES_ENV = "TIRX_INTERNAL_BENCH_REFERENCES"
+
+
+def set_external_references_enabled(enabled: bool) -> None:
+    """Select explicit diagnostic reference timing for the current process."""
+    if not isinstance(enabled, bool):
+        raise TypeError("external reference mode must be a bool")
+    if enabled:
+        os.environ[_EXTERNAL_REFERENCES_ENV] = "1"
+    else:
+        os.environ[_EXTERNAL_REFERENCES_ENV] = "0"
+
+
+def external_references_enabled() -> bool:
+    """Whether this process may prepare, launch, and time benchmark references."""
+    return os.environ.get(_EXTERNAL_REFERENCES_ENV) == "1"
 
 
 @runtime_checkable
@@ -127,7 +143,7 @@ class PreparedKernelBenchmark:
 class _CudaAssignment:
     indices: tuple[int, ...]
     uuids: tuple[str, ...]
-    previously_assigned: set[int]
+    previously_assigned_uuids: set[str]
 
 
 _NVML_LOCK = threading.Lock()
@@ -139,8 +155,8 @@ _ORIGINAL_TVM_COMPILE = tvm.compile
 _CUDA_ASSIGNMENT: _CudaAssignment | None = None
 
 
-def _current_process_cuda_gpus(*, required: bool = False) -> tuple[int, ...]:
-    """Return physical GPUs on which this PID owns a CUDA compute context."""
+def _current_process_cuda_gpu_uuids(*, required: bool = False) -> tuple[str, ...]:
+    """Return physical GPU UUIDs on which this PID owns a CUDA compute context."""
     global _NVML_MODULE, _NVML_UNAVAILABLE
     if _NVML_UNAVAILABLE:
         if required:
@@ -178,7 +194,8 @@ def _current_process_cuda_gpus(*, required: bool = False) -> tuple[int, ...]:
         for index in range(count):
             handle = pynvml.nvmlDeviceGetHandleByIndex(index)
             if any(int(process.pid) == pid for process in process_query(handle)):
-                owned.append(index)
+                uuid = pynvml.nvmlDeviceGetUUID(handle)
+                owned.append(uuid.decode() if isinstance(uuid, bytes) else str(uuid))
     except Exception as error:
         # Torch remains an independent oracle. NVML sampling failures must not
         # make ordinary standalone CPU tooling unusable.
@@ -192,7 +209,7 @@ def cuda_is_initialized() -> bool:
     """Report framework or driver-level CUDA initialization without creating it."""
     torch = sys.modules.get("torch")
     torch_initialized = bool(torch is not None and torch.cuda.is_initialized())
-    return torch_initialized or bool(_current_process_cuda_gpus())
+    return torch_initialized or bool(_current_process_cuda_gpu_uuids())
 
 
 def hardware_num_sms(default: int = 148) -> int:
@@ -279,10 +296,10 @@ def bind_cuda_assignment(
             f"late GPU assignment identity mismatch: requested {list(expected)}, "
             f"physical {list(actual)}"
         )
-    previously_assigned = set(indices)
+    previously_assigned_uuids = set(actual)
     if _CUDA_ASSIGNMENT is not None:
-        previously_assigned.update(_CUDA_ASSIGNMENT.previously_assigned)
-    _CUDA_ASSIGNMENT = _CudaAssignment(indices, actual, previously_assigned)
+        previously_assigned_uuids.update(_CUDA_ASSIGNMENT.previously_assigned_uuids)
+    _CUDA_ASSIGNMENT = _CudaAssignment(indices, actual, previously_assigned_uuids)
     validate_current_cuda_assignment("after ASSIGN")
     return actual
 
@@ -313,26 +330,26 @@ def validate_current_cuda_assignment(stage: str, *, restore: bool = False) -> tu
         raise RuntimeError(
             f"{stage}: assigned CUDA UUIDs changed from {_CUDA_ASSIGNMENT.uuids!r} to {actual!r}"
         )
-    unexpected = set(_current_process_cuda_gpus(required=True)) - (
-        _CUDA_ASSIGNMENT.previously_assigned
+    unexpected = set(_current_process_cuda_gpu_uuids(required=True)) - (
+        _CUDA_ASSIGNMENT.previously_assigned_uuids
     )
     if unexpected:
         raise RuntimeError(
-            f"{stage}: process owns CUDA context(s) on never-assigned physical GPU(s) "
+            f"{stage}: process owns CUDA context(s) on never-assigned physical GPU UUID(s) "
             f"{sorted(unexpected)}"
         )
     return actual
 
 
 def bench(*args: Any, references: Mapping[str, Any] | None = None, **kwargs: Any):
-    """Run the canonical timer with assignment checks around external setup."""
+    """Run the canonical timer, admitting references only in explicit diagnostic mode."""
     from tvm.tirx.bench import bench as canonical_bench
 
     if _CUDA_ASSIGNMENT is not None:
         validate_current_cuda_assignment("before benchmark setup", restore=True)
 
     checked_references = None
-    if references is not None:
+    if references is not None and external_references_enabled():
         checked_references = {}
         for name, builder in references.items():
 


### PR DESCRIPTION
## Summary

- keep every kernel's original `CONFIGS` matrix as the correctness authority and run it through pytest-xdist with 16 workers by default
- pin mutually compatible upstream reference revisions in `reference-dependencies.json` and install or verify them with one command
- keep benchmark references available behind `--with-references`; the default bench-suite path does not launch or time them
- schedule correctness subprocesses onto GPUs by current free memory and in-flight reservations; per-GPU capacity derives from the xdist worker count (16 workers -> 4 slots, explicit 32 workers -> 8 slots on an 8-GPU host)
- fix the low-level IR violations exposed by the complete DeepEP combine and radix-top-k config matrices, and load the pinned SGLang kernel reference without initializing its unrelated frontend

## Scope

- no benchmark YAML changes
- no `CONFIGS` / `BENCH_CONFIGS` changes relative to `main`
- no reduced correctness shapes and no separate correctness config matrices
- `reference-dependencies.json` is the single source of truth for upstream revisions and Python package versions

## Validation

- pinned dependency verification: passed
- correctness collection: 1,644 original configs
- Ruff, license headers, and `git diff --check`: passed
- DeepEP combine + radix-top-k regressions: all 86 previously rejected configs passed their upstream oracles
- scheduler stress: five large MegaMoE configs passed concurrently without a GPU-ID restriction (48.98 s pytest / 49.37 s wall)
- default bench discovery/import gate: 48 kernels / 140 workloads; references disabled

### Long-run evidence

- 16-worker run excluding GemmRS, before reservation-aware scoring: 1,626 passed, 2 scheduler OOMs in 44:20.15; both OOM cases passed in a focused parallel rerun (43.72 s)
- 32-worker experiment with 8 slots/GPU was rejected: after 49:12.92 it had 1,622 passed, one MegaMoE OOM, one distributed rendezvous port collision, and two long MegaMoE cases still running; the default remains 16 workers
- GemmRS is excluded from these counts: its failing workload reproduces alone on otherwise idle GPUs, so it is not a pytest overlap failure

Focused reruns are used for scheduler OOMs; the original correctness configs remain unchanged.
