### PR TITLE
fix: stabilize GPU suite execution

### DIFF
--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -528,16 +528,19 @@ freedom before profiling wait stalls and tail-dominated shapes.
 **Symptoms:** `illegal_instruction`, `unspecified_launch_failure`, `multimem_early_exit`, `distributed_flake`
 
 A host barrier after launch cannot keep a rank's device workers alive while
-peer ranks are still issuing `multimem.ld_reduce`.  Give every persistent
-worker its own symmetric exit flag, release-increment the multicast flag after
-all local multimem users finish, and acquire-wait on the local flag until every
-rank arrives before releasing device resources or exiting the kernel.
+peer ranks are still issuing `multimem.ld_reduce`.  Establish rank-local
+all-worker completion on device, then release-increment a multicast rank flag
+and acquire-wait on the local flag until every rank arrives before releasing
+the final device resources or exiting the kernel.
 
 Keep this barrier outside the tile protocol: first complete the local CTA or
 cluster drain, then perform the system-scope rank rendezvous, then deallocate
-TMEM and exit.  A single flag per rank is insufficient when independently
-scheduled persistent workers can finish at different times; index the flags by
-the physical worker or SM identity used by the grid.
+TMEM and exit.  A bare single flag per rank is insufficient when independently
+scheduled persistent workers can finish at different times.  Two correct forms
+are known: index symmetric flags by physical worker, or first release-aggregate
+every local cluster into a rank-local counter and let only the last cluster
+perform the cross-rank rendezvous.  In the aggregate form, keep both CTAs of
+that last cluster behind a cluster barrier until the rank rendezvous completes.
 
 The missing exit rendezvous presented as two different asynchronous CUDA
 faults at two different TP4 shapes across two full correctness matrices, while
@@ -546,6 +549,22 @@ non-blocking relaunches across both failing shapes, the complete 16-shape
 TP1/TP4 matrix, and a 1402-configuration full suite.  Launch blocking is a
 localization tool here, not a fix: it passed 200 relaunches but does not prove
 the cross-rank kernel-exit invariant.
+
+A later full sweep still observed one standalone-unreproducible TP4 launch
+failure with the per-worker form.  Replacing 148 multicast arrivals per rank
+with a 74-cluster local completion counter plus one multicast arrival per rank
+passed the failing shape for 20 relaunches and the complete 16-shape matrix for
+320 relaunches, including 160 TP4 launches.  The terminal-state oracle checked
+both the 74 local cluster arrivals and all rank arrivals on every launch.
+
+Do not interpret an isolated `illegal_instruction` from a full-TMEM persistent
+kernel until the runner has excluded co-runners.  A subsequent shared-runner
+sweep allowed single-GPU cases to overlap and admitted GPUs already owned by
+external processes.  Its TP1 failure localized to the kernel's intentional
+`trap` when a 512-column allocation did not start at TMEM column zero; two TP4
+launch faults were likewise collected without a valid exclusive-device
+invariant.  Make full-resource kernels exclusive and reject externally occupied
+cards before treating a remaining failure as evidence about the exit barrier.
 
 ## Size swizzles and fragments physically
 

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import fcntl
 import json
-import math
 import os
 import subprocess
 import sys
@@ -40,7 +39,7 @@ def _correctness_cases() -> list[Any]:
     return cases
 
 
-def _visible_gpu_memory() -> list[tuple[str, int]]:
+def _visible_gpu_memory() -> list[tuple[str, int, bool]]:
     output = subprocess.check_output(
         [
             "nvidia-smi",
@@ -49,10 +48,22 @@ def _visible_gpu_memory() -> list[tuple[str, int]]:
         ],
         text=True,
     )
+    compute_processes = {
+        line.strip()
+        for line in subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=gpu_uuid",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        ).splitlines()
+        if line.strip()
+    }
     rows = []
     for line in output.splitlines():
         index, uuid, free_memory = (field.strip() for field in line.split(","))
-        rows.append((index, uuid, int(free_memory)))
+        rows.append((index, uuid, int(free_memory), uuid in compute_processes))
 
     configured = os.environ.get("CUDA_VISIBLE_DEVICES")
     if configured is None:
