### PR TITLE
feat(kernel): port flashinfer fast topk clusters kernel to tirx

### DIFF
--- a/.agents/sketch/flashinfer/topk/fast_topk_clusters.md
+++ b/.agents/sketch/flashinfer/topk/fast_topk_clusters.md
@@ -1,0 +1,972 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of FlashInfer's
+include/flashinfer/fast_topk_clusters_exact.cuh fast_topk_clusters_exact family.
+-->
+
+# fast_topk_clusters SM100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/flashinfer/topk/fast_topk_clusters.py`](../../../../tirx_kernels/flashinfer/topk/fast_topk_clusters.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **three kernels**, because they are one program: a single device
+worker `fast_topk_cuda_v4` (`:80-405`) behind three `__global__` wrappers that
+differ only in where the row length comes from and what the epilogue does to each
+index -- `fast_topk_clusters_exact_kernel` (`:407-449`),
+`fast_topk_clusters_exact_page_table_transform_kernel` (`:451-494`), and
+`fast_topk_clusters_exact_ragged_transform_kernel` (`:496-538`). All three carry
+`__launch_bounds__(1024)` and `__cluster_dims__(NClusters, 1, 1)`. This is the
+kernel [`filtered_topk.md`](filtered_topk.md) and
+[`radix_topk_single_cta.md`](radix_topk_single_cta.md) name as out of scope --
+`radix_topk_multi_cta.md` inherits that scope by deferring to its single-CTA
+sibling rather than naming this kernel itself: the SM100 cluster algorithm, which the Python layer selects
+*before* the FFI (`flashinfer/topk.py:502-507`, requiring `not deterministic`,
+`tie_break == NONE`, `not dsa_graph_safe`, and compute capability major 10), so
+the C++ `TopKDispatch` those three ports go through never reaches it.
+
+Instantiations: `DType in {f32, f16, bf16}` x `NClusters in {1, 2, 4, 8}` x
+`{plain int32, plain int64, page_table, ragged}` = **48 reachable
+specializations**, all exported in `.porting/fast_topk_clusters/ptx/`. `TopK`,
+`num_cached`, `NClusters`, the mode, and the index width are static per config
+here, exactly the values the launchers (`:584-693`) and their Python caller pick
+per call.
+
+Accepted target SM100/B200. Out of scope, with the predicate that excludes each:
+`PDL_ENABLED == true` -- `pdl` is `False` at every Python call site and no caller
+passes `True` (`topk.py:404, 443, 473`), so `cudaGridDependencySynchronize`
+(`:156`) is unreachable; the pre-computed histogram -- `pre_hist` is always
+`None` (`topk.py:432, 463, 492`), so `:159-163` and the `sum_hist == false`
+threshold path (`:187`) are dead; `NClusters` outside `{1, 2, 4, 8}` -- the
+launcher rewrites it to `1` and re-dispatches before any kernel is selected
+(`:607-611`). Tile (`Tx`) primitives are out of scope everywhere.
+
+## Pipeline at a glance
+
+One CTA owns one `(row, rank)` pair; `NC` CTAs form one cluster and cooperate on
+one row of `logits`. The grid is `batch * NC`.
+
+| Kernel / role | Program | Publication / reuse edges |
+| --- | --- | --- |
+| **All three wrappers**, all 32 warps, trivial branch | when `seq_len <= TopK`, write **this mode's** index for `i < seq_len` (plain: `i`, `:421`; page_table: `page_table[pt_off + i]`, `:471`; ragged: `i + ragged_offset`, `:515`) then `-1` padding, distributed across the cluster by `(blockIdx.x % NC) * 1024`, and return without entering the worker | Nothing is published. This is the **only** path whose output is positionally deterministic, and the only one that never touches shared memory. |
+| **Worker**, all 32 warps, histogram | scalar strided read of this CTA's slice of the row, `to_ordered` then `>> LSHIFT_START`, bump `hist[bin]` | `atom.shared.add.u32` into bank 0. Bank 0 is the input to the first threshold, and then becomes this CTA's DSMEM publication when `:122` overwrites it with the local cumsum -- what peers read at `:129-130` is that republished cumsum, not the raw histogram. Protecting bank 0 from being cleared while peers are still reading it is what the split cluster barrier does. |
+| **Worker**, lanes `< 256` (`radix_thread`), threshold | 256-bin suffix cumsum of one bank; at `NC > 1` add the same bin from every peer CTA through distributed shared memory; select the bin where the running count crosses `k_remaining` | `cluster.sync()` separates publication from the peer reads; bank 2 receives the cluster-wide sums; `threshold_bin` publishes the choice to the whole CTA through `bar.sync 0`. |
+| **Worker**, 8 warps, inside the cumsum | each warp suffix-scans 32 bins by `shfl.sync.down.b32`, lane 0 publishes its warp total (a `.down` scan totals into the low lane), warp 0 scans the 8 totals | `s_cum_reduce_buf[8]` is the only cross-warp edge in the scan; one `bar.warp.sync` inside it. |
+| **Worker**, all 32 warps, classification and refinement | split each element on the current byte: above the threshold bin, equal to it, or below | above -> `topk_inds` by `atom.shared.add.u32` compaction; equal -> the double-buffered candidate cache, spilling to this CTA's global overflow ring, and bumps the next round's histogram bank. Below is dropped. |
+| **Worker**, all 32 warps, final round only | the equal-bin survivors race a DSMEM atomic on **rank 0's** counter for the remaining slots | `atom.shared::cluster.add.u32`; the first `top_k_remaining` arrivals win and the rest latch out. Present even at `NC == 1`. |
+| **Worker**, thread 0 of ranks `> 0`, epilogue | claim a contiguous output range with a DSMEM atomic on rank 0's output cursor | `atom.shared::cluster.add.u32` between two `cluster.sync()` edges; the claimed base is broadcast to the CTA through shared memory. Rank 0 keeps base 0. |
+| **All three wrappers**, all 32 warps, writeback | strided store of this CTA's slice of the result, guarded `offs < TopK` | plain re-gathers each value from global; page_table maps the index through the table; ragged adds the row's offset. |
+
+There is no producer/consumer split, no warp specialization, no pipe, no
+mbarrier, and no asynchronous copy anywhere in this family. Every warp runs the
+same program and the roles above are lane predicates. The only asynchrony is the
+**split cluster barrier** -- an `arrive` issued before a classification loop and
+the matching `wait` issued at the top of the next round -- which exists so peers
+may finish reading a histogram bank before it is cleared (`:218-225`, `:248`).
+The candidate and overflow loops stride by `1024`, not by `1024 * NC`: each CTA
+owns its own candidate slice and the cluster does **not** re-partition after the
+first pass.
+
+## Primitive vocabulary
+
+```python
+copy_g2r(reg, gmem)               # ld.global.nc.b32 | ld.global.nc.b16 on the
+                                  #   READ-ONLY inputs -- logits, page_table,
+                                  #   offsets, seq_lens -- which are __restrict__
+                                  #   (:82), unlike stable_sort and like the
+                                  #   filtered unified kernel.  ONE EXCEPTION:
+                                  #   cached_overflow is written by this kernel,
+                                  #   so reads of the ring are plain ld.global.b32
+copy_g2r_v(dst, gmem, n)          # ld.global.nc.v4.b32 (f32, 16 B) |
+                                  #   ld.global.nc.v2.b32 (16-bit, 8 B); vec_t<T,4>
+                                  #   (:228-233), one issue, VEC_SIZE = 4 lanes
+copy_r2g(gmem, reg)               # st.global.b32 | st.global.b64 (i64 indices) |
+                                  #   st.global.b16 (16-bit values)
+copy_s2r(reg, smem) / copy_r2s    # ld.shared.b32 / st.shared.b32, always T.ptx,
+                                  #   through the [base+imm] form when the
+                                  #   target is `shared_hist` or a tail scalar,
+                                  #   and at displacement 0 for the runtime-
+                                  #   indexed `topk_inds` / `cached_*` -- see
+                                  #   the addressing note below
+atomic_add_shared(smem, v)        # atom.shared.add.u32, returns old (:178, :194, ...)
+to_ordered(x)                     # RadixTopKTraits::ToOrdered, the XOR form
+                                  #   (topk_common.cuh:35-39); already ported as
+                                  #   topk_radix.to_ordered_u32/u16
+digit(bits, shift)                # shift then mask -- but the emitted form
+                                  #   depends on the CALL SITE and on the shift
+                                  #   VALUE, not on the dtype alone.  There are
+                                  #   three sites (histogram seed, classify,
+                                  #   next-bank seed) and they lower differently;
+                                  #   each is annotated where it is called.
+                                  #   The CLASSIFY site emits nothing when its
+                                  #   shift is 0 (nvcc narrows the candidate load
+                                  #   to b8 and compares the byte directly).  The
+                                  #   two HISTOGRAM-BUMP sites always emit the
+                                  #   x4 bin-to-byte scaling, even at shift 0 --
+                                  #   but not always a mask.  `and.b32 1020`
+                                  #   accompanies it everywhere EXCEPT 16-bit
+                                  #   :178, where `mul.wide.u16 ..., 4` consumes
+                                  #   the u16 left by `shr.u16 8` at :177, which
+                                  #   is already <= 255, so the x4 product cannot
+                                  #   exceed 1020 and no mask is needed.
+                                  #   NEVER bfe on SM >= 70
+warp_suffix_scan_step(v, d)       # ONE shfl.sync.down.b32, mask -1, clamp 31.
+                                  #   The caller supplies the explicit d-loop and
+                                  #   the `lane < width - d` guard (:24-28), so
+                                  #   the 32-wide instance is five steps and the
+                                  #   8-wide instance is three.  A SUFFIX scan,
+                                  #   hence .down (:21-31), which is why the
+                                  #   total lands in lane 0
+barrier()                         # bar.sync 0
+warp_barrier()                    # bar.warp.sync, once inside cum_sum (:48)
+map_peer(smem, rank)              # cvta_generic_to_shared + mapa.shared::cluster.u32
+                                  #   -- produces an address, moves nothing
+                                  #   (:129, :309, :391).  SPELLING: the port
+                                  #   emits the 32-bit shared-window form, which
+                                  #   is the form this repo can construct; the
+                                  #   reference emits the 64-bit generic form
+                                  #   in the OPPOSITE order: mapa.u64 first
+                                  #   (generic -> peer generic), then
+                                  #   cvta.to.shared::cluster.u64 (generic ->
+                                  #   cluster window).  Verified def-use over
+                                  #   the whole export: all 468 cvta consume a
+                                  #   preceding mapa result, 0 exceptions.
+                                  #   Both name the same byte -- one carries the
+                                  #   peer address in the shared window, the
+                                  #   other in the generic window.  The reference
+                                  #   spelling appears below only as PTX evidence
+copy_peer_s2r(reg, peer)          # ld.shared::cluster.b32 -- see below
+atomic_add_peer(peer, v)          # atom.shared::cluster.add.u32, returns old
+cluster_arrive() / cluster_wait() # barrier.cluster.arrive / .wait, the SPLIT form
+cluster_sync()                    # barrier.cluster.arrive + .wait, the FUSED form
+```
+
+There is deliberately no compound `radix_select`, `histogram`, `threshold`,
+`refine`, `cluster_reduce`, `ration_ties`, tile-copy, or tile-compute primitive.
+`threshold(...)` appears in the body as a named region for readability, but every
+COPY, COMPUTE and SYNC operation inside it is drawn from the list above and is
+written out in full at its first use. Plain scalar arithmetic (`add`, `sub`,
+`min`, `max`), register declarations (`reg`), compile-time loops (`unroll`) and
+the structural views (`ring`, `phase_half`) are ordinary Python and carry no
+`instruction_selection` -- they are the incidental plumbing the reviewer bound
+excludes.
+
+### Peer shared memory is a different address space
+
+`map_peer` is a separate primitive from the access that follows it, and the two
+must agree. `mapa` returns an address in `shared::cluster`; reaching it with an
+own-CTA `ld.shared.b32` is an **illegal instruction**, not a wrong value -- an
+asynchronous trap with no attribution to the offending access. The reference's
+own export pairs them correctly and never mixes them:
+
+The `PTX in the export` column is the **reference's** spelling, and its order is
+`mapa.u64` -> `cvta.to.shared::cluster.u64` -> `ld.shared::cluster.b32` /
+`atom.shared::cluster.add.u32`. The port emits the two address steps in the
+opposite order -- `cvta_generic_to_shared` then `mapa.shared::cluster.u32`, the
+32-bit shared-window form, which is what this repo can construct -- for the same
+peer byte. The load and atomic opcodes are identical on both sides; only the
+address-forming pair, and its order, differ.
+
+| operation | source | PTX in the reference export |
+| --- | --- | --- |
+| peer histogram read | `map_shared_rank(&hist[hist_idx * 256 + tid], r)[0]` (`:129-130`) -- the PING-PONG bank, not bank 2 | `mapa.u64` -> `cvta.to.shared::cluster.u64` -> `ld.shared::cluster.b32` |
+| tie rationing | `atomicAdd(map_shared_rank(s_k_remaining_counter, 0), 1)` (`:309`, `:360`) | `mapa.u64` -> `cvta.to.shared::cluster.u64` -> `atom.shared::cluster.add.u32`. The mapa is CSE'd *within* each tie loop across its unrolled copies, and across the *two* tie sites only at f32 -- f32 NC=1 is 1 mapa / 2 atomics, 16-bit NC=1 is 2 mapa / 10 atomics -- so the atomics always outnumber it |
+| output range claim | `atomicAdd(map_shared_rank(shared_final_idx_count, 0), n)` (`:391`) | `mapa.u64` -> `cvta.to.shared::cluster.u64` -> `atom.shared::cluster.add.u32`, with a REGISTER value operand (`topk_num`), unlike the tie sites' immediate `1` |
+
+The atomics are safe by construction because the space is part of the opcode
+name; only the load can be spelled wrongly, and `.porting/fast_topk_clusters/probe_findings.md`
+records that trap being reproduced and fixed before any kernel code existed.
+
+### Shared accesses carry the carve offset in the addressing mode
+
+The reference holds one base per carve block and lets the offset ride in the
+instruction:
+
+```
+st.shared.b32        [%r+1024], %r;      # hist bank 1
+atom.shared.add.u32  %r, [%r+3072], 1;   # final_idx_count
+ld.global.nc.b32     %r, [%rd+-114688];  # the global side does it too
+```
+
+`copy_s2r` / `copy_r2s` / `atomic_add_shared` mean that form wherever the target
+sits at a constant offset within an already-materialized block base -- the
+`shared_hist` banks and the tail scalars. `topk_inds[slot]` and `cached_*[slot]`
+get their own base plus a runtime element index, so the reference leaves them at
+displacement 0 and the port follows.
+
+`T.ptx.addr(base, byte_offset)` reaches this form: it builds `[base+byte_offset]`
+for any operand slot declared `kind="addr"` with `allow_imm_offset=True`, which is
+how `atom`, `ld` and `st` declare their address operand. `byte_offset` is a byte
+displacement, not an element index, and cannot be nested.
+
+The reference's IMMEDIATE INCREMENT is not reachable: it writes
+`atom.shared.add.u32 %r, [%r+3072], 1`, but `atom`'s `value` is a plain register
+slot with no `kind="imm"`, so the port emits `..., %r`. Opcode and count match;
+only that operand differs, and it is not a port error.
+
+Measured displacement sets, per-entry access counts, the mode/index spread and
+the two mechanisms behind it are in
+`.porting/fast_topk_clusters/probe_findings.md`, re-derivable with
+`check_sketch_counts.py`. They are evidence for this rule, not part of the
+design.
+
+### The tie-rationing atomic is not guarded by cluster width
+
+`atom.shared::cluster.add.u32` appears **twice** in the f32 `NClusters == 1`
+export (and **ten** times in the 16-bit one), even though those entries have zero
+cluster barriers and zero peer loads. The mapping is CSE'd rather than paired
+1:1 with the atomics: f32 `NC = 1` is 2 atomics behind **1** `mapa`, and f16
+`NC = 1` is 10 atomics behind **2**. The address is CSE'd *within* each tie loop
+across its unrolled copies; it is additionally CSE'd *across* the two tie sites
+only at f32. That is exactly why the 16-bit entry shows two -- one feeding the
+five shared-cache-loop atomics (`:309`) and one feeding the five overflow-loop
+atomics (`:360`). The histogram peer-sum (`:121-131`) and the epilogue range claim
+(`:379-399`) are both inside `if (NClusters > 1)`; the two tie sites (`:309`,
+`:360`) are not -- they call `map_shared_rank(..., 0)` unconditionally, which at
+one CTA per cluster maps to the CTA itself. A port that hoists all DSMEM behind
+`NC > 1` diverges from the reference on every single-cluster shape, which is the
+whole large-batch and short-row half of the matrix.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+@specialize(
+    DTYPE=("f32", "f16", "bf16"),          # ROUNDS = sizeof(T), LSHIFT_START = 8*sizeof(T)-8
+    MODE=("plain", "page_table", "ragged"),
+    IDX=("i32", "i64"),                    # i64 only reachable when MODE == "plain"
+    NC=(1, 2, 4, 8),                       # NClusters, a template parameter (:598-605)
+    TOPK="positive compile-time integer",
+    NUM_CACHED="positive compile-time integer",
+    TARGET="sm_100a",
+)
+# instruction_selection: none; extent: 48 compile-time instantiations
+@launch(
+    grid=(batch * NC, 1, 1),               # :615
+    block=(1024, 1, 1),                    # :571, __launch_bounds__(1024)
+    cluster=((NC, 1, 1) if NC > 1 else None),   # :408, :563-565
+    dynamic_smem_bytes=16 * NUM_CACHED + 4 * TOPK + 3124,   # :579-582
+)
+# instruction_selection: none; extent: static launch metadata.  Codegen emits no
+#   __cluster_dims__; the cluster dimension reaches the driver as
+#   CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION, exactly as the source's own
+#   cudaLaunchKernelExC does (:563-576).  The source's explicit
+#   cudaFuncAttributeMaxDynamicSharedMemorySize / carveout calls (:557-558) have
+#   no counterpart: the runtime opts in past 48 KB on its own.
+def fast_topk_clusters(
+    logits,           # DTYPE [batch, seq_len], __restrict__, row stride logit_stride
+    output_indices,   # IDX   [batch, TOPK],  row stride indices_stride
+    output_values,    # DTYPE [batch, TOPK] or None -- MODE == "plain" only
+    seq_lens,         # i32   [batch]        -- MODE != "plain" only
+    page_table,       # i32   [batch, pt_stride]  -- MODE == "page_table" only
+    offsets,          # i32   [batch]        -- MODE == "ragged" only
+    cached_overflow,  # i32   [batch, 4 * overflow_stride * NC], scratch, uninitialized
+    overflow_stride: i32, logit_stride: i32, indices_stride: i32,
+    pt_stride: i32, seq_len_scalar: i32,
+):
+    tid  = thread_id(extent=1024)          # instruction_selection: mov.u32 %tid.x
+    cta  = cta_id(axis="x", extent=batch * NC)   # instruction_selection: mov.u32 %ctaid.x
+    rank = cta_id_in_cluster(extent=NC)
+    # instruction_selection: mov.u32 %cluster_ctarank; extent: one scalar.
+    #   MUST stay live even at NC == 1 and even where the value folds: the
+    #   resolved launch params carry the cluster dimension only when the body
+    #   binds the scope.
+    row  = cta // NC                       # :414, cluster_id
+    warp, lane = tid >> 5, tid & 31
+
+    logit_base = row * logit_stride        # :415
+    ind_base   = row * indices_stride      # :416
+    seq_len    = seq_len_scalar if MODE == "plain" else copy_g2r(seq_lens[row])
+    # instruction_selection: ld.global.nc.b32 on the transform modes only
+    #   (:466, :509); extent: one scalar per CTA
+    if MODE == "ragged":
+        ragged_offset = copy_g2r(offsets[row])
+        # instruction_selection: ld.global.nc.b32; extent: ONE scalar per CTA.
+        #   Hoisted above the trivial branch exactly as the source does (:510),
+        #   and reused by both the trivial branch and the writeback -- neither
+        #   re-loads it, so this is not a per-slot or per-result read.
+
+    # =======================================================================
+    # Trivial branch (:417-429 / :467-476 / :511-520)
+    # =======================================================================
+    # Distributed across the cluster, and the only positionally deterministic
+    # output in the family.  Note it does NOT wait on PDL -- the wait lives
+    # inside the worker at :156 -- which is one reason PDL is out of scope.
+    if seq_len <= TOPK:
+        for i in range(tid + (cta % NC) * 1024, TOPK, 1024 * NC):
+            if i < seq_len:
+                if MODE == "plain":
+                    out = i
+                elif MODE == "page_table":
+                    out = copy_g2r(page_table[row * pt_stride + i])
+                    # instruction_selection: ld.global.nc.b32; extent: one per slot
+                else:
+                    out = i + ragged_offset      # hoisted at CTA entry (:510)
+                copy_r2g(output_indices[ind_base + i], out)
+                # instruction_selection: st.global.b32 | st.global.b64 by IDX;
+                #   extent: one per in-range slot
+                if MODE == "plain" and output_values is not None:
+                    copy_r2g(output_values[ind_base + i], copy_g2r(logits[logit_base + i]))
+                    # instruction_selection: ld.global.nc.{b32,b16} then
+                    #   st.global.{b32,b16}; extent: one pair per in-range slot
+            else:
+                copy_r2g(output_indices[ind_base + i], -1)
+                # instruction_selection: st.global.b32 | st.global.b64; extent:
+                #   one per pad slot.  NOTE output_values is left UNTOUCHED over
+                #   the pad region (:425-427) -- the port must not zero it.
+        return
+
+    # =======================================================================
+    # Shared carve, in source declaration order (:95-106)
+    # =======================================================================
+    smem           = raw_shared(16 * NUM_CACHED + 4 * TOPK + 3124, align=128)
+    cached_bits    = view(smem, "u32", 0,                       2 * NUM_CACHED)
+    cached_indices = view(smem, "i32", 8 * NUM_CACHED,          2 * NUM_CACHED)
+    topk_inds      = view(smem, "i32", 16 * NUM_CACHED,         TOPK)
+    hist           = view(smem, "i32", 16 * NUM_CACHED + 4*TOPK, 3 * 256)
+    final_count    = view(smem, "i32", ..., 1)   # output cursor; rank 0's copy is
+                                                 #   also the cluster's range allocator
+    num_cached_cnt = view(smem, "i32", ..., 2)   # one cursor per phase
+    threshold_bin  = view(smem, "i32", ..., 1)
+    cum_reduce_buf = view(smem, "i32", ..., 8)   # one slot per warp
+    k_rem_counter  = view(smem, "i32", ..., 1)   # rank 0's copy rations the ties
+    # instruction_selection: none; extent: dynamic shared layout.
+    #   cached_bits/cached_indices are DOUBLE-BUFFERED: half `ph`, half `ph^1`.
+    #   hist has THREE banks: 0/1 ping-pong per round; bank 2 receives this
+    #   CTA's cluster-wide cumsum and is read ONLY LOCALLY (written
+    #   :132 on the cluster path and :136 on the single-CTA path,
+    #   read :142 / :151).  Note :149 reads `shared_threshold_bin`
+    #   at +3084, not bank 2.
+    #   The bank peers read is the PING-PONG bank `hist_idx`, republished with
+    #   the local cumsum at :122 just before the cluster.sync at :124 --
+    #   `map_shared_rank(&shared_hist[hist_idx * 256 + threadIdx.x], ...)` at
+    #   :129-130.  Bank 2 is not even written until AFTER the peer reads, so
+    #   mapping the peer read onto it would read uninitialized memory.
+
+    # This CTA's slice of the global overflow ring (:433).  Per CTA, not per
+    # cluster: 4*overflow_stride ints = 2 phases x overflow_stride {bits,index}
+    # pairs.  The header comment at :71-74 describes a struct-of-arrays layout;
+    # the code implements array-of-structs and the code is authoritative.
+    ring_base = cta * overflow_stride * 4
+    ring = lambda ph: ring_base + ph * overflow_stride * 2
+
+    # =======================================================================
+    # Phase 0: seed the histogram (:158-180)
+    # =======================================================================
+    if tid < 256:
+        copy_r2s(hist[tid], 0)
+        copy_r2s(hist[256 + tid], 0)
+        # instruction_selection: st.shared.b32; extent: two per radix lane
+    if tid == 0:
+        copy_r2s(final_count, 0)
+        copy_r2s(k_rem_counter, 0)
+        copy_r2s(num_cached_cnt[0], 0)
+        # instruction_selection: st.shared.b32; extent: three scalars.
+        #   HAZARD: threshold_bin is deliberately NOT initialized here, matching
+        #   :166-170 exactly.  A round in which no lane satisfies the crossing
+        #   test reads the previous round's value.  Reproduce, do not repair.
+    barrier()
+    # instruction_selection: bar.sync 0; extent: CTA-wide
+
+    for i in range(tid + rank * 1024, seq_len, 1024 * NC):
+        x = copy_g2r(logits[logit_base + i])
+        # instruction_selection: ld.global.nc.b32 (f32) | ld.global.nc.b16
+        #   (16-bit); extent: one scalar per iteration.  SCALAR, not vectorized:
+        #   the source's first pass is a plain strided read (:173-179) and only
+        #   the classification pass uses vec_t.  The row is therefore read from
+        #   global TWICE in total.
+        atomic_add_shared(hist[digit(to_ordered(x), LSHIFT_START)], 1)
+        # instruction_selection: atom.shared.add.u32; extent: one per element.
+        #   The digit extraction HERE is not the classify form: the x4 int
+        #   scaling of the bin index folds into it, so f32 emits
+        #   `shr.u32 22` + `and.b32 1020` (:178) -- a mask IS present, and the
+        #   immediate is 1020, not 0xff -- and 16-bit emits `shr.u16 8`
+        #   followed by `mul.wide.u16 ..., 4`, with no `cvt.u32.u16` at all.
+```
+
+```python
+    # =======================================================================
+    # threshold(bank, k_rem, sum_across_cluster) -- called once per round (:116-154)
+    # =======================================================================
+    # Written out here at first use.  It carries every peer read in the kernel.
+    def threshold(bank, k_rem, sum_across_cluster=True):
+        barrier()
+        # instruction_selection: bar.sync 0; extent: one per call
+
+        # --- 256-bin suffix cumsum, 8 warps x 32 bins (cum_sum, :33-58) -----
+        v = reg(0)                     # meaningful only for tid < 256
+        if tid < 256:                  # :38 -- warps 8..31 do NOT scan at all
+            v = copy_s2r(hist[bank * 256 + tid])
+            # instruction_selection: ld.shared.b32; extent: one per radix lane
+            for d in (1, 2, 4, 8, 16):
+                p = warp_suffix_scan_step(v, d)
+                # instruction_selection: shfl.sync.down.b32, mask -1, clamp 31;
+                #   extent: five steps at THIS site, and only for warps 0..7.
+                #   A threshold() call issues 8 shuffles in total -- these 5
+                #   plus the 3 of the warp-0 scan below -- not 8 here and not
+                #   8 per warp.  .down
+                #   because this is a SUFFIX scan: the count of everything at
+                #   or above a bin (:26).
+                if lane < 32 - d:
+                    v = add(v, p)
+            if lane == 0:
+                copy_r2s(cum_reduce_buf[warp], v)
+                # instruction_selection: st.shared.b32; extent: one per warp.
+                #   LANE 0, not lane 31: a .down (suffix) scan accumulates
+                #   toward the low lanes, so the warp's total over its 32 bins
+                #   lands in lane 0.  Lane 31 holds only bin 255's own count.
+        barrier()
+        if warp == 0:
+            w = copy_s2r(cum_reduce_buf[lane]) if lane < 8 else 0
+            # instruction_selection: ld.shared.b32; extent: one per lane of warp 0
+            for d in (1, 2, 4):
+                p = warp_suffix_scan_step(w, d)
+                # instruction_selection: shfl.sync.down.b32; extent: three steps
+                if lane < 8 - d:
+                    w = add(w, p)
+            warp_barrier()
+            # instruction_selection: bar.warp.sync; extent: one per call, and
+            #   only for warp 0 (:48).  It orders the 3-step scan's shuffles
+            #   against the write-back into the SAME buffer, so it must sit
+            #   between them -- moving it after the store would leave the
+            #   buffer it exists to protect unprotected.
+            if lane < 8:
+                copy_r2s(cum_reduce_buf[lane], w)
+                # instruction_selection: st.shared.b32; extent: one per valid
+                #   slot (:49-51).  The guard is load-bearing, not cosmetic:
+                #   cum_reduce_buf is 8 ints at +3088 and k_remaining_counter is
+                #   at +3120, both measured from `shared_hist` (pool-relative
+                #   they are 16*nc + 4*TopK + 3088 / + 3120).  The 32 B between
+                #   them is what matters: an unguarded 32-lane store writes
+                #   128 B where 32 B are allocated, running 96 B past the buffer
+                #   and over k_remaining_counter.
+        barrier()
+        if warp < 7:
+            v = add(v, copy_s2r(cum_reduce_buf[warp + 1]))
+            # instruction_selection: ld.shared.b32 + add.s32; extent: one per
+            #   lane of warps 0..6 (:54-56)
+
+        # --- cluster-wide sum of the same bin (:120-138) --------------------
+        if NC > 1 and sum_across_cluster:
+            if tid < 256:
+                copy_r2s(hist[bank * 256 + tid], v)
+                # instruction_selection: st.shared.b32; extent: one per radix
+                #   lane.  This IS the DSMEM publication -- peers read this bank.
+            cluster_sync()
+            # instruction_selection: barrier.cluster.arrive + barrier.cluster.wait;
+            #   extent: one per CTA.  Separates publication from every peer read.
+            if tid < 256:
+                for c in unroll(NC - 1):                       # #pragma unroll (:127)
+                    src = map_peer(hist[bank * 256 + tid], (c + rank + 1) % NC)
+                    # instruction_selection: cvta_generic_to_shared then
+                    #   mapa.shared::cluster.u32; extent: NC-1 per radix lane.
+                    #   The reference builds the same peer byte with the two
+                    #   steps in the REVERSE order -- mapa.u64 then
+                    #   cvta.to.shared::cluster.u64 -- because it maps a generic
+                    #   pointer and then narrows, while the port narrows to the
+                    #   shared window first and then maps.  The rank rotation
+                    #   is not addressing detail: it staggers which peer each CTA
+                    #   hits at each unrolled step.
+                    v = add(v, copy_peer_s2r(src))
+                    # instruction_selection: ld.shared::cluster.b32; extent:
+                    #   NC-1 per radix lane
+                copy_r2s(hist[2 * 256 + tid], v)
+                # instruction_selection: st.shared.b32; extent: one per radix lane
+        else:
+            if tid < 256:
+                copy_r2s(hist[2 * 256 + tid], v)
+                # instruction_selection: st.shared.b32; extent: one per radix lane
+        barrier()
+
+        # --- pick the crossing bin (:142-152) -------------------------------
+        nxt = copy_s2r(hist[2 * 256 + tid + 1]) if tid < 255 else 0
+        # instruction_selection: ld.shared.b32; extent: one per radix lane
+        if tid < 256 and v > k_rem and nxt <= k_rem:
+            copy_r2s(threshold_bin, tid)
+            # instruction_selection: st.shared.b32; extent: at most one lane.
+            #   INVARIANT: exactly one lane satisfies this on a well-formed
+            #   histogram; zero lanes on a degenerate one, which is what makes
+            #   the uninitialized threshold_bin observable.
+        barrier()
+        bin_ = copy_s2r(threshold_bin)
+        # instruction_selection: ld.shared.b32; extent: one per call.  Reads a
+        #   location that is never zeroed between rounds (see the hazard note).
+        if bin_ < 255:
+            k_rem = sub(k_rem, copy_s2r(hist[2 * 256 + bin_ + 1]))
+            # instruction_selection: ld.shared.b32 + sub.s32; extent: one scalar
+        return bin_, k_rem
+
+    # =======================================================================
+    # classify(...) -- the three-way split, shared by every round (:189-217)
+    # =======================================================================
+    def classify(bits, index, bin_, phase, shift, last_round):
+        d = digit(bits, shift)
+        # instruction_selection: varies by SITE and by SHIFT VALUE; extent:
+        #   one per element.  This annotation covers the CLASSIFY site only
+        #   (:191, :276, :328); the two histogram-bump sites are different and
+        #   are annotated at their own call sites.
+        #     f32 :191 (shift == LSHIFT_START == 24)  `shr.u32` alone
+        #     f32 :276/:328, rounds t = 1,2           `shr.u32` + `and.b32 255`
+        #     f32 :276/:328, round  t = 3             NOTHING
+        #     16-bit :191 (shift == 8)                `shr.u16` + `cvt.u32.u16`
+        #     16-bit :276/:328, its only round        NOTHING
+        #   The empty cases are SHIFT-driven, not dtype-driven: whenever
+        #   `shift == 0` the whole extraction disappears because nvcc narrows
+        #   the candidate load to `b8` and compares that byte directly.  f32
+        #   reaches shift 0 on its last of three refinement rounds and 16-bit on
+        #   its only one, which is why `.loc 1 276` carries `shr.u32` x2 rather
+        #   than x3 in the f32 export.  Never `bfe` on SM >= 70 (absent in all
+        #   48 entries).
+        if d > bin_:
+            slot = atomic_add_shared(final_count, 1)
+            # instruction_selection: atom.shared.add.u32; extent: one per survivor
+            copy_r2s(topk_inds[slot], index)
+            # instruction_selection: st.shared.b32; extent: one per survivor.
+            #   HAZARD: unguarded.  The source's `if (topk_offset < TopK)` is
+            #   commented out at :195-197.  Reproduce, do not repair -- the
+            #   writeback's `offs < TOPK` guard is what bounds the global store.
+        elif d == bin_ and not last_round:
+            slot = atomic_add_shared(num_cached_cnt[phase], 1)
+            # instruction_selection: atom.shared.add.u32; extent: one per tie
+            if slot < NUM_CACHED:
+                copy_r2s(phase_half(cached_indices, phase)[slot], index)
+                copy_r2s(phase_half(cached_bits,    phase)[slot], bits)
+                # instruction_selection: st.shared.b32 x2; extent: one pair.
+                #   `bits` is held in a 16-BIT register end to end for the
+                #   16-bit dtypes -- `to_ordered` leaves it in %rs, and it stays
+                #   there.  `cvt.u32.u16` appears at three independent sites,
+                #   9 issues each in the f16 NC=1 export, because three separate
+                #   consumers each widen the SAME u16 register:
+                #     :191  the bin extraction shifts in 16 bits (`shr.u16`) and
+                #           widens the EXTRACTED BIN afterwards
+                #     :205  this shared store widens the unshifted value
+                #     :211  the ring spill widens it again, independently
+                #   The port must NOT widen `bits` once up front: doing so makes
+                #   it a u32 register and collapses all three sites to one.
+            elif slot - NUM_CACHED < overflow_stride:
+                copy_r2g(ring(phase)[slot - NUM_CACHED].bits,  bits)
+                copy_r2g(ring(phase)[slot - NUM_CACHED].index, index)
+                # instruction_selection: st.global.b32 x2; extent: one pair.
+                #   The spill is the only global write before the epilogue.
+            else:
+                return          # ring full: candidate silently dropped (:210-214)
+            atomic_add_shared(hist[(phase ^ 1) * 256 + digit(bits, shift - 8)], 1)
+            # instruction_selection: atom.shared.add.u32; extent: one per cached
+            #   tie -- seeds the NEXT round's bank while this round classifies.
+            #   The extraction again folds the x4 bin-to-byte scaling, and
+            #   this ONE sketch line is reached from pass 1 and from both
+            #   refinement rounds, so at f32 it lowers three different ways:
+            #     f32 pass 1 (:206/:213), shift-8 == 16   `shr.u32 14` + `and.b32 1020`
+            #     f32 t = 1  (:289/:296/:341/:347), == 8  `shr.u32 6`  + `and.b32 1020`
+            #     f32 t = 2  (same locs),           == 0  `shl.b32 2`  + `and.b32 1020`
+            #     16-bit pass 1 (:206/:213)              `mul.wide.u16 ...,4` + `and.b32 1020`
+            #   Note the t = 2 case: shift 0 does NOT make this site vanish the
+            #   way it does at classify -- the x4 scaling still has to happen, so
+            #   the shift becomes a left shift.  At 16 bits pass 1 is the ONLY
+            #   reachable instance: the single refinement round is also the final
+            #   round, so `t < NRemainingRounds` is dead and the bump never runs.
+            #   The 16-bit widening here is `mul.wide.u16`, not `cvt.u32.u16`.
+        elif d == bin_ and last_round:
+            ration(index)
+
+    # =======================================================================
+    # ration(...) -- final-round tie arbitration (:300-319, dup :351-370)
+    # =======================================================================
+    # `exceeded` is declared INSIDE the refinement-round body (:268), so it
+    # resets at the top of every round and is shared between that round's shared
+    # -cache loop (:306) and its overflow loop (:357).  Only the final round
+    # reaches ration() today, which makes the lifetime unobservable -- but it is
+    # the round's scalar state, and the port must scope it that way.
+    def ration(index):
+        if k_rem > 0 and not exceeded:
+            got = atomic_add_peer(map_peer(k_rem_counter, 0), 1)
+            # instruction_selection: cvta_generic_to_shared + mapa.shared::cluster.u32,
+            #   then atom.shared::cluster.add.u32; extent: one per tie candidate until
+            #   the thread latches out.  NOT guarded by NC > 1 -- at one CTA per
+            #   cluster rank 0 is this CTA, and the reference's NC == 1 export
+            #   still carries this opcode.
+            if got < k_rem:
+                slot = atomic_add_shared(final_count, 1)
+                # instruction_selection: atom.shared.add.u32; extent: one per winner
+                copy_r2s(topk_inds[slot], index)
+                # instruction_selection: st.shared.b32; extent: one per winner
+            else:
+                exceeded = True
+    # INVARIANT: every candidate reaching ration() is bit-equal in the final
+    # byte, so the winners are arbitrary and vary run to run, while the selected
+    # VALUE multiset does not.  This is why the correctness gate compares
+    # multisets and never positions.
+
+    # =======================================================================
+    # Pass 1: first classification (:186-239)
+    # =======================================================================
+    k_rem = TOPK
+    bin0, k_rem = threshold(bank=0, k_rem=k_rem, sum_across_cluster=True)
+
+    if NC > 1:
+        cluster_arrive()
+        # instruction_selection: barrier.cluster.arrive; extent: one per CTA.
+        #   SPLIT BARRIER: the matching wait is the first statement of round 1.
+        #   The arrive straddles the whole classification loop and says "I am
+        #   done reading peers' bank 0"; the wait says "everyone is done, bank
+        #   may be cleared" (:218-225, :248).  Without it a peer clears bank 0
+        #   while this CTA still reads it (:219-224).
+
+    # PASS 1 IS THE `phase == 0` PRODUCER.  `classify(phase=p)` writes cursor
+    # `num_cached_cnt[p]`, candidate half `p`, ring `p`, and seeds histogram bank
+    # `p ^ 1`.  The source's pass 1 (:200-215) writes count[0], half 0, ring(0)
+    # and seeds bank 1, so `p = 0`.  Round `t = 1` then consumes `phase ^ 1 = 0`
+    # -- exactly what pass 1 produced -- and thresholds bank `phase = 1`, which
+    # pass 1 seeded.  Passing `phase=1` here would invert all four destinations
+    # and leave round 1 thresholding an all-zero bank over an empty half.
+    base = rank * 1024 + tid
+    for i in range(base * 4, (seq_len // 4) * 4, NC * 1024 * 4):
+        v4 = copy_g2r_v(logits[logit_base + i], n=4)
+        # instruction_selection: ld.global.nc.v4.b32 (f32) | ld.global.nc.v2.b32
+        #   (16-bit); extent: one vector per iteration
+        for j in unroll(4):
+            classify(to_ordered(v4[j]), i + j, bin0, phase=0, shift=LSHIFT_START,
+                     last_round=False)
+    for i in range((seq_len // 4) * 4 + base, seq_len, NC * 1024):
+        classify(to_ordered(copy_g2r(logits[logit_base + i])), i, bin0,
+                 phase=0, shift=LSHIFT_START, last_round=False)
+        # instruction_selection: ld.global.nc.{b32,b16}; extent: one per tail element
+
+    # =======================================================================
+    # Refinement rounds t = 1 .. sizeof(T)-1 (:241-373), fully unrolled
+    # =======================================================================
+    for t in unroll(range(1, ROUNDS)):                        # #pragma unroll (:241)
+        phase = t % 2
+        exceeded = reg(False)          # :268 -- per round, per thread; latches
+                                       #   once this thread loses a tie race
+        if NC > 1:
+            cluster_wait()
+            # instruction_selection: barrier.cluster.wait; extent: one per CTA.
+            #   Pairs with the arrive issued before the previous classification.
+        if tid < 256:
+            copy_r2s(hist[(phase ^ 1) * 256 + tid], 0)
+            # instruction_selection: st.shared.b32; extent: one per radix lane
+        if tid == 0:
+            copy_r2s(num_cached_cnt[phase], 0)
+            # instruction_selection: st.shared.b32; extent: one scalar, thread 0
+            #   only (:256)
+
+        bin_t, k_rem = threshold(bank=phase, k_rem=k_rem, sum_across_cluster=True)
+
+        if NC > 1 and t < ROUNDS - 1:
+            cluster_arrive()
+            # instruction_selection: barrier.cluster.arrive; extent: one per CTA.
+            #   Skipped on the final round: no further threshold() means no
+            #   further peer read of this bank (:260-263).
+
+        raw   = copy_s2r(num_cached_cnt[phase ^ 1])
+        # instruction_selection: ld.shared.b32; extent: one scalar per thread,
+        #   once per round (:265)
+        n_sh  = min(NUM_CACHED, raw)                          # :266
+        n_gl  = min(overflow_stride, max(0, raw - NUM_CACHED))  # :267
+        shift = LSHIFT_START - t * 8
+        last  = (t == ROUNDS - 1)
+
+        # Stride 1024, NOT 1024*NC: each CTA owns its own candidate slice and the
+        # cluster does not re-partition here (:271-273).
+        for i in range(tid, n_sh, 1024):
+            b  = copy_s2r(phase_half(cached_bits,    phase ^ 1)[i])
+            ix = copy_s2r(phase_half(cached_indices, phase ^ 1)[i])
+            # instruction_selection: ld.shared.b32 x2; extent: one pair per
+            #   candidate.  The f32 export shows `ld.shared.b32` x2 +
+            #   `ld.shared.b8` x1 at `.loc 1 274` (at 16 bits that loc is
+            #   `ld.shared.b8` x5 and no b32, since its only round has
+            #   shift 0): on the final round only the low byte of
+            #   `bits` is read, so nvcc narrows that load while the index load
+            #   stays b32.  That narrowing is a benign compiler consequence of
+            #   `shift == 0`, not a selection the port must reproduce -- the
+            #   port emits the uniform b32 form.
+            classify(b, ix, bin_t, phase, shift, last)
+        for i in range(tid, n_gl, 1024):
+            b  = copy_g2r(ring(phase ^ 1)[i].bits)
+            ix = copy_g2r(ring(phase ^ 1)[i].index)
+            # instruction_selection: ld.global.b32 x2 -- NO `.nc`; extent: one
+            #   pair per spill.  The ring is written by this same kernel, so
+            #   despite `__restrict__` the read is coherent: `.loc 1 325` carries
+            #   zero `ld.global.nc.*` in every entry.  Two separate scalar loads,
+            #   never a `v2` pair.
+            #   Static shape at that loc, per dtype:
+            #     f32     `ld.global.b32` x5 + `ld.global.b8` x1
+            #     16-bit  `ld.global.b32` x5 + `ld.global.b8` x5
+            #   The b8 is the shift-0 (final-round) narrowing of `bits`, which is
+            #   why f32 has one (only t = 3 is final) and 16-bit has five (its
+            #   only round is the final one).  That narrowing is a benign
+            #   compiler consequence, NOT a selection the port reproduces -- the
+            #   port emits the uniform b32 pair, exactly as at the shared twin.
+            classify(b, ix, bin_t, phase, shift, last)
+
+    # =======================================================================
+    # Epilogue: cluster-wide output range (:374-404)
+    # =======================================================================
+    barrier()
+    # instruction_selection: bar.sync 0; extent: CTA-wide, final_count settled
+    if NC > 1:
+        my_num, my_start = copy_s2r(final_count), 0
+        # instruction_selection: ld.shared.b32; extent: one scalar per thread
+        #   (:381).  Load-bearing for the ordering argument below: it must
+        #   complete before rank 0's cursor starts absorbing peer counts.
+        cluster_sync()
+        # instruction_selection: barrier.cluster.arrive + barrier.cluster.wait;
+        #   extent: one per CTA.  Every CTA must read its OWN count before rank
+        #   0's cursor starts absorbing peers' contributions (:386).
+        if rank > 0:
+            if tid == 0:
+                my_start = atomic_add_peer(map_peer(final_count, 0), my_num)
+                # instruction_selection: cvta_generic_to_shared +
+                #   mapa.shared::cluster.u32, then atom.shared::cluster.add.u32;
+                #   extent: one per CTA with rank > 0
+                copy_r2s(final_count, my_start)   # broadcast locally (:392)
+                # instruction_selection: st.shared.b32; extent: one scalar,
+                #   thread 0 of ranks > 0
+            barrier()
+            my_start = copy_s2r(final_count)
+            # instruction_selection: ld.shared.b32; extent: one scalar per
+            #   thread of ranks > 0 (:395)
+        cluster_sync()
+        # instruction_selection: barrier.cluster.arrive + barrier.cluster.wait;
+        #   extent: one per CTA.  No CTA may exit while a peer still reads its
+        #   cursor (:398).
+        n_out, out_start = min(TOPK, my_num), my_start        # :400
+    else:
+        n_out, out_start = TOPK, 0                            # :403
+        # NOTE the single-cluster path returns TOPK, not the measured count, so
+        # the writeback bound is TOPK and an over-count from the unguarded emit
+        # cannot walk past the output row.
+
+    # =======================================================================
+    # Writeback (:438-447 / :486-492 / :530-536)
+    # =======================================================================
+    for i in range(tid, n_out, 1024):
+        offs = i + out_start
+        if offs < TOPK:
+            ind = copy_s2r(topk_inds[i])
+            # instruction_selection: `ld.shared.b32` for plain-i32 (:441) and
+            #   ragged (:533); `ld.shared.s32` wherever the index feeds a
+            #   64-bit address computation -- page_table (:489, s32 x5, zero
+            #   b32) and, mixed, plain-i64 (:441, s32 x5 + b32 x5).  extent:
+            #   one per result
+            if MODE == "plain":
+                out = ind
+            elif MODE == "page_table":
+                out = copy_g2r(page_table[row * pt_stride + ind])
+                # instruction_selection: ld.global.nc.b32; extent: one per result
+            else:
+                out = ind + ragged_offset        # hoisted at CTA entry (:510)
+            copy_r2g(output_indices[ind_base + offs], out)
+            # instruction_selection: st.global.b32 | st.global.b64 by IDX;
+            #   extent: one per result
+            if MODE == "plain" and output_values is not None:
+                copy_r2g(output_values[ind_base + offs],
+                         copy_g2r(logits[logit_base + ind]))
+                # instruction_selection: ld.global.nc.{b32,b16} then
+                #   st.global.{b32,b16}; extent: one pair per result.  The value
+                #   is RE-GATHERED from global, never carried through shared.
+```
+
+## Cluster barrier and DSMEM accounting
+
+Per launch, per CTA. `P = ROUNDS - 1` refinement rounds (3 for f32, 1 for the
+16-bit dtypes), so `threshold()` is called `P + 1` times.
+
+| region | `cluster.sync()` | split arrive / wait | peer loads | peer atomics | source |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `threshold()`, each call | 1 | 0 | `NC - 1` per radix lane | 0 | :124-131 |
+| before pass 1 | 0 | 1 arrive | 0 | 0 | :218-225 |
+| each round head | 0 | 1 wait | 0 | 0 | :248 |
+| each round, `t < P` | 0 | 1 arrive | 0 | 0 | :261 |
+| final round ties | 0 | 0 | 0 | 1 per candidate until latched | :309, :360 |
+| epilogue | 2 | 0 | 0 | 1 for ranks > 0 | :386, :391, :398 |
+
+Totals at `NC > 1`, counting arrives and waits separately, for f32 (`P = 3`):
+
+| contributor | arrives | waits |
+| --- | ---: | ---: |
+| `threshold()` x (P+1) = 4 fused syncs | 4 | 4 |
+| split barrier: 1 before pass 1, then 1 per round with `t < P` | 3 | 0 |
+| split barrier: 1 wait at each round head | 0 | 3 |
+| epilogue, 2 fused syncs | 2 | 2 |
+| **total** | **9** | **9** |
+
+which is exactly what the `NC = 4` f32 entry exports. The split barrier
+contributes an equal number of arrives and waits only because the arrive issued
+before pass 1 is consumed by the first round's wait and the final round skips
+its arrive -- the pairing is offset by one region, not nested.
+
+At the 16-bit dtypes (`P = 1`) the same table gives `2 (threshold x 2) + 1 (the
+single pass-1 arrive; no round satisfies t < P) + 2 (epilogue) = 5` arrives and
+`2 + 1 + 2 = 5` waits, which is what the `NC = 4` f16 and bf16 entries export.
+The 16-bit columns of the opcode table below are measured, not carried over from
+f32. Only the SCAN rows halve exactly (`shfl.sync.down.b32` 32 -> 16,
+`bar.warp.sync` 4 -> 2), because they scale with the `P + 1` = 4 -> 2 threshold
+calls. The barrier rows do NOT halve: `bar.sync` goes 22 -> 12 at `NC = 1` and
+23 -> 13 at `NC > 1`, and the cluster barriers go 9/9 -> 5/5. The cluster total
+is `(P + 1) + P + 2 = 2P + 3`: `threshold()` contributes `P + 1` fused syncs
+(4 -> 2), the SPLIT barrier contributes `P` (3 -> 1), and only the epilogue's 2
+is fixed. So 9 at `P = 3` and 5 at `P = 1` -- a shrink, but not a halving,
+because of that constant epilogue term. The split barrier is NOT a fixed
+contributor: treating it as 1 would give `4 + 1 + 2 = 7` at f32, which the export
+contradicts.
+
+At `NC == 1` every row above collapses to zero **except** the tie atomics, which
+remain (see the vocabulary section).  Those atomics are *more* numerous at 16
+bits, not fewer: with `P = 1` the single refinement round is also the final
+round, so both tie sites inline into every unrolled copy.
+
+## Shared-memory budget
+
+`num_cached` IS derived from `TOPK`, inversely: the host solves for the cache
+size that makes the TOTAL request fill half the device's opt-in shared budget
+(`topk.py:375-387`), so `16*num_cached` falls by exactly what `4*TopK` rises
+(111040/1024, 107968/4096, 103872/8192 -- all summing to 112064). That is why the
+request lands on the same 115188 B at every k in this matrix. The cancellation is
+exact only for `TopK` a multiple of 4; see the residue note in the addressing
+section.
+
+| region | elements | bytes | source |
+| --- | --- | ---: | --- |
+| `s_cached_logit_bits[2][num_cached]` | `2 * nc` u32 | `8 * nc` | :97 |
+| `s_cached_indices[2][num_cached]` | `2 * nc` i32 | `8 * nc` | :98 |
+| `s_topk_inds[TopK]` | `TopK` i32 | `4 * TopK` | :99 |
+| `shared_hist[3][256]` | 768 i32 | 3072 | :101 |
+| `shared_final_idx_count` | 1 i32 | 4 | :102 |
+| `shared_num_cached_count[2]` | 2 i32 | 8 | :103 |
+| `shared_threshold_bin` | 1 i32 | 4 | :104 |
+| `s_cum_reduce_buf[8]` | 8 i32 | 32 | :105 |
+| `s_k_remaining_counter` | 1 i32 | 4 | :106 |
+| **total** | | **`16*nc + 4*TopK + 3124`** | :579-582 |
+
+On B200 `shared_memory_per_block_optin` is 232448, so `num_cached` is 6940 at
+`k = 256` and the realized request is **115188 bytes** -- confirmed on device in
+`.porting/fast_topk_clusters/probe_findings.md`, which also confirms the runtime
+opts in past the 48 KB static ceiling without the explicit `cudaFuncSetAttribute`
+calls the source's launcher makes (`:557-558`).
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `NClusters` | static, template parameter | the peer-sum loop is `#pragma unroll` (`:127`); the port specializes per width and the launch tag set changes with it |
+| `TopK`, `num_cached` | static per config here, kernel args in the source | fix the shared carve offsets at compile time |
+| `overflow_stride` | **runtime, and never passed** | derived in the binding as `cached_overflow.stride(0) / (4 * num_clusters)` (binding:47) -- the port must reproduce the derivation, not invent a parameter |
+| `pre_hist` | **dead from Python** | always `None` (`topk.py:432`), so `:159-163` and `sum_hist == false` are unreachable and dropped |
+| `PDL_ENABLED` | **dead from Python** | `pdl` defaults `False` everywhere; `cudaGridDependencySynchronize` (`:156`) is dropped |
+| `seq_len` | scalar arg on plain, `seq_lens[row]` on the transforms | selects the trivial branch per row on the transforms, per launch on plain |
+| `shared_threshold_bin` | **runtime, uninitialized** | never zeroed or reset (`:166-170`, `:104`); a degenerate round reads the previous round's value. Reproduced deliberately |
+| emit bounds check | **absent in source** | `:195-197` is commented out; the `offs < TOPK` writeback guard is the only bound |
+| tie survivors | **race-dependent** | arbitrary among bit-equal candidates; the selected set is exact, the selected indices are not stable |
+| output order | **race-dependent** | atomic compaction plus a racing per-CTA base; positions carry no meaning |
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "fast_topk_clusters", "category": "flashinfer",
+  "compute_capability": 10}`; device symbol `fast_topk_clusters_kernel`.
+- Plain TIRx only: a dynamic shared allocation carved by explicit views, explicit
+  loops, and native `T.ptx.*` forms for every key operation. Global and shared
+  memory are reached exclusively through `T.ptx.ld/st.*` on
+  `buffer.ptr_to([...])` -- never a native `BufferLoad`/`BufferStore`, which the
+  repository's low-level IR contract forbids. No `T.cuda.func_call`. No `Tx` tile
+  primitives anywhere.
+- The cluster scope is bound with `T.cta_id_in_cluster([NC])` and kept live even
+  where the value folds; `clusterCtaIdx.x` is added to
+  `tirx.kernel_launch_params` only when `NC > 1`.
+- Reference: the source's own FFI, reached as
+  `getattr(source_module(), "fast_topk_clusters_exact")` and the two transform
+  siblings. The entries do **not** appear in `dir(module)`; they must be taken by
+  name. `num_clusters` and `num_cached` are passed explicitly and identically to
+  both sides, never left to the Python heuristic.
+- Correctness compares **value multisets per row**, bit-exactly, against both
+  `torch.topk` and the reference -- never positions, because both sides are
+  nondeterministic in order and in tie choice. Additional per-row checks: indices
+  in range, no duplicates, `output_values[i] == logits[row, ind[i]]` bit-exact on
+  plain, and the transform inverse applied before comparison. The trivial branch
+  is the one path compared positionally.
+- Benchmark: one kernel per launch on both sides. The overflow workspace and every
+  output tensor are allocated in `prepare_bench`, never inside the timed closure.
+
+## Instruction selection is a lowering consequence
+
+The sketch never requests a hardware instruction. Placement, address space, tile
+width, and synchronization scope select the following families:
+
+| Primitive / pattern | PTX family (fresh sm_100a export, 48 entries) |
+| --- | --- |
+| row read, first pass | `ld.global.nc.b32` \| `ld.global.nc.b16` -- `.nc` because `logits` is `const` AND `__restrict__` (`:82`); both are required, and `cached_overflow` (`:85`) is `__restrict__` WITHOUT `const`, which is exactly why its reads carry no `.nc` |
+| row read, classification | `ld.global.nc.v4.b32` (f32) \| `ld.global.nc.v2.b32` (16-bit), one issue per `vec_t<T,4>` |
+| `to_ordered` | f32: `setp.gt.s32 %r, -1` + `selp.b32` (of the two masks) + `xor.b32` (`topk_common.cuh:35-39`). 16-bit: `setp.gt.s16` + `selp.b16` + `xor.b16`, staying in 16-bit registers (`topk_common.cuh:61-64` for half, `:87-90` for bf16 -- both emit the identical triple), `bits` then stays in a 16-bit register; `cvt.u32.u16` widens it at **three independent** sites, 9 each in the f16 `NC=1` export -- after the 16-bit shift at `:191`, at the shared store `:205`, and at the ring spill `:211` |
+| `digit`, classify site (`:191`, `:276`, `:328`) | f32 first pass `shr.u32` alone; f32 rounds t = 1,2 `shr.u32` + `and.b32 255`; **f32 round t = 3 and the 16-bit refinement round emit NOTHING** (`shift == 0`, candidate load narrowed to `b8`); 16-bit first pass `shr.u16` + `cvt.u32.u16`. The empty case is shift-driven, not dtype-driven -- **never** `bfe` on SM >= 70 |
+| `digit`, histogram-bump sites (`:178`, `:206`/`:213`, `:289`/`:296`/`:341`/`:347`) | always emit the x4 bin-to-byte scaling, even at shift 0: f32 `shr.u32 22`/`14`/`6` or `shl.b32 2`, each + `and.b32 1020`; 16-bit, per site: `:178` is `mul.wide.u16 ...,4` with NO mask (the `shr.u16 8` belongs to `.loc 1 177`, and a `u16 >> 8` bin already fits 8 bits), while `:206`/`:213` are `mul.wide.u16 ...,4` + `and.b32 1020` with NO shift (their shift is 0). These sites never vanish |
+| cursors (`final_count`, `num_cached_cnt`) | `atom.shared.add.u32`, result used |
+| histogram bumps | `atom.shared.add.u32` with the destination DISCARDED -- 55 of 85 per f32 entry, 47 of 85 at 16 bits. nvcc never narrows these to `red.shared.add.u32`: `red.*` is **0** across the whole 48-entry export. A port that emitted `red` where the old value is unused would diverge on most of its shared atomics |
+| suffix scan | `shfl.sync.down.b32` x5 (warps 0-7 only) then x3 (warp 0 only), plus one `bar.warp.sync` inside warp 0 |
+| peer histogram read | port: `cvta_generic_to_shared` + `mapa.shared::cluster.u32` + `ld.shared::cluster.b32`; reference PTX, in this order: `mapa.u64` -> `cvta.to.shared::cluster.u64` -> `ld.shared::cluster.b32` (468/468 def-use, 0 exceptions) |
+| tie rationing, range claim | port: `cvta_generic_to_shared` + `mapa.shared::cluster.u32` + `atom.shared::cluster.add.u32`; reference PTX: `mapa.u64` -> `cvta.to.shared::cluster.u64` -> the same atomic |
+| overflow-ring read | `ld.global.b32` x2 -- the one global read with **no** `.nc`, because this kernel writes the ring |
+| fused cluster edge | `barrier.cluster.arrive` + `barrier.cluster.wait` |
+| split cluster edge | the same two opcodes, issued in different regions |
+| block synchronization | `bar.sync 0` |
+| absent everywhere | `match.any`, `vote.sync`, `prmt`, `popc`, `clz`, `atom.global.*`, `mbarrier.*`, `cp.async.*`, `st.async.*`, `setmaxnreg`, `elect.sync` |
+
+Static opcode counts per exported instantiation, measured on the **plain-int32**
+entries (full table in
+`.porting/fast_topk_clusters/ptx/opcode_table.md`):
+
+`total instructions` and `ld.shared.b32` are the two rows that also move with
+mode and index width; the rest are invariant across all four modes. At f32
+`NC = 1` the totals run 1907 (plain-i32) / 1904 (plain-i64) / 1729 (ragged) /
+1703 (page_table).
+
+| op | f32 NC=1 | f32 NC=4 | f16 NC=1 | f16 NC=4 |
+| --- | ---: | ---: | ---: | ---: |
+| total instructions | 1907 | 2125 | 1790 | 1913 |
+| `mapa` | 1 | 14 | 2 | 9 |
+| `cvta.to.shared::cluster.u64` | 1 | 14 | 2 | 9 |
+| `ld.shared::cluster.b32` | 0 | 12 | 0 | 6 |
+| `atom.shared::cluster.add.u32` | **2** | 3 | **10** | 11 |
+| `barrier.cluster.arrive` / `.wait` | 0 / 0 | 9 / 9 | 0 / 0 | 5 / 5 |
+| `atom.shared.add.u32` | 85 | 85 | 85 | 85 |
+| `bar.sync` | 22 | 23 | 12 | 13 |
+| `bar.warp.sync` | 4 | 4 | 2 | 2 |
+| `shfl.sync.down.b32` | 32 | 32 | 16 | 16 |
+| `ld.global.nc.v4.b32` | 1 | 1 | 0 | 0 |
+| `ld.global.nc.v2.b32` | 0 | 0 | 1 | 1 |
+
+`bf16` is byte-identical to `f16` at every NC. The 16-bit columns are measured,
+not derived from the f32 ones: `ROUNDS = 2` gives `P = 1`, so `threshold()` runs
+twice instead of four times and `vec_t<T,4>` is 8 B rather than 16 B.
+
+Two rows are port checks rather than description. `atom.shared::cluster.add.u32`
+at **2 with zero cluster barriers** on the f32 `NC = 1` entry (and **10** on the
+16-bit one) is the check that the tie-rationing atomic stayed outside the
+`NC > 1` guard; a port that hoisted it would show 0. And `ld.shared::cluster.b32`
+at 12 in the f32 `NC = 4` entry is the check that peer reads were spelled in the
+cluster space -- that count and `ld.shared.b32` must never trade places, because
+a peer read spelled `ld.shared.b32` does not produce a wrong number, it produces
+an asynchronous illegal-instruction trap with no attribution.
+
+Both tables are the **plain-int32** entries. `ld.shared.b32` and the totals also
+move with mode and index width; the spread and its causes are in
+`.porting/fast_topk_clusters/probe_findings.md`.
+
+The counts are audit evidence, not operands or issue-count hints in the sketch.

--- a/.agents/skills/tirx-codegen-tuning/references/db/scale-a-staged-load-unroll-to-the-trip-count.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/scale-a-staged-load-unroll-to-the-trip-count.md
@@ -37,12 +37,37 @@ thread the deeper unroll took four shapes from 0.91-0.98x to 1.18-1.21x; at 6.8
 iterations the remainder dominated and the same change took one shape from 1.11x
 to 0.95x.
 
+A second kernel reproduced the scaling law with a different threshold, so derive
+it per kernel rather than reusing a number. A clustered radix select swept the
+factor against its per-thread trip count and found the crossover at 8, not 28:
+
+| trips/thread | unroll 4 | unroll 6 | unroll 8 |
+| ---: | --- | --- | --- |
+| 4 | **1.083, 1.032** | - | 0.896, 0.955 |
+| 8 | 0.977 | 0.959 | **0.995** |
+| 16 | 0.987, 1.006 | 0.924, 0.969 | **1.060, 1.011** |
+| 32 | 0.963 | 0.970 | **1.009**, and 12 fell back to 0.920 |
+
+`unroll = 8 if trips >= 8 else min(4, trips)` took that kernel's whole matrix
+from three failing shapes to zero.
+
 ## Boundary
 
 Do not assume monotonicity: unroll 6 and 8 regressed back to 5.75 and 6.26
 warp-cycles on register pressure. Sweep instead. Confirm the two trip-count
 regimes are actually separated in the config domain before picking a threshold,
 and do not apply the factor globally.
+
+The non-monotonicity is not only at the top of the range. In the sweep above,
+unroll 6 was worse than BOTH 4 and 8 on every shape tested, at every trip count.
+A three-point sweep that brackets the current factor can therefore point the
+wrong way; sweep the endpoints you would actually ship.
+
+The lever also does not transfer between loops in the same kernel. Applying the
+same staging to a loop whose bound is a runtime value, rather than an exact
+multiple of the stride, regressed three shapes (0.966 -> 0.946, 0.984 -> 0.944,
+0.988 -> 0.863): the per-element bounds re-check the runtime bound forces costs
+more than the added parallelism returns.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/stage-unrolled-loads-into-distinct-registers.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/stage-unrolled-loads-into-distinct-registers.md
@@ -1,0 +1,69 @@
+# Stage unrolled loads into distinct registers
+
+**Symptoms:** `long_scoreboard`, `exposed_load_latency`, `insufficient_memory_parallelism`, `unroll_no_effect`
+
+## Symptom
+
+An `unroll=` annotation measurably helps, but the shape is still behind the
+reference and the profile still shows exposed load latency. Paired NCU on the
+failing shape reports identical global load sectors on both sides and FEWER
+executed instructions on ours, with the whole gap in `long_scoreboard`:
+22.48 warp-cycles per issued instruction against the reference's 7.02 at
+4352 load sectors each, 14336 instructions against 24832.
+
+Reading the generated CUDA shows why the unroll did not buy what it looked like
+it bought: every unrolled copy writes the SAME destination local.
+
+```c
+alignas(64) uint _ptr_6[1];
+tvm_builtin_ptx_ld_global_nc_b32(_ptr_6[0], ...);   // copy 0
+tvm_builtin_ptx_st_global_b32(...);                 // consumes it
+tvm_builtin_ptx_ld_global_nc_b32(_ptr_6[0], ...);   // copy 1 must wait
+```
+
+The copies exist, but each load waits for the previous consumer to free the
+register, so no two loads are ever in flight.
+
+## What to change
+
+Stage the whole chunk into distinct registers before consuming any of it: an
+explicitly unrolled Python-level loop over a `T.alloc_local((N,), ...)` array,
+loads first, uses second.
+
+```python
+stage = T.alloc_local((trips,), "int32")
+for u in range(trips):                      # python unroll -> one register each
+    stage[u] = load(base + u * stride)
+for u in range(trips):
+    consume(stage[u])
+```
+
+This took a page-table transform's trivial path from 0.825x to 0.992x, and the
+kernel's complete matrix from five failing shapes to three.
+
+## Rationale
+
+`T.serial(..., unroll=N)` is a hint about loop structure, not about register
+allocation. The unrolled body reuses the destination the helper allocated, which
+serializes exactly the loads the unroll was meant to overlap. Splitting the
+load phase from the use phase is what actually creates the independent
+destinations, and `T.alloc_local((N,), ...)` indexed by a Python-level loop
+variable is the way to name them.
+
+## Boundary
+
+Applies where the trip count is a compile-time exact multiple of the stride, so
+the staged loop needs no per-element bounds check. Where the bound is a runtime
+value, the re-check costs more than the parallelism returns: the same transform
+on a loop bounded by a runtime row length regressed three shapes
+(0.966 -> 0.946, 0.984 -> 0.944, 0.988 -> 0.863). Guard the exact-divisor case
+and leave the general path on the ordinary loop.
+
+The staged array is real registers. Keep `trips` small; the win here came at 4.
+
+## Verification
+
+Diagnose with paired stall breakdowns, not instruction counts -- fewer
+instructions plus more time is the signature. Confirm the fix in the generated
+CUDA by checking that the unrolled copies write different destinations, then
+accept or reject on bench-suite.

--- a/tests/lint/check_fast_topk_clusters_no_tile.py
+++ b/tests/lint/check_fast_topk_clusters_no_tile.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every clustered exact top-k specialization.
+
+Reuses the single-CTA scanner.  The three source wrappers share one device
+worker and are built from one ``get_kernel``, so the IR scan walks one entry
+point per config; the config matrix is what spreads it across the modes, the
+cluster widths, and both index widths.
+
+``utils/topk_radix.py`` is scanned here as well as by the sibling checkers: the
+monotone key map, the shared-memory intrinsics, and the warp shuffle all come
+from it, and a tile primitive introduced there would reach this port too.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import check_radix_topk_single_cta_no_tile as no_tile
+
+from tirx_kernels.flashinfer.topk import fast_topk_clusters as target
+
+no_tile.target = target
+
+_CANDIDATE_TARGETS = (
+    "tirx_kernels/flashinfer/topk/fast_topk_clusters.py",
+    "tirx_kernels/flashinfer/utils/topk_radix.py",
+)
+no_tile.TARGETS = tuple(
+    no_tile.REPO / rel for rel in _CANDIDATE_TARGETS if (no_tile.REPO / rel).exists()
+)
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "3df3e86a",
-    "tirx-kernels": "919f1c6b-dirty",
+    "tir": "f20fa692",
+    "tirx-kernels": "fc344e9e-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "48e74a7a7521932b7124d6ed1cae9eaee3954b27"
+    "tirx-kernels:tirx_kernels": "4a09dabf5bb867211c1f794472733fdac2f87a31"
   },
   "baselines": {
     "torch": {
@@ -1018,6 +1018,482 @@
       "impls": {
         "tirx": 83.96102247146229,
         "deepgemm": 91.63302354900253
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_plain_b16_l16384_k256",
+      "label": "bf16_plain_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.315430039853691,
+        "flashinfer": 10.636390047572817
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_plain_b64_l16384_k1024_tie_heavy",
+      "label": "bf16_plain_b64_l16384_k1024_tie_heavy",
+      "status": "ok",
+      "impls": {
+        "tirx": 11.808709440817704,
+        "flashinfer": 12.889005253321622
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_plain_b64_l65536_k1024",
+      "label": "bf16_plain_b64_l65536_k1024",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.98384416324642,
+        "flashinfer": 17.379626806477507
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_pt_b16_l16384_k256",
+      "label": "bf16_pt_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.135281795175032,
+        "flashinfer": 11.315999284079126
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_rag_b16_l16384_k256",
+      "label": "bf16_rag_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.148079509086005,
+        "flashinfer": 10.141660470624371
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "bf16_rag_b300_l16384_k256",
+      "label": "bf16_rag_b300_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 17.736769374056607,
+        "flashinfer": 18.811297763426722
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_plain_b16_l16384_k256",
+      "label": "f16_plain_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.330373941198276,
+        "flashinfer": 10.367677404945761
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_plain_b16_l4096_k256",
+      "label": "f16_plain_b16_l4096_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.7626278062022385,
+        "flashinfer": 5.720782937867246
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_plain_b64_l16384_k1024_tie_heavy",
+      "label": "f16_plain_b64_l16384_k1024_tie_heavy",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.310705824602685,
+        "flashinfer": 10.834010305937683
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_plain_b64_l65536_k2048_i64",
+      "label": "f16_plain_b64_l65536_k2048_i64",
+      "status": "ok",
+      "impls": {
+        "tirx": 17.86619196443973,
+        "flashinfer": 18.91182523135481
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_pt_b16_l16384_k256",
+      "label": "f16_pt_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.990122267768026,
+        "flashinfer": 10.891726528891365
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f16_rag_b16_l16384_k256",
+      "label": "f16_rag_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 9.095775680713702,
+        "flashinfer": 9.904250605408697
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k2048_all_equal",
+      "label": "f32_plain_b16_l16384_k2048_all_equal",
+      "status": "ok",
+      "impls": {
+        "tirx": 17.02906334374407,
+        "flashinfer": 18.84488740855133
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k256",
+      "label": "f32_plain_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.466725761891453,
+        "flashinfer": 14.399956962439427
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k256_all_equal",
+      "label": "f32_plain_b16_l16384_k256_all_equal",
+      "status": "ok",
+      "impls": {
+        "tirx": 16.623915558773916,
+        "flashinfer": 18.154122963852434
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k256_i64",
+      "label": "f32_plain_b16_l16384_k256_i64",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.420686040314143,
+        "flashinfer": 14.482802491022296
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k256_neg",
+      "label": "f32_plain_b16_l16384_k256_neg",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.569874037143865,
+        "flashinfer": 15.402587414600815
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l16384_k256_tie_heavy",
+      "label": "f32_plain_b16_l16384_k256_tie_heavy",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.36879530372728,
+        "flashinfer": 16.350402340406173
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b16_l4096_k256",
+      "label": "f32_plain_b16_l4096_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.705360241543075,
+        "flashinfer": 7.298516449760636
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b200_l16384_k256",
+      "label": "f32_plain_b200_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 24.860179582464507,
+        "flashinfer": 25.405898567657005
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b200_l65536_k1024",
+      "label": "f32_plain_b200_l65536_k1024",
+      "status": "ok",
+      "impls": {
+        "tirx": 45.58549359469851,
+        "flashinfer": 46.1854230209686
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b300_l16384_k256",
+      "label": "f32_plain_b300_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 20.97409959806401,
+        "flashinfer": 22.08633863271252
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b64_l16384_k1024",
+      "label": "f32_plain_b64_l16384_k1024",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.871124585168214,
+        "flashinfer": 15.65283767985314
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b64_l16384_k2048",
+      "label": "f32_plain_b64_l16384_k2048",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.051104769999581,
+        "flashinfer": 15.801412140170715
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b64_l16384_k256",
+      "label": "f32_plain_b64_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.65114702208196,
+        "flashinfer": 14.268870524209298
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b64_l65536_k1024",
+      "label": "f32_plain_b64_l65536_k1024",
+      "status": "ok",
+      "impls": {
+        "tirx": 20.9927620851139,
+        "flashinfer": 21.414696338019116
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_plain_b8_l4096_k4096",
+      "label": "f32_plain_b8_l4096_k4096",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.672630117828723,
+        "flashinfer": 2.711304928986408
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_pt_b16_l16384_k256",
+      "label": "f32_pt_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.176903112475797,
+        "flashinfer": 15.382819182524589
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_pt_b16_l16384_k256_rowvar",
+      "label": "f32_pt_b16_l16384_k256_rowvar",
+      "status": "ok",
+      "impls": {
+        "tirx": 12.433105173142899,
+        "flashinfer": 12.903365349462904
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_pt_b200_l16384_k256",
+      "label": "f32_pt_b200_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 26.733519204956824,
+        "flashinfer": 26.79326579260196
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_pt_b8_l4096_k4096",
+      "label": "f32_pt_b8_l4096_k4096",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.9397018277168736,
+        "flashinfer": 2.933718772726037
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_rag_b16_l16384_k256",
+      "label": "f32_rag_b16_l16384_k256",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.351923925198077,
+        "flashinfer": 13.930256621474793
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_rag_b16_l16384_k256_rowvar",
+      "label": "f32_rag_b16_l16384_k256_rowvar",
+      "status": "ok",
+      "impls": {
+        "tirx": 11.592190640733152,
+        "flashinfer": 11.901982678247125
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "fast_topk_clusters",
+      "config": "f32_rag_b8_l4096_k4096",
+      "label": "f32_rag_b8_l4096_k4096",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.101097896651712,
+        "flashinfer": 2.2161202971603635
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '3df3e86a', 'tirx-kernels': '919f1c6b-dirty', 'tirx-bench-ci': None}`
-- Workloads: 347 ok, 0 failed
+- Git:       `{'tir': 'f20fa692', 'tirx-kernels': 'fc344e9e-dirty', 'tirx-bench-ci': None}`
+- Workloads: 381 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -143,6 +143,45 @@ Grouped workloads show one row per config and one timing column per implementati
 | `m64_n24_k28672_s112` | tirx | 7.2039 | deepgemm | 7.2959 | 1.013 | — |
 | `m8192_n24_k16384_s1` | tirx | 50.5342 | deepgemm | 60.5773 | 1.199 | — |
 | `m8192_n24_k28672_s1` | tirx | 83.9610 | deepgemm | 91.6330 | 1.091 | — |
+
+## fast_topk_clusters
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_plain_b16_l16384_k256` | tirx | 9.3154 | flashinfer | 10.6364 | 1.142 | — |
+| `bf16_plain_b64_l16384_k1024_tie_heavy` | tirx | 11.8087 | flashinfer | 12.8890 | 1.091 | — |
+| `bf16_plain_b64_l65536_k1024` | tirx | 15.9838 | flashinfer | 17.3796 | 1.087 | — |
+| `bf16_pt_b16_l16384_k256` | tirx | 10.1353 | flashinfer | 11.3160 | 1.116 | — |
+| `bf16_rag_b16_l16384_k256` | tirx | 9.1481 | flashinfer | 10.1417 | 1.109 | — |
+| `bf16_rag_b300_l16384_k256` | tirx | 17.7368 | flashinfer | 18.8113 | 1.061 | — |
+| `f16_plain_b16_l16384_k256` | tirx | 9.3304 | flashinfer | 10.3677 | 1.111 | — |
+| `f16_plain_b16_l4096_k256` | tirx | 4.7626 | flashinfer | 5.7208 | 1.201 | — |
+| `f16_plain_b64_l16384_k1024_tie_heavy` | tirx | 10.3107 | flashinfer | 10.8340 | 1.051 | — |
+| `f16_plain_b64_l65536_k2048_i64` | tirx | 17.8662 | flashinfer | 18.9118 | 1.059 | — |
+| `f16_pt_b16_l16384_k256` | tirx | 9.9901 | flashinfer | 10.8917 | 1.090 | — |
+| `f16_rag_b16_l16384_k256` | tirx | 9.0958 | flashinfer | 9.9043 | 1.089 | — |
+| `f32_plain_b16_l16384_k2048_all_equal` | tirx | 17.0291 | flashinfer | 18.8449 | 1.107 | — |
+| `f32_plain_b16_l16384_k256` | tirx | 13.4667 | flashinfer | 14.4000 | 1.069 | — |
+| `f32_plain_b16_l16384_k256_all_equal` | tirx | 16.6239 | flashinfer | 18.1541 | 1.092 | — |
+| `f32_plain_b16_l16384_k256_i64` | tirx | 13.4207 | flashinfer | 14.4828 | 1.079 | — |
+| `f32_plain_b16_l16384_k256_neg` | tirx | 13.5699 | flashinfer | 15.4026 | 1.135 | — |
+| `f32_plain_b16_l16384_k256_tie_heavy` | tirx | 15.3688 | flashinfer | 16.3504 | 1.064 | — |
+| `f32_plain_b16_l4096_k256` | tirx | 6.7054 | flashinfer | 7.2985 | 1.088 | — |
+| `f32_plain_b200_l16384_k256` | tirx | 24.8602 | flashinfer | 25.4059 | 1.022 | — |
+| `f32_plain_b200_l65536_k1024` | tirx | 45.5855 | flashinfer | 46.1854 | 1.013 | — |
+| `f32_plain_b300_l16384_k256` | tirx | 20.9741 | flashinfer | 22.0863 | 1.053 | — |
+| `f32_plain_b64_l16384_k1024` | tirx | 14.8711 | flashinfer | 15.6528 | 1.053 | — |
+| `f32_plain_b64_l16384_k2048` | tirx | 15.0511 | flashinfer | 15.8014 | 1.050 | — |
+| `f32_plain_b64_l16384_k256` | tirx | 13.6511 | flashinfer | 14.2689 | 1.045 | — |
+| `f32_plain_b64_l65536_k1024` | tirx | 20.9928 | flashinfer | 21.4147 | 1.020 | — |
+| `f32_plain_b8_l4096_k4096` | tirx | 2.6726 | flashinfer | 2.7113 | 1.014 | — |
+| `f32_pt_b16_l16384_k256` | tirx | 14.1769 | flashinfer | 15.3828 | 1.085 | — |
+| `f32_pt_b16_l16384_k256_rowvar` | tirx | 12.4331 | flashinfer | 12.9034 | 1.038 | — |
+| `f32_pt_b200_l16384_k256` | tirx | 26.7335 | flashinfer | 26.7933 | 1.002 | — |
+| `f32_pt_b8_l4096_k4096` | tirx | 2.9397 | flashinfer | 2.9337 | 0.998 | — |
+| `f32_rag_b16_l16384_k256` | tirx | 13.3519 | flashinfer | 13.9303 | 1.043 | — |
+| `f32_rag_b16_l16384_k256_rowvar` | tirx | 11.5922 | flashinfer | 11.9020 | 1.027 | — |
+| `f32_rag_b8_l4096_k4096` | tirx | 2.1011 | flashinfer | 2.2161 | 1.055 | — |
 
 ## filtered_topk
 

--- a/tirx_kernels/bench_suite/config/flashinfer/topk/fast_topk_clusters.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/topk/fast_topk_clusters.yaml
@@ -1,0 +1,65 @@
+# Every specialization of the clustered exact top-k family that the port covers:
+# the three source wrappers (plain, page-table transform, ragged transform) crossed
+# with the three dtypes, the four cluster widths the launcher instantiates, and both
+# index widths on the wrapper that supports them.
+#
+# `num_clusters` is not a free parameter. The host derives it from the shape
+# (flashinfer/topk.py:390-400) -- batch<=32 -> 8, <128 -> 4, <256 -> 2, else 1 --
+# and clamps it to 1 whenever the row is shorter than 8192 (:412-413). Cluster
+# coverage is therefore obtained by choosing batch sizes that land on each rung,
+# and the clamp is exercised on its own. Both matter: the cluster-wide threshold
+# sum, the tie rationing, and the output-range allocation all scale with the width,
+# and at one CTA per cluster the first and last of those compile away entirely
+# while the tie rationing does not.
+#
+# The patterns are domain coverage rather than test flavor. Selection is exact, so
+# the only data-dependent behavior is what lands in the boundary bin: `tie_heavy`
+# and `all_equal` are what drive the candidate cache into the global overflow ring
+# and then into the cluster-wide tie race, and `all_equal` at k=2048 puts an entire
+# row in that path. `rowvar` gives the transforms per-row lengths, including rows
+# short enough to take the trivial branch beside full rows in the same launch.
+#
+# `f16`/`bf16` at one shape are a measurement control, not extra coverage: the two
+# differ only in the ordered-bit map and compile to the same instruction sequence,
+# so any spread between them is measurement rather than kernel.
+#
+# Every entry launches exactly one kernel on each side; the reference is the
+# source's own FFI (`fast_topk_clusters_exact` and its two transform siblings),
+# which ships in the same JIT module as the radix path.
+kernel: fast_topk_clusters
+selection_rationale: The fp32 plain column is what `flashinfer.top_k` itself reaches on this path. `b16_l4096_k256` is the short-row clamp, the one shape where the launcher forces a single CTA per cluster and every cluster collective except the tie rationing disappears; `b64_l16384_k256` is the four-cluster mid rung the batch heuristic picks most often; and `b64_l65536_k1024` is the longest row crossed with a large k, where the candidate cache spills to the global overflow ring and the refinement rounds carry the most work.
+configs:
+  - {config: f32_plain_b16_l16384_k256, default: false}
+  - {config: f16_plain_b16_l16384_k256, default: false}
+  - {config: bf16_plain_b16_l16384_k256, default: false}
+  - {config: f32_pt_b16_l16384_k256, default: false}
+  - {config: f16_pt_b16_l16384_k256, default: false}
+  - {config: bf16_pt_b16_l16384_k256, default: false}
+  - {config: f32_rag_b16_l16384_k256, default: false}
+  - {config: f16_rag_b16_l16384_k256, default: false}
+  - {config: bf16_rag_b16_l16384_k256, default: false}
+  - {config: f32_plain_b64_l16384_k256, default: true, selection_role: medium}
+  - {config: f32_plain_b200_l16384_k256, default: false}
+  - {config: f32_plain_b300_l16384_k256, default: false}
+  - {config: f32_plain_b16_l4096_k256, default: true, selection_role: small}
+  - {config: f16_plain_b16_l4096_k256, default: false}
+  - {config: f32_plain_b64_l16384_k1024, default: false}
+  - {config: f32_plain_b64_l16384_k2048, default: false}
+  - {config: f32_plain_b64_l65536_k1024, default: true, selection_role: large}
+  - {config: bf16_plain_b64_l65536_k1024, default: false}
+  - {config: f32_plain_b16_l16384_k256_i64, default: false}
+  - {config: f16_plain_b64_l65536_k2048_i64, default: false}
+  - {config: f32_plain_b8_l4096_k4096, default: false}
+  - {config: f32_pt_b8_l4096_k4096, default: false}
+  - {config: f32_rag_b8_l4096_k4096, default: false}
+  - {config: f32_plain_b16_l16384_k256_tie_heavy, default: false}
+  - {config: f32_plain_b16_l16384_k256_all_equal, default: false}
+  - {config: f32_plain_b16_l16384_k256_neg, default: false}
+  - {config: f32_plain_b16_l16384_k2048_all_equal, default: false}
+  - {config: f32_pt_b16_l16384_k256_rowvar, default: false}
+  - {config: f32_rag_b16_l16384_k256_rowvar, default: false}
+  - {config: f32_plain_b200_l65536_k1024, default: false}
+  - {config: f32_pt_b200_l16384_k256, default: false}
+  - {config: bf16_rag_b300_l16384_k256, default: false}
+  - {config: f16_plain_b64_l16384_k1024_tie_heavy, default: false}
+  - {config: bf16_plain_b64_l16384_k1024_tie_heavy, default: false}

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -1,0 +1,1480 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2024 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer clustered exact top-k port.
+
+Ports the ``fast_topk_clusters_exact`` family
+(``include/flashinfer/fast_topk_clusters_exact.cuh``): one device worker
+``fast_topk_cuda_v4`` (``:80-405``) behind three thin ``__global__`` wrappers that
+differ only in where the row length comes from and what the epilogue does to each
+index -- plain (``:407-449``), page-table transform (``:451-494``) and ragged
+transform (``:496-538``).
+
+This is the path ``flashinfer.top_k`` takes on SM100 whenever the caller asks for
+neither determinism nor a tie-break rule (``topk.py:502-507``).  The selection
+happens in Python, *before* the FFI, so the C++ ``TopKDispatch`` that the four
+sibling ports go through never reaches it.
+
+The algorithm is an exact 256-bin MSB-first radix select over the monotone
+ordered bits of the row -- four rounds for fp32, two for the 16-bit dtypes -- run
+across a **thread-block cluster**.  Each CTA histograms its slice into shared
+memory; the threshold bin is then chosen from the cluster-wide sum, which every
+CTA assembles by reading its peers' histograms through distributed shared memory.
+Candidates equal to the threshold bin are carried in a double-buffered shared
+cache that spills to a per-CTA global ring, and are re-classified one byte at a
+time until the deficit closes.  Two things are settled by DSMEM atomics into rank
+0: which of the bit-equal boundary candidates make the cut, and where each CTA's
+results land in the output row.
+
+Three consequences shape the port.
+
+* **The result set is exact; the result order is not.**  Output slots are handed
+  out by atomic compaction, the per-CTA base comes from a racing atomic, and the
+  boundary bin's survivors are whichever lanes arrive first (``:306-308``).
+  Correctness therefore compares value multisets, never positions -- which loses
+  nothing, because an exact radix select over the ordered bits admits exactly one
+  multiset.
+* **Peer shared memory is a different address space.**  An address produced by
+  ``mapa`` lives in ``shared::cluster``; reading it with a plain ``ld.shared`` is
+  an illegal instruction, not a wrong answer.
+* **Two source hazards are reproduced, not repaired.**  The emit at ``:195-197``
+  has its bounds check commented out, and ``shared_threshold_bin`` is never
+  initialized or reset between rounds (``:166-170`` seeds only the other three
+  scalars), so a round in which no lane satisfies the crossing test reads the
+  previous round's value.
+
+Out of scope, with the predicate that excludes each: ``PDL_ENABLED`` (``pdl``
+defaults to ``False`` at every Python call site and no caller passes ``True``);
+the pre-computed histogram branch (``pre_hist`` is always ``None``, ``:159-163``);
+and ``num_clusters`` outside ``{1, 2, 4, 8}`` (the launcher degrades it to 1
+before the kernel sees it, ``:607-611``).
+"""
+
+from typing import Any
+
+from tirx_kernels.flashinfer.utils import topk_radix as R
+from tirx_kernels.flashinfer.utils.filtered_topk_ops import st_global_bits
+from tirx_kernels.flashinfer.utils.topk_harness import source_module, torch_dtype
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {"name": "fast_topk_clusters", "category": "flashinfer", "compute_capability": 10}
+
+
+# `clusterCtaIdx.x` is requested only when the cluster is real; a one-CTA cluster
+# takes the plain form, as the sibling cluster kernels do.  The tag alone does not
+# produce a cluster launch -- the body must bind the scope.
+# The source writes `__cluster_dims__(NClusters, 1, 1)` unconditionally, so its
+# `NClusters == 1` entries still declare a one-CTA cluster: all 12 carry
+# `.reqnctapercluster 1, 1, 1` and still read `%cluster_ctarank`.
+#
+# TIRx cannot reproduce that. An extent-1 `cta_id_in_cluster` binding folds away
+# and the `clusterCtaIdx.x` tag then fails to resolve ("Cannot find thread var"),
+# so the tag must be gated on `nc > 1` -- which is what every cluster kernel in
+# this repo already does (`deepep/dispatch.py:192-196`,
+# `flashinfer/norm/rmsnorm.py:845-848`). The port therefore diverges from the
+# reference on exactly one launch attribute at `nc == 1`: no cluster dimension is
+# declared where the reference declares a trivial one. Nothing in the algorithm
+# depends on it -- at one CTA per cluster the peer sum and the epilogue range
+# claim are both compiled out, and rank is statically 0.
+def launch_tags(nc: int) -> list[str]:
+    tags = ["blockIdx.x"]
+    if nc > 1:
+        tags.append("clusterCtaIdx.x")
+    tags += ["threadIdx.x", "tirx.use_dyn_shared_memory"]
+    return tags
+
+
+# `__launch_bounds__(1024)` gives `.maxntid 1024` and nothing else: the export
+# carries no `.minnctapersm` and no `.maxnreg`. Occupancy is already pinned at
+# 2 blocks/SM by the 115188 B carve against a 232448 B optin, so a min-blocks
+# bound would restate it and diverge.
+LAUNCH_BOUNDS_MAX_THREADS = 1024
+
+# --- source constants ------------------------------------------------------
+# 256 bins, 8 bits per round (:93).
+RADIX = 256
+# `NRemainingRounds = sizeof(T) - 1`, `LShiftStart = 8 * sizeof(T) - 8` (:90-92).
+BLOCK_THREADS = 1024
+# The launcher instantiates exactly these cluster widths; anything else degrades
+# to 1 before the kernel is selected (:598-611).
+CLUSTER_WIDTHS = (1, 2, 4, 8)
+# `get_fast_topk_clusters` (topk.py:390-400) plus the short-row clamp (:412-413).
+SHORT_ROW_CLUSTER_LIMIT = 8192
+
+DTYPES = ("float32", "float16", "bfloat16")
+MODES = ("plain", "page_table", "ragged")
+PATTERNS = ("unique", "tie_heavy", "all_equal", "neg", "rowvar")
+
+
+def dtype_bytes(dtype: str) -> int:
+    return 4 if dtype == "float32" else 2
+
+
+def radix_rounds(dtype: str) -> int:
+    """`NRemainingRounds + 1` -- the total number of 8-bit passes (:90)."""
+    return dtype_bytes(dtype)
+
+
+def shared_mem_bytes(top_k: int, num_cached: int) -> int:
+    """`get_shared_mem_bytes` (:579-582)."""
+    return 16 * num_cached + 4 * top_k + 3124
+
+
+def num_cached_for(top_k: int, shared_optin: int) -> int:
+    """`get_num_cached_for_topk` (topk.py:375-387).
+
+    The host sizes the candidate cache to fill half the opt-in shared budget,
+    which is what makes the dynamic request ~112 KiB independently of ``k``.
+    """
+    shared_per_block = shared_optin // 2
+    buffers_used = (top_k + 5 + 3 * RADIX + 8) * 4
+    return (shared_per_block - buffers_used - 1024) // 16
+
+
+def clusters_for(batch_size: int, seq_len: int) -> int:
+    """`get_fast_topk_clusters` + the short-row clamp (topk.py:390-400, 412-413)."""
+    if seq_len < SHORT_ROW_CLUSTER_LIMIT:
+        return 1
+    if batch_size <= 32:
+        return 8
+    if batch_size < 128:
+        return 4
+    if batch_size < 256:
+        return 2
+    return 1
+
+
+# Global memory goes through raw PTX, never BufferLoad/BufferStore: the repo's
+# low-level IR contract rejects the latter outright (db entry
+# `express-low-level-memory-access-through-raw-ptx`).
+def _ld_nc32(buf, index):
+    """One `ld.global.nc.b32`. `topk_radix.ld_global_u32` drops the `.nc`, and
+    every read-only input here (`logits`, `page_table`, `offsets`, `seq_lens`) is
+    `const __restrict__` on the source side, so the reference reads all of them
+    non-coherently. Only the overflow ring is deliberately unqualified -- this
+    kernel writes it, so its parameter cannot be `const`."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.ld.global_.nc.b32(out[0], buf.ptr_to([index])))
+    return out[0]
+
+
+def _ld_nc_bits(buf, index, is32):
+    """The scalar mirror of `_ld_vec4`: `ld.global.nc.b32` | `ld.global.nc.b16`."""
+    if is32:
+        return _ld_nc32(buf, index)
+    out = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.ld.global_.nc.b16(out[0], buf.ptr_to([index])))
+    return out[0]
+
+
+def _ld_vec4(buf, elem_index, is32):
+    """One `vec_t<T,4>` load, returned as raw 32-bit words.
+
+    The reference emits `ld.global.nc.v4.b32` at f32 and `ld.global.nc.v2.b32` at
+    16 bits (:227-236). `topk_radix.ld_global_words` spells the same widths
+    WITHOUT `.nc`; `logits` is `const __restrict__`, so the qualified form is the
+    faithful one, and it carries almost all of this kernel's memory traffic.
+    """
+    if is32:
+        w = T.alloc_local((4,), "uint32", align=16)
+        T.evaluate(T.ptx["ld.global.nc.v4.b32"](w[0], w[1], w[2], w[3], buf.ptr_to([elem_index])))
+        return w
+    w2 = T.alloc_local((2,), "uint32", align=8)
+    T.evaluate(T.ptx["ld.global.nc.v2.b32"](w2[0], w2[1], buf.ptr_to([elem_index])))
+    return w2
+
+
+def _st_idx(buf, index, value, i64: bool):
+    """One index store: `st.global.b64` on the i64 plain wrapper, else `b32`.
+
+    A Python-int `value` (the `-1` pad) is converted at trace time. Two traps
+    live here: reinterpreting a literal generates `*(uint *)(&(-1))`, which is
+    not an lvalue, and `-1` as an unsigned 64-bit constant overflows a C long on
+    the way in -- so the pad is written as a signed constant of the right width.
+    """
+    if isinstance(value, int):
+        if i64:
+            # `-1` cannot be written as a uint64 literal: the unsigned form
+            # overflows a C long on the way in, and casting the signed constant
+            # constant-folds into "cannot make uint from negative value". The
+            # bit-complement of its magnitude produces the same pattern.
+            imm = T.bitwise_not(T.uint64(-value - 1)) if value < 0 else T.uint64(value)
+            T.evaluate(T.ptx.st.global_.b64(buf.ptr_to([index]), imm))
+        else:
+            R.st_global_u32(buf, index, T.uint32(value & 0xFFFFFFFF))
+    elif i64:
+        T.evaluate(
+            T.ptx.st.global_.b64(buf.ptr_to([index]), T.cast(T.cast(value, "int64"), "uint64"))
+        )
+    else:
+        R.st_global_u32(buf, index, T.reinterpret("uint32", T.cast(value, "int32")))
+
+
+def _ld_i32(buf, index):
+    """One `ld.global.nc.b32` of an int32, returned as int32."""
+    return T.cast(_ld_nc32(buf, index), "int32")
+
+
+def get_kernel(
+    dtype: str = "float32",
+    batch: int = 16,
+    seq_len: int = 16384,
+    k: int = 256,
+    mode: str = "plain",
+    pattern: str = "unique",
+    idx_dtype: str = "int32",
+    **kwargs: Any,
+):
+    """One PrimFunc per reachable specialization of `fast_topk_cuda_v4`.
+
+    `NClusters`, `TopK`, `num_cached` and the dtype are template parameters and
+    launcher constants on the source side (:598-605, :555-576), so they are static
+    here too; `mode` and the index width select the wrapper (:407/:451/:496).
+    """
+    is32 = dtype == "float32"
+    rounds = 4 if is32 else 2  # NRemainingRounds + 1 (:90)
+    lshift_start = 8 * (4 if is32 else 2) - 8  # (:91)
+    nc = clusters_for(batch, seq_len)
+    num_cached = num_cached_for_device(k)
+    ovf_stride = seq_len // nc  # binding:47, from the row stride
+    plain = mode == "plain"
+    pt = mode == "page_table"
+    ragged = mode == "ragged"
+    i64 = plain and idx_dtype == "int64"
+    idx_t = "int64" if i64 else "int32"
+    val_t = dtype
+    bits_t = "uint32" if is32 else "uint16"
+    grid = batch * nc
+    # Per-thread trip counts of the two element loops. The db entry
+    # `scale-a-staged-load-unroll-to-the-trip-count` says a reference's unroll is
+    # a statement about how many independent global loads it wants in flight, and
+    # the factor must be derived from the trip count rather than copied.
+    hist_trips = max(1, seq_len // (BLOCK_THREADS * nc))
+    vec_trips = max(1, (seq_len // 4) // (BLOCK_THREADS * nc))
+    # The unroll factor must SCALE with the per-thread trip count, not be a
+    # single constant: measured on an idle GPU, 3-4 repeats each,
+    #   trips  4 -> hu4 1.083/1.032   hu8 0.896/0.955   (small, medium)
+    #   trips  8 -> hu4 0.977         hu8 0.995         (pt b200 l16384)
+    #   trips 16 -> hu4 0.987/1.006   hu8 1.060/1.011   (rag b300, plain b64 l65536)
+    #   trips 32 -> hu4 0.963         hu8 1.009         (plain b200 l65536)
+    # hu6 was worse than both neighbours on every shape tested (0.959/0.924/0.969/
+    # 0.970), so this is swept rather than interpolated -- the db entry
+    # `scale-a-staged-load-unroll-to-the-trip-count` warns against assuming
+    # monotonicity and that warning holds here.
+    hist_unroll = int(kwargs.get("hist_unroll", 8 if hist_trips >= 8 else min(4, hist_trips)))
+    vec_unroll = int(kwargs.get("vec_unroll", min(4, vec_trips)))
+    # The trivial branch and the writeback are the two remaining element loops.
+    # Both are bounded by TopK rather than seq_len, so their per-thread trip count
+    # is k/(1024*nc) -- 4 on the `seq_len == k == 4096` shapes, which are exactly
+    # the two worst rows and which never enter the worker at all.
+    triv_trips = max(1, k // (BLOCK_THREADS * nc))
+    triv_unroll = int(kwargs.get("triv_unroll", min(4, triv_trips)))
+    wb_unroll = int(kwargs.get("wb_unroll", min(4, triv_trips)))
+
+    # The 13 tail scalars, in the source's declaration order (:102-106):
+    # final_idx_count[1], num_cached_count[2], threshold_bin[1],
+    # cum_reduce_buf[8], k_remaining_counter[1].
+    FINAL = 0
+    NCACHED = 1
+    THR = 3
+    CUM0 = 4
+    KREM = 12
+    NSCAL = 13
+
+    # The plain wrapper takes (logits, indices, values, overflow); the transforms
+    # take (logits, indices, seq_lens, table_or_offsets, overflow). That arity
+    # difference is the source's own (:410-413 vs :454-461 / :499-505), so the
+    # entry points differ and the body is emitted by one shared function.
+    @T.macro
+    def _threshold(hist, scal, tid, warp, lane, rank, bank, k_rem, sum_across):
+        """`get_threshold_bin` (:116-154). Leaves the bin in `scal[THR]` and
+        updates the caller's `k_rem` local; a macro cannot return."""
+        T.evaluate(T.tvm_storage_sync("shared"))
+
+        v = T.alloc_local((1,), "int32")
+        v[0] = T.int32(0)
+        if tid < RADIX:
+            v[0] = T.cast(R.ld_shared_u32(hist, bank * RADIX + tid), "int32")
+            # Five-step warp suffix scan (:21-31), unrolled. `.down` accumulates
+            # toward lane 0, so the warp's total over its 32 bins lands THERE.
+            s1 = R.shfl_down_u32(T.reinterpret("uint32", v[0]), 1)
+            if lane < 31:
+                v[0] += T.cast(s1, "int32")
+            s2 = R.shfl_down_u32(T.reinterpret("uint32", v[0]), 2)
+            if lane < 30:
+                v[0] += T.cast(s2, "int32")
+            s4 = R.shfl_down_u32(T.reinterpret("uint32", v[0]), 4)
+            if lane < 28:
+                v[0] += T.cast(s4, "int32")
+            s8 = R.shfl_down_u32(T.reinterpret("uint32", v[0]), 8)
+            if lane < 24:
+                v[0] += T.cast(s8, "int32")
+            s16 = R.shfl_down_u32(T.reinterpret("uint32", v[0]), 16)
+            if lane < 16:
+                v[0] += T.cast(s16, "int32")
+            if lane == 0:
+                R.st_shared_u32(scal, CUM0 + warp, T.reinterpret("uint32", v[0]))
+        T.evaluate(T.tvm_storage_sync("shared"))
+
+        if warp == 0:
+            w = T.alloc_local((1,), "int32")
+            w[0] = T.int32(0)
+            if lane < 8:
+                w[0] = T.cast(R.ld_shared_u32(scal, CUM0 + lane), "int32")
+            t1 = R.shfl_down_u32(T.reinterpret("uint32", w[0]), 1)
+            if lane < 7:
+                w[0] += T.cast(t1, "int32")
+            t2 = R.shfl_down_u32(T.reinterpret("uint32", w[0]), 2)
+            if lane < 6:
+                w[0] += T.cast(t2, "int32")
+            t4 = R.shfl_down_u32(T.reinterpret("uint32", w[0]), 4)
+            if lane < 4:
+                w[0] += T.cast(t4, "int32")
+            # `__syncwarp` sits BETWEEN the scan and the write-back into the same
+            # buffer (:48). After the store it would protect nothing.
+            T.evaluate(T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF)))
+            # The guard is load-bearing: cum_reduce_buf is 8 ints with
+            # k_remaining_counter 32 B later, so an unguarded 32-lane store puts
+            # 128 B where 32 are allocated (:49-51).
+            if lane < 8:
+                R.st_shared_u32(scal, CUM0 + lane, T.reinterpret("uint32", w[0]))
+        T.evaluate(T.tvm_storage_sync("shared"))
+        if warp < 7:
+            v[0] += T.cast(R.ld_shared_u32(scal, CUM0 + warp + 1), "int32")
+
+        # --- cluster-wide sum of the same bin (:120-138) --------------------
+        if nc > 1 and sum_across:
+            if tid < RADIX:
+                # This IS the DSMEM publication: peers read the PING-PONG bank.
+                R.st_shared_u32(hist, bank * RADIX + tid, T.reinterpret("uint32", v[0]))
+            T.evaluate(T.ptx.barrier.cluster.arrive())
+            T.evaluate(T.ptx.barrier.cluster.wait())
+            if tid < RADIX:
+                for c in T.unroll(nc - 1):
+                    peer = T.alloc_local((1,), "uint32")
+                    T.evaluate(
+                        T.ptx.mapa.shared__cluster.u32(
+                            peer[0],
+                            T.cuda.cvta_generic_to_shared(hist.ptr_to([bank * RADIX + tid])),
+                            T.cast((c + rank + 1) % nc, "uint32"),
+                        )
+                    )
+                    got = T.alloc_local((1,), "uint32")
+                    T.evaluate(T.ptx.ld.shared__cluster.b32(got[0], peer[0]))
+                    v[0] += T.cast(got[0], "int32")
+                R.st_shared_u32(hist, 2 * RADIX + tid, T.reinterpret("uint32", v[0]))
+        else:
+            if tid < RADIX:
+                R.st_shared_u32(hist, 2 * RADIX + tid, T.reinterpret("uint32", v[0]))
+        T.evaluate(T.tvm_storage_sync("shared"))
+
+        # --- pick the crossing bin (:142-152) --------------------------------
+        nxt = T.alloc_local((1,), "int32")
+        nxt[0] = T.int32(0)
+        if tid < RADIX - 1:
+            nxt[0] = T.cast(R.ld_shared_u32(hist, 2 * RADIX + tid + 1), "int32")
+        if tid < RADIX:
+            if v[0] > k_rem[0] and nxt[0] <= k_rem[0]:
+                R.st_shared_u32(scal, THR, T.reinterpret("uint32", tid))
+        T.evaluate(T.tvm_storage_sync("shared"))
+        bin_ = T.alloc_local((1,), "int32")
+        bin_[0] = T.cast(R.ld_shared_u32(scal, THR), "int32")
+        if bin_[0] < RADIX - 1:
+            k_rem[0] -= T.cast(R.ld_shared_u32(hist, 2 * RADIX + bin_[0] + 1), "int32")
+
+    @T.macro
+    def _classify(
+        hist,
+        scal,
+        topk_inds,
+        cbits,
+        cidx,
+        ovf,
+        bits,
+        index,
+        bin_,
+        phase,
+        shift,
+        last,
+        k_rem,
+        exceeded,
+        ring_base,
+        tid,
+    ):
+        """The three-way split of :189-217, shared by pass 1 and every round."""
+        d = T.alloc_local((1,), "int32")
+        if is32:
+            d[0] = T.cast(T.shift_right(bits, T.uint32(shift)), "int32") & 0xFF
+        else:
+            d[0] = T.cast(T.shift_right(bits, T.uint16(shift)), "int32") & 0xFF
+        if d[0] > bin_[0]:
+            # HAZARD: unguarded. The source's `if (topk_offset < TopK)` is
+            # commented out at :195-197; the writeback's `offs < TopK` is what
+            # bounds the global store. Reproduce, do not repair.
+            slot = R.atom_shared_add_u32(scal, FINAL, T.uint32(1))
+            R.st_shared_u32(topk_inds, T.cast(slot, "int32"), T.reinterpret("uint32", index))
+        else:
+            if d[0] == bin_[0]:
+                if not last:
+                    slot = T.cast(
+                        R.atom_shared_add_u32(scal, NCACHED + phase, T.uint32(1)), "int32"
+                    )
+                    keep = T.alloc_local((1,), "int32")
+                    keep[0] = T.int32(1)
+                    if slot < num_cached:
+                        R.st_shared_u32(
+                            cidx, phase * num_cached + slot, T.reinterpret("uint32", index)
+                        )
+                        R.st_shared_u32(cbits, phase * num_cached + slot, T.cast(bits, "uint32"))
+                    else:
+                        if slot - num_cached < ovf_stride:
+                            off = ring_base + phase * ovf_stride * 2 + (slot - num_cached) * 2
+                            R.st_global_u32(ovf, off, T.cast(bits, "uint32"))
+                            R.st_global_u32(ovf, off + 1, T.reinterpret("uint32", index))
+                        else:
+                            keep[0] = T.int32(0)  # ring full: dropped (:210-214)
+                    if keep[0] == 1:
+                        nb = T.alloc_local((1,), "int32")
+                        if is32:
+                            nb[0] = T.cast(T.shift_right(bits, T.uint32(shift - 8)), "int32") & 0xFF
+                        else:
+                            nb[0] = T.cast(T.shift_right(bits, T.uint16(shift - 8)), "int32") & 0xFF
+                        R.atom_shared_add_u32(hist, (phase ^ 1) * RADIX + nb[0], T.uint32(1))
+                else:
+                    # Final-round tie rationing on rank 0's counter (:300-319).
+                    # NOT guarded by nc > 1: at one CTA per cluster rank 0 is
+                    # this CTA, and the reference's NC==1 export still carries
+                    # the cluster atomic.
+                    if k_rem[0] > 0 and exceeded[0] == 0:
+                        # NOT guarded by nc > 1. The source calls
+                        # `map_shared_rank(s_k_remaining_counter, 0)`
+                        # unconditionally (:309, :360) and its NC==1 export still
+                        # carries the cluster atomic (2 at f32, 10 at 16-bit).
+                        # Only the peer sum (:121-131) and the epilogue claim
+                        # (:379-399) sit inside `if (NClusters > 1)`.
+                        # probe_nc1_atom.py confirms the cluster-space atomic
+                        # works with no `clusterCtaIdx.x` tag bound, so at one
+                        # CTA per cluster rank 0 is this CTA and the mapping is
+                        # the identity.
+                        peer = T.alloc_local((1,), "uint32")
+                        T.evaluate(
+                            T.ptx.mapa.shared__cluster.u32(
+                                peer[0],
+                                T.cuda.cvta_generic_to_shared(scal.ptr_to([KREM])),
+                                T.uint32(0),
+                            )
+                        )
+                        got = T.alloc_local((1,), "uint32")
+                        T.evaluate(T.ptx.atom.shared__cluster.add.u32(got[0], peer[0], T.uint32(1)))
+                        if T.cast(got[0], "int32") < k_rem[0]:
+                            slot = R.atom_shared_add_u32(scal, FINAL, T.uint32(1))
+                            R.st_shared_u32(
+                                topk_inds, T.cast(slot, "int32"), T.reinterpret("uint32", index)
+                            )
+                        else:
+                            exceeded[0] = T.int32(1)
+
+    @T.macro
+    def _round(
+        hist,
+        scal,
+        topk_inds,
+        cached_bits,
+        cached_idx,
+        ovf,
+        tid,
+        warp,
+        lane,
+        rank,
+        ring_base,
+        k_rem,
+        exceeded,
+        t,
+    ):
+        """One refinement round (:241-373).
+
+        `t` arrives as a PYTHON int, so `phase`, `shift` and `last` are
+        compile-time constants and the round is emitted as straight-line code.
+        Writing `for t in range(1, rounds)` inside a parsed body instead makes
+        TVMScript emit `T.serial` -- a real runtime loop -- which collapses the
+        four static `threshold()` regions into two, turns `last` into a runtime
+        predicate, and leaves the per-round `digit` forms unreachable.
+        """
+        phase = t % 2
+        exceeded[0] = T.int32(0)  # :268 -- per round, per thread
+        if nc > 1:
+            T.evaluate(T.ptx.barrier.cluster.wait())
+        if tid < RADIX:
+            R.st_shared_u32(hist, (phase ^ 1) * RADIX + tid, T.uint32(0))
+        if tid == 0:
+            R.st_shared_u32(scal, NCACHED + phase, T.uint32(0))
+        _threshold(hist, scal, tid, warp, lane, rank, phase, k_rem, True)
+        bin_t = T.alloc_local((1,), "int32")
+        bin_t[0] = T.cast(R.ld_shared_u32(scal, THR), "int32")
+        if nc > 1 and t < rounds - 1:
+            # Skipped on the final round: no further threshold() means no
+            # further peer read of this bank (:260-263).
+            T.evaluate(T.ptx.barrier.cluster.arrive())
+
+        raw = T.alloc_local((1,), "int32")
+        raw[0] = T.cast(R.ld_shared_u32(scal, NCACHED + (phase ^ 1)), "int32")
+        n_sh = T.alloc_local((1,), "int32")
+        n_gl = T.alloc_local((1,), "int32")
+        n_sh[0] = T.min(T.int32(num_cached), raw[0])
+        n_gl[0] = T.min(T.int32(ovf_stride), T.max(T.int32(0), raw[0] - num_cached))
+        shift = lshift_start - t * 8
+        last = t == rounds - 1
+
+        # Stride 1024, NOT 1024*nc: each CTA owns its own candidate slice and
+        # the cluster does not re-partition here (:271-273).
+        for i in T.serial(tid, n_sh[0], step=BLOCK_THREADS):
+            b = R.ld_shared_u32(cached_bits, (phase ^ 1) * num_cached + i)
+            ix = T.cast(R.ld_shared_u32(cached_idx, (phase ^ 1) * num_cached + i), "int32")
+            _classify(
+                hist,
+                scal,
+                topk_inds,
+                cached_bits,
+                cached_idx,
+                ovf,
+                b,
+                ix,
+                bin_t,
+                phase,
+                shift,
+                last,
+                k_rem,
+                exceeded,
+                ring_base,
+                tid,
+            )
+        for i in T.serial(tid, n_gl[0], step=BLOCK_THREADS):
+            off = ring_base + (phase ^ 1) * ovf_stride * 2 + i * 2
+            b = R.ld_global_u32(ovf, off)
+            ix = T.cast(R.ld_global_u32(ovf, off + 1), "int32")
+            _classify(
+                hist,
+                scal,
+                topk_inds,
+                cached_bits,
+                cached_idx,
+                ovf,
+                b,
+                ix,
+                bin_t,
+                phase,
+                shift,
+                last,
+                k_rem,
+                exceeded,
+                ring_base,
+                tid,
+            )
+
+    @T.macro
+    def _emit(logits, out_idx, out_val, seq_lens_g, aux, ovf):
+        T.device_entry()
+
+        cta = T.cta_id([grid])
+        rank = T.cta_id_in_cluster([nc]) if nc > 1 else T.int32(0)
+        tid = T.thread_id([BLOCK_THREADS])
+        row = cta // nc
+        warp = tid >> 5
+        lane = tid & 31
+
+        logit_base = row * seq_len
+        ind_base = row * k
+
+        row_len = T.alloc_local((1,), "int32")
+        row_len[0] = T.int32(seq_len)
+        if not plain:
+            row_len[0] = _ld_i32(seq_lens_g, row)
+        rag_off = T.alloc_local((1,), "int32")
+        rag_off[0] = T.int32(0)
+        # `page_table_offset` is hoisted ONCE per CTA in the source (:465) and
+        # reused by both the trivial branch (:471) and the writeback (:490).
+        # Recomputing `row * pt_stride` inside those loops costs a multiply-add
+        # per element on the one path that has no other per-element arithmetic,
+        # which is exactly where the page_table trivial shape loses to ragged.
+        pt_base = T.alloc_local((1,), "int32")
+        pt_base[0] = T.int32(0)
+        if pt:
+            pt_base[0] = row * seq_len
+        if ragged:
+            # Hoisted above the trivial branch exactly as the source does (:510)
+            # and reused by both it and the writeback.
+            rag_off[0] = _ld_i32(aux, row)
+
+        # ---- trivial branch (:417-429 / :467-476 / :511-520) ---------------
+        if row_len[0] <= k:
+            if pt and triv_trips * BLOCK_THREADS * nc == k:
+                # Stage the page-table loads into DISTINCT registers before any
+                # store. `T.serial(..., unroll=N)` reuses one destination local
+                # across the unrolled copies, so the loads serialize: each waits
+                # for the previous store to consume the register. Paired NCU on
+                # this shape measured long_scoreboard 22.48 vs the reference's
+                # 7.02 at IDENTICAL global load sectors (4352 both) -- exposed
+                # load latency, not extra traffic. An explicitly unrolled body
+                # with one register per load lets all `triv_trips` be in flight.
+                stage = T.alloc_local((triv_trips,), "int32")
+                tbase = tid + (cta % nc) * BLOCK_THREADS
+                for u in range(triv_trips):
+                    iu = tbase + u * BLOCK_THREADS * nc
+                    if iu < row_len[0]:
+                        stage[u] = _ld_i32(aux, pt_base[0] + iu)
+                    else:
+                        stage[u] = T.int32(-1)
+                for u in range(triv_trips):
+                    iu = tbase + u * BLOCK_THREADS * nc
+                    _st_idx(out_idx, ind_base + iu, stage[u], i64)
+            else:
+                for i in T.serial(
+                    tid + (cta % nc) * BLOCK_THREADS, k, step=BLOCK_THREADS * nc, unroll=triv_unroll
+                ):
+                    if i < row_len[0]:
+                        if plain:
+                            _st_idx(out_idx, ind_base + i, i, i64)
+                            st_global_bits(
+                                out_val,
+                                ind_base + i,
+                                _ld_nc_bits(logits, logit_base + i, is32),
+                                is32,
+                            )
+                        elif pt:
+                            _st_idx(out_idx, ind_base + i, _ld_i32(aux, pt_base[0] + i), i64)
+                        else:
+                            _st_idx(out_idx, ind_base + i, i + rag_off[0], i64)
+                    else:
+                        # output_values is left UNTOUCHED over the pad region
+                        # (:425-427) -- the port must not zero it.
+                        _st_idx(out_idx, ind_base + i, -1, i64)
+        else:
+            pool = T.SMEMPool()
+            cached_bits = pool.alloc((2 * num_cached,), "uint32", align=128)
+            cached_idx = pool.alloc((2 * num_cached,), "int32")
+            topk_inds = pool.alloc((k,), "int32")
+            hist = pool.alloc((3 * RADIX,), "int32")
+            scal = pool.alloc((NSCAL,), "int32")
+            pool.commit()
+
+            ring_base = cta * ovf_stride * 4
+            exceeded = T.alloc_local((1,), "int32")
+            exceeded[0] = T.int32(0)
+
+            # ---- zero banks 0/1 and three scalars (:158-170) ---------------
+            if tid < RADIX:
+                R.st_shared_u32(hist, tid, T.uint32(0))
+                R.st_shared_u32(hist, RADIX + tid, T.uint32(0))
+            if tid == 0:
+                R.st_shared_u32(scal, FINAL, T.uint32(0))
+                R.st_shared_u32(scal, KREM, T.uint32(0))
+                R.st_shared_u32(scal, NCACHED, T.uint32(0))
+                # threshold_bin is deliberately NOT initialized (:166-170): a
+                # round whose crossing test selects no lane reads the previous
+                # round's value. Reproduce, do not repair.
+            T.evaluate(T.tvm_storage_sync("shared"))
+
+            # ---- first histogram pass: SCALAR strided (:174-179) -----------
+            for i in T.serial(
+                tid + rank * BLOCK_THREADS, row_len[0], step=BLOCK_THREADS * nc, unroll=hist_unroll
+            ):
+                xb = _ld_nc_bits(logits, logit_base + i, is32)
+                ob = R.to_ordered_u32(xb) if is32 else R.to_ordered_u16(xb)
+                if is32:
+                    d0 = T.cast(T.shift_right(ob, T.uint32(lshift_start)), "int32") & 0xFF
+                else:
+                    d0 = T.cast(T.shift_right(ob, T.uint16(lshift_start)), "int32") & 0xFF
+                R.atom_shared_add_u32(hist, d0, T.uint32(1))
+
+            k_rem = T.alloc_local((1,), "int32")
+            k_rem[0] = T.int32(k)
+            _threshold(hist, scal, tid, warp, lane, rank, 0, k_rem, True)
+            bin0 = T.alloc_local((1,), "int32")
+            bin0[0] = T.cast(R.ld_shared_u32(scal, THR), "int32")
+
+            if nc > 1:
+                # SPLIT barrier: the matching wait heads round 1 (:218-225, :248).
+                T.evaluate(T.ptx.barrier.cluster.arrive())
+
+            # Vectorized classification (:227-236): four elements per issue,
+            # then a scalar tail (:237-239). Only THIS pass is vectorized -- the
+            # first histogram pass above is a plain strided scalar read, which is
+            # why the row is read from global twice in total.
+            vbase = (rank * BLOCK_THREADS + tid) * 4
+            for i in T.serial(
+                vbase, (row_len[0] // 4) * 4, step=BLOCK_THREADS * nc * 4, unroll=vec_unroll
+            ):
+                w = _ld_vec4(logits, logit_base + i, is32)
+                for j in T.unroll(4):
+                    if is32:
+                        eb = w[j]
+                    else:
+                        eb = T.cast(
+                            T.bitwise_and(
+                                T.shift_right(w[j // 2], T.uint32(16 * (j % 2))), T.uint32(0xFFFF)
+                            ),
+                            "uint16",
+                        )
+                    ob = R.to_ordered_u32(eb) if is32 else R.to_ordered_u16(eb)
+                    _classify(
+                        hist,
+                        scal,
+                        topk_inds,
+                        cached_bits,
+                        cached_idx,
+                        ovf,
+                        ob,
+                        i + j,
+                        bin0,
+                        0,
+                        lshift_start,
+                        False,
+                        k_rem,
+                        exceeded,
+                        ring_base,
+                        tid,
+                    )
+            for i in T.serial(
+                (row_len[0] // 4) * 4 + rank * BLOCK_THREADS + tid,
+                row_len[0],
+                step=BLOCK_THREADS * nc,
+            ):
+                xb = _ld_nc_bits(logits, logit_base + i, is32)
+                ob = R.to_ordered_u32(xb) if is32 else R.to_ordered_u16(xb)
+                _classify(
+                    hist,
+                    scal,
+                    topk_inds,
+                    cached_bits,
+                    cached_idx,
+                    ovf,
+                    ob,
+                    i,
+                    bin0,
+                    0,
+                    lshift_start,
+                    False,
+                    k_rem,
+                    exceeded,
+                    ring_base,
+                    tid,
+                )
+
+            # ---- refinement rounds (:241-373), emitted as straight-line code
+            # so each round's phase/shift/last stay compile-time, matching the
+            # source's `#pragma unroll` (:241).
+            _round(
+                hist,
+                scal,
+                topk_inds,
+                cached_bits,
+                cached_idx,
+                ovf,
+                tid,
+                warp,
+                lane,
+                rank,
+                ring_base,
+                k_rem,
+                exceeded,
+                1,
+            )
+            if rounds == 4:
+                _round(
+                    hist,
+                    scal,
+                    topk_inds,
+                    cached_bits,
+                    cached_idx,
+                    ovf,
+                    tid,
+                    warp,
+                    lane,
+                    rank,
+                    ring_base,
+                    k_rem,
+                    exceeded,
+                    2,
+                )
+                _round(
+                    hist,
+                    scal,
+                    topk_inds,
+                    cached_bits,
+                    cached_idx,
+                    ovf,
+                    tid,
+                    warp,
+                    lane,
+                    rank,
+                    ring_base,
+                    k_rem,
+                    exceeded,
+                    3,
+                )
+            # ---- epilogue: claim the output range (:374-404) ----------------
+            T.evaluate(T.tvm_storage_sync("shared"))
+            n_out = T.alloc_local((1,), "int32")
+            out_start = T.alloc_local((1,), "int32")
+            n_out[0] = T.int32(k)
+            out_start[0] = T.int32(0)
+            if nc > 1:
+                my_num = T.alloc_local((1,), "int32")
+                # Read own count BEFORE rank 0's cursor absorbs peers (:379-386).
+                my_num[0] = T.cast(R.ld_shared_u32(scal, FINAL), "int32")
+                T.evaluate(T.ptx.barrier.cluster.arrive())
+                T.evaluate(T.ptx.barrier.cluster.wait())
+                if rank > 0:
+                    if tid == 0:
+                        peer = T.alloc_local((1,), "uint32")
+                        T.evaluate(
+                            T.ptx.mapa.shared__cluster.u32(
+                                peer[0],
+                                T.cuda.cvta_generic_to_shared(scal.ptr_to([FINAL])),
+                                T.uint32(0),
+                            )
+                        )
+                        old = T.alloc_local((1,), "uint32")
+                        T.evaluate(
+                            T.ptx.atom.shared__cluster.add.u32(
+                                old[0], peer[0], T.reinterpret("uint32", my_num[0])
+                            )
+                        )
+                        R.st_shared_u32(scal, FINAL, old[0])  # broadcast (:392)
+                    T.evaluate(T.tvm_storage_sync("shared"))
+                    out_start[0] = T.cast(R.ld_shared_u32(scal, FINAL), "int32")
+                T.evaluate(T.ptx.barrier.cluster.arrive())
+                T.evaluate(T.ptx.barrier.cluster.wait())
+                n_out[0] = T.min(T.int32(k), my_num[0])
+
+            # ---- writeback (:438-447 / :486-492 / :530-536) -----------------
+            for i in T.serial(tid, n_out[0], step=BLOCK_THREADS, unroll=wb_unroll):
+                offs = i + out_start[0]
+                if offs < k:
+                    ind = T.cast(R.ld_shared_u32(topk_inds, i), "int32")
+                    if plain:
+                        _st_idx(out_idx, ind_base + offs, ind, i64)
+                        # The value is RE-GATHERED from global, never carried
+                        # through shared (:444).
+                        st_global_bits(
+                            out_val,
+                            ind_base + offs,
+                            _ld_nc_bits(logits, logit_base + ind, is32),
+                            is32,
+                        )
+                    elif pt:
+                        _st_idx(out_idx, ind_base + offs, _ld_i32(aux, pt_base[0] + ind), i64)
+                    else:
+                        _st_idx(out_idx, ind_base + offs, ind + rag_off[0], i64)
+
+    if plain:
+
+        @T.prim_func
+        def fast_topk_clusters_kernel(
+            logits_h: T.handle, indices_h: T.handle, values_h: T.handle, overflow_h: T.handle
+        ):
+            T.func_attr(
+                {"global_symbol": "fast_topk_clusters_kernel", "tirx.launch_tags": launch_tags(nc)}
+            )
+            _emit(
+                T.match_buffer(logits_h, (batch * seq_len,), val_t, scope="global"),
+                T.match_buffer(indices_h, (batch * k,), idx_t, scope="global"),
+                T.match_buffer(values_h, (batch * k,), val_t, scope="global"),
+                None,
+                None,
+                T.match_buffer(overflow_h, (batch * 4 * ovf_stride * nc,), "int32", scope="global"),
+            )
+
+    else:
+
+        @T.prim_func
+        def fast_topk_clusters_kernel(
+            logits_h: T.handle,
+            indices_h: T.handle,
+            seq_lens_h: T.handle,
+            aux_h: T.handle,
+            overflow_h: T.handle,
+        ):
+            T.func_attr(
+                {"global_symbol": "fast_topk_clusters_kernel", "tirx.launch_tags": launch_tags(nc)}
+            )
+            _emit(
+                T.match_buffer(logits_h, (batch * seq_len,), val_t, scope="global"),
+                T.match_buffer(indices_h, (batch * k,), idx_t, scope="global"),
+                None,
+                T.match_buffer(seq_lens_h, (batch,), "int32", scope="global"),
+                T.match_buffer(aux_h, (batch * seq_len if pt else batch,), "int32", scope="global"),
+                T.match_buffer(overflow_h, (batch * 4 * ovf_stride * nc,), "int32", scope="global"),
+            )
+
+    return fast_topk_clusters_kernel
+
+
+@T.prim_func
+def fast_topk_clusters_kernel() -> None:
+    """Scaffold entry for the kernel-sketch stage."""
+    T.func_attr({"global_symbol": "fast_topk_clusters_kernel"})
+    # TIRX_TRANSCRIBE_START fast_topk_clusters
+    T.evaluate(0)
+
+
+# ---------------------------------------------------------------------------
+# Harness.
+# ---------------------------------------------------------------------------
+def _row_lengths(batch: int, seq_len: int, k: int, pattern: str, device):
+    """Per-row `seq_lens` for the transform modes.
+
+    `rowvar` deliberately mixes rows that take the trivial branch with rows that
+    do not, in one launch: the branch is per row on the transforms (`:466`,
+    `:511`) but per launch on plain.
+    """
+    import torch
+
+    if pattern == "rowvar":
+        lens = torch.full((batch,), seq_len, dtype=torch.int32, device=device)
+        lens[0::3] = min(k, seq_len)  # short enough for the trivial branch
+        lens[1::3] = max(1, seq_len // 2)
+        return lens
+    return torch.full((batch,), seq_len, dtype=torch.int32, device=device)
+
+
+def prepare_data(
+    dtype: str = "float32",
+    batch: int = 16,
+    seq_len: int = 16384,
+    k: int = 256,
+    mode: str = "plain",
+    pattern: str = "unique",
+    idx_dtype: str = "int32",
+    **kwargs: Any,
+):
+    """One launch's inputs, outputs, and scratch.
+
+    Selection here is exact over the ordered bits, so the only data-dependent
+    behavior is what lands in the boundary bin.  The patterns are chosen for that
+    path: `tie_heavy` and `all_equal` are what push the candidate cache past
+    `num_cached` into the global overflow ring and then into the cluster-wide tie
+    race, and `neg` takes the other half of the monotone-flip sign branch.
+
+    Every tensor is materialized here, including the overflow scratch, so that
+    nothing is allocated inside a timed closure.
+    """
+    import torch
+
+    device = "cuda"
+    g = torch.Generator(device=device).manual_seed(1234)
+
+    if pattern in ("unique", "rowvar"):
+        logits = torch.randn(batch, seq_len, dtype=torch.float32, device=device, generator=g) * 4
+    elif pattern == "tie_heavy":
+        # Few distinct values: most of the row collides in one bin, so the
+        # boundary bin overflows and the tie race decides the tail.
+        logits = torch.randint(
+            0, 8, (batch, seq_len), dtype=torch.int32, device=device, generator=g
+        ).to(torch.float32)
+    elif pattern == "all_equal":
+        # The entire row is one bin: every selected element is a tie winner.
+        logits = torch.full((batch, seq_len), 1.5, dtype=torch.float32, device=device)
+    elif pattern == "neg":
+        logits = -(
+            torch.rand(batch, seq_len, dtype=torch.float32, device=device, generator=g) * 8 + 0.5
+        )
+    else:
+        raise ValueError(f"Unknown pattern: {pattern}")
+
+    logits = logits.to(torch_dtype(dtype)).contiguous()
+
+    idx_torch = torch.int64 if idx_dtype == "int64" else torch.int32
+    data: dict[str, Any] = {
+        "logits": logits,
+        "batch": batch,
+        "seq_len": seq_len,
+        "k": k,
+        "mode": mode,
+        "dtype": dtype,
+        "idx_dtype": idx_dtype,
+        "num_clusters": clusters_for(batch, seq_len),
+        "idx_torch": idx_torch,
+    }
+
+    if mode != "plain":
+        data["seq_lens"] = _row_lengths(batch, seq_len, k, pattern, device)
+    if mode == "page_table":
+        # A per-row permutation.  The source's own tests use `randint`, which
+        # repeats entries; here the table must be invertible, because the only
+        # way to check the selection is to map an output index back to the row
+        # position it came from and look at the logit there.  A permutation keeps
+        # the mapping non-identity -- so a missing lookup still fails -- while
+        # making that inverse exact.
+        data["page_table"] = (
+            torch.argsort(torch.rand(batch, seq_len, device=device, generator=g), dim=1)
+            .to(torch.int32)
+            .contiguous()
+        )
+    if mode == "ragged":
+        data["offsets"] = (
+            torch.arange(batch, dtype=torch.int32, device=device) * seq_len
+        ).contiguous()
+
+    return data
+
+
+# `shared_memory_per_block_optin` on every SM100 part. Hard-coded rather than
+# queried because `get_kernel` runs in the bench suite's CPU prepare stage, which
+# fails the workload outright if it initializes CUDA ("CPU prepare changed CUDA
+# initialization state from False to True"). The value is asserted against the
+# live device in `prepare_data`, so a wrong constant cannot pass silently.
+SM100_SHARED_OPTIN = 232448
+
+
+def num_cached_for_device(k: int) -> int:
+    """`get_num_cached_for_topk` (topk.py:375-387), without touching the device."""
+    return num_cached_for(k, SM100_SHARED_OPTIN)
+
+
+def alloc_outputs(data: dict[str, Any]):
+    """Outputs plus the overflow ring, sized exactly as the Python layer sizes it."""
+    import torch
+
+    assert (
+        torch.cuda.get_device_properties(0).shared_memory_per_block_optin == SM100_SHARED_OPTIN
+    ), "SM100_SHARED_OPTIN disagrees with the live device; num_cached would diverge"
+
+    batch, k = data["batch"], data["k"]
+    device = data["logits"].device
+    nc = data["num_clusters"]
+    out: dict[str, Any] = {"indices": torch.empty(batch, k, dtype=data["idx_torch"], device=device)}
+    if data["mode"] == "plain":
+        out["values"] = torch.empty(batch, k, dtype=data["logits"].dtype, device=device)
+    # topk.py:414-420 -- `overflow_stride` is recovered by the binding from this
+    # tensor's row stride, so the shape is load-bearing, not just a capacity.
+    out["overflow"] = torch.empty(
+        batch, 4 * (data["seq_len"] // nc) * nc, dtype=torch.int32, device=device
+    )
+    return out
+
+
+def run_reference(data: dict[str, Any], out: dict[str, Any]) -> None:
+    """Drive the source's own FFI for this mode.
+
+    The entries are absent from `dir(module)`; they must be taken by name.
+    `num_clusters` and `num_cached` are passed explicitly so both sides run the
+    same specialization rather than whatever the Python heuristic would pick.
+    """
+    module = source_module()
+    nc = data["num_clusters"]
+    ncache = num_cached_for_device(data["k"])
+    mode = data["mode"]
+
+    if mode == "plain":
+        fn = getattr(module, "fast_topk_clusters_exact")
+        fn(
+            data["logits"],
+            out["indices"],
+            out["values"],
+            None,
+            out["overflow"],
+            data["k"],
+            ncache,
+            nc,
+            False,
+        )
+    elif mode == "page_table":
+        fn = getattr(module, "fast_topk_clusters_exact_page_table_transform")
+        fn(
+            data["logits"],
+            out["indices"],
+            data["seq_lens"],
+            data["page_table"],
+            None,
+            out["overflow"],
+            data["k"],
+            ncache,
+            nc,
+            False,
+        )
+    else:
+        fn = getattr(module, "fast_topk_clusters_exact_ragged_transform")
+        fn(
+            data["logits"],
+            out["indices"],
+            data["seq_lens"],
+            data["offsets"],
+            None,
+            out["overflow"],
+            data["k"],
+            ncache,
+            nc,
+            False,
+        )
+
+
+def local_indices(data: dict[str, Any], indices, row: int):
+    """Undo the mode's index transform, giving indices into the row itself."""
+    mode = data["mode"]
+    if mode == "plain":
+        return indices
+    if mode == "ragged":
+        return indices - int(data["offsets"][row].item())
+    # page_table: invert the permutation built in prepare_data
+    import torch
+
+    table = data["page_table"][row].long()
+    inverse = torch.empty_like(table)
+    inverse[table] = torch.arange(table.numel(), device=table.device)
+    return inverse[indices.long()]
+
+
+def assert_selection_is_top_k(data: dict[str, Any], indices, row: int, row_len: int) -> None:
+    """The oracle: the selected *value multiset* must equal `torch.topk`'s.
+
+    Positions carry no meaning on this path -- output slots are handed out by
+    atomic compaction, the per-CTA base comes from a racing atomic, and the
+    boundary bin's survivors are whichever lanes arrive first (`:306-308`).  The
+    multiset is still unique, because an exact radix select over the ordered bits
+    admits exactly one answer, so this is a bit-exact check and not a tolerance.
+    """
+    import torch
+
+    k = data["k"]
+    row_logits = data["logits"][row, :row_len].float()
+    local = local_indices(data, indices, row).long()
+
+    assert int(local.min()) >= 0 and int(local.max()) < row_len, (
+        f"row {row}: index out of range [0, {row_len})"
+    )
+    assert len(set(local.tolist())) == local.numel(), f"row {row}: duplicate indices"
+
+    got = torch.sort(row_logits[local]).values
+    want = torch.sort(torch.topk(row_logits, min(k, row_len)).values).values
+    assert torch.equal(got, want), (
+        f"row {row}: selected value multiset differs from torch.topk; "
+        f"max|delta| = {(got - want).abs().max().item()}"
+    )
+
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    cfg = {
+        "dtype": "float32",
+        "batch": 16,
+        "seq_len": 16384,
+        "k": 256,
+        "mode": "plain",
+        "pattern": "unique",
+        "idx_dtype": "int32",
+    }
+    cfg.update({key: value for key, value in config.items() if key != "label"})
+    return cfg
+
+
+def build_tirx_args(data: dict[str, Any], out: dict[str, Any]):
+    """Bind the flat launch ABI once, outside any timed region."""
+    args = [data["logits"].reshape(-1), out["indices"].reshape(-1)]
+    if data["mode"] == "plain":
+        args.append(out["values"].reshape(-1))
+    else:
+        args.append(data["seq_lens"])
+    if data["mode"] == "page_table":
+        args.append(data["page_table"].reshape(-1))
+    elif data["mode"] == "ragged":
+        args.append(data["offsets"])
+    args.append(out["overflow"].reshape(-1))
+    return tuple(args)
+
+
+def compare_outputs(data: dict[str, Any], mine: dict[str, Any], theirs: dict[str, Any]) -> None:
+    """Both sides are nondeterministic in order; compare what is well defined.
+
+    The selected *set* is exact on this path, so the comparison is bit-exact on
+    value multisets rather than tolerant on positions.  The trivial branch is the
+    exception: identity indices with ``-1`` padding are deterministic, so those
+    rows are compared positionally against the reference.
+    """
+    import torch
+
+    k, mode = data["k"], data["mode"]
+    for row in range(data["batch"]):
+        row_len = int(data["seq_lens"][row].item()) if mode != "plain" else data["seq_len"]
+        if row_len <= k:
+            assert torch.equal(mine["indices"][row], theirs["indices"][row]), (
+                f"row {row}: the trivial branch is deterministic and must match positionally"
+            )
+            continue
+        assert_selection_is_top_k(data, mine["indices"][row], row, row_len)
+        ours = torch.sort(
+            data["logits"][row, local_indices(data, mine["indices"][row], row).long()].float()
+        ).values
+        ref = torch.sort(
+            data["logits"][row, local_indices(data, theirs["indices"][row], row).long()].float()
+        ).values
+        assert torch.equal(ours, ref), f"row {row}: value multiset differs from the reference"
+        if mode == "plain":
+            gathered = data["logits"][row, mine["indices"][row].long()]
+            assert torch.equal(mine["values"][row], gathered), (
+                f"row {row}: output_values is not the gather of its own indices"
+            )
+
+
+def run_test(**config: Any) -> None:
+    import unittest
+
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover
+        raise unittest.SkipTest(f"torch unavailable: {exc}") from exc
+    if not torch.cuda.is_available():  # pragma: no cover
+        raise unittest.SkipTest("CUDA unavailable")
+
+    from tirx_kernels.runner import compile_kernel
+
+    cfg = _normalize_config(config)
+    data = prepare_data(**cfg)
+
+    mine = alloc_outputs(data)
+    ex = compile_kernel(get_kernel(**cfg))
+    ex(*build_tirx_args(data, mine))
+    torch.cuda.synchronize()
+
+    theirs = alloc_outputs(data)
+    run_reference(data, theirs)
+    torch.cuda.synchronize()
+
+    compare_outputs(data, mine, theirs)
+
+
+def prepare_bench(**kwargs: Any):
+    """Specialize and compile before the workload receives a GPU.
+
+    The reference is NOT built here. `source_module()` JITs the FlashInfer module,
+    which initializes CUDA, and the suite fails any workload whose CPU prepare
+    does that ("CPU prepare changed CUDA initialization state from False to
+    True"). It is built by the lazy `references` builder in `run_gpu` instead,
+    which is what the bench API expects and what the sibling ports do.
+    """
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    cfg = _normalize_config(kwargs)
+    return prepared_gpu_benchmark(
+        run_gpu, {"config": cfg, "executable": compile_kernel(get_kernel(**cfg))}
+    )
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    """Kernel-only comparison against the source launch.
+
+    Both implementations ALTERNATE over the same two working sets in opposite
+    phase, so each spends half its calls on each buffer. This is the bench-suite
+    README's cancellation for the per-implementation allocation draw, and it is
+    not optional here: giving each side its own outputs made this kernel's
+    smallest shape read 0.725x-0.900x across repeats with no code change, with
+    the tirx side alone swinging 8.2us to 14.3us while the reference held steady.
+
+    An earlier version of this function reasoned the effect could not bite
+    because the input row is shared and only the outputs are per-side. That was
+    wrong: the overflow ring is about 1 MB per side at the small shape, it is
+    both written and read back during the refinement rounds, and where it lands
+    dominates a kernel this short.
+
+    Every tensor is allocated before the closures are built. Allocating inside
+    one would enqueue fill kernels that a per-kernel timer charges here.
+    """
+    cfg = dict(prepared["config"])
+    ex = prepared["executable"]
+
+    data = prepare_data(**cfg)
+    set_a, set_b = alloc_outputs(data), alloc_outputs(data)
+    args_a, args_b = build_tirx_args(data, set_a), build_tirx_args(data, set_b)
+
+    phase = [0]
+
+    def tirx_launch():
+        ex(*(args_a if phase[0] & 1 == 0 else args_b))
+        phase[0] += 1
+
+    def build_reference():
+        module = source_module()
+        nc = data["num_clusters"]
+        ncache = num_cached_for_device(data["k"])
+        k, mode = data["k"], data["mode"]
+
+        def ref_args(out):
+            if mode == "plain":
+                return (
+                    data["logits"],
+                    out["indices"],
+                    out["values"],
+                    None,
+                    out["overflow"],
+                    k,
+                    ncache,
+                    nc,
+                    False,
+                )
+            if mode == "page_table":
+                return (
+                    data["logits"],
+                    out["indices"],
+                    data["seq_lens"],
+                    data["page_table"],
+                    None,
+                    out["overflow"],
+                    k,
+                    ncache,
+                    nc,
+                    False,
+                )
+            return (
+                data["logits"],
+                out["indices"],
+                data["seq_lens"],
+                data["offsets"],
+                None,
+                out["overflow"],
+                k,
+                ncache,
+                nc,
+                False,
+            )
+
+        name = {
+            "plain": "fast_topk_clusters_exact",
+            "page_table": "fast_topk_clusters_exact_page_table_transform",
+            "ragged": "fast_topk_clusters_exact_ragged_transform",
+        }[mode]
+        fn = getattr(module, name)
+        # OPPOSITE phase to tirx: b, a, b, a ... against tirx's a, b, a, b ...
+        rargs_a, rargs_b = ref_args(set_a), ref_args(set_b)
+        rphase = [0]
+
+        def reference_launch():
+            fn(*(rargs_b if rphase[0] & 1 == 0 else rargs_a))
+            rphase[0] += 1
+
+        return reference_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(**config: Any):
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu()
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+# ---------------------------------------------------------------------------
+_DT_TAG = {"float32": "f32", "float16": "f16", "bfloat16": "bf16"}
+_MODE_TAG = {"plain": "plain", "page_table": "pt", "ragged": "rag"}
+
+
+def _cfg(dtype, batch, seq_len, k, mode="plain", pattern="unique", idx_dtype="int32"):
+    label = f"{_DT_TAG[dtype]}_{_MODE_TAG[mode]}_b{batch}_l{seq_len}_k{k}"
+    if pattern != "unique":
+        label += f"_{pattern}"
+    if idx_dtype != "int32":
+        label += "_i64"
+    return {
+        "label": label,
+        "dtype": dtype,
+        "batch": batch,
+        "seq_len": seq_len,
+        "k": k,
+        "mode": mode,
+        "pattern": pattern,
+        "idx_dtype": idx_dtype,
+    }
+
+
+def _build_configs():
+    """Representative cover of the reachable domain.
+
+    The axes are not crossed.  ``num_clusters`` is not a free parameter -- the
+    host derives it from ``(batch, seq_len)`` -- so cluster coverage is obtained
+    by choosing batch sizes that land on each rung of that heuristic, and the
+    ``seq_len < 8192`` clamp is exercised on its own.
+
+    Retained in full: every mode x dtype pair; every cluster width the launcher
+    can instantiate; both index widths on the mode that supports them; the
+    trivial ``seq_len <= k`` branch on every mode; and every input pattern that
+    can change which elements are selected.
+    """
+    configs = []
+
+    # 1. Every mode x dtype at one carrier shape (batch 16 -> 8 clusters).
+    for mode in MODES:
+        for dtype in DTYPES:
+            configs.append(_cfg(dtype, 16, 16384, 256, mode=mode))
+
+    # 2. Cluster width.  The heuristic is batch<=32 -> 8, <128 -> 4, <256 -> 2,
+    #    else 1, and any seq_len < 8192 clamps to 1 regardless of batch.
+    for batch in (16, 64, 200, 300):
+        configs.append(_cfg("float32", batch, 16384, 256))
+    configs.append(_cfg("float32", 16, 4096, 256))  # clamp to one cluster
+    configs.append(_cfg("float16", 16, 4096, 256))
+
+    # 3. k ladder, and the largest row the tests exercise.
+    for k in (256, 1024, 2048):
+        configs.append(_cfg("float32", 64, 16384, k))
+    configs.append(_cfg("float32", 64, 65536, 1024))
+    configs.append(_cfg("bfloat16", 64, 65536, 1024))
+
+    # 4. int64 indices -- plain only, the width `flashinfer.top_k` itself uses.
+    configs.append(_cfg("float32", 16, 16384, 256, idx_dtype="int64"))
+    configs.append(_cfg("float16", 64, 65536, 2048, idx_dtype="int64"))
+
+    # 5. The trivial branch (:417-429, :467-476, :511-520): seq_len <= k skips
+    #    the worker entirely and is the one path with a deterministic output.
+    for mode in MODES:
+        configs.append(_cfg("float32", 8, 4096, 4096, mode=mode))
+
+    # 6. Input patterns.  Ties are the interesting axis here: the boundary bin
+    #    is what drives the overflow ring and the cluster-wide tie rationing,
+    #    and `all_equal` puts the entire row in it.
+    for pattern in ("tie_heavy", "all_equal", "neg"):
+        configs.append(_cfg("float32", 16, 16384, 256, pattern=pattern))
+    configs.append(_cfg("float32", 16, 16384, 2048, pattern="all_equal"))
+    #    Per-row lengths, including rows short enough to take the trivial path
+    #    beside full rows in the same launch.
+    for mode in ("page_table", "ragged"):
+        configs.append(_cfg("float32", 16, 16384, 256, mode=mode, pattern="rowvar"))
+
+    #    Two clusters is otherwise reached by only one shape, and the transforms
+    #    otherwise run at only one cluster width; both matter because the
+    #    cluster-wide tie rationing and range allocation scale with the width.
+    configs.append(_cfg("float32", 200, 65536, 1024))
+    configs.append(_cfg("float32", 200, 16384, 256, mode="page_table"))
+    configs.append(_cfg("bfloat16", 300, 16384, 256, mode="ragged"))
+
+    # 7. Measurement control: float16 and bfloat16 differ only in the ordered-bit
+    #    map, and compile to the same instruction sequence at a given rung, so a
+    #    spread between this pair is measurement rather than kernel.
+    for dtype in ("float16", "bfloat16"):
+        configs.append(_cfg(dtype, 64, 16384, 1024, pattern="tie_heavy"))
+
+    seen: dict[str, dict[str, Any]] = {}
+    for cfg in configs:
+        seen.setdefault(cfg["label"], cfg)
+    deduped = list(seen.values())
+
+    covered = {clusters_for(c["batch"], c["seq_len"]) for c in deduped}
+    assert covered == set(CLUSTER_WIDTHS), f"cluster widths not covered: {covered}"
+    assert {c["mode"] for c in deduped} == set(MODES)
+    assert {c["dtype"] for c in deduped} == set(DTYPES)
+    return deduped
+
+
+CONFIGS = _build_configs()
+BENCH_CONFIGS = CONFIGS
+
+_ = (bench, dtype_bytes, radix_rounds, shared_mem_bytes, num_cached_for, clusters_for, PATTERNS)


### PR DESCRIPTION
Ports `fast_topk_clusters_exact` and both transform wrappers from FlashInfer (`include/flashinfer/fast_topk_clusters_exact.cuh` @ `f2e04400`) as the registry module `fast_topk_clusters`. This is the last unported member of the `flashinfer.topk` family.

## What this is

The SM100 cluster path `flashinfer.top_k` selects in Python *before* the FFI, when `not deterministic and tie_break is NONE and not dsa_graph_safe` (`topk.py:502-507`) — it bypasses the C++ `TopKDispatch` entirely.

An exact 256-bin MSB-first radix select distributed across a CTA cluster: four rounds at fp32 and two at 16-bit, a DSMEM peer-summed histogram, a double-buffered candidate cache that spills to a per-CTA global ring, cluster-wide tie rationing on rank 0, and a cluster-wide output-range claim. It is this repo's first kernel to use DSMEM atomics.

All three wrappers are one module with a `mode` axis, covering three dtypes, the four cluster widths the launcher instantiates, and both index widths on the wrapper that supports them. PDL and the pre-computed histogram are out of scope with the excluding predicate documented: both are dead from every Python call site.

## Correctness

34 configs, **34 passing, 0 skips**, against the source's own FFI.

Selection is exact but output *order* is not — compaction races an atomic and boundary-bin tie winners are arbitrary. Comparison is therefore bit-exact on sorted value multisets rather than positions. The trivial (`seq_len <= TopK`) branch is the exception and compares positionally, since identity indices plus `-1` padding are deterministic; note it is transform-aware, so the three wrappers expect different indices there.

Two source hazards are reproduced deliberately rather than repaired: the unguarded `s_topk_inds` emit whose bounds check is commented out at `:195-197`, and the never-initialized `shared_threshold_bin` at `:166-170`.

## Performance

Above `0.99x` source on every config, confirmed on **two independent complete bench-suite matrices**. Measured on a quiet GPU the thinnest row is `f32_pt_b200_l16384_k256` at `0.998x`; every other row carries `+0.019` to `+0.026`.

## Codegen findings

Two entries in the tuning database, both measured:

- **New** — `stage-unrolled-loads-into-distinct-registers`. `T.serial(..., unroll=N)` reuses a single destination local across the unrolled copies, so unrolled loads serialize on the register instead of overlapping. Paired NCU showed identical global load sectors on both sides and *fewer* executed instructions on ours, with the whole gap in `long_scoreboard` (22.48 vs 7.02). Staging a chunk into distinct registers before consuming any of it is what creates the parallelism.
- **Updated** — `scale-a-staged-load-unroll-to-the-trip-count`. The factor must be derived per kernel: this kernel's crossover is at 8 trips where the entry recorded 28. Also adds two boundaries it lacked — the non-monotonicity is not only at the top of the range (unroll 6 was worse than both 4 and 8 at every trip count), and the lever does not transfer between loops in the same kernel (applying it to a runtime-bounded loop regressed three shapes).

## Notes for review

`baseline.json` / `baseline.md` carry the promoted rows for the 34 new configs; the merge preserves all 53 pre-existing kernels. No shared utility was modified — `topk_radix.py` is untouched, so no sibling topk regression run was required.