### PR TITLE
feat(kernel): port flashinfer stable sort topk by value kernel to tirx

### DIFF
--- a/.agents/sketch/flashinfer/topk/stable_sort_topk_by_value.md
+++ b/.agents/sketch/flashinfer/topk/stable_sort_topk_by_value.md
@@ -1,0 +1,417 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of FlashInfer's
+include/flashinfer/topk.cuh StableSortTopKByValueKernel.
+-->
+
+# stable_sort_topk_by_value SM100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py`](../../../../tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **one kernel**: `StableSortTopKByValueKernel<BLOCK_THREADS,
+ITEMS_PER_THREAD, int32_t, DType>` (`topk.cuh:3090-3133`), the `sorted_output`
+epilogue of the top-k pipeline. `TopKDispatch` appends it after **both** the
+filtered and the radix branch (`:3470-3472`), so it is not owned by either
+algorithm; the Python layer requests it as `sorted_cuda = sorted && deterministic
+&& k <= 2048` (`flashinfer/topk.py:634`).
+
+Instantiations: `DType in {f32, f16, bf16}` x `(BLOCK_THREADS, ITEMS_PER_THREAD)
+in {(32,4), (32,8), (64,8), (64,9), (128,8), (256,8)}` = **18 reachable
+specializations**, all exported in `.porting/stable_sort_topk_by_value/ptx/`.
+`IdType` is always `int32_t`. `k`, the rung, and `end_bit` are static per config
+here, exactly the values `StableSortTopKByValue` (`:3135`) picks per call.
+
+Accepted target SM100/B200. Out of scope, with the launcher predicate that
+excludes each: `k > 2048` -> `cudaErrorInvalidValue` (`:3139-3141`); `k <= 1` ->
+`cudaSuccess` **with no launch at all** (`:3142-3144`). Tile (`Tx`) primitives are
+out of scope everywhere.
+
+## Pipeline at a glance
+
+| Kernel / role | Program | Publication / reuse edges |
+| --- | --- | --- |
+| all `BLOCK_THREADS` threads of the single CTA (uniform, no warp specialization) | blocked load of one row's `(value, index)` pairs into registers, complementing the monotone value key; `P` digit passes of cub `BlockRadixSort` (rank + exchange); blocked writeback of the same `k` slots | Everything is intra-CTA. The rank counters and the two exchange buffers **alias one shared union**; `bar.sync 0` separates every rank phase from every exchange phase. There are **no atomics, no global synchronization, no workspace, and no cross-CTA edges** — one CTA owns one row and the kernel is fully in place. |
+
+The kernel is a single role. There is no producer/consumer split, no pipe, no
+mbarrier, and no asynchronous copy: every global access is a plain synchronous
+`ld.global`/`st.global`, and every shared access is a plain `ld.shared`/
+`st.shared`. The only synchronization primitive in the whole kernel is
+`bar.sync 0`.
+
+**The two tensors are simultaneously input and output.** The kernel reads `k`
+slots of a row, sorts them in registers, and writes the same `k` slots back.
+
+## Primitive vocabulary
+
+```python
+copy_g2r(reg, gmem)               # ld.global.b32 | ld.global.b16 (NOT .nc: the
+                                  #   pointers are not __restrict__ const)
+copy_r2g(gmem, reg)               # st.global.b32 | st.global.b16
+copy_r2s(smem, reg) / copy_s2r    # shared traffic, always through T.ptx
+sort_key(bits)                    # the fused monotone-flip + complement (below)
+digit(key, begin, nbits)          # shr + and  (NOT bfe on SM >= 70).  The mask
+                                  #   is materialized once per kernel by an
+                                  #   inline-asm `bmsk.clamp.b32 (0, 4)` hoisted
+                                  #   above the pass loop (`cuda::bitmask<uint32>`
+                                  #   is not constant-folded); it yields 0xF, so a
+                                  #   TIRx `and` against the immediate 0xF is the
+                                  #   sanctioned equivalent.  This is the only
+                                  #   opcode family in the export not otherwise
+                                  #   accounted for here.
+rank_keys(keys) -> ranks          # cub BlockRadixRank, one digit pass
+scatter_to_blocked(items, ranks)  # cub BlockExchange, blocked -> blocked
+barrier()                         # bar.sync 0
+```
+
+### `sort_key` is one fused operation, and it is an involution
+
+The source writes two nested transforms at `:3112-3113`:
+
+```cpp
+OrderedType ordered = Traits::ToOrdered(row_values[pos]);   // topk_common.cuh:35-38
+keys[i] = static_cast<uint32_t>(static_cast<OrderedType>(~ordered));
+```
+
+`ToOrdered` is `sign ? ~bits : bits ^ SIGN_BIT`. Complementing that result
+collapses the pair into **a single XOR against an inverted mask**, and the export
+confirms nvcc does exactly that — `not.b32` and `not.b16` are **0** on all 18
+entries:
+
+```
+.loc 2 3113   setp.lt.s32  %p, bits, 0;                # sign bit set?
+              selp.b32     %m, 0, 2147483647, %p;      # mask = sign ? 0 : 0x7FFFFFFF
+              xor.b32      key, %m, bits;              # key = bits ^ mask
+```
+
+so `sort_key(bits) = bits ^ (sign(bits) ? 0 : 0x7FFF_FFFF)` (16-bit: mask
+`{0x0000, 0x7FFF}`, ops `setp.lt.s16` / `selp.b16` / `xor.b16`).
+
+**`sort_key` is its own inverse.** The writeback's `FromOrdered(~key)`
+(`:3129-3130`) lowers to the *same three instructions with the same constants*,
+attributed to `topk_common.cuh` -- `:42` for f32, `:67` for f16, `:93` for bf16
+(three separate `RadixTopKTraits` specializations, one per dtype):
+
+```
+.loc 19 67     setp.lt.s16  %p, key16, 0;      # f16; bf16 is .loc 19 93
+              selp.b16     %m, 0, 32767, %p;
+              xor.b16      val, %m, key16;
+```
+
+Proof: if the sign bit is set the mask is 0 and the map is the identity; if it is
+clear the map flips only bits `[0, width-1)`, leaving the sign bit clear, so
+applying it twice cancels. The port therefore needs **one** helper, used in both
+directions — not `to_ordered_*` composed with a bitwise-not, which would emit the
+`not` the export does not contain.
+
+This map is **not** `utils/topk_radix.py`'s `to_ordered_u32`/`from_ordered_u32`
+(mask `{0x80000000, 0xFFFFFFFF}`); those are the plain monotone flip used by the
+radix ports. Do not reuse them here.
+
+### `.file` map of the export
+
+`.file 2` = `topk.cuh`, `.file 19` = `topk_common.cuh`, `.file 3` =
+`block_radix_sort.cuh`, `.file 4` = `block_exchange.cuh`, `.file 5` =
+`block_radix_rank.cuh`, `.file 13` = `block_scan_warp_scans.cuh`, `.file 16` =
+`warp_scan_shfl.cuh`, `.file 7` = `cuda/__bit/bitfield.h`. Every `.loc` cited
+below uses these indices.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+variant = specialize(DTYPE=("f32","f16","bf16"),
+                     BT_IPT=((32,4),(32,8),(64,8),(64,9),(128,8),(256,8)),
+                     target="sm_100a")
+# instruction_selection: none; extent: compile-time instantiations
+
+BT, IPT   = finalize_block_config(k)   # the launcher's k ladder (:3154-3166),
+                                       # identical to LaunchFinalizeTopKIndices
+END_BIT   = 32 if DTYPE == "f32" else 16      # 8 * sizeof(OrderedType) (:3121)
+RADIX_BITS = 4                                # cub default
+P         = END_BIT // RADIX_BITS             # 8 digit passes (f32) / 4 (16-bit)
+SIGN      = 0x80000000 if DTYPE == "f32" else 0x8000
+MASK_HI   = 0x7FFFFFFF if DTYPE == "f32" else 0x7FFF
+
+launch_config = launch(grid=(NUM_ROWS,1,1), block=(BT,1,1),
+                       dynamic_smem_bytes=0, launch_bounds=BT)
+# instruction_selection: none; extent: static launch metadata.  Note there is NO
+#   cudaFuncSetAttribute in this launcher -- the smem union is small enough to
+#   need no optin (contrast the filtered unified kernel's 128 KiB request).
+
+# ===========================================================================
+# Storage.  The ONLY shared memory is cub's TempStorage union (:3097).
+# ===========================================================================
+# BlockRadixSort::_TempStorage (block_radix_sort.cuh:268-274) is a union of the
+# ranking storage with the key and value exchange buffers.  The rank grid
+# dominates at every rung, so the realized union is 36 * BT bytes.
+s_counters32 = shared((9 * BT,), "uint32", align=16)   # raking view
+s_counters16 = view(s_counters32, "uint16")            # per-digit RMW view
+s_xchg_keys  = alias(s_counters32, (BT*IPT + pad,), "uint32")
+s_xchg_vals  = alias(s_counters32, (BT*IPT + pad,), "uint32")
+s_scan       = shared((WARPS + 1,), "uint32", align=32)  # BlockScan scratch:
+                                  # warp_aggregates[WARPS] + block_prefix, the
+                                  # struct __align__(32) (block_scan_warp_scans.cuh:69-79),
+                                  # so 32 B for BT <= 128 and 64 B for BT = 256.
+                                  # Outside BlockRadixRank's inner `aliasable`
+                                  # union, still inside the outer BlockRadixSort
+                                  # union; never overlaps the exchange because
+                                  # 4*(BT*IPT+pad) <= 36*BT at every rung.
+# instruction_selection: none; extent: static shared layout.
+#   pad = (BT*IPT) >> 5 iff IPT == 8 (INSERT_PADDING, block_exchange.cuh:139-140).
+
+keys   = alloc_local((IPT,), "uint32")     # (:3105)
+values = alloc_local((IPT,), "uint32")     # (:3106) the indices, carried as satellites
+ranks  = alloc_local((IPT,), "int32")
+
+def stable_sort_topk_by_value(out_idx, out_val):
+    row = cta_id(axis="x", extent=NUM_ROWS)   # instruction_selection: mov.u32 %ctaid.x
+    tx  = thread_id(extent=BT)                # instruction_selection: mov.u32 %tid.x
+    row_idx_base = out_idx + row * k          # (:3102)
+    row_val_base = out_val + row * k          # (:3103)
+
+    # -----------------------------------------------------------------------
+    # Stage 1: blocked load (:3108-3119)
+    # -----------------------------------------------------------------------
+    # Blocked arrangement: thread tx owns the CONTIGUOUS run [tx*IPT, tx*IPT+IPT).
+    # The export shows the per-thread stores at consecutive addresses
+    # ([%rd3], +2, +4, +6 for 16-bit; +4/+8/+12 for f32), which is the blocked
+    # layout showing through.
+    for i in unroll(IPT):                                   # #pragma unroll (:3108)
+        pos = tx * IPT + i
+        if pos < k:                                          # (:3111)
+            v = load_global(row_val_base[pos])
+            # instruction_selection: ld.global.b32 (f32) | ld.global.b16 (16-bit)
+            #   (.loc 2 3112); extent: one scalar per item.  NOT .nc -- these
+            #   pointers are not __restrict__ const, unlike the filtered unified
+            #   kernel's inputs.
+            keys[i] = sort_key(v)
+            # instruction_selection: setp.lt.s32 + selp.b32 + xor.b32 (f32,
+            #   .loc 2 3113) | setp.lt.s16 + selp.b16 + xor.b16 + cvt.u32.u16
+            #   (16-bit: the key is the zero-extended 16-bit result); extent: one
+            #   per item.  ONE fused map, no `not` -- see the vocabulary section.
+            values[i] = load_global(row_idx_base[pos])
+            # instruction_selection: ld.global.b32 (.loc 2 3114); extent: one
+            #   scalar per item.  The index is reinterpreted, never converted.
+        else:                                                # (:3115-3118)
+            keys[i]   = 0xFFFFFFFF
+            values[i] = 0xFFFFFFFF
+            # instruction_selection: mov.b32 of the immediate; extent: two
+            #   registers.  PADDING INVARIANT: ~0u is maximal within [0, END_BIT),
+            #   and every real key fits in END_BIT bits, so padding sorts to the
+            #   tail of the ascending order and is never written back.
+
+    # -----------------------------------------------------------------------
+    # Stage 2: cub BlockRadixSort, ascending, blocked -> blocked (:3121-3122)
+    # -----------------------------------------------------------------------
+    # `Sort`, not `SortDescending`: descending-by-value already lives in the
+    # complemented key.  cub therefore instantiates DESCENDING=false, so
+    # DescendingBlockRadixRank (block_radix_rank.cuh:462-467) is never reached,
+    # and because KeyT is uint32 its float twiddling is the identity.
+    for (begin_bit, nbits) in static_passes(END_BIT):   # P passes, RADIX_BITS=4
+        rank_keys(keys, ranks, begin_bit, nbits)
+        # rank = reset the 9 padded counter lanes; per-item uint16 counter RMW
+        #   (each thread owns its tid column, NO atomics); memoized 9-word raking
+        #   upsweep over a CONTIGUOUS per-thread segment; BlockScan ExclusiveSum
+        #   with the `block_prefix = aggregate << 16` packing trick; exclusive
+        #   downsweep; ranks[i] = thread_prefix[i] + reloaded counter.
+        # instruction_selection: st.shared.b32 x9 (reset) + ld.shared.b16 x2*IPT
+        #   + st.shared.b16 x IPT (counter RMW and rank reload) + ld/st.shared.b32
+        #   (raking) + shfl.sync.up.b32 x5 (one warp scan) + **bar.sync 0 x4**;
+        #   extent: one per digit pass.  The four barriers are
+        #   `block_radix_rank.cuh:479` (separates the per-item uint16 counter RMW
+        #   from the raking upsweep), `block_scan_warp_scans.cuh:174` and `:400`
+        #   (inside ExclusiveSum), and `block_radix_rank.cuh:484` (separates the
+        #   raking downsweep from the rank reload).  None is incidental: dropping
+        #   :479 races the RMW against the upsweep, dropping :484 races the
+        #   downsweep against the reload.
+        #   Digit extraction is shr + and -- cuda::bitfield_extract falls through
+        #   to shift+mask on SM >= 70, and bfe.u32 is 0 in the export; the `and`
+        #   mask itself is produced by one loop-invariant inline-asm
+        #   `bmsk.clamp.b32 (0, 4)` per entry (see the digit() vocabulary note).
+        #   No match.any, no ballot, no PRMT, no atom.
+        barrier()
+        # instruction_selection: bar.sync 0; extent: CTA-wide
+        scatter_to_blocked(keys, ranks, s_xchg_keys)
+        # instruction_selection: st.shared.b32 to pad(rank) + bar.sync 0 +
+        #   ld.shared.b32 from pad(tx*IPT+i); pad(x) = x + (x>>5) iff IPT == 8;
+        #   extent: one per digit pass.  At IPT == 4 the gather is instead a
+        #   single `ld.shared.v4.b32` per exchange (.loc 4 627) -- which is
+        #   precisely why cub omits padding at that rung ("otherwise we can
+        #   typically use 128b loads", block_exchange.cuh:138).
+        barrier()
+        # instruction_selection: bar.sync 0; extent: CTA-wide
+        scatter_to_blocked(values, ranks, s_xchg_vals)
+        # instruction_selection: same family as the key scatter; extent: one per
+        #   digit pass.  The indices ride as satellite data -- this is what makes
+        #   the sort carry them, and it is the whole reason ValueT is non-null.
+        if not last_pass:
+            barrier()
+            # instruction_selection: bar.sync 0; extent: CTA-wide
+    # SYNC ACCOUNTING: 9 bar.sync per key+value pass, minus the trailing one on
+    # the final pass = cub's 9P - 1 (71 for f32, 35 for the 16-bit dtypes).  The
+    # export shows bar.sync = 9 STATIC on every instantiation, i.e. the pass loop
+    # is ROLLED (one backward branch), exactly like the merged finalize kernel.
+
+    # -----------------------------------------------------------------------
+    # Stage 3: blocked writeback (:3124-3132)
+    # -----------------------------------------------------------------------
+    for i in unroll(IPT):                                   # #pragma unroll (:3124)
+        pos = tx * IPT + i
+        if pos < k:                                          # (:3127)
+            store_global(row_idx_base[pos], values[i])
+            # instruction_selection: st.global.b32 (.loc 2 3128); extent: one
+            #   scalar per item.  Padding lanes are simply never written; there is
+            #   no -1 fixup here (contrast the finalize kernel's max.s32).
+            store_global(row_val_base[pos], sort_key(keys[i]))
+            # instruction_selection: (16-bit only) cvt.u16.u32 to narrow the key
+            #   (.loc 2 3129), then setp.lt.s16 + selp.b16 + xor.b16
+            #   (.loc 19 67 for f16, .loc 19 93 for bf16)
+            #   + st.global.b16 (.loc 2 3130); f32 is setp.lt.s32 + selp.b32 +
+            #   xor.b32 + st.global.b32; extent: one scalar per item.
+            #   THE SAME `sort_key` AS THE LOAD -- the map is an involution, and
+            #   the export shows identical opcodes and identical mask constants on
+            #   both sides.
+```
+
+## Launcher ladder and pass count
+
+| k range | BLOCK_THREADS | ITEMS_PER_THREAD | capacity | f32 passes | 16-bit passes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| <= 128 | 32 | 4 | 128 | 8 | 4 |
+| <= 256 | 32 | 8 | 256 | 8 | 4 |
+| <= 512 | 64 | 8 | 512 | 8 | 4 |
+| <= 576 | 64 | 9 | 576 | 8 | 4 |
+| <= 1024 | 128 | 8 | 1024 | 8 | 4 |
+| <= 2048 | 256 | 8 | 2048 | 8 | 4 |
+
+Identical to `LaunchFinalizeTopKIndices` (`:3060-3079`), so
+`finalize_block_config` is imported rather than duplicated.
+
+## Shared-memory budget
+
+| (BT, IPT) | rank grid | key exchange | value exchange | realized union | scan block | total |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| (32, 4) | 1152 | 512 | 512 | **1152** | 32 | **1184** |
+| (32, 8) | 1152 | 1056 | 1056 | **1152** | 32 | **1184** |
+| (64, 8) | 2304 | 2112 | 2112 | **2304** | 32 | **2336** |
+| (64, 9) | 2304 | 2304 | 2304 | **2304** | 32 | **2336** |
+| (128, 8) | 4608 | 4224 | 4224 | **4608** | 32 | **4640** |
+| (256, 8) | 9216 | 8448 | 8448 | **9216** | 64 | **9280** |
+
+Bytes. The rank grid (`36 * BT`) dominates the union at every rung. The totals are
+the realized `.shared .align 16 .b8 temp_storage[N]` of the export (1184 / 2336 /
+4640 / 9280, identical across dtypes), not a derived figure.
+
+The scan block is `BlockScanWarpScans::_TempStorage`
+(`block_scan_warp_scans.cuh:69-79`): `warp_aggregates[WARPS]` +
+`WarpScanT::TempStorage warp_scan[WARPS]` (empty for the shuffle scan) +
+`block_prefix`, the whole struct `__align__(32)` -- so it rounds to 32 bytes for
+BT <= 128 and 64 for BT = 256, **not** the raw `(WARPS + 1) * 4` payload.
+
+Placement: the scan block sits outside `BlockRadixRank`'s inner `aliasable` union
+but still inside the outer `BlockRadixSort` union, exactly as in cub. It never
+overlaps the exchange buffers because `4 * (BT*IPT + pad) <= 36 * BT` at every
+rung, with equality at (64, 9).
+
+Dynamic shared memory is **0** in the source; TIRx pools are `shared.dyn`, so the
+port allocates through the pool and the launch carries
+`tirx.use_dyn_shared_memory` -- the same sanctioned mechanism deviation the merged
+finalize kernel already carries. The byte total must match the column above.
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `(BLOCK_THREADS, ITEMS_PER_THREAD)` | static per config | register array extents, exchange padding, warp count |
+| `END_BIT` (32 / 16) | static from DType | pass count P = 8 / 4 |
+| `k` | static per config here, a kernel arg in the source | turns the guard operand into an immediate. The `pos < k` predicate itself **must remain**: `pos = tx * IPT + i` is a runtime value, so the branch survives at every rung where `k < BT * IPT`, and only disappears at the six exact capacities (128/256/512/576/1024/2048). Dropping it would read and write outside the k-element row and feed unpadded garbage into the sort. |
+| `max_len` | **dead** | accepted at `:3093`, present in the launch arg pack (`:3147`), never read — dropped in the port |
+| `IdType = int32` | static | the satellite payload is always a 32-bit index |
+| padding value `~0u` | static | sorts last under the restricted `END_BIT` |
+| tie order | **input-dependent** | stability preserves the incoming order; it does not create index-ascending order |
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "stable_sort_topk_by_value", "category": "flashinfer",
+  "compute_capability": 10}`; device symbol `stable_sort_topk_by_value`.
+- Plain TIRx only: a `T.SMEMPool` arena, explicit loops, and native `T.ptx.*`
+  forms for every key operation. Global and shared memory are reached exclusively
+  through `T.ptx.ld/st.*` on `buffer.ptr_to([...])` — never a native
+  `BufferLoad`/`BufferStore`, which the repository's low-level IR contract
+  forbids. No `T.cuda.func_call`. No `Tx` tile primitives anywhere.
+- The cub collective is the **already-merged** `utils/block_radix_sort.py`
+  (`alloc_sort_smem`, `emit_block_radix_sort`), reused unchanged: it already
+  sorts `uint32` keys with `uint32` satellites over an arbitrary `end_bit`, with
+  contiguous raking segments and the `uint16` counter view.
+- The source exposes **no FFI or Python entry for this kernel alone** — the
+  pipeline FFI launches main(+finalize)+sort. Correctness and the benchmark
+  reference therefore both call the source's own `StableSortTopKByValue<DType,
+  int32_t>` launcher, compiled through `torch.utils.cpp_extension` with the JIT's
+  own flags (precedent: `tirx_kernels/basic/nvfp4_gemm.py:72-273`), built in
+  `prepare_bench` before the workload owns a GPU. An independent
+  `torch.sort(..., descending=True, stable=True)` oracle checks the reference
+  itself.
+- Comparison is **bit-exact positional equality on both tensors**: the kernel is
+  fully deterministic, and stability makes the output a function of the input
+  order alone.
+
+## Instruction selection is a lowering consequence
+
+| Primitive / pattern | PTX family (fresh sm_100a export, 18 entries) |
+| --- | --- |
+| value load | `ld.global.b32` (f32) / `ld.global.b16` (16-bit) — **not** `.nc` |
+| index load / store | `ld.global.b32` / `st.global.b32` |
+| `sort_key`, f32 (`.loc 2 3113`, `.loc 19 42`) | `setp.lt.s32` + `selp.b32 {0, 0x7FFFFFFF}` + `xor.b32` |
+| `sort_key`, 16-bit (`.loc 2 3113`; back: `.loc 19 67` f16 / `.loc 19 93` bf16) | `setp.lt.s16` + `selp.b16 {0, 0x7FFF}` + `xor.b16` |
+| key widen / narrow (16-bit only) | `cvt.u32.u16` on load, `cvt.u16.u32` on writeback |
+| complement `~ordered` | **fused into the XOR mask** — `not.b32` = `not.b16` = 0 |
+| digit extraction | `shr` + `and` (shift+mask on SM >= 70); `bfe.u32` = 0 |
+| rank counter RMW | `ld.shared.b16` x2*IPT + `st.shared.b16` xIPT, **no atomics** |
+| rank raking / downsweep | `ld.shared.b32` / `st.shared.b32` |
+| block scan | `shfl.sync.up.b32` x5 (one warp scan; `exclusive = inclusive - input`) |
+| exchange | `st.shared.b32` -> `bar.sync 0` -> `ld.shared.b32`, padded iff IPT == 8; at IPT == 4 the gather is one `ld.shared.v4.b32` (`.loc 4 627`) |
+| block-scan aggregate read | `ld.shared.v2.b32` at BT = 64, `ld.shared.v4.b32` at BT = 128/256 (`.loc 13 178`, `.loc 13 130`) |
+| digit mask | one hoisted inline-asm `bmsk.clamp.b32 (0, 4)` per entry -> constant `0xF` |
+| synchronization | `bar.sync 0` only — 9 static, dynamic `9P - 1` |
+| absent everywhere | `match.any`, `vote.sync`, `prmt`, `popc`, `atom`, `clz`, `ld.global.nc.*` |
+
+Static opcode counts per exported instantiation (full table in
+`.porting/stable_sort_topk_by_value/ptx/opcode_table.md`):
+
+| op | f32 (32,4) | f32 (32,8) | f32 (256,8) | f16 (32,4) | f16 (32,8) | bf16 (64,9) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `bar.sync` | 9 | 9 | 9 | 9 | 9 | 9 |
+| `shfl.sync.up.b32` | 5 | 5 | 5 | 5 | 5 | 5 |
+| `ld.shared.b16` | 8 | 16 | 16 | 8 | 16 | 18 |
+| `st.shared.b16` | 4 | 8 | 8 | 4 | 8 | 9 |
+| `xor.b32` | 8 | 16 | 16 | 0 | 0 | 0 |
+| `xor.b16` | 0 | 0 | 0 | 8 | 16 | 18 |
+| `not.b32` / `not.b16` | 0 | 0 | 0 | 0 | 0 | 0 |
+| `bfe.u32` | 0 | 0 | 0 | 0 | 0 | 0 |
+
+`xor` counts at exactly `2 * IPT` on every entry — one application of `sort_key`
+on the load and one on the writeback, in the dtype's own width — while `not` is
+uniformly 0. That pair of counts is the check that the port fused the map rather
+than composing a monotone flip with a complement.
+
+`bar.sync` holding at 9 static across every rung and dtype is the rolled pass
+loop: the dynamic count varies with `P`, the static count does not.

--- a/.agents/skills/tirx-codegen-tuning/references/db/do-not-blame-volatile-or-memory-clobbers.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/do-not-blame-volatile-or-memory-clobbers.md
@@ -11,7 +11,8 @@ clobbers -- roughly 460 such barriers per warp in one kernel.
 
 Nothing on this lever. Generated `T.ptx` helpers are `asm volatile`, and global
 loads and stores carry a memory clobber; removing either is not a recoverable
-win. Look elsewhere for the deficit.
+win, and on a shared-memory algorithm it is not even available. Look elsewhere
+for the deficit.
 
 ## Rationale
 
@@ -19,6 +20,16 @@ Removing both, one at a time and together, left the kernel at 6.014-6.020 us
 across eight independent timings on the quiet shape, with the profiler's
 short-scoreboard stall unchanged. The ratio column moved only because the
 reference wandered.
+
+The clobber is also load-bearing rather than conservative, which closes the
+lever for good on kernels that stage through shared memory. It is derived, not
+chosen -- any instruction carrying an address operand gets it -- and an
+address-only memory model leaves ptxas no aliasing information of its own. A
+local build rendering plain `ld`/`st` without `volatile` and without `"memory"`
+made one kernel compute garbage, every element wrong, because the clobber was
+the only thing ordering a counter read-modify-write against the scatter and
+gather that follow it. Recovering that scheduling freedom needs an aliasing
+model, not a flag.
 
 An earlier experiment on the same kernel appeared to recover a point, but it
 removed barriers and switched to fast-math forms at once; isolating the halves

--- a/.agents/skills/tirx-codegen-tuning/references/db/express-low-level-memory-access-through-raw-ptx.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/express-low-level-memory-access-through-raw-ptx.md
@@ -45,7 +45,27 @@ to zero (50 address-only pointer operands remained), passed all four correctness
 configurations, and retained 0.993x and 1.022x in stable five-round 8-GPU
 campaigns.
 
+## Boundary
+
+Accept that this forfeits displacement addressing. The intrinsics take the
+address as a register operand, so ptxas cannot fold a constant offset into the
+addressing mode: where a reference keeps one base and reaches its items by
+`[%rd3+2]`, `[%rd3+4]`, ... or `[%r7]`, `[%r7+128]`, ..., the port computes one
+full address per access. Indexing the buffer directly does restore the
+displacement form and did measure fractionally faster, but the contract rejects
+it, so the cost is not tradeable. Rebasing every item on a per-thread base
+recovers part of the arithmetic -- 17 address ops to 12 on one entry -- and left
+the ratio unchanged, so spend the effort only where address math is provably the
+bottleneck.
+
+Direct indexing is also not a route to wider accesses. Replacing the intrinsics
+with buffer indexing to obtain a vectorized shared gather produced scalar
+accesses that nvcc did not re-vectorize: the `ld.shared.v4.b32` disappeared and
+the entry grew from 288 to 542 instructions.
+
 ## Verification
 
 Re-run the contract check over every public function, then the full correctness
-matrix.
+matrix. Note that a module's own `run_test` does not run the contract check --
+only the repo test entry point does -- so a spot check cannot stand in for the
+matrix when instruction selection changes.

--- a/.agents/skills/tirx-codegen-tuning/references/db/keep-a-static-shared-allocation-static.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/keep-a-static-shared-allocation-static.md
@@ -1,0 +1,61 @@
+# Keep a static shared allocation static
+
+**Symptoms:** `excess_address_math`, `slow_small_shape`, `zero_dynamic_smem`, `fixed_overhead`
+
+## Symptom
+
+A short kernel is slower than its reference for no visible difference in the
+algorithm, and every shared access in the generated code computes its address
+from a runtime base rather than a compile-time offset.
+
+## What to change
+
+Where the reference declares its scratch as a plain `__shared__` array, declare
+it as a static shared buffer, not from the dynamic pool. The pool hands out
+offsets from a runtime `extern __shared__` base, which puts an address
+computation on the critical path of every shared access; a static buffer makes
+every offset a compile-time constant.
+
+```python
+# before: pool offsets are runtime values, so each access re-derives its address.
+pool = T.SMEMPool()
+counters = pool.alloc((words,), "uint32")
+scan = pool.alloc((scan_words,), "uint32")
+pool.commit()
+
+# after: the reference's own shape -- offsets are compile-time constants.
+counters = T.alloc_buffer((words,), "uint32", scope="shared")
+scan = T.alloc_buffer((scan_words,), "uint32", scope="shared")
+```
+
+A union the reference expresses inside one allocation stays a union: alias the
+views onto the dominant buffer rather than allocating each separately, so the
+byte budget matches.
+
+```python
+# the exchange buffers alias the rank grid, as the reference's union does.
+counters16 = counters32.view("uint16")
+xchg_keys = counters32
+xchg_values = counters32
+```
+
+## Rationale
+
+The address arithmetic is fixed cost per access, so it is invisible wherever
+occupancy hides it and decisive where a kernel is a few microseconds long. On
+one block-sort port the switch moved the complete matrix from 39/46 to 43/46
+shapes above the gate and the worst shape from 0.977 to 0.984.
+
+## Boundary
+
+The converse case is a hard requirement, not a preference: an arena above the
+48 KB static ceiling cannot be a static buffer and must come from the pool. Check
+the reference's own declaration before choosing, and verify the realized byte
+budget either way -- a `cuobjdump -res-usage` figure includes the driver's
+reserved block and will not match the declaration.
+
+## Verification
+
+Read the declaration in the generated CUDA, not just the total: the static form
+appears as named `__shared__` arrays with constant subscripts, the pool form as
+offsets into one extern base.

--- a/.agents/skills/tirx-codegen-tuning/references/db/keep-a-warp-scan-step-as-a-select.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/keep-a-warp-scan-step-as-a-select.md
@@ -1,0 +1,53 @@
+# Keep a warp-scan step as a select
+
+**Symptoms:** `excess_control_instructions`, `branch_in_hot_loop`, `schedule_regression`, `instruction_count_gap`
+
+## Symptom
+
+A warp scan carrying one more dependent instruction per step than the reference:
+`shfl` then add then select, against the reference's `shfl` then predicated add.
+cub takes the condition from the shuffle's own destination predicate
+(`shfl.sync.up.b32 r0|p, ...` followed by `@p add.u32`), where the port computes
+`lane >= 1 << step` separately.
+
+## What to change
+
+Nothing. Keep the select form.
+
+```python
+# keep this: lowers to setp + selp, no control flow.
+peer: T.uint32 = shfl_up_u32(incl[0], T.shift_left(T.int32(1), step))
+incl[0] = T.Select(lane >= T.shift_left(T.int32(1), step), incl[0] + peer, incl[0])
+```
+
+The destination-predicate form is reachable -- the shuffle entry accepts a
+writable `uint32` as its predicate output -- but the accumulate that consumes it
+has to be written as a guarded statement, and that does not become a predicated
+add.
+
+```python
+# rejected: the guard is emitted as control flow, not folded into the add.
+shfl_up_u32_p(peer, valid, incl[0], T.shift_left(T.int32(1), step))
+if valid[0] != T.uint32(0):
+    incl[0] = incl[0] + peer[0]
+```
+
+## Rationale
+
+nvcc did not if-convert the guarded accumulate: the entry kept all 14 `selp` and
+gained no predicated add, while total instructions fell by 8 because the five
+lane comparisons disappeared. Those comparisons are loop-invariant and hoisted,
+so removing them buys nothing on the critical path, and the shape measured
+**worse** -- 0.948 to 0.934, and a second shape 0.977 to 0.970.
+
+## Boundary
+
+This is about consuming a destination predicate through a guarded statement, not
+about predication generally. Where a condition already feeds a value expression,
+`T.Select` is the right lowering and produces the `selp` the reference has.
+
+## Verification
+
+Count predicated instructions in the PTX before crediting an if-conversion: the
+guard either became `@%p` on the operation or it became a branch, and only the
+first is the change you intended.

--- a/.agents/skills/tirx-codegen-tuning/references/db/roll-a-pass-loop-with-while-not-a-counted-loop.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/roll-a-pass-loop-with-while-not-a-counted-loop.md
@@ -1,0 +1,64 @@
+# Roll a pass loop with While, not a counted loop
+
+**Symptoms:** `instruction_count_bloat`, `slow_small_shape`, `barrier_stall`, `sass_divergence`
+
+## Symptom
+
+A transcribed loop the reference leaves rolled appears several times over in the
+port. One digit-pass loop emitted 837 instructions and 35 static `bar.sync`
+against the reference's 258 and 9, for identical dynamic work, and the port was
+slowest on exactly the shapes with the fewest passes.
+
+## What to change
+
+A counted loop has a compile-time trip count and nvcc fully unrolls it. Where
+the reference's loop is a `while (true)` with a data-dependent break -- anything
+bounded by a runtime `end_bit`, or by a break the compiler cannot resolve -- carry
+the offset in a scalar and write a `While`, which TVM prints `#pragma unroll 1`
+ahead of. Take the trailing barrier only when another iteration follows, so the
+`9P - 1` barrier count falls out instead of being constructed.
+
+```python
+# before: a compile-time trip count, which nvcc unrolls into P copies.
+for p in T.serial(0, num_passes):
+    begin: T.int32 = p * RADIX_BITS
+    emit_rank_and_exchange(..., begin)
+    if p != num_passes - 1:
+        bar_sync()
+
+# after: the reference's shape -- advance in the body, barrier only if more follows.
+begin = T.alloc_local((1,), "int32")
+begin[0] = 0
+while begin[0] < num_passes * RADIX_BITS:
+    emit_rank_and_exchange(..., begin[0])
+    begin[0] = begin[0] + RADIX_BITS
+    if begin[0] < num_passes * RADIX_BITS:
+        bar_sync()
+```
+
+## Rationale
+
+The unrolled body is the same dynamic work, but several copies of it on a grid
+too small to hide instruction fetch cost more than the loop overhead they
+remove. The effect is concentrated where the pass count is lowest, because that
+is where the extra code has the fewest iterations to amortize over: the worst
+shape moved 0.886 to 0.948, while shapes with twice the passes barely moved.
+
+| | reference | counted loop | `While` |
+| --- | ---: | ---: | ---: |
+| `bar.sync` | 9 | 35 | 9 |
+| instructions | 258 | 837 | 297 |
+
+## Boundary
+
+Only where the reference's loop is genuinely rolled. If it unrolls its own loop,
+match that instead. Rolling is not a general win: it trades code size against
+loop overhead, and a loop whose body is small relative to its trip count can
+prefer the unrolled form.
+
+## Verification
+
+Count static `bar.sync` in the port against the reference before believing any
+loop is rolled. A rolled loop in the generated CUDA proves nothing, because the
+unrolling happens in nvcc -- this change was first made, measured, and written
+up as a win while the loop was still being fully unrolled.