@@ -60,8 +71,8 @@ def _visible_gpu_memory() -> list[tuple[str, int]]:
     else:
         visible = {token.strip() for token in configured.split(",") if token.strip()}
     return [
-        (uuid if uuid in visible else index, free_memory)
-        for index, uuid, free_memory in rows
+        (uuid if uuid in visible else index, free_memory, has_compute_process)
+        for index, uuid, free_memory, has_compute_process in rows
         if index in visible or uuid in visible
     ]
 
@@ -80,10 +91,8 @@ def _try_lock(path: Path):
 def _reserve_gpus(test_run_uid: str, count: int):
     lock_root = Path("/tmp") / f"tirx-correctness-{test_run_uid}"
     lock_root.mkdir(parents=True, exist_ok=True)
-    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
-
     selected: list[str] = []
-    slot_handles = []
+    gpu_handles = []
     while not selected:
         with (lock_root / "allocator.lock").open("a+") as allocator:
             fcntl.flock(allocator, fcntl.LOCK_EX)
@@ -95,43 +104,35 @@ def _reserve_gpus(test_run_uid: str, count: int):
                     f"correctness case requires {count} GPUs, "
                     f"but only {len(gpu_memory)} are visible"
                 )
-            # Any four visible GPUs can absorb all xdist workers, while free
-            # cards remain eligible to take work from cards occupied externally.
-            active_gpu_target = min(4, len(gpu_memory))
-            slots_per_gpu = math.ceil(worker_count / active_gpu_target)
+            # Kernel resource use has no divisible per-card contract: one case
+            # may consume all memory, SMs, or TMEM. Own each assigned GPU as a
+            # unit and reject externally occupied cards.
             candidates = []
