### PR TITLE
feat(kernel): add FlashInfer RMSNorm

### DIFF
--- a/.agents/sketch/flashinfer/norm/rmsnorm.md
+++ b/.agents/sketch/flashinfer/norm/rmsnorm.md
@@ -1,0 +1,640 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+RMSNormKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer 2-D RMSNorm / Gemma RMSNorm SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the implementation
+shape of FlashInfer's CuTe-DSL `RMSNormKernel` for the paired target
+[`tirx_kernels/flashinfer/norm/rmsnorm.py`](../../../../tirx_kernels/flashinfer/norm/rmsnorm.py).
+The target may become executable only after this sketch passes independent
+source/PTX review; after the first PASS this file is permanently frozen.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/norm/kernels/rmsnorm.py`, SHA256
+  `b273fe5444aaf86a1600c196817b7a733b18f6f82030a16e1ef2731c784d48f0`;
+- `flashinfer/norm/utils.py`, SHA256
+  `3f44ac6727c58883420068bf0aa5b239b12d2e86819ad80e54bc1bc016ec881a`;
+- public dispatch in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+The shared family covers FP16/BF16, `weight_bias=0.0` RMSNorm and
+`weight_bias=1.0` Gemma RMSNorm, compact and explicit Int64 row-strided
+addressing, PDL off/on, synchronous and `cp.async` input traffic, sub-warp,
+one-warp, multi-warp, and cluster reduction, and cluster sizes 1/2/4/8/16.
+Only the 2-D source body is in scope. QK RMSNorm, fused-add, quantization,
+legacy CUDA, and every tile primitive are out of scope.
+
+## Source dispatch and resource formulae
+
+These are compile-time formulae copied mechanically from `RMSNormKernel`.
+They are part of the sketch, not tuning choices:
+
+```python
+ELEM_BYTES = 2
+MAX_VEC = 128 // 8 // ELEM_BYTES                         # 8 elements
+
+def threads_per_row(h_per_cta):
+    if h_per_cta <= 64: return 8
+    if h_per_cta <= 128: return 16
+    if h_per_cta <= 3072: return 32
+    if h_per_cta <= 6144: return 64
+    if h_per_cta <= 16384: return 128
+    return 256
+
+def num_threads(h_per_cta):
+    return 128 if h_per_cta <= 16384 else 256
+
+def source_config(H):
+    # Select the first feasible divisor exactly in this order. Source fallback
+    # remains 16 even if no candidate was feasible.
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and estimate_smem(H, candidate) <= 232448:
+            cluster_n = candidate
+            break
+    else:
+        cluster_n = 16
+
+    H_per_cta = H // cluster_n
+    tpr = threads_per_row(H_per_cta)
+    threads = num_threads(H_per_cta)
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, MAX_VEC)
+    copy_bits = 16 * vec
+    vec_blocks = max(1, ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    tile_bytes = rows * cols * ELEM_BYTES
+    use_async = copy_bits >= 32 and tile_bytes <= 232448 // 2
+    reduce_bytes = rows * warps_per_row * 4
+    if cluster_n > 1:
+        reduce_bytes *= cluster_n
+    smem_bytes = (tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return cluster_n, H_per_cta, tpr, threads, rows, warps_per_row, \
+           vec, copy_bits, vec_blocks, cols, use_async, smem_bytes
+
+def estimate_smem(H, cluster_n):
+    # Same derived values as above, but the estimate always includes the X
+    # tile even when the eventual body selects synchronous register loads.
+    H_per_cta = H // cluster_n
+    tpr = threads_per_row(H_per_cta)
+    threads = num_threads(H_per_cta)
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, MAX_VEC)
+    vec_blocks = max(1, ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    bytes_ = rows * cols * ELEM_BYTES
+    bytes_ += rows * warps_per_row * cluster_n * 4
+    return bytes_ + (8 if cluster_n > 1 else 0)
+```
+
+The host selects compact only when both logical tensors are contiguous and
+`M*H <= 2**31-1`. Otherwise it passes explicit `x_row_stride:int64` and
+`y_row_stride:int64` in elements. This predicate must not be weakened.
+
+## Pipeline at a glance
+
+| lanes / CTA role | source-owned work | publication or reuse edge |
+| --- | --- | --- |
+| each contiguous group of `threads_per_row` threads | one logical row; each thread owns `vec_size` adjacent columns in every vector block | no communication during X/W load |
+| each sub-warp/full warp within a row | ordered local sum followed by butterfly sum at widths 8/16/32 | shuffle result is replicated within its reduction subgroup |
+| lane 0 of every row warp, cluster 1 multi-warp path | publish one partial to `(row,warp_in_row)` | one CTA barrier before final warp load |
+| lanes `<cluster_n` of every warp, clustered path | send that warp's partial to the same slot on every peer CTA | remote `st.async.shared::cluster...mbarrier::complete_tx` and one local mbarrier wait |
+| every row warp after publication | redundantly load the row's `warps_per_row*cluster_n` partials and full-warp reduce | the replicated row sum in every row warp feeds FP32 mean/rsqrt |
+| all threads after reduction | clustered arrive/wait or CTA barrier, reload staged X when async, scale and store | barrier protects shared X reuse and completes source reduction phase |
+
+There is one `cp.async` group, not a multi-stage pipeline. Weight is loaded
+synchronously between async commit and wait. PDL wait is the first executable
+operation; PDL signal is the last. PDL-disabled specializations contain no PDL
+instruction and no launch attribute.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)       # compile-time family member
+launch(...)           # exact grid, block, cluster, dynamic shared, PDL attrs
+raw_shared(...)       # one dynamic shared allocation
+view(...)             # typed view at an explicit byte offset
+reg_tile(...)         # thread-private register fragment
+address(...)          # compact or explicit Int64 backing-store address
+pair_view(...)        # register-only adjacent-lane view; no instruction
+scalar_pair(...)      # {scalar,scalar}, except {scalar,undefined} for final odd pair
+```
+
+Data movement, arithmetic, and synchronization remain primitive:
+
+```python
+copy_g2r(src, dst, bits, predicate=None)
+copy_g2s_async_ca(src, dst, bits, source_bytes)
+copy_s2r(src, dst, bits)
+copy_r2s(src, dst)
+copy_r2g(src, dst, bits, predicate=None)
+cast(dtype, src, rounding=None)
+mul(lhs, rhs, lanes=1)
+add(lhs, rhs, lanes=1)
+fma(lhs, rhs, acc)
+div(lhs, rhs)
+rsqrt_fast(src)
+shuffle_xor(src, delta, width)
+elect_one()
+cp_async_commit()
+cp_async_wait(group)
+cta_barrier()
+cluster_arrive_relaxed()
+cluster_wait()
+mbarrier_init(ptr, arrivals)
+mbarrier_init_fence()
+mbarrier_arrive_expect_tx(ptr, bytes)
+map_shared_to_peer(ptr, peer)
+remote_store_complete_tx(value, dst, mbarrier)
+mbarrier_try_wait_parity(ptr, phase, timeout)
+pdl_wait()
+pdl_signal()
+```
+
+A stated vector copy is exactly one reviewed copy. The address-space-specific
+table is:
+
+| `VEC` | global X/W load and Y store | shared X load | reviewed narrowing |
+| ---: | --- | --- | --- |
+| 1 | scalar `ld/st.global.b16` | n/a in the reviewed sync-vec1 path | scalar `cvt.rn.{f16,bf16}.f32` |
+| 2 | `ld/st.global.v2.b16` | `ld.shared.v2.b16` | scalar `cvt.rn.{f16,bf16}.f32` for all six values of the reviewed `(VEC=2,VEC_BLOCKS=3)` H66 profile |
+| 4 | `ld/st.global.v2.b32` | `ld.shared.v4.b16` | `cvt.rn.{f16,bf16}x2.f32`, two issues per vector block |
+| 8 | `ld/st.global.v4.b32` | `ld.shared.v4.b32` | `cvt.rn.{f16,bf16}x2.f32`, four issues per vector block |
+
+Every async row copy is `cp.async.ca.shared.global`, with immediate copy size
+`COPY_BITS/8` and the same runtime source-size operand for tail zero-fill.
+`mul(..., lanes=2)` and `add(..., lanes=2)` name one native packed-FP32
+instruction. There is deliberately no compound `rmsnorm`,
+`row_reduce`, `block_reduce`, `cluster_reduce`, tile-copy, or tile-compute
+primitive.
+
+## Complete sketch
+
+```python
+@specialize(
+    VARIANT_WEIGHT_BIAS=(("rmsnorm", 0.0), ("gemma_rmsnorm", 1.0)),
+    DTYPE=("f16", "bf16"),
+    H="positive compile-time integer",
+    LAYOUT=("compact", "strided_i64"),
+    ENABLE_PDL=(False, True),
+    TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M, ROWS_PER_BLOCK), CLUSTER_N, 1),
+    block=(NUM_THREADS, 1, 1),
+    cluster=((1, CLUSTER_N, 1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_rmsnorm(
+    x_storage,             # DTYPE one-dimensional backing storage
+    weight,                # DTYPE [H], compact
+    y_storage,             # DTYPE one-dimensional backing storage
+    runtime_M: i64,
+    runtime_eps: f32,
+    x_row_stride: i64 = H, # present only in strided_i64 specialization
+    y_row_stride: i64 = H, # present only in strided_i64 specialization
+):
+    tid = thread_id_x(NUM_THREADS)
+    block_x = block_id_x()
+    block_y = 0                  # cluster-1 source specialization folds this
+    cta_rank = 0
+    if CLUSTER_N > 1:
+        block_y = block_id_y()   # global H-tile coordinate, source blockIdx.y
+        cta_rank = cta_rank_in_cluster()  # flat DSMEM source-slot rank
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one issue per CTA
+
+    # CuTe TV layout:
+    # shape=((TPR,ROWS),(VEC,VEC_BLOCKS))
+    # stride=((VEC*ROWS,1),(ROWS,ROWS*VEC*TPR)).
+    row_in_cta = tid // TPR
+    thread_in_row = tid % TPR
+    row_i32 = block_x * ROWS + row_in_cta
+    row_i64 = cast_i64(row_i32)
+    row_valid = row_i64 < runtime_M
+    warp = tid // 32
+    lane = tid % 32
+    WARPS_PER_ROW = max(TPR // 32, 1)
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+
+    smem = raw_shared("u8", SMEM_BYTES, alignment=16)
+    cursor = 0
+    if USE_ASYNC:
+        sX = view(smem, DTYPE, (ROWS, COLS_PER_TILE),
+                  byte_offset=cursor, row_major=True, alignment=16)
+        cursor += ROWS * COLS_PER_TILE * 2
+    if CLUSTER_N == 1:
+        reduction = view(smem, "f32", shape=(ROWS, WARPS_PER_ROW),
+                         stride=(1, ROWS), byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * 4
+    else:
+        reduction = view(
+            smem, "f32", shape=(ROWS, (WARPS_PER_ROW, CLUSTER_N)),
+            stride=(1, (ROWS, ROWS * WARPS_PER_ROW)),
+            byte_offset=cursor, alignment=4,
+        )
+        cursor += ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+        mbar = view(smem, "mbarrier", (1,), byte_offset=cursor, alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar, arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; extent: one per CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; extent: one per CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA;
+        # the reviewed source PTX has no .acquire modifier
+
+    # Source fragment layout is (VEC,VEC_BLOCKS):(1,VEC). Flattened adjacent
+    # values therefore use flat = v + VEC*vb, including pairs spanning vector
+    # block boundaries when VEC==1.
+    x_frag = reg_tile(DTYPE, shape=(VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_frag = reg_tile(DTYPE, shape=(VEC,VEC_BLOCKS), stride=(1,VEC))
+    x_f32 = reg_tile("f32", shape=(VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_f32 = reg_tile("f32", shape=(VEC,VEC_BLOCKS), stride=(1,VEC))
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    PACKED_PAIRS = ceil_div(TOTAL_VALUES, 2)
+
+    # ----------------------------------------------------------------------
+    # Pass 1: X and W traffic. Every address in strided_i64 uses i64 from
+    # row-stride multiplication through final pointer addition.
+    # ----------------------------------------------------------------------
+    if not USE_ASYNC:
+        for vb in static_range(VEC_BLOCKS):
+            for v in static_range(VEC):
+                x_frag[v,vb] = zero(DTYPE)
+                # instruction_selection: mov.b16 zero initialization propagated
+                # across the complete fragment; reviewed sync-vec1 H111 emits
+                # seven mov.b16 issues for its seven physical values
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        col_valid = absolute_col < H
+
+        if USE_ASYNC:
+            if row_valid:
+                x_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                           (row_i64 * x_row_stride + absolute_col)
+                source_bytes = (COPY_BITS // 8) if col_valid else 0
+                copy_g2s_async_ca(
+                    address(x_storage, x_offset),
+                    sX[row_in_cta, local_col:local_col+VEC],
+                    bits=COPY_BITS,
+                    source_bytes=source_bytes,
+                )
+                # instruction_selection: cp.async.ca.shared.global with
+                # immediate size COPY_BITS/8 and runtime source-size operand;
+                # extent: one issue per vb for an in-bounds row, using zero
+                # source bytes to zero-fill an invalid column tail
+        else:
+            if row_valid and col_valid:
+                x_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                           (row_i64 * x_row_stride + absolute_col)
+                copy_g2r(address(x_storage, x_offset), x_frag[:,vb], COPY_BITS)
+                # instruction_selection: exact global load from the VEC table;
+                # extent: one row-and-column-predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_commit()
+        # instruction_selection: cp.async.commit_group; extent: one per CTA thread
+
+    # Weight is source-ordered after X issue/commit and before async wait.
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        if absolute_col < H:
+            copy_g2r(weight[absolute_col:absolute_col+VEC], w_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact global load from the VEC table;
+            # extent: one column-predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_wait(0)
+        # instruction_selection: cp.async.wait_group 0; extent: one per CTA thread
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact shared load from the VEC table;
+            # extent: one vector per vb
+
+    # Preserve source fragment order: widen all loaded X values, form squares,
+    # then reduce the complete fragment in its source profile order.
+    # Phase 1a: widen the complete fragment before any square.
+    for vb in static_range(VEC_BLOCKS):
+        for v in static_range(VEC):
+            x_f32[v,vb] = cast("f32", x_frag[v,vb])
+            # instruction_selection: scalar f16/bf16-to-f32 conversion;
+            # extent: every physical fragment value, source value order
+
+    # Phase 1b: square every adjacent flattened pair. The last high lane when
+    # TOTAL_VALUES is odd is an emitted but semantically unused register lane;
+    # its square is not consumed by Phase 1c.
+    x_sq = reg_tile("f32", shape=(TOTAL_VALUES,))
+    for pair in static_range(PACKED_PAIRS):
+        square_pair = mul(
+            pair_view(x_f32, pair, unused_high_if_odd=True),
+            pair_view(x_f32, pair, unused_high_if_odd=True), lanes=2)
+        # instruction_selection: mul.f32x2; extent: ceil(TOTAL_VALUES/2)
+        # packed issues, including four issues for the seven-value H111 case
+        for packed_lane in static_range(2):
+            flat = pair * 2 + packed_lane
+            if flat < TOTAL_VALUES:
+                x_sq[flat] = square_pair[packed_lane]
+
+    # Phase 1c: only valid flattened values participate, in source order.
+    local_sum = 0.0
+    for flat in static_range(TOTAL_VALUES):
+        local_sum = add(local_sum, x_sq[flat])
+        # instruction_selection: add.f32; extent: one ordered issue per valid
+        # fragment value (seven, not eight, for reviewed H111)
+
+    # ----------------------------------------------------------------------
+    # row_reduce_sum_multirow, expanded without a compound reduction helper.
+    # ----------------------------------------------------------------------
+    WARP_WIDTH = min(TPR, 32)
+    for delta in powers_of_two_below(WARP_WIDTH):   # 1,2,4,(8),(16)
+        peer = shuffle_xor(local_sum, delta, width=32)
+        # instruction_selection: shfl.sync.bfly.b32; extent: one scalar at
+        # every explicit stage, member mask -1 and clamp operand 31; subgroup
+        # width limits only the number of offsets
+        local_sum = add(local_sum, peer)
+        # instruction_selection: add.f32; extent: one scalar per stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            copy_r2s(warp_sum, reduction[row_warp,warp_in_row])
+            # instruction_selection: st.shared.b32; extent: one per row warp
+        cta_barrier()
+        # instruction_selection: bar.sync; extent: one CTA-wide publication edge
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = copy_s2r(reduction[row_warp,lane])
+            # instruction_selection: ld.shared.b32; extent: one scalar per
+            # participating lane of every row warp
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32, mask -1, clamp 31;
+            # extent: one scalar at each full-warp stage in every row warp
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+
+    elif CLUSTER_N > 1:
+        if warp == 0:
+            if elect_one():
+                # instruction_selection: elect.sync; extent: one election in warp 0
+                EXPECTED_BYTES = ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+                mbarrier_arrive_expect_tx(mbar, EXPECTED_BYTES)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one elected active-lane issue per CTA
+        if lane < CLUSTER_N:
+            peer_reduction = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cta_rank)], lane)
+            peer_mbar = map_shared_to_peer(mbar, lane)
+            # instruction_selection: mapa.shared::cluster for destination and
+            # barrier; extent: two addresses per sending lane
+            remote_store_complete_tx(warp_sum, peer_reduction, peer_mbar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # extent: one partial from every warp to every peer CTA
+        wait_done = False
+        while not wait_done:
+            wait_done = mbarrier_try_wait_parity(mbar, phase=0, timeout=10000000)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 with
+            # parity 0 and timeout 10000000, followed by bra.uni retry;
+            # extent: one uniform retry loop per CTA thread
+
+        total_partials = WARPS_PER_ROW * CLUSTER_N
+        final = 0.0
+        for i in static_range(ceil_div(total_partials, 32)):
+            partial = lane + i * 32
+            if partial < total_partials:
+                partial_value = copy_s2r(reduction[row_warp,partial])
+                # instruction_selection: ld.shared.b32; extent: one scalar
+                # for each owned partial in every row warp
+                final = add(final, partial_value)
+                # instruction_selection: add.f32; extent: one per loaded partial
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32, mask -1, clamp 31;
+            # extent: one scalar at each full-warp stage in every row warp
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+
+    else:
+        sum_sq = warp_sum
+
+    if is_power_of_two(H):
+        shifted = fma(sum_sq, exact_float32_reciprocal(H), runtime_eps)
+        # instruction_selection: fma.rn.f32; extent: one scalar per thread in
+        # reviewed H64/H4096 and cluster H131072/H262144/H524288/H1048576
+    else:
+        mean_sq = div(sum_sq, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread in
+        # reviewed H66/H111/H500
+        shifted = add(mean_sq, runtime_eps)
+        # instruction_selection: add.f32; extent: one scalar per thread
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar per thread
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        cluster_wait()
+        # instruction_selection: barrier.cluster.arrive.relaxed followed by
+        # barrier.cluster.wait (no .acquire); extent: one pair per CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync; extent: one post-reduction CTA edge
+
+    # ----------------------------------------------------------------------
+    # Pass 2: async source reload, weight bias, scale, cast, predicated store.
+    # The synchronous path keeps x_f32 live across reduction exactly as source.
+    # ----------------------------------------------------------------------
+    if USE_ASYNC:
+        # Phase 2a: reload the entire input fragment before any conversion.
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact shared load from the VEC table;
+            # extent: one vector per vb after the reduction barrier
+
+        # Phase 2b: convert the complete reloaded X fragment.
+        for flat in static_range(TOTAL_VALUES):
+            x_f32.flat[flat] = cast("f32", x_frag.flat[flat])
+            # instruction_selection: scalar f16/bf16-to-f32 conversion;
+            # extent: every physical X value
+
+    # Phase 2c: convert the complete W fragment. Invalid column-tail registers
+    # are semantically dead but still follow the source conversion/dataflow.
+    for flat in static_range(TOTAL_VALUES):
+        w_f32.flat[flat] = cast("f32", w_frag.flat[flat])
+        # instruction_selection: scalar f16/bf16-to-f32 conversion;
+        # extent: every physical W value
+
+    # Phase 2d: first packed multiply over the complete flattened fragment.
+    normalized = reg_tile("f32", shape=(TOTAL_VALUES,))
+    for pair in static_range(PACKED_PAIRS):
+        normalized_pair = mul(
+            pair_view(x_f32, pair, unused_high_if_odd=True),
+            scalar_pair(rstd, pair, TOTAL_VALUES,
+                        undefined_high_if_odd=True), lanes=2)
+        # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues
+        for packed_lane in static_range(2):
+            flat = pair * 2 + packed_lane
+            if flat < TOTAL_VALUES:
+                normalized[flat] = normalized_pair[packed_lane]
+
+    # Phase 2e: bias add is physically present for both public variants,
+    # including packed +0.0 in ordinary RMSNorm.
+    biased_w = reg_tile("f32", shape=(TOTAL_VALUES,))
+    for pair in static_range(PACKED_PAIRS):
+        biased_pair = add(
+            pair_view(w_f32, pair, unused_high_if_odd=True),
+            scalar_pair(WEIGHT_BIAS, pair, TOTAL_VALUES,
+                        undefined_high_if_odd=True), lanes=2)
+        # instruction_selection: add.f32x2; extent: PACKED_PAIRS issues for
+        # both WEIGHT_BIAS=0.0 and WEIGHT_BIAS=1.0
+        for packed_lane in static_range(2):
+            flat = pair * 2 + packed_lane
+            if flat < TOTAL_VALUES:
+                biased_w[flat] = biased_pair[packed_lane]
+
+    # Phase 2f: second packed multiply, still for the full fragment.
+    y_f32 = reg_tile("f32", shape=(TOTAL_VALUES,))
+    for pair in static_range(PACKED_PAIRS):
+        y_pair = mul(
+            pair_view(normalized, pair, unused_high_if_odd=True),
+            pair_view(biased_w, pair, unused_high_if_odd=True), lanes=2)
+        # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues,
+        # source-ordered after every bias add
+        for packed_lane in static_range(2):
+            flat = pair * 2 + packed_lane
+            if flat < TOTAL_VALUES:
+                y_f32[flat] = y_pair[packed_lane]
+
+    # Phase 2g: narrow the complete valid fragment before any global store.
+    y_frag = reg_tile(DTYPE, shape=(VEC,VEC_BLOCKS), stride=(1,VEC))
+    if VEC == 1 or (VEC == 2 and VEC_BLOCKS == 3):
+        for flat in static_range(TOTAL_VALUES):
+            y_frag.flat[flat] = cast(DTYPE, y_f32[flat], rounding="rn")
+            # instruction_selection: cvt.rn.{f16,bf16}.f32; extent:
+            # TOTAL_VALUES scalar issues (seven for reviewed H111, six for
+            # reviewed H66), independently of FP16 versus BF16
+    else:
+        for pair in static_range(PACKED_PAIRS):
+            narrowed_pair = cast(
+                DTYPE + "x2", pair_view(y_f32,pair,unused_high_if_odd=True),
+                rounding="rn")
+            # instruction_selection: cvt.rn.{f16,bf16}x2.f32; extent:
+            # PACKED_PAIRS issues for reviewed VEC 4/8 branches
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    y_frag.flat[flat] = narrowed_pair[packed_lane]
+
+    # Phase 2h: only the final copy is row/column predicated.
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        col_valid = absolute_col < H
+        if row_valid and col_valid:
+            y_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                       (row_i64 * y_row_stride + absolute_col)
+            copy_r2g(y_frag[:,vb], address(y_storage,y_offset), COPY_BITS)
+            # instruction_selection: exact global store from the VEC table;
+            # extent: one row-and-column-predicated vector per vb
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; extent: one issue per CTA
+```
+
+## Addressing, predicates, and tail behavior
+
+- Compact coordinates and `row_i32*H + col` offsets remain Int32 exactly as
+  the source compiler path; the host has proved `M*H` fits signed Int32. Only
+  the row bound comparison widens `row_i32` to the runtime `M:int64` ABI.
+- Strided rows use `row_i64*x_row_stride + col` and
+  `row_i64*y_row_stride + col` entirely in Int64 (`mad.lo.s64` in reviewed
+  PTX). The buffers are one-dimensional backing storage; no dynamic-stride
+  2-D `match_buffer` is allowed.
+- The column predicate is the source `predicate_k`: one predicate per vector
+  block, testing the first element's absolute hidden coordinate against `H`.
+  Source vector alignment makes an accepted vector wholly in bounds.
+- The row predicate gates async/sync X issue and final Y store. For an in-range
+  async row the column predicate becomes a zero source-size, not skipped work.
+  Weight loads remain independent of row validity. Out-of-range rows still
+  execute every reduction and synchronization operation.
+- Grid `block_y` owns disjoint `[block_y*COLS_PER_TILE, ...]` global ranges;
+  the separate flat `cta_rank` selects the source-CTA slot in DSMEM. The
+  registered cluster branch closure uses exact partitions; the `H` predicate
+  remains present and is not replaced by a shape whitelist.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime / reuse rule |
+| --- | --- | --- |
+| `sX` | each thread writes and reads its own `(row,local_col)` vectors | async issue through the post-reduction reload; the final CTA/cluster barrier is the reuse edge |
+| cluster-1 reduction | lane 0 of each row warp publishes one scalar | publication barrier through the redundant final reduction in every row warp |
+| clustered reduction | every source warp sends its partial to every peer; slot records source CTA rank | remote completion through local mbarrier wait and final reduction |
+| cluster mbarrier | thread 0 initializes; one elected lane of warp 0 arrives with the byte expectation; all remote stores complete it | cluster initialization through the one reduction transaction epoch |
+| X fragment | one thread | synchronous path: load through pass 2; async path: first load through square/reduction then discarded and reloaded after barrier |
+| W fragment | one thread | global load before the async X wait (or at the same source-ordered point in the sync path) through pass 2 |
+| output fragment | one thread | first FP32 multiply, bias add, second FP32 multiply, narrowing, then one predicated vector store |
+
+No race depends on scheduling. Every row subgroup owns one row, every vector
+has one thread owner, the cluster transaction byte count includes exactly all
+warp-to-peer scalar stores, all participants execute the wait, and output
+columns are disjoint across threads and cluster CTAs.
+
+## Module and verification contract
+
+- Registry name is `flashinfer_rmsnorm`, category `flashinfer`, compute
+  capability 10; `get_kernel` is the only registered factory.
+- `CONFIGS` contains exactly 279 unique executable configurations and
+  `BENCH_CONFIGS` contains exactly the five frozen BF16 performance workloads.
+- Each upstream matrix config executes both implicit FlashInfer output and the
+  caller-provided `out` API without duplicating the compile label.
+- Correctness compares the public FlashInfer CuTe-DSL path and an independent
+  FP32 oracle at `rtol=atol=1e-3`, asserts output object identity, immutable
+  inputs/weight, finite output, and sampled Int64 boundary rows for huge cases.
+- Static verification rejects `TilePrimitiveCall`, `tirx.tile.*`, imports of
+  `tvm.script.tirx.tile`, and tile primitives in every generated PrimFunc.
+- The only performance authority is a complete five-workload
+  `python -m tirx_kernels.bench_suite` run. Each exact
+  `flashinfer_cutedsl_time / tirx_time` ratio must be strictly greater than
+  0.99; diagnostic PTX/SASS/NCU results never replace that gate.
+
+## Instruction selection is a lowering consequence
+
+The port first preserves the source thread-value layout, vector width, copy
+path, ordered fragment reduction, shuffle topology, shared offsets, cluster
+transaction protocol, register lifetime, and barriers. Plain TIRx and local
+typed PTX may then express the reviewed opcodes. It may not use a tile
+primitive, change row ownership, substitute a different block/cluster
+reduction, scalarize reviewed vector traffic, keep async X live instead of
+reloading it, fuse or reassociate the two scale multiplies, replace
+`rsqrt.approx.ftz.f32`, or introduce PDL operations into a disabled
+specialization.

--- a/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
@@ -36,7 +36,18 @@ for no in T.unroll(MMA_N // EPI_TILE):
 One measured FP32 bias hoist regressed 6.6%; by contrast, staging a larger load
 set won when it created enough outstanding DRAM misses.
 
+## Boundary
+
+Do not shorten a fragment lifetime across an ordering that belongs to the
+correctness contract. One vector-at-a-time epilogue reduced registers from 96
+to 94 and moved a ratio from 0.979x to 0.981x, but it also stored each vector
+before the remaining fragment had completed its multiply, bias, and narrowing
+phases. The measured gain was rejected and the full-fragment phase order was
+restored.
+
 ## Verification
 
 Compare registers and dynamic LDL/STL before instruction count, and sweep the
-tightest specialization where one spill can reverse the result.
+tightest specialization where one spill can reverse the result. Verify the
+compute and store order in emitted PTX/SASS before treating a shorter lifetime
+as a legal candidate.

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -76,6 +76,11 @@ no spill.
   reconvergence per CTA; reissuing it as a predicated store matched the
   reference exactly at BSYNC 9216 to 6144 and BRA 7680 to 6144, and moved two
   shapes from 0.982x and 0.988x to 1.007-1.019x and 1.012x.
+- In a measured 128-thread dependency-protocol path, moving the same tail guard
+  from an outer C++ branch onto the vector stores removed the remaining BSSY and
+  BSYNC, reduced registers from 105 to 96 with no spill, and moved the gate from
+  0.959x to 0.976x. The change was useful even though another register-budget
+  change was still needed to clear the final threshold.
 - Guarding a block of single-issue matrix and copy instructions on the elected
   lane costs a reconvergence pair per iteration, measured at 4.53 instructions
   per K block against the reference's roughly zero, because the reference's
@@ -106,6 +111,12 @@ totals. Check the lowering before assuming the written form survived.
 
 In the elected-lane case, extending the rewrite to the epilogue produced no
 separation from run-to-run drift; that is where to stop.
+
+Hoisting a uniform guard can be execution-path-specific. Replacing eight
+repeated asynchronous-copy branches with one outer branch improved the
+non-protocol path but moved the dependency-protocol path from 3.386 to 3.425
+microseconds, so the shared rewrite was reverted. Match the source topology,
+then retain the hoist only on the paths where the gate confirms it.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/issue-loads-before-conversions.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/issue-loads-before-conversions.md
@@ -66,6 +66,12 @@ The measurement that does answer it is the scheduled-SASS distance from the last
 load to its first consumer, which moved from 17 to 215 instructions when the
 conversion was written later.
 
+Source and PTX order are not enough. Separating a complete shared-word load
+phase from its unpack phase made one PTX stream match the reference more closely,
+but the final cubin remained identical at 661 instructions, 92 registers, and
+the same relevant opcode counts. With no generated-code lever left, the rewrite
+was reverted before timing.
+
 ## Verification
 
 Confirm the load issue window and load-to-first-consumer distance in SASS, then

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-launch-bounds.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-launch-bounds.md
@@ -45,10 +45,25 @@ nine on the larger block cut its allocation to 32 registers before timing. The
 shape-aware 9/1 selector cleared its five-workload boundary matrix at
 1.003-1.028x.
 
+In a measured 128-thread single-wave family, setting the minimum-block count to
+one moved the allocation from 63 to 90 registers, reduced static SASS from 664
+to 656 instructions, and introduced no spill. Two non-protocol paths reached
+1.016x and 1.005x, while the dependency-protocol path improved from about
+0.945x to 0.959x.
+
 ## Boundary
 
 Treat a large allocation shift as a separate shape A/B even when neither variant
 spills: ptxas can trade registers for recomputation and address instructions.
+
+Lower allocation is not the objective. In the same family, a minimum-block
+count of six later realized 80 registers with zero stack and local traffic, yet
+regressed the gate from 0.981x to 0.976x. Match an occupancy mechanism, not the
+reference's register number.
+
+Use `tirx.max_registers` when an exact per-specialization ceiling, rather than a
+minimum resident-block target, is the demonstrated lever. The two contracts are
+mutually exclusive.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/materialize-and-forward-reused-values.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/materialize-and-forward-reused-values.md
@@ -73,8 +73,16 @@ The reverse direction has a limit. Hoisting address invariants the backend
 already merges changes almost nothing: one such hoist moved static SASS by five
 instructions and left the shift count untouched.
 
+A smaller generated program is not sufficient evidence to keep this rewrite.
+In one dependency-protocol specialization, forwarding a row predicate removed
+eight static instructions but raised registers from 96 to 98 and left the gate
+unchanged at 0.979-0.980x. A broader address-base materialization removed 16
+static instructions and reduced registers from 92 to 88 with no spill, yet the
+affected path still regressed to 0.985x. Both changes were reverted.
+
 ## Verification
 
 Count instructions in the corresponding PTX/SASS basic block and inspect ptxas
 resources and SASS; source or PTX size can remain unchanged while registers and
-SASS move.
+SASS move. Treat those changes as mechanism evidence, then require a measured
+gain on the affected and guard workloads before retaining the materialization.

--- a/.agents/skills/tirx-codegen-tuning/references/db/select-address-lowering-by-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/select-address-lowering-by-shape.md
@@ -49,7 +49,21 @@ no consistent full-matrix gain. ptxas had already strength-reduced much of the
 original indexing, while the explicit cursors extended five live ranges and
 added loop-back updates.
 
+The reverse static win can also lose. One grouped native-offset rewrite issued
+eight asynchronous copies from one base plus immediates, removed 16 static SASS
+instructions, and moved the first copy earlier without changing the floating
+point, copy, or store counts. It still measured only 0.980x, so the shorter
+instruction stream did not translate to a shorter timed path and the rewrite
+was reverted.
+
+## Boundary
+
+Native offsets, explicit arithmetic, and cursor induction are alternative
+dependency graphs, not an ordering from worse to better. Do not retain one from
+instruction count or first-issue position alone.
+
 ## Verification
 
 Confirm normalized PTX/SASS addresses, register counts, integer address ops,
-spills, and latency per specialization.
+spills, and latency per specialization. Require the affected performance path
+and its guard shapes to agree with the static diagnosis.

--- a/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
@@ -43,6 +43,11 @@ The selected cap of 64 subsequently cleared a five-shape guard matrix at
 caps of 93 and 96 for two non-protocol 128-thread shape regimes, while its
 256-thread regime retained a launch bound instead of a static cap.
 
+The wider 128-thread regime had a separate hard boundary: every cap below 92
+produced 8-40 bytes of stack, while cap 96 kept both guarded variants spill-free
+and measured 0.992x. Cap 104 also passed but with less margin, so the selector
+retained 96 rather than applying the dependency-protocol cap globally.
+
 ## Boundary
 
 `tirx.max_registers` and `tirx.launch_bounds_*` are alternative static codegen
@@ -51,6 +56,12 @@ and dependency-protocol families separate when their live ranges differ. A cap
 that is too low can introduce spills or recomputation; a cap that is too high
 can reduce occupancy or produce a worse schedule. Re-sweep after any change to
 fragment lifetime, instruction ordering, or launch protocol.
+
+Do not copy the reference's realized register count into the cap. One
+source-like cap of 74 moved a wide-fragment path to 4.7-4.9 microseconds, and a
+cap matching the reference's 56-register dependency path improved the target
+only slightly without clearing the gate. The two instruction streams can need
+different budgets to realize comparable schedules.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
@@ -1,0 +1,60 @@
+# Specialize static register caps by execution path
+
+**Symptoms:** `register_budget_mismatch`, `schedule_regression`, `dispatch_specific_deficit`, `low_occupancy`
+
+## Symptom
+
+A spill-free kernel has a persistent deficit in one compile-time execution path,
+or neighboring shape families realize different register allocations and
+schedules despite sharing a block size.
+
+## What to change
+
+Place `tirx.max_registers` immediately after `T.device_entry()` and select it by
+the compile-time path that changes the live range or scheduling problem. Sweep
+neighboring integer caps for each affected path instead of assuming that the
+response is monotonic or that one cap fits the whole kernel family.
+
+```python
+T.device_entry()
+if USE_DEPENDENCY_PROTOCOL:
+    T.attr({"tirx.max_registers": 64})
+elif LARGE_FRAGMENT:
+    T.attr({"tirx.max_registers": 96})
+else:
+    T.attr({"tirx.max_registers": 93})
+```
+
+This is a static whole-kernel ceiling. It is not a replacement for
+`setmaxnreg.sync.aligned`, which transfers register budget between warpgroup
+roles while a kernel is running.
+
+## Rationale
+
+The static ceiling participates in ptxas scheduling and allocation. It can
+therefore change recomputation, instruction placement, and occupancy even when
+both candidates report zero stack and local-memory use.
+
+One measured 128-thread dependency-protocol specialization was non-monotonic at
+single-register granularity: caps 61, 63, 64, 65, and 68 measured 0.984x,
+0.983x, 0.998x, 0.978x, and 0.985x respectively against the same reference.
+The selected cap of 64 subsequently cleared a five-shape guard matrix at
+0.993-1.026x, with the affected path at 1.001x. The same source family required
+caps of 93 and 96 for two non-protocol 128-thread shape regimes, while its
+256-thread regime retained a launch bound instead of a static cap.
+
+## Boundary
+
+`tirx.max_registers` and `tirx.launch_bounds_*` are alternative static codegen
+contracts and must not be declared together. Keep block-size, fragment-width,
+and dependency-protocol families separate when their live ranges differ. A cap
+that is too low can introduce spills or recomputation; a cap that is too high
+can reduce occupancy or produce a worse schedule. Re-sweep after any change to
+fragment lifetime, instruction ordering, or launch protocol.
+
+## Verification
+
+Confirm that CUDA and PTX contain the requested `__maxnreg__` and `.maxnreg`,
+then read the realized register allocation, stack size, local-memory traffic,
+and scheduled SASS rather than trusting the declaration. Run correctness plus
+the affected performance shapes and guard shapes on every retained cap.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ upstream project.
 | `flash_attention_backward_sm100` | `flash_attention_backward.py` | Two-CTA FlashAttention backward (D=128); [schedule sketch](tirx_kernels/flashattention/flash_attention_backward_sm100_sketch.md) |
 
 `flashinfer/` — FlashInfer ports, sub-bucketed by the FlashInfer Python entry
-point each port backs (`activation`, `quantization` — CuTe-DSL backend —,
+point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend —,
 `mamba`, `kda`, `gdn_decode`, `gdn_prefill`, `gemm`):
 
 | Kernel                                  | Module                                              | What it is |
@@ -38,6 +38,7 @@ point each port backs (`activation`, `quantization` — CuTe-DSL backend —,
 | `nvfp4_quantize_per_token`              | `quantization/nvfp4_quantize_per_token.py`          | Per-token-activation quantization |
 | `mxfp4_quantize`                        | `quantization/mxfp4_quantize.py`                    | Block quantization with UE8M0 scales |
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
+| `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `selective_state_update_stp_simple`     | `mamba/selective_state_update_stp_simple.py`        | Single-token, `algorithm="simple"` |
 | `selective_state_update_stp_vertical`   | `mamba/selective_state_update_stp_vertical.py`      | Single-token, `algorithm="vertical"` |
 | `selective_state_update_stp_horizontal` | `mamba/selective_state_update_stp_horizontal.py`    | Single-token, `algorithm="horizontal"` |

--- a/tests/lint/check_flashinfer_rmsnorm_no_tile.py
+++ b/tests/lint/check_flashinfer_rmsnorm_no_tile.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every FlashInfer RMSNorm specialization."""
+
+import sys
+
+import check_gdn_decode_bf16_wide_vec_t1_no_tile as no_tile
+
+from tirx_kernels.flashinfer.norm import rmsnorm as target
+
+no_tile.target = target
+no_tile.TARGET = no_tile.REPO / "tirx_kernels/flashinfer/norm/rmsnorm.py"
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "f20fa692",
-    "tirx-kernels": "b74762d3-dirty",
+    "tir": "3df3e86a",
+    "tirx-kernels": "abb50263-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "5a92f7b6847eed22f86bbae1ea6d70e43e8a3307"
+    "tirx-kernels:tirx_kernels": "4d0584f1fc0655f65f541190d8af337a69b759db"
   },
   "baselines": {
     "torch": {
@@ -1606,6 +1606,76 @@
       "impls": {
         "tir": 5549.111992647058,
         "flashattn_sm100": 5662.155411764706
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm",
+      "config": "gemma_bf16_m32_h4096_xc_yc_pdl0",
+      "label": "gemma_bf16_m32_h4096_xc_yc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.3629560297147543,
+        "flashinfer_cutedsl": 3.4510390326071674
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm",
+      "config": "gemma_bf16_m64_h8192_xc_yc_pdl0",
+      "label": "gemma_bf16_m64_h8192_xc_yc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.4773465698180908,
+        "flashinfer_cutedsl": 3.452984607375942
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm",
+      "config": "rms_bf16_m32_h4096_xc_yc_pdl0",
+      "label": "rms_bf16_m32_h4096_xc_yc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.364439676928304,
+        "flashinfer_cutedsl": 3.452695622404946
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm",
+      "config": "rms_bf16_m32_h4096_xc_yc_pdl1",
+      "label": "rms_bf16_m32_h4096_xc_yc_pdl1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.3515764867977045,
+        "flashinfer_cutedsl": 3.3558080135711537
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm",
+      "config": "rms_bf16_m64_h8192_xc_yc_pdl0",
+      "label": "rms_bf16_m64_h8192_xc_yc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.4584417197769426,
+        "flashinfer_cutedsl": 3.4412295032725257
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': 'f20fa692', 'tirx-kernels': 'b74762d3-dirty', 'tirx-bench-ci': None}`
-- Workloads: 336 ok, 0 failed
+- Git:       `{'tir': '3df3e86a', 'tirx-kernels': 'abb50263-dirty', 'tirx-bench-ci': None}`
+- Workloads: 341 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -200,6 +200,16 @@ Grouped workloads show one row per config and one timing column per implementati
 | `b2_s4096_h16_causal` | tir | 388.0339 | flashattn_sm100 | 390.3185 | 1.006 | — |
 | `b4_s8192_h16_causal` | tir | 2473.1056 | flashattn_sm100 | 2496.3857 | 1.009 | — |
 | `b4_s8192_h16_noncausal` | tir | 5549.1120 | flashattn_sm100 | 5662.1554 | 1.020 | — |
+
+## flashinfer_rmsnorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `gemma_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.3630 | flashinfer_cutedsl | 3.4510 | 1.026 | — |
+| `gemma_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4773 | flashinfer_cutedsl | 3.4530 | 0.993 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.3644 | flashinfer_cutedsl | 3.4527 | 1.026 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl1` | tirx | 3.3516 | flashinfer_cutedsl | 3.3558 | 1.001 | — |
+| `rms_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4584 | flashinfer_cutedsl | 3.4412 | 0.995 | — |
 
 ## flashkda_bf16_fused_m128
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm.yaml
@@ -1,0 +1,8 @@
+kernel: flashinfer_rmsnorm
+selection_rationale: The small non-PDL RMS case, otherwise-identical PDL RMS case, and largest Gemma case span launch dependency, variant, and workload scale.
+configs:
+  - {config: rms_bf16_m32_h4096_xc_yc_pdl0, default: true, selection_role: small}
+  - {config: rms_bf16_m64_h8192_xc_yc_pdl0, default: false}
+  - {config: rms_bf16_m32_h4096_xc_yc_pdl1, default: true, selection_role: medium}
+  - {config: gemma_bf16_m32_h4096_xc_yc_pdl0, default: false}
+  - {config: gemma_bf16_m64_h8192_xc_yc_pdl0, default: true, selection_role: large}

--- a/tirx_kernels/flashinfer/norm/__init__.py
+++ b/tirx_kernels/flashinfer/norm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Ports of the kernels behind ``flashinfer.norm``."""

--- a/tirx_kernels/flashinfer/norm/rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm.py
@@ -1,0 +1,1206 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL 2-D RMSNorm and Gemma RMSNorm port.
+
+The source implementation is ``RMSNormKernel`` plus its 2-D host dispatch in
+``flashinfer/norm/kernels/rmsnorm.py``.  The public entry points are
+``rmsnorm`` and ``gemma_rmsnorm`` in ``flashinfer/norm/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {"name": "flashinfer_rmsnorm", "category": "flashinfer", "compute_capability": 10}
+
+_VARIANTS = ("rmsnorm", "gemma_rmsnorm")
+_DTYPES = ("float16", "bfloat16")
+_LAYOUTS = ("compact", "strided")
+_INT32_MAX = 2**31 - 1
+_DEFAULT_EPS = 1e-6
+_OPTIN_SMEM_BYTES = 232448
+_ELEM_BYTES = 2
+
+
+def _ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def _threads_per_row(H_per_cta: int) -> int:
+    if H_per_cta <= 64:
+        return 8
+    if H_per_cta <= 128:
+        return 16
+    if H_per_cta <= 3072:
+        return 32
+    if H_per_cta <= 6144:
+        return 64
+    if H_per_cta <= 16384:
+        return 128
+    return 256
+
+
+def _derived_config(H: int, cluster_n: int) -> dict[str, int | bool]:
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, 8)
+    copy_bits = 16 * vec
+    vec_blocks = max(1, _ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    tile_bytes = rows * cols * _ELEM_BYTES
+    use_async = copy_bits >= 32 and tile_bytes <= _OPTIN_SMEM_BYTES // 2
+    reduce_bytes = rows * warps_per_row * 4
+    if cluster_n > 1:
+        reduce_bytes *= cluster_n
+    smem_bytes = (tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return {
+        "cluster_n": cluster_n,
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec": vec,
+        "copy_bits": copy_bits,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+        "use_async": use_async,
+        "smem_bytes": smem_bytes,
+    }
+
+
+def _estimate_smem(H: int, cluster_n: int) -> int:
+    config = _derived_config(H, cluster_n)
+    rows = int(config["rows"])
+    warps_per_row = int(config["warps_per_row"])
+    cols = int(config["cols"])
+    return (
+        rows * cols * _ELEM_BYTES
+        + rows * warps_per_row * cluster_n * 4
+        + (8 if cluster_n > 1 else 0)
+    )
+
+
+def _source_config(H: int) -> dict[str, int | bool]:
+    cluster_n = 16
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and _estimate_smem(H, candidate) <= _OPTIN_SMEM_BYTES:
+            cluster_n = candidate
+            break
+    return _derived_config(H, cluster_n)
+
+
+def _ptx_unary(chain: str, value, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _ptx_ternary(chain: str, lhs, rhs, acc, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _div_rn_f32(lhs, rhs):
+    return _ptx_binary("div.rn.f32", lhs, rhs)
+
+
+def _fma_rn_f32(lhs, rhs, acc):
+    return _ptx_ternary("fma.rn.f32", lhs, rhs, acc)
+
+
+def _rsqrt_approx_ftz(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _cvt_to_f32(bits, dtype: str):
+    if dtype == "float16":
+        return _ptx_unary("cvt.f32.f16", T.cast(bits, "uint16"))
+    return _ptx_unary("cvt.f32.bf16", T.cast(bits, "uint16"))
+
+
+def _cvt_from_f32(value, dtype: str):
+    if dtype == "float16":
+        return _ptx_unary("cvt.rn.f16.f32", value, dtype="uint16")
+    return _ptx_unary("cvt.rn.bf16.f32", value, dtype="uint16")
+
+
+def _cvt_pair_from_f32(high, low, dtype: str):
+    if dtype == "float16":
+        return _ptx_binary("cvt.rn.f16x2.f32", high, low, dtype="uint32")
+    return _ptx_binary("cvt.rn.bf16x2.f32", high, low, dtype="uint32")
+
+
+def _shfl_bfly_f32(value, lane_xor: int):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _butterfly_sum_f32(value, lane_xors: tuple[int, ...]):
+    for lane_xor in lane_xors:
+        peer = _shfl_bfly_f32(value, lane_xor)
+        value = _add_f32(value, peer)
+    return value
+
+
+def _mapa_u32(pointer, peer):
+    mapped = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.mapa.shared__cluster.u32(
+            mapped[0], T.cuda.cvta_generic_to_shared(pointer), T.cast(peer, "uint32")
+        )
+    )
+    return mapped[0]
+
+
+def _cluster_mbarrier_wait(pointer):
+    return T.cuda.mbarrier_wait(pointer, T.int32(0))
+
+
+@T.inline
+def _load_global_bits(buffer, index, values, value_offset, VEC: T.constexpr):
+    if VEC == 1:
+        T.ptx.ld.global_.b16(values[value_offset], buffer.ptr_to([index]))
+    elif VEC == 2:
+        T.ptx.ld.global_.v2.b16(
+            values[value_offset], values[value_offset + 1], buffer.ptr_to([index])
+        )
+    else:
+        words = T.alloc_local((VEC // 2,), "uint32")
+        if VEC == 4:
+            T.ptx.ld.global_.v2.b32(words[0], words[1], buffer.ptr_to([index]))
+        else:
+            T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+        for pair in T.unroll(VEC // 2):
+            values[value_offset + pair * 2] = T.cast(
+                T.bitwise_and(words[pair], T.uint32(0xFFFF)), "uint16"
+            )
+            values[value_offset + pair * 2 + 1] = T.cast(
+                T.shift_right(words[pair], T.uint32(16)), "uint16"
+            )
+
+
+@T.inline
+def _load_shared_bits(shared_raw, byte_offset, values, value_offset, VEC: T.constexpr):
+    if VEC == 2:
+        T.ptx.ld.shared.v2.b16(
+            values[value_offset], values[value_offset + 1], shared_raw.ptr_to([byte_offset])
+        )
+    else:
+        words = T.alloc_local((VEC // 2,), "uint32")
+        if VEC == 4:
+            halves = T.alloc_local((4,), "uint16")
+            T.ptx.ld.shared.v4.b16(
+                halves[0], halves[1], halves[2], halves[3], shared_raw.ptr_to([byte_offset])
+            )
+            for value in T.unroll(4):
+                values[value_offset + value] = halves[value]
+        else:
+            T.ptx.ld.shared.v4.b32(
+                words[0], words[1], words[2], words[3], shared_raw.ptr_to([byte_offset])
+            )
+            for pair in T.unroll(4):
+                values[value_offset + pair * 2] = T.cast(
+                    T.bitwise_and(words[pair], T.uint32(0xFFFF)), "uint16"
+                )
+                values[value_offset + pair * 2 + 1] = T.cast(
+                    T.shift_right(words[pair], T.uint32(16)), "uint16"
+                )
+
+
+@T.inline
+def _store_global_fragment(
+    buffer,
+    index,
+    bits,
+    words,
+    predicate,
+    value_offset,
+    word_offset,
+    VEC: T.constexpr,
+    PACKED_NARROW: T.constexpr,
+):
+    if VEC == 1:
+        T.ptx.st.global_.b16(buffer.ptr_to([index]), bits[value_offset], pred=predicate)
+    elif VEC == 2:
+        if PACKED_NARROW:
+            bits[value_offset] = T.cast(
+                T.bitwise_and(words[word_offset], T.uint32(0xFFFF)), "uint16"
+            )
+            bits[value_offset + 1] = T.cast(
+                T.shift_right(words[word_offset], T.uint32(16)), "uint16"
+            )
+        T.ptx.st.global_.v2.b16(
+            buffer.ptr_to([index]), bits[value_offset], bits[value_offset + 1], pred=predicate
+        )
+    elif VEC == 4:
+        T.ptx.st.global_.v2.b32(
+            buffer.ptr_to([index]), words[word_offset], words[word_offset + 1], pred=predicate
+        )
+    else:
+        T.ptx.st.global_.v4.b32(
+            buffer.ptr_to([index]),
+            words[word_offset],
+            words[word_offset + 1],
+            words[word_offset + 2],
+            words[word_offset + 3],
+            pred=predicate,
+        )
+
+
+def _short_variant(variant: str) -> str:
+    return {"rmsnorm": "rms", "gemma_rmsnorm": "gemma"}[variant]
+
+
+def _short_dtype(dtype: str) -> str:
+    return {"float16": "fp16", "bfloat16": "bf16"}[dtype]
+
+
+def _layout_code(layout: str) -> str:
+    return {"compact": "c", "strided": "s"}[layout]
+
+
+def _cfg(
+    variant: str,
+    dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    *,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    y_row_stride: int | None = None,
+    suffix: str | None = None,
+) -> dict[str, Any]:
+    label = (
+        f"{_short_variant(variant)}_{_short_dtype(dtype)}_m{M}_h{H}_"
+        f"x{_layout_code(input_layout)}_y{_layout_code(output_layout)}_"
+        f"pdl{int(enable_pdl)}"
+    )
+    if suffix:
+        label += f"_{suffix}"
+    config: dict[str, Any] = {
+        "label": label,
+        "variant": variant,
+        "dtype": dtype,
+        "M": M,
+        "H": H,
+        "input_layout": input_layout,
+        "output_layout": output_layout,
+        "enable_pdl": enable_pdl,
+        "eps": eps,
+    }
+    if x_row_stride is not None:
+        config["x_row_stride"] = x_row_stride
+    if y_row_stride is not None:
+        config["y_row_stride"] = y_row_stride
+    return config
+
+
+# The 256 upstream 2-D pytest combinations.  ``run_test`` executes each entry
+# once with implicit FlashInfer output and once with a caller-provided output.
+_UPSTREAM_CONFIGS = [
+    _cfg(
+        variant,
+        "float16",
+        M,
+        H,
+        input_layout,
+        "compact",
+        enable_pdl,
+        x_row_stride=2 * H if input_layout == "strided" else None,
+    )
+    for variant in _VARIANTS
+    for M in (1, 19, 99, 989)
+    for H in (111, 500, 1024, 3072, 3584, 4096, 8192, 16384)
+    for input_layout in _LAYOUTS
+    for enable_pdl in (False, True)
+]
+
+# Every 2-D performance workload supplied by the pinned FlashInfer source.
+BENCH_CONFIGS = [
+    _cfg("rmsnorm", "bfloat16", 32, 4096, "compact", "compact", False),
+    _cfg("rmsnorm", "bfloat16", 64, 8192, "compact", "compact", False),
+    _cfg("rmsnorm", "bfloat16", 32, 4096, "compact", "compact", True),
+    _cfg("gemma_rmsnorm", "bfloat16", 32, 4096, "compact", "compact", False),
+    _cfg("gemma_rmsnorm", "bfloat16", 64, 8192, "compact", "compact", False),
+]
+
+_I64_CONFIGS = [
+    _cfg(
+        "rmsnorm",
+        "bfloat16",
+        2,
+        128,
+        "strided",
+        "compact",
+        False,
+        x_row_stride=2**31,
+        suffix="i64_xstride",
+    ),
+    _cfg(
+        "rmsnorm",
+        "float16",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        False,
+        suffix="compact_overflow_strided",
+    ),
+    _cfg(
+        "gemma_rmsnorm",
+        "float16",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        False,
+        suffix="compact_overflow_strided",
+    ),
+]
+
+_TRACE_CONFIGS = [
+    _cfg("rmsnorm", "bfloat16", 8, 256, "compact", "compact", False),
+    _cfg("gemma_rmsnorm", "bfloat16", 8, 256, "compact", "compact", False),
+    _cfg("rmsnorm", "bfloat16", 3, 320, "compact", "compact", False),
+    _cfg("gemma_rmsnorm", "bfloat16", 3, 320, "compact", "compact", False),
+    _cfg("rmsnorm", "bfloat16", 32, 7168, "compact", "compact", False),
+    _cfg("gemma_rmsnorm", "bfloat16", 32, 4608, "compact", "compact", False),
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg("rmsnorm", "float16", 3, 64, "compact", "compact", False, suffix="tpr8"),
+    _cfg("gemma_rmsnorm", "bfloat16", 3, 66, "compact", "compact", True, suffix="vec2"),
+    _cfg("rmsnorm", "float16", 3, 16385, "compact", "compact", False, suffix="sync_vec1"),
+    _cfg(
+        "gemma_rmsnorm",
+        "bfloat16",
+        3,
+        65536,
+        "compact",
+        "compact",
+        True,
+        suffix="sync_capacity_cluster1",
+    ),
+    _cfg("rmsnorm", "float16", 3, 131072, "compact", "compact", False, suffix="cluster2"),
+    _cfg("gemma_rmsnorm", "bfloat16", 3, 262144, "compact", "compact", True, suffix="cluster4"),
+    _cfg("rmsnorm", "float16", 3, 524288, "compact", "compact", False, suffix="cluster8"),
+    _cfg("gemma_rmsnorm", "bfloat16", 3, 1048576, "compact", "compact", True, suffix="cluster16"),
+]
+
+_ABI_CONFIGS = [
+    _cfg(
+        "rmsnorm",
+        "float16",
+        19,
+        500,
+        "compact",
+        "strided",
+        True,
+        eps=1e-4,
+        y_row_stride=1000,
+        suffix="eps1e4_abi",
+    )
+]
+
+CONFIGS = [
+    *_UPSTREAM_CONFIGS,
+    *BENCH_CONFIGS,
+    *_I64_CONFIGS,
+    *_TRACE_CONFIGS,
+    *_STRUCTURE_CONFIGS,
+    *_ABI_CONFIGS,
+]
+
+assert len(CONFIGS) == 279
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+assert len(BENCH_CONFIGS) == 5
+
+
+def _validate(
+    variant: str, dtype: str, M: int, H: int, input_layout: str, output_layout: str, eps: float
+) -> None:
+    if variant not in _VARIANTS:
+        raise ValueError(f"unsupported variant: {variant}")
+    if dtype not in _DTYPES:
+        raise ValueError(f"unsupported dtype: {dtype}")
+    if input_layout not in _LAYOUTS or output_layout not in _LAYOUTS:
+        raise ValueError(f"unsupported layouts: input={input_layout}, output={output_layout}")
+    if M <= 0 or H <= 0:
+        raise ValueError(f"M and H must be positive, got M={M}, H={H}")
+    if eps <= 0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+
+def _uses_compact_specialization(M: int, H: int, input_layout: str, output_layout: str) -> bool:
+    return input_layout == "compact" and output_layout == "compact" and M * H <= _INT32_MAX
+
+
+def get_kernel(
+    variant: str,
+    dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    eps: float = _DEFAULT_EPS,
+    **kwargs: Any,
+):
+    """Return the compact or explicit-i64-strided runtime-M specialization."""
+    _validate(variant, dtype, M, H, input_layout, output_layout, eps)
+    compact = _uses_compact_specialization(M, H, input_layout, output_layout)
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec = int(source["vec"])
+    copy_bits = int(source["copy_bits"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    use_async = bool(source["use_async"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = vec * vec_blocks
+    packed_pairs = _ceil_div(total_values, 2)
+    pair_values = packed_pairs * 2
+    packed_narrow = not (vec == 1 or (vec == 2 and vec_blocks == 3))
+    weight_bias = 0.0 if variant == "rmsnorm" else 1.0
+    copy_bytes = copy_bits // 8
+    cp_async_chain = "cp.async.ca.shared.global"
+    reduce_base = tile_bytes if use_async else 0
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+
+    x_row_stride_hint = kwargs.get("x_row_stride", H)
+    y_row_stride_hint = kwargs.get("y_row_stride", H)
+    if x_row_stride_hint is not None and int(x_row_stride_hint) % vec != 0:
+        raise ValueError(f"x_row_stride={x_row_stride_hint} must be divisible by vec={vec}")
+    if y_row_stride_hint is not None and int(y_row_stride_hint) % vec != 0:
+        raise ValueError(f"y_row_stride={y_row_stride_hint} must be divisible by vec={vec}")
+
+    @T.inline
+    def kernel_body(x, weight, y, runtime_M, runtime_eps, x_row_stride, y_row_stride):
+        # TIRX_TRANSCRIBE_START flashinfer_rmsnorm
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        row_i32: T.int32 = block_x * rows + row_in_cta
+        row_i64: T.int64 = T.cast(row_i32, "int64")
+        row_valid: T.bool = row_i64 < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+        if threads == 128:
+            if enable_pdl:
+                T.attr({"tirx.max_registers": 64})
+            elif H == 8192:
+                T.attr({"tirx.max_registers": 96})
+            else:
+                T.attr({"tirx.max_registers": 93})
+        else:
+            T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        x_bits = T.alloc_local((pair_values,), "uint16")
+        w_bits = T.alloc_local((pair_values,), "uint16")
+        x_f32 = T.alloc_local((pair_values,), "float32")
+        w_f32 = T.alloc_local((pair_values,), "float32")
+        x_sq = T.alloc_local((pair_values,), "float32")
+        undefined_f32 = T.alloc_local((1,), "float32")
+
+        if not use_async:
+            for value in T.unroll(total_values):
+                x_bits[value] = T.uint16(0)
+
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                x_offset = row_i32 * H + absolute_col
+            else:
+                x_offset = row_i64 * x_row_stride + T.cast(absolute_col, "int64")
+
+            if use_async:
+                if row_valid:
+                    source_bytes: T.uint32 = T.cast(
+                        T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                    )
+                    T.ptx[cp_async_chain](
+                        shared_raw.ptr_to([(row_in_cta * cols + local_col) * _ELEM_BYTES]),
+                        x.ptr_to([x_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+            else:
+                if row_valid and col_valid:
+                    _load_global_bits(x, x_offset, x_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.commit_group()
+
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            if absolute_col < H:
+                _load_global_bits(weight, absolute_col, w_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.wait_group(0)
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    (row_in_cta * cols + local_col) * _ELEM_BYTES,
+                    x_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+
+        for value in T.unroll(total_values):
+            x_f32[value] = _cvt_to_f32(x_bits[value], dtype)
+
+        for pair in T.unroll(packed_pairs):
+            product = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                product[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(x_sq[pair * 2], x_sq[pair * 2 + 1], product[0])
+
+        local_sum: T.float32 = T.float32(0.0)
+        for value in T.unroll(total_values):
+            local_sum = _add_f32(local_sum, x_sq[value])
+
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+
+            T.evaluate(_cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset])))
+
+            final_sum: T.float32 = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        else:
+            sum_sq: T.float32 = warp_sum
+
+        if H & (H - 1) == 0:
+            shifted: T.float32 = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted: T.float32 = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        if use_async:
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    (row_in_cta * cols + local_col) * _ELEM_BYTES,
+                    x_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+            for value in T.unroll(total_values):
+                x_f32[value] = _cvt_to_f32(x_bits[value], dtype)
+
+        for value in T.unroll(total_values):
+            w_f32[value] = _cvt_to_f32(w_bits[value], dtype)
+
+        for pair in T.unroll(packed_pairs):
+            high_scale: T.float32 = rstd
+            if pair * 2 + 1 >= total_values:
+                high_scale = undefined_f32[0]
+            product = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                product[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                T.cuda.make_float2(rstd, high_scale),
+            )
+            T.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], product[0])
+
+        for pair in T.unroll(packed_pairs):
+            high_bias: T.float32 = T.float32(weight_bias)
+            if pair * 2 + 1 >= total_values:
+                high_bias = undefined_f32[0]
+            biased = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                biased[0],
+                T.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+                T.cuda.make_float2(T.float32(weight_bias), high_bias),
+            )
+            T.ptx.mov.b64(w_f32[pair * 2], w_f32[pair * 2 + 1], biased[0])
+
+        for pair in T.unroll(packed_pairs):
+            product = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                product[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                T.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], product[0])
+
+        y_bits = T.alloc_local((pair_values,), "uint16")
+        y_words = T.alloc_local((packed_pairs,), "uint32")
+        if packed_narrow:
+            for pair in T.unroll(packed_pairs):
+                y_words[pair] = _cvt_pair_from_f32(x_f32[pair * 2 + 1], x_f32[pair * 2], dtype)
+        else:
+            for value in T.unroll(total_values):
+                y_bits[value] = _cvt_from_f32(x_f32[value], dtype)
+
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                y_offset = row_i32 * H + absolute_col
+            else:
+                y_offset = row_i64 * y_row_stride + T.cast(absolute_col, "int64")
+            _store_global_fragment(
+                y,
+                y_offset,
+                y_bits,
+                y_words,
+                row_valid and col_valid,
+                vb * vec,
+                vb * vec // 2,
+                VEC=vec,
+                PACKED_NARROW=packed_narrow,
+            )
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    if compact:
+
+        @T.prim_func
+        def flashinfer_rmsnorm_compact(
+            x_ptr: T.handle,
+            weight_ptr: T.handle,
+            y_ptr: T.handle,
+            runtime_M: T.int64,
+            runtime_eps: T.float32,
+        ):
+            x = T.match_buffer(x_ptr, shape=(runtime_M * T.int64(H),), dtype=dtype, scope="global")
+            weight = T.match_buffer(weight_ptr, shape=(H,), dtype=dtype, scope="global")
+            y = T.match_buffer(y_ptr, shape=(runtime_M * T.int64(H),), dtype=dtype, scope="global")
+            T.device_entry()
+            kernel_body(x, weight, y, runtime_M, runtime_eps, T.int64(H), T.int64(H))
+
+        kernel = flashinfer_rmsnorm_compact
+    else:
+
+        @T.prim_func
+        def flashinfer_rmsnorm_strided(
+            x_ptr: T.handle,
+            weight_ptr: T.handle,
+            y_ptr: T.handle,
+            runtime_M: T.int64,
+            runtime_eps: T.float32,
+            x_row_stride: T.int64,
+            y_row_stride: T.int64,
+        ):
+            x = T.match_buffer(
+                x_ptr,
+                shape=((runtime_M - T.int64(1)) * x_row_stride + T.int64(H),),
+                dtype=dtype,
+                scope="global",
+            )
+            weight = T.match_buffer(weight_ptr, shape=(H,), dtype=dtype, scope="global")
+            y = T.match_buffer(
+                y_ptr,
+                shape=((runtime_M - T.int64(1)) * y_row_stride + T.int64(H),),
+                dtype=dtype,
+                scope="global",
+            )
+            T.device_entry()
+            kernel_body(x, weight, y, runtime_M, runtime_eps, x_row_stride, y_row_stride)
+
+        kernel = flashinfer_rmsnorm_strided
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return kernel.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Create deterministic tensors for one specialization."""
+    data = _prepare_tensors(config)
+    return data["x"], data["weight"]
+
+
+_GUARD_ELEMENTS = 64
+_GUARD_VALUE = 123.0
+
+
+def _torch_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _row_strides(config: dict[str, Any]) -> tuple[int, int]:
+    H = int(config["H"])
+    x_stride = int(config.get("x_row_stride", 2 * H if config["input_layout"] == "strided" else H))
+    y_stride = int(config.get("y_row_stride", 2 * H if config["output_layout"] == "strided" else H))
+    return x_stride, y_stride
+
+
+def _storage_size(M: int, H: int, row_stride: int) -> int:
+    return (M - 1) * row_stride + H
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M = int(config["M"])
+    H = int(config["H"])
+    dtype = str(config["dtype"])
+    input_layout = str(config["input_layout"])
+    output_layout = str(config["output_layout"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    _validate(str(config["variant"]), dtype, M, H, input_layout, output_layout, eps)
+    x_stride, y_stride = _row_strides(config)
+    vec = int(_source_config(H)["vec"])
+    if x_stride < H or y_stride < H:
+        raise ValueError(f"row strides must cover H={H}: x={x_stride}, y={y_stride}")
+    if x_stride % vec != 0 or y_stride % vec != 0:
+        raise ValueError(f"row strides must be divisible by vec={vec}: x={x_stride}, y={y_stride}")
+
+    torch_dtype = _torch_dtype(dtype)
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(42)
+
+    x_storage_size = _storage_size(M, H, x_stride)
+    x_backing = torch.empty(x_storage_size + _GUARD_ELEMENTS, dtype=torch_dtype, device="cuda")
+    x_arg = x_backing[:x_storage_size]
+    x = x_arg.as_strided((M, H), (x_stride, 1))
+    # The large-H structural cases isolate the DSMEM reduction topology with
+    # exactly representable values and an exactly accumulated sum of squares.
+    # The 257-column cycle and alternating rows also make X-address, CTA-slice,
+    # and async-reload mistakes visible.  Random BF16 values at million-wide
+    # shapes can make FlashInfer's approximate-rsqrt result miss its naive FP32
+    # oracle by one BF16 bin despite matching the port bit-for-bit.
+    if (dtype == "bfloat16" and H >= 4096) or H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        magnitude = torch.where(columns % 257 < 128, 0.5, 1.0)
+        pattern = torch.where(columns % 2 == 0, magnitude, -magnitude).to(torch_dtype)
+        x.copy_(pattern.expand(M, H))
+        x[1::2].neg_()
+    else:
+        x.normal_(generator=generator)
+    x_backing[x_storage_size:].fill_(_GUARD_VALUE)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=torch_dtype, device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    weight_backing[H:].fill_(_GUARD_VALUE)
+
+    return {
+        "x": x,
+        "x_arg": x_arg,
+        "x_backing": x_backing,
+        "x_storage_size": x_storage_size,
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "x_row_stride": x_stride,
+        "y_row_stride": y_stride,
+    }
+
+
+def _prepare_output(
+    M: int, H: int, row_stride: int, dtype: str, *, initialize_padding: bool
+) -> dict[str, Any]:
+    import torch
+
+    size = _storage_size(M, H, row_stride)
+    backing = torch.empty(size + _GUARD_ELEMENTS, dtype=_torch_dtype(dtype), device="cuda")
+    if initialize_padding and row_stride > H:
+        for row in range(M - 1):
+            backing[row * row_stride + H : (row + 1) * row_stride].fill_(_GUARD_VALUE)
+    backing[size:].fill_(_GUARD_VALUE)
+    arg = backing[:size]
+    view = arg.as_strided((M, H), (row_stride, 1))
+    return {"view": view, "arg": arg, "backing": backing, "size": size}
+
+
+def _assert_guard(backing, size: int, *, name: str) -> None:
+    import torch
+
+    expected = torch.full(
+        (_GUARD_ELEMENTS,), _GUARD_VALUE, dtype=backing.dtype, device=backing.device
+    )
+    if not torch.equal(backing[size:], expected):
+        raise AssertionError(f"{name} guard was modified")
+
+
+def _assert_output_padding(
+    output: dict[str, Any], M: int, H: int, row_stride: int, *, name: str
+) -> None:
+    import torch
+
+    _assert_guard(output["backing"], output["size"], name=name)
+    if row_stride > H:
+        for row in range(M - 1):
+            padding = output["backing"][row * row_stride + H : (row + 1) * row_stride]
+            expected = torch.full_like(padding, _GUARD_VALUE)
+            if not torch.equal(padding, expected):
+                raise AssertionError(f"{name} row {row} padding was modified")
+
+
+def _overflow_rows(M: int, H: int) -> list[int] | None:
+    if M * H <= _INT32_MAX:
+        return None
+    boundary = _ceil_div(2**31, H)
+    return sorted(
+        {row for row in (0, 1, boundary - 1, boundary, boundary + 1, M - 1) if 0 <= row < M}
+    )
+
+
+def _checked_view(tensor, rows: list[int] | None):
+    return tensor if rows is None else tensor[rows]
+
+
+def _math_oracle(x, weight, variant: str, eps: float, rows: list[int] | None):
+    x_checked = _checked_view(x, rows).float()
+    weight_f32 = weight.float()
+    variance = x_checked.square().mean(dim=-1, keepdim=True)
+    normalized = x_checked * variance.add(eps).rsqrt()
+    bias = 0.0 if variant == "rmsnorm" else 1.0
+    return (normalized * (weight_f32 + bias)).to(dtype=x.dtype)
+
+
+def _assert_close(actual, expected, *, name: str) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual, expected, rtol=1e-3, atol=1e-3, msg=lambda message: f"{name}: {message}"
+    )
+
+
+def _flashinfer_api(variant: str, device):
+    import flashinfer
+    import flashinfer.norm as flashinfer_norm
+
+    if flashinfer_norm._use_cuda_norm(device):
+        raise AssertionError("FlashInfer RMSNorm oracle dispatched to legacy CUDA")
+    api = getattr(flashinfer, variant)
+    return api, flashinfer_norm
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]) -> None:
+    M = int(config["M"])
+    H = int(config["H"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    compact = _uses_compact_specialization(
+        M, H, str(config["input_layout"]), str(config["output_layout"])
+    )
+    if compact:
+        executable(data["x_arg"], data["weight"], output["arg"], M, eps)
+    else:
+        executable(
+            data["x_arg"],
+            data["weight"],
+            output["arg"],
+            M,
+            eps,
+            data["x_row_stride"],
+            data["y_row_stride"],
+        )
+
+
+def _input_snapshot(data, M: int, H: int) -> dict[str, Any]:
+    rows = _overflow_rows(M, H)
+    if rows is None:
+        values = data["x"].clone()
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        values = data["x"][rows][:, columns].clone()
+    return {"rows": rows, "values": values, "weight": data["weight"].clone()}
+
+
+def _assert_inputs_unchanged(data, snapshot, M: int, H: int) -> None:
+    import torch
+
+    rows = snapshot["rows"]
+    if rows is None:
+        observed = data["x"]
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        observed = data["x"][rows][:, columns]
+    if not torch.equal(observed, snapshot["values"]):
+        raise AssertionError("input tensor was modified")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError("weight tensor was modified")
+    _assert_guard(data["x_backing"], data["x_storage_size"], name="input")
+    _assert_guard(data["weight_backing"], H, name="weight")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one config."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = dict(config)
+    M = int(config["M"])
+    H = int(config["H"])
+    dtype = str(config["dtype"])
+    variant = str(config["variant"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    snapshot = _input_snapshot(data, M, H)
+    output = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=True)
+    reference_out = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=True)
+
+    kernel = get_kernel(**config)
+    executable = compile_kernel(kernel)
+    _launch_tirx(executable, data, output, config)
+
+    api, flashinfer_norm = _flashinfer_api(variant, data["x"].device)
+    original_cute = flashinfer_norm.rmsnorm_cute
+    cute_calls = 0
+
+    def tracked_cute(*args, **kwargs):
+        nonlocal cute_calls
+        cute_calls += 1
+        return original_cute(*args, **kwargs)
+
+    flashinfer_norm.rmsnorm_cute = tracked_cute
+    try:
+        reference_implicit = api(data["x"], data["weight"], eps, enable_pdl=enable_pdl)
+        returned = api(
+            data["x"], data["weight"], eps, out=reference_out["view"], enable_pdl=enable_pdl
+        )
+    finally:
+        flashinfer_norm.rmsnorm_cute = original_cute
+    if cute_calls != 2:
+        raise AssertionError(f"expected two CuTe-DSL oracle dispatches, observed {cute_calls}")
+    if returned is not reference_out["view"]:
+        raise AssertionError("FlashInfer caller-provided out did not preserve object identity")
+
+    torch.cuda.synchronize()
+    rows = _overflow_rows(M, H)
+    actual_checked = _checked_view(output["view"], rows)
+    implicit_checked = _checked_view(reference_implicit, rows)
+    explicit_checked = _checked_view(reference_out["view"], rows)
+    oracle = _math_oracle(data["x"], data["weight"], variant, eps, rows)
+    if not torch.isfinite(actual_checked).all():
+        raise AssertionError("TIRx output contains non-finite values")
+    _assert_close(actual_checked, implicit_checked, name="FlashInfer implicit output")
+    _assert_close(actual_checked, explicit_checked, name="FlashInfer explicit output")
+    _assert_close(actual_checked, oracle, name="FP32 math oracle")
+    _assert_inputs_unchanged(data, snapshot, M, H)
+    _assert_output_padding(output, M, H, data["y_row_stride"], name="TIRx output")
+    _assert_output_padding(reference_out, M, H, data["y_row_stride"], name="FlashInfer output")
+
+
+def prepare_bench(**config: Any):
+    """Compile the selected TIRx specialization before GPU assignment."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Construct and validate both timed closures before benchmarking."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    M = int(config["M"])
+    H = int(config["H"])
+    dtype = str(config["dtype"])
+    variant = str(config["variant"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    tirx_output = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=False)
+    flashinfer_output = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=False)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        _launch_tirx(executable, data, tirx_output, config)
+
+    # Warm up and validate the TIRx closure before it enters the canonical timer.
+    tirx_launch()
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        api, _ = _flashinfer_api(variant, data["x"].device)
+
+        def flashinfer_launch():
+            return api(
+                data["x"], data["weight"], eps, out=flashinfer_output["view"], enable_pdl=enable_pdl
+            )
+
+        returned = flashinfer_launch()
+        if returned is not flashinfer_output["view"]:
+            raise AssertionError("FlashInfer benchmark out did not preserve object identity")
+        torch.cuda.synchronize()
+        _assert_close(tirx_output["view"], flashinfer_output["view"], name="benchmark precheck")
+        return flashinfer_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark a TIRx specialization against FlashInfer CuTe-DSL."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer's CuTe-DSL 2-D RMSNorm kernel to a shared TIRx PrimFunc family
- expose both RMSNorm and Gemma RMSNorm through the single `flashinfer_rmsnorm` registry entry
- preserve FP16/BF16, compact and explicit int64-strided addressing, PDL, synchronous/asynchronous copies, and warp/block/cluster reductions for cluster sizes 1/2/4/8/16
- add the complete 279-case correctness closure, five upstream performance workloads, a no-tile static check, the reviewed kernel sketch, and benchmark baselines
- record the reusable perf-gate findings in the TIRx codegen database: predicated stores, launch bounds, fragment lifetime, load/conversion order, value forwarding, address lowering, and per-path static register caps

## Dependency

This draft depends on apache/tvm#20159, which adds the `tirx.max_registers` lowering used by the tuned specializations and enables CUDA launches for non-portable cluster sizes above eight CTAs.

## Source and impact

The port is fixed to FlashInfer commit `f2e04400e330fb2debe0bf8730d9424a1d37927f` and shares one implementation between standard and Gemma RMSNorm through a compile-time weight bias. It provides source-matched 2-D normalization on SM100 without tile primitives while retaining caller-provided output, dynamic row count, runtime epsilon, and explicit strided ABI support.

## Validation

- `CUDA_VISIBLE_DEVICES=7 python -m tirx_kernels.test --kernel flashinfer_rmsnorm` (`279 passed`, `0 failed`, `0 skipped`)
- complete five-workload `python -m tirx_kernels.bench_suite --with-references ...` run 71, five standard-timer rounds, no interference retries
- FlashInfer/TIRx ratios: `1.0262`, `0.9930`, `1.0262`, `1.0013`, and `0.9950` (all strictly above `0.99`)
- `python tests/lint/check_flashinfer_rmsnorm_no_tile.py`
- strict bench-suite import check for `flashinfer_rmsnorm`
- tuning-entry structure checks and targeted pre-commit hooks for every file in this PR

The repository-wide license hook currently reports the pre-existing missing FlashInfer source citation in `tirx_kernels/flashinfer/utils/block_radix_sort.py`; that file is unchanged by this PR.