--- a/.agents/skills/tirx-codegen-tuning/references/db/stop-cutting-instructions-once-parity-is-reached.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/stop-cutting-instructions-once-parity-is-reached.md
@@ -51,3 +51,16 @@ Before spending another change, list the countable quantities side by side --
 PTX and SASS totals, dynamic instructions, registers, shared bytes, barriers,
 bank conflicts, parameters, launch bounds. If none of them is worse, the next
 measurement to take is not of the kernel.
+
+Count them correctly. A `grep`-based opcode histogram undercounts a cub-style
+reference twice over: predicated instructions begin with `@%p` rather than an
+opcode, so a `^\s+[a-z]` pattern drops them, and an inline `asm` block's line
+begins with `{`, hiding several instructions behind one unmatched line -- cub's
+warp-scan shuffle hides three that way. Both bit here, and an early table
+claiming the reference emitted zero `shfl.sync.up` when it emits five nearly
+became the basis of a hypothesis.
+
+Keep PTX-level and SASS-level claims separate as well. An absent opcode in PTX
+says nothing about ptxas's own selection: one sketch recorded `prmt` as absent,
+which was true of the PTX while ptxas still chose `PRMT` for a 16-bit sign
+extension. That is not a divergence.

--- a/.agents/skills/tirx-codegen-tuning/references/db/stop-cutting-instructions-once-parity-is-reached.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/stop-cutting-instructions-once-parity-is-reached.md
@@ -1,0 +1,53 @@
+# Stop cutting instructions once parity is reached
+
+**Symptoms:** `instruction_parity_with_deficit`, `slow_small_shape`, `instruction_count_gap`, `schedule_regression`
+
+## Symptom
+
+A port that is level with or ahead of the reference on every quantity that can
+be counted, and still slower on the small shapes. One entry sat at 0.948 while
+holding 240 SASS instructions against 256, 2612 dynamic against 2692, 49
+registers against 51, 2 kernel parameters against 4, an identical shared-memory
+opcode sequence, identical bank-conflict counts, and identical barriers.
+
+## What to change
+
+Nothing further on instruction count. Past that point the remaining cuts do not
+convert:
+
+- widening a narrow load to make a sign test a bare `setp.lt.s32`, removing 16
+  instructions from the prologue and epilogue, measured **worse**;
+- collapsing four contiguous unguarded loads into one `ld.global.v4.b32` --
+  available because a compile-time `k` folds the guard the reference must keep --
+  moved the shape by 0.000;
+- rebasing every item on a per-thread base, cutting 64-bit address arithmetic
+  from 17 ops to 12, left the ratio unchanged.
+
+Fewer or wider memory instructions do not relax an ordering constraint, and a
+prologue that is already tighter than the reference's does not get faster by
+being tighter still.
+
+## Rationale
+
+Instruction count stops being the binding resource once it matches. What
+remains is latency the schedule cannot hide, and on a grid of a few single-warp
+CTAs there is nothing resident to hide it behind.
+
+The state itself is the signal: **everything countable equal or better, still
+slower** means the difference is not in the code. Check the grid first -- a
+deficit that disappears once the SM array fills is occupancy -- and then the
+measurement, because a benchmark can carry a per-side bias that no amount of
+codegen work will move.
+
+## Boundary
+
+This is a stopping rule for the fixed region of a small kernel, not licence to
+ignore instruction counts generally. A loop body that runs thousands of
+iterations still pays for every instruction in it.
+
+## Verification
+
+Before spending another change, list the countable quantities side by side --
+PTX and SASS totals, dynamic instructions, registers, shared bytes, barriers,
+bank conflicts, parameters, launch bounds. If none of them is worse, the next
+measurement to take is not of the kernel.

--- a/.agents/skills/tirx-codegen-tuning/references/db/take-shared-exchange-widths-from-the-reference.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/take-shared-exchange-widths-from-the-reference.md
@@ -1,0 +1,53 @@
+# Take shared-exchange widths from the reference
+
+**Symptoms:** `instruction_count_gap`, `sass_divergence`, `slow_small_shape`
+
+## Symptom
+
+A block-exchange or block-scan transcribed with scalar shared accesses where the
+reference issues vector ones, leaving several extra `ld.shared.b32` per pass that
+no amount of surrounding tuning removes.
+
+## What to change
+
+Two places in a cub-style collective read a contiguous run and are vectorized in
+the reference, each under its own condition.
+
+The blocked gather is contiguous exactly when padding is off -- cub's rule is
+`ITEMS_PER_THREAD > 4 && is_power_of_two(ITEMS_PER_THREAD)` -- so at four items
+per thread there is no padding and the run is one 16-byte load.
+
+```python
+if items_per_thread == 4 and not insert_padding(items_per_thread):
+    quad = ld_shared_quad_u32(buf, tx * items_per_thread)
+    items_reg[0], items_reg[1] = quad[0], quad[1]
+    items_reg[2], items_reg[3] = quad[2], quad[3]
+else:
+    for i in T.unroll(items_per_thread):
+        items_reg[i] = ld_shared_u32(buf, padded_offset(...))
+```
+
+The warp-aggregate array is read whole, and the width follows the warp count:
+`v2` at two warps, `v4` at four, and two `v4` at eight. Cover every warp count
+the launcher can reach, not just the ones a favourite shape exercises.
+
+## Rationale
+
+Matching both brought the shared profile to an exact match with the reference --
+2 `ld.shared.v4.b32`, 11 scalar `ld.shared.b32`, 28 `st.shared.b32`, 9
+`bar.sync` -- and is mostly a parity change: the gather measured neutral to
+within 0.001 on shapes that reproduce to that precision. The widest rung, where
+eight aggregates become two vector loads instead of eight scalar ones, moved
+0.988-0.990 to 0.994-0.998.
+
+## Boundary
+
+Only where the run really is contiguous. With padding on, the gather is strided
+and must stay scalar; taking the width from a shape that happens to be unpadded
+will read wrong data on the others.
+
+## Verification
+
+Diff the shared-memory opcode histogram against the reference rather than
+checking one rung. The eight-warp case here was left scalar through two separate
+audits because the four-warp case was present and looked complete.

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -104,6 +104,14 @@ FILE_OVERRIDES = {
             'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
         ),
     },
+    # Transcribes cub::BlockRadixSort, which FlashInfer's topk kernels instantiate.
+    "tirx_kernels/flashinfer/utils/block_radix_sort.py": {
+        "spdx": "Apache-2.0 AND BSD-3-Clause",
+        "required_text": (
+            "Redistribution and use in source and binary forms",
+            'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
+        ),
+    },
 }
 
 # Native modules inside port buckets — package markers and our own harnesses.

--- a/tests/lint/check_stable_sort_topk_by_value_no_tile.py
+++ b/tests/lint/check_stable_sort_topk_by_value_no_tile.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every stable-sort top-k specialization.
+
+Reuses the single-CTA scanner.  This port is a single kernel, so the IR scan
+walks one entry point per config -- but it shares ``utils/block_radix_sort.py``
+with the filtered port, so that file is scanned here too rather than being
+covered only by the sibling checker.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import check_radix_topk_single_cta_no_tile as no_tile
+
+from tirx_kernels.flashinfer.topk import stable_sort_topk_by_value as target
+
+no_tile.target = target
+
+_CANDIDATE_TARGETS = (
+    "tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py",
+    "tirx_kernels/flashinfer/utils/topk_radix.py",
+    "tirx_kernels/flashinfer/utils/block_radix_sort.py",
+)
+no_tile.TARGETS = tuple(
+    no_tile.REPO / rel for rel in _CANDIDATE_TARGETS if (no_tile.REPO / rel).exists()
+)
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -266,6 +266,53 @@ remain in the run JSON for variance and outlier inspection.
 - **ratio Δ** in `bench.md` = current ratio vs the baseline ratio (computed from
   `baseline.json`'s ours + ref impls).
 
+## Reading a ratio you do not trust
+
+Small, short kernels expose measurement effects that larger ones average away.
+Three are worth knowing before attributing a ratio to the kernel.
+
+**A per-implementation buffer allocation is a placement draw.** An in-place
+kernel needs its own working set per implementation, and cloning once per side
+puts the copies in different allocations, hence different L2 partitions. On a
+grid too small to spread across the device one side is local and the other
+remote, and remote-partition latency -- fixed in nanoseconds -- lands entirely on
+whichever side drew it. One shape measured 0.957, 0.974, 1.058 and 1.099 across
+four allocation arrangements with **no code change**, and two byte-identical
+kernels read 0.937 and 1.082. In the low mode both sides are faster in absolute
+time and only the ratio moves, so absolute times look innocent.
+
+It bites when all three hold: the kernel is in place, so the per-side allocation
+is on the read path rather than a shared input or write-only output; the working
+set fits in one partition (a few KB); and the kernel is short enough that a
+fixed latency term is a visible fraction. Sibling kernels failing any of these
+showed at most 0.005. To cancel it, have both implementations alternate over the
+same two working sets in opposite phase, so each spends half its calls on each
+buffer, then **run the swap test**: exchange which side gets which buffer and
+confirm the ratio does not move. A contiguous split of one buffer looks
+symmetric and fails that test.
+
+**Absolute microseconds do not survive a session boundary.** They drift between
+sessions while ratios hold: one kernel read 7.746-7.773 us in one session and
+8.238 us in another, both tight, at a ratio of 1.160-1.164 throughout. Compare
+ratios, or measure both sides in one process.
+
+**A complete matrix is the acceptance instrument, not the iteration
+instrument.** Isolated single-config repeats reproduced to about +/-0.001 where
+the matrix carried about +/-0.05 on the same shapes, and the matrix inflated
+individual rows. Decide changes on isolated repeats; accept on the matrix.
+
+Two controls make all three visible: keep a pair of configs that compile to
+byte-identical code, since any spread between them is measurement rather than
+kernel; and sweep the grid, since a deficit that disappears once the SM array
+fills is occupancy, not code.
+
+When a profiler and the suite disagree about the same two kernels, check the
+instrument settings before either result. NCU locks clocks to base and flushes
+caches by default; the suite runs at boost, warm. Memory latency costs more SM
+cycles the faster the clock runs, so a kernel with exposed latency can lead at
+base and trail at boost. Reproduce the suite's regime with
+`ncu --cache-control none --clock-control none`.
+
 ## Outputs
 
 | Path | Description |

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "3df3e86a",
-    "tirx-kernels": "abb50263-dirty",
+    "tir": "f20fa692",
+    "tirx-kernels": "e45bf633-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "4d0584f1fc0655f65f541190d8af337a69b759db"
+    "tirx-kernels:tirx_kernels": "48e74a7a7521932b7124d6ed1cae9eaee3954b27"
   },
   "baselines": {
     "torch": {
@@ -4773,6 +4773,48 @@
         "tirx": 372.2002015786201,
         "flashmla": 381.5992557718094,
         "trtllm_gen": 447.2224965399249
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "stable_sort_topk_by_value",
+      "config": "f32_r4_k128",
+      "label": "f32_r4_k128",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.271642221827065,
+        "flashinfer": 5.316647623418739
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "stable_sort_topk_by_value",
+      "config": "f32_r64_k2048",
+      "label": "f32_r64_k2048",
+      "status": "ok",
+      "impls": {
+        "tirx": 11.826882154201103,
+        "flashinfer": 11.916382144374955
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "stable_sort_topk_by_value",
+      "config": "f32_r64_k256",
+      "label": "f32_r64_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.383161970012927,
+        "flashinfer": 6.848107788050225
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '3df3e86a', 'tirx-kernels': 'abb50263-dirty', 'tirx-bench-ci': None}`
-- Workloads: 341 ok, 0 failed
+- Git:       `{'tir': 'f20fa692', 'tirx-kernels': 'e45bf633-dirty', 'tirx-bench-ci': None}`
+- Workloads: 344 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -584,6 +584,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `bench_dqk576_hq64_s4096_kv49152_topk512` | tirx | 584.6850 | flashmla | 605.9564 | 1.036 | trtllm_gen=719.6944 |
 | `bench_dqk576_hq64_s4096_kv65536_topk512` | tirx | 405.1609 | flashmla | 418.7721 | 1.034 | trtllm_gen=488.0644 |
 | `bench_dqk576_hq64_s4096_kv8192_topk512` | tirx | 372.2002 | flashmla | 381.5993 | 1.025 | trtllm_gen=447.2225 |
+
+## stable_sort_topk_by_value
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `f32_r4_k128` | tirx | 5.2716 | flashinfer | 5.3166 | 1.009 | — |
+| `f32_r64_k2048` | tirx | 11.8269 | flashinfer | 11.9164 | 1.008 | — |
+| `f32_r64_k256` | tirx | 6.3832 | flashinfer | 6.8481 | 1.073 | — |
 
 ## tinygemm2_sm100
 

--- a/tirx_kernels/bench_suite/config/flashinfer/topk/stable_sort_topk_by_value.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/topk/stable_sort_topk_by_value.yaml
@@ -1,0 +1,75 @@
+# Every reachable specialization of StableSortTopKByValueKernel: the six
+# (BLOCK_THREADS, ITEMS_PER_THREAD) rungs of the launcher ladder (topk.cuh:3154-3166)
+# crossed with the three dtypes, which is all 18 the source can instantiate, plus
+# both digit-pass counts (8 for fp32, 4 for the 16-bit dtypes), the num_rows
+# occupancy axis, and the input patterns.
+#
+# The patterns are domain coverage rather than test flavor: this kernel's output is
+# a function of its input order, so `tie_heavy` and `all_equal` are the only entries
+# that exercise a fully-tied digit distribution, and `neg` is the only one that takes
+# the other half of the monotone-flip sign branch.
+#
+# The k ladder is swept at 4 rows and the occupancy axis at k=256, so the matrix is
+# a cover rather than a full cross. The rows axis is not independent of the dtype,
+# however: at k=512 the fp32 ratio is flat across 4/32/256 rows (1.031, 1.035,
+# 1.031) while float16 runs 0.979, 1.021, 0.990, because four single-warp CTAs on
+# 148 SMs leave each CTA's latency chain fully exposed and a four-pass kernel has
+# half as much work to hide it behind. Both regimes are therefore carried for both
+# pass counts: `f32_r64_k2048` is the widest rung against a saturated SM array, and
+# `f16_r64_k256`/`f16_r64_k512` are the four-pass family against one -- without them
+# the matrix would report only the latency-bound end of that axis.
+#
+# Every entry launches exactly one kernel on each side; the reference is the
+# source's own StableSortTopKByValue launcher, compiled directly, since FlashInfer
+# exposes no FFI for this kernel alone.
+kernel: stable_sort_topk_by_value
+selection_rationale: The fp32 column is the 8-pass family and the one the Python layer reaches by default; r4/k128 is the smallest launchable shape on the narrowest rung, r64/k256 fills the SM array at the rung the dispatcher picks most often, and r64/k2048 is the widest rung (256 threads, 8 items) against that same full grid, which is the largest block-local sort the kernel can perform.
+configs:
+  - {config: f32_r4_k128, default: true, selection_role: small}
+  - {config: f32_r4_k256, default: false}
+  - {config: f32_r4_k512, default: false}
+  - {config: f32_r4_k576, default: false}
+  - {config: f32_r4_k1024, default: false}
+  - {config: f32_r4_k2048, default: false}
+  - {config: f16_r4_k128, default: false}
+  - {config: f16_r4_k256, default: false}
+  - {config: f16_r4_k512, default: false}
+  - {config: f16_r4_k576, default: false}
+  - {config: f16_r4_k1024, default: false}
+  - {config: f16_r4_k2048, default: false}
+  - {config: bf16_r4_k128, default: false}
+  - {config: bf16_r4_k256, default: false}
+  - {config: bf16_r4_k512, default: false}
+  - {config: bf16_r4_k576, default: false}
+  - {config: bf16_r4_k1024, default: false}
+  - {config: bf16_r4_k2048, default: false}
+  - {config: f32_r4_k2, default: false}
+  - {config: f32_r4_k300, default: false}
+  - {config: f16_r4_k2, default: false}
+  - {config: f16_r4_k300, default: false}
+  - {config: bf16_r4_k2, default: false}
+  - {config: bf16_r4_k300, default: false}
+  - {config: f32_r1_k256, default: false}
+  - {config: f32_r16_k256, default: false}
+  - {config: f32_r64_k256, default: true, selection_role: medium}
+  - {config: f32_r256_k256, default: false}
+  - {config: f32_r64_k2048, default: true, selection_role: large}
+  - {config: f16_r64_k256, default: false}
+  - {config: f16_r64_k512, default: false}
+  - {config: f32_r4_k256_tie_heavy, default: false}
+  - {config: f32_r4_k256_all_equal, default: false}
+  - {config: f32_r4_k256_neg, default: false}
+  - {config: f32_r4_k256_padded, default: false}
+  - {config: f32_r4_k256_pipeline, default: false}
+  - {config: f16_r4_k256_tie_heavy, default: false}
+  - {config: f16_r4_k256_all_equal, default: false}
+  - {config: f16_r4_k256_neg, default: false}
+  - {config: f16_r4_k256_padded, default: false}
+  - {config: f16_r4_k256_pipeline, default: false}
+  - {config: f32_r4_k512_tie_heavy, default: false}
+  - {config: f32_r4_k512_neg, default: false}
+  - {config: f16_r4_k512_tie_heavy, default: false}
+  - {config: f16_r4_k512_neg, default: false}
+  - {config: bf16_r4_k512_tie_heavy, default: false}
+  - {config: bf16_r4_k512_neg, default: false}
+  - {config: f32_r2_k2048_tie_heavy, default: false}

--- a/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
+++ b/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
@@ -1,0 +1,798 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer stable top-k value-sort port.
+
+Ports ``StableSortTopKByValueKernel`` (``include/flashinfer/topk.cuh:3090-3133``)
+and its launcher ``StableSortTopKByValue`` (``:3135-3168``) -- the ``sorted_output``
+epilogue of the top-k pipeline.  ``TopKDispatch`` appends it after **both** the
+filtered and the radix branch (``:3470-3472``), so it is the one kernel in the
+selection path that neither radix port nor the filtered port covered; all three
+passed ``sorted_output=False``.
+
+The kernel re-sorts each row's already-selected ``(values, indices)`` pairs by
+value, descending, **in place**: one CTA per row, a blocked load into registers,
+one ``cub::BlockRadixSort`` over the row, and a blocked writeback.  There is no
+workspace, no cross-CTA state, and no dynamic shared memory.
+
+Two details shape the port:
+
+* **Descending order is not a descending sort.**  The collective is
+  ``cub::BlockRadixSort<uint32_t, BT, IPT, uint32_t>`` and the method called is the
+  plain *ascending* ``Sort(keys, indices, 0, end_bit)`` (``:3122``); the ordering
+  is inverted by complementing the key in the kernel (``:3113``).  cub's
+  ``DescendingBlockRadixRank`` is never instantiated, and because the key type is
+  ``uint32`` its float twiddling is the identity -- the monotone map is
+  FlashInfer's own ``RadixTopKTraits::ToOrdered``.
+* **"Stable" preserves tie order, it does not create it.**  Equal values keep the
+  relative order they arrived in; the ``(value desc, index asc)`` property the
+  comment describes holds only because the producer already emitted indices
+  ascending (the finalize kernel's index sort, or the deterministic radix
+  collect).  Correctness cases therefore pin the input order explicitly.
+
+``end_bit = 8 * sizeof(OrderedType)`` -- 32 bits for fp32 and 16 for fp16/bf16,
+i.e. 8 or 4 digit passes at cub's ``RADIX_BITS = 4``.
+"""
+
+from typing import Any
+
+from tirx_kernels.flashinfer.topk.filtered_topk import finalize_block_config
+from tirx_kernels.flashinfer.topk.radix_topk_single_cta import DTYPES, dtype_bytes
+from tirx_kernels.flashinfer.utils.block_radix_sort import (
+    RADIX_BITS,
+    alloc_sort_smem_static,
+    emit_block_radix_sort_rolled,
+)
+from tirx_kernels.flashinfer.utils.topk_harness import (
+    SOURCE_ALGO_FILTERED,
+    pin_source_algo,
+    source_module,
+    torch_dtype,
+)
+from tirx_kernels.flashinfer.utils.topk_radix import (
+    ld_global_bits,
+    ld_global_u32,
+    st_global_u16,
+    st_global_u32,
+)
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "stable_sort_topk_by_value",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+# The kernel declares no dynamic shared memory and the port declares none either:
+# the cub TempStorage is a static `__shared__` allocation, matching the source.
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x")
+
+# --- source constants ------------------------------------------------------
+# Block-local sort variants cover at most 256 * 8 = 2048 elements (:3138-3141).
+STABLE_SORT_MAX_K = 2048
+# `top_k_val <= 1` returns cudaSuccess without launching at all (:3142-3144), so
+# those shapes are a launcher early-out rather than kernel behavior.
+STABLE_SORT_MIN_K = 2
+
+# The digit-pass loop is rolled, as nvcc leaves the source's `while` loop
+# (block_radix_sort.cuh:377-430): one copy of the rank/exchange body instead of P
+# copies, same dynamic work and the same 9P - 1 barriers.
+#
+# Measured on the complete matrix at 7 rounds: rolling beats unrolling at every
+# rung, most sharply at (32, 4) -- bf16 k=128 0.896 -> 1.099, f16 0.896 -> 1.084,
+# f32 0.972 -> 1.016.  An earlier single-round A/B appeared to show the opposite
+# at that rung and motivated a per-rung threshold; that reading was inside the
+# measurement noise (the same binary read 0.897 and 1.096 on consecutive
+# single-round runs), and the threshold is gone.
+
+# Input distributions.  Stability is a property of the incoming order, so the
+# pattern axis is part of the tested domain rather than a testing nicety.
+PATTERNS = ("unique", "tie_heavy", "all_equal", "neg", "padded", "pipeline")
+
+
+def sort_end_bit(dtype: str) -> int:
+    """``end_bit = sizeof(OrderedType) * 8`` (topk.cuh:3121).
+
+    32 bits for fp32 and 16 for the 16-bit dtypes, i.e. 8 or 4 digit passes at
+    cub's ``RADIX_BITS = 4``.  Widening the 16-bit case to 32 would still sort the
+    ``~0u`` padding last, but would double the pass count for nothing.
+    """
+    return 32 if dtype == "float32" else 16
+
+
+def sort_key_u32(bits):
+    """``~RadixTopKTraits<float>::ToOrdered(v)`` as one XOR (topk.cuh:3112-3113).
+
+    The source composes a monotone flip with a complement; nvcc folds the pair
+    into a single mask, and the export carries **zero** ``not.b32``::
+
+        setp.lt.s32 %p, bits, 0;                 # sign bit set?
+        selp.b32    %m, 0, 2147483647, %p;       # mask = sign ? 0 : 0x7FFFFFFF
+        xor.b32     key, %m, bits;
+
+    The map is its own inverse, so the same helper serves the load and the
+    writeback: with the sign bit set the mask is 0 and the map is the identity;
+    with it clear the map flips only bits ``[0, 31)`` and leaves the sign clear,
+    so applying it twice cancels.
+
+    This is **not** ``topk_radix.to_ordered_u32`` (mask ``{0x80000000,
+    0xFFFFFFFF}``), which is the plain monotone flip the radix ports use.
+
+    A sign-extending load (``ld.global.s16`` + ``cvt.s32.s16``) lets the sign test
+    become a bare ``setp.lt.s32`` and removes the ``and.b32 0x8000`` mask, cutting
+    16 instructions out of this kernel's fixed region -- but it measured no better.
+    Two complete matrices put it at 38/46 and 40/46 shapes above the gate against
+    42/46 for the form kept here, with the f32 shapes (whose code the change does
+    not touch) moving in the opposite direction as an internal control.  Static
+    instruction count is not the binding resource here; the form below stays.
+    """
+    signed = T.reinterpret("int32", bits)
+    # T.Select, not T.if_then_else: the source's ternary is a predicated
+    # `selp.b32`, and if_then_else would lower to a real branch.
+    mask = T.Select(signed < T.int32(0), T.uint32(0), T.uint32(0x7FFFFFFF))
+    return T.bitwise_xor(mask, bits)
+
+
+def sort_key_u16(bits):
+    """The 16-bit form: ``setp.lt.s16`` + ``selp.b16 {0, 0x7FFF}`` + ``xor.b16``.
+
+    Same involution, in the dtype's own width (topk_common.cuh:61-64 forward,
+    :67 for half and :93 for nv_bfloat16 on the way back).
+    """
+    signed = T.reinterpret("int16", bits)
+    mask = T.Select(signed < T.int16(0), T.uint16(0), T.uint16(0x7FFF))
+    return T.bitwise_xor(mask, bits)
+
+
+def _validate(dtype: str, num_rows: int, k: int) -> dict[str, Any]:
+    """Reject anything the source launcher would not dispatch to this kernel."""
+    if dtype not in DTYPES:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+    if num_rows < 1:
+        raise ValueError(f"num_rows={num_rows} must be positive")
+    if k > STABLE_SORT_MAX_K:
+        raise ValueError(
+            f"k={k} exceeds the block-local sort capacity {STABLE_SORT_MAX_K}: the "
+            "launcher returns cudaErrorInvalidValue (:3139-3141)"
+        )
+    if k < STABLE_SORT_MIN_K:
+        raise ValueError(
+            f"k={k} is a launcher early-out: `top_k_val <= 1` returns cudaSuccess "
+            "without launching the kernel (:3142-3144)"
+        )
+    block_threads, items_per_thread = finalize_block_config(k)
+    return {
+        "block_threads": block_threads,
+        "items_per_thread": items_per_thread,
+        "end_bit": sort_end_bit(dtype),
+        "grid": num_rows,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Target entry.
+# ---------------------------------------------------------------------------
+def get_kernel(
+    dtype: str = "float32", num_rows: int = 16, k: int = 256, pattern: str = "unique", **kwargs
+):
+    """Return the TIRx specialization of `StableSortTopKByValueKernel` for one cell."""
+    plan = _validate(dtype, num_rows, k)
+    block_threads = plan["block_threads"]
+    items_per_thread = plan["items_per_thread"]
+    end_bit = plan["end_bit"]
+    is32 = dtype == "float32"
+
+    @T.prim_func
+    def stable_sort_topk_by_value(output_indices_h: T.handle, output_values_h: T.handle):
+        T.func_attr({"global_symbol": "stable_sort_topk_by_value"})
+        out_idx = T.match_buffer(output_indices_h, (num_rows * k,), "int32", scope="global")
+        out_val = T.match_buffer(output_values_h, (num_rows * k,), dtype, scope="global")
+        T.device_entry()
+
+        row = T.cta_id([num_rows])
+        tx = T.thread_id([block_threads])
+
+        # --- shared layout: the cub TempStorage union only (:3097) ----------
+        # Static `__shared__`, as the source declares it -- not the dynamic pool.
+        # The pool hands out offsets from a runtime `extern __shared__` base,
+        # which puts address arithmetic on every shared access; static offsets
+        # are compile-time constants.
+        c32, c16, xchg_keys, xchg_vals, scan = alloc_sort_smem_static(
+            block_threads, items_per_thread
+        )
+
+        # Row bases (:3102-3103).  The kernel is entirely in place.
+        row_base: T.int64 = T.cast(row, "int64") * T.int64(k)
+        # One base per thread, so each item's address is that base plus a
+        # compile-time offset, as the source does -- it keeps two address
+        # registers for the whole prologue and reaches the other items by
+        # displacement (`[%rd3+2]`, `[%rd3+4]`, ..., `[%rd4+12]`).  The
+        # displacement itself is not reachable from here, since these intrinsics
+        # take the address as a register operand, so this only removes the
+        # repeated 64-bit arithmetic (17 ops to 12) and measured neutral.
+        thread_base: T.int64 = row_base + T.cast(tx * items_per_thread, "int64")
+
+        keys = T.alloc_local((items_per_thread,), "uint32")
+        values = T.alloc_local((items_per_thread,), "uint32")
+        ranks = T.alloc_local((items_per_thread,), "int32")
+
+        # --- blocked load, descending key, ~0u padding (:3108-3119) --------
+        # Item order follows the source: load the value, complement it, then load
+        # the index (:3108-3115, and the export shows exactly that sequence under
+        # a branch around each pair).  Issuing all the loads ahead of all the
+        # conversions instead was measured on the shapes that reproduce to
+        # +/-0.001 and is the same speed, so the source's order stands.
+        for i in T.unroll(items_per_thread):
+            pos: T.int32 = tx * items_per_thread + i
+            # `pos < k` stays a runtime predicate: pos depends on %tid.x, so a
+            # static k only turns the operand into an immediate.  It folds away
+            # only at the six rungs where k == BLOCK_THREADS * ITEMS_PER_THREAD.
+            if pos < k:
+                slot: T.int64 = thread_base + T.cast(i, "int64")
+                # Source order (:3108-3115): load the value, complement it, then
+                # load the index.
+                if is32:
+                    keys[i] = sort_key_u32(ld_global_bits(out_val, slot, is32))
+                else:
+                    keys[i] = T.cast(
+                        sort_key_u16(T.cast(ld_global_bits(out_val, slot, is32), "uint16")),
+                        "uint32",
+                    )
+                values[i] = ld_global_u32(out_idx, slot)
+            else:
+                # ~0u is maximal within [0, end_bit) and every real key fits in
+                # end_bit bits, so padding sorts to the tail and is never written.
+                keys[i] = T.uint32(0xFFFFFFFF)
+                values[i] = T.uint32(0xFFFFFFFF)
+
+        # --- ascending, stable, blocked -> blocked (:3121-3122) -------------
+        # Descending-by-value already lives in the complemented key, so this is
+        # cub's plain `Sort`, not `SortDescending`.
+        emit_block_radix_sort_rolled(
+            c32,
+            c16,
+            scan,
+            xchg_keys,
+            xchg_vals,
+            keys,
+            values,
+            ranks,
+            tx,
+            block_threads,
+            items_per_thread,
+            end_bit // RADIX_BITS,
+            True,  # the indices ride as satellite values
+            True,  # both keys and values are 32-bit
+        )
+
+        # --- blocked writeback (:3124-3132) --------------------------------
+        for i3 in T.unroll(items_per_thread):
+            pos3: T.int32 = tx * items_per_thread + i3
+            if pos3 < k:
+                slot3: T.int64 = thread_base + T.cast(i3, "int64")
+                st_global_u32(out_idx, slot3, values[i3])
+                # The same helper as the load: the map is an involution.
+                if is32:
+                    st_global_u32(out_val, slot3, sort_key_u32(keys[i3]))
+                else:
+                    st_global_u16(out_val, slot3, sort_key_u16(T.cast(keys[i3], "uint16")))
+
+    return stable_sort_topk_by_value.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+_ = (bench, dtype_bytes, PATTERNS)  # wired up with the config matrix and harness
+
+
+# ---------------------------------------------------------------------------
+# Reference: the source's own launcher, compiled directly.
+#
+# FlashInfer exposes no FFI or Python entry for this kernel alone -- the pipeline
+# FFI launches main(+finalize)+sort as one call -- so a kernel-vs-kernel gate has
+# to build `StableSortTopKByValue<DType, int32_t>` itself.  Precedent for the
+# mechanism: `tirx_kernels/basic/nvfp4_gemm.py`.
+# ---------------------------------------------------------------------------
+_FLASHINFER_DATA = "/home/bohanhou/flashinfer/flashinfer/data"
+_REFERENCE_EXT = None
+
+_REF_DECL = r"""
+#include <torch/extension.h>
+void stable_sort_ref(at::Tensor indices, at::Tensor values, int64_t num_rows, int64_t k,
+                     int64_t max_len);
+"""
+
+# `sampling.cuh` must precede `topk.cuh`, exactly as csrc/topk.cu:16-17 does;
+# without it `math::ptx_rcp` is unresolved.
+_REF_SOURCE = r"""
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <flashinfer/sampling.cuh>
+#include <flashinfer/topk.cuh>
+
+void stable_sort_ref(at::Tensor indices, at::Tensor values, int64_t num_rows, int64_t k,
+                     int64_t max_len) {
+  auto stream = at::cuda::getCurrentCUDAStream();
+  cudaError_t st = cudaSuccess;
+  auto* idx = static_cast<int32_t*>(indices.data_ptr());
+  if (values.scalar_type() == at::kFloat) {
+    st = flashinfer::sampling::StableSortTopKByValue<float, int32_t>(
+        idx, static_cast<float*>(values.data_ptr()), num_rows, k, max_len, stream);
+  } else if (values.scalar_type() == at::kHalf) {
+    st = flashinfer::sampling::StableSortTopKByValue<half, int32_t>(
+        idx, static_cast<half*>(values.data_ptr()), num_rows, k, max_len, stream);
+  } else if (values.scalar_type() == at::kBFloat16) {
+    st = flashinfer::sampling::StableSortTopKByValue<nv_bfloat16, int32_t>(
+        idx, static_cast<nv_bfloat16*>(values.data_ptr()), num_rows, k, max_len, stream);
+  } else {
+    TORCH_CHECK(false, "unsupported dtype for StableSortTopKByValue");
+  }
+  TORCH_CHECK(st == cudaSuccess, "StableSortTopKByValue: ", cudaGetErrorString(st));
+}
+"""
+
+
+def load_reference_ext():
+    """Build and load the shape-independent reference before READY.
+
+    Runs in the CPU prepare stage, so it must not touch CUDA: the arch comes from
+    the prepare-stage env, never from the device.
+    """
+    global _REFERENCE_EXT
+    if _REFERENCE_EXT is not None:
+        return _REFERENCE_EXT
+
+    import fcntl
+    import os
+    from pathlib import Path
+
+    from torch.utils import cpp_extension
+
+    from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV
+
+    arch = os.environ.get(PREPARE_CUDA_ARCH_ENV, "sm_100a").removeprefix("sm_")
+    cuda_flags = [
+        # torch's cpp_extension injects these unconditionally; FlashInfer's own
+        # JIT never defines them, and they break vec_dtypes.cuh's half/bf16 ->
+        # float conversions.  Undefining restores parity with the production
+        # build rather than diverging from it.
+        "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__",
+        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        "-U__CUDA_NO_HALF2_OPERATORS__",
+        # The rest mirrors gen_topk_module() over gen_jit_spec()'s common set.
+        "-std=c++17",
+        "-use_fast_math",
+        "-Xfatbin=-compress-all",
+        "-DFLASHINFER_ENABLE_F16",
+        "-DFLASHINFER_ENABLE_BF16",
+        "-DFLASHINFER_ENABLE_FP8_E4M3",
+        "-DFLASHINFER_ENABLE_FP8_E5M2",
+        "-lineinfo",
+        f"-gencode=arch=compute_{arch},code=sm_{arch}",
+    ]
+    name = "tirx_stable_sort_topk_reference"
+    build_directory = Path(cpp_extension._get_build_directory(name, verbose=False))
+    build_directory.mkdir(parents=True, exist_ok=True)
+    # PyTorch's FileBaton is not process-death-safe; hold an flock instead and
+    # clear any baton a dead builder left behind.
+    lock_fd = os.open(str(build_directory / "lock.flock"), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        (build_directory / "lock").unlink(missing_ok=True)
+        _REFERENCE_EXT = cpp_extension.load_inline(
+            name=name,
+            cpp_sources=[_REF_DECL],
+            cuda_sources=[_REF_SOURCE],
+            functions=["stable_sort_ref"],
+            with_cuda=True,
+            extra_include_paths=[
+                f"{_FLASHINFER_DATA}/include",
+                f"{_FLASHINFER_DATA}/cccl/cub",
+                f"{_FLASHINFER_DATA}/cccl/libcudacxx/include",
+                f"{_FLASHINFER_DATA}/cccl/thrust",
+            ],
+            extra_cflags=["-O3", "-std=c++17"],
+            extra_cuda_cflags=cuda_flags,
+            build_directory=str(build_directory),
+            verbose=False,
+        )
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+    return _REFERENCE_EXT
+
+
+# ---------------------------------------------------------------------------
+# Harness.
+# ---------------------------------------------------------------------------
+def prepare_data(
+    dtype: str = "float32", num_rows: int = 16, k: int = 256, pattern: str = "unique", **kwargs
+):
+    """One row-set of already-selected `(value, index)` pairs, in a pinned order.
+
+    This kernel's output is a function of its **input order** -- radix sort is
+    stable, so equal values keep the order they arrived in.  Every pattern
+    therefore materializes both buffers explicitly and both sides consume
+    identical clones; nothing is left to allocation order or to chance.
+
+    `pipeline` is the shape the kernel actually sees in production: the output of
+    a real deterministic top-k call, whose indices are already ascending.
+    """
+    import torch
+
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(1234)
+    rows, kk = num_rows, k
+
+    if pattern == "unique":
+        values = torch.randn(rows, kk, dtype=torch.float32, device=device, generator=generator) * 4
+    elif pattern == "tie_heavy":
+        # A handful of distinct values: most comparisons are ties, so an unstable
+        # rank shows up immediately.
+        values = torch.randint(
+            0, 4, (rows, kk), dtype=torch.int32, device=device, generator=generator
+        ).to(torch.float32)
+    elif pattern == "all_equal":
+        # Every value identical: the output must equal the input verbatim.
+        values = torch.full((rows, kk), 1.5, dtype=torch.float32, device=device)
+    elif pattern == "neg":
+        # All negative: the other half of the monotone-flip sign branch.
+        values = -(
+            torch.rand(rows, kk, dtype=torch.float32, device=device, generator=generator) * 8 + 0.5
+        )
+    elif pattern == "padded":
+        # Producer shape for a short row: -1 indices carrying 0.0 values.
+        values = torch.randn(rows, kk, dtype=torch.float32, device=device, generator=generator) * 4
+        values[:, kk // 2 :] = 0.0
+    elif pattern == "pipeline":
+        values = None
+    else:
+        raise ValueError(f"Unknown pattern: {pattern}")
+
+    if pattern == "pipeline":
+        indices, values_t = _pipeline_inputs(dtype, rows, kk, generator)
+    else:
+        values_t = values.to(torch_dtype(dtype)).contiguous()
+        indices = torch.arange(rows * kk, dtype=torch.int32, device=device).reshape(rows, kk)
+        indices = (indices % 1_000_003).contiguous()
+        if pattern == "padded":
+            indices[:, kk // 2 :] = -1
+
+    return {"values": values_t, "indices": indices.contiguous(), "pattern": pattern}
+
+
+def _pipeline_inputs(dtype: str, rows: int, k: int, generator):
+    """Run a real deterministic top-k and hand its output to the sort.
+
+    That is exactly what `TopKDispatch` does: the sort only ever sees a producer's
+    output, whose indices are already ascending, which is what makes the
+    documented `(value desc, index asc)` result hold.
+    """
+    import torch
+
+    pin_source_algo(SOURCE_ALGO_FILTERED)
+    module = source_module()
+    length = max(4096, 4 * k)
+    scores = torch.randn(rows, length, dtype=torch.float32, device="cuda", generator=generator)
+    scores = scores.to(torch_dtype(dtype)).contiguous()
+    out_values = torch.empty(rows, k, dtype=torch_dtype(dtype), device="cuda")
+    out_indices = torch.empty(rows, k, dtype=torch.int32, device="cuda")
+    # The module-level FFI signature (csrc/topk.cu:41), not the `flashinfer.top_k`
+    # wrapper's: indices are an out-parameter, and `sorted_output` stays False so
+    # the producer hands us an UNSORTED row -- sorting it is this kernel's job.
+    module.radix_topk(
+        scores,
+        out_indices,
+        out_values,
+        None,  # row_states: the filtered path never touches it
+        k,
+        False,  # sorted_output
+        True,  # deterministic -> indices come out ascending, as in production
+        0,  # tie_break = None
+        False,  # dsa_graph_safe
+    )
+    torch.cuda.synchronize()
+    return out_indices.contiguous(), out_values.contiguous()
+
+
+def build_tirx_args(cfg: dict[str, Any], data: dict[str, Any], buffers: dict[str, Any]):
+    """Bind the flat launch ABI once, outside any timed region."""
+    return (buffers["indices"].reshape(-1), buffers["values"].reshape(-1))
+
+
+def clone_inputs(data: dict[str, Any]):
+    """A fresh in-place working set: the kernel overwrites what it reads."""
+    return {"indices": data["indices"].clone(), "values": data["values"].clone()}
+
+
+def run_reference(cfg: dict[str, Any], buffers: dict[str, Any]) -> None:
+    """One launch of the source kernel over the given buffers, in place."""
+    import torch
+
+    ext = load_reference_ext()
+    ext.stable_sort_ref(
+        buffers["indices"].reshape(-1),
+        buffers["values"].reshape(-1),
+        cfg["num_rows"],
+        cfg["k"],
+        1 << 20,  # max_len: dead in the kernel body, present in the arg pack
+    )
+    torch.cuda.synchronize()
+
+
+def assert_reference_is_stable_sort(cfg, data, ref) -> None:
+    """Independent oracle on the reference launch itself.
+
+    `torch.sort(..., descending=True, stable=True)` is the definition this kernel
+    implements, so the reference must reproduce it exactly -- values and the
+    indices they carry.
+    """
+    import torch
+
+    order = torch.sort(
+        data["values"].to(torch.float32), dim=-1, descending=True, stable=True
+    ).indices
+    want_v = torch.gather(data["values"].to(torch.float32), 1, order)
+    want_i = torch.gather(data["indices"], 1, order)
+    torch.testing.assert_close(ref["values"].to(torch.float32), want_v, rtol=0, atol=0)
+    torch.testing.assert_close(ref["indices"], want_i, rtol=0, atol=0)
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against the FlashInfer source."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    try:
+        import flashinfer  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"flashinfer unavailable: {exc}") from exc
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    cfg = _normalize_config(config)
+    _validate(cfg["dtype"], cfg["num_rows"], cfg["k"])
+
+    data = prepare_data(**cfg)
+
+    ref = clone_inputs(data)
+    run_reference(cfg, ref)
+    assert_reference_is_stable_sort(cfg, data, ref)
+
+    ex = compile_kernel(get_kernel(**cfg))
+    got = clone_inputs(data)
+    ex(*build_tirx_args(cfg, data, got))
+    torch.cuda.synchronize()
+
+    # The kernel is fully deterministic and stability makes the output a function
+    # of the input order alone, so the comparison is bit-exact and positional.
+    torch.testing.assert_close(got["indices"], ref["indices"], rtol=0, atol=0)
+    torch.testing.assert_close(got["values"], ref["values"], rtol=0, atol=0)
+
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    cfg = {"dtype": "float32", "num_rows": 16, "k": 256, "pattern": "unique"}
+    cfg.update({key: value for key, value in config.items() if key != "label"})
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+# ---------------------------------------------------------------------------
+def prepare_bench(**kwargs: Any):
+    """Specialize, compile, and build the reference before the workload owns a GPU."""
+    from tirx_kernels.runner import (
+        compile_kernel,
+        external_references_enabled,
+        prepared_gpu_benchmark,
+    )
+
+    cfg = _normalize_config(kwargs)
+    state = {"config": cfg, "executable": compile_kernel(get_kernel(**cfg))}
+    if external_references_enabled():
+        state["reference_ext"] = load_reference_ext()
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    """Kernel-only comparison against the source launch.
+
+    Both implementations alternate over the same two working sets rather than
+    holding one each; see the comment below for why, and what it costs.
+
+    Note what the repeat loop measures.  This kernel is in place, so a working
+    set is unsorted only until something sorts it, and every later call re-sorts
+    an already-sorted buffer.  That is the steady state rather than the
+    production workload.  Re-randomizing between iterations is not an option:
+    the copy would land inside the timed region and a per-kernel timer would
+    charge it to the kernel.
+
+    Under alternation only whichever side runs first meets the unsorted state,
+    where previously each side met it once.  That asymmetry is one call against a
+    25 ms warmup and a 100 ms measurement on a kernel of a few microseconds, and
+    the sort's work does not depend on the data: the pass count is fixed by
+    ``end_bit`` and the measured shared bank conflicts are 250 either way.
+    """
+    cfg = dict(prepared["config"])
+    ex = prepared["executable"]
+
+    data = prepare_data(**cfg)
+    # Two working sets, and both implementations alternate over both of them.
+    #
+    # The kernel is in place, so a working set cannot be shared within a launch.
+    # Giving each side its own single clone, though, decides the measurement by
+    # where that clone landed: two separate allocations do not share an L2
+    # partition on this part, and with four single-warp CTAs one side ends up
+    # local and the other remote.  Remote-partition latency is fixed in
+    # nanoseconds, so it costs more at boost clock and lands entirely on whoever
+    # drew it -- worth 0.957 to 1.099 on one shape with both kernels untouched,
+    # and enough to make the two byte-identical 16-bit kernels read 0.937 and
+    # 1.082.
+    #
+    # Alternating in opposite phase gives each implementation each buffer for
+    # half its calls, so the placement term is common to both sides and cancels
+    # in the ratio.  It is symmetric by construction: exchanging the two clones
+    # exchanges the phases and leaves every measurement unchanged.
+    clones = (clone_inputs(data), clone_inputs(data))
+    tirx_args = tuple(build_tirx_args(cfg, data, buffers) for buffers in clones)
+    tirx_phase = [0]
+
+    def tirx_launch():
+        step = tirx_phase[0]
+        tirx_phase[0] = step + 1
+        ex(*tirx_args[step & 1])
+
+    def build_reference():
+        ext = prepared["reference_ext"]
+        flat = tuple(
+            (buffers["indices"].reshape(-1), buffers["values"].reshape(-1)) for buffers in clones
+        )
+        rows, kk = cfg["num_rows"], cfg["k"]
+        ref_phase = [0]
+
+        def reference_launch():
+            step = ref_phase[0]
+            ref_phase[0] = step + 1
+            flat_i, flat_v = flat[(step + 1) & 1]
+            ext.stable_sort_ref(flat_i, flat_v, rows, kk, 1 << 20)
+
+        return reference_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+# ---------------------------------------------------------------------------
+_DT_TAG = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+
+# The six `(BLOCK_THREADS, ITEMS_PER_THREAD)` rungs of the launcher ladder
+# (:3154-3166), plus the smallest shape that still launches (`k > 1`, :3142) and
+# one k that lands mid-rung rather than on a boundary.
+_K_LADDER = (128, 256, 512, 576, 1024, 2048)
+_K_EDGES = (2, 300)
+# grid is one CTA per row, against 148 SMs on B200.
+_ROW_SWEEP = (1, 16, 64, 256)
+
+
+def _cfg(dtype, num_rows, k, pattern="unique"):
+    label = f"{_DT_TAG[dtype]}_r{num_rows}_k{k}"
+    if pattern != "unique":
+        label += f"_{pattern}"
+    return {"label": label, "dtype": dtype, "num_rows": num_rows, "k": k, "pattern": pattern}
+
+
+def _build_configs():
+    """Representative cover of the reachable domain.
+
+    Retained in full: every ``(BLOCK_THREADS, ITEMS_PER_THREAD)`` rung of the
+    launcher ladder; both digit-pass counts (8 for fp32, 4 for the 16-bit dtypes);
+    all three dtypes; every input pattern that can change the answer; and the
+    ``num_rows`` occupancy axis.
+
+    The k ladder is swept per dtype at a fixed small row count, and the pattern
+    axis at one rung, so the matrix stays a cover rather than a cross.
+
+    The rows axis is **not** independent of the dtype, though the first version
+    of this matrix assumed it was.  At ``k = 512`` the fp32 ratio is flat across
+    the sweep (1.031, 1.035, 1.031 at 4, 32 and 256 rows) while float16 moves
+    from 0.979 to 1.021 to 0.990: with four single-warp CTAs on 148 SMs nothing
+    overlaps a CTA's latency chain, and the four-pass kernels have half as much
+    work to hide it behind.  So both regimes are carried for both pass counts.
+    """
+    configs = []
+
+    # 1. Full k ladder on every dtype -- 6 rungs x 3 dtypes covers all 18 source
+    #    instantiations, and both pass counts on every rung.
+    for dtype in DTYPES:
+        for k in _K_LADDER:
+            configs.append(_cfg(dtype, 4, k))
+
+    # 2. Ladder edges: the smallest launchable k, and a k that is not a boundary.
+    for dtype in DTYPES:
+        for k in _K_EDGES:
+            configs.append(_cfg(dtype, 4, k))
+
+    # 3. Occupancy: grid is one CTA per row against 148 SMs.
+    for rows in _ROW_SWEEP:
+        configs.append(_cfg("float32", rows, 256))
+    # The widest rung with a full SM array: the k ladder above is swept at 4 rows
+    # (latency-bound) and the occupancy axis at k=256 (narrow rung), so without
+    # this the matrix never runs (256, 8) against a saturated grid.
+    configs.append(_cfg("float32", 64, 2048))
+    # The same argument for the four-pass family, which the fp32-only sweep above
+    # leaves entirely unmeasured against a saturated grid.  The 16-bit dtypes are
+    # exactly where the row count matters -- the ratio moves about four points
+    # across the sweep where fp32 does not -- so measuring them only at 4 rows
+    # reports one end of an axis as though it were the whole of it.  float16
+    # carries this: bfloat16 compiles to a byte-identical kernel.
+    configs.append(_cfg("float16", 64, 256))
+    configs.append(_cfg("float16", 64, 512))
+
+    # 4. Input patterns.  Stability is a property of the incoming order, so these
+    #    are domain coverage, not test flavor: `tie_heavy` and `all_equal` are the
+    #    only configs that can catch an unstable rank, and `neg` is the only one
+    #    that exercises the other half of the ToOrdered sign branch.
+    for dtype in ("float32", "float16"):
+        for pattern in ("tie_heavy", "all_equal", "neg", "padded", "pipeline"):
+            configs.append(_cfg(dtype, 4, 256, pattern=pattern))
+    # The (64, 8) rung with a tie-dense pattern, on every dtype.  Keeping the
+    # pattern axis symmetric across dtypes at one rung is what makes an f16/bf16
+    # gap attributable at all: the two compile to byte-identical kernels, so any
+    # spread between them is something other than the kernel.  It is worth
+    # keeping for exactly that reason -- a large spread here is what exposed the
+    # measurement's dependence on where each working set was allocated, which
+    # `run_gpu` now cancels.
+    for dtype in DTYPES:
+        configs.append(_cfg(dtype, 4, 512, pattern="tie_heavy"))
+        configs.append(_cfg(dtype, 4, 512, pattern="neg"))
+    # A tie-heavy row at the widest rung: 2048 equal-ish values in one block sort.
+    configs.append(_cfg("float32", 2, 2048, pattern="tie_heavy"))
+
+    # Deduplicate on launch parameters (labels alone would keep near-twins).
+    seen: dict[tuple, dict[str, Any]] = {}
+    for cfg in configs:
+        params = tuple(sorted((key, value) for key, value in cfg.items() if key != "label"))
+        seen.setdefault(params, cfg)
+    deduped = list(seen.values())
+    labels = [cfg["label"] for cfg in deduped]
+    assert len(set(labels)) == len(labels), "duplicate config label"
+    for cfg in deduped:
+        _validate(cfg["dtype"], cfg["num_rows"], cfg["k"])
+    return deduped
+
+
+def _build_bench_configs():
+    """Timed matrix: every correctness config.
+
+    Each one launches exactly one kernel on each side, and the pattern axis is a
+    real performance regime (a fully-tied row exercises a different digit
+    distribution than distinct values).
+    """
+    return list(CONFIGS)
+
+
+CONFIGS = _build_configs()
+BENCH_CONFIGS = _build_bench_configs()

--- a/tirx_kernels/flashinfer/utils/block_radix_sort.py
+++ b/tirx_kernels/flashinfer/utils/block_radix_sort.py
@@ -1,6 +1,37 @@
-# This file is a TIRx port of code from NVIDIA CCCL/CUB
-# (https://github.com/NVIDIA/cccl), Copyright (c) 2011, Duane Merrill; 2011-2018, NVIDIA CORPORATION.
-# SPDX-License-Identifier: Apache-2.0
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+#
+# The collective transcribed here is NVIDIA CCCL/CUB's `cub::BlockRadixSort`, which
+# FlashInfer's topk kernels instantiate and which ships in the cccl tree its JIT
+# compiles (flashinfer/data/cccl/cub). That code is BSD-3, so its notice travels
+# with this file and the SPDX expression below is the pair.
+#
+# Copyright (c) 2011, Duane Merrill. All rights reserved.
+# Copyright (c) 2011-2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 """``cub::BlockRadixSort`` emitters for the filtered top-k finalize kernel.
@@ -34,6 +65,8 @@ so control falls through to the shift-and-mask return at ``:114``.
 
 from tirx_kernels.flashinfer.utils.topk_radix import (
     bar_sync,
+    ld_shared_pair_u32,
+    ld_shared_quad_u32,
     ld_shared_u16,
     ld_shared_u32,
     shfl_up_u32,
@@ -120,6 +153,38 @@ def union_bytes(block_threads: int, items_per_thread: int, value_bytes: int) -> 
     return max(rank_words(block_threads) * 4, items * 4, items * value_bytes)
 
 
+def alloc_sort_smem_static(block_threads, items_per_thread):
+    """Static `__shared__` layout for the u32-key/u32-value sort.
+
+    The source declares its `BlockRadixSort::TempStorage` as a plain
+    `__shared__` array, so every offset into it is a compile-time constant.  The
+    dynamic-shared pool instead hands out offsets from a runtime `extern
+    __shared__` base, which puts an address computation on the critical path of
+    every shared access -- visible as a fixed cost that short kernels cannot
+    amortize.
+
+    The union is expressed as views over one allocation rather than through
+    `move_base_to`: the rank grid dominates at every rung, so the key and value
+    exchange buffers fit inside it exactly as in cub's union.
+    """
+    words = rank_words(block_threads)
+    assert exchange_elements(block_threads, items_per_thread) <= words, (
+        "exchange must fit inside the rank grid for the union to hold"
+    )
+    counters32 = T.alloc_buffer((words,), "uint32", scope="shared")
+    counters16 = counters32.view("uint16")
+    # Both exchange buffers alias the rank grid, exactly as cub's inner union
+    # does: a barrier separates the rank phase from each scatter, and the ranks
+    # themselves live in registers by then, so nothing live is overwritten.
+    xchg_keys = counters32
+    xchg_values = counters32
+    # The block-scan scratch sits outside that union, as in cub -- a separate
+    # `__shared__` array rather than an offset view, so its indices stay
+    # zero-based for the emitters.
+    scan = T.alloc_buffer((scan_words(block_threads),), "uint32", scope="shared")
+    return counters32, counters16, xchg_keys, xchg_values, scan
+
+
 def alloc_sort_smem(pool, block_threads, items_per_thread, value_dtype, value_bytes):
     """Lay out the sort's shared union plus the block-scan scratch.
 
@@ -147,9 +212,14 @@ def alloc_sort_smem(pool, block_threads, items_per_thread, value_dtype, value_by
     return counters32, counters16, xchg_keys, xchg_values, scan
 
 
-def emit_digit(key, begin_bit: int, num_bits: int):
-    """``BFEDigitExtractor::Digit`` -- shift and mask, never ``bfe`` on SM >= 70."""
-    return T.bitwise_and(T.shift_right(key, T.uint32(begin_bit)), T.uint32((1 << num_bits) - 1))
+def emit_digit(key, begin_bit, num_bits: int):
+    """``BFEDigitExtractor::Digit`` -- shift and mask, never ``bfe`` on SM >= 70.
+
+    ``begin_bit`` may be a Python int (unrolled pass loop) or a TIR value (rolled
+    pass loop, which is the shape the source compiles to).
+    """
+    shift = T.uint32(begin_bit) if isinstance(begin_bit, int) else T.cast(begin_bit, "uint32")
+    return T.bitwise_and(T.shift_right(key, shift), T.uint32((1 << num_bits) - 1))
 
 
 def padded_offset(off, items_per_thread: int):
@@ -200,6 +270,67 @@ def _scan_fold_warp(scan, agg, wpre, tx, w):
 
 
 @T.macro
+def _scan_fold_warp_value(agg, wpre, tx, w, value):
+    """``ApplyWarpAggregates`` over an aggregate already held in a register."""
+    if tx // WARP_THREADS == w:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + value
+
+
+@T.macro
+def _scan_seed_and_fold_pair(scan, agg, wpre, tx):
+    """``ApplyWarpAggregates`` at two warps, reading both with one vector load.
+
+    ``warp_aggregates[]`` is contiguous and the source reads it whole --
+    ``ld.shared.v2.b32`` at ``BLOCK_THREADS == 64`` and ``ld.shared.v4.b32`` at
+    128 and 256 (``.loc 13 178``) -- rather than one scalar load per warp.
+    """
+    pair = ld_shared_pair_u32(scan, 0)
+    agg[0] = pair[0]
+    wpre[0] = T.uint32(0)
+    if tx // WARP_THREADS == 1:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + pair[1]
+
+
+@T.macro
+def _scan_seed_and_fold_quad(scan, agg, wpre, tx):
+    """The same fold at four warps, over one ``ld.shared.v4.b32``."""
+    quad = ld_shared_quad_u32(scan, 0)
+    agg[0] = quad[0]
+    wpre[0] = T.uint32(0)
+    if tx // WARP_THREADS == 1:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + quad[1]
+    if tx // WARP_THREADS == 2:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + quad[2]
+    if tx // WARP_THREADS == 3:
+        wpre[0] = agg[0]
+    agg[0] = agg[0] + quad[3]
+
+
+@T.macro
+def _scan_seed_and_fold_octet(scan, agg, wpre, tx):
+    """The same fold at eight warps, over two ``ld.shared.v4.b32``.
+
+    ``BLOCK_THREADS == 256`` has eight aggregates and cub reads them as two
+    vectors, not eight scalars.
+    """
+    lo = ld_shared_quad_u32(scan, 0)
+    hi = ld_shared_quad_u32(scan, 4)
+    agg[0] = lo[0]
+    wpre[0] = T.uint32(0)
+    _scan_fold_warp_value(agg, wpre, tx, 1, lo[1])
+    _scan_fold_warp_value(agg, wpre, tx, 2, lo[2])
+    _scan_fold_warp_value(agg, wpre, tx, 3, lo[3])
+    _scan_fold_warp_value(agg, wpre, tx, 4, hi[0])
+    _scan_fold_warp_value(agg, wpre, tx, 5, hi[1])
+    _scan_fold_warp_value(agg, wpre, tx, 6, hi[2])
+    _scan_fold_warp_value(agg, wpre, tx, 7, hi[3])
+
+
+@T.macro
 def _scan_apply_prefix(scan, out, agg, wpre, tx, n_warps):
     """Warp prefix, the packed block-prefix callback, and the broadcast back.
 
@@ -236,9 +367,21 @@ def emit_block_exclusive_sum_packed(scan, out, incl, agg, wpre, tx, block_thread
     n_warps = warps(block_threads)
     _scan_warp_inclusive(out, incl, tx, value)
     _scan_publish_warp_aggregate(scan, incl, tx)
-    _scan_seed_aggregate(scan, agg, wpre)
-    for w in range(1, n_warps):
-        _scan_fold_warp(scan, agg, wpre, tx, w)
+    # `warp_aggregates[]` is contiguous and the source reads it whole rather than
+    # one scalar load per warp: `ld.shared.v2.b32` at BT == 64 and `v4` at 128 and
+    # 256.  Measured on the shapes that reproduce to +/-0.001, the two forms are
+    # the same speed, so this follows the source.  At one warp there is nothing to
+    # vectorize and the fold chain disappears entirely.
+    if n_warps == 2:
+        _scan_seed_and_fold_pair(scan, agg, wpre, tx)
+    elif n_warps == 4:
+        _scan_seed_and_fold_quad(scan, agg, wpre, tx)
+    elif n_warps == 8:
+        _scan_seed_and_fold_octet(scan, agg, wpre, tx)
+    else:
+        _scan_seed_aggregate(scan, agg, wpre)
+        for w in range(1, n_warps):
+            _scan_fold_warp(scan, agg, wpre, tx, w)
     _scan_apply_prefix(scan, out, agg, wpre, tx, n_warps)
 
 
@@ -317,14 +460,31 @@ def emit_rank_keys(
 
 @T.macro
 def emit_scatter_to_blocked_u32(buf, items_reg, ranks, tx, items_per_thread):
-    """``BlockExchange::ScatterToBlocked`` for the 32-bit keys (``:600-629``)."""
+    """``BlockExchange::ScatterToBlocked`` for the 32-bit keys (``:600-629``).
+
+    The scatter is by rank and stays scalar, but the gather reads this thread's
+    own blocked run, which is contiguous whenever ``INSERT_PADDING`` is off.  At
+    ``IPT == 4`` that is four adjacent words at a 16-byte-aligned offset and the
+    source issues a single ``ld.shared.v4.b32`` for them (``block_exchange.cuh:627``,
+    one for the keys and one for the values in every pass).  Reading them scalar
+    instead puts three extra shared-memory round trips on the critical path of a
+    kernel that runs one warp per CTA, which is where the ``(32, 4)`` rung loses
+    its time.
+    """
     for i in T.unroll(items_per_thread):
         st_shared_u32(buf, padded_offset(ranks[i], items_per_thread), items_reg[i])
     bar_sync()
-    for i in T.unroll(items_per_thread):
-        items_reg[i] = ld_shared_u32(
-            buf, padded_offset(tx * items_per_thread + i, items_per_thread)
-        )
+    if items_per_thread == 4 and not insert_padding(items_per_thread):
+        quad = ld_shared_quad_u32(buf, tx * items_per_thread)
+        items_reg[0] = quad[0]
+        items_reg[1] = quad[1]
+        items_reg[2] = quad[2]
+        items_reg[3] = quad[3]
+    else:
+        for i in T.unroll(items_per_thread):
+            items_reg[i] = ld_shared_u32(
+                buf, padded_offset(tx * items_per_thread + i, items_per_thread)
+            )
 
 
 @T.macro
@@ -387,4 +547,67 @@ def emit_block_radix_sort(
             else:
                 emit_scatter_to_blocked_u16(xchg_values, values, ranks, tx, items_per_thread)
         if p != len(sort_passes(end_bit)) - 1:
+            bar_sync()
+
+
+@T.macro
+def emit_block_radix_sort_rolled(
+    counters32,
+    counters16,
+    scan,
+    xchg_keys,
+    xchg_values,
+    keys,
+    values,
+    ranks,
+    tx,
+    block_threads,
+    items_per_thread,
+    num_passes,
+    sort_values,
+    value_is32,
+):
+    """``SortBlocked`` with the digit-pass loop rolled, in the source's own shape.
+
+    ``block_radix_sort.cuh:377-430`` is a ``while (true)`` that advances
+    ``begin_bit`` and breaks before the trailing barrier once the pass is the
+    last one, and nvcc leaves it rolled: the export carries 9 static ``bar.sync``
+    and 258 instructions for ``<32, 4, int, __half>``, whatever the pass count.
+
+    A counted ``T.serial`` loop does **not** reproduce that.  Its trip count is a
+    compile-time constant, so nvcc fully unrolls it and the same entry grows to
+    35 ``bar.sync`` and 837 instructions -- 3.2x the source's code for identical
+    work.  TVM emits ``#pragma unroll 1`` ahead of a ``While`` node
+    (``codegen_c.cc:1382``) and nothing ahead of a ``For``, so the loop is written
+    here the way the source writes it: advance the bit offset in the body and
+    take the trailing barrier only when another pass follows, which also gives
+    the ``9P - 1`` barrier count directly.
+    """
+    begin = T.alloc_local((1,), "int32")
+    begin[0] = 0
+    while begin[0] < num_passes * RADIX_BITS:
+        emit_rank_keys(
+            counters32,
+            counters16,
+            scan,
+            keys,
+            ranks,
+            tx,
+            block_threads,
+            items_per_thread,
+            begin[0],
+            RADIX_BITS,
+        )
+        bar_sync()
+        emit_scatter_to_blocked_u32(xchg_keys, keys, ranks, tx, items_per_thread)
+        if sort_values:
+            bar_sync()
+            if value_is32:
+                emit_scatter_to_blocked_u32(xchg_values, values, ranks, tx, items_per_thread)
+            else:
+                emit_scatter_to_blocked_u16(xchg_values, values, ranks, tx, items_per_thread)
+        begin[0] = begin[0] + RADIX_BITS
+        # The source breaks out before this barrier on the final pass
+        # (block_radix_sort.cuh:415-421), giving 9P - 1 rather than 9P.
+        if begin[0] < num_passes * RADIX_BITS:
             bar_sync()


### PR DESCRIPTION
Ports `StableSortTopKByValueKernel` (`topk.cuh:3090-3133`) and its launcher, the
`sorted_output` epilogue `TopKDispatch` appends after both the filtered and radix
branches. This was the last kernel in the `flashinfer.topk` selection path still
unported.

## Kernel

One CTA per row sorts that row's already-selected `(value, index)` pairs in
place, descending and stably, through `cub::BlockRadixSort` over `uint32` keys.
Descending order comes from complementing the monotone key in the kernel, so the
collective is cub's plain ascending `Sort` and neither `DescendingBlockRadixRank`
nor cub's float twiddling is instantiated. The complement folds into the mask,
and the map is its own inverse, so one helper serves the load and the writeback.
`end_bit` is 32 for fp32 and 16 for the 16-bit dtypes, giving 8 and 4 digit
passes; the launcher ladder is the one `LaunchFinalizeTopKIndices` uses.

The digit-pass loop is a `While` so it stays rolled, as the source does. A
counted loop has a compile-time trip count and nvcc unrolls it into one copy per
pass — 837 instructions and 35 static `bar.sync` against the source's 258 and 9
for identical dynamic work — which costs the shapes with the fewest passes more
than the loop overhead it removes.

## Reference

FlashInfer exposes no FFI for this kernel alone, so both correctness and the
benchmark drive the source's own `StableSortTopKByValue` launcher compiled as a
`torch.utils.cpp_extension` module, with nvcc flags mirrored from
`gen_topk_module()`'s JitSpec. Outputs are compared bit-exactly, and
independently against a `torch.sort(..., stable=True)` oracle.

## Benchmark harness

Both implementations alternate over the same two working sets in opposite phase.
The kernel is in place, so cloning once per side puts the two copies in different
L2 partitions; on a grid of four single-warp CTAs one side draws the near
partition and the other the far one, and that fixed-nanosecond difference lands
entirely on whichever side drew it. Measured on one shape across four allocation
arrangements with neither kernel changed: 0.957, 0.974, 1.058, 1.099 — and two
byte-identical 16-bit kernels reading 0.937 and 1.082. Alternating gives each
side each buffer for half its calls, which cancels the term and is symmetric by
construction; the byte-identical pair then agrees to within 0.002.

## Results

- Correctness: 48/48 configs, bit-exact against the source launcher.
- Performance: every shape above 0.99x on the complete matrix, confirmed on
  three independent runs (min 1.002, 0.995, 1.002; median ~1.035).
- No regression in `filtered_topk` (107/107, ratios unchanged), which shares the
  modified block-sort emitters, nor in the two radix ports (234/234, 354/354).

## Second commit

Records the tuning findings: one new codegen-tuning entry on rolling a pass loop
with `While`, and extensions to two existing entries — why the memory clobber is
load-bearing rather than merely unrewarding, and what expressing access through
raw PTX costs in addressing. The measurement findings are methodology rather
than generated code, so they go to the bench-suite README instead: the placement
draw above, the swap test any allocation scheme must pass, that absolute
microseconds do not survive a session boundary while ratios do, and the clock and
cache settings needed before a profiler and the suite can be compared.