-            for gpu, free_memory in gpu_memory:
-                active_slots = 0
-                candidate_handle = None
-                for slot in range(slots_per_gpu):
-                    slot_handle = _try_lock(lock_root / f"gpu-{gpu}-slot-{slot}.lock")
-                    if slot_handle is None:
-                        active_slots += 1
-                    elif candidate_handle is None:
-                        candidate_handle = slot_handle
-                    else:
-                        slot_handle.close()
-                if candidate_handle is not None:
-                    candidates.append(
-                        (free_memory // (active_slots + 1), free_memory, gpu, candidate_handle)
-                    )
+            for gpu, free_memory, has_compute_process in gpu_memory:
+                gpu_handle = _try_lock(lock_root / f"gpu-{gpu}.lock")
+                if gpu_handle is None:
+                    continue
+                if has_compute_process:
+                    gpu_handle.close()
+                    continue
+                candidates.append((free_memory, gpu, gpu_handle))
 
-            candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+            candidates.sort(key=lambda item: item[0], reverse=True)
             if len(candidates) >= count:
-                for _score, _free_memory, gpu, slot_handle in candidates[:count]:
+                for _free_memory, gpu, gpu_handle in candidates[:count]:
                     selected.append(gpu)
-                    slot_handles.append(slot_handle)
+                    gpu_handles.append(gpu_handle)
                 candidates = candidates[count:]
-            for _score, _free_memory, _gpu, slot_handle in candidates:
-                slot_handle.close()
+            for _free_memory, _gpu, gpu_handle in candidates:
+                gpu_handle.close()
         if not selected:
             time.sleep(0.1)
 
     try:
         yield selected
     finally:
-        for slot_handle in slot_handles:
-            slot_handle.close()
+        for gpu_handle in gpu_handles:
+            gpu_handle.close()
 
 
 def _last_json_object(output: str) -> dict[str, Any]:
@@ -174,7 +175,12 @@ def test_kernel_correctness(
         )
 
     payload = _last_json_object(completed.stdout)
-    assert completed.returncode == 0, completed.stdout[-12000:] + completed.stderr[-12000:]
+    diagnostic = (
+        f"assigned GPUs: {','.join(selected_gpus)}\n"
+        + completed.stdout[-12000:]
+        + completed.stderr[-12000:]
+    )
+    assert completed.returncode == 0, diagnostic
     assert payload["passed"] == 1, payload
     assert payload["failed"] == 0, payload
     assert payload["skipped"] == 0, payload

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -65,6 +65,8 @@ WARP_NUMBER = 4
 NUM_CONSUMER = 2
 NUM_THREADS = 32 * WARP_NUMBER * WG_NUMBER
 SM_NUMBER = 148
+NUM_CLUSTERS = SM_NUMBER // M_CLUSTER
+assert NUM_CLUSTERS * M_CLUSTER == SM_NUMBER
 PIPELINE_DEPTH = 4
 F16_BYTES = 2
 F128_BYTES = 16
@@ -199,23 +201,28 @@ ld_reduce_8xfp16 = '\n__forceinline__ __device__ void ld_reduce_8_fp16(void* src
 semaphore_notify_remote = "\n__forceinline__ __device__ uint64_t semaphore_notify_remote(int32_t signal_rank, uint64_t* addr, uint64_t signal_value) {\n    auto dst_addr = reinterpret_cast<unsigned long long*>(nvshmem_ptr(addr, signal_rank));\n    return atomicAdd_system(dst_addr, signal_value);\n}\n"
 exit_barrier_arrive_and_wait = """
 __forceinline__ __device__ void exit_barrier_arrive_and_wait(
-        uint32_t* flags, int32_t worker_idx, int32_t expected) {
-    uint32_t* flag = flags + worker_idx;
-    auto mc_flag = reinterpret_cast<uint32_t*>(
-        nvshmemx_mc_ptr(NVSHMEM_TEAM_WORLD, flag));
+        uint32_t* flags, int32_t local_expected, int32_t rank_expected) {
+    __threadfence_system();
+    uint32_t local_arrivals = atomicAdd_system(flags, 1) + 1;
+    if (local_arrivals != static_cast<uint32_t>(local_expected)) {
+        return;
+    }
+    uint32_t* rank_arrivals = flags + 1;
+    auto mc_rank_arrivals = reinterpret_cast<uint32_t*>(
+        nvshmemx_mc_ptr(NVSHMEM_TEAM_WORLD, rank_arrivals));
     asm volatile(
         "multimem.red.release.sys.global.add.u32 [%0], 1;"
         :
-        : "l"(mc_flag)
+        : "l"(mc_rank_arrivals)
         : "memory");
     uint32_t value;
     do {
         asm volatile(
             "ld.global.acquire.sys.b32 %0, [%1];"
             : "=r"(value)
-            : "l"(flag)
+            : "l"(rank_arrivals)
             : "memory");
-    } while (value != static_cast<uint32_t>(expected));
+    } while (value != static_cast<uint32_t>(rank_expected));
 }
 """
 enqueue_remote = """
@@ -577,7 +584,7 @@ def test_mma_ss_tma_2sm_persistent(
     rs_task_idxs: Tx.Buffer((CAPACITY, 2), "int32"),
     rs_head: Tx.Buffer((1,), "int32"),
     rs_tail: Tx.Buffer((1,), "int32"),
-    exit_barrier: Tx.Buffer((SM_NUMBER,), "uint32"),
+    exit_barrier: Tx.Buffer((2,), "uint32"),
 ):
     A_tensor_map: Tx.let[Tx.handle("tensormap")] = Tx.tvm_stack_alloca("tensormap", 1)
     B_tensor_map: Tx.let[Tx.handle("tensormap")] = Tx.tvm_stack_alloca("tensormap", 1)
@@ -1009,14 +1016,17 @@ def test_mma_ss_tma_2sm_persistent(
     Tx.ptx.barrier.cluster.arrive()
     Tx.ptx.barrier.cluster.wait()
     if WORLD_SIZE > 1:
-        if tid == 0:
+        if (cbx == 0) & (tid == 0):
             Tx.cuda.func_call(
                 "exit_barrier_arrive_and_wait",
-                exit_barrier.ptr_to([bx]),
-                Tx.int32(0),
+                exit_barrier.ptr_to([0]),
+                Tx.int32(NUM_CLUSTERS),
                 Tx.int32(WORLD_SIZE),
                 source_code=exit_barrier_arrive_and_wait,
             )
+        Tx.cuda.cta_sync()
+        Tx.ptx.barrier.cluster.arrive()
+        Tx.ptx.barrier.cluster.wait()
     if (wg_id == 0) & (warp_id == 0):
         Tx.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{CTA_GROUP}.sync.aligned"]()
         Tx.ptx.ld.shared.u32(tmem_addr_local, tmem_addr.ptr_to([0]))
@@ -1249,9 +1259,16 @@ class _Case:
             self.semaphore_torch,
             torch.full_like(self.semaphore_torch, self.config.completion_count),
         )
-        expected_exit_count = self.config.world_size if self.config.world_size > 1 else 0
+        expected_exit_state = (
+            (NUM_CLUSTERS, self.config.world_size) if self.config.world_size > 1 else (0, 0)
+        )
         torch.testing.assert_close(
-            self.exit_barrier_torch, torch.full_like(self.exit_barrier_torch, expected_exit_count)
+            self.exit_barrier_torch,
+            torch.tensor(
+                expected_exit_state,
+                dtype=self.exit_barrier_torch.dtype,
+                device=self.exit_barrier_torch.device,
+            ),
         )
         if torch.isnan(self.gemm_out_torch).any() or torch.isnan(self.out).any():
             raise AssertionError("GemmRS output contains an uncovered tile")
@@ -1272,7 +1289,7 @@ def _allocate_case(
     rs_task_idxs = symmetric_empty(runtime, (CAPACITY, TASK_IDX_LEN), "int32")
     rs_head = symmetric_empty(runtime, (1,), "int32")
     rs_tail = symmetric_empty(runtime, (1,), "int32")
-    exit_barrier = symmetric_empty(runtime, (SM_NUMBER,), "uint32")
+    exit_barrier = symmetric_empty(runtime, (2,), "uint32")
     exit_barrier_torch = torch_view(exit_barrier)
     initial_queues = tuple(
         torch.from_numpy(array[runtime.rank].copy()).to(device) for array in queue_state

--- a/tirx_kernels/basic/utils/_baselines.py
+++ b/tirx_kernels/basic/utils/_baselines.py
@@ -114,7 +114,7 @@ def _read_nvshmem_version() -> tuple[str, str]:
 def _library_provenance() -> dict[str, dict[str, Any]]:
     """Verify every configured lock against the library resolving its API symbol."""
 
-    configured = _locked_library_paths(required=True)
+    configured = _locked_library_paths(required=tuple(_LIBRARY_SYMBOLS))
     result = {}
     for name, symbol in _LIBRARY_SYMBOLS.items():
         actual = _symbol_library_path(symbol)

--- a/tirx_kernels/basic/utils/_runtime.py
+++ b/tirx_kernels/basic/utils/_runtime.py
@@ -10,7 +10,7 @@ import gc
 import os
 import tempfile
 from collections.abc import Callable, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -223,7 +223,8 @@ def sync_communication_to_compute(runtime: DistributedRuntime) -> None:
 def _rank_library_preload(*, required: bool = False):
     """Preload explicitly selected communication libraries in spawned ranks."""
 
-    libraries = _locked_library_paths(required=required)
+    required_libraries = ("nccl", "nvshmem") if required else ()
+    libraries = _locked_library_paths(required=required_libraries)
     if not libraries:
         yield
         return
@@ -241,15 +242,34 @@ def _rank_library_preload(*, required: bool = False):
             os.environ["LD_PRELOAD"] = original
 
 
-def _locked_library_paths(*, required: bool) -> dict[str, Path]:
+@contextmanager
+def _rank_cuda_visibility(device_indices: Sequence[int]):
+    """Expose a late physical assignment as dense rank-local CUDA indices."""
+
+    original = os.environ.get("CUDA_VISIBLE_DEVICES")
+    os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(index) for index in device_indices)
+    try:
+        yield tuple(range(len(device_indices)))
+    finally:
+        if original is None:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        else:
+            os.environ["CUDA_VISIBLE_DEVICES"] = original
+
+
+def _locked_library_paths(*, required: Sequence[str] = ()) -> dict[str, Path]:
     """Resolve the exact shared-library files selected for rank workers."""
+
+    unknown = set(required).difference(_LOCKED_LIBRARY_ENVS)
+    if unknown:
+        raise ValueError(f"unknown locked libraries: {', '.join(sorted(unknown))}")
 
     result: dict[str, Path] = {}
     missing = []
     for name, env_name in _LOCKED_LIBRARY_ENVS.items():
         configured = os.environ.get(env_name)
         if not configured:
-            if required:
+            if name in required:
                 missing.append(env_name)
             continue
         path = Path(configured)
@@ -312,9 +332,11 @@ def _cleanup_runtime(runtime: DistributedRuntime | None) -> None:
             runtime.device.sync(stream)
         except Exception:
             pass
-    runtime.device.set_raw_stream(0)
-    runtime.device.free_raw_stream(runtime.communication_stream)
-    runtime.device.free_raw_stream(runtime.compute_stream)
+    with suppress(Exception):
+        runtime.device.set_raw_stream(0)
+    for stream in (runtime.communication_stream, runtime.compute_stream):
+        with suppress(Exception):
+            runtime.device.free_raw_stream(stream)
 
 
 def _rank_entry(
@@ -474,7 +496,10 @@ def _run_distributed_library(
     result_queue = context.SimpleQueue()
     with tempfile.TemporaryDirectory(prefix="tirx-gemm-comm-ranks-") as tmpdir:
         init_method = f"file://{Path(tmpdir) / 'torch-distributed-init'}"
-        with _rank_library_preload(required=mode == "bench"):
+        with (
+            _rank_library_preload(required=mode == "bench"),
+            _rank_cuda_visibility(device_indices) as rank_device_indices,
+        ):
             mp.spawn(
                 _rank_entry,
                 args=(
@@ -485,7 +510,7 @@ def _run_distributed_library(
                     mode,
                     worker_kwargs,
                     result_queue,
-                    tuple(device_indices),
+                    rank_device_indices,
                     tuple(device_uuids),
                 ),
                 nprocs=world_size,

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -132,15 +132,16 @@ Run artifacts (logs, `runs/*.json`, `reports/*`) live under `.bench-suite/` and 
    and, with `--with-references`, every reference implementation, retaining the original implementation
    order, correctness/reference setup, timer, warmup/repeat, five rounds, 1.0s
    cooldown before every implementation/round, raw samples, and arithmetic mean.
-5. **Fail fast**: the first workload/subprocess `FAIL` stops new scheduling,
-   terminates the suite's in-flight subprocesses, writes the partial run for
-   diagnosis, and exits with code 1. `INTERFERED` is not a workload failure and
-   is retried in the same child without repeating CPU prepare; `SKIP` is accepted
-   without retry. The old claim is released before reassignment, and the child
-   rebuilds all GPU tensors, references, workspaces, and timer state on the newly
-   assigned card. Every interference retry records the workload, attempt,
-   intruder PIDs, and `retry_in_place: true`; retried results otherwise follow
-   the ordinary measurement path.
+5. **Collect every failure**: a workload/subprocess `FAIL` is recorded and its
+   resources are released without stopping other pending or in-flight workloads.
+   After the complete sweep, the suite prints every failed workload and exits with
+   code 1. `INTERFERED` is not a workload failure and is retried in the same child
+   without repeating CPU prepare; `SKIP` is accepted without retry. The old claim
+   is released before reassignment, and the child rebuilds all GPU tensors,
+   references, workspaces, and timer state on the newly assigned card. Every
+   interference retry records the workload, attempt, intruder PIDs, and
+   `retry_in_place: true`; retried results otherwise follow the ordinary
+   measurement path.
 6. **Ratio regression report** is generated only by `--with-references` and
    compares current ref/ours ratio vs the pinned `baseline.json` ratio. Only a
    reference-enabled run can be promoted with `promote_baseline.py`.
@@ -279,6 +280,6 @@ remain in the run JSON for variance and outlier inspection.
 | Code | Meaning |
 |------|---------|
 | `0` | No regressions over threshold (or no baseline yet) |
-| `1` | A workload failed; the suite stopped immediately |
+| `1` | One or more workloads failed; all workloads were allowed to finish |
 | `2` | Config error |
 | `3` | One or more regressions exceeded `--threshold` |

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -12,7 +12,7 @@ Quick start:
 
 Exit codes:
     0  no regressions (or no baseline yet)
-    1  workload failure (suite stopped immediately)
+    1  one or more workloads failed
     2  config error (no workloads / bad YAML)
     3  one or more regressions exceeded the threshold
 """
@@ -1613,7 +1613,6 @@ def run_scheduled_jobs(
     records: list[dict] = []
     retry_log: list[dict[str, Any]] = []
     completed = 0
-    failed = False
     last_interference_poll = 0.0
     physical_uuid_by_index = dict(pool._all_gpus())
 
@@ -1635,16 +1634,15 @@ def run_scheduled_jobs(
             item.gpu_ownership_released = True
 
     def fail(item: _PreparedAttempt, message: dict | None = None) -> None:
-        nonlocal completed, failed
+        nonlocal completed
         if item.state == "FAILED":
             return
         item.state = "FAILED"
         record = _record_child_failure(item, message)
         records.append(record)
         completed += 1
-        failed = True
         detail = record.get("error") or "unknown workload failure"
-        log(f"[bench-suite] >>> FAIL-FAST {item.label} attempt {item.attempt}: {detail[:160]} <<<")
+        log(f"[bench-suite] >>> FAIL {item.label} attempt {item.attempt}: {detail[:160]} <<<")
 
     def request_interference_stop(
         item: _PreparedAttempt, intruders: list[int], detail: str
@@ -1694,7 +1692,6 @@ def run_scheduled_jobs(
     def spawn_available() -> None:
         while (
             pending
-            and not failed
             and preparing_count() < max_prepare_processes
             and buffered_count() < ready_backlog
             and len(active) < ready_backlog + visible
@@ -1713,8 +1710,6 @@ def run_scheduled_jobs(
             log(f"[bench-suite] {now_iso()} prepare pid={item.process.pid} START {item.label}")
 
     def dispatch_ready() -> None:
-        if failed:
-            return
         ordered = sorted(
             ready,
             key=lambda item: (
@@ -1784,7 +1779,7 @@ def run_scheduled_jobs(
     occupancy_thread.start()
     dispatch_thread.start()
     try:
-        while completed < n_jobs and not failed:
+        while completed < n_jobs:
             spawn_available()
             dispatch_ready()
 
@@ -1817,8 +1812,6 @@ def run_scheduled_jobs(
                         },
                     )
                     break
-            if failed:
-                break
 
             sockets = [dispatch_reader, *(item.control for item in active.values())]
             readable, _, _ = select.select(sockets, [], [], 0.1)
@@ -1923,7 +1916,11 @@ def run_scheduled_jobs(
                             f"{item.label} {impl_str}"
                         )
                         if record.get("status") not in ("ok", "SKIP"):
-                            failed = True
+                            detail = record.get("error") or "unknown workload failure"
+                            log(
+                                f"[bench-suite] >>> FAIL {item.label} attempt {item.attempt}: "
+                                f"{detail[:160]} <<<"
+                            )
                     elif message_type == "FAIL":
                         fail(item, message)
                         break
@@ -1936,15 +1933,20 @@ def run_scheduled_jobs(
                             },
                         )
                         break
-                if failed:
-                    break
                 if eof and item.state not in ("RESULT", "FAILED"):
                     item.process.poll()
                     fail(item)
                     break
 
             for item in list(active.values()):
-                if item.state == "RESULT" and item.process.poll() is not None:
+                if item.state == "FAILED":
+                    if item.process.poll() is None:
+                        _terminate_subprocess(item.process)
+                    release_gpus(item)
+                    fd = item.control.fileno()
+                    _finish_attempt_process(item)
+                    active.pop(fd, None)
+                elif item.state == "RESULT" and item.process.poll() is not None:
                     fd = item.control.fileno()
                     _finish_attempt_process(item)
                     active.pop(fd, None)
@@ -1958,7 +1960,7 @@ def run_scheduled_jobs(
         dispatch_writer.close()
         for item in list(active.values()):
             fd = item.control.fileno()
-            if item.process.poll() is None and item.state == "RESULT" and not failed:
+            if item.process.poll() is None and item.state == "RESULT":
                 try:
                     item.process.wait(timeout=10)
                 except subprocess.TimeoutExpired:
@@ -1989,6 +1991,7 @@ def run_scheduled_jobs(
         },
         "interference_retry_count": len(retry_log),
         "interference_retries": retry_log,
+        "failure_count": sum(record.get("status") == "FAIL" for record in records),
     }
     return records, retry_log, pipeline
 
@@ -2303,12 +2306,14 @@ def main() -> None:
 
     failures = [record for record in results if record.get("status") == "FAIL"]
     if failures:
-        first = failures[0]
-        print(
-            f"[bench-suite] stopped after workload failure: "
-            f"{first['kernel']}/{first.get('config') or first.get('label')}",
-            file=sys.stderr,
-        )
+        print(f"[bench-suite] workload failure summary: {len(failures)}", file=sys.stderr)
+        for failure in failures:
+            detail = (failure.get("error") or "unknown workload failure").splitlines()[0]
+            print(
+                f"[bench-suite]   - {failure['kernel']}/"
+                f"{failure.get('config') or failure.get('label')}: {detail}",
+                file=sys.stderr,
+            )
         sys.exit(1)
 
     if args.no_report:


### PR DESCRIPTION
## Summary

Persistent GemmReduceScatter kernels could release TMEM while peer ranks were still issuing multicast reductions. The suite infrastructure could also manufacture similar CUDA failures by assigning physical GPU indices directly to rank processes or co-locating correctness cases on one card. Benchmark sweeps stopped at the first workload failure, hiding later failures.

This PR establishes one execution contract across those paths:

- Aggregate all 74 local GemmRS clusters before one leader enters the cross-rank rendezvous, and keep each CTA pair joined until every rank arrives.
- Verify the compact two-counter GemmRS terminal state on every correctness relaunch.
- Translate late GemmComm GPU assignments into a dense rank-local `CUDA_VISIBLE_DEVICES` space.
- Separate required communication-library locks from optional external-baseline provenance.
- Give every correctness case exclusive ownership of its assigned GPUs and reject cards with foreign compute processes.
- Reap and record failed benchmark workloads while unrelated work continues, then print one complete failure summary.

The CUDA tensor-map enum fix needed by the swizzle=4 path is covered by apache/tvm#20154. This branch is rebased onto the low-level helper refactor in #62 and retains only the explicitly allowed NVSHMEM exit helper.

## Validation

- Default benchmark suite: 140/140 workloads passed; 8 detected interference attempts retried successfully.
- Complete 16-shape GemmRS matrix: 320 correctness relaunches passed, including 160 TP4 launches.
- Previously failing TP4 benchmark: 5 rounds / 175 launches passed.
- Collect-all fault injection: two failures were recorded, a later valid workload still ran, and the final exit code remained 1.
- `pytest -q tests/test_low_level_ir.py`: 2 passed.
- Correctness collection: 1644 cases collected; 1636 are compatible with GPU0-6. The remaining 8 DeepEP cases require 8 GPUs.
- `ruff check`, `py_compile`, and `git diff --check` passed.
- apache/tvm#20154 rebuilt with `USE_NVSHMEM=ON`; the rebased TP4 module compiled offline without initializing CUDA.

## Full-sweep evidence

A pre-isolation collect-all sweep completed with 1633/1636 compatible cases passing and collected three GemmRS CUDA failures. The TP1 fault localized to the kernel's intentional full-TMEM allocation trap under a co-runner. The TP4 faults were collected on cards that the old allocator admitted despite external processes. The standalone GemmRS matrix passed after the exit fix.

A final full sweep with the new whole-GPU allocator could not be scheduled because every allowed GPU0-6 had a foreign compute process. The PR does not hide or retry those correctness failures.
