### PR TITLE
feat(kernel): port flashinfer filtered topk kernel to tirx

### DIFF
--- a/.agents/sketch/flashinfer/topk/filtered_topk.md
+++ b/.agents/sketch/flashinfer/topk/filtered_topk.md
@@ -1,0 +1,710 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of FlashInfer's
+include/flashinfer/topk.cuh FilteredTopK pipeline: FilteredTopKUnifiedKernel
+and its companion FinalizeTopKIndicesKernel.
+-->
+
+# filtered_topk SM100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/flashinfer/topk/filtered_topk.py`](../../../../tirx_kernels/flashinfer/topk/filtered_topk.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **two kernels**, because the dispatchers launch them as one
+pipeline. `FilteredTopKUnifiedKernel<DType, int32_t, VEC_SIZE, DETERMINISTIC,
+MODE, TIE_BREAK>` (:2362) selects the top-k; `FinalizeTopKIndicesKernel<SORT,
+MODE, BT, IPT, DType, int32_t>` (:2958) then sorts each row's indices ascending
+and applies the deferred PageTable/Ragged transform whenever the first kernel
+deferred it. Omitting the second would leave "deterministic" output with a
+deterministic *set* in a nondeterministic *order*.
+
+Instantiations: `DType in {f32, f16, bf16}` x `MODE in {Plain, PageTable,
+Ragged}` x `TIE_BREAK in {None, Small, Large}` x `DETERMINISTIC` x `VEC_SIZE in
+{4,2,1}` (f32) / `{8,4,2,1}` (16-bit). `DETERMINISTIC` is not the user's
+`deterministic` flag: it is `deterministic || tie_break != None` (:3181), so the
+four reachable template combinations are `(F,None)`, `(T,None)`, `(T,Small)`,
+`(T,Large)`. `num_rows`, `max_len`, `top_k` and the derived `VEC_SIZE`,
+`end_bit`, finalize `(BT, IPT)` are static per config, exactly like the values
+`LaunchFilteredTopKUnified` (:3170) and `LaunchFinalizeTopKIndices` (:3032)
+compute per call.
+
+Accepted target SM100/B200. Out of scope, with the dispatch predicate that
+excludes each: `top_k > FILTERED_TOPK_MAX_K == 2048` (radix-only, :3333);
+`sorted_output` (`StableSortTopKByValueKernel` :3090, which both radix ports also
+leave out); fp8 (never instantiated, :2277-2337); and the SM100 cluster kernel,
+which the `FLASHINFER_TOPK_ALGO=filtered` pin keeps out of the reference path.
+Tile (`Tx`) primitives are out of scope everywhere.
+
+## Pipeline at a glance
+
+| Kernel / role | Program | Publication / reuse edges |
+| --- | --- | --- |
+| **Unified**, all 32 warps of the single CTA (uniform, no warp specialization) | trivial early-out; coarse 256-bin histogram over `ToCoarseKey`; 8-step ping-pong suffix scan; threshold-bin pick; **filter** pass compacting only threshold-bin candidates into a 16K shared index buffer; 1 or 4 refine rounds over that buffer; tie collection; mode epilogue | Everything is intra-CTA: `bar.sync 0` around `s_histogram`, `s_indices`, `s_input_idx`, and the scalars. `atom.shared.add.u32` publishes histogram bins and output slots. There are **no global atomics, no workspace, no clusters, and no cross-CTA edges at all** — one CTA owns one row. |
+| **Unified**, thread 0 / one predicated thread | `s_refine_overflow` init (:2451); per-round pivot bytes under DETERMINISTIC (:2683-2687); and — note — the counter resets at :2519-2523 are done by *the single thread that finds the threshold bin*, not by tx0 | published through `bar.sync 0` |
+| **Finalize**, all BT threads | load <= k row indices as blocked per-thread `uint32` keys with `~0u` padding; `SORT` ? cub BlockRadixSort over `[0, end_bit)` : nothing; deferred transform; writeback with `~0u -> -1` | rank counters and the exchange buffer alias one shared union; `bar.sync 0` per rank/exchange phase |
+
+The two kernels communicate only through `output_indices` (and `output_values`
+in Plain) in global memory — the finalize kernel re-reads what the unified kernel
+wrote.
+
+## Primitive vocabulary
+
+```python
+copy_g2r_v(dst_reg, gmem, n)      # vectorized row read, VEC_SIZE lanes
+copy_r2s(smem, reg) / copy_s2r    # shared traffic, always through T.ptx
+to_coarse(v)                      # Traits::ToCoarseKey  (:2282-2289 / :2306-2311 / :2326-2331)
+to_ordered(v)                     # Traits::ToOrdered     (:2291-2294 / :2313-2316 / :2333-2336)
+# Both are written in source as `(bits & sign) ? ~bits : (bits | sign)`, i.e. the OR/NOT form.
+# RadixTopKTraits::ToOrdered (topk_common.cuh:35-49) is the XOR form instead; the two must NOT be
+# unified, because StableSortTopKByValueKernel (:3094) needs the XOR form's FromOrdered inverse.
+# NOTE this is a SOURCE-level distinction only -- see the instruction-selection table for what
+# each one actually lowers to, which is not the same thing.
+atomic_add_shared(smem, i, v)     # atom.shared.add.u32, returns old
+atomic_or_shared(smem, i, v)      # atom.shared.or.b32, result discarded
+barrier()                         # bar.sync 0
+warp_incl_sum(v, lane)            # 5-step shfl.sync.up.b32 inclusive scan
+block_exclusive_sum(v)            # cub BlockScan, RAKING_MEMOIZE geometry
+rank_keys(keys) / scatter_blocked(items, ranks)   # finalize only, per digit pass
+```
+
+`for_each_score(fn)` is the row-scan helper (:2467-2481): a `#pragma unroll 2`
+vector loop over `aligned_length = (length / VEC_SIZE) * VEC_SIZE` followed by a
+scalar tail.  The vector load is `ld.global.nc.v4.b32` for **both** f32 VEC_SIZE=4
+and 16-bit VEC_SIZE=8 (16 bytes either way), `ld.global.nc.v2.b32` for f32
+VEC_SIZE=2, `ld.global.nc.v2.b16` for 16-bit VEC_SIZE=2, and a scalar
+`ld.global.nc.b32`/`b16` for the tail. It is shown expanded once and folded thereafter; it is re-run in
+full on every phase that rescans the row.
+
+## Complete sketch — unified kernel
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+variant = specialize(DTYPE=("f32","f16","bf16"), MODE=("Plain","PageTable","Ragged"),
+                     TIE_BREAK=("None","Small","Large"), DETERMINISTIC=(False,True),
+                     VEC_SIZE=(8,4,2,1), target="sm_100a")
+# instruction_selection: none; extent: compile-time instantiations
+
+BLOCK        = 1024                    # FILTERED_TOPK_BLOCK_THREADS (:2341)
+RADIX        = 256
+SMEM_INPUT   = 16384                   # FILTERED_TOPK_SMEM_INPUT_SIZE (:2342)
+DYN_SMEM     = 4 * 2 * SMEM_INPUT      # 131072 B, compile-time constant (:2343-2344)
+NUM_ROUNDS   = 4 if DTYPE == "f32" else 1     # Traits::NUM_REFINE_ROUNDS
+FIRST_SHIFT  = 24 if DTYPE == "f32" else 0    # Traits::FIRST_REFINE_SHIFT
+# VEC_SIZE = gcd(max_len, 16/sizeof) (:2941), forced to 1 by dsa_graph_safe (:2936-2938)
+# and by a non-null row_starts on a transform mode (:3190-3192).
+
+launch_config = launch(grid=(NUM_ROWS,1,1), block=(BLOCK,1,1),
+                       dynamic_smem_bytes=DYN_SMEM, launch_bounds=BLOCK)
+# instruction_selection: none; extent: static launch metadata.  cudaFuncSetAttribute
+#   (MaxDynamicSharedMemorySize, 131072) is re-issued on every launch (:3198); in TIRx the
+#   pool high-water mark drives the request via `tirx.use_dyn_shared_memory`.
+
+# ===========================================================================
+# Storage  (:2431-2446)
+# ===========================================================================
+s_hist2   = static_shared((2, RADIX + 128), "int32", align=128)   # (:2432) ping-pong scan
+s_hist    = view(s_hist2[0])                                      # (:2443) buffer 0 is live
+s_counter          = static_shared((1,), "int32")                 # (:2433)
+s_threshold_bin_id = static_shared((1,), "int32")                 # (:2434)
+s_refine_thresholds= static_shared((4,), "int32")                 # (:2436) DETERMINISTIC only
+s_num_input        = static_shared((2,), "int32")                 # (:2437)
+s_indices          = static_shared((2048,), "int32", align=128)   # (:2438) FILTERED_TOPK_MAX_K
+s_refine_overflow  = static_shared((1,), "int32")                 # (:2440)
+s_last_remain      = static_shared((1,), "int32")                 # (:2441)
+s_input_idx        = dyn_shared((2, SMEM_INPUT), "int32")         # (:2446) 131072 B
+if DETERMINISTIC:
+    s_scan_temp = static_shared(cub_blockscan_raking_bytes)       # (:2584-2585)
+if TIE_BREAK in (Small, Large):
+    s_emitted    = static_shared((1,), "uint32")                  # (:313) chunk-walk state,
+    s_chunk_base = static_shared((1,), "uint32")                  # (:314) 12 B total, live only
+    s_chunk_take = static_shared((1,), "uint32")                  # (:315) across the collector
+# instruction_selection: none; extent: static shared layout.
+#   INVARIANT: `s_hist[RADIX]` must stay 0.  It is the exclusive-suffix sentinel read at
+#   :2508/:2513/:2519/:2527/:2688 and again in both fallbacks at :2842/:2843/:2850; it is
+#   zeroed by the `tx < RADIX + 1` clears (:2457, :2562, :2650, :2712, :2816) and never
+#   written by the scan (which only ever writes indices < RADIX).
+
+def filtered_topk(input, out_idx, out_val, aux, lengths, row_starts,
+                  page_table_row_starts, row_to_batch, aux_stride):
+    row = cta_id(axis="x", extent=NUM_ROWS)     # instruction_selection: mov.u32 %ctaid.x
+    tx  = thread_id(extent=BLOCK)               # instruction_selection: mov.u32 %tid.x
+    if row >= NUM_ROWS: return                  # (:2382)
+
+    # ---- per-row header (:2384-2406) --------------------------------------
+    length     = load_global(lengths[row]) if lengths else MAX_LEN     # (:2384)
+    row_start  = load_global(row_starts[row]) if (row_starts and MODE != Plain) else 0
+    page_start = load_global(page_table_row_starts[row]) if (pts and MODE == PageTable) else row_start
+    score      = input + row * MAX_LEN + row_start                     # (:2391)
+    dst        = out_idx + row * top_k                                 # (:2392)
+    # instruction_selection: ld.global.nc.b32 per optional pointer (the inputs are
+    #   `__restrict__ const`, so every unified-kernel global read is non-coherent);
+    #   extent: scalar per row
+    if MODE == PageTable:
+        batch = load_global(row_to_batch[row]) if row_to_batch else row
+        src_page_entry = aux + batch * aux_stride                      # (:2400-2402)
+    elif MODE == Ragged:
+        offset_val = load_global(aux[row])                             # (:2403)
+    else:
+        dst_values = out_val + row * top_k                             # (:2404)
+
+    # ---- trivial early-out, length <= top_k (:2409-2429) ------------------
+    if length <= top_k:
+        i = tx
+        while i < top_k:                                               # (:2410)
+            # The source is an if/else with FOUR independent store sites.  nvcc splits them
+            # by shape: the two arms that must GUARD A LOAD (:2414 Plain value, :2423 PageTable
+            # gather) become `@p bra`, while the two that merely SELECT A VALUE (:2421, :2425)
+            # become `selp.b32`.  Same rule as the finalize writeback below.
+            if MODE == Plain:
+                if i < length:                                          # (:2412-2415)
+                    store_global(dst[i], i)
+                    store_global(dst_values[i], load_global(score[i]))
+                    # instruction_selection: st.global.b32 (.loc 2 2413) +
+                    #   ld.global.nc.b32|b16 (.loc 2 2414) + st.global.b32|b16; extent: one pair
+                else:                                                   # (:2416-2417)
+                    store_global(dst[i], -1); store_global(dst_values[i], 0)
+                    # instruction_selection: 2x st.global.b32|b16 of immediates
+            elif DETERMINISTIC:
+                store_global(dst[i], i if i < length else -1)            # (:2419-2421)
+                # NOTE local index, transform DEFERRED to the finalize kernel
+                # instruction_selection: selp.b32 (.loc 2 2421) + st.global.b32; extent: one
+                #   scalar store.  Pure value select, no load to guard -> no branch.
+            elif MODE == PageTable:
+                if i < length:                                          # (:2422-2423)
+                    store_global(dst[i], load_global(src_page_entry[page_start + i]))
+                else:
+                    store_global(dst[i], -1)
+                # instruction_selection: @p bra over ld.global.nc.b32 (.loc 2 2423) +
+                #   st.global.b32; extent: one gather pair.  No selp is emitted here.
+            else:
+                store_global(dst[i], i + offset_val if i < length else -1)   # (:2424-2426)
+                # instruction_selection: add.s32 + selp.b32 (.loc 2 2425) + st.global.b32;
+                #   extent: one scalar store.  Value select, not a branch.
+            i = i + BLOCK
+        return                                                          # (:2428)
+
+    # ---- init (:2450-2458) ------------------------------------------------
+    topk = top_k                                                        # register (:2450)
+    if tx == 0: store_shared(s_refine_overflow, 0)                      # (:2451)
+    if DETERMINISTIC and tx < 4: store_shared(s_refine_thresholds[tx], 0xFF)
+    if tx < RADIX + 1: store_shared(s_hist[tx], 0)                      # 257 entries (:2457)
+    barrier()
+    # instruction_selection: st.shared.b32 + bar.sync 0; extent: CTA-wide
+
+    # ===================================================================
+    # Stage 1: coarse histogram over the whole row (:2482-2487)
+    # ===================================================================
+    for v, i in for_each_score():                                       # (:2486)
+        atomic_add_shared(s_hist, to_coarse(v), 1)
+        # instruction_selection: cvt.rn.f16.f32 (f32 only) + setp/selp/or/not for the
+        #   monotone flip + shr + atom.shared.add.u32; extent: one per element.
+        #   f32's ToCoarseKey rounds through fp16 (:2284) and is therefore LOSSY, but it is
+        #   re-derived identically in every phase, so the partition stays consistent.
+    barrier()
+
+    # ---- run_cumsum: Hillis-Steele inclusive SUFFIX scan (:2489-2504) -----
+    def run_cumsum():
+        for i in unroll(8):                                             # (:2490-2491)
+            if tx < RADIX:
+                j = 1 << i; k = i & 1
+                value = load_shared(s_hist2[k][tx])
+                if tx < RADIX - j:
+                    value = value + load_shared(s_hist2[k][tx + j])
+                store_shared(s_hist2[k ^ 1][tx], value)
+                # instruction_selection: ld.shared.b32 x2 + add.s32 + st.shared.b32;
+                #   extent: one per active lane per step
+            barrier()                                                   # (:2502)
+        # INVARIANT: 8 is even, so the result lands back in buffer 0 == s_hist.
+        # Changing RADIX or the step count silently breaks this.
+
+    # ---- first threshold pick (:2517-2524) --------------------------------
+    run_cumsum()
+    if tx < RADIX and load_shared(s_hist[tx]) > topk and load_shared(s_hist[tx+1]) <= topk:
+        store_shared(s_threshold_bin_id, tx)                            # (:2519-2523)
+        store_shared(s_num_input[0], 0)
+        store_shared(s_counter, 0)
+        # instruction_selection: three short-circuit guards (`@%p bra` over setp.gt.u32
+        #   (tx > 255) / setp.le.s32 / setp.gt.s32 -- these are the NEGATED source predicates,
+        #   emitted in that order; the export shows and.pred = 0) + 3x st.shared.b32;
+        #   extent: exactly ONE thread satisfies this.  The counter resets ride on that same
+        #   predicate -- they are NOT a tx0 block.  Uniqueness follows from the suffix scan's
+        #   monotonicity plus `length > top_k`.
+    barrier()
+    threshold_bin = load_shared(s_threshold_bin_id)                     # (:2526)
+    topk = topk - load_shared(s_hist[threshold_bin + 1])                # (:2527) now = how
+                                                                        # many are still owed
+                                                                        # from INSIDE the bin
+    topk_after_coarse = topk                                            # (:2528)
+
+    # ---- fast exit: the coarse pass already resolved k (:2549-2559) -------
+    if topk == 0:
+        for v, i in for_each_score():
+            if to_coarse(v) > threshold_bin:
+                pos = atomic_add_shared(s_counter, 1)
+                store_shared(s_indices[pos], i)
+                # instruction_selection: atom.shared.add.u32 + st.shared.b32
+        barrier()
+        goto OUTPUT
+
+    # ===================================================================
+    # Stage 2: FILTER -- the step the algorithm is named for (:2611-2629)
+    # Only the threshold bin's candidates are compacted into s_input_idx, so
+    # every later pass re-reads <= 16384 scattered elements instead of the row.
+    # ===================================================================
+    barrier()                                                           # (:2561) opens the
+                                                                        # else branch
+    if tx < RADIX + 1: store_shared(s_hist[tx], 0)                      # (:2562)
+    barrier()                                                           # (:2563)
+    for v, i in for_each_score():                                       # (:2628)
+        bin = to_coarse(v)
+        if bin > threshold_bin:                                         # strict winner
+            pos = atomic_add_shared(s_counter, 1)
+            store_shared(s_indices[pos], i)
+        elif bin == threshold_bin:                                      # candidate
+            pos = atomic_add_shared(s_num_input[0], 1)
+            if likely(pos < SMEM_INPUT):                                # __builtin_expect (:2618)
+                store_shared(s_input_idx[0][pos], i)
+                sub = (to_ordered(v) >> FIRST_SHIFT) & 0xFF
+                atomic_add_shared(s_hist, sub, 1)
+                # instruction_selection: atom.shared.add.u32 x2 + st.shared.b32 + shr + and
+            else:
+                atomic_or_shared(s_refine_overflow, 1)                  # (:2624)
+                # instruction_selection: atom.shared.or.b32 (result discarded -- the export
+                #   shows atom, NOT the red.shared.or.b32 reduction form)
+    barrier()
+
+    # ===================================================================
+    # Stage 3: refine rounds over the candidate buffer (:2675-2709)
+    # ===================================================================
+    def run_refine_round(r_idx, offset, is_last):
+        # r_idx is the PING-PONG BUFFER index (round % 2, :2775), never the round number --
+        # s_input_idx / s_num_input are 2 deep, so indexing them by the round would run off
+        # the end from round 2 onwards.
+        num_input = min(load_shared(s_num_input[r_idx]), SMEM_INPUT)     # (:2677-2678)
+        update_refine_threshold(next=r_idx ^ 1, reset=True)              # (:2680) = run_cumsum
+                                                                         # (:2507) + the same
+                                                                         # predicated pick, also
+                                                                         # writing s_last_remain
+                                                                         # (:2513).  It does NOT
+                                                                         # touch s_counter --
+                                                                         # only the first pick
+                                                                         # (:2522) resets that.
+        threshold = load_shared(s_threshold_bin_id)
+        if DETERMINISTIC and tx == 0:
+            store_shared(s_refine_thresholds[(FIRST_SHIFT - offset) // 8], threshold)  # (:2685)
+        topk = topk - load_shared(s_hist[threshold + 1])                 # (:2688)
+        if topk == 0:                                                    # (:2689-2701)
+            i = tx
+            while i < num_input:
+                idx = load_shared(s_input_idx[r_idx][i])
+                # instruction_selection: ld.shared.b32 (.loc 2 2692); extent: one per candidate
+                if ((to_ordered(load_global(score[idx])) >> offset) & 0xFF) > threshold:
+                    # instruction_selection: ld.global.nc.b32|b16 (.loc 2 2693) + the ToOrdered
+                    #   sequence + shr + and + setp.gt.s32; extent: one per candidate
+                    pos = atomic_add_shared(s_counter, 1)
+                    store_shared(s_indices[pos], idx)
+                    # instruction_selection: atom.shared.add.u32 + st.shared.b32 (.loc 2 2696)
+                i = i + BLOCK
+            barrier()                                                    # (:2699)
+            return True                                                  # pivot resolved
+        if is_last:
+            collect_with_threshold_last_round(r_idx, num_input, offset, threshold)  # (:2635-2645)
+            # one barrier (:2644)
+        else:
+            collect_with_threshold_non_last_round(r_idx, num_input, offset, threshold)  # (:2646-2672)
+            # THREE barriers (:2649, :2651, :2671): clear the histogram, then ping-pong the
+            # survivors into s_input_idx[r_idx ^ 1] with the NEXT byte's histogram, or set
+            # s_refine_overflow when that buffer would overflow too.
+        return False
+
+    if NUM_ROUNDS == 1:                                                  # 16-bit (:2710-2766)
+        if load_shared(s_refine_overflow):                               # (:2711) FALLBACK
+            # A coarse bin held more than 16384 candidates, so the compacted buffer is
+            # truncated and unusable.  Rebuild the selection from the row instead.
+            if tx < RADIX + 1: store_shared(s_hist[tx], 0)               # (:2712)
+            barrier()                                                    # (:2713)
+            for v, i in for_each_score():                                # (:2715-2724)
+                if to_coarse(v) == threshold_bin:
+                    atomic_add_shared(s_hist, to_ordered(v) & 0xFF, 1)
+                    # instruction_selection: ld.global.nc.b16 + the ToOrdered pair + and +
+                    #   atom.shared.add.u32; extent: one per row element in the bin
+            barrier()                                                    # (:2725)
+            if tx == 0:                                                  # (:2727-2730)
+                store_shared(s_threshold_bin_id, 0); store_shared(s_last_remain, 0)
+            barrier()                                                    # (:2731)
+            update_refine_threshold(next=0, reset=False)                 # (:2733) the ONLY
+                                                                         # RESET_NEXT_INPUT=false
+                                                                         # call in the kernel
+            for v, i in for_each_score():                                # (:2740-2748)
+                if to_coarse(v) != threshold_bin: continue               # (:2741-2744) ONLY
+                                                                         # threshold-bin elements
+                                                                         # are re-examined by low
+                                                                         # byte; without this the
+                                                                         # pass would re-collect
+                                                                         # the strict winners the
+                                                                         # filter stage already
+                                                                         # appended
+                collect_gt_and_nondet_eq_threshold(to_ordered(v) & 0xFF,  # (:2745-2747)
+                                                   load_shared(s_threshold_bin_id), i, True)
+                # appends AFTER the s_counter prefix the coarse pass already wrote (:2737-2739)
+            barrier()                                                    # (:2751)
+            if DETERMINISTIC:
+                collect_det_eq_pivot(pivot=(threshold_bin << 8) | threshold,
+                                     eq_needed=load_shared(s_last_remain))   # (:2752-2757)
+        else:
+            run_refine_round(r_idx=0, offset=FIRST_SHIFT, is_last=True)  # (:2759-2762)
+            if DETERMINISTIC:
+                collect_det_eq_pivot(pivot=build_det_pivot(0), eq_needed=topk)  # (:2763-2765)
+    else:                                                                # f32 (:2767-2902)
+        det_stop_round = NUM_ROUNDS - 1                                  # (:2771)
+        if not load_shared(s_refine_overflow):                           # (:2772) the whole
+                                                                         # round loop is GUARDED
+            for round in unroll(4):                                      # (:2774)
+                r_idx  = round % 2                                       # (:2775) buffer index
+                offset = FIRST_SHIFT - round * 8                         # (:2776)
+                if run_refine_round(r_idx, offset, is_last=(round == 3)):
+                    det_stop_round = round; break                        # (:2778-2787)
+                if load_shared(s_refine_overflow): break                 # (:2788-2790)
+        # (:2792) the guarded round loop CLOSES here.  The deterministic collect below is at
+        # the OUTER level and carries its OWN re-check, because run_refine_round can set
+        # s_refine_overflow mid-loop via the atomicOr at :2667; the source comments exactly this
+        # at :2798-2799 ("intentionally separate from the first if (!s_refine_overflow)").
+        # Nesting it inside the pre-loop guard would let a stale collect write tie fillers that
+        # the fallback then re-collects at a different offset.
+        if DETERMINISTIC:                                                # (:2793)
+            if not load_shared(s_refine_overflow):                       # (:2794) SEPARATE check
+                collect_det_eq_pivot(pivot=build_det_pivot(det_stop_round),
+                                     eq_needed=topk)                     # (:2795)
+        if load_shared(s_refine_overflow):                               # (:2800) FALLBACK
+            # 32-bit pivot rebuild.  static_assert(sizeof(OrderedType) == 4) at :2801-2802.
+            topk_remain = topk_after_coarse                              # (:2804)
+            threshold_bytes = [0xFF, 0xFF, 0xFF, 0xFF]                   # (:2805-2810)
+            stop_round = NUM_ROUNDS - 1
+            for round in unroll(4):                                      # (:2812)
+                if tx < RADIX + 1: store_shared(s_hist[tx], 0)           # (:2816)
+                barrier()                                                # (:2817)
+                for v, i in for_each_score():                            # (:2819-2837)
+                    ordered = to_ordered(v)
+                    if to_coarse(v) == threshold_bin and prefix_matches(ordered, threshold_bytes, round):
+                        atomic_add_shared(s_hist, (ordered >> (24 - round*8)) & 0xFF, 1)
+                        # instruction_selection: ld.global.nc.b32 + ToOrdered + shr + and +
+                        #   setp chain + atom.shared.add.u32; extent: one per row element
+                barrier()                                                # (:2839)
+                run_cumsum()                                             # (:2841)
+                if tx < RADIX and crossing_predicate:                    # (:2842-2846)
+                    store_shared(s_threshold_bin_id, tx)                 # writes ONLY the bin id
+                barrier()                                                # (:2846)
+                threshold_bytes[round] = load_shared(s_threshold_bin_id)
+                topk_remain -= load_shared(s_hist[threshold_bytes[round] + 1])   # (:2850)
+                barrier()                                                # (:2852)
+                if topk_remain == 0: stop_round = round; break           # (:2853-2856)
+            pivot = assemble(threshold_bytes, stop_round)                # (:2859-2868) byte[round]
+                                                                         # is forced to 0xFF when
+                                                                         # topk_remain == 0 and
+                                                                         # round > stop_round
+                                                                         # (:2864-2866)
+            if tx == 0:                                                  # (:2873-2876)
+                store_shared(s_counter, 0); store_shared(s_last_remain, topk_remain)
+            barrier()                                                    # (:2877)
+            for v, i in for_each_score():                                # (:2883-2895)
+                # three-way dispatch, NOT a single collector call:
+                if to_coarse(v) > threshold_bin:                         # (:2885-2889)
+                    collect_gt_and_nondet_eq_threshold(to_coarse(v), threshold_bin, i,
+                                                       allow_eq_claim=False)
+                    continue                                             # compares COARSE keys
+                elif to_coarse(v) != threshold_bin:                      # (:2890-2892)
+                    continue                                             # dropped
+                collect_gt_and_nondet_eq_threshold(to_ordered(v), pivot, i,   # (:2893-2894)
+                                                   allow_eq_claim=(eq_needed > 0))
+                # compares the FULL 32-bit ordered key against the rebuilt pivot
+            barrier()                                                    # (:2897)
+            if DETERMINISTIC:
+                collect_det_eq_pivot(pivot=pivot, eq_needed=topk_remain) # (:2898-2900)
+
+    # ===================================================================
+    # Stage 4: tie handling at the pivot -- SHARED HELPER DESCRIPTION.
+    # The four call sites are shown above at their source positions inside the
+    # Stage-3 branch structure (:2752-2757, :2763-2765, :2793-2797, :2898-2900),
+    # each with its own pivot source and eq_needed source.
+    # ===================================================================
+    # NON-DETERMINISTIC (:2571-2578) -- inside collect_gt_and_nondet_eq_threshold:
+    #   equal-to-pivot elements race for the remaining slots, filling s_indices from the BACK:
+    #       pos = atomic_add_shared(s_last_remain, -1)      # atom.shared.add.u32 (negative)
+    #       if pos > 0: store_shared(s_indices[top_k - pos], idx)
+    #   So s_indices[0:s_counter) are strict winners and the tail holds tie fillers; WHICH ties
+    #   win is racy.  This branch is `else if constexpr (!DETERMINISTIC)` -- it does not exist
+    #   in the deterministic instantiations.
+    #
+    # DETERMINISTIC (:2582-2608) -- collect_det_eq_pivot(pivot, eq_needed):
+    def collect_det_eq_pivot(pivot, eq_needed):   # (:2582-2608), DETERMINISTIC only
+      if eq_needed > 0:
+        if TIE_BREAK == Small:
+            deterministic_contiguous_collect(REVERSE=False)   # (:2591-2595) -> smallest indices
+        elif TIE_BREAK == Large:
+            deterministic_contiguous_collect(REVERSE=True)    # (:2596-2600) -> largest indices
+        else:
+            deterministic_thread_strided_collect()            # (:2601-2606)
+        # predicate is always `to_ordered(score[idx]) == pivot`; emit target is
+        # s_indices[top_k - eq_needed + local_pos] (:2587-2590).
+        # instruction_selection: cub BlockScan ExclusiveSum -> 5x shfl.sync.up.b32 per warp
+        #   scan + bar.sync 0; extent: the export shows shfl.sync.up.b32 = 10 on every
+        #   DETERMINISTIC instantiation and 0 on every non-deterministic one.
+        # contiguous variant (:298-377): ITEMS_PER_THREAD=4, CHUNK=4096, a quota walk with
+        #   shared s_emitted/s_chunk_base/s_chunk_take and an early break at the limit.
+        # instruction_selection: the predicate re-reads the row: ld.global.nc.b32|b16
+        #   (.loc 2 2594/2599/2604) + the ToOrdered sequence + setp.eq; extent: one per
+        #   scanned index.
+        # build_det_pivot(stop_round) (:2534-2547) reassembles the pivot from
+        #   s_refine_thresholds: 16-bit -> (threshold_bin << 8) | s_refine_thresholds[0];
+        #   32-bit -> OR of s_refine_thresholds[round] << (24 - round*8) for round <=
+        #   stop_round, 0xFF for later rounds.
+
+    # ===================================================================
+    # Stage 5: output (:2905-2918).  All top_k slots are filled on this path
+    # (strict winners + tie fillers sum to exactly top_k), so there is NO -1
+    # padding here -- only the trivial path pads.
+    # ===================================================================
+    OUTPUT:
+    for base in serial(tx, top_k, step=BLOCK, unroll=2):                 # (:2906)
+        idx = load_shared(s_indices[base])
+        if MODE == Plain:
+            store_global(dst[base], idx)                                 # (:2910)
+            store_global(dst_values[base], load_global(score[idx]))      # (:2911)
+            # instruction_selection: st.global.b32 (.loc 2 2910) +
+            #   ld.global.nc.b32|b16 (.loc 2 2911) + st.global.b32|b16
+        elif DETERMINISTIC:
+            store_global(dst[base], idx)                                 # (:2913) transform
+                                                                         # DEFERRED to finalize
+            # instruction_selection: st.global.b32; extent: one scalar store
+        elif MODE == PageTable:
+            store_global(dst[base], load_global(src_page_entry[page_start + idx]))   # (:2915)
+            # instruction_selection: ld.global.nc.b32 (.loc 2 2915) + st.global.b32;
+            #   extent: one gather pair
+        else:
+            store_global(dst[base], idx + offset_val)                    # (:2917)
+            # instruction_selection: add.s32 + st.global.b32; extent: one scalar store
+```
+
+## Complete sketch — finalize kernel
+
+```python
+# Launched only when `finalize_plan` says so; see the matrix below.
+launch_config = launch(grid=(NUM_ROWS,1,1), block=(BT,1,1), dynamic_smem_bytes=0,
+                       launch_bounds=BT)
+# BT, IPT from the k ladder (:3061-3079); end_bit = bit_length(max_len), static here
+# (the reference computes it at runtime -- the export shows clz.b32 = 1 per instantiation).
+
+def filtered_topk_finalize(out_idx, out_val, aux, page_table_row_starts, row_to_batch, aux_stride):
+    row = cta_id(axis="x", extent=NUM_ROWS); tx = thread_id(extent=BT)
+    row_output = out_idx + row * top_k                                   # (:2971)
+    keys   = alloc_local(IPT, "uint32")
+    values = alloc_local(IPT, DTYPE)          # Plain only
+
+    # ---- load, blocked arrangement, ~0u padding (:2976-2991) -------------
+    for i in unroll(IPT):
+        pos = tx * IPT + i
+        if pos < top_k:
+            idx = load_global(row_output[pos])
+            keys[i] = select(idx >= 0, idx, 0xFFFFFFFF)                  # (:2980)
+            # instruction_selection: ld.global.b32 + **max.s32 (imm -1)** (.loc 2 2981) --
+            #   nvcc folds the `(idx >= 0) ? idx : ~0u` clamp into a single max; there is no
+            #   setp/selp pair.  Note the finalize kernel's pointers are NOT __restrict__, so
+            #   its loads are plain `ld.global.b32`, unlike the unified kernel's `.nc` forms.
+            if MODE == Plain: values[i] = load_global(out_val[row*top_k + pos])
+        else:
+            keys[i] = 0xFFFFFFFF; values[i] = 0                          # (:2986-2990)
+    # PADDING INVARIANT: the sort covers [0, end_bit) and `~0u` truncated to end_bit bits is
+    # 2^end_bit - 1, while every valid index is <= max_len - 1 < 2^end_bit - 1.  So padding is
+    # strictly maximal in EVERY digit pass and sorts last.  The full 0xFFFFFFFF survives in the
+    # untouched high bits, which is what the `idx != ~0u` guards below still test.
+
+    # ---- block radix sort, ascending over [0, end_bit) (:2993-2999) ------
+    if SORT:
+        for (begin_bit, pass_bits) in static_passes(end_bit):   # 2..5 passes, RADIX_BITS=4
+            rank_keys(keys, ranks, begin_bit, pass_bits)
+            # rank = reset 9-lane counter grid; per-item u16 counter RMW (each thread owns its
+            #   tid column, NO atomics); memoized 9-word raking upsweep; BlockScan ExclusiveSum
+            #   with the `block_prefix = aggregate << 16` packing trick; exclusive downsweep;
+            #   ranks[i] = thread_prefix[i] + reloaded counter.
+            # instruction_selection: ld/st.shared.b32 + ld/st.shared.b16 + 5x shfl.sync.up.b32
+            #   + bar.sync 0 x2 inside the scan; extent: one per digit pass.
+            #   Digit extraction is shr + and (cub's bitfield_extract falls through to
+            #   shift+mask on SM>=70), NOT bfe.  No match.any, no ballot, no PRMT anywhere.
+            barrier()
+            scatter_to_blocked(keys, ranks)                     # blocked -> blocked
+            # instruction_selection: st.shared.b32 to pad(rank) + bar.sync 0 + ld.shared.b32
+            #   from pad(tx*IPT+i); pad(x) = x + (x>>5) iff IPT == 8.  The export shows
+            #   ld.shared.v4.b32 = 2 on (256,8) as well as (32,4), i.e. nvcc vectorizes part
+            #   of the gather at IPT=8 too.
+            if MODE == Plain:
+                barrier(); scatter_to_blocked(values, ranks)
+            if not last_pass: barrier()
+    # sync accounting: keys-only 7P-1, key-value 9P-1 (P = pass count).
+    # When SORT is False the whole block above vanishes: the export's keys-only PageTable
+    # SORT=false instantiation has ZERO shared traffic and ZERO bar.sync -- it is a
+    # transform-only kernel, not a sort with a flag off.
+
+    # ---- deferred transform + writeback (:3002-3029) ---------------------
+    if MODE == PageTable:
+        batch = load_global(row_to_batch[row]) if row_to_batch else row
+        src_page_entry = aux + batch * aux_stride
+        page_start = load_global(page_table_row_starts[row]) if pts else 0
+    elif MODE == Ragged:
+        offset = load_global(aux[row])
+    for i in unroll(IPT):
+        pos = tx * IPT + i
+        if pos < top_k:
+            idx = keys[i]
+            if MODE == Plain:
+                store_global(row_output[pos], idx)          # ~0u reinterprets to -1 for free
+                store_global(out_val[row*top_k + pos], values[i])
+            elif MODE == PageTable:
+                store_global(row_output[pos],
+                             select(idx != 0xFFFFFFFF, load_global(src_page_entry[page_start+idx]), -1))
+                # instruction_selection: setp.eq.b32 + `@p bra` over ld.global.b32 +
+                #   st.global.b32 (.loc 2 3023) -- a branch, not a select
+            else:
+                store_global(row_output[pos], select(idx != 0xFFFFFFFF, idx + offset, -1))
+                # instruction_selection: setp.eq.b32 + add.s32 + selp.b32 + st.global.b32
+                #   (.loc 2 3026) -- this one IS a select, because there is no load to guard
+            # Plain writes both stores unguarded; `~0u` reinterprets to -1 for free.
+```
+
+## Finalize launch matrix (verified in all three dispatchers)
+
+| runtime flags | Plain (:3460-3464) | PageTable (:3392-3402) / Ragged (:3428-3437) |
+| --- | --- | --- |
+| det=F, tie=None | main only | main only |
+| det=T (any tie) | + finalize SORT=true, keys+values | + finalize SORT=true, keys-only |
+| det=F, tie=Small/Large | **main only** | + finalize SORT=false (transform only) |
+
+Early-outs: `k == 0` -> none; Plain and `k <= 1` -> none (:3043-3047); `k > 2048`
+-> `cudaErrorInvalidValue` (:3040). The asymmetry in the last row is real: a
+tie-break-only Plain config gets no second launch, because Plain has nothing to
+defer.
+
+## Shared-memory budget
+
+| region | bytes | source |
+| --- | ---: | --- |
+| `s_input_idx[2][16384]` (dynamic) | 131072 | :2343-2344 |
+| `s_histogram_buf[2][384]` | 3072 | :2432 |
+| `s_indices[2048]` | 8192 | :2438 |
+| scalars (`s_counter`, `s_threshold_bin_id`, `s_refine_thresholds[4]`, `s_num_input[2]`, `s_refine_overflow`, `s_last_remain`) | 40 | :2433-2441 |
+| cub BlockScan TempStorage (DETERMINISTIC only) | ~4256 | :2584-2585 |
+| `s_emitted` / `s_chunk_base` / `s_chunk_take` (TIE_BREAK Small\|Large only) | 12 | :313-315 |
+| **total** | **~146644** vs 232448 optin on B200 | |
+
+The 128 KiB arena is a compile-time constant, never scaled by `max_len` or `k`.
+That is why `CanImplementFilteredTopK` (:3285-3294) gates on
+`maxSharedMemoryPerMultiprocessor >= 131072` rather than anything shape-dependent,
+and why SM89/SM120 cannot run this path at all.
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `DETERMINISTIC = deterministic \|\| tie_break != None` | static | selects the tie collector, enables `s_refine_thresholds`, defers the transform |
+| `TIE_BREAK` | static | contiguous ascending / descending / thread-strided collector |
+| `MODE` | static | header, trivial branch, epilogue, and whether finalize transforms |
+| `VEC_SIZE` | static per config | staging load width; forced to 1 by `dsa_graph_safe` or by `row_starts` on a transform mode |
+| `NUM_ROUNDS`, `FIRST_SHIFT` | static from DType | 4/24 for f32, 1/0 for 16-bit |
+| dynamic smem = 131072 | static constant | independent of shape |
+| `end_bit`, finalize `(BT, IPT)` | static per config here, runtime in the source | the digit-pass loop unrolls; `clz.b32` disappears |
+| `s_refine_overflow` | **runtime, data-dependent** | the only branch this port cannot reach by shape alone — needs tie-heavy inputs |
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "filtered_topk", "category": "flashinfer",
+  "compute_capability": 10}`; device symbols `filtered_topk` and
+  `filtered_topk_finalize`.
+- Plain TIRx only: a `T.SMEMPool` arena at the source's byte offsets, explicit
+  loops, and native `T.ptx.*` forms for every key operation. Global and shared
+  memory are reached exclusively through `T.ptx.ld/st.*` on `buffer.ptr_to([...])`
+  — never a native `BufferLoad`/`BufferStore`, which the repository's low-level IR
+  contract forbids. No `T.cuda.func_call` (this kernel has no allowlist budget).
+- The finalize kernel's rank counter grid is addressed as **both** `uint32`
+  (packed raking adds) and `uint16` (per-digit RMW). There is no buffer re-view
+  API in this tree; the union is built by allocating both dtypes at the same pool
+  offset via `move_base_to`, verified on device (see
+  `.porting/filtered_topk/probe_findings.md`). Pool offsets must be **Python
+  literals** — capturing `pool.offset` inside the traced body makes it a TIR
+  variable and `move_base_to` then fails in `__bool__`.
+- No `Tx` tile primitives anywhere.
+- Correctness compares against the same FlashInfer pipeline launched through the
+  raw `topk` FFI module with `FLASHINFER_TOPK_ALGO=filtered`, which
+  `GetTopKAlgoOverride` (:3299-3305) maps to `TopKAlgoOverride::FILTERED`. That
+  pin skips the `num_rows`/`max_len` heuristics (:3346-3368) but not the hard
+  preconditions, and it also keeps the SM100 cluster kernel out of the reference
+  path. Comparison per flag combination: exact positional equality where the
+  reference finalize-sorts; exact selected-index **sets** where a tie-break makes
+  the set unique but the order racy; selected-value multisets otherwise.
+- Both sides launch the same pipeline: one kernel where `finalize_plan` returns
+  `None`, two where it does not. The canonical timer aggregates every kernel in a
+  closure (probe: 58.3 / 92.7 / 152.1 us for 1 / 2 / 3 launches).
+
+## Instruction selection is a lowering consequence
+
+| Primitive / pattern | PTX family (fresh sm_100a export) |
+| --- | --- |
+| `ToCoarseKey`, f32 (`.loc 2 2284/2287`) | `cvt.rn.f16.f32`, then `not.b16` + `or.b16` + `setp.lt.s16` + `selp.b16` + `shr.u16` |
+| `ToCoarseKey`, 16-bit (`.loc 2 2309`) | same 16-bit sequence, no `cvt` |
+| `ToOrdered`, f32 (`.loc 2 2293`) | `not.b32` + `abs.ftz.f32` + `neg.ftz.f32` + `setp.lt.s32` + `selp.b32` |
+| `ToOrdered`, 16-bit (`.loc 2 2315`) | `shr.s16` (sign broadcast) + `xor.b16` |
+| histogram / counter bump | `atom.shared.add.u32` |
+| non-deterministic tie back-fill | `atom.shared.add.u32` with `-1`, present only when DETERMINISTIC is false |
+| overflow flag | `atom.shared.or.b32` (result discarded; not `red.shared.or.b32`) |
+| ping-pong suffix scan | `ld.shared.b32` x2 + `add.s32` + `st.shared.b32` + `bar.sync 0`, 8 steps |
+| threshold pick | three short-circuit `@p bra` guards (no `and.pred`) + `st.shared.b32` |
+| tie collection (DETERMINISTIC) | cub BlockScan -> `shfl.sync.up.b32` x5 per warp scan |
+| row scan (unified) | `ld.global.nc.v4.b32` (f32 v4 and 16-bit v8) / `nc.v2.b32` / `nc.v2.b16` / scalar `nc` tail |
+| all unified global reads | `.nc` qualified — the inputs are `__restrict__ const` |
+| finalize global reads | plain `ld.global.b32` — those pointers are not `__restrict__` |
+| finalize pad clamp | `max.s32` with immediate `-1` (not `setp`+`selp`) |
+| finalize rank | `ld/st.shared.b16` + `ld/st.shared.b32` + `shfl.sync.up.b32` |
+| finalize digit extraction | `shr` + `and` (shift+mask on SM>=70, not `bfe`) |
+| finalize exchange | `st.shared.b32` / `ld.shared.b32`, partly `ld.shared.v4.b32` |
+| finalize writeback | PageTable: `setp.eq.b32` + `@p bra` + `ld.global.b32`; Ragged: `setp.eq.b32` + `add.s32` + `selp.b32` |
+
+The two `ToOrdered` forms differ in *lowering* even though the source writes one
+expression: on 16 bits nvcc recognises `(bits & 0x8000) ? ~bits : (bits | 0x8000)`
+as a sign-broadcast XOR, and on 32 bits it routes the same shape through
+`abs`/`neg`. The `or.b16`/`not.b16` counts in the table below belong to
+**`ToCoarseKey`**, not to `ToOrdered`.
+
+Static opcode counts per exported instantiation (full table in
+`.porting/filtered_topk/ptx/opcode_table.md`):
+
+| op | f32 v4 Plain nondet | f32 v4 Plain det | f32 v4 Plain tieSmall | f32 v1 Plain nondet | f16 v8 Plain nondet | f16 v8 Plain det |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `atom.shared.add.u32` | 237 | 219 | 219 | 51 | 255 | 225 |
+| `atom.shared.or.b32` | 20 | 20 | 20 | 6 | 29 | 29 |
+| `bar.sync` | 115 | 121 | 129 | 115 | 39 | 45 |
+| `shfl.sync.up.b32` | 0 | 10 | 10 | 0 | 0 | 10 |
+| `cvt.rn.f16.f32` | 154 | 154 | 154 | 24 | 0 | 0 |
+| `xor.b16` | 0 | 0 | 0 | 0 | 99 | 99 |
+| `or.b16` | 154 | 154 | 154 | 24 | 165 | 225 |
+
+The `bar.sync` drop from 115 (f32, four refine rounds) to 39 (16-bit, one round)
+is the refine structure showing through; tie-break adds a further 8 for the
+chunked contiguous collector. `shfl.sync.up.b32` appearing only on DETERMINISTIC
+instantiations is the cub BlockScan, which the non-deterministic tie race does not
+use.

--- a/.agents/skills/tirx-instruction-selection/references/db.md
+++ b/.agents/skills/tirx-instruction-selection/references/db.md
@@ -1211,3 +1211,27 @@ with existing typed PTX helpers left zero violations across the complete
 configurations then passed their upstream oracles under a 16-worker run.
 Inspect every public configuration after specialization; validating only one
 default `get_kernel()` result is insufficient.
+
+## Profile the launch closure, not just the kernel
+
+**Symptoms:** `slow_small_shape`, `fixed_overhead`, `extra_kernels_in_profile`, `ratio_scales_with_shape`
+
+A per-kernel timer charges a workload for *every* kernel its closure enqueues.
+Tensors materialized inside the timed closure -- placeholder index buffers, a
+`lengths` fallback, a mode-specific `aux` -- each launch a fill kernel, and those
+land in the measured time.
+
+The signature is a ratio that tracks shape size rather than any property of the
+kernel: a port measured 0.54-0.63x on 7-15us shapes while already passing at
+1.03-1.09x on 120-190us ones. That is a constant addend, not a kernel defect, and
+it is easy to misread as latency-bound behavior on a small grid and then chase
+unrolls and stall counters. NCU settled it in one run: the reference profiled as
+one kernel, the port as four, the extra three being `FillFunctor`. Hoisting the
+argument materialization into a builder called once outside the closure moved the
+same shapes to 1.08-1.16x.
+
+Check the kernel count in the profile before forming any hypothesis about a
+small-shape deficit. `grep` the closure for allocation calls -- `torch.zeros`,
+`torch.full`, `.reshape` on a non-contiguous view -- and bind every argument in a
+prepare step. The same discipline applies to the reference closure: it must
+enqueue exactly what the dispatcher enqueues and nothing else.

--- a/tests/lint/check_filtered_topk_no_tile.py
+++ b/tests/lint/check_filtered_topk_no_tile.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every filtered top-k specialization.
+
+Reuses the single-CTA scanner.  This port is a two-kernel pipeline, so the IR
+scan walks the unified kernel *and* the finalize kernel for every config.
+``get_finalize_kernel`` returns ``None`` for the configs where the dispatcher
+issues no second launch; those contribute the unified kernel only.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import check_radix_topk_single_cta_no_tile as no_tile
+
+import tvm
+from tirx_kernels.flashinfer.topk import filtered_topk as target
+
+no_tile.target = target
+_CANDIDATE_TARGETS = (
+    "tirx_kernels/flashinfer/topk/filtered_topk.py",
+    "tirx_kernels/flashinfer/utils/topk_radix.py",
+    # Added when the BlockRadixSort emitters land with the finalize kernel.
+    "tirx_kernels/flashinfer/utils/block_radix_sort.py",
+    # Traits, row scan, collectors, refine rounds and both overflow fallbacks.
+    "tirx_kernels/flashinfer/utils/filtered_topk_ops.py",
+)
+no_tile.TARGETS = tuple(
+    no_tile.REPO / rel for rel in _CANDIDATE_TARGETS if (no_tile.REPO / rel).exists()
+)
+
+
+def _bodies(kernel: Any) -> list[tuple[str, Any]]:
+    """Yield every scannable function body, for a PrimFunc or an IRModule."""
+    if kernel is None:
+        return []
+    if isinstance(kernel, tvm.IRModule):
+        return [
+            (global_var.name_hint, function.body)
+            for global_var, function in kernel.functions.items()
+            if hasattr(function, "body")
+        ]
+    return [("", kernel.body)]
+
+
+def _ir_findings() -> list[no_tile.Finding]:
+    findings: list[no_tile.Finding] = []
+    for config in target.CONFIGS:
+        label = str(config["label"])
+        params = {key: value for key, value in config.items() if key != "label"}
+        for entry, build in (("main", target.get_kernel), ("finalize", target.get_finalize_kernel)):
+            for name, body in _bodies(build(**params)):
+                scope = f"CONFIGS[{label!r}]::{entry}" + (f"::{name}" if name else "")
+                scanner = no_tile._IRScanner(scope)
+                scanner(body)
+                findings.extend(scanner.findings)
+    return findings
+
+
+no_tile._ir_findings = _ir_findings
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "5f901d39",
-    "tirx-kernels": "bfda68bb-dirty",
+    "tir": "f20fa692",
+    "tirx-kernels": "b74762d3-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "bbec2597d14718e31f46e6379af4064e42b0ace7"
+    "tirx-kernels:tirx_kernels": "5a92f7b6847eed22f86bbae1ea6d70e43e8a3307"
   },
   "baselines": {
     "torch": {
@@ -1018,6 +1018,48 @@
       "impls": {
         "tirx": 83.96102247146229,
         "deepgemm": 91.63302354900253
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "filtered_topk",
+      "config": "f32_plain_det_r2_l524288_k256_endbit",
+      "label": "f32_plain_det_r2_l524288_k256_endbit",
+      "status": "ok",
+      "impls": {
+        "tirx": 116.88407736044608,
+        "flashinfer": 128.47340505093595
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "filtered_topk",
+      "config": "f32_plain_r4_l8192_k256",
+      "label": "f32_plain_r4_l8192_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.241476387555622,
+        "flashinfer": 9.563901958120834
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "filtered_topk",
+      "config": "f32_plain_r64_l8192_k256",
+      "label": "f32_plain_r64_l8192_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.479418874979165,
+        "flashinfer": 9.790764905560959
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '5f901d39', 'tirx-kernels': 'bfda68bb-dirty', 'tirx-bench-ci': None}`
-- Workloads: 333 ok, 0 failed
+- Git:       `{'tir': 'f20fa692', 'tirx-kernels': 'b74762d3-dirty', 'tirx-bench-ci': None}`
+- Workloads: 336 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -143,6 +143,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `m64_n24_k28672_s112` | tirx | 7.2039 | deepgemm | 7.2959 | 1.013 | — |
 | `m8192_n24_k16384_s1` | tirx | 50.5342 | deepgemm | 60.5773 | 1.199 | — |
 | `m8192_n24_k28672_s1` | tirx | 83.9610 | deepgemm | 91.6330 | 1.091 | — |
+
+## filtered_topk
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `f32_plain_det_r2_l524288_k256_endbit` | tirx | 116.8841 | flashinfer | 128.4734 | 1.099 | — |
+| `f32_plain_r4_l8192_k256` | tirx | 8.2415 | flashinfer | 9.5639 | 1.160 | — |
+| `f32_plain_r64_l8192_k256` | tirx | 8.4794 | flashinfer | 9.7908 | 1.155 | — |
 
 ## flash_attention4
 

--- a/tirx_kernels/bench_suite/config/flashinfer/topk/filtered_topk.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/topk/filtered_topk.yaml
@@ -1,0 +1,122 @@
+# Representative cover of the FilteredTopK dispatch domain under the
+# `FLASHINFER_TOPK_ALGO=filtered` pin.  All 54 dtype x mode x
+# (deterministic, tie_break) cells appear, so every kernel instantiation and all
+# three finalize behaviors (no launch / sorting / transform-only) are timed.  The
+# axis sweeps that are orthogonal to the cell -- VEC_SIZE, the k ladder covering
+# every finalize (BLOCK_THREADS, ITEMS_PER_THREAD) rung, end_bit across 2..5 digit
+# passes, and the num_rows occupancy axis -- run on carrier cells rather than
+# being repeated in all 54, which is the difference between this list and a full
+# cross of the domain.
+#
+# The tie_heavy / quantized entries are the only way to reach the data-dependent
+# s_refine_overflow fallbacks, and they are real performance regimes, so they stay
+# in the timed set; both sides consume identical seeded inputs.
+#
+# Deterministic and tie-break configs are a two-kernel pipeline on both sides
+# (unified + FinalizeTopKIndicesKernel); the timed closure launches whatever the
+# dispatcher launches.  Trivial-path-only configs are correctness cases and stay
+# out of this timed matrix.
+kernel: filtered_topk
+selection_rationale: The fp32 Plain non-deterministic column is the base dispatch; r4/l8192/k256 is the smallest shape that still exercises the filter and a full four-round refine, r64/l8192 fills the SM array so the one-CTA-per-row grid is the binding resource, and l524288 is the widest row the upstream benchmark sweeps and the only one reaching a five-pass finalize sort.
+configs:
+  - {config: f32_plain_r4_l8192_k256, default: true, selection_role: small}
+  - {config: f32_plain_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_plain_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_plain_det_r4_l8192_k256, default: false}
+  - {config: f32_plain_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_plain_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_pt_r4_l8192_k256, default: false}
+  - {config: f32_pt_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_pt_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_pt_det_r4_l8192_k256, default: false}
+  - {config: f32_pt_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_pt_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_rag_r4_l8192_k256, default: false}
+  - {config: f32_rag_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_rag_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_rag_det_r4_l8192_k256, default: false}
+  - {config: f32_rag_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f32_rag_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_plain_r4_l8192_k256, default: false}
+  - {config: f16_plain_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_plain_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_plain_det_r4_l8192_k256, default: false}
+  - {config: f16_plain_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_plain_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_pt_r4_l8192_k256, default: false}
+  - {config: f16_pt_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_pt_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_pt_det_r4_l8192_k256, default: false}
+  - {config: f16_pt_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_pt_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_rag_r4_l8192_k256, default: false}
+  - {config: f16_rag_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_rag_tlarge_r4_l8192_k256, default: false}
+  - {config: f16_rag_det_r4_l8192_k256, default: false}
+  - {config: f16_rag_det_tsmall_r4_l8192_k256, default: false}
+  - {config: f16_rag_det_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_plain_r4_l8192_k256, default: false}
+  - {config: bf16_plain_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_plain_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_plain_det_r4_l8192_k256, default: false}
+  - {config: bf16_plain_det_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_plain_det_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_pt_r4_l8192_k256, default: false}
+  - {config: bf16_pt_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_pt_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_pt_det_r4_l8192_k256, default: false}
+  - {config: bf16_pt_det_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_pt_det_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_rag_r4_l8192_k256, default: false}
+  - {config: bf16_rag_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_rag_tlarge_r4_l8192_k256, default: false}
+  - {config: bf16_rag_det_r4_l8192_k256, default: false}
+  - {config: bf16_rag_det_tsmall_r4_l8192_k256, default: false}
+  - {config: bf16_rag_det_tlarge_r4_l8192_k256, default: false}
+  - {config: f32_plain_r4_l8190_k256_vec, default: false}
+  - {config: f32_plain_r4_l8189_k256_vec, default: false}
+  - {config: f16_plain_r4_l8188_k256_vec, default: false}
+  - {config: f16_plain_r4_l8190_k256_vec, default: false}
+  - {config: f16_plain_r4_l8189_k256_vec, default: false}
+  - {config: bf16_plain_r4_l8188_k256_vec, default: false}
+  - {config: bf16_plain_r4_l8190_k256_vec, default: false}
+  - {config: bf16_plain_r4_l8189_k256_vec, default: false}
+  - {config: f32_plain_r4_l8192_k1, default: false}
+  - {config: f32_plain_r4_l8192_k128, default: false}
+  - {config: f32_plain_r4_l8192_k512, default: false}
+  - {config: f32_plain_r4_l8192_k576, default: false}
+  - {config: f32_plain_r4_l8192_k1024, default: false}
+  - {config: f32_plain_r4_l8192_k2048, default: false}
+  - {config: f32_plain_det_r4_l8192_k1, default: false}
+  - {config: f32_plain_det_r4_l8192_k128, default: false}
+  - {config: f32_plain_det_r4_l8192_k512, default: false}
+  - {config: f32_plain_det_r4_l8192_k576, default: false}
+  - {config: f32_plain_det_r4_l8192_k1024, default: false}
+  - {config: f32_plain_det_r4_l8192_k2048, default: false}
+  - {config: f32_plain_det_r2_l200_k128_endbit, default: false}
+  - {config: f32_plain_det_r2_l4096_k256_endbit, default: false}
+  - {config: f32_plain_det_r2_l65536_k256_endbit, default: false}
+  - {config: f32_plain_det_r2_l524288_k256_endbit, default: true, selection_role: large}
+  - {config: f32_plain_r1_l8192_k256, default: false}
+  - {config: f32_plain_r16_l8192_k256, default: false}
+  - {config: f32_plain_r64_l8192_k256, default: true, selection_role: medium}
+  - {config: f32_plain_r256_l8192_k256, default: false}
+  - {config: f32_plain_r2_l131072_k256_quantized, default: false}
+  - {config: f32_plain_r2_l131072_k256_tie_heavy, default: false}
+  - {config: f32_plain_det_r2_l131072_k256_quantized, default: false}
+  - {config: f32_plain_det_r2_l131072_k256_tie_heavy, default: false}
+  - {config: f32_plain_tsmall_r4_l8192_k256_pivot_tie, default: false}
+  - {config: f32_plain_tlarge_r4_l8192_k256_pivot_tie, default: false}
+  - {config: f16_plain_r2_l131072_k256_quantized, default: false}
+  - {config: f16_plain_r2_l131072_k256_tie_heavy, default: false}
+  - {config: f16_plain_det_r2_l131072_k256_quantized, default: false}
+  - {config: f16_plain_det_r2_l131072_k256_tie_heavy, default: false}
+  - {config: f16_plain_tsmall_r4_l8192_k256_pivot_tie, default: false}
+  - {config: f16_plain_tlarge_r4_l8192_k256_pivot_tie, default: false}
+  - {config: f32_plain_r4_l8192_k256_dsa, default: false}
+  - {config: f32_pt_r4_l8192_k256_dsa, default: false}
+  - {config: f32_rag_r4_l8192_k256_dsa, default: false}
+  - {config: f32_pt_tsmall_r4_l8192_k256_rs, default: false}
+  - {config: f32_rag_r4_l8192_k256_rs, default: false}
+  - {config: f32_pt_tsmall_r4_l8192_k256_rs_pts, default: false}
+  - {config: f32_pt_tsmall_r4_l8192_k256_r2b, default: false}

--- a/tirx_kernels/flashinfer/topk/filtered_topk.py
+++ b/tirx_kernels/flashinfer/topk/filtered_topk.py
@@ -1,0 +1,1411 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer filtered top-k port.
+
+Ports the **FilteredTopK** pipeline that ``TopKDispatch`` selects when a row fits
+one CTA's candidate budget: ``FilteredTopKUnifiedKernel<DType, int32_t, VEC_SIZE,
+DETERMINISTIC, MODE, TIE_BREAK>`` (``include/flashinfer/topk.cuh:2362``) plus its
+companion ``FinalizeTopKIndicesKernel`` (``:2958``).
+
+The unified kernel runs one CTA of 1024 threads per row (``:3183-3184``) with a
+fixed 128 KiB dynamic shared arena (``FILTERED_TOPK_SMEM_DYNAMIC``, ``:2343-2344``)
+and no global workspace at all -- everything is shared-memory atomics and
+``__syncthreads()``.  It builds a 256-bin coarse histogram over a lossy
+``ToCoarseKey`` (fp32 rounds through fp16, ``:2282-2289``), suffix-scans it to pick
+the threshold bin, then *filters*: only the candidates landing in that bin are
+compacted into a 16384-entry shared index buffer and refined byte-by-byte
+(``:2611-2627``, ``:2674-2709``).  That is the whole point of the algorithm --
+later passes re-read at most 16K scattered elements instead of the whole row.
+When a coarse bin holds more than 16384 candidates the kernel sets
+``s_refine_overflow`` and falls back to full-row histogram passes (``:2711-2757``
+for 16-bit, ``:2800-2901`` for fp32).
+
+``DETERMINISTIC`` is ``deterministic || tie_break != None`` (``:3181``).  It swaps
+the racing back-fill tie claim (``:2567-2580``) for a CUB-scan collector -- thread
+strided for plain determinism (``:255-286``), contiguous ascending/descending for
+``TopKTieBreak::Small``/``Large`` (``:298-377``) -- and defers the PageTable/Ragged
+index transform to the finalize kernel.
+
+**The finalize kernel is part of this port, not an optional extra.**  For
+``deterministic`` (and for ``tie_break`` on the transform modes) the dispatchers
+launch it after the main kernel (``:3460-3464`` Plain, ``:3392-3402`` PageTable,
+``:3428-3437`` Ragged) to block-radix-sort each row's indices ascending and apply
+the deferred transform.  Without it "deterministic" would yield a deterministic
+*set* in a nondeterministic *order*, so both the semantics and an honest benchmark
+require the pair.
+
+FilteredTopK is the **only** implementation of ``tie_break != None``
+(``:3327-3329``) and of ``dsa_graph_safe`` (``:3323-3325``); both radix ports
+excluded them because ``ShouldUseFilteredTopK`` returns true unconditionally for
+those flags.
+
+In-scope specialization: ``k <= FILTERED_TOPK_MAX_K == 2048`` with ``max_len > k``
+(or either forcing flag set), all three dtypes, all three modes, every reachable
+``VEC_SIZE``, both collect paths, all three tie-break modes, and the runtime
+``row_starts`` / ``page_table_row_starts`` / ``row_to_batch`` branches.  Out of
+scope, with the dispatch predicate that excludes each: ``k > 2048`` (radix only,
+``:3333``); ``sorted_output`` (``StableSortTopKByValueKernel`` ``:3090``, which both
+radix ports also leave out); fp8 (never instantiated, ``:2277-2337``); and the
+SM100 cluster kernel, which the ``FLASHINFER_TOPK_ALGO=filtered`` pin keeps out of
+the reference path.
+"""
+
+from typing import Any
+
+from tirx_kernels.flashinfer.topk.radix_topk_single_cta import (
+    DTYPES,
+    MODES,
+    aux_elements,
+    dtype_bytes,
+    hardware_max_smem_optin,
+    page_table_batch,
+    vec_size,
+)
+from tirx_kernels.flashinfer.utils.block_radix_sort import alloc_sort_smem, emit_block_radix_sort
+from tirx_kernels.flashinfer.utils.filtered_topk_ops import (
+    FIRST_REFINE_SHIFT,
+    NUM_REFINE_ROUNDS,
+    NUM_SCALARS,
+    FilteredCfg,
+    emit_filtered_topk_main,
+    ld_global_nc_bits,
+    ld_global_nc_u32,
+    scan_elements,
+    st_global_bits,
+)
+from tirx_kernels.flashinfer.utils.topk_harness import (
+    SOURCE_ALGO_FILTERED,
+    alloc_outputs,
+    assert_device_matches_compile_profile,
+    pin_source_algo,
+    row_local_indices,
+    selected_values,
+    source_module,
+    torch_dtype,
+)
+from tirx_kernels.flashinfer.utils.topk_radix import (
+    ld_global_bits,
+    ld_global_u32,
+    st_global_u16,
+    st_global_u32,
+)
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+# Patterns whose whole purpose is to overflow the candidate arena; prepare_data
+# asserts on the host that they still do.
+_OVERFLOW_PATTERNS = ("tie_heavy", "quantized")
+# One coarse bin must be able to exceed FILTERED_TOPK_SMEM_INPUT_SIZE for the
+# fallback to be reachable at all, so the overflow patterns get a long row.
+_OVERFLOW_LENGTH = 131072
+
+KERNEL_META = {"name": "filtered_topk", "category": "flashinfer", "compute_capability": 10}
+
+# The unified kernel takes the 128 KiB candidate arena as dynamic shared memory;
+# the finalize kernel's BlockRadixSort scratch is static-sized per (BT, IPT).
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+FINALIZE_LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+
+# --- source constants (topk.cuh:2339-2347) ---------------------------------
+FILTERED_TOPK_MAX_K = 2048
+FILTERED_TOPK_BLOCK_THREADS = 1024
+FILTERED_TOPK_SMEM_INPUT_SIZE = 16 * 1024
+FILTERED_TOPK_SMEM_DYNAMIC = 4 * 2 * FILTERED_TOPK_SMEM_INPUT_SIZE  # 131072
+RADIX = 256
+
+# Row-scan unroll: per-thread trips at or above this get the deeper factor.
+SCAN_DEEP_UNROLL_TRIPS = 16
+SCAN_DEEP_UNROLL = 4
+
+# `CanImplementFilteredTopK` (:3285-3294) gates on
+# cudaDevAttrMaxSharedMemoryPerMultiprocessor >= FILTERED_TOPK_SMEM_DYNAMIC.
+MIN_SMEM_PER_SM = FILTERED_TOPK_SMEM_DYNAMIC
+
+# TopKTieBreak (topk.cuh:36-40); the FFI takes the int64 form (csrc/topk.cu:25-39).
+TIE_NONE = 0
+TIE_SMALL = 1
+TIE_LARGE = 2
+TIE_BREAKS = (TIE_NONE, TIE_SMALL, TIE_LARGE)
+
+# Input distributions mirroring benchmarks/bench_topk.py --input-pattern
+# (:982-996).  `tie_heavy`/`quantized` are the only way to reach the
+# `s_refine_overflow` fallbacks, which are data- not shape-dependent.
+PATTERNS = ("random", "quantized", "tie_heavy", "pivot_tie")
+
+
+def finalize_block_config(k: int) -> tuple[int, int]:
+    """`LaunchFinalizeTopKIndices`'s block/items ladder (topk.cuh:3061-3079)."""
+    if k <= 128:
+        return (32, 4)
+    if k <= 256:
+        return (32, 8)
+    if k <= 512:
+        return (64, 8)
+    if k <= 576:
+        return (64, 9)
+    if k <= 1024:
+        return (128, 8)
+    return (256, 8)
+
+
+def finalize_end_bit(max_len: int) -> int:
+    """``end_bit = 32 - __clz(max_len)`` (topk.cuh:2994), static per config."""
+    return max_len.bit_length()
+
+
+def effective_page_table_row_starts(mode: str, page_table_row_starts: bool, row_starts: bool):
+    """`TopKPageTableTransformDispatch` substitutes `row_starts` for a null pointer.
+
+    ``:3379-3380`` runs ``if (page_table_row_starts == nullptr) page_table_row_starts
+    = row_starts;`` before dispatching, so **both** launches see a non-null
+    pointer whenever ``row_starts`` is non-null.  It is invisible in the unified
+    kernel, whose own ternary (``:2387-2390``) falls back to ``row_start`` and so
+    computes the same value either way, but it is load-bearing in the finalize
+    kernel, which falls back to ``0`` instead (``:3008``) and would otherwise drop
+    the row offset from the deferred page-table transform.
+    """
+    if mode != "page_table":
+        return page_table_row_starts
+    return page_table_row_starts or row_starts
+
+
+def finalize_plan(mode: str, k: int, deterministic: bool, tie_break: int):
+    """Which finalize launch (if any) the dispatcher issues after the main kernel.
+
+    Verified in all three dispatchers: Plain :3460-3464, PageTable :3392-3402,
+    Ragged :3428-3437.  ``sort_local_indices`` distinguishes the deterministic
+    launch (block-radix-sort the row, then transform) from the tie-break-only
+    launch on the transform modes (transform, no sort).
+    """
+    if k == 0:
+        return None
+    if deterministic:
+        if mode == "basic" and k <= 1:
+            return None  # LaunchFinalizeTopKIndices early-out (:3043-3047)
+        return {"sort_local_indices": True}
+    if tie_break != TIE_NONE and mode != "basic":
+        return {"sort_local_indices": False}
+    return None
+
+
+def filtered_vec_size(
+    dtype: str, max_len: int, scalar_addressing: bool, dsa_graph_safe: bool
+) -> int:
+    """`ComputeFilteredTopKVecSize` (:2934-2943) plus the launcher's row_starts clause.
+
+    ``dsa_graph_safe`` pins 1 so the instantiation cannot depend on a runtime
+    ``max_len`` (graph-capture stable); a non-null ``row_starts`` on a transform
+    mode pins 1 because the row base pointer can then be misaligned (:3190-3192).
+    """
+    if dsa_graph_safe:
+        return 1
+    return vec_size(dtype, max_len, scalar_addressing=scalar_addressing)
+
+
+def _validate(
+    dtype: str,
+    mode: str,
+    num_rows: int,
+    length: int,
+    k: int,
+    deterministic: bool,
+    tie_break: int,
+    dsa_graph_safe: bool,
+) -> dict[str, Any]:
+    """Reject anything outside the FilteredTopK dispatch domain.
+
+    Mirrors `ShouldUseFilteredTopK` (:3318-3369) under the
+    ``FLASHINFER_TOPK_ALGO=filtered`` override: the override skips the
+    num_rows/max_len heuristics (:3346-3368) but not the hard preconditions, and
+    the dispatchers' guard (:3382-3385) still errors when a forcing flag meets
+    ``k > FILTERED_TOPK_MAX_K``.
+    """
+    if dtype not in DTYPES:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+    if mode not in MODES:
+        raise ValueError(f"Unsupported mode: {mode}")
+    if tie_break not in TIE_BREAKS:
+        raise ValueError(f"Unsupported tie_break: {tie_break}")
+    if num_rows < 1 or length < 1 or k < 1:
+        raise ValueError(f"num_rows={num_rows}, length={length}, k={k} must be positive")
+    if k > FILTERED_TOPK_MAX_K:
+        raise ValueError(
+            f"k={k} exceeds FILTERED_TOPK_MAX_K={FILTERED_TOPK_MAX_K}: radix-only shape"
+        )
+    forced = dsa_graph_safe or tie_break != TIE_NONE
+    if not forced and length <= k:
+        raise ValueError(
+            f"length={length} <= k={k} only reaches FilteredTopK through "
+            "dsa_graph_safe or a tie-break mode (:3333)"
+        )
+    scalar_addressing = False  # set by the caller through row_starts on non-basic modes
+    vec = filtered_vec_size(dtype, length, scalar_addressing, dsa_graph_safe)
+    return {
+        "vec_size": vec,
+        "block_threads": FILTERED_TOPK_BLOCK_THREADS,
+        "grid": num_rows,
+        "smem_bytes": FILTERED_TOPK_SMEM_DYNAMIC,
+        "finalize": finalize_plan(mode, k, deterministic, tie_break),
+        "finalize_block": finalize_block_config(k),
+        "end_bit": finalize_end_bit(length),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Target entries.
+# ---------------------------------------------------------------------------
+def get_kernel(
+    dtype: str = "float32",
+    mode: str = "basic",
+    num_rows: int = 16,
+    length: int = 8192,
+    k: int = 256,
+    deterministic: bool = False,
+    tie_break: int = TIE_NONE,
+    dsa_graph_safe: bool = False,
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    pattern: str = "random",
+    **kwargs,
+):
+    """Return the TIRx specialization of `FilteredTopKUnifiedKernel` for one cell."""
+    scalar_addressing = row_starts and mode != "basic"
+    plan = _validate(dtype, mode, num_rows, length, k, deterministic, tie_break, dsa_graph_safe)
+    vec = filtered_vec_size(dtype, length, scalar_addressing, dsa_graph_safe)
+    aux_elems = aux_elements(mode, num_rows, length, row_to_batch)
+    grid = plan["grid"]
+
+    basic = mode == "basic"
+    page_table = mode == "page_table"
+    ragged = mode == "ragged"
+    is32 = dtype == "float32"
+    # DETERMINISTIC is not the user's `deterministic` flag: it is
+    # `deterministic || tie_break != None` (:3181), and it is what swaps the
+    # racing tie back-fill for a CUB-scan collector and defers the transform.
+    det = deterministic or tie_break != TIE_NONE
+    num_rounds = NUM_REFINE_ROUNDS[dtype]
+    first_shift = FIRST_REFINE_SHIFT[dtype]
+    load_bytes = vec * dtype_bytes(dtype)
+    smem_input = FILTERED_TOPK_SMEM_INPUT_SIZE
+    hist_stride = RADIX + 128  # s_histogram_buf[2][RADIX + 128] (:2432)
+    # `length <= top_k` (:2409) tests the *per-row* length.  On the transform
+    # modes that is a runtime value, so the branch must always be emitted there;
+    # only Plain, whose row length is the static kernel stride, can fold it away.
+    trivial_path = (not basic) or length <= k
+    # Per-thread trips through the row-scan vector loop.  The source's literal
+    # `#pragma unroll 2` (:2469) encodes an intent -- keep independent loads in
+    # flight -- not a portable constant, so the factor is derived from the trip
+    # count and swept rather than assumed.
+    scan_trips = max(1, (length // vec) // FILTERED_TOPK_BLOCK_THREADS)
+    scan_unroll = SCAN_DEEP_UNROLL if scan_trips >= SCAN_DEEP_UNROLL_TRIPS else 2
+    cfg = FilteredCfg(
+        top_k=k,
+        vec=vec,
+        load_bytes=load_bytes,
+        is32=is32,
+        det=det,
+        tie_break=tie_break,
+        num_rounds=num_rounds,
+        first_shift=first_shift,
+        smem_input=smem_input,
+        hist_stride=hist_stride,
+        scan_unroll=scan_unroll,
+        basic=basic,
+        page_table=page_table,
+        ragged=ragged,
+        block=FILTERED_TOPK_BLOCK_THREADS,
+        radix=RADIX,
+    )
+
+    @T.prim_func
+    def filtered_topk(
+        input_h: T.handle,
+        output_indices_h: T.handle,
+        output_values_h: T.handle,
+        aux_data_h: T.handle,
+        lengths_h: T.handle,
+        row_starts_h: T.handle,
+        page_table_row_starts_h: T.handle,
+        row_to_batch_h: T.handle,
+        aux_stride: T.int64,
+    ):
+        T.func_attr({"global_symbol": "filtered_topk"})
+        inp = T.match_buffer(input_h, (num_rows * length,), dtype, scope="global")
+        out_idx = T.match_buffer(output_indices_h, (num_rows * k,), "int32", scope="global")
+        out_val = T.match_buffer(output_values_h, (num_rows * k,), dtype, scope="global")
+        aux = T.match_buffer(aux_data_h, (aux_elems,), "int32", scope="global")
+        lengths_g = T.match_buffer(lengths_h, (num_rows,), "int32", scope="global")
+        row_starts_g = T.match_buffer(row_starts_h, (num_rows,), "int32", scope="global")
+        pt_starts_g = T.match_buffer(page_table_row_starts_h, (num_rows,), "int32", scope="global")
+        row_to_batch_g = T.match_buffer(row_to_batch_h, (num_rows,), "int32", scope="global")
+        T.device_entry()
+        row = T.cta_id([grid])
+        tx = T.thread_id([FILTERED_TOPK_BLOCK_THREADS])
+
+        # --- shared layout (:2431-2446) --------------------------------------
+        pool = T.SMEMPool()
+        s_hist2 = pool.alloc((2 * hist_stride,), "uint32", align=128)
+        s_indices = pool.alloc((FILTERED_TOPK_MAX_K,), "uint32", align=128)
+        s_scal = pool.alloc((NUM_SCALARS,), "uint32")
+        if det:
+            s_scan = pool.alloc((scan_elements(),), "uint32", align=16)
+        # The candidate arena is a fixed 128 KiB, never scaled by max_len or k
+        # (:2343-2344); that constant is exactly what CanImplementFilteredTopK
+        # gates on (:3285-3294).
+        s_input = pool.alloc((2 * smem_input,), "uint32", align=128)
+        pool.commit()
+
+        # --- per-row header (:2384-2406) --------------------------------------
+        # Basic's row length is the static kernel stride, so it stays a Python
+        # constant and `aligned_length` folds to a literal exactly as in the
+        # source.  Binding it to a name inside the traced body would make it a TIR
+        # variable and turn the row-scan bound into a runtime read.
+        row_len_rt: T.int32 = T.int32(0)
+        row_start: T.int32 = T.int32(0)
+        page_start: T.int32 = T.int32(0)
+        if not basic:
+            row_len_rt = T.reinterpret("int32", ld_global_nc_u32(lengths_g, row))
+            if row_starts:
+                row_start = T.reinterpret("int32", ld_global_nc_u32(row_starts_g, row))
+            if page_table:
+                if page_table_row_starts:
+                    page_start = T.reinterpret("int32", ld_global_nc_u32(pt_starts_g, row))
+                else:
+                    page_start = row_start
+        row_in: T.int64 = T.cast(row, "int64") * T.int64(length) + T.cast(row_start, "int64")
+        row_out: T.int64 = T.cast(row, "int64") * T.int64(k)
+
+        batch_idx: T.int32 = row
+        offset_val: T.int32 = T.int32(0)
+        if page_table:
+            if row_to_batch:
+                batch_idx = T.reinterpret("int32", ld_global_nc_u32(row_to_batch_g, row))
+        if ragged:
+            offset_val = T.reinterpret("int32", ld_global_nc_u32(aux, T.cast(row, "int64")))
+
+        # --- trivial early-out, length <= top_k (:2409-2429) ------------------
+        take_main: T.int32 = T.int32(1)
+        if trivial_path:
+            if (length if basic else row_len_rt) <= k:
+                take_main = T.int32(0)
+                for i0 in T.serial(tx, k, step=FILTERED_TOPK_BLOCK_THREADS):
+                    slot0: T.int64 = row_out + T.cast(i0, "int64")
+                    if basic:
+                        if i0 < (length if basic else row_len_rt):
+                            st_global_u32(out_idx, slot0, T.reinterpret("uint32", i0))
+                            st_global_bits(
+                                out_val,
+                                slot0,
+                                ld_global_nc_bits(inp, row_in + T.cast(i0, "int64"), is32),
+                                is32,
+                            )
+                        else:
+                            # A literal -1 is written as its bit pattern: reinterpreting
+                            # an immediate lowers to an address-of-literal, which is
+                            # not an lvalue.
+                            st_global_u32(out_idx, slot0, T.uint32(0xFFFFFFFF))
+                            st_global_bits(
+                                out_val, slot0, T.uint32(0) if is32 else T.uint16(0), is32
+                            )
+                    elif det:
+                        # Local index; the transform is deferred to the finalizer.
+                        st_global_u32(
+                            out_idx,
+                            slot0,
+                            T.reinterpret(
+                                "uint32",
+                                T.Select(i0 < (length if basic else row_len_rt), i0, T.int32(-1)),
+                            ),
+                        )
+                    elif page_table:
+                        page0: T.int32 = T.int32(-1)
+                        if i0 < (length if basic else row_len_rt):
+                            page0 = T.reinterpret(
+                                "int32",
+                                ld_global_nc_u32(
+                                    aux,
+                                    T.cast(batch_idx, "int64") * aux_stride
+                                    + T.cast(page_start + i0, "int64"),
+                                ),
+                            )
+                        st_global_u32(out_idx, slot0, T.reinterpret("uint32", page0))
+                    else:
+                        st_global_u32(
+                            out_idx,
+                            slot0,
+                            T.reinterpret(
+                                "uint32",
+                                T.Select(
+                                    i0 < (length if basic else row_len_rt),
+                                    i0 + offset_val,
+                                    T.int32(-1),
+                                ),
+                            ),
+                        )
+
+        if take_main == 1:
+            emit_filtered_topk_main(
+                inp,
+                out_idx,
+                out_val,
+                aux,
+                s_hist2,
+                s_indices,
+                s_scal,
+                s_input,
+                s_scan if det else s_scal,
+                tx,
+                row_in,
+                row_out,
+                length if basic else row_len_rt,
+                batch_idx,
+                page_start,
+                offset_val,
+                aux_stride,
+                cfg,
+            )
+
+    return filtered_topk.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+def get_finalize_kernel(
+    dtype: str = "float32",
+    mode: str = "basic",
+    num_rows: int = 16,
+    length: int = 8192,
+    k: int = 256,
+    deterministic: bool = False,
+    tie_break: int = TIE_NONE,
+    dsa_graph_safe: bool = False,
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    pattern: str = "random",
+    **kwargs,
+):
+    """Return the TIRx specialization of `FinalizeTopKIndicesKernel`, or None.
+
+    ``None`` means the dispatcher issues no second launch for this config, in
+    which case the harness must launch only the unified kernel.
+    """
+    plan = _validate(dtype, mode, num_rows, length, k, deterministic, tie_break, dsa_graph_safe)
+    fin = plan["finalize"]
+    if fin is None:
+        return None
+    block_threads, items_per_thread = plan["finalize_block"]
+    end_bit = plan["end_bit"]
+    do_sort = fin["sort_local_indices"]
+    basic = mode == "basic"
+    page_table = mode == "page_table"
+    ragged = mode == "ragged"
+    is32 = dtype == "float32"
+    # Plain keeps the scores paired with the keys through the sort; the transform
+    # modes instantiate the keys-only specialization (:2993-2999).
+    sort_values = do_sort and basic
+    val_bytes = dtype_bytes(dtype)
+    aux_elems = aux_elements(mode, num_rows, length, row_to_batch)
+
+    @T.prim_func
+    def filtered_topk_finalize(
+        output_indices_h: T.handle,
+        output_values_h: T.handle,
+        aux_data_h: T.handle,
+        page_table_row_starts_h: T.handle,
+        row_to_batch_h: T.handle,
+        aux_stride: T.int64,
+    ):
+        T.func_attr({"global_symbol": "filtered_topk_finalize"})
+        out_idx = T.match_buffer(output_indices_h, (num_rows * k,), "int32", scope="global")
+        out_val = T.match_buffer(output_values_h, (num_rows * k,), dtype, scope="global")
+        aux = T.match_buffer(aux_data_h, (aux_elems,), "int32", scope="global")
+        pt_starts_g = T.match_buffer(page_table_row_starts_h, (num_rows,), "int32", scope="global")
+        row_to_batch_g = T.match_buffer(row_to_batch_h, (num_rows,), "int32", scope="global")
+        T.device_entry()
+
+        row = T.cta_id([num_rows])
+        tx = T.thread_id([block_threads])
+
+        pool = T.SMEMPool()
+        if do_sort:
+            c32, c16, xk, xv, sscan = alloc_sort_smem(
+                pool, block_threads, items_per_thread, dtype, val_bytes
+            )
+        pool.commit()
+
+        row_out: T.int64 = T.cast(row, "int64") * T.int64(k)
+        keys = T.alloc_local((items_per_thread,), "uint32")
+        values = T.alloc_local((items_per_thread,), "uint32")
+
+        # --- blocked load with ~0u padding (:2976-2991) --------------------
+        for i in T.unroll(items_per_thread):
+            pos: T.int32 = tx * items_per_thread + i
+            keys[i] = T.uint32(0xFFFFFFFF)
+            values[i] = T.uint32(0)
+            if pos < k:
+                slot: T.int64 = row_out + T.cast(pos, "int64")
+                idx: T.int32 = T.reinterpret("int32", ld_global_u32(out_idx, slot))
+                # `(idx >= 0) ? idx : ~0u` -- nvcc folds the clamp to a single
+                # max.s32 against immediate -1 (:2981).
+                keys[i] = T.reinterpret("uint32", T.max(idx, T.int32(-1)))
+                if sort_values:
+                    values[i] = ld_global_bits(out_val, slot, is32)
+
+        # --- ascending block radix sort over [0, end_bit) (:2993-2999) -----
+        # `~0u` truncated to end_bit bits is 2**end_bit - 1 while every real
+        # index is <= max_len - 1 < 2**end_bit - 1, so padding is strictly
+        # maximal in every digit pass and lands at the tail.
+        if do_sort:
+            ranks = T.alloc_local((items_per_thread,), "int32")
+            emit_block_radix_sort(
+                c32,
+                c16,
+                sscan,
+                xk,
+                xv,
+                keys,
+                values,
+                ranks,
+                tx,
+                block_threads,
+                items_per_thread,
+                end_bit,
+                sort_values,
+                is32,
+            )
+
+        # --- deferred transform + writeback (:3002-3029) -------------------
+        batch_idx: T.int32 = row
+        page_start: T.int32 = T.int32(0)
+        offset: T.int32 = T.int32(0)
+        if page_table:
+            if row_to_batch:
+                batch_idx = T.reinterpret("int32", ld_global_u32(row_to_batch_g, row))
+            # `:3008` falls back to 0, but the dispatcher already substituted
+            # row_starts for a null pointer at `:3379-3380`.
+            if effective_page_table_row_starts(mode, page_table_row_starts, row_starts):
+                page_start = T.reinterpret("int32", ld_global_u32(pt_starts_g, row))
+        if ragged:
+            offset = T.reinterpret("int32", ld_global_u32(aux, T.cast(row, "int64")))
+
+        for i in T.unroll(items_per_thread):
+            pos2: T.int32 = tx * items_per_thread + i
+            if pos2 < k:
+                slot2: T.int64 = row_out + T.cast(pos2, "int64")
+                key: T.uint32 = keys[i]
+                if basic:
+                    # `~0u` reinterprets to -1 for free, so both stores are
+                    # unguarded (:3010-3014).
+                    st_global_u32(out_idx, slot2, key)
+                    if sort_values:
+                        # The exchange keeps values in uint32 registers; narrow
+                        # them back on the way out for the 16-bit dtypes.
+                        if is32:
+                            st_global_u32(out_val, slot2, values[i])
+                        else:
+                            st_global_u16(out_val, slot2, T.cast(values[i], "uint16"))
+                elif page_table:
+                    page_id: T.int32 = T.int32(-1)
+                    if key != T.uint32(0xFFFFFFFF):
+                        src: T.int64 = T.cast(batch_idx, "int64") * aux_stride
+                        page_id = T.reinterpret(
+                            "int32",
+                            ld_global_u32(
+                                aux, src + T.cast(page_start + T.reinterpret("int32", key), "int64")
+                            ),
+                        )
+                    st_global_u32(out_idx, slot2, T.reinterpret("uint32", page_id))
+                else:
+                    val2: T.int32 = T.int32(-1)
+                    if key != T.uint32(0xFFFFFFFF):
+                        val2 = T.reinterpret("int32", key) + offset
+                    st_global_u32(out_idx, slot2, T.reinterpret("uint32", val2))
+
+    return filtered_topk_finalize.with_attr("tirx.kernel_launch_params", list(FINALIZE_LAUNCH_TAGS))
+
+
+_ = (
+    bench,
+    dtype_bytes,
+    hardware_max_smem_optin,
+    page_table_batch,
+    PATTERNS,
+    MIN_SMEM_PER_SM,
+    RADIX,
+    TIE_SMALL,
+    TIE_LARGE,
+)  # wired up with the config matrix and harness
+
+
+def prepare_data(
+    dtype: str = "float32",
+    mode: str = "basic",
+    num_rows: int = 16,
+    length: int = 8192,
+    k: int = 256,
+    pattern: str = "random",
+    row_starts: bool = False,
+    page_table_row_starts: bool = False,
+    row_to_batch: bool = False,
+    trivial: bool = False,
+    **kwargs,
+):
+    """Logical inputs for one config.
+
+    ``pattern`` mirrors ``benchmarks/bench_topk.py --input-pattern`` (``:982-996``).
+    It is part of the config domain rather than a testing nicety: the
+    ``s_refine_overflow`` fallbacks (``:2711-2757`` for 16-bit, ``:2800-2901`` for
+    fp32) are reached only when one coarse bin holds more than
+    ``FILTERED_TOPK_SMEM_INPUT_SIZE`` candidates, which seeded normals never do at
+    these lengths (about ``length / 256`` per bin).  ``tie_heavy`` and
+    ``quantized`` collapse the row onto few distinct values so a single bin
+    overflows; ``pivot_tie`` piles ties exactly at the pivot.
+
+    Configs tagged with an overflow-reaching pattern are checked on the host
+    below, so the coverage cannot silently rot if the traits or the arena size
+    ever change.
+    """
+    import torch
+
+    device = "cuda"
+    rows = num_rows
+    generator = torch.Generator(device=device).manual_seed(1234)
+    if pattern == "random":
+        scores = torch.randn(rows, length, dtype=torch.float32, device=device, generator=generator)
+    elif pattern == "quantized":
+        # A few distinct magnitudes: many rows share a coarse bin.
+        levels = torch.randint(
+            0, 6, (rows, length), dtype=torch.int32, device=device, generator=generator
+        )
+        scores = levels.to(torch.float32)
+    elif pattern == "tie_heavy":
+        # Two values, so the winning coarse bin holds a third of the row.
+        pick = torch.randint(
+            0, 3, (rows, length), dtype=torch.int32, device=device, generator=generator
+        )
+        scores = torch.where(
+            pick == 0,
+            torch.full((rows, length), 2.0, device=device),
+            torch.full((rows, length), 1.0, device=device),
+        )
+    elif pattern == "pivot_tie":
+        # Distinct values above the pivot, then a wide plateau exactly at it.
+        scores = torch.randn(rows, length, dtype=torch.float32, device=device, generator=generator)
+        plateau = max(1, k // 2)
+        scores = torch.sort(scores, dim=-1, descending=True).values
+        scores[:, plateau : plateau + 4 * k] = scores[:, plateau : plateau + 1]
+        perm = torch.randperm(length, device=device, generator=generator)
+        scores = scores[:, perm].contiguous()
+    else:
+        raise ValueError(f"Unknown pattern: {pattern}")
+    scores = scores.to(torch_dtype(dtype)).contiguous()
+
+    data: dict[str, Any] = {"scores": scores, "pattern": pattern}
+    if mode != "basic":
+        if trivial:
+            lengths = torch.full((rows,), min(k, length), dtype=torch.int32, device=device)
+        else:
+            lengths = torch.full((rows,), length, dtype=torch.int32, device=device)
+        if row_starts:
+            starts = torch.arange(rows, dtype=torch.int32, device=device) % 8
+            lengths = torch.clamp(lengths - starts, min=min(k, length))
+            data["row_starts"] = starts
+        data["lengths"] = lengths
+    if mode == "page_table":
+        batch = page_table_batch(rows, row_to_batch)
+        if row_to_batch:
+            data["row_to_batch"] = (
+                torch.arange(rows, dtype=torch.int32, device=device) % batch
+            ).contiguous()
+        # Injective page ids (batch-major) so a returned page id inverts back to
+        # the row-local index the kernel selected: id == batch * length + slot.
+        data["src_page_table"] = (
+            torch.arange(batch * length, dtype=torch.int32, device=device)
+            .reshape(batch, length)
+            .contiguous()
+        )
+        data["page_table_batch"] = batch
+        if page_table_row_starts:
+            data["page_table_row_starts"] = (
+                torch.arange(rows, dtype=torch.int32, device=device) % 4
+            ).contiguous()
+    if mode == "ragged":
+        data["offsets"] = (
+            torch.arange(rows, dtype=torch.int32, device=device) * length
+        ).contiguous()
+    return data
+
+
+def assert_pattern_reaches_overflow(cfg: dict[str, Any], data: dict[str, Any]) -> None:
+    """Check on the host that an overflow-tagged config really overflows.
+
+    Recomputes ``ToCoarseKey`` and the suffix scan exactly as the kernel does,
+    finds the threshold bin, and requires its population to exceed the 16384-entry
+    candidate arena -- the condition that sets ``s_refine_overflow`` (``:2618-2625``).
+    Without this the fallback coverage could vanish silently.
+    """
+    import torch
+
+    if cfg["pattern"] not in _OVERFLOW_PATTERNS:
+        return
+    scores = data["scores"]
+    lengths = data.get("lengths")
+    bins = _coarse_key_host(scores)
+    reached = False
+    for r in range(scores.size(0)):
+        n = int(lengths[r]) if lengths is not None else scores.size(1)
+        hist = torch.bincount(bins[r, :n], minlength=RADIX).to(torch.int64)
+        suffix = torch.flip(torch.cumsum(torch.flip(hist, [0]), 0), [0])
+        topk = cfg["k"]
+        above = torch.cat([suffix[1:], suffix.new_zeros(1)])
+        hit = ((suffix > topk) & (above <= topk)).nonzero()
+        if hit.numel() == 0:
+            continue
+        if int(hist[int(hit[0])]) > FILTERED_TOPK_SMEM_INPUT_SIZE:
+            reached = True
+            break
+    assert reached, (
+        f"pattern {cfg['pattern']!r} at length={cfg['length']} k={cfg['k']} no longer "
+        f"overflows the {FILTERED_TOPK_SMEM_INPUT_SIZE}-entry candidate arena, so the "
+        "s_refine_overflow fallback is untested by this config"
+    )
+
+
+def _coarse_key_host(scores):
+    """``Traits::ToCoarseKey`` on the host: fp16 round, monotone flip, high byte."""
+    import torch
+
+    if scores.dtype == torch.float32:
+        bits = scores.to(torch.float16).view(torch.int16).to(torch.int32) & 0xFFFF
+    else:
+        bits = scores.view(torch.int16).to(torch.int32) & 0xFFFF
+    flipped = torch.where(bits & 0x8000 != 0, (~bits) & 0xFFFF, bits | 0x8000)
+    return (flipped >> 8).to(torch.int64)
+
+
+def run_reference(config: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]) -> None:
+    """One launch of the FlashInfer source pipeline with preallocated outputs.
+
+    The filtered path never touches ``row_states``, so the optional workspace is
+    passed as ``None``: an accidental dispatch back to a radix kernel would fail
+    loudly instead of silently producing a correct answer by another route.
+    """
+    import torch
+
+    pin_source_algo(SOURCE_ALGO_FILTERED)
+    module = source_module()
+    fn, args = _reference_args(config, data, outputs)
+    fn(*args)
+    torch.cuda.synchronize()
+
+
+def _reference_args(config: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]):
+    mode = config["mode"]
+    k = config["k"]
+    det = config["deterministic"]
+    tie = config["tie_break"]
+    dsa = config["dsa_graph_safe"]
+    indices = outputs["indices"]
+    scores = data["scores"]
+    if mode == "basic":
+        return module_fn(mode), (
+            scores,
+            indices,
+            outputs["values"],
+            None,  # row_states: unused on the filtered path
+            k,
+            False,  # sorted_output
+            det,
+            tie,
+            dsa,
+        )
+    if mode == "page_table":
+        return module_fn(mode), (
+            scores,
+            indices,
+            data["src_page_table"],
+            data.get("row_to_batch"),
+            data["lengths"],
+            None,
+            k,
+            det,
+            tie,
+            dsa,
+            data.get("row_starts"),
+            data.get("page_table_row_starts"),
+        )
+    return module_fn(mode), (
+        scores,
+        indices,
+        data["offsets"],
+        data["lengths"],
+        None,
+        k,
+        det,
+        tie,
+        dsa,
+        data.get("row_starts"),
+    )
+
+
+def module_fn(mode: str):
+    module = source_module()
+    if mode == "basic":
+        return module.radix_topk
+    if mode == "page_table":
+        return module.radix_topk_page_table_transform
+    return module.radix_topk_ragged_transform
+
+
+def build_reference_launch(config: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]):
+    """Resolve the module and bind every argument once; return a bare launch.
+
+    The timed closure must enqueue exactly what the dispatcher enqueues -- which
+    for a deterministic or tie-break config is the unified kernel *and* the
+    finalize kernel -- and nothing else: no env writes, no module lookup, no host
+    synchronize.
+    """
+    pin_source_algo(SOURCE_ALGO_FILTERED)
+    fn, args = _reference_args(config, data, outputs)
+
+    def launch():
+        fn(*args)
+
+    return launch
+
+
+def build_tirx_args(cfg: dict[str, Any], data: dict[str, Any], outputs: dict[str, Any]):
+    """Materialize the flat launch ABI once, outside any timed region.
+
+    Every tensor the kernels read must exist before the launch closure is built:
+    allocating placeholders inside the closure would enqueue extra fill kernels
+    that a per-kernel timer attributes to this workload.
+    """
+    import torch
+
+    rows = cfg["num_rows"]
+    length = cfg["length"]
+    mode = cfg["mode"]
+    device = "cuda"
+    empty = torch.zeros(rows, dtype=torch.int32, device=device)
+    lengths = data.get("lengths")
+    if lengths is None:
+        lengths = torch.full((rows,), length, dtype=torch.int32, device=device)
+    row_starts = data.get("row_starts", empty)
+    # Mirror the dispatcher's null-pointer substitution (:3379-3380) so both
+    # launches see what the reference's launches see.
+    pt_starts = data.get("page_table_row_starts")
+    if pt_starts is None and mode == "page_table":
+        pt_starts = data.get("row_starts", empty)
+    if pt_starts is None:
+        pt_starts = empty
+    r2b = data.get("row_to_batch", empty)
+    if mode == "page_table":
+        aux = data["src_page_table"].reshape(-1)
+        aux_stride = length
+    elif mode == "ragged":
+        aux = data["offsets"]
+        aux_stride = 1
+    else:
+        aux = torch.zeros(1, dtype=torch.int32, device=device)
+        aux_stride = 1
+    scores = data["scores"].reshape(-1)
+    indices = outputs["indices"].reshape(-1)
+    values = outputs["values"].reshape(-1)
+    return {
+        "main": (scores, indices, values, aux, lengths, row_starts, pt_starts, r2b, aux_stride),
+        "finalize": (indices, values, aux, pt_starts, r2b, aux_stride),
+    }
+
+
+def _launch_tirx(ex, ex_finalize, args) -> None:
+    """Enqueue the ported pipeline: unified kernel, then finalize when dispatched.
+
+    Nothing but the launches -- no allocation, no host synchronize.
+    """
+    ex(*args["main"])
+    if ex_finalize is not None:
+        ex_finalize(*args["finalize"])
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against the FlashInfer source."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import check_low_level_ir, compile_kernel
+
+    try:
+        import flashinfer  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"flashinfer unavailable: {exc}") from exc
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    cfg = _normalize_config(config)
+    assert_device_matches_compile_profile(hardware_max_smem_optin(), "filtered")
+    _validate(
+        cfg["dtype"],
+        cfg["mode"],
+        cfg["num_rows"],
+        cfg["length"],
+        cfg["k"],
+        cfg["deterministic"],
+        cfg["tie_break"],
+        cfg["dsa_graph_safe"],
+    )
+
+    data = prepare_data(**cfg)
+    assert_pattern_reaches_overflow(cfg, data)
+
+    ref_out = alloc_outputs(cfg)
+    run_reference(cfg, data, ref_out)
+    assert_reference_is_top_k(cfg, data, ref_out)
+    assert_reference_tie_break(cfg, data, ref_out)
+
+    kernel = get_kernel(**cfg)
+    finalize = get_finalize_kernel(**cfg)
+    # The runner only contract-checks `get_kernel`; the finalize kernel is a
+    # second entry point, so check it here too.
+    if finalize is not None:
+        check_low_level_ir(finalize)
+    ex = compile_kernel(kernel)
+    ex_finalize = compile_kernel(finalize) if finalize is not None else None
+
+    tirx_out = alloc_outputs(cfg)
+    _launch_tirx(ex, ex_finalize, build_tirx_args(cfg, data, tirx_out))
+    torch.cuda.synchronize()
+
+    compare_filtered_outputs(cfg, data, ref_out, tirx_out)
+
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    cfg = {
+        "dtype": "float32",
+        "mode": "basic",
+        "num_rows": 16,
+        "length": 8192,
+        "k": 256,
+        "deterministic": False,
+        "tie_break": TIE_NONE,
+        "dsa_graph_safe": False,
+        "row_starts": False,
+        "page_table_row_starts": False,
+        "row_to_batch": False,
+        "trivial": False,
+        "pattern": "random",
+    }
+    cfg.update({key: value for key, value in config.items() if key != "label"})
+    return cfg
+
+
+def assert_reference_is_top_k(
+    cfg: dict[str, Any], data: dict[str, Any], ref: dict[str, Any]
+) -> None:
+    """Independent oracle on the reference launch itself (tie-robust)."""
+    import torch
+
+    if cfg["trivial"]:
+        return
+    scores = data["scores"].to(torch.float32)
+    row_starts = data.get("row_starts")
+    lengths = data.get("lengths")
+    if row_starts is None and lengths is None:
+        window = scores
+    else:
+        rows, length = cfg["num_rows"], cfg["length"]
+        starts = (
+            torch.zeros(rows, dtype=torch.int64, device=scores.device)
+            if row_starts is None
+            else row_starts.to(torch.int64)
+        )
+        lens = (
+            torch.full((rows,), length, dtype=torch.int64, device=scores.device)
+            if lengths is None
+            else lengths.to(torch.int64)
+        )
+        cols = torch.arange(length, device=scores.device).unsqueeze(0)
+        inside = (cols >= starts.unsqueeze(-1)) & (cols < (starts + lens).unsqueeze(-1))
+        window = torch.where(inside, scores, torch.full_like(scores, float("-inf")))
+    expect = torch.sort(torch.topk(window, cfg["k"], dim=-1).values, dim=-1, descending=True).values
+    actual = selected_values(cfg, data, ref["indices"])
+    torch.testing.assert_close(actual, expect, rtol=0, atol=0)
+
+
+def assert_reference_tie_break(
+    cfg: dict[str, Any], data: dict[str, Any], ref: dict[str, Any]
+) -> None:
+    """Oracle for ``tie_break``: the claimed ties must be the extremal indices.
+
+    A plain top-k check cannot see this -- every tie subset has the same values.
+    ``Small`` must claim the smallest row-local indices among the elements equal
+    to the pivot, ``Large`` the largest (``:2591-2600``).
+    """
+    import torch
+
+    if cfg["tie_break"] == TIE_NONE or cfg["trivial"]:
+        return
+    scores = data["scores"].to(torch.float32)
+    idx, pad = row_local_indices(cfg, data, ref["indices"])
+    row_starts = data.get("row_starts")
+    lengths = data.get("lengths")
+    for r in range(cfg["num_rows"]):
+        start = int(row_starts[r]) if row_starts is not None else 0
+        span = int(lengths[r]) if lengths is not None else cfg["length"]
+        keep = ~pad[r]
+        chosen = (idx[r][keep] + start).tolist()
+        if not chosen:
+            continue
+        pivot = min(scores[r][c].item() for c in chosen)
+        window = scores[r][start : start + span]
+        eq_all = (window == pivot).nonzero().flatten() + start
+        eq_chosen = sorted(c for c in chosen if scores[r][c].item() == pivot)
+        n = len(eq_chosen)
+        want = eq_all[:n] if cfg["tie_break"] == TIE_SMALL else eq_all[-n:]
+        assert eq_chosen == sorted(want.tolist()), (
+            f"row {r}: tie_break={cfg['tie_break']} claimed {eq_chosen[:6]}... but the "
+            f"{'smallest' if cfg['tie_break'] == TIE_SMALL else 'largest'} equal-valued "
+            f"indices are {sorted(want.tolist())[:6]}..."
+        )
+
+
+def compare_filtered_outputs(
+    cfg: dict[str, Any], data: dict[str, Any], ref: dict[str, Any], got: dict[str, Any]
+) -> None:
+    """Compare a TIRx pipeline launch against the FlashInfer pipeline.
+
+    Three regimes, matching what the source actually guarantees:
+
+    * ``DETERMINISTIC`` (``deterministic``, or ``tie_break`` on a transform mode):
+      the reference finalize-sorts each row ascending, so the outputs must match
+      **element for element**.
+    * ``tie_break`` without ``deterministic`` on Plain: no finalize launch, so the
+      order is racy, but the selected *set* is unique because ties are broken by
+      extremal index.  Compare sorted index sets -- strictly stronger than the
+      value check.
+    * otherwise: which ties win is genuinely racy on both sides, so compare the
+      multiset of selected score values, which every valid top-k shares.
+    """
+    import torch
+
+    plan = finalize_plan(cfg["mode"], cfg["k"], cfg["deterministic"], cfg["tie_break"])
+    if plan is not None and plan["sort_local_indices"]:
+        torch.testing.assert_close(got["indices"], ref["indices"], rtol=0, atol=0)
+        if cfg["mode"] == "basic":
+            torch.testing.assert_close(got["values"], ref["values"], rtol=0, atol=0)
+        return
+
+    if cfg["tie_break"] != TIE_NONE:
+        ref_idx = torch.sort(ref["indices"].to(torch.int64), dim=-1).values
+        got_idx = torch.sort(got["indices"].to(torch.int64), dim=-1).values
+        torch.testing.assert_close(got_idx, ref_idx, rtol=0, atol=0)
+        return
+
+    ref_vals = selected_values(cfg, data, ref["indices"])
+    got_vals = selected_values(cfg, data, got["indices"])
+    torch.testing.assert_close(got_vals, ref_vals, rtol=0, atol=0)
+    if cfg["mode"] == "basic":
+        ref_out = torch.sort(ref["values"].to(torch.float32), dim=-1, descending=True).values
+        got_out = torch.sort(got["values"].to(torch.float32), dim=-1, descending=True).values
+        torch.testing.assert_close(got_out, ref_out, rtol=0, atol=0)
+        # The emitted values must be the scores at the emitted indices.  On the
+        # trivial path the padding slots carry a literal 0 (:2417) that is not a
+        # score, and `selected_values` sorts padding to -inf, so the two orderings
+        # only line up over the real entries; restrict the check to those.
+        _, pad = row_local_indices(cfg, data, got["indices"])
+        real = torch.where(
+            pad,
+            torch.full_like(got["values"].to(torch.float32), float("-inf")),
+            got["values"].to(torch.float32),
+        )
+        real = torch.sort(real, dim=-1, descending=True).values
+        torch.testing.assert_close(real, got_vals, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+# ---------------------------------------------------------------------------
+def prepare_bench(**kwargs: Any):
+    """Specialize and compile both executables before the workload receives a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    cfg = _normalize_config(kwargs)
+    finalize = get_finalize_kernel(**cfg)
+    state = {
+        "config": cfg,
+        "executable": compile_kernel(get_kernel(**cfg)),
+        # None where `finalize_plan` says the dispatcher issues no second launch.
+        "finalize": compile_kernel(finalize) if finalize is not None else None,
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    """Timed comparison against the FlashInfer source pipeline.
+
+    Both sides enqueue the same number of kernels: one where ``finalize_plan``
+    returns ``None``, two where it does not.  Every tensor is allocated before the
+    closure is built -- allocating inside it would enqueue fill kernels that a
+    per-kernel timer attributes to this workload.
+    """
+    cfg = dict(prepared["config"])
+    ex = prepared["executable"]
+    ex_finalize = prepared["finalize"]
+
+    data = prepare_data(**cfg)
+    tirx_out = alloc_outputs(cfg)
+    tirx_args = build_tirx_args(cfg, data, tirx_out)
+
+    def tirx_launch():
+        _launch_tirx(ex, ex_finalize, tirx_args)
+
+    def build_reference():
+        ref_out = alloc_outputs(cfg)
+        return build_reference_launch(cfg, data, ref_out)
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+# ---------------------------------------------------------------------------
+_DT_TAG = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+_MODE_TAG = {"basic": "plain", "page_table": "pt", "ragged": "rag"}
+_TIE_TAG = {TIE_NONE: "", TIE_SMALL: "_tsmall", TIE_LARGE: "_tlarge"}
+
+# Every finalize (BLOCK_THREADS, ITEMS_PER_THREAD) rung of the ladder at
+# :3061-3079, plus k == 1 for the Plain finalize early-out at :3043-3047.
+_K_SWEEP = (1, 128, 256, 512, 576, 1024, 2048)
+# end_bit = bit_length(max_len), giving 2..5 digit passes in the finalize sort.
+_END_BIT_LENGTHS = (200, 4096, 65536, 524288)
+# grid is one CTA per row, against 148 SMs on B200.
+_ROW_SWEEP = (1, 16, 64, 256)
+_VEC_BASE = 8192
+# Offsets from _VEC_BASE whose gcd with 16/sizeof(DType) walks every reachable
+# VEC_SIZE: f32 gives 4/2/1, the 16-bit dtypes 8/4/2/1 (ComputeFilteredTopKVecSize
+# :2934-2943).
+_VEC_OFFSETS = {4: (0, -2, -3), 8: (0, -4, -2, -3)}
+
+
+def _cfg(
+    dtype,
+    mode,
+    num_rows,
+    length,
+    k,
+    deterministic=False,
+    tie_break=TIE_NONE,
+    dsa_graph_safe=False,
+    row_starts=False,
+    page_table_row_starts=False,
+    row_to_batch=False,
+    trivial=False,
+    pattern="random",
+    tag="",
+):
+    label = f"{_DT_TAG[dtype]}_{_MODE_TAG[mode]}"
+    if deterministic:
+        label += "_det"
+    label += _TIE_TAG[tie_break]
+    label += f"_r{num_rows}_l{length}_k{k}"
+    if dsa_graph_safe:
+        label += "_dsa"
+    if row_starts:
+        label += "_rs"
+    if page_table_row_starts:
+        label += "_pts"
+    if row_to_batch:
+        label += "_r2b"
+    if trivial:
+        label += "_trivial"
+    if pattern != "random":
+        label += f"_{pattern}"
+    if tag:
+        label += f"_{tag}"
+    return {
+        "label": label,
+        "dtype": dtype,
+        "mode": mode,
+        "num_rows": num_rows,
+        "length": length,
+        "k": k,
+        "deterministic": deterministic,
+        "tie_break": tie_break,
+        "dsa_graph_safe": dsa_graph_safe,
+        "row_starts": row_starts,
+        "page_table_row_starts": page_table_row_starts,
+        "row_to_batch": row_to_batch,
+        "trivial": trivial,
+        "pattern": pattern,
+    }
+
+
+def _reachable_vec_lengths(dtype):
+    """(length, vec) for every VEC_SIZE the launcher can instantiate."""
+    max_vec = 16 // dtype_bytes(dtype)
+    out = []
+    for off in _VEC_OFFSETS[max_vec]:
+        length = _VEC_BASE + off
+        out.append((length, vec_size(dtype, length)))
+    seen = set()
+    uniq = []
+    for length, vec in out:
+        if vec not in seen:
+            seen.add(vec)
+            uniq.append((length, vec))
+    return uniq
+
+
+# Cells that carry the axis sweeps.  Every cell of the 54-cell grid still gets a
+# base config, so no template instantiation or finalize behavior goes untested;
+# the sweeps that are orthogonal to the cell -- k, end_bit, VEC_SIZE, num_rows --
+# run only where they are structurally distinct, instead of being repeated in all
+# 54 cells.
+_CARRIER_NONDET = ("float32", "basic", False, TIE_NONE)  # base dispatch, no finalize
+_CARRIER_DET = ("float32", "basic", True, TIE_NONE)  # sorting finalize, keys+values
+_CARRIER_XFORM = ("float32", "page_table", False, TIE_SMALL)  # transform-only finalize
+
+
+def _build_configs():
+    """Representative cover of the FilteredTopK dispatch domain.
+
+    Retained in full:
+
+    * all **54 cells** -- dtype x mode x (deterministic, tie_break) -- one base
+      config each.  These pin every distinct kernel instantiation and all three
+      finalize behaviors (no launch / sorting / transform-only).
+    * every reachable **VEC_SIZE** per dtype (f32 4/2/1, 16-bit 8/4/2/1).
+    * the whole **k ladder**, so each of the six finalize ``(BLOCK_THREADS,
+      ITEMS_PER_THREAD)`` rungs is exercised, plus ``k == 1`` for the Plain
+      finalize early-out.
+    * the **end_bit** sweep covering 2..5 digit passes in the finalize sort.
+    * both data-dependent **overflow fallbacks**, on both dtype families, since
+      the 16-bit and fp32 fallbacks are different code.
+    * ``dsa_graph_safe``, the in-kernel **trivial path**, every runtime pointer
+      branch, and the ``num_rows`` occupancy axis.
+
+    Reduced: those sweeps used to be repeated inside every cell, which is what a
+    cross of all axes costs.  They now run on the carrier cells above, where the
+    behavior they exercise actually differs; other cells inherit coverage of the
+    swept axis from the carrier that shares its code path.
+    """
+    configs = []
+    base = _VEC_BASE
+
+    # 1. Cell grid: one config per (dtype, mode, deterministic, tie_break).
+    for dtype in DTYPES:
+        for mode in MODES:
+            for deterministic in (False, True):
+                for tie_break in TIE_BREAKS:
+                    configs.append(_cfg(dtype, mode, 4, base, 256, deterministic, tie_break))
+
+    # 2. VEC_SIZE dispatch, per dtype.
+    for dtype in DTYPES:
+        for length, _vec in _reachable_vec_lengths(dtype):
+            configs.append(_cfg(dtype, "basic", 4, length, 256, tag="vec"))
+
+    # 3. k ladder: the six finalize rungs, with and without the sorting finalize.
+    for carrier in (_CARRIER_NONDET, _CARRIER_DET):
+        dtype, mode, det, tie = carrier
+        for k in _K_SWEEP:
+            configs.append(_cfg(dtype, mode, 4, base, k, det, tie))
+
+    # 4. end_bit sweep -- only the sorting finalize depends on the pass count.
+    dtype, mode, det, tie = _CARRIER_DET
+    for length in _END_BIT_LENGTHS:
+        configs.append(
+            _cfg(dtype, mode, 2, length, 128 if length < 1024 else 256, det, tie, tag="endbit")
+        )
+
+    # 5. Occupancy: grid is one CTA per row against 148 SMs.
+    dtype, mode, det, tie = _CARRIER_NONDET
+    for rows in _ROW_SWEEP:
+        configs.append(_cfg(dtype, mode, rows, base, 256, det, tie))
+
+    # 6. Data-dependent paths.  The 16-bit slow path (:2711-2757) and the fp32
+    #    32-bit pivot rebuild (:2800-2901) are different code, so both dtype
+    #    families carry the overflow patterns; `prepare_data` asserts each one
+    #    still overflows the candidate arena.
+    for dtype in ("float32", "float16"):
+        for det in (False, True):
+            for pattern in ("quantized", "tie_heavy"):
+                configs.append(_cfg(dtype, "basic", 2, _OVERFLOW_LENGTH, 256, det, pattern=pattern))
+        for tie in (TIE_SMALL, TIE_LARGE):
+            configs.append(_cfg(dtype, "basic", 4, base, 256, False, tie, pattern="pivot_tie"))
+
+    # 7. dsa_graph_safe: unconditional filtered dispatch and VEC_SIZE forced to 1.
+    for mode in MODES:
+        configs.append(_cfg("float32", mode, 4, base, 256, dsa_graph_safe=True))
+
+    # 8. Runtime pointer branches (transform modes only).
+    for dtype, mode, det, tie in (_CARRIER_XFORM, ("float32", "ragged", False, TIE_NONE)):
+        configs.append(_cfg(dtype, mode, 4, base, 256, det, tie, row_starts=True))
+    configs.append(
+        _cfg(
+            *_CARRIER_XFORM[:2],
+            4,
+            base,
+            256,
+            *_CARRIER_XFORM[2:],
+            row_starts=True,
+            page_table_row_starts=True,
+        )
+    )
+    configs.append(_cfg(*_CARRIER_XFORM[:2], 4, base, 256, *_CARRIER_XFORM[2:], row_to_batch=True))
+
+    # 9. In-kernel trivial path (length <= k, :2409-2429): reachable on the
+    #    transform modes through short per-row lengths, and on Plain only when a
+    #    forcing flag bypasses the `max_len > k` precondition.
+    configs.append(_cfg("float32", "page_table", 4, base, 256, trivial=True))
+    configs.append(_cfg("float32", "ragged", 4, base, 256, trivial=True))
+    configs.append(_cfg("float32", "basic", 4, 256, 256, False, TIE_SMALL, trivial=True))
+    configs.append(_cfg("float16", "basic", 4, 256, 256, True, TIE_LARGE, trivial=True))
+    # `length < k` (not just `==`) is the only shape that reaches the `:2416-2417`
+    # padding arm of the Plain trivial path; a forcing flag is what makes it
+    # dispatchable at all.
+    configs.append(_cfg("float16", "basic", 4, 200, 256, True, TIE_LARGE, trivial=True))
+    configs.append(_cfg("float32", "basic", 4, 200, 256, dsa_graph_safe=True, trivial=True))
+
+    # Deduplicate on launch parameters (labels alone would keep near-twins).
+    seen: dict[tuple, dict[str, Any]] = {}
+    for cfg in configs:
+        params = tuple(sorted((key, value) for key, value in cfg.items() if key != "label"))
+        seen.setdefault(params, cfg)
+    deduped = list(seen.values())
+    labels = [cfg["label"] for cfg in deduped]
+    assert len(set(labels)) == len(labels), "duplicate config label"
+    return deduped
+
+
+def _build_bench_configs():
+    """Timed matrix: drop the trivial-path cases, keep everything else.
+
+    The overflow patterns stay in -- the fallbacks are real performance regimes
+    and both sides consume identical seeded inputs.
+    """
+    return [cfg for cfg in _build_configs() if not cfg["trivial"]]
+
+
+CONFIGS = _build_configs()
+BENCH_CONFIGS = _build_bench_configs()

--- a/tirx_kernels/flashinfer/utils/block_radix_sort.py
+++ b/tirx_kernels/flashinfer/utils/block_radix_sort.py
@@ -1,0 +1,390 @@
+# This file is a TIRx port of code from NVIDIA CCCL/CUB
+# (https://github.com/NVIDIA/cccl), Copyright (c) 2011, Duane Merrill; 2011-2018, NVIDIA CORPORATION.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""``cub::BlockRadixSort`` emitters for the filtered top-k finalize kernel.
+
+``FinalizeTopKIndicesKernel`` (``include/flashinfer/topk.cuh:2993``) instantiates
+``cub::BlockRadixSort<uint32_t, BLOCK_THREADS, ITEMS_PER_THREAD, DType>`` -- key
+plus value for ``Plain``, and keys-only (``DType = uint8_t`` with null values) for
+the transform modes.  These helpers reproduce that collective's per-pass
+structure so the finalize kernel can call it the way the source does.
+
+Template defaults that fix the shape (``cub/block/block_radix_sort.cuh:221-231``):
+``RadixBits = 4`` for **every** ``(BLOCK_THREADS, ITEMS_PER_THREAD)`` pair,
+``MemoizeOuterScan = true``, ``InnerScanAlgorithm = BLOCK_SCAN_WARP_SCANS``.  The
+ranker is the basic ``BlockRadixRank`` (``:250-255``), so there is no
+``match.any``, ballot, or ``PRMT`` on any path, and no arch-conditional fork --
+SM100 compiles the classic algorithm.
+
+With ``RadixBits = 4`` and ``uint16``/``uint32`` counters
+(``block_radix_rank.cuh:229-262``): ``PACKING_RATIO = 2``, ``COUNTER_LANES = 8``,
+``PADDED_COUNTER_LANES = RAKING_SEGMENT = 9``, and ``BINS_TRACKED_PER_THREAD = 1``
+for every block size used here.  The counter grid is ``9 * BLOCK_THREADS`` words
+addressed both as ``uint32`` (packed raking adds) and as ``uint16`` (per-digit
+read-modify-write); each thread owns column ``tid``, so the RMW needs **no**
+atomics.
+
+Digit extraction is a shift plus a mask, not ``bfe``: ``BFEDigitExtractor``
+(``radix_rank_sort_operations.cuh:102-105``) calls ``cuda::bitfield_extract``,
+whose ``NV_PROVIDES_SM_70`` dispatch arm is empty (``cuda/__bit/bitfield.h:107``)
+so control falls through to the shift-and-mask return at ``:114``.
+"""
+
+from tirx_kernels.flashinfer.utils.topk_radix import (
+    bar_sync,
+    ld_shared_u16,
+    ld_shared_u32,
+    shfl_up_u32,
+    st_shared_u16,
+    st_shared_u32,
+)
+from tvm.script import tirx as T
+
+# Every loop in this module is a Python loop, not ``T.unroll``/``T.serial``.
+# These emitters are called from inside a traced prim_func body but are not
+# themselves parsed by TVMScript, so a ``T.unroll`` frame here is never turned
+# into a loop -- it just fails to iterate.  A Python loop emits the same
+# straight-line TIR that cub's ``_CCCL_PRAGMA_UNROLL_FULL`` produces, and the
+# digit-pass loop is likewise unrolled because ``end_bit`` is static per config.
+
+# --- cub::BlockRadixRank geometry for RadixBits == 4 -------------------------
+RADIX_BITS = 4
+RADIX_DIGITS = 1 << RADIX_BITS  # 16
+PACKING_RATIO = 2  # sizeof(uint32) / sizeof(uint16)
+LOG_COUNTER_LANES = RADIX_BITS - 1  # 3
+COUNTER_LANES = 1 << LOG_COUNTER_LANES  # 8
+PADDED_COUNTER_LANES = COUNTER_LANES + 1  # 9
+RAKING_SEGMENT = PADDED_COUNTER_LANES  # 9
+WARP_THREADS = 32
+LOG_SMEM_BANKS = 5
+
+
+def sort_passes(end_bit: int) -> list[tuple[int, int]]:
+    """``[begin_bit, end_bit)`` split into ``RADIX_BITS``-wide digit passes.
+
+    ``SortBlocked`` (``block_radix_sort.cuh:377-429``) walks ``begin_bit`` up by
+    ``RADIX_BITS`` and clamps the last pass, so a non-multiple ``end_bit`` gets a
+    narrow final digit rather than an extra full one.
+    """
+    passes = []
+    begin = 0
+    while begin < end_bit:
+        passes.append((begin, min(RADIX_BITS, end_bit - begin)))
+        begin += RADIX_BITS
+    return passes
+
+
+def insert_padding(items_per_thread: int) -> bool:
+    """``BlockExchange::INSERT_PADDING`` (``block_exchange.cuh:139``).
+
+    ``ItemsPerThread > 4 && is_power_of_two(ItemsPerThread)`` -- true only for
+    ``IPT == 8`` among the six finalize configs; ``IPT == 4`` fails the first
+    clause and ``IPT == 9`` the second.
+    """
+    return items_per_thread > 4 and (items_per_thread & (items_per_thread - 1)) == 0
+
+
+def exchange_elements(block_threads: int, items_per_thread: int) -> int:
+    """``TIME_SLICED_ITEMS + PADDING_ITEMS`` (``block_exchange.cuh:140-145``)."""
+    items = block_threads * items_per_thread
+    pad = (items >> LOG_SMEM_BANKS) if insert_padding(items_per_thread) else 0
+    return items + pad
+
+
+def rank_words(block_threads: int) -> int:
+    """``uint32`` words in the counter grid: ``PADDED_COUNTER_LANES * BLOCK_THREADS``."""
+    return RAKING_SEGMENT * block_threads
+
+
+def warps(block_threads: int) -> int:
+    return (block_threads + WARP_THREADS - 1) // WARP_THREADS
+
+
+def scan_words(block_threads: int) -> int:
+    """``BlockScanWarpScans::_TempStorage``: ``warp_aggregates[WARPS]`` + ``block_prefix``.
+
+    ``WarpScanShfl::TempStorage`` is an empty struct
+    (``warp_scan_shfl.cuh:74-77``), so the shuffle scan itself needs no storage.
+    """
+    return warps(block_threads) + 1
+
+
+def union_bytes(block_threads: int, items_per_thread: int, value_bytes: int) -> int:
+    """``BlockRadixSort::_TempStorage`` (``block_radix_sort.cuh:268-274``).
+
+    A union of the ranking storage with the key and value exchange buffers.
+    """
+    items = exchange_elements(block_threads, items_per_thread)
+    return max(rank_words(block_threads) * 4, items * 4, items * value_bytes)
+
+
+def alloc_sort_smem(pool, block_threads, items_per_thread, value_dtype, value_bytes):
+    """Lay out the sort's shared union plus the block-scan scratch.
+
+    The counter grid is addressed as ``uint32`` and as ``uint16`` over the same
+    bytes, and the key/value exchange buffers alias it, exactly as cub's nested
+    unions do.  Every offset passed to ``move_base_to`` is a Python literal:
+    reading ``pool.offset`` inside a traced body turns it into a TIR variable and
+    the ``max()`` inside ``move_base_to`` then fails.
+    """
+    base = 0
+    xchg_items = exchange_elements(block_threads, items_per_thread)
+    total = union_bytes(block_threads, items_per_thread, value_bytes)
+
+    pool.move_base_to(base)
+    counters32 = pool.alloc((rank_words(block_threads),), "uint32", align=16)
+    pool.move_base_to(base)
+    counters16 = pool.alloc((rank_words(block_threads) * PACKING_RATIO,), "uint16", align=16)
+    pool.move_base_to(base)
+    xchg_keys = pool.alloc((xchg_items,), "uint32", align=16)
+    pool.move_base_to(base)
+    xchg_values = pool.alloc((xchg_items,), value_dtype, align=16)
+
+    pool.move_base_to(base + total)
+    scan = pool.alloc((scan_words(block_threads),), "uint32", align=16)
+    return counters32, counters16, xchg_keys, xchg_values, scan
+
+
+def emit_digit(key, begin_bit: int, num_bits: int):
+    """``BFEDigitExtractor::Digit`` -- shift and mask, never ``bfe`` on SM >= 70."""
+    return T.bitwise_and(T.shift_right(key, T.uint32(begin_bit)), T.uint32((1 << num_bits) - 1))
+
+
+def padded_offset(off, items_per_thread: int):
+    """``BlockExchange``'s bank-conflict padding: ``x + (x >> 5)`` when enabled."""
+    if not insert_padding(items_per_thread):
+        return off
+    return off + T.shift_right(off, T.int32(LOG_SMEM_BANKS))
+
+
+@T.macro
+def _scan_warp_inclusive(out, incl, tx, value):
+    """``WarpScanShfl`` inclusive sum plus cub's integer ``Update`` shortcut.
+
+    Five ``shfl.sync.up.b32`` steps give the inclusive scan; for ``plus<>`` on an
+    integer type cub takes ``exclusive = inclusive - input``
+    (``warp_scan_shfl.cuh:700-706``) instead of a sixth shuffle, which is why the
+    export shows exactly five shuffles per instantiation.
+    """
+    lane: T.int32 = tx % WARP_THREADS
+    incl[0] = value
+    for step in T.unroll(5):
+        peer: T.uint32 = shfl_up_u32(incl[0], T.shift_left(T.int32(1), step))
+        incl[0] = T.Select(lane >= T.shift_left(T.int32(1), step), incl[0] + peer, incl[0])
+    out[0] = incl[0] - value
+
+
+@T.macro
+def _scan_publish_warp_aggregate(scan, incl, tx):
+    """Last lane of each warp shares its warp aggregate (``:169-172``)."""
+    if tx % WARP_THREADS == WARP_THREADS - 1:
+        st_shared_u32(scan, tx // WARP_THREADS, incl[0])
+    bar_sync()
+
+
+@T.macro
+def _scan_seed_aggregate(scan, agg, wpre):
+    """``block_aggregate = warp_aggregates[0]`` (``:179``)."""
+    agg[0] = ld_shared_u32(scan, 0)
+    wpre[0] = T.uint32(0)
+
+
+@T.macro
+def _scan_fold_warp(scan, agg, wpre, tx, w):
+    """One step of ``ApplyWarpAggregates`` (``:129-134``)."""
+    if tx // WARP_THREADS == w:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + ld_shared_u32(scan, w)
+
+
+@T.macro
+def _scan_apply_prefix(scan, out, agg, wpre, tx, n_warps):
+    """Warp prefix, the packed block-prefix callback, and the broadcast back.
+
+    ``BlockRadixRank::PrefixCallBack`` returns ``aggregate << 16``
+    (``block_radix_rank.cuh:359-374``); the packing loop runs only for
+    ``PACKED == 1`` because ``PACKING_RATIO == 2``.
+    """
+    warp_id: T.int32 = tx // WARP_THREADS
+    lane: T.int32 = tx % WARP_THREADS
+    # Apply the warp prefix; lane0 of a non-zero warp takes it outright (:308-317).
+    if warp_id != 0:
+        out[0] = wpre[0] + out[0]
+        if lane == 0:
+            out[0] = wpre[0]
+    # Warp 0 evaluates the prefix callback and shares it (:387-398).
+    if warp_id == 0:
+        if lane == 0:
+            st_shared_u32(scan, n_warps, T.shift_left(agg[0], T.uint32(16)))
+            out[0] = T.shift_left(agg[0], T.uint32(16))
+    bar_sync()
+    bp: T.uint32 = ld_shared_u32(scan, n_warps)
+    if tx > 0:
+        out[0] = bp + out[0]
+
+
+def emit_block_exclusive_sum_packed(scan, out, incl, agg, wpre, tx, block_threads, value):
+    """``BlockScanWarpScans::ExclusiveScan`` with a block-prefix callback.
+
+    Mirrors ``block_scan_warp_scans.cuh:299-408``.  Two ``bar.sync`` per scan, as
+    in the source.  The warp-fold walk is a Python-level loop here so it emits
+    cub's straight-line ``ApplyWarpAggregates`` chain and simply disappears when
+    the block is a single warp; ``out[0]`` receives the exclusive result.
+    """
+    n_warps = warps(block_threads)
+    _scan_warp_inclusive(out, incl, tx, value)
+    _scan_publish_warp_aggregate(scan, incl, tx)
+    _scan_seed_aggregate(scan, agg, wpre)
+    for w in range(1, n_warps):
+        _scan_fold_warp(scan, agg, wpre, tx, w)
+    _scan_apply_prefix(scan, out, agg, wpre, tx, n_warps)
+
+
+@T.macro
+def emit_rank_keys(
+    counters32,
+    counters16,
+    scan,
+    keys,
+    ranks,
+    tx,
+    block_threads,
+    items_per_thread,
+    begin_bit,
+    num_bits,
+):
+    """``BlockRadixRank::RankKeys`` (``block_radix_rank.cuh:436-493``).
+
+    Reset the nine padded lanes, take each item's ``uint16`` counter slot and
+    read back its thread-exclusive prefix while bumping it, scan the packed
+    counters, then add the block-exclusive prefix back in.  Each thread owns
+    column ``tid``, so the read-modify-write needs no atomics -- two
+    ``ld.shared.b16`` plus one ``st.shared.b16`` per item, which is exactly what
+    the export shows at every ``ITEMS_PER_THREAD``.
+    """
+    prefixes = T.alloc_local((items_per_thread,), "uint32")
+    slots = T.alloc_local((items_per_thread,), "int32")
+
+    # ResetCounters: one packed zero per padded lane (:346-355).
+    for lane in T.unroll(PADDED_COUNTER_LANES):
+        st_shared_u32(counters32, lane * block_threads + tx, T.uint32(0))
+        # counter view: &digit_counters[LANE][tid][0] as one packed word.
+
+    for i in T.unroll(items_per_thread):
+        digit: T.uint32 = emit_digit(keys[i], begin_bit, num_bits)
+        sub_counter: T.int32 = T.cast(T.shift_right(digit, T.uint32(LOG_COUNTER_LANES)), "int32")
+        counter_lane: T.int32 = T.cast(T.bitwise_and(digit, T.uint32(COUNTER_LANES - 1)), "int32")
+        # &digit_counters[counter_lane][tid][sub_counter] over the uint16 view.
+        slots[i] = (counter_lane * block_threads + tx) * PACKING_RATIO + sub_counter
+        prefixes[i] = T.cast(ld_shared_u16(counters16, slots[i]), "uint32")
+        st_shared_u16(counters16, slots[i], T.cast(prefixes[i] + T.uint32(1), "uint16"))
+
+    bar_sync()
+
+    # ScanCounters (:376-392): memoized raking upsweep, packed block scan, then
+    # an exclusive downsweep back into the same words.
+    # raking_grid[linear_tid][RAKING_SEGMENT] -- each thread rakes a CONTIGUOUS
+    # nine-word segment, so the block scan runs over the flat array in index
+    # order.  In the counter view that same flat index is `lane * BT + tid`, i.e.
+    # digit-major and thread-minor, which is what makes the ranks group by digit.
+    # Striding the segment instead would order the prefix by thread first.
+    cached = T.alloc_local((RAKING_SEGMENT,), "uint32")
+    partial = T.alloc_local((1,), "uint32")
+    partial[0] = T.uint32(0)
+    for j in T.unroll(RAKING_SEGMENT):
+        cached[j] = ld_shared_u32(counters32, tx * RAKING_SEGMENT + j)
+        partial[0] = partial[0] + cached[j]
+
+    exclusive = T.alloc_local((1,), "uint32")
+    incl = T.alloc_local((1,), "uint32")
+    agg = T.alloc_local((1,), "uint32")
+    wpre = T.alloc_local((1,), "uint32")
+    emit_block_exclusive_sum_packed(scan, exclusive, incl, agg, wpre, tx, block_threads, partial[0])
+
+    for j in T.unroll(RAKING_SEGMENT):
+        st_shared_u32(counters32, tx * RAKING_SEGMENT + j, exclusive[0])
+        exclusive[0] = exclusive[0] + cached[j]
+
+    bar_sync()
+
+    for i in T.unroll(items_per_thread):
+        ranks[i] = T.cast(
+            prefixes[i] + T.cast(ld_shared_u16(counters16, slots[i]), "uint32"), "int32"
+        )
+
+
+@T.macro
+def emit_scatter_to_blocked_u32(buf, items_reg, ranks, tx, items_per_thread):
+    """``BlockExchange::ScatterToBlocked`` for the 32-bit keys (``:600-629``)."""
+    for i in T.unroll(items_per_thread):
+        st_shared_u32(buf, padded_offset(ranks[i], items_per_thread), items_reg[i])
+    bar_sync()
+    for i in T.unroll(items_per_thread):
+        items_reg[i] = ld_shared_u32(
+            buf, padded_offset(tx * items_per_thread + i, items_per_thread)
+        )
+
+
+@T.macro
+def emit_scatter_to_blocked_u16(buf, items_reg, ranks, tx, items_per_thread):
+    """The same exchange for 16-bit paired values."""
+    for i in T.unroll(items_per_thread):
+        st_shared_u16(
+            buf, padded_offset(ranks[i], items_per_thread), T.cast(items_reg[i], "uint16")
+        )
+    bar_sync()
+    for i in T.unroll(items_per_thread):
+        items_reg[i] = T.cast(
+            ld_shared_u16(buf, padded_offset(tx * items_per_thread + i, items_per_thread)), "uint32"
+        )
+
+
+def emit_block_radix_sort(
+    counters32,
+    counters16,
+    scan,
+    xchg_keys,
+    xchg_values,
+    keys,
+    values,
+    ranks,
+    tx,
+    block_threads,
+    items_per_thread,
+    end_bit,
+    sort_values,
+    value_is32,
+):
+    """``BlockRadixSort::SortBlocked`` (``block_radix_sort.cuh:377-429``).
+
+    One rank plus exchange per digit pass, ascending, blocked in and blocked out.
+    The trailing barrier is skipped after the final pass, giving cub's
+    ``7P - 1`` / ``9P - 1`` barrier counts for keys-only and key-value.  The pass
+    loop is unrolled here because ``end_bit`` is static per config, which is also
+    why no ``clz.b32`` appears.
+    """
+    for p, (begin, nbits) in enumerate(sort_passes(end_bit)):
+        emit_rank_keys(
+            counters32,
+            counters16,
+            scan,
+            keys,
+            ranks,
+            tx,
+            block_threads,
+            items_per_thread,
+            begin,
+            nbits,
+        )
+        bar_sync()
+        emit_scatter_to_blocked_u32(xchg_keys, keys, ranks, tx, items_per_thread)
+        if sort_values:
+            bar_sync()
+            if value_is32:
+                emit_scatter_to_blocked_u32(xchg_values, values, ranks, tx, items_per_thread)
+            else:
+                emit_scatter_to_blocked_u16(xchg_values, values, ranks, tx, items_per_thread)
+        if p != len(sort_passes(end_bit)) - 1:
+            bar_sync()

--- a/tirx_kernels/flashinfer/utils/filtered_topk_ops.py
+++ b/tirx_kernels/flashinfer/utils/filtered_topk_ops.py
@@ -1,0 +1,1455 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""``FilteredTopKUnifiedKernel`` building blocks (``include/flashinfer/topk.cuh``).
+
+``FilteredTopKTraits`` (``:2272-2337``) and the row-scan helper the kernel funnels
+every full-row pass through (``for_each_score``, ``:2463-2481``).
+
+The traits are **not** interchangeable with ``RadixTopKTraits``
+(``topk_common.cuh:35-49``).  Both make a float's bit pattern monotone, but the
+filtered ones are written as ``(bits & sign) ? ~bits : (bits | sign)`` while the
+radix ones use the XOR form, whose ``FromOrdered`` inverse
+``StableSortTopKByValueKernel`` (``:3094``) depends on.  Keeping them separate is
+deliberate.
+
+The two are also lowered differently even though the source writes one
+expression: on 16 bits nvcc recognises the shape as a sign-broadcast XOR
+(``shr.s16`` + ``xor.b16``), and on 32 bits it routes it through
+``abs``/``neg`` (``not.b32`` + ``abs.ftz.f32`` + ``neg.ftz.f32`` + ``setp.lt.s32``
++ ``selp.b32``).
+
+Everything here that emits statements is a ``T.macro``: a plain Python helper
+called from a traced body can build expressions but silently drops ``if``
+statements and cannot write a local buffer.
+"""
+
+from typing import NamedTuple
+
+from tirx_kernels.flashinfer.utils.topk_radix import (
+    atom_shared_add_u32,
+    bar_sync,
+    ld_shared_u32,
+    st_global_u16,
+    st_global_u32,
+    st_shared_u32,
+    warp_inclusive_sum_u32,
+)
+from tvm.script import tirx as T
+
+# Traits constants (:2279-2280, :2303-2304, :2323-2324).
+NUM_REFINE_ROUNDS = {"float32": 4, "float16": 1, "bfloat16": 1}
+FIRST_REFINE_SHIFT = {"float32": 24, "float16": 0, "bfloat16": 0}
+
+
+def to_ordered_filtered_u32(bits):
+    """``FilteredTopKTraits<float>::ToOrdered`` (``:2291-2294``).
+
+    ``(bits & 0x80000000) ? ~bits : (bits | 0x80000000)``.
+    """
+    return T.Select(
+        T.bitwise_and(bits, T.uint32(0x80000000)) != T.uint32(0),
+        T.bitwise_xor(bits, T.uint32(0xFFFFFFFF)),
+        T.bitwise_or(bits, T.uint32(0x80000000)),
+    )
+
+
+def to_ordered_filtered_u16(bits):
+    """``FilteredTopKTraits<half|nv_bfloat16>::ToOrdered`` (``:2313-2316``, ``:2333-2336``)."""
+    return T.Select(
+        T.bitwise_and(bits, T.uint16(0x8000)) != T.uint16(0),
+        T.bitwise_xor(bits, T.uint16(0xFFFF)),
+        T.bitwise_or(bits, T.uint16(0x8000)),
+    )
+
+
+def to_coarse_key_u16(bits):
+    """The shared tail of every ``ToCoarseKey``: monotone flip, then ``>> 8``.
+
+    ``:2286-2288`` / ``:2308-2310`` / ``:2328-2330``.  The flip is the same one
+    ``ToOrdered`` performs on 16 bits, so the coarse key is the ordered key's
+    high byte.
+    """
+    return T.cast(T.shift_right(to_ordered_filtered_u16(bits), T.uint16(8)), "int32")
+
+
+def to_coarse_key_f32(bits):
+    """``FilteredTopKTraits<float>::ToCoarseKey`` (``:2282-2289``).
+
+    Rounds through fp16 first (``__float2half_rn``, ``cvt.rn.f16.f32``), so the
+    coarse key is **lossy** -- distinct floats can share a coarse bin.  That is
+    fine because every phase re-derives it the same way, so the partition stays
+    consistent; it is also why the refine rounds exist at all.
+    """
+    half_bits = T.reinterpret("uint16", T.cast(T.reinterpret("float32", bits), "float16"))
+    return to_coarse_key_u16(half_bits)
+
+
+def coarse_key(bits, is32):
+    return to_coarse_key_f32(bits) if is32 else to_coarse_key_u16(bits)
+
+
+def ordered_key(bits, is32):
+    return to_ordered_filtered_u32(bits) if is32 else to_ordered_filtered_u16(bits)
+
+
+# --- non-coherent global loads ----------------------------------------------
+# Every input pointer of FilteredTopKUnifiedKernel is `__restrict__ const`
+# (:2364-2373), so nvcc routes all of its global reads through the read-only
+# path: the export carries 1476 `ld.global.nc.*` and no plain unified-kernel
+# load.  These wrappers are local to this port on purpose -- the finalize
+# kernel's pointers are NOT `__restrict__`, and its loads must stay plain
+# `ld.global.b32`, as must the two merged radix ports that share
+# `utils/topk_radix.py`.
+def ld_global_nc_u32(buffer, index):
+    """``ld.global.nc.b32``."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def ld_global_nc_bits(buf, elem_index, is32):
+    """One scalar element's raw bits: ``ld.global.nc.b32`` | ``ld.global.nc.b16``."""
+    if is32:
+        return ld_global_nc_u32(buf, elem_index)
+    out16 = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.nc.b16(out16[0], buf.ptr_to([elem_index])))
+    return out16[0]
+
+
+def ld_global_nc_words(buf, elem_index, load_bytes):
+    """One vector load of ``load_bytes`` bytes, returned as 32-bit words."""
+    if load_bytes == 16:
+        w = T.alloc_local((4,), "uint32", align=16)
+        T.evaluate(T.ptx["ld.global.nc.v4.b32"](w[0], w[1], w[2], w[3], buf.ptr_to([elem_index])))
+        return [w[0], w[1], w[2], w[3]]
+    if load_bytes == 8:
+        w = T.alloc_local((2,), "uint32", align=8)
+        T.evaluate(T.ptx["ld.global.nc.v2.b32"](w[0], w[1], buf.ptr_to([elem_index])))
+        return [w[0], w[1]]
+    w = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(w[0], buf.ptr_to([elem_index])))
+    return [w[0]]
+
+
+def ld_global_nc_pair_u16(buffer, index):
+    """``ld.global.nc.v2.b16``; both 16-bit lanes land in 16-bit registers.
+
+    The source's ``vec_t<DType, 2>::cast_load`` keeps the monotone key flip on
+    16-bit operands with no extract or repack arithmetic.
+    """
+    out = T.alloc_local((2,), "uint16")
+    T.evaluate(T.ptx["ld.global.nc.v2.b16"](out[0], out[1], buffer.ptr_to([index])))
+    return out[0], out[1]
+
+
+def st_global_bits(buf, elem_index, bits, is32):
+    """Store a raw 32- or 16-bit value; the mirror of ``ld_global_bits``."""
+    if is32:
+        st_global_u32(buf, elem_index, bits)
+    else:
+        st_global_u16(buf, elem_index, bits)
+
+
+def atom_shared_or_b32(buffer, index, value):
+    """``atom.shared.or.b32`` with the result discarded (``:2624``, ``:2667``).
+
+    The source writes ``atomicOr(&s_refine_overflow, 1)`` and ignores the return
+    value, yet nvcc still emits the ``atom`` form rather than the ``red``
+    reduction form -- the export shows ``atom.shared.or.b32`` 20/29 times and
+    ``red.shared.or.b32`` zero times, so the return operand is kept here too.
+    """
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.atom.shared.or_.b32(out[0], buffer.ptr_to([index]), value))
+    return out[0]
+
+
+# --- scalar slots -----------------------------------------------------------
+# The source declares these as separate __shared__ scalars (:2433-2441); they
+# live in one small buffer here, which is the same bytes with the offsets folded
+# into the address.
+SC_COUNTER = 0  # s_counter
+SC_THRESH_BIN = 1  # s_threshold_bin_id
+SC_REFINE_OVERFLOW = 2  # s_refine_overflow
+SC_LAST_REMAIN = 3  # s_last_remain
+SC_NUM_INPUT = 4  # s_num_input[2]
+SC_REFINE_TH = 6  # s_refine_thresholds[4]
+# DeterministicContiguousCollect's chunk-walk state (:313-315); live only across
+# that collector, but allocated with the rest so the layout stays static.
+SC_EMITTED = 10
+SC_CHUNK_BASE = 11
+SC_CHUNK_TAKE = 12
+NUM_SCALARS = 13
+
+
+class FilteredCfg(NamedTuple):
+    """Compile-time specialization carried into the macros below.
+
+    Read fields **inline** as ``cfg.field``; never unpack them into locals first.
+    Assigning a scalar inside a ``T.macro`` body turns it into a TIR expression,
+    after which any Python-level use of it -- an ``if``, a ternary, ``not``, a
+    ``range()`` bound, a list index -- fails or silently misbehaves, and the
+    damage propagates to every macro the value is forwarded to.  Buffers are
+    unaffected and may be unpacked normally.
+    """
+
+    top_k: int
+    vec: int
+    load_bytes: int
+    is32: bool
+    det: bool
+    tie_break: int
+    num_rounds: int
+    first_shift: int
+    smem_input: int
+    hist_stride: int
+    # `#pragma unroll 2` on the row-scan vector loop (:2469) is how many
+    # independent global loads the source wants in flight.  This toolchain can
+    # extract less memory parallelism from the same factor, so the value is
+    # derived from the compile-time per-thread trip count rather than pinned to
+    # the source's literal.
+    scan_unroll: int
+    basic: bool
+    page_table: bool
+    ragged: bool
+    block: int = 1024
+    radix: int = 256
+
+
+def _emit_word_fanout(body, ctx, words, base, is32):
+    """Hand each element of one vector load to the body, in index order.
+
+    A plain Python function because the fan-out width is a compile-time count
+    over a Python list: inside a macro, ``range(len(words))`` would become a TIR
+    loop whose variable cannot index that list.
+    """
+    if is32:
+        for w in range(len(words)):
+            body(ctx, words[w], base + w)
+    else:
+        # Each loaded word carries two 16-bit lanes, low lane first.
+        for w in range(len(words)):
+            body(ctx, T.cast(T.bitwise_and(words[w], T.uint32(0xFFFF)), "uint16"), base + 2 * w)
+            body(ctx, T.cast(T.shift_right(words[w], T.uint32(16)), "uint16"), base + 2 * w + 1)
+
+
+@T.macro
+def for_each_score(inp, row_in, tx, row_len, body, ctx, cfg):
+    """``for_each_score`` / ``for_each_score_full`` (``:2463-2481``).
+
+    A ``#pragma unroll 2`` vector loop over ``aligned_length = length / VEC_SIZE *
+    VEC_SIZE`` followed by a scalar tail.  ``body(ctx, raw_bits, index)`` is a
+    macro, matching the C++ lambdas the source hands this helper; ``ctx`` is an
+    opaque tuple of the buffers and values that body needs, standing in for the
+    lambdas' capture list.  Every load is ``.nc``-qualified because the kernel's
+    inputs are ``__restrict__ const``.
+
+    The kernel re-runs this in full on every phase that rescans the row, so the
+    same load widths reappear in the histogram, the filter, and both fallbacks.
+    """
+    aligned: T.int32 = row_len // cfg.vec * cfg.vec
+    for i in T.serial(tx * cfg.vec, aligned, step=cfg.block * cfg.vec, unroll=cfg.scan_unroll):
+        if cfg.vec == 1:
+            body(ctx, ld_global_nc_bits(inp, row_in + T.cast(i, "int64"), cfg.is32), i)
+        else:
+            if cfg.load_bytes == 4:
+                if cfg.is32:
+                    _emit_word_fanout(
+                        body,
+                        ctx,
+                        ld_global_nc_words(inp, row_in + T.cast(i, "int64"), cfg.load_bytes),
+                        i,
+                        True,
+                    )
+                else:
+                    # VEC_SIZE == 2 on a 16-bit dtype: the source's native
+                    # ld.global.nc.v2.b16 pair, kept in 16-bit registers rather
+                    # than routed through one 32-bit word and unpacked.
+                    lo, hi = ld_global_nc_pair_u16(inp, row_in + T.cast(i, "int64"))
+                    body(ctx, lo, i)
+                    body(ctx, hi, i + 1)
+            else:
+                _emit_word_fanout(
+                    body,
+                    ctx,
+                    ld_global_nc_words(inp, row_in + T.cast(i, "int64"), cfg.load_bytes),
+                    i,
+                    cfg.is32,
+                )
+    # Scalar tail (:2477-2480); empty when VEC_SIZE divides the row length.
+    for j in T.serial(aligned + tx, row_len, step=cfg.block):
+        body(ctx, ld_global_nc_bits(inp, row_in + T.cast(j, "int64"), cfg.is32), j)
+
+
+@T.macro
+def collect_gt_and_nondet_eq(ctx, value, threshold, idx, allow_eq):
+    """``collect_gt_and_nondet_eq_threshold`` (``:2567-2580``).
+
+    Strict winners are appended at ``s_counter``.  Equal-to-threshold elements
+    only matter when ``!DETERMINISTIC``: they race for the remaining slots by
+    counting ``s_last_remain`` **down** and writing from the back of
+    ``s_indices``, so which ties win is genuinely racy.  Under ``DETERMINISTIC``
+    this ``else if constexpr`` branch does not exist at all; those ties are
+    collected later by ``collect_det_eq_pivot``.
+
+    ``ctx = (s_scal, s_indices, cfg)``.
+    """
+    s_scal = ctx[0]
+    s_indices = ctx[1]
+    if value > threshold:
+        pos: T.int32 = T.reinterpret("int32", atom_shared_add_u32(s_scal, SC_COUNTER, T.uint32(1)))
+        st_shared_u32(s_indices, pos, T.reinterpret("uint32", idx))
+    else:
+        if not ctx[2].det:
+            if allow_eq:
+                if value == threshold:
+                    back: T.int32 = T.reinterpret(
+                        "int32", atom_shared_add_u32(s_scal, SC_LAST_REMAIN, T.uint32(0xFFFFFFFF))
+                    )
+                    if back > 0:
+                        st_shared_u32(s_indices, ctx[2].top_k - back, T.reinterpret("uint32", idx))
+
+
+@T.macro
+def body_coarse_hist(ctx, bits, index):
+    """``accumulate_coarse_hist`` (``:2482-2485``).  ``ctx = (s_hist2, cfg)``."""
+    atom_shared_add_u32(ctx[0], coarse_key(bits, ctx[1].is32), T.uint32(1))
+
+
+@T.macro
+def body_collect_coarse_gt(ctx, bits, index):
+    """``collect_coarse_gt`` on the coarse fast exit (``:2551-2557``).
+
+    ``ctx = (s_scal, s_indices, threshold_bin, cfg)``.
+    """
+    if coarse_key(bits, ctx[3].is32) > ctx[2]:
+        pos: T.int32 = T.reinterpret("int32", atom_shared_add_u32(ctx[0], SC_COUNTER, T.uint32(1)))
+        st_shared_u32(ctx[1], pos, T.reinterpret("uint32", index))
+
+
+@T.macro
+def body_filter(ctx, bits, index):
+    """``filter_and_add_to_histogram`` (``:2611-2627``) -- the step the algorithm is named for.
+
+    Strict winners go straight out; only threshold-bin candidates are compacted
+    into ``s_input_idx[0]``, and each one also bumps the first refine byte's
+    histogram.  Past ``SMEM_INPUT_SIZE`` the compacted buffer is truncated and
+    unusable, so the overflow flag is raised and a fallback rebuilds from the
+    row.  The source's ``__builtin_expect(pos < SMEM_INPUT_SIZE, 1)`` marks that
+    arm cold.
+
+    ``ctx = (s_hist2, s_scal, s_indices, s_input, threshold_bin, cfg)``.
+    """
+    s_hist2 = ctx[0]
+    s_scal = ctx[1]
+    s_indices = ctx[2]
+    s_input = ctx[3]
+    bin_id: T.int32 = coarse_key(bits, ctx[5].is32)
+    if bin_id > ctx[4]:
+        pos: T.int32 = T.reinterpret("int32", atom_shared_add_u32(s_scal, SC_COUNTER, T.uint32(1)))
+        st_shared_u32(s_indices, pos, T.reinterpret("uint32", index))
+    else:
+        if bin_id == ctx[4]:
+            slot: T.int32 = T.reinterpret(
+                "int32", atom_shared_add_u32(s_scal, SC_NUM_INPUT, T.uint32(1))
+            )
+            if slot < ctx[5].smem_input:
+                st_shared_u32(s_input, slot, T.reinterpret("uint32", index))
+                sub: T.int32 = T.cast(
+                    T.bitwise_and(
+                        T.shift_right(
+                            T.cast(ordered_key(bits, ctx[5].is32), "uint32"),
+                            T.uint32(ctx[5].first_shift),
+                        ),
+                        T.uint32(0xFF),
+                    ),
+                    "int32",
+                )
+                atom_shared_add_u32(s_hist2, sub, T.uint32(1))
+            else:
+                atom_shared_or_b32(s_scal, SC_REFINE_OVERFLOW, T.uint32(1))
+
+
+@T.macro
+def run_cumsum(s_hist2, tx, cfg):
+    """Hillis-Steele inclusive **suffix** scan, eight ping-pong steps (``:2490-2504``).
+
+    Eight is even, so the result lands back in buffer 0, which is the alias the
+    rest of the kernel reads as ``s_histogram``.  ``s_histogram[RADIX]`` must stay
+    zero throughout: it is the exclusive-suffix sentinel every threshold test
+    reads at ``tx + 1``, and the scan only ever writes indices below ``RADIX``.
+    """
+    for i in T.unroll(8):
+        if tx < cfg.radix:
+            j: T.int32 = T.shift_left(T.int32(1), i)
+            src: T.int32 = T.bitwise_and(i, T.int32(1)) * cfg.hist_stride
+            dst: T.int32 = T.bitwise_xor(T.bitwise_and(i, T.int32(1)), T.int32(1)) * cfg.hist_stride
+            value: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, src + tx))
+            if tx < cfg.radix - j:
+                value = value + T.reinterpret("int32", ld_shared_u32(s_hist2, src + tx + j))
+            st_shared_u32(s_hist2, dst + tx, T.reinterpret("uint32", value))
+        bar_sync()
+
+
+# --- cub::BlockScan<uint32_t, 1024, BLOCK_SCAN_RAKING_MEMOIZE> geometry -------
+# The tie collectors share one instance of this scan (:2584-2585).  It is the
+# same collective the radix single-CTA port already carries, so the raking layout
+# matches: one warp rakes 32-element segments with a padded stride.
+RAKING_THREADS = 32
+RAKING_SEGMENT = 32
+RAKING_STRIDE = RAKING_SEGMENT + 1  # cub BlockRakingLayout segment padding
+RAKING_ELEMENTS = RAKING_THREADS * RAKING_STRIDE  # 1056
+DET_ITEMS_PER_THREAD = 4  # DeterministicContiguousCollect (:311)
+
+
+def raking_offset(tx):
+    """Padded placement of a thread's cell in the raking grid."""
+    return tx // RAKING_SEGMENT * RAKING_STRIDE + tx % RAKING_SEGMENT
+
+
+def scan_elements():
+    """Raking grid plus one slot for the block aggregate."""
+    return RAKING_ELEMENTS + 1
+
+
+@T.macro
+def block_exclusive_sum_raking(s_scan, out, total_out, tx, value):
+    """``BlockScan::ExclusiveSum`` with ``BLOCK_SCAN_RAKING_MEMOIZE``.
+
+    Place into the padded raking grid; one warp serially reduces its 32-element
+    segment while memoizing it in registers, a warp shuffle scan runs over the
+    segment totals, then the same warp scatters the prefixes back.  ``out[0]``
+    receives this thread's exclusive prefix and ``total_out[0]`` the block
+    aggregate, which the contiguous collector needs for its quota walk.
+    """
+    off: T.int32 = raking_offset(tx)
+    st_shared_u32(s_scan, off, value)
+    bar_sync()
+    if tx < RAKING_THREADS:
+        base: T.int32 = tx * RAKING_STRIDE
+        cache = T.alloc_local((RAKING_SEGMENT,), "uint32")
+        total: T.uint32 = T.uint32(0)
+        for j in T.unroll(RAKING_SEGMENT):
+            cache[j] = ld_shared_u32(s_scan, base + j)
+            total = total + cache[j]
+        incl: T.uint32 = warp_inclusive_sum_u32(total, tx)
+        run: T.uint32 = incl - total
+        for j2 in T.unroll(RAKING_SEGMENT):
+            st_shared_u32(s_scan, base + j2, run)
+            run = run + cache[j2]
+        if tx == RAKING_THREADS - 1:
+            st_shared_u32(s_scan, RAKING_ELEMENTS, incl)
+    bar_sync()
+    out[0] = ld_shared_u32(s_scan, off)
+    total_out[0] = ld_shared_u32(s_scan, RAKING_ELEMENTS)
+
+
+@T.macro
+def det_thread_strided_collect(inp, s_scan, s_indices, tx, row_in, row_len, cfg, pivot, eq_needed):
+    """``DeterministicThreadStridedCollect`` (``:255-286``), the TIE_BREAK=None collector.
+
+    Count matches per thread over a thread-strided walk, block-scan the counts,
+    then re-walk and emit.  The emit target is
+    ``s_indices[top_k - eq_needed + local_pos]`` (``:2587-2590``); the predicate
+    is ``ToOrdered(score[idx]) == pivot``.
+    """
+    count = T.alloc_local((1,), "uint32")
+    count[0] = T.uint32(0)
+    for i in T.serial(tx, row_len, step=cfg.block):
+        cur: T.uint32 = T.cast(
+            ordered_key(ld_global_nc_bits(inp, row_in + T.cast(i, "int64"), cfg.is32), cfg.is32),
+            "uint32",
+        )
+        if cur == pivot:
+            count[0] = count[0] + T.uint32(1)
+    prefix = T.alloc_local((1,), "uint32")
+    total = T.alloc_local((1,), "uint32")
+    block_exclusive_sum_raking(s_scan, prefix, total, tx, count[0])
+    if count[0] > T.uint32(0):
+        if prefix[0] < T.cast(eq_needed, "uint32"):
+            pos = T.alloc_local((1,), "uint32")
+            pos[0] = prefix[0]
+            end: T.uint32 = T.min(prefix[0] + count[0], T.cast(eq_needed, "uint32"))
+            done = T.alloc_local((1,), "int32")
+            done[0] = T.int32(0)
+            for i2 in T.serial(tx, row_len, step=cfg.block):
+                if done[0] == 0:
+                    cur2: T.uint32 = T.cast(
+                        ordered_key(
+                            ld_global_nc_bits(inp, row_in + T.cast(i2, "int64"), cfg.is32), cfg.is32
+                        ),
+                        "uint32",
+                    )
+                    if cur2 == pivot:
+                        st_shared_u32(
+                            s_indices,
+                            cfg.top_k - eq_needed + T.reinterpret("int32", pos[0]),
+                            T.reinterpret("uint32", i2),
+                        )
+                        pos[0] = pos[0] + T.uint32(1)
+                        if pos[0] == end:
+                            done[0] = T.int32(1)
+    bar_sync()
+
+
+@T.macro
+def det_contiguous_collect(
+    inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, pivot, eq_needed, reverse
+):
+    """``DeterministicContiguousCollect`` (``:298-377``), the TIE_BREAK=Small/Large collector.
+
+    Walks the row in **contiguous** index order across the CTA in
+    ``BLOCK_THREADS * 4``-element chunks, so equal-valued candidates are claimed
+    smallest index first, or largest first when ``REVERSE``.  ``s_emitted`` /
+    ``s_chunk_base`` / ``s_chunk_take`` carry the quota between chunks and the
+    walk stops once it is met.
+    """
+    if tx == 0:
+        st_shared_u32(s_scal, SC_EMITTED, T.uint32(0))
+        st_shared_u32(s_scal, SC_CHUNK_BASE, T.uint32(0))
+        st_shared_u32(s_scal, SC_CHUNK_TAKE, T.uint32(0))
+    bar_sync()
+    chunk_items: T.int32 = cfg.block * DET_ITEMS_PER_THREAD
+    num_chunks: T.int32 = (row_len + chunk_items - 1) // chunk_items
+    stop = T.alloc_local((1,), "int32")
+    stop[0] = T.int32(0)
+    for chunk in T.serial(0, num_chunks):
+        if stop[0] == 0:
+            rows_of = T.alloc_local((DET_ITEMS_PER_THREAD,), "int32")
+            sel_of = T.alloc_local((DET_ITEMS_PER_THREAD,), "uint32")
+            cnt = T.alloc_local((1,), "uint32")
+            cnt[0] = T.uint32(0)
+            for item in T.unroll(DET_ITEMS_PER_THREAD):
+                linear: T.int32 = chunk * chunk_items + tx * DET_ITEMS_PER_THREAD + item
+                rows_of[item] = T.int32(0)
+                sel_of[item] = T.uint32(0)
+                if linear < row_len:
+                    if reverse:
+                        rows_of[item] = row_len - 1 - linear
+                    else:
+                        rows_of[item] = linear
+                    curc: T.uint32 = T.cast(
+                        ordered_key(
+                            ld_global_nc_bits(
+                                inp, row_in + T.cast(rows_of[item], "int64"), cfg.is32
+                            ),
+                            cfg.is32,
+                        ),
+                        "uint32",
+                    )
+                    if curc == pivot:
+                        sel_of[item] = T.uint32(1)
+                        cnt[0] = cnt[0] + T.uint32(1)
+            prefix = T.alloc_local((1,), "uint32")
+            blocksel = T.alloc_local((1,), "uint32")
+            block_exclusive_sum_raking(s_scan, prefix, blocksel, tx, cnt[0])
+            if tx == 0:
+                emitted: T.uint32 = ld_shared_u32(s_scal, SC_EMITTED)
+                st_shared_u32(s_scal, SC_CHUNK_BASE, emitted)
+                remaining: T.uint32 = T.uint32(0)
+                if emitted < T.cast(eq_needed, "uint32"):
+                    remaining = T.cast(eq_needed, "uint32") - emitted
+                take: T.uint32 = T.min(remaining, blocksel[0])
+                st_shared_u32(s_scal, SC_CHUNK_TAKE, take)
+                st_shared_u32(s_scal, SC_EMITTED, emitted + take)
+            bar_sync()
+            chunk_take: T.uint32 = ld_shared_u32(s_scal, SC_CHUNK_TAKE)
+            chunk_base: T.uint32 = ld_shared_u32(s_scal, SC_CHUNK_BASE)
+            if cnt[0] > T.uint32(0):
+                if prefix[0] < chunk_take:
+                    epos = T.alloc_local((1,), "uint32")
+                    epos[0] = prefix[0]
+                    eend: T.uint32 = T.min(prefix[0] + cnt[0], chunk_take)
+                    fin = T.alloc_local((1,), "int32")
+                    fin[0] = T.int32(0)
+                    for item2 in T.unroll(DET_ITEMS_PER_THREAD):
+                        if fin[0] == 0:
+                            if sel_of[item2] == T.uint32(1):
+                                st_shared_u32(
+                                    s_indices,
+                                    cfg.top_k
+                                    - eq_needed
+                                    + T.reinterpret("int32", chunk_base + epos[0]),
+                                    T.reinterpret("uint32", rows_of[item2]),
+                                )
+                                epos[0] = epos[0] + T.uint32(1)
+                                if epos[0] == eend:
+                                    fin[0] = T.int32(1)
+            bar_sync()
+            if ld_shared_u32(s_scal, SC_EMITTED) >= T.cast(eq_needed, "uint32"):
+                stop[0] = T.int32(1)
+    bar_sync()
+
+
+@T.macro
+def collect_det_eq_pivot(
+    inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, pivot, eq_needed
+):
+    """``collect_det_eq_pivot`` (``:2582-2608``).
+
+    Picks the collector by ``TIE_BREAK``: contiguous ascending for ``Small``,
+    contiguous descending for ``Large``, thread-strided for plain determinism.
+    All three share one BlockScan instance and the same
+    ``ToOrdered(score[idx]) == pivot`` predicate.
+    """
+    if eq_needed > 0:
+        if cfg.tie_break == 1:
+            det_contiguous_collect(
+                inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, pivot, eq_needed, False
+            )
+        elif cfg.tie_break == 2:
+            det_contiguous_collect(
+                inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, pivot, eq_needed, True
+            )
+        else:
+            det_thread_strided_collect(
+                inp, s_scan, s_indices, tx, row_in, row_len, cfg, pivot, eq_needed
+            )
+
+
+@T.macro
+def update_refine_threshold(s_hist2, s_scal, tx, cfg, topk, next_idx, reset_next):
+    """``update_refine_threshold`` (``:2505-2516``).
+
+    ``run_cumsum`` plus the same predicated pick as the first one, except that it
+    also publishes ``s_last_remain`` and never touches ``s_counter`` -- only the
+    first pick (``:2522``) resets that.  ``RESET_NEXT_INPUT`` is false at exactly
+    one call site, the 16-bit overflow fallback (``:2733``).
+    """
+    run_cumsum(s_hist2, tx, cfg)
+    if tx < cfg.radix:
+        cur: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx))
+        if cur > topk[0]:
+            nxt: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx + 1))
+            if nxt <= topk[0]:
+                st_shared_u32(s_scal, SC_THRESH_BIN, T.reinterpret("uint32", tx))
+                if reset_next:
+                    st_shared_u32(s_scal, SC_NUM_INPUT + next_idx, T.uint32(0))
+                st_shared_u32(s_scal, SC_LAST_REMAIN, T.reinterpret("uint32", topk[0] - nxt))
+    bar_sync()
+
+
+@T.macro
+def run_refine_round(
+    inp,
+    s_hist2,
+    s_indices,
+    s_scal,
+    s_input,
+    tx,
+    row_in,
+    cfg,
+    topk,
+    resolved,
+    r_idx,
+    offset,
+    is_last,
+):
+    """``run_refine_round`` (``:2675-2709``).
+
+    ``r_idx`` is the ping-pong **buffer** index (``round % 2``, ``:2775``), never
+    the round number: ``s_input_idx`` and ``s_num_input`` are two deep, so
+    indexing them by the round would run off the end from round 2 on.  Sets
+    ``resolved[0]`` when the round fully resolves the pivot.
+    """
+    raw: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_NUM_INPUT + r_idx))
+    num_input: T.int32 = T.min(raw, cfg.smem_input)
+
+    update_refine_threshold(s_hist2, s_scal, tx, cfg, topk, r_idx ^ 1, True)
+
+    threshold: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_THRESH_BIN))
+    if cfg.det:
+        if tx == 0:
+            st_shared_u32(
+                s_scal,
+                SC_REFINE_TH + (cfg.first_shift - offset) // 8,
+                T.reinterpret("uint32", threshold),
+            )
+    topk[0] = topk[0] - T.reinterpret("int32", ld_shared_u32(s_hist2, threshold + 1))
+    if topk[0] == 0:
+        # Pivot resolved: only bins strictly greater than the threshold remain.
+        for i in T.serial(tx, num_input, step=cfg.block):
+            idx: T.int32 = T.reinterpret(
+                "int32", ld_shared_u32(s_input, r_idx * cfg.smem_input + i)
+            )
+            bin_id: T.int32 = T.cast(
+                T.bitwise_and(
+                    T.shift_right(
+                        T.cast(
+                            ordered_key(
+                                ld_global_nc_bits(inp, row_in + T.cast(idx, "int64"), cfg.is32),
+                                cfg.is32,
+                            ),
+                            "uint32",
+                        ),
+                        T.uint32(offset),
+                    ),
+                    T.uint32(0xFF),
+                ),
+                "int32",
+            )
+            if bin_id > threshold:
+                pos: T.int32 = T.reinterpret(
+                    "int32", atom_shared_add_u32(s_scal, SC_COUNTER, T.uint32(1))
+                )
+                st_shared_u32(s_indices, pos, T.reinterpret("uint32", idx))
+        bar_sync()
+        resolved[0] = T.int32(1)
+    else:
+        if is_last:
+            # collect_with_threshold_last_round (:2635-2645): one barrier.
+            for i2 in T.serial(tx, num_input, step=cfg.block):
+                idx2: T.int32 = T.reinterpret(
+                    "int32", ld_shared_u32(s_input, r_idx * cfg.smem_input + i2)
+                )
+                bin2: T.int32 = T.cast(
+                    T.bitwise_and(
+                        T.shift_right(
+                            T.cast(
+                                ordered_key(
+                                    ld_global_nc_bits(
+                                        inp, row_in + T.cast(idx2, "int64"), cfg.is32
+                                    ),
+                                    cfg.is32,
+                                ),
+                                "uint32",
+                            ),
+                            T.uint32(offset),
+                        ),
+                        T.uint32(0xFF),
+                    ),
+                    "int32",
+                )
+                collect_gt_and_nondet_eq((s_scal, s_indices, cfg), bin2, threshold, idx2, True)
+            bar_sync()
+        else:
+            # collect_with_threshold_non_last_round (:2646-2672): three barriers,
+            # ping-ponging the survivors into s_input_idx[r_idx ^ 1] together with
+            # the next byte's histogram.
+            bar_sync()
+            if tx < cfg.radix + 1:
+                st_shared_u32(s_hist2, tx, T.uint32(0))
+            bar_sync()
+            for i3 in T.serial(tx, num_input, step=cfg.block):
+                idx3: T.int32 = T.reinterpret(
+                    "int32", ld_shared_u32(s_input, r_idx * cfg.smem_input + i3)
+                )
+                ord3: T.uint32 = T.cast(
+                    ordered_key(
+                        ld_global_nc_bits(inp, row_in + T.cast(idx3, "int64"), cfg.is32), cfg.is32
+                    ),
+                    "uint32",
+                )
+                bin3: T.int32 = T.cast(
+                    T.bitwise_and(T.shift_right(ord3, T.uint32(offset)), T.uint32(0xFF)), "int32"
+                )
+                if bin3 > threshold:
+                    pos3: T.int32 = T.reinterpret(
+                        "int32", atom_shared_add_u32(s_scal, SC_COUNTER, T.uint32(1))
+                    )
+                    st_shared_u32(s_indices, pos3, T.reinterpret("uint32", idx3))
+                else:
+                    if bin3 == threshold:
+                        slot3: T.int32 = T.reinterpret(
+                            "int32",
+                            atom_shared_add_u32(s_scal, SC_NUM_INPUT + (r_idx ^ 1), T.uint32(1)),
+                        )
+                        if slot3 < cfg.smem_input:
+                            st_shared_u32(
+                                s_input,
+                                (r_idx ^ 1) * cfg.smem_input + slot3,
+                                T.reinterpret("uint32", idx3),
+                            )
+                            sub3: T.int32 = T.cast(
+                                T.bitwise_and(
+                                    T.shift_right(ord3, T.uint32(offset - 8)), T.uint32(0xFF)
+                                ),
+                                "int32",
+                            )
+                            atom_shared_add_u32(s_hist2, sub3, T.uint32(1))
+                        else:
+                            atom_shared_or_b32(s_scal, SC_REFINE_OVERFLOW, T.uint32(1))
+            bar_sync()
+
+
+@T.macro
+def body_rehist_threshold_bin(ctx, bits, index):
+    """16-bit fallback re-histogram (``:2715-2724``): low byte, threshold bin only.
+
+    ``ctx = (s_hist2, threshold_bin, cfg)``.
+    """
+    if coarse_key(bits, ctx[2].is32) == ctx[1]:
+        atom_shared_add_u32(
+            ctx[0],
+            T.cast(
+                T.bitwise_and(T.cast(ordered_key(bits, ctx[2].is32), "uint32"), T.uint32(0xFF)),
+                "int32",
+            ),
+            T.uint32(1),
+        )
+
+
+@T.macro
+def body_recollect_threshold_bin(ctx, bits, index):
+    """16-bit fallback re-collect (``:2740-2748``).
+
+    The ``coarse_bin != threshold_bin`` guard at ``:2741-2744`` is load-bearing:
+    without it the pass would compare out-of-bin elements by their low byte and
+    re-collect every strict winner the filter stage already appended.
+
+    ``ctx = (s_scal, s_indices, threshold_bin, cfg)``.
+    """
+    if coarse_key(bits, ctx[3].is32) == ctx[2]:
+        sub: T.int32 = T.cast(
+            T.bitwise_and(T.cast(ordered_key(bits, ctx[3].is32), "uint32"), T.uint32(0xFF)), "int32"
+        )
+        threshold: T.int32 = T.reinterpret("int32", ld_shared_u32(ctx[0], SC_THRESH_BIN))
+        collect_gt_and_nondet_eq((ctx[0], ctx[1], ctx[3]), sub, threshold, index, True)
+
+
+@T.macro
+def _prefix_match_one(match, ordered, threshold_bytes, prev):
+    """One already-fixed byte of the fallback's prefix test (``:2823-2831``)."""
+    got: T.int32 = T.cast(
+        T.bitwise_and(T.shift_right(ordered, T.uint32(24 - prev * 8)), T.uint32(0xFF)), "int32"
+    )
+    if got != T.cast(threshold_bytes[prev], "int32"):
+        match[0] = T.int32(0)
+
+
+def _prefix_match(match, ordered, threshold_bytes, rnd):
+    """Compare every byte fixed by an earlier round; a Python loop, so it unrolls."""
+    for prev in range(rnd):
+        _prefix_match_one(match, ordered, threshold_bytes, prev)
+
+
+@T.macro
+def body_fallback_rehist(ctx, bits, index):
+    """fp32 fallback per-round re-histogram (``:2819-2837``).
+
+    Only threshold-bin elements whose ordered key still matches the bytes fixed
+    by earlier rounds contribute to this round's byte histogram.
+    ``threshold_bytes`` is the per-thread register array of ``:2805``.
+
+    ``ctx = (s_hist2, threshold_bytes, threshold_bin, cfg, round)``.
+    """
+    if coarse_key(bits, ctx[3].is32) == ctx[2]:
+        ordered: T.uint32 = T.cast(ordered_key(bits, ctx[3].is32), "uint32")
+        match = T.alloc_local((1,), "int32")
+        match[0] = T.int32(1)
+        _prefix_match(match, ordered, ctx[1], ctx[4])
+        if match[0] == 1:
+            atom_shared_add_u32(
+                ctx[0],
+                T.cast(
+                    T.bitwise_and(
+                        T.shift_right(ordered, T.uint32(24 - ctx[4] * 8)), T.uint32(0xFF)
+                    ),
+                    "int32",
+                ),
+                T.uint32(1),
+            )
+
+
+@T.macro
+def body_collect_by_pivot(ctx, bits, index):
+    """fp32 fallback re-collect (``:2883-2895``) -- a three-way dispatch.
+
+    Coarse-bin winners are compared on the **coarse** key with no eq claim;
+    out-of-bin elements are dropped; threshold-bin elements are compared on the
+    full 32-bit ordered key against the rebuilt pivot.
+
+    ``ctx = (s_scal, s_indices, threshold_bin, cfg, pivot, eq_needed)``.
+    """
+    bin_id: T.int32 = coarse_key(bits, ctx[3].is32)
+    if bin_id > ctx[2]:
+        collect_gt_and_nondet_eq((ctx[0], ctx[1], ctx[3]), bin_id, ctx[2], index, False)
+    else:
+        if bin_id == ctx[2]:
+            collect_gt_and_nondet_eq(
+                (ctx[0], ctx[1], ctx[3]),
+                T.cast(ordered_key(bits, ctx[3].is32), "uint32"),
+                ctx[4],
+                index,
+                ctx[5] > 0,
+            )
+
+
+@T.macro
+def _fp32_refine_one_round(
+    inp, s_hist2, s_indices, s_scal, s_input, tx, row_in, cfg, topk, resolved, stop, det_stop, rnd
+):
+    """One iteration of the source's ``#pragma unroll`` refine loop (``:2774-2790``)."""
+    if stop[0] == 0:
+        run_refine_round(
+            inp,
+            s_hist2,
+            s_indices,
+            s_scal,
+            s_input,
+            tx,
+            row_in,
+            cfg,
+            topk,
+            resolved,
+            rnd % 2,  # ping-pong BUFFER index (:2775), not the round
+            cfg.first_shift - rnd * 8,
+            rnd == 3,
+        )
+        if resolved[0] == 1:
+            det_stop[0] = T.int32(rnd)
+            stop[0] = T.int32(1)
+        else:
+            if T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_OVERFLOW)) != 0:
+                stop[0] = T.int32(1)
+
+
+@T.macro
+def _fp32_fallback_one_round(
+    inp,
+    s_hist2,
+    s_scal,
+    tx,
+    row_in,
+    row_len,
+    cfg,
+    threshold_bin,
+    bytes_reg,
+    remain,
+    stop_round,
+    halt,
+    rnd,
+):
+    """One iteration of the fallback's ``#pragma unroll`` rebuild loop (``:2812-2856``)."""
+    if halt[0] == 0:
+        if tx < cfg.radix + 1:
+            st_shared_u32(s_hist2, tx, T.uint32(0))
+        bar_sync()
+        for_each_score(
+            inp,
+            row_in,
+            tx,
+            row_len,
+            body_fallback_rehist,
+            (s_hist2, bytes_reg, threshold_bin, cfg, rnd),
+            cfg,
+        )
+        bar_sync()
+        run_cumsum(s_hist2, tx, cfg)
+        if tx < cfg.radix:
+            curf: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx))
+            if curf > remain[0]:
+                nxtf: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx + 1))
+                if nxtf <= remain[0]:
+                    # Only the bin id here; s_num_input and s_last_remain stay
+                    # untouched (:2842-2845).
+                    st_shared_u32(s_scal, SC_THRESH_BIN, T.reinterpret("uint32", tx))
+        bar_sync()
+        thrf: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_THRESH_BIN))
+        # threshold_bytes is a per-thread register array in the source (:2805);
+        # every thread reads the same s_threshold_bin_id, so no publication step
+        # and no extra barrier is needed.
+        bytes_reg[rnd] = T.cast(thrf, "uint32")
+        remain[0] = remain[0] - T.reinterpret("int32", ld_shared_u32(s_hist2, thrf + 1))
+        bar_sync()
+        if remain[0] == 0:
+            stop_round[0] = T.int32(rnd)
+            halt[0] = T.int32(1)
+
+
+@T.macro
+def _fp32_build_det_pivot(s_scal, piv, det_stop, rnd):
+    """One byte of ``build_det_pivot`` (``:2539-2544``)."""
+    byte0: T.uint32 = T.Select(
+        T.int32(rnd) <= det_stop[0], ld_shared_u32(s_scal, SC_REFINE_TH + rnd), T.uint32(0xFF)
+    )
+    piv[0] = T.bitwise_or(piv[0], T.shift_left(byte0, T.uint32(24 - rnd * 8)))
+
+
+@T.macro
+def _fp32_assemble_pivot(pivf, bytes_reg, remain, stop_round, rnd):
+    """One byte of the fallback pivot (``:2860-2867``).
+
+    A byte is forced to ``0xFF`` only once the quota is met and the round is past
+    ``stop_round``.
+    """
+    bytef = T.alloc_local((1,), "uint32")
+    bytef[0] = bytes_reg[rnd]
+    if remain[0] == 0:
+        if T.int32(rnd) > stop_round[0]:
+            bytef[0] = T.uint32(0xFF)
+    pivf[0] = T.bitwise_or(pivf[0], T.shift_left(bytef[0], T.uint32(24 - rnd * 8)))
+
+
+def _fp32_rounds_unrolled(
+    inp, s_hist2, s_indices, s_scal, s_input, tx, row_in, cfg, topk, resolved, stop, det_stop
+):
+    for rnd in range(4):
+        _fp32_refine_one_round(
+            inp,
+            s_hist2,
+            s_indices,
+            s_scal,
+            s_input,
+            tx,
+            row_in,
+            cfg,
+            topk,
+            resolved,
+            stop,
+            det_stop,
+            rnd,
+        )
+
+
+def _fp32_det_pivot_bytes(s_scal, piv, det_stop):
+    for rnd in range(4):
+        _fp32_build_det_pivot(s_scal, piv, det_stop, rnd)
+
+
+def _fp32_fallback_rounds(
+    inp,
+    s_hist2,
+    s_scal,
+    tx,
+    row_in,
+    row_len,
+    cfg,
+    threshold_bin,
+    bytes_reg,
+    remain,
+    stop_round,
+    halt,
+):
+    for rnd in range(4):
+        _fp32_fallback_one_round(
+            inp,
+            s_hist2,
+            s_scal,
+            tx,
+            row_in,
+            row_len,
+            cfg,
+            threshold_bin,
+            bytes_reg,
+            remain,
+            stop_round,
+            halt,
+            rnd,
+        )
+
+
+def _fp32_pivot_bytes(pivf, bytes_reg, remain, stop_round):
+    for rnd in range(4):
+        _fp32_assemble_pivot(pivf, bytes_reg, remain, stop_round, rnd)
+
+
+@T.macro
+def _fp32_refine_prologue(
+    s_scal, tx, det_stop, stop, remain, stop_round, halt, bytes_reg, topk_after_coarse
+):
+    """Register state the fp32 refine path carries across its unrolled rounds."""
+    det_stop[0] = T.int32(3)  # NUM_ROUNDS - 1 (:2771)
+    stop[0] = T.int32(0)
+    remain[0] = topk_after_coarse  # (:2804)
+    stop_round[0] = T.int32(3)
+    halt[0] = T.int32(0)
+    for r in T.unroll(4):
+        bytes_reg[r] = T.uint32(0xFF)  # (:2805-2810)
+
+
+def emit_fp32_refine(
+    inp,
+    s_hist2,
+    s_indices,
+    s_scal,
+    s_input,
+    s_scan,
+    tx,
+    row_in,
+    row_len,
+    cfg,
+    topk,
+    resolved,
+    det_stop,
+    stop,
+    remain,
+    stop_round,
+    halt,
+    bytes_reg,
+    piv,
+    pivf,
+    threshold_bin,
+    topk_after_coarse,
+):
+    """fp32's four refine rounds and the 32-bit pivot-rebuild fallback (``:2767-2902``).
+
+    A plain Python function so the ``#pragma unroll`` loops over ``NUM_ROUNDS``
+    stay compile-time: inside a macro ``range(4)`` becomes a TIR loop, which would
+    make the ping-pong index, the byte offset, and ``IS_LAST_ROUND`` runtime
+    values and collapse the source's four distinct round bodies into one.
+    """
+    _fp32_refine_prologue(
+        s_scal, tx, det_stop, stop, remain, stop_round, halt, bytes_reg, topk_after_coarse
+    )
+    _fp32_guarded_rounds(
+        inp, s_hist2, s_indices, s_scal, s_input, tx, row_in, cfg, topk, resolved, stop, det_stop
+    )
+    _fp32_det_collect(inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, topk, det_stop, piv)
+    _fp32_fallback(
+        inp,
+        s_hist2,
+        s_indices,
+        s_scal,
+        s_scan,
+        tx,
+        row_in,
+        row_len,
+        cfg,
+        threshold_bin,
+        bytes_reg,
+        remain,
+        stop_round,
+        halt,
+        pivf,
+    )
+
+
+@T.macro
+def _fp32_guarded_rounds(
+    inp, s_hist2, s_indices, s_scal, s_input, tx, row_in, cfg, topk, resolved, stop, det_stop
+):
+    """The whole round loop is guarded on the flag the filter stage may have set (``:2772``)."""
+    if T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_OVERFLOW)) == 0:
+        _fp32_rounds_unrolled(
+            inp,
+            s_hist2,
+            s_indices,
+            s_scal,
+            s_input,
+            tx,
+            row_in,
+            cfg,
+            topk,
+            resolved,
+            stop,
+            det_stop,
+        )
+
+
+@T.macro
+def _fp32_det_collect(
+    inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, topk, det_stop, piv
+):
+    """The deterministic collect sits OUTSIDE the guard and re-checks the flag itself.
+
+    ``run_refine_round`` can raise ``s_refine_overflow`` mid-loop through the
+    ``atomicOr`` at ``:2667``; the source spells this out at ``:2798-2799``.
+    """
+    if cfg.det:
+        if T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_OVERFLOW)) == 0:
+            piv[0] = T.uint32(0)
+            _fp32_det_pivot_bytes(s_scal, piv, det_stop)
+            collect_det_eq_pivot(
+                inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, piv[0], topk[0]
+            )
+
+
+@T.macro
+def _fp32_fallback(
+    inp,
+    s_hist2,
+    s_indices,
+    s_scal,
+    s_scan,
+    tx,
+    row_in,
+    row_len,
+    cfg,
+    threshold_bin,
+    bytes_reg,
+    remain,
+    stop_round,
+    halt,
+    pivf,
+):
+    """32-bit pivot rebuild after an overflow (``:2800-2900``).
+
+    Overflow can follow partial writes to ``s_indices`` / ``s_counter``, so the
+    selection is rebuilt from scratch.
+    """
+    if T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_OVERFLOW)) != 0:
+        _fp32_fallback_rounds(
+            inp,
+            s_hist2,
+            s_scal,
+            tx,
+            row_in,
+            row_len,
+            cfg,
+            threshold_bin,
+            bytes_reg,
+            remain,
+            stop_round,
+            halt,
+        )
+        pivf[0] = T.uint32(0)
+        _fp32_pivot_bytes(pivf, bytes_reg, remain, stop_round)
+        if tx == 0:
+            st_shared_u32(s_scal, SC_COUNTER, T.uint32(0))
+            st_shared_u32(s_scal, SC_LAST_REMAIN, T.reinterpret("uint32", remain[0]))
+        bar_sync()
+        for_each_score(
+            inp,
+            row_in,
+            tx,
+            row_len,
+            body_collect_by_pivot,
+            (s_scal, s_indices, threshold_bin, cfg, pivf[0], remain[0]),
+            cfg,
+        )
+        bar_sync()
+        if cfg.det:
+            collect_det_eq_pivot(
+                inp, s_scan, s_indices, s_scal, tx, row_in, row_len, cfg, pivf[0], remain[0]
+            )
+
+
+@T.macro
+def emit_filtered_topk_main(
+    inp,
+    out_idx,
+    out_val,
+    aux,
+    s_hist2,
+    s_indices,
+    s_scal,
+    s_input,
+    s_scan,
+    tx,
+    row_in,
+    row_out,
+    row_len,
+    batch_idx,
+    page_start,
+    offset_val,
+    aux_stride,
+    cfg,
+):
+    """``FilteredTopKUnifiedKernel``'s non-trivial path (``:2431-2919``)."""
+    topk = T.alloc_local((1,), "int32")
+    topk[0] = cfg.top_k
+
+    # --- init (:2450-2458) -------------------------------------------------
+    if tx == 0:
+        st_shared_u32(s_scal, SC_REFINE_OVERFLOW, T.uint32(0))
+    if cfg.det:
+        if tx < 4:
+            st_shared_u32(s_scal, SC_REFINE_TH + tx, T.uint32(0xFF))
+    if tx < cfg.radix + 1:
+        st_shared_u32(s_hist2, tx, T.uint32(0))
+    bar_sync()
+
+    # --- Stage 1: coarse histogram over the whole row (:2482-2487) ---------
+    for_each_score(inp, row_in, tx, row_len, body_coarse_hist, (s_hist2, cfg), cfg)
+    bar_sync()
+
+    # --- first threshold pick (:2518-2524) ---------------------------------
+    # Three short-circuit guards, not a fused predicate: the export shows three
+    # `@p bra` and zero `and.pred`.  Exactly one thread satisfies all three, and
+    # the counter resets ride on that same predicate rather than on tx == 0.
+    run_cumsum(s_hist2, tx, cfg)
+    if tx < cfg.radix:
+        cur0: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx))
+        if cur0 > topk[0]:
+            nxt0: T.int32 = T.reinterpret("int32", ld_shared_u32(s_hist2, tx + 1))
+            if nxt0 <= topk[0]:
+                st_shared_u32(s_scal, SC_THRESH_BIN, T.reinterpret("uint32", tx))
+                st_shared_u32(s_scal, SC_NUM_INPUT, T.uint32(0))
+                st_shared_u32(s_scal, SC_COUNTER, T.uint32(0))
+    bar_sync()
+    threshold_bin: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_THRESH_BIN))
+    topk[0] = topk[0] - T.reinterpret("int32", ld_shared_u32(s_hist2, threshold_bin + 1))
+    topk_after_coarse: T.int32 = topk[0]
+
+    if topk[0] == 0:
+        # The coarse pass already resolved k (:2549-2559).
+        for_each_score(
+            inp,
+            row_in,
+            tx,
+            row_len,
+            body_collect_coarse_gt,
+            (s_scal, s_indices, threshold_bin, cfg),
+            cfg,
+        )
+        bar_sync()
+    else:
+        # --- Stage 2: the filter (:2561-2629) ------------------------------
+        bar_sync()
+        if tx < cfg.radix + 1:
+            st_shared_u32(s_hist2, tx, T.uint32(0))
+        bar_sync()
+        for_each_score(
+            inp,
+            row_in,
+            tx,
+            row_len,
+            body_filter,
+            (s_hist2, s_scal, s_indices, s_input, threshold_bin, cfg),
+            cfg,
+        )
+        bar_sync()
+
+        # --- Stage 3: refine (:2710-2902) ----------------------------------
+        resolved = T.alloc_local((1,), "int32")
+        resolved[0] = T.int32(0)
+        if cfg.num_rounds == 1:
+            # 16-bit: a single refine round, with a full-row slow path on overflow.
+            if T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_OVERFLOW)) != 0:
+                if tx < cfg.radix + 1:
+                    st_shared_u32(s_hist2, tx, T.uint32(0))
+                bar_sync()
+                for_each_score(
+                    inp,
+                    row_in,
+                    tx,
+                    row_len,
+                    body_rehist_threshold_bin,
+                    (s_hist2, threshold_bin, cfg),
+                    cfg,
+                )
+                bar_sync()
+                if tx == 0:
+                    st_shared_u32(s_scal, SC_THRESH_BIN, T.uint32(0))
+                    st_shared_u32(s_scal, SC_LAST_REMAIN, T.uint32(0))
+                bar_sync()
+                # The only RESET_NEXT_INPUT=false call in the kernel (:2733).
+                update_refine_threshold(s_hist2, s_scal, tx, cfg, topk, 0, False)
+                for_each_score(
+                    inp,
+                    row_in,
+                    tx,
+                    row_len,
+                    body_recollect_threshold_bin,
+                    (s_scal, s_indices, threshold_bin, cfg),
+                    cfg,
+                )
+                bar_sync()
+                if cfg.det:
+                    thr_f: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_THRESH_BIN))
+                    eq_f: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_LAST_REMAIN))
+                    collect_det_eq_pivot(
+                        inp,
+                        s_scan,
+                        s_indices,
+                        s_scal,
+                        tx,
+                        row_in,
+                        row_len,
+                        cfg,
+                        T.bitwise_or(
+                            T.shift_left(T.cast(threshold_bin, "uint32"), T.uint32(8)),
+                            T.cast(thr_f, "uint32"),
+                        ),
+                        eq_f,
+                    )
+            else:
+                run_refine_round(
+                    inp,
+                    s_hist2,
+                    s_indices,
+                    s_scal,
+                    s_input,
+                    tx,
+                    row_in,
+                    cfg,
+                    topk,
+                    resolved,
+                    0,
+                    cfg.first_shift,
+                    True,
+                )
+                if cfg.det:
+                    # build_det_pivot(0) on 16 bits (:2535-2537).
+                    th0: T.int32 = T.reinterpret("int32", ld_shared_u32(s_scal, SC_REFINE_TH))
+                    collect_det_eq_pivot(
+                        inp,
+                        s_scan,
+                        s_indices,
+                        s_scal,
+                        tx,
+                        row_in,
+                        row_len,
+                        cfg,
+                        T.bitwise_or(
+                            T.shift_left(T.cast(threshold_bin, "uint32"), T.uint32(8)),
+                            T.cast(th0, "uint32"),
+                        ),
+                        topk[0],
+                    )
+        else:
+            det_stop = T.alloc_local((1,), "int32")
+            stop = T.alloc_local((1,), "int32")
+            remain = T.alloc_local((1,), "int32")
+            stop_round = T.alloc_local((1,), "int32")
+            halt = T.alloc_local((1,), "int32")
+            # threshold_bytes: a per-thread register array in the source (:2805),
+            # not shared state.
+            bytes_reg = T.alloc_local((4,), "uint32")
+            piv = T.alloc_local((1,), "uint32")
+            pivf = T.alloc_local((1,), "uint32")
+            emit_fp32_refine(
+                inp,
+                s_hist2,
+                s_indices,
+                s_scal,
+                s_input,
+                s_scan,
+                tx,
+                row_in,
+                row_len,
+                cfg,
+                topk,
+                resolved,
+                det_stop,
+                stop,
+                remain,
+                stop_round,
+                halt,
+                bytes_reg,
+                piv,
+                pivf,
+                threshold_bin,
+                topk_after_coarse,
+            )
+
+    # --- Stage 5: output (:2905-2918) --------------------------------------
+    # Strict winners plus tie fillers sum to exactly top_k on this path, so
+    # nothing is padded here; only the trivial path emits -1.
+    for base in T.serial(tx, cfg.top_k, step=cfg.block, unroll=2):
+        sel: T.int32 = T.reinterpret("int32", ld_shared_u32(s_indices, base))
+        slot: T.int64 = row_out + T.cast(base, "int64")
+        if cfg.basic:
+            st_global_u32(out_idx, slot, T.reinterpret("uint32", sel))
+            st_global_bits(
+                out_val,
+                slot,
+                ld_global_nc_bits(inp, row_in + T.cast(sel, "int64"), cfg.is32),
+                cfg.is32,
+            )
+        elif cfg.det:
+            # Local index; the transform is deferred to the finalize kernel.
+            st_global_u32(out_idx, slot, T.reinterpret("uint32", sel))
+        elif cfg.page_table:
+            st_global_u32(
+                out_idx,
+                slot,
+                ld_global_nc_u32(
+                    aux, T.cast(batch_idx, "int64") * aux_stride + T.cast(page_start + sel, "int64")
+                ),
+            )
+        else:
+            st_global_u32(out_idx, slot, T.reinterpret("uint32", sel + offset_val))

--- a/tirx_kernels/flashinfer/utils/topk_harness.py
+++ b/tirx_kernels/flashinfer/utils/topk_harness.py
@@ -22,6 +22,7 @@ from typing import Any
 
 SOURCE_ALGO_ENV = "FLASHINFER_TOPK_ALGO"
 SOURCE_ALGO_VALUE = "multi_cta"
+SOURCE_ALGO_FILTERED = "filtered"
 
 WORKSPACE_BYTES = 1024 * 1024
 
@@ -39,16 +40,24 @@ def source_module():
     return gen_topk_module().build_and_load()
 
 
-def pin_source_algo() -> None:
-    """Force dispatch onto the radix family this port targets.
+def pin_source_algo(value: str = SOURCE_ALGO_VALUE) -> None:
+    """Force ``TopKDispatch`` onto one algorithm family.
 
-    ``GetTopKAlgoOverride`` (``topk.cuh``) maps this value to
-    ``TopKAlgoOverride::MULTI_CTA``, which makes ``ShouldUseFilteredTopK``
-    return false so FilteredTopK is never selected.  Which radix
-    specialization then runs is decided by ``ctas_per_group`` inside the
-    launcher, i.e. by the shape.
+    ``GetTopKAlgoOverride`` (``topk.cuh``) recognizes exactly two values:
+
+    ``"multi_cta"`` maps to ``TopKAlgoOverride::MULTI_CTA``, which makes
+    ``ShouldUseFilteredTopK`` return false so FilteredTopK is never selected;
+    which radix specialization then runs is decided by ``ctas_per_group``
+    inside the launcher, i.e. by the shape.
+
+    ``"filtered"`` maps to ``TopKAlgoOverride::FILTERED``, selecting the
+    FilteredTopK path past the ``num_rows``/``max_len`` heuristics (the
+    ``k <= FILTERED_TOPK_MAX_K`` and ``max_len > k`` preconditions still
+    apply).  It also keeps the SM100 cluster kernel out of the reference path,
+    since the Python-side ``can_use_clusters_topk`` requires the override to be
+    unset or ``"clusters"``.
     """
-    os.environ[SOURCE_ALGO_ENV] = SOURCE_ALGO_VALUE
+    os.environ[SOURCE_ALGO_ENV] = value
 
 
 def row_states_buffer(nbytes: int = WORKSPACE_BYTES):


### PR DESCRIPTION
Ports FlashInfer's **FilteredTopK** pipeline — the path `TopKDispatch` selects when a row fits one CTA's candidate budget — as a new `filtered_topk` kernel. Source pinned at `f2e04400`.

This is the third and last top-k algorithm after `radix_topk_single_cta` (#64/#65) and `radix_topk_multi_cta` (#71), and it is the only one that reaches `tie_break != None` and `dsa_graph_safe`.

## What the algorithm does

One CTA of 1024 threads per row, a fixed 128 KiB dynamic shared arena, and no global workspace at all — shared-memory atomics and `__syncthreads()` only. A 256-bin coarse histogram over a lossy `ToCoarseKey` (fp32 rounds through fp16) is suffix-scanned to pick a threshold bin; then the *filter* step compacts only that bin's candidates into a 16384-entry shared buffer and refines them byte by byte. Later passes therefore re-read at most 16K scattered elements instead of the whole row.

When a coarse bin overflows the buffer the kernel falls back to full-row histogram passes — separate code for the 16-bit and fp32 families.

## Two kernels, not one

`FinalizeTopKIndicesKernel` is part of the port. For deterministic runs, and for tie-break on the transform modes, the dispatchers launch it after the main kernel to block-radix-sort each row's indices ascending and apply the deferred page-table/ragged transform. Without it "deterministic" yields a deterministic *set* in a nondeterministic *order*, so both the semantics and an honest benchmark require the pair — the timed closure launches whatever the dispatcher launches.

Its `cub::BlockRadixSort` is ported in `utils/block_radix_sort.py`: `RADIX_BITS=4`, the basic `BlockRadixRank` (no `match.any`/ballot/PRMT), shift-and-mask digit extraction (cub's `bitfield_extract` falls through to shift+mask on SM≥70, so there is no `bfe`), and a `uint16` counter view whose per-thread raking segment is contiguous.

## Coverage

**107 correctness configs**: all 54 dtype × mode × (deterministic, tie_break) cells, every reachable `VEC_SIZE`, all six finalize `(BLOCK_THREADS, ITEMS_PER_THREAD)` rungs, `end_bit` across 2–5 digit passes, both overflow fallbacks on both dtype families, the in-kernel trivial path, `dsa_graph_safe`, and every runtime pointer branch. Axis sweeps orthogonal to the cell run on carrier cells rather than being repeated in all 54.

The overflow fallbacks are data- not shape-dependent, so `prepare_data` asserts on the host that the tie-heavy/quantized patterns still exceed the candidate arena — otherwise that coverage could rot silently while still looking green.

## Results

| | |
|---|---|
| Correctness | **107/107** against the FlashInfer source under `FLASHINFER_TOPK_ALGO=filtered`, 0 skipped |
| Regressions | radix single-CTA **234/234**, multi-CTA **354/354** |
| Performance | **101/101** timed configs above the 0.99x gate, on two complete `bench_suite --with-references` runs (min 1.017 / 1.021, median ~1.08, max ~1.20) |

## Notes for review

- The shared `utils/topk_radix.py` is untouched. The unified kernel's reads must be `.nc`-qualified (its inputs are `__restrict__ const`) while the finalize kernel's must not, so the `.nc` helpers are local to this port.
- `utils/topk_harness.py` gains one parameter: `pin_source_algo(value=...)`, defaulted so both existing radix callers are unchanged.
- Worth knowing for future ports: `TopKPageTableTransformDispatch` rewrites a null `page_table_row_starts` to `row_starts` *before* either launch (`topk.cuh:3379-3380`). It is invisible when reading either kernel against its own source — the unified kernel's own ternary computes the same value either way — but the finalize kernel falls back to `0` instead, so porting the kernels without the dispatcher silently drops the row offset.