### PR TITLE
feat(kernel): port msa sparse prepare fwd split atomic kernel to tirx

### DIFF
--- a/.agents/sketch/msa/sparse_prepare_fwd_split_atomic.md
+++ b/.agents/sketch/msa/sparse_prepare_fwd_split_atomic.md
@@ -1,0 +1,385 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of MSA's
+python/fmha_sm100/cute/src/sm100/prepare_scheduler.py
+SparseAttentionPrepareFwdSplitAtomicSm100.
+-->
+
+# msa_sparse_prepare_fwd_split_atomic_sm100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py`](../../../tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **one kernel**: `SparseAttentionPrepareFwdSplitAtomicSm100.kernel`
+(`prepare_scheduler.py:432-481`) with its launcher `__call__` (`:366-430`), the
+stage that hands every CSR edge a split slot so the forward attention kernel can
+write its partial output without a second round of atomics.
+
+Instantiations: **exactly one**. The compile shim keys its cache on the constant
+tuple `("sparse_prepare_fwd_split_atomic_sm100_csr_varlen",)` (`:496-498`) and
+`to_cute_tensor` marks every layout dynamic, so one binary serves every shape;
+all extents, strides and scalars are runtime. The compile-time constants are
+`num_threads = 256` (`:354`) and the three-slot shared struct (`:360-364`).
+
+Accepted target SM100/B200. Out of scope, with the predicate that excludes each:
+the host rejects `topk > 255` (`:673`) and `max_seqlen_q >= 2^24` (`:675`); the
+default adapter path builds its schedule with the fused CUDA builder and skips
+this kernel entirely, so it runs only when the caller passes no prebuilt
+schedule or limits `usable_SM_count`. The producing sibling
+`SparseAttentionPrepareFlatScheduleSm100` (`:124-345`) is a separate kernel with
+its own cache key, already ported. Tile (`Tx`) primitives are out of scope
+everywhere.
+
+## Pipeline at a glance
+
+| Kernel / role | Program | Publication / reuse edges |
+| --- | --- | --- |
+| **CTA `b`, all 256 threads** (`:445-455`) | read `work_count`, exit if `b >= work_count`; load `head_kv_idx` from the work item | `head_kv_idx` stays in every thread's registers — it is the one metadata field the emission loop needs per thread, and the export keeps its load unsunk for exactly that reason |
+| **CTA `b`, thread 0 only** (`:457-461`) | load `row_linear`, `q_begin`, `q_count`, `batch_idx` from the work item; load the row's CSR base; publish `(row_start, q_count, batch_idx)` into `sRow[0..2]` | Publishes to shared memory. nvcc **sinks** those four metadata loads into this block, so the other 255 threads never issue them — which is what makes all three shared slots load-bearing rather than redundant. |
+| **CTA `b`, all 256 threads** (`:462-481`) | one `bar.sync`; read the three fields back from `sRow`; stride `qi += 256` over the row's edges, reserving a slot per valid edge with a device-scope atomic and writing the packed field under the capacity guard | Consumes `sRow`. Publishes to global memory only. Slot order is the atomic arrival order, so the schedule is defined as a **per-`(q_abs, head_kv)` permutation**, not a fixed assignment. |
+
+There is no producer/consumer warp split, no pipe, no stage, no phase, no
+mbarrier, and no async copy. The only intra-CTA edge is the single `bar.sync`
+separating thread 0's three shared stores from everyone's three shared loads,
+and the only cross-CTA edge is the atomic.
+
+**One CTA owns one work item.** The grid is `work_capacity` CTAs of 256 threads
+— sized by the work list's *capacity*, not its length, because `work_count`
+lives on the device and is never read back to the host. On the decode shapes
+that leaves most CTAs doing nothing but the early-out.
+
+## Primitive vocabulary
+
+```python
+load_global(buf, idx) -> reg          # ld.global.b32 | ld.global.s32 (address operands)
+store_global(buf, idx, reg)           # st.global.b32
+atom_add_global(buf, idx) -> old      # atom.global.add.u32 d, [a], 1
+store_shared(smem, idx, reg)          # st.shared.b32
+load_shared(smem, idx) -> reg         # ld.shared.b32
+barrier()                             # bar.sync 0
+pack(q_idx, slot)                     # shl.b32 24 + or.b32
+```
+
+### The atomic is raw inline PTX with an immediate operand
+
+Unlike the sibling kernel, which asks for `sem="relaxed", scope="gpu"` and lets
+the DSL choose the encoding, this kernel calls `copy_utils.atomic_add_i32`
+(`src/common/copy_utils.py:159-172`), which *is* the instruction:
+
+```python
+llvm.inline_asm(T.i32(), [ptr], "atom.global.add.u32 $0, [$1], 1;\n", "=r,l", ...)
+```
+
+The export carries it verbatim inside `// begin inline asm` markers, with the
+addend as the **immediate `1`**. TIRx's `T.ptx.atom.global_.add.u32` takes the
+addend as a register operand, so the port emits `mov.b32 %r, 1` plus the same
+instruction — an operand-form difference ptxas folds, already recorded from the
+sibling port. Relaxed ordering and device scope remain the defaults: no
+`.relaxed`, no `.gpu`, no surrounding fence.
+
+### The shared storage is dynamic, and its base is broadcast
+
+The source's `@cute.struct SharedStorage` reads like a static `__shared__` array,
+but `cutlass.utils.SmemAllocator` allocates from the dynamic pool, and the export
+broadcasts the base pointer across the warp:
+
+```
+.extern .shared .align 1024 .b8 __dynamic_shmem__0[];
+...
+.loc 1 432   mov.b32           %r8, __dynamic_shmem__0;
+             shfl.sync.idx.b32 %r2, %r8, 0, 31, -1;
+```
+
+So the matching TIRx form is a `T.SMEMPool()` allocation plus the
+`tirx.use_dyn_shared_memory` launch tag, not a static `T.alloc_shared`. The
+declared size is 12 bytes (`3 * int32`, no padding); the `.align 1024` is the
+pool's alignment, not the struct's.
+
+### `.file` map of the export
+
+`.file 1` = `prepare_scheduler.py`, `.file 2` = `src/common/utils.py` (only
+`elem_pointer`'s `shl.b64` at `:371`). Line info comes from a fresh
+`CUTE_DSL_KEEP=ptx CUTE_DSL_LINEINFO=1 CUTE_DSL_NO_CACHE=1` export preserved at
+`.porting/sparse_prepare_fwd_split_atomic/ptx_lineinfo/source_split_atomic_lineinfo.sm_100a.ptx`
+(42 `.loc`, 73 instructions). Every `.loc` cited below uses that file.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+variant = specialize(NUM_THREADS=256, SROW_FIELDS=3, target="sm_100a")
+# instruction_selection: none; extent: the only compile-time constants (:354, :360-364)
+SLOT_SHIFT, SLOT_MASK = 24, 0xFF          # packing constants (:479)
+
+# Runtime ABI -- all int32, all global, all `assume_tensor_aligned` (:395-414).
+#   k2q_row_ptr        [head_kv, total_rows + 1]      read-only
+#   k2q_q_indices      [head_kv, total_q * topk]      read-only  (-1 past nnz)
+#   scheduler_metadata [work_capacity, 6]             read-only  (cols 0..4; col 5 unused)
+#   work_count         [1]                            read-only  (the early-out bound)
+#   k2q_qsplit_indices [head_kv, total_q * topk]      write-only, sparse, UNINITIALIZED
+#   split_counts       [total_q, head_kv]             read-modify-write, must arrive zeroed
+#   cu_seqlens_q       [num_batches + 1]              read-only
+# Runtime scalars: max_seqlen_q, topk (+ the extents the port passes explicitly).
+
+launch_config = launch(grid=(work_capacity, 1, 1), block=(256, 1, 1),
+                       dynamic_smem_bytes=12)
+# instruction_selection: none; extent: static launch metadata (:425-430).
+#   grid.x is the work list's CAPACITY, not its length -- `work_count` is device
+#   resident, so the launch is deliberately oversized and the tail CTAs exit.
+
+# ===========================================================================
+# Storage.  One 12-byte dynamic shared allocation; everything else is registers.
+# ===========================================================================
+sRow = smem_pool.alloc((3,), "int32")     # SharedStorage.sRow (:360-364, :448-450)
+# instruction_selection: mov.b32 of __dynamic_shmem__0 + shfl.sync.idx.b32
+#   broadcast of the base (.loc 1 432); extent: one allocation per CTA.
+
+def kernel():
+    tidx  = thread_id(extent=NUM_THREADS)   # instruction_selection: mov.u32 %tid.x (.loc 1 445)
+    block = cta_id(axis="x")                # instruction_selection: mov.u32 %ctaid.x (.loc 1 446)
+
+    # -----------------------------------------------------------------------
+    # Stage 1: the oversized-grid early-out (:447)
+    # -----------------------------------------------------------------------
+    produced = load_global(work_count, 0)
+    # instruction_selection: ld.global.b32 (.loc 1 447 19); extent: one scalar,
+    #   issued by every thread of every CTA including the ones about to exit
+    if block >= produced:
+        return
+    # instruction_selection: setp.ge.s32 + predicated branch to the exit
+    #   (.loc 1 447 7); extent: CTA-uniform branch. It precedes every shared
+    #   access, so the barrier below is never reached by a partial CTA.
+
+    # -----------------------------------------------------------------------
+    # Stage 2: the one metadata field every thread needs (:451)
+    # -----------------------------------------------------------------------
+    head_kv_idx = load_global(scheduler_metadata, block * 6 + 0)
+    # instruction_selection: ld.global.s32 (.loc 1 451 22) -- sign-extending,
+    #   because the value feeds 64-bit address arithmetic; extent: one scalar
+    #   per thread.  This load stays UNSUNK: every thread uses it in the
+    #   emission loop.
+
+    # -----------------------------------------------------------------------
+    # Stage 3: thread 0 publishes the row through shared memory (:457-461)
+    # -----------------------------------------------------------------------
+    if tidx == 0:
+        # instruction_selection: setp.ne.b32 + predicated branch (.loc 1 457 11);
+        #   extent: intra-CTA branch -- 255 threads jump straight to the barrier
+        batch_idx = load_global(scheduler_metadata, block * 6 + 4)
+        # instruction_selection: ld.global.b32 (.loc 1 455 23); extent: one scalar
+        q_count   = load_global(scheduler_metadata, block * 6 + 3)
+        # instruction_selection: ld.global.b32 (.loc 1 454 18); extent: one scalar
+        q_begin   = load_global(scheduler_metadata, block * 6 + 2)
+        # instruction_selection: ld.global.b32 (.loc 1 453 18); extent: one scalar
+        row_linear = load_global(scheduler_metadata, block * 6 + 1)
+        # instruction_selection: ld.global.s32 (.loc 1 452 21) -- sign-extending,
+        #   same reason as head_kv_idx; extent: one scalar.
+        # THESE FOUR ARE SUNK HERE BY THE COMPILER.  The source reads all five
+        # columns with every thread; only head_kv_idx survives that way, because
+        # only it is used outside this block.  The consequence is that all three
+        # shared slots below are load-bearing -- the other 255 threads never
+        # issue these loads at all.
+        row_base = load_global(k2q_row_ptr, head_kv_idx * (total_rows + 1) + row_linear)
+        # instruction_selection: mad.lo.s64 + shl.b64 + add.s64 + ld.global.b32
+        #   (.loc 1 458 27); extent: one scalar -- the extra load thread 0 exists
+        #   to amortize
+        store_shared(sRow, 0, row_base + q_begin)                       # (:459)
+        # instruction_selection: add.s32 + st.shared.b32 [base] (.loc 1 459 12); extent: one
+        store_shared(sRow, 1, q_count)                                  # (:460)
+        # instruction_selection: st.shared.b32 [base+4] (.loc 1 460 12); extent: one
+        store_shared(sRow, 2, batch_idx)                                # (:461)
+        # instruction_selection: st.shared.b32 [base+8] (.loc 1 461 12); extent: one
+
+    barrier()                                                           # (:462)
+    # instruction_selection: bar.sync 0 (.loc 1 462 8); extent: CTA-wide.  The
+    #   only synchronization in the kernel.
+
+    # -----------------------------------------------------------------------
+    # Stage 4: everyone reads the row back (:463-465)
+    # -----------------------------------------------------------------------
+    row_count = load_shared(sRow, 1)
+    # instruction_selection: ld.shared.b32 [base+4] (.loc 1 464 20); extent: one.
+    #   Read FIRST in the export, because it is the loop guard below.
+    row_start = load_shared(sRow, 0)
+    # instruction_selection: ld.shared.b32 [base] (.loc 1 463 20); extent: one
+    batch_idx = load_shared(sRow, 2)
+    # instruction_selection: ld.shared.b32 [base+8] (.loc 1 465 20); extent: one
+
+    # -----------------------------------------------------------------------
+    # Stage 5: lane-strided edge emission (:466-481)
+    # -----------------------------------------------------------------------
+    qi = tidx                                                           # (:466)
+    while qi < row_count:                                               # (:467)
+        # instruction_selection: setp.ge.s32 to skip the loop entirely, then
+        #   setp.lt.s32 + backward branch for the back edge (.loc 1 467 14);
+        #   extent: ceil(row_count / 256) iterations per thread.  The source
+        #   carries NO nounroll pragma here and nvcc leaves it rolled anyway;
+        #   the trip count is the runtime, data-dependent row_count.
+        edge = row_start + qi                                           # (:468)
+        # instruction_selection: add.s32 (.loc 1 468 19); extent: scalar
+        q_idx = load_global(k2q_q_indices, head_kv_idx * nnz_capacity + edge)
+        # instruction_selection: cvt.s64.s32 + add.s64 + shl.b64 + add.s64 +
+        #   ld.global.b32 (.loc 1 469 20); extent: one scalar per iteration.
+        #   The row base is hoisted above the loop (mul.lo.s64); only the
+        #   per-edge displacement is computed inside.
+        if q_idx >= 0 and q_idx < max_seqlen_q:                         # (:470)
+            # instruction_selection: setp.lt.s32 + setp.ge.s32 + or.pred +
+            #   predicated branch (.loc 1 470 15, 470 37); extent: scalar.  A
+            #   real branch, not if-conversion.  Well-formed input never takes
+            #   it -- the CSR row covers only filled entries -- but the guard
+            #   exists because the GPU index builder leaves its tail
+            #   uninitialized and the reference builder fills it with -1.
+            q_abs = load_global(cu_seqlens_q, batch_idx) + q_idx        # (:471)
+            # instruction_selection: ld.global.b32 + add.s32 (.loc 1 471 24);
+            #   extent: one scalar PER ITERATION.  The address is hoisted
+            #   (mul.wide.s32 + add.s64 above the loop) but the load is not:
+            #   the atomic's memory clobber keeps this loop-invariant value
+            #   being re-fetched every edge.
+            slot = atom_add_global(split_counts, q_abs * num_heads_kv + head_kv_idx)
+            # instruction_selection: cvt.s64.s32 + mad.lo.s64 (.loc 1 472 28) +
+            #   shl.b64 + add.s64 (.loc 2 371 11, elem_pointer) then
+            #   `atom.global.add.u32 %r, [%rd], 1` inside inline-asm markers
+            #   (.loc 1 476 29); extent: one instruction per valid edge.
+            #   Returns the pre-increment value.  Relaxed, device scope, no fence.
+            if slot < topk:                                             # (:477)
+                # instruction_selection: setp.ge.s32 + predicated branch
+                #   (.loc 1 477 19); extent: scalar.  SIGNED compare against the
+                #   u32 the atomic returned.  Also never taken on well-formed
+                #   input, where a (q_abs, head) group has at most topk edges.
+                store_global(k2q_qsplit_indices,
+                             head_kv_idx * nnz_capacity + edge,
+                             q_idx | ((slot & SLOT_MASK) << SLOT_SHIFT))
+                # instruction_selection: shl.b32 by 24 (.loc 1 479 33) + or.b32
+                #   (.loc 1 479 24) + add.s64 + shl.b64 + add.s64 +
+                #   st.global.b32 (.loc 1 478 20); extent: one store per written
+                #   edge.  The `& 0xFF` folds away -- ptxas knows the shift
+                #   discards everything above bit 7 -- so the export carries a
+                #   bare shl+or, no `and.b32`.
+        qi += 256                                                       # (:481)
+        # instruction_selection: add.s32 with the immediate 256 (.loc 1 481 12);
+        #   extent: scalar
+```
+
+## Control-flow map
+
+| Region | Source | Predicate | Who executes |
+| --- | --- | --- | --- |
+| oversized-grid early-out | `:447` | `block_idx < work_count[0]` | CTA-uniform; precedes every shared access, so the barrier is never partial |
+| row publisher | `:457` | `tidx == 0` | one thread per CTA; the other 255 branch to the barrier |
+| emission loop | `:467` | `qi < row_count` | all 256 threads, stride 256, rolled |
+| edge validity | `:470` | `0 <= q_idx < max_seqlen_q` | per edge; a real branch, unreachable on well-formed input |
+| slot capacity | `:477` | `split_slot < topk` | per valid edge; drops the store, keeps the atomic; unreachable on well-formed input |
+
+Per valid edge the kernel issues two `ld.global.b32`, one
+`atom.global.add.u32`, and one predicated `st.global.b32`. That is the whole
+cost model: the prefill shapes are edge-bound, and the decode shapes are
+dominated instead by CTAs that take the first branch and retire.
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `num_threads = 256` | static (`:354`) | block shape and the `qi += 256` stride immediate |
+| `SharedStorage` = 3 x int32 | static (`:360-364`) | 12 dynamic-pool bytes and the `+0/+4/+8` displacements |
+| metadata columns 0..4, stride 6 | static | the `[%rd2]`, `+4`, `+8`, `+12`, `+16` displacements off one base |
+| `0xFF`, `24` | static (`:479`) | `shl.b32` + `or.b32`; the mask folds away |
+| `work_capacity` | **runtime**, host-only | becomes `grid.x`; never a kernel argument in the source |
+| `work_count[0]` | **runtime**, device-resident | why the grid is oversized in the first place |
+| `max_seqlen_q`, `topk` | **runtime** | guard operands stay registers, never immediates |
+| every extent and stride | **runtime** | dynamic layouts; one binary for all shapes |
+| slot assignment | **non-deterministic** | atomic arrival order; only the per-group permutation is defined |
+| `split_counts` initial value | **caller contract** | zeroed by the host before every launch (`:695-696`), never by the kernel |
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "msa_sparse_prepare_fwd_split_atomic_sm100", "category":
+  "msa", "compute_capability": 10}`.
+- Plain TIRx only: a `T.SMEMPool()` arena for `sRow`, explicit loops, scalar
+  registers via `T.alloc_local`, and native `T.ptx.*` forms for every key
+  operation. Global **and shared** memory are reached exclusively through
+  `T.ptx.ld/st.*` on `buffer.ptr_to([...])` — the repository's low-level IR
+  contract forbids a native `BufferLoad`/`BufferStore` in either scope. No
+  `T.cuda.func_call`. No `Tx` tile primitives anywhere.
+- The 2-D source tensors are matched as flat 1-D buffers, with the row strides
+  passed as scalars, which reproduces the export's addresses without a dynamic
+  stride operand.
+- Correctness compares against **MSA's own compiled kernel** over identical
+  inputs, plus a host oracle built from the same edge list. Because slot
+  assignment is arrival-ordered, the comparison is over invariants, not values:
+  `split_counts` element-wise; a written entry's low 24 bits equal that edge's
+  `q_idx`; and per `(q_abs, head_kv)` the slots are exactly `{0..degree-1}`,
+  gapless and without duplicates. That last one is the consumer's requirement,
+  not a testing convenience — the forward kernel writes `split_counts` partials
+  into `O_partial[0..count-1]` and combine reduces exactly that many. The oracle
+  reads only each head's live CSR range, since `k2q_qsplit_indices` arrives
+  uninitialized.
+- The benchmark is **kernel-only** on both sides: the timed closure holds one
+  launch, with the CSR build, the work list, the allocation and every zeroing
+  outside it — the same line MSA's own instrumentation draws by putting
+  `split_counts.zero_()` in a separate NVTX range. `split_counts` is
+  read-modify-write and the kernel never resets it, so both sides rotate over
+  pre-zeroed slices and re-zero once per rotation; without that, the second and
+  every later launch finds `split_slot >= topk` everywhere and the store path
+  stops firing, leaving a strictly cheaper kernel being timed.
+
+## Instruction selection is a lowering consequence
+
+| Primitive / pattern | PTX family (fresh `sm_100a` lineinfo export) |
+| --- | --- |
+| `work_count` load (`:447`) | `ld.global.b32` |
+| `head_kv_idx`, `row_linear` (`:451`, `:452`) | `ld.global.s32` — sign-extending, they feed 64-bit addressing |
+| `q_begin`, `q_count`, `batch_idx` (`:453-455`) | `ld.global.b32`, **sunk into the `tidx == 0` block** |
+| CSR row base (`:458`) | `mad.lo.s64` + `shl.b64` + `add.s64` + `ld.global.b32` |
+| shared publish (`:459-461`) | `st.shared.b32` x3 at `+0/+4/+8` |
+| barrier (`:462`) | `bar.sync 0` |
+| shared read-back (`:463-465`) | `ld.shared.b32` x3; `q_count` first, it is the loop guard |
+| edge `q_idx` load (`:469`) | `ld.global.b32`, row base hoisted |
+| validity guard (`:470`) | `setp.lt.s32` + `setp.ge.s32` + `or.pred` + branch |
+| `cu_seqlens_q[batch_idx]` (`:471`) | `ld.global.b32` **per iteration** — address hoisted, load not |
+| slot reservation (`:476`) | `atom.global.add.u32 d, [a], 1` inside inline-asm markers, immediate addend |
+| capacity guard (`:477`) | `setp.ge.s32` + branch, signed |
+| packing (`:479`) | `shl.b32 24` + `or.b32`; the `& 0xFF` folds away, no `and.b32` |
+| work-item store (`:478`) | `st.global.b32`, row base hoisted |
+| smem base | `mov.b32 __dynamic_shmem__0` + `shfl.sync.idx.b32` broadcast |
+| absent everywhere | `mbarrier`, `cp.async`, `fence`, `red.*`, `vote.sync`, `match.any`, `ld.global.nc`, `ld/st.global.v2\|v4`, any `div`, `.relaxed`, `.gpu` |
+
+Static opcode counts of the exported entry (73 instructions,
+`.reg .b32 %r<23>`, `.reg .b64 %rd<37>`, `.reg .pred %p<9>`):
+
+| op | count | op | count |
+| --- | ---: | --- | ---: |
+| `add.s64` | 8 | `mad.lo.s64` | 2 |
+| `ld.global.b32` | 7 | `ld.global.s32` | 2 |
+| `shl.b64` | 5 | `cvt.s64.s32` | 2 |
+| `setp.ge.s32` | 4 | `st.global.b32` | 1 |
+| `add.s32` | 4 | `shfl.sync.idx.b32` | 1 |
+| `st.shared.b32` | 3 | `atom.global.add.u32` | 1 |
+| `mul.lo.s64` | 3 | `bar.sync` | 1 |
+| `ld.shared.b32` | 3 | `or.pred` / `or.b32` | 1 / 1 |
+| `setp.lt.s32` | 2 | `shl.b32` | 1 |
+
+`st.shared.b32 = ld.shared.b32 = 3` with a single `bar.sync` between them is the
+whole synchronization protocol. `ld.global.b32 = 7` decomposes as one
+`work_count`, three sunk metadata fields, one CSR base, and the two per-edge
+loads; `atom.global.add.u32 = 1` and `st.global.b32 = 1` are the emission tail.
+The absence of `and.b32` is the check that the port folded the `& 0xFF` rather
+than emitting it, and `div` being absent everywhere is why the sibling port's
+unsigned-division lever has nothing to act on here.

--- a/.agents/skills/tirx-codegen-tuning/references/db/keep-a-static-shared-allocation-static.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/keep-a-static-shared-allocation-static.md
@@ -54,6 +54,16 @@ the reference's own declaration before choosing, and verify the realized byte
 budget either way -- a `cuobjdump -res-usage` figure includes the driver's
 reserved block and will not match the declaration.
 
+Take that declaration from the reference's export, not its source text. A DSL
+frontend can allocate from the dynamic pool something whose source reads exactly
+like a static array: a fixed-size struct member, no pool or arena in sight,
+allocated through the frontend's own allocator and emitted as
+`.extern .shared .b8 __dynamic_shmem__[]` with the base broadcast across the
+warp. Reading the source there yields the opposite answer and sends a port away
+from the reference rather than toward it. Where the reference is already the pool
+form, matching it is what this entry asks for, and a static buffer is then a
+candidate for beating the reference rather than a fidelity fix.
+
 ## Verification
 
 Read the declaration in the generated CUDA, not just the total: the static form

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 
 `msa/` — MSA sparse attention ports:
 
-| Kernel                                   | Module                             | What it is |
-| ---------------------------------------- | ---------------------------------- | ---------- |
-| `msa_sparse_prepare_flat_schedule_sm100` | `sparse_prepare_flat_schedule.py`  | Flat work-list preparation for sparse attention |
+| Kernel                                     | Module                              | What it is |
+| ------------------------------------------ | ----------------------------------- | ---------- |
+| `msa_sparse_prepare_flat_schedule_sm100`   | `sparse_prepare_flat_schedule.py`   | Flat work-list preparation for sparse attention |
+| `msa_sparse_prepare_fwd_split_atomic_sm100` | `sparse_prepare_fwd_split_atomic.py` | Forward split-slot preparation (packed `q_idx`/slot metadata) |
 
 ## Performance
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "0d695aa0",
-    "tirx-kernels": "fc344e9e-dirty",
+    "tirx-kernels": "db0958ea-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "4a09dabf5bb867211c1f794472733fdac2f87a31"
+    "tirx-kernels:tirx_kernels": "75f7a5c54e09bd808690a85e1ed985c30df760f8"
   },
   "baselines": {
     "torch": {
@@ -3529,6 +3529,118 @@
       "impls": {
         "tirx": 5.104288343425731,
         "msa": 5.981656413391014
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "decode_b128_k65536_h4",
+      "label": "decode_b128_k65536_h4",
+      "status": "ok",
+      "impls": {
+        "tirx": 217.28074204704527,
+        "msa": 219.68232452074372
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "decode_b32_k8192_h4",
+      "label": "decode_b32_k8192_h4",
+      "status": "ok",
+      "impls": {
+        "tirx": 15.11112974095685,
+        "msa": 15.411196760328396
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "decode_b64_k16384_h4_varlen",
+      "label": "decode_b64_k16384_h4_varlen",
+      "status": "ok",
+      "impls": {
+        "tirx": 29.64779907220087,
+        "msa": 30.254163280826035
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "edge_b1_k512_h1",
+      "label": "edge_b1_k512_h1",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.342684901524134,
+        "msa": 4.398679375281474
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "prefill_b1_k131072_h1",
+      "label": "prefill_b1_k131072_h1",
+      "status": "ok",
+      "impls": {
+        "tirx": 33.2527484426999,
+        "msa": 33.43431891075929
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "prefill_b1_k32768_h2",
+      "label": "prefill_b1_k32768_h2",
+      "status": "ok",
+      "impls": {
+        "tirx": 16.556753578263546,
+        "msa": 16.84091493152361
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "prefill_b1_k8192_h2",
+      "label": "prefill_b1_k8192_h2",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.146323571670095,
+        "msa": 7.3066606137813555
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
+      "config": "prefill_b3_k8192_h2_varlen",
+      "label": "prefill_b3_k8192_h2_varlen",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.7838855016142,
+        "msa": 10.998679620186552
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '0d695aa0', 'tirx-kernels': 'fc344e9e-dirty', 'tirx-bench-ci': None}`
-- Workloads: 389 ok, 0 failed
+- Git:       `{'tir': '0d695aa0', 'tirx-kernels': 'db0958ea-dirty', 'tirx-bench-ci': None}`
+- Workloads: 397 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -406,6 +406,19 @@ Grouped workloads show one row per config and one timing column per implementati
 | `prefill_b1_k32768_h2` | tirx | 4.4183 | msa | 4.7939 | 1.085 | — |
 | `prefill_b1_k8192_h2` | tirx | 3.9548 | msa | 4.2960 | 1.086 | — |
 | `prefill_b3_k8192_h2_varlen` | tirx | 5.1043 | msa | 5.9817 | 1.172 | — |
+
+## msa_sparse_prepare_fwd_split_atomic_sm100
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `decode_b128_k65536_h4` | tirx | 217.2807 | msa | 219.6823 | 1.011 | — |
+| `decode_b32_k8192_h4` | tirx | 15.1111 | msa | 15.4112 | 1.020 | — |
+| `decode_b64_k16384_h4_varlen` | tirx | 29.6478 | msa | 30.2542 | 1.020 | — |
+| `edge_b1_k512_h1` | tirx | 4.3427 | msa | 4.3987 | 1.013 | — |
+| `prefill_b1_k131072_h1` | tirx | 33.2527 | msa | 33.4343 | 1.005 | — |
+| `prefill_b1_k32768_h2` | tirx | 16.5568 | msa | 16.8409 | 1.017 | — |
+| `prefill_b1_k8192_h2` | tirx | 7.1463 | msa | 7.3067 | 1.022 | — |
+| `prefill_b3_k8192_h2_varlen` | tirx | 10.7839 | msa | 10.9987 | 1.020 | — |
 
 ## mxfp4_quantize
 

--- a/tirx_kernels/bench_suite/config/msa/msa_sparse_prepare_fwd_split_atomic_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/msa/msa_sparse_prepare_fwd_split_atomic_sm100.yaml
@@ -1,0 +1,11 @@
+kernel: msa_sparse_prepare_fwd_split_atomic_sm100
+selection_rationale: Edge count drives the emission loop while the capacity-sized grid drives the early-out, so the defaults pair the smallest prefill with the widest one and the deepest decode, whose grid is two orders of magnitude larger than its work count.
+configs:
+  - {config: prefill_b1_k8192_h2, default: true, selection_role: small}
+  - {config: prefill_b1_k32768_h2, default: false}
+  - {config: prefill_b1_k131072_h1, default: true, selection_role: medium}
+  - {config: prefill_b3_k8192_h2_varlen, default: false}
+  - {config: decode_b32_k8192_h4, default: false}
+  - {config: decode_b64_k16384_h4_varlen, default: false}
+  - {config: decode_b128_k65536_h4, default: true, selection_role: large}
+  - {config: edge_b1_k512_h1, default: false}

--- a/tirx_kernels/msa/sparse_prepare_flat_schedule.py
+++ b/tirx_kernels/msa/sparse_prepare_flat_schedule.py
@@ -27,6 +27,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from tirx_kernels.msa.utils._scalar_ops import (
+    atom_add_global_i32,
+    ld_global_i32,
+    shfl_idx_i32,
+    st_global_i32,
+    uceil_div_i32,
+    udiv_i32,
+)
 from tvm.script import tirx as T
 
 KERNEL_META = {
@@ -98,67 +106,22 @@ def flat_schedule_capacity(
 # ---------------------------------------------------------------------------
 # Scalar memory and cross-lane primitives.
 #
-# Global memory is reached only through `T.ptx.*` on `ptr_to`, as the low-level
-# IR contract requires, and each helper is one PTX instruction of the family the
-# source export uses.
+# Shared with the other MSA prepare kernel; see `utils/_scalar_ops.py` for the
+# instruction each one emits and why global memory is reached only through
+# `T.ptx.*` on `ptr_to`.
+#
+# Call-site map for this kernel: the scalar loads are the CSR bounds (:307-308)
+# and the `cu_seqlens_k` scans (:165); the store is one work-item field
+# (:151-156); the atomic is the slot reservation (:326-331), whose explicit
+# `sem="relaxed", scope="gpu"` are PTX's defaults and so leave no qualifier in
+# the export; the shuffle is the warp broadcast (:319-322).
 # ---------------------------------------------------------------------------
-def _ld_global_i32(buffer, index):
-    """``ld.global.b32``; the source's plain scalar load (:165, :307-308)."""
-    out = T.alloc_local((1,), "int32")
-    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
-    return out[0]
-
-
-def _st_global_i32(buffer, index, value):
-    """``st.global.b32``; one work-item field (:151-156)."""
-    T.evaluate(T.ptx.st.global_.b32(buffer.ptr_to([index]), value))
-
-
-def _atom_add_global_i32(buffer, index, value):
-    """``atom.global.add.u32``; returns the value held before the addition.
-
-    The source asks for `sem="relaxed", scope="gpu"` (:326-331), which are PTX's
-    defaults for `atom.global`, so its export carries this short encoding with no
-    `.relaxed`, no `.gpu`, and no surrounding fence.
-    """
-    out = T.alloc_local((1,), "uint32")
-    T.evaluate(T.ptx.atom.global_.add.u32(out[0], buffer.ptr_to([index]), value))
-    return T.reinterpret("int32", out[0])
-
-
-def _udiv_i32(x, d):
-    """`x / d` for a non-negative `x` and positive `d`, without the sign fixup.
-
-    Every quotient in this kernel divides a count by a block size or a head
-    count, so no operand can be negative -- but they arrive from signed int32
-    globals and kernel arguments, which gives the compiler no such proof, and a
-    signed `//` then carries the full floordiv correction chain on the decode's
-    innermost loop. Routing through unsigned keeps the same quotient and drops
-    the correction; the divisors stay runtime values, so both sides still issue
-    a real integer divide.
-    """
-    return T.cast(T.cast(x, "uint32") // T.cast(d, "uint32"), "int32")
-
-
-def _uceil_div_i32(x, d):
-    """`ceil(x / d)` under the same non-negativity argument as `_udiv_i32`."""
-    numerator: T.uint32 = T.cast(x, "uint32") + T.cast(d, "uint32") - T.uint32(1)
-    return T.cast(numerator // T.cast(d, "uint32"), "int32")
-
-
-def _shfl_idx_i32(value, source_lane):
-    """``shfl.sync.idx.b32 d, a, src, 31, -1``; the warp broadcast (:319-322)."""
-    out = T.alloc_local((1,), "uint32")
-    T.evaluate(
-        T.ptx.shfl_sync.idx.b32(
-            out[0],
-            T.reinterpret("uint32", value),
-            T.uint32(source_lane),
-            T.uint32(31),
-            T.uint32(0xFFFFFFFF),
-        )
-    )
-    return T.reinterpret("int32", out[0])
+_ld_global_i32 = ld_global_i32
+_st_global_i32 = st_global_i32
+_atom_add_global_i32 = atom_add_global_i32
+_udiv_i32 = udiv_i32
+_uceil_div_i32 = uceil_div_i32
+_shfl_idx_i32 = shfl_idx_i32
 
 
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
+++ b/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
@@ -1,0 +1,835 @@
+# This file is a TIRx port of code from MSA
+# (https://github.com/MiniMax-AI/MSA @ 80434d7f), Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""MSA sparse-attention forward split-slot preparation.
+
+Ports ``SparseAttentionPrepareFwdSplitAtomicSm100`` -- the stage that hands every
+CSR edge a split slot, so the forward attention kernel can write its partial
+output without a second round of atomics.
+
+One CTA per work item. The work list comes from the flat-schedule kernel
+(:mod:`tirx_kernels.msa.sparse_prepare_flat_schedule`), and the grid is sized by
+that list's *capacity* rather than its length, so CTAs past ``work_count`` exit
+immediately. A surviving CTA reads its work item's ``(head_kv, row, q_begin,
+q_count, batch)``, thread 0 broadcasts the row's CSR base through shared memory,
+and the 256 threads then stride over the row's edges: each edge reserves a slot
+with a device-scope atomic on ``split_counts[q_abs, head_kv]`` and writes
+``q_idx | (slot << 24)``.
+
+Slots are handed out in atomic-arrival order, so which edge of a
+``(q_abs, head_kv)`` group gets which slot is not reproducible. What is defined,
+and what the consumer relies on, is that the group's slots are exactly
+``{0 .. degree-1}`` with no gap and no duplicate: the forward kernel writes
+``split_counts[q_abs, h]`` partials into ``O_partial[0..count-1]`` and the
+combine kernel reduces exactly that many.
+
+Upstream source: python/fmha_sm100/cute/src/sm100/prepare_scheduler.py:348.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tirx_kernels.msa.sparse_prepare_flat_schedule import (
+    _seqlens_k,
+    _seqlens_q,
+    flat_schedule_capacity,
+    row_coords,
+    target_q_per_cta,
+)
+from tirx_kernels.msa.utils._scalar_ops import (
+    atom_add_global_i32,
+    bar_sync,
+    ld_global_i32,
+    ld_shared_i32,
+    st_global_i32,
+    st_shared_i32,
+)
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "msa_sparse_prepare_fwd_split_atomic_sm100",
+    "category": "msa",
+    "compute_capability": 10,
+}
+
+# `__init__(num_threads=256)` (:351-358); validated a multiple of 32.
+NUM_THREADS = 256
+
+# `SharedStorage.sRow: MemRange[Int32, 3]` (:360-364) -- 12 bytes.
+SROW_FIELDS = 3
+
+# `scheduler_metadata` columns; this kernel reads 0..4 and ignores 5.
+WORK_FIELDS = 6
+
+# `q_idx | ((split_slot & 0xFF) << 24)` (:478-480).
+SLOT_SHIFT = 24
+SLOT_MASK = 0xFF
+Q_IDX_MASK = (1 << SLOT_SHIFT) - 1
+
+# The source's `@cute.struct SharedStorage` reads static, but `SmemAllocator`
+# takes it from the dynamic pool -- the export carries
+# `.extern .shared .align 1024 .b8 __dynamic_shmem__0[]` -- so the matching TIRx
+# form is a pool allocation plus this launch tag, not `T.alloc_shared`.
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+
+
+# ---------------------------------------------------------------------------
+# Target entry.
+# ---------------------------------------------------------------------------
+@T.jit
+def _kernel(
+    k2q_row_ptr_h: T.handle,
+    k2q_q_indices_h: T.handle,
+    scheduler_metadata_h: T.handle,
+    work_count_h: T.handle,
+    k2q_qsplit_indices_h: T.handle,
+    split_counts_h: T.handle,
+    cu_seqlens_q_h: T.handle,
+    total_rows: T.int32,
+    num_batches: T.int32,
+    work_capacity: T.int32,
+    nnz_capacity: T.int32,
+    total_q: T.int32,
+    num_heads_kv: T.int32,
+    max_seqlen_q: T.int32,
+    topk: T.int32,
+):
+    k2q_row_ptr = T.match_buffer(
+        k2q_row_ptr_h, (num_heads_kv * (total_rows + 1),), "int32", scope="global"
+    )
+    k2q_q_indices = T.match_buffer(
+        k2q_q_indices_h, (num_heads_kv * nnz_capacity,), "int32", scope="global"
+    )
+    scheduler_metadata = T.match_buffer(
+        scheduler_metadata_h, (work_capacity * WORK_FIELDS,), "int32", scope="global"
+    )
+    work_count = T.match_buffer(work_count_h, (1,), "int32", scope="global")
+    k2q_qsplit_indices = T.match_buffer(
+        k2q_qsplit_indices_h, (num_heads_kv * nnz_capacity,), "int32", scope="global"
+    )
+    split_counts = T.match_buffer(
+        split_counts_h, (total_q * num_heads_kv,), "int32", scope="global"
+    )
+    cu_seqlens_q = T.match_buffer(cu_seqlens_q_h, (num_batches + 1,), "int32", scope="global")
+
+    T.device_entry()
+
+    # CUDA TRANSCRIPTION START
+    # sketch: static ABI/launch, one CTA per work item -> :445-446.
+    block = T.cta_id([work_capacity])
+    tidx = T.thread_id([NUM_THREADS])
+
+    # sketch: the row published through shared memory -> :360-364, :448-450.
+    # The source's struct is allocated from the dynamic pool, not a static
+    # `__shared__` array; the export shows `.extern .shared __dynamic_shmem__0`.
+    pool = T.SMEMPool()
+    srow = pool.alloc((SROW_FIELDS,), "int32", align=16)
+    pool.commit()
+
+    # sketch: the oversized-grid early-out -> :447.  The grid is sized by the
+    # work list's capacity because `work_count` is device-resident, so the tail
+    # CTAs retire here.  It precedes every shared access, so the barrier below
+    # is never reached by a partial CTA.
+    if block < ld_global_i32(work_count, 0):
+        # sketch: the one metadata field every thread needs -> :451.
+        work_base: T.int32 = block * WORK_FIELDS
+        head_kv_idx: T.int32 = ld_global_i32(scheduler_metadata, work_base)
+
+        # sketch: thread 0 publishes the row -> :457-461.  The compiler sinks
+        # the other four metadata loads into this block, which is what makes
+        # all three shared slots load-bearing rather than redundant.
+        if tidx == 0:
+            batch_idx_t0: T.int32 = ld_global_i32(scheduler_metadata, work_base + 4)
+            q_count_t0: T.int32 = ld_global_i32(scheduler_metadata, work_base + 3)
+            q_begin_t0: T.int32 = ld_global_i32(scheduler_metadata, work_base + 2)
+            row_linear_t0: T.int32 = ld_global_i32(scheduler_metadata, work_base + 1)
+            row_base_t0: T.int32 = ld_global_i32(
+                k2q_row_ptr, head_kv_idx * (total_rows + 1) + row_linear_t0
+            )
+            st_shared_i32(srow, 0, row_base_t0 + q_begin_t0)
+            st_shared_i32(srow, 1, q_count_t0)
+            st_shared_i32(srow, 2, batch_idx_t0)
+
+        # sketch: the only synchronization in the kernel -> :462.
+        bar_sync()
+
+        # sketch: everyone reads the row back -> :463-465.  `q_count` first: it
+        # is the loop guard, and the export reads it first for that reason.
+        row_count: T.int32 = ld_shared_i32(srow, 1)
+        row_start: T.int32 = ld_shared_i32(srow, 0)
+        batch_idx: T.int32 = ld_shared_i32(srow, 2)
+
+        # sketch: lane-strided edge emission -> :466-481.
+        qi = T.alloc_local((1,), "int32")
+        qi[0] = tidx
+        while qi[0] < row_count:
+            edge: T.int32 = row_start + qi[0]
+            q_idx: T.int32 = ld_global_i32(k2q_q_indices, head_kv_idx * nnz_capacity + edge)
+            # sketch: the validity guard -> :470.  Well-formed input never takes
+            # it -- a CSR row covers only filled entries -- but the guard exists
+            # because the GPU index builder leaves its tail uninitialized and the
+            # reference builder fills it with -1.
+            if q_idx >= 0 and q_idx < max_seqlen_q:
+                # The address of `cu_seqlens_q[batch_idx]` is loop-invariant, but
+                # the export re-loads the value every edge: the atomic's memory
+                # clobber prevents hoisting it. The port leaves it in the body.
+                q_abs: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx) + q_idx
+                split_slot: T.int32 = atom_add_global_i32(
+                    split_counts, q_abs * num_heads_kv + head_kv_idx, T.uint32(1)
+                )
+                # sketch: the capacity guard -> :477.  Signed compare against the
+                # value the atomic returned; also unreachable on well-formed
+                # input, where a (q_abs, head) group holds at most `topk` edges.
+                if split_slot < topk:
+                    st_global_i32(
+                        k2q_qsplit_indices,
+                        head_kv_idx * nnz_capacity + edge,
+                        T.bitwise_or(
+                            q_idx, T.shift_left(T.bitwise_and(split_slot, SLOT_MASK), SLOT_SHIFT)
+                        ),
+                    )
+            qi[0] = qi[0] + NUM_THREADS
+
+
+def get_kernel(**config):
+    """Return the TIRx specialization of `SparseAttentionPrepareFwdSplitAtomicSm100`.
+
+    Nothing about a config reaches the kernel as a compile-time constant: the
+    source's compile cache key is a bare string tuple (:496-498), so one binary
+    serves every shape and all extents and scalars stay runtime arguments.
+    """
+    config.pop("label", None)
+    return _kernel.specialize().with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+#
+# The eight benchmark shapes are the ones the flat-schedule sibling uses, which
+# already span this kernel's two cost regimes: the prefill shapes are edge-bound
+# (up to ~4.2M edges) while the decode shapes launch a capacity-sized grid whose
+# CTAs mostly exit at once. Their `target_q_per_cta` also falls either side of
+# the 256-thread stride, so both the multi-iteration and single-iteration forms
+# of the emission loop are covered.
+# ---------------------------------------------------------------------------
+def _case(
+    *,
+    batch: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    head_kv: int,
+    qhead_per_kv: int,
+    topk: int,
+    blk_kv: int = 128,
+    seqlen_pattern: str = "uniform",
+    label: str,
+) -> dict:
+    return {
+        "label": label,
+        "batch": batch,
+        "seqlen_q": seqlen_q,
+        "seqlen_k": seqlen_k,
+        "head_kv": head_kv,
+        "qhead_per_kv": qhead_per_kv,
+        "topk": topk,
+        "blk_kv": blk_kv,
+        "seqlen_pattern": seqlen_pattern,
+    }
+
+
+BENCH_CONFIGS = [
+    _case(
+        label="prefill_b1_k8192_h2",
+        batch=1,
+        seqlen_q=8192,
+        seqlen_k=8192,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=16,
+    ),
+    _case(
+        label="prefill_b1_k32768_h2",
+        batch=1,
+        seqlen_q=32768,
+        seqlen_k=32768,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=16,
+    ),
+    _case(
+        label="prefill_b1_k131072_h1",
+        batch=1,
+        seqlen_q=131072,
+        seqlen_k=131072,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=32,
+    ),
+    _case(
+        label="prefill_b3_k8192_h2_varlen",
+        batch=3,
+        seqlen_q=8192,
+        seqlen_k=8192,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="decode_b32_k8192_h4",
+        batch=32,
+        seqlen_q=8,
+        seqlen_k=8192,
+        head_kv=4,
+        qhead_per_kv=16,
+        topk=32,
+    ),
+    _case(
+        label="decode_b64_k16384_h4_varlen",
+        batch=64,
+        seqlen_q=8,
+        seqlen_k=16384,
+        head_kv=4,
+        qhead_per_kv=16,
+        topk=32,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="decode_b128_k65536_h4",
+        batch=128,
+        seqlen_q=8,
+        seqlen_k=65536,
+        head_kv=4,
+        qhead_per_kv=16,
+        topk=32,
+    ),
+    _case(
+        label="edge_b1_k512_h1",
+        batch=1,
+        seqlen_q=256,
+        seqlen_k=512,
+        head_kv=1,
+        qhead_per_kv=1,
+        topk=4,
+    ),
+]
+
+# Correctness adds the sibling's small boundary shapes: a varlen pair whose rows
+# fit in one level band, and a fanout sparse enough that some rows are empty.
+CONFIGS = [
+    *BENCH_CONFIGS,
+    _case(
+        label="tiny_b2_k384_uneven",
+        batch=2,
+        seqlen_q=128,
+        seqlen_k=384,
+        head_kv=2,
+        qhead_per_kv=2,
+        topk=2,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="sparse_b4_k2048_h1_topk1",
+        batch=4,
+        seqlen_q=64,
+        seqlen_k=2048,
+        head_kv=1,
+        qhead_per_kv=1,
+        topk=1,
+        seqlen_pattern="varlen",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Data preparation.
+#
+# The flat-schedule sibling's generator is expectation-based and produces per-row
+# counts only; this kernel needs the real edge payload, so the CSR is built
+# edge-first here. Three properties of the real index builder have to hold, and
+# each one the benchmark or the oracle depends on:
+#
+#   * degree per `(q_abs, head)` is `min(topk, visible) <= topk`, so
+#     `split_slot < topk` always holds and every valid edge is written. Filling
+#     pre-computed row slots by sampling `q_idx` instead would give an expected
+#     degree of exactly `topk`, so about half the queries would overshoot and
+#     half the stores would silently die.
+#   * edges inside a row ascend by `q_idx`. Production's scatter is sorted
+#     (`build_k2q_csr.cu:15, 341-349`), and it is what makes one iteration's 256
+#     threads hit 256 consecutive `(q_abs, h)` cells rather than scattering
+#     across the whole tensor.
+#   * the tail past `nnz` is `-1`, as the reference builder writes
+#     (`sparse_index_utils.py:250`) and the CUDA builder memsets -- which is what
+#     the kernel's `q_idx >= 0` guard exists for.
+# ---------------------------------------------------------------------------
+def _select_blocks(q_len: int, rows_in_batch: int, topk: int, blk_kv: int, k_len: int, generator):
+    """Per query, the kv blocks it attends: the sink plus a causal sample."""
+    import torch
+
+    device = "cuda"
+    queries = torch.arange(q_len, device=device)
+    last_visible = ((k_len - q_len) + queries).div(blk_kv, rounding_mode="floor")
+    last_visible = last_visible.clamp(min=0, max=rows_in_batch - 1)
+    keep = torch.clamp(last_visible + 1, max=topk)
+
+    # Rank the visible blocks by a random priority, with block 0 pinned first:
+    # it is the attention sink and every query keeps it.
+    priority = torch.rand((q_len, rows_in_batch), device=device, generator=generator)
+    block_ids = torch.arange(rows_in_batch, device=device).unsqueeze(0)
+    priority = torch.where(block_ids == 0, torch.full_like(priority, -1.0), priority)
+    priority = torch.where(
+        block_ids <= last_visible.unsqueeze(1), priority, torch.full_like(priority, 2.0)
+    )
+    rank = priority.argsort(dim=1).argsort(dim=1)
+    return torch.nonzero(rank < keep.unsqueeze(1), as_tuple=True)
+
+
+def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
+    """Build the CSR edge payload, the work list, and the schedule sizing."""
+    import torch
+
+    from tirx_kernels.runner import hardware_num_sms
+
+    config.pop("label", None)
+    batch = config["batch"]
+    blk_kv = config["blk_kv"]
+    head_kv = config["head_kv"]
+    topk = config["topk"]
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(1234 + seed)
+
+    seqlens_k = _seqlens_k(batch, config["seqlen_k"], blk_kv, config["seqlen_pattern"])
+    seqlens_q = _seqlens_q(seqlens_k, config["seqlen_q"])
+    total_q = sum(seqlens_q)
+    max_seqlen_q = max(seqlens_q)
+
+    cu_seqlens_q = torch.zeros(batch + 1, dtype=torch.int32, device=device)
+    cu_seqlens_q[1:] = torch.tensor(seqlens_q, dtype=torch.int32, device=device).cumsum(0)
+    q_offsets = [0]
+    for length in seqlens_q:
+        q_offsets.append(q_offsets[-1] + length)
+
+    batch_of_row, level_of_row = row_coords(seqlens_k, blk_kv)
+    total_rows = len(batch_of_row)
+    row_of_coord = {
+        (b, level): r for r, (b, level) in enumerate(zip(batch_of_row, level_of_row, strict=True))
+    }
+
+    nnz_capacity = total_q * topk
+    k2q_row_ptr = torch.zeros((head_kv, total_rows + 1), dtype=torch.int32, device=device)
+    k2q_q_indices = torch.full((head_kv, nnz_capacity), -1, dtype=torch.int32, device=device)
+    degrees = torch.zeros((total_q, head_kv), dtype=torch.int64, device=device)
+
+    for h in range(head_kv):
+        rows, q_idx, q_abs = [], [], []
+        for b, (k_len, q_len) in enumerate(zip(seqlens_k, seqlens_q, strict=True)):
+            rows_in_batch = (k_len + blk_kv - 1) // blk_kv
+            qi, block = _select_blocks(q_len, rows_in_batch, topk, blk_kv, k_len, generator)
+            lookup = torch.tensor(
+                [row_of_coord[(b, level)] for level in range(rows_in_batch)],
+                dtype=torch.int64,
+                device=device,
+            )
+            rows.append(lookup[block])
+            q_idx.append(qi.to(torch.int32))
+            q_abs.append(qi.to(torch.int64) + q_offsets[b])
+        rows_cat = torch.cat(rows)
+        q_idx_cat = torch.cat(q_idx)
+        q_abs_cat = torch.cat(q_abs)
+
+        # Row-major, q ascending within a row -- production's sorted scatter.
+        order = (rows_cat * (max_seqlen_q + 1) + q_idx_cat.to(torch.int64)).argsort(stable=True)
+        rows_sorted = rows_cat[order]
+        k2q_row_ptr[h, 1:] = (
+            torch.bincount(rows_sorted, minlength=total_rows).cumsum(0).to(torch.int32)
+        )
+        k2q_q_indices[h, : order.numel()] = q_idx_cat[order]
+        degrees[:, h] = torch.bincount(q_abs_cat, minlength=total_q)
+
+    target = target_q_per_cta(
+        total_q=total_q,
+        topk=topk,
+        blk_kv=blk_kv,
+        head_kv=head_kv,
+        qhead_per_kv=config["qhead_per_kv"],
+        num_sms=hardware_num_sms(),
+    )
+    capacity = flat_schedule_capacity(
+        total_rows=total_rows, total_q=total_q, topk=topk, head_kv=head_kv, target=target
+    )
+    counts = (k2q_row_ptr[:, 1:] - k2q_row_ptr[:, :-1]).to(torch.int64)
+    work = _work_items(counts, target, batch_of_row, head_kv, total_rows, device)
+
+    scheduler_metadata = torch.zeros((capacity, WORK_FIELDS), dtype=torch.int32, device=device)
+    scheduler_metadata[: work.shape[0]] = work
+    work_count = torch.tensor([work.shape[0]], dtype=torch.int32, device=device)
+    if work.shape[0] > capacity:
+        raise AssertionError(f"work list {work.shape[0]} exceeds capacity {capacity}")
+
+    return {
+        "config": dict(config),
+        "seqlens_k": seqlens_k,
+        "seqlens_q": seqlens_q,
+        "cu_seqlens_q": cu_seqlens_q,
+        "k2q_row_ptr": k2q_row_ptr.contiguous(),
+        "k2q_q_indices": k2q_q_indices.contiguous(),
+        "scheduler_metadata": scheduler_metadata.contiguous(),
+        "work_count": work_count,
+        "degrees": degrees,
+        "total_rows": total_rows,
+        "total_q": total_q,
+        "max_seqlen_q": max_seqlen_q,
+        "nnz_capacity": nnz_capacity,
+        "work_capacity": capacity,
+        "head_kv": head_kv,
+        "topk": topk,
+    }
+
+
+def _work_items(counts, target: int, batch_of_row, head_kv: int, total_rows: int, device):
+    """The work list the flat-schedule kernel produces, in row-head order.
+
+    Synthesized rather than produced by running that kernel: a device-produced
+    list redraws its atomic-arrival permutation on every invocation, which would
+    add run-to-run noise and couple this benchmark's input to another kernel.
+    Row-head order is the flat-schedule kernel's own indexing (`row_head_idx =
+    block * 4 + warp`), so it is the closest deterministic stand-in for real
+    arrival order -- and it keeps the heavy level-0 sink rows at the front,
+    which a uniform shuffle would not.
+    """
+    import torch
+
+    chunks = torch.where(
+        counts > 0, torch.div(counts + target - 1, target, rounding_mode="floor"), 0
+    )
+    head_idx, row_idx = torch.meshgrid(
+        torch.arange(head_kv, device=device), torch.arange(total_rows, device=device), indexing="ij"
+    )
+    flat = chunks.reshape(-1)
+    head_rep = torch.repeat_interleave(head_idx.reshape(-1), flat)
+    row_rep = torch.repeat_interleave(row_idx.reshape(-1), flat)
+    count_rep = torch.repeat_interleave(counts.reshape(-1), flat)
+
+    starts = torch.cumsum(flat, 0) - flat
+    ordinal = torch.arange(int(flat.sum().item()), device=device) - torch.repeat_interleave(
+        starts, flat
+    )
+    q_begin = ordinal * target
+    q_count = torch.clamp(count_rep - q_begin, max=target)
+    batch_row = torch.tensor(batch_of_row, dtype=torch.int64, device=device)
+
+    table = torch.stack(
+        [
+            head_rep,
+            row_rep,
+            q_begin,
+            q_count,
+            batch_row[row_rep],
+            torch.zeros_like(row_rep),  # kv_block_idx: written by the producer, unread here
+        ],
+        dim=1,
+    ).to(torch.int32)
+    return table[(row_rep * head_kv + head_rep).argsort(stable=True)]
+
+
+def make_outputs(data: dict[str, Any]) -> dict[str, Any]:
+    """Fresh outputs: `qsplit` uninitialized and `split_counts` zeroed, as the host does."""
+    import torch
+
+    return {
+        "k2q_qsplit_indices": torch.empty(
+            (data["head_kv"], data["nnz_capacity"]), dtype=torch.int32, device="cuda"
+        ),
+        "split_counts": torch.zeros(
+            (data["total_q"], data["head_kv"]), dtype=torch.int32, device="cuda"
+        ),
+    }
+
+
+def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
+    """The flat launch ABI, bound once outside any timed region."""
+    return (
+        data["k2q_row_ptr"].reshape(-1),
+        data["k2q_q_indices"].reshape(-1),
+        data["scheduler_metadata"].reshape(-1),
+        data["work_count"],
+        outputs["k2q_qsplit_indices"].reshape(-1),
+        outputs["split_counts"].reshape(-1),
+        data["cu_seqlens_q"],
+        data["total_rows"],
+        len(data["seqlens_k"]),
+        data["work_capacity"],
+        data["nnz_capacity"],
+        data["total_q"],
+        data["head_kv"],
+        data["max_seqlen_q"],
+        data["topk"],
+    )
+
+
+def launch_reference(data: dict[str, Any], outputs: dict[str, Any], compiled_factory) -> None:
+    """One launch of the MSA kernel over the given buffers."""
+    case = _reference_case(data, outputs)
+    compiled_factory(case)(
+        case["k2q_row_ptr"],
+        case["k2q_q_indices"],
+        case["scheduler_metadata"],
+        case["work_count"],
+        case["k2q_qsplit_indices"],
+        case["split_counts"],
+        case["cu_seqlens_q"],
+        case["work_capacity"],
+        case["max_seqlen_q"],
+        case["topk"],
+    )
+
+
+def _reference_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "k2q_row_ptr": data["k2q_row_ptr"],
+        "k2q_q_indices": data["k2q_q_indices"],
+        "scheduler_metadata": data["scheduler_metadata"],
+        "work_count": data["work_count"],
+        "k2q_qsplit_indices": outputs["k2q_qsplit_indices"],
+        "split_counts": outputs["split_counts"],
+        "cu_seqlens_q": data["cu_seqlens_q"],
+        "work_capacity": data["work_capacity"],
+        "max_seqlen_q": data["max_seqlen_q"],
+        "topk": data["topk"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Correctness: invariants, not element-wise equality.
+# ---------------------------------------------------------------------------
+def assert_split_metadata(data: dict[str, Any], outputs: dict[str, Any]) -> None:
+    """Check the three properties that survive the atomic's arrival order.
+
+    Slot assignment is not reproducible, so a bitwise comparison against another
+    run means nothing. What is defined, and what the forward/combine pair
+    depends on, is: the per-`(q_abs, head)` counts; the low 24 bits of a written
+    entry; and that a group's slots are exactly `{0..degree-1}`, gapless and
+    without duplicates -- a gap would make combine reduce an uninitialized
+    `O_partial` slice, a duplicate would double-count one and stale another.
+    """
+    import torch
+
+    torch.testing.assert_close(
+        outputs["split_counts"], data["degrees"].to(torch.int32), rtol=0, atol=0
+    )
+
+    row_ptr = data["k2q_row_ptr"]
+    q_indices = data["k2q_q_indices"]
+    packed = outputs["k2q_qsplit_indices"]
+    total_rows = data["total_rows"]
+    head_kv = data["head_kv"]
+    cu_q = data["cu_seqlens_q"].to(torch.int64)
+    batch_of_row = torch.tensor(
+        [b for b, _ in zip(*row_coords(data["seqlens_k"], data["config"]["blk_kv"]), strict=True)],
+        dtype=torch.int64,
+        device=packed.device,
+    )
+
+    for h in range(head_kv):
+        live = int(row_ptr[h, total_rows].item())
+        if live == 0:
+            continue
+        edge_q = q_indices[h, :live].to(torch.int64)
+        got = packed[h, :live]
+        # low 24 bits are a pure passthrough of that edge's own q_idx
+        torch.testing.assert_close(
+            torch.bitwise_and(got, Q_IDX_MASK), edge_q.to(torch.int32), rtol=0, atol=0
+        )
+        slots = torch.bitwise_right_shift(got, SLOT_SHIFT).bitwise_and(SLOT_MASK).to(torch.int64)
+
+        # group each edge by its (q_abs, head) and check the slots form range(n)
+        starts = row_ptr[h, :total_rows].to(torch.int64)
+        ends = row_ptr[h, 1 : total_rows + 1].to(torch.int64)
+        row_of_edge = torch.repeat_interleave(
+            torch.arange(total_rows, device=packed.device), (ends - starts)
+        )
+        q_abs = cu_q[batch_of_row[row_of_edge]] + edge_q
+        order = (q_abs * (data["topk"] + 1) + slots).argsort(stable=True)
+        q_sorted, slot_sorted = q_abs[order], slots[order]
+        group_start = torch.cat(
+            [torch.ones(1, dtype=torch.bool, device=packed.device), q_sorted[1:] != q_sorted[:-1]]
+        )
+        expected = torch.arange(q_sorted.numel(), device=packed.device)
+        expected = (
+            expected
+            - torch.cummax(torch.where(group_start, expected, torch.zeros_like(expected)), 0).values
+        )
+        if not bool(torch.equal(slot_sorted, expected)):
+            raise AssertionError(f"head {h}: slots are not a gapless permutation per (q_abs, head)")
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against MSA's own kernel."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    config.pop("label", None)
+    data = prepare_data(**config)
+
+    try:
+        from tirx_kernels.msa.utils._msa_bench import compiled_fwd_split_atomic
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+    reference_outputs = make_outputs(data)
+    try:
+        launch_reference(data, reference_outputs, compiled_fwd_split_atomic)
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+    torch.cuda.synchronize()
+    assert_split_metadata(data, reference_outputs)
+
+    executable = compile_kernel(get_kernel(**config))
+    outputs = make_outputs(data)
+    executable(*tirx_args(data, outputs))
+    torch.cuda.synchronize()
+    assert_split_metadata(data, outputs)
+    torch.testing.assert_close(
+        outputs["split_counts"], reference_outputs["split_counts"], rtol=0, atol=0
+    )
+
+
+def prepare_bench(**config):
+    """Compile the TIRx specialization without initializing CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config.pop("label", None)
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+#
+# `split_counts` is read-modify-write and the kernel never resets it, so the
+# first launch hands out slots `0..degree-1` and every later one starts at
+# `degree` -- `split_slot < topk` then fails everywhere and the store path stops
+# firing, leaving a strictly cheaper kernel being timed. The counters have to be
+# zero at every launch.
+#
+# They cannot be zeroed per launch: that work would land inside the timed region,
+# and the local bench API rejects a per-iteration `prepare` callback. So both
+# sides rotate over pre-zeroed copies and re-zero the block once per rotation.
+# Clearing N copies every N launches averages to clearing one copy per launch, so
+# N does not change the cost -- it only bounds memory. The block is sized past
+# this part's L2 so a wrap's fill evicts the slice it is about to hand out, and
+# no slice is ever measured warmer than another.
+#
+# Do not pin `timer:` in the bench-suite config. `cudagraph_proton` captures the
+# closure and replays it, so the rotation would advance only at capture and every
+# replay would reuse one spent slice.
+# ---------------------------------------------------------------------------
+SPLIT_BLOCK_BYTES = 256 << 20
+
+
+def _rotating_split_counts(data: dict[str, Any]):
+    """A pre-zeroed `(slots, total_q, head_kv)` block plus its per-slot views."""
+    import torch
+
+    slice_elems = data["total_q"] * data["head_kv"]
+    slots = max(8, min(4096, SPLIT_BLOCK_BYTES // max(slice_elems * 4, 1)))
+    block = torch.zeros((slots, data["total_q"], data["head_kv"]), dtype=torch.int32, device="cuda")
+    views = [block[i] for i in range(slots)]
+    for view in views:
+        if view.data_ptr() % 16 != 0:
+            raise AssertionError("split_counts slice is not 16-byte aligned")
+    return block, views, slots
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    """Kernel-only comparison against MSA's compiled split-atomic launch."""
+    from tirx_kernels.runner import bench
+
+    config = {**prepared["config"], **config}
+    config.pop("label", None)
+    data = prepare_data(**config)
+    executable = prepared["executable"]
+
+    tirx_outputs = make_outputs(data)
+    tirx_block, tirx_views, slots = _rotating_split_counts(data)
+    tirx_base = tirx_args(data, tirx_outputs)
+    tirx_step = [0]
+
+    def tirx_launch():
+        step = tirx_step[0]
+        slot = step % slots
+        if slot == 0 and step:
+            tirx_block.zero_()
+        tirx_step[0] = step + 1
+        executable(*tirx_base[:5], tirx_views[slot].reshape(-1), *tirx_base[6:])
+
+    def build_reference():
+        from tirx_kernels.msa.utils._msa_bench import compiled_fwd_split_atomic
+
+        reference_outputs = make_outputs(data)
+        block, views, ref_slots = _rotating_split_counts(data)
+        case = _reference_case(data, reference_outputs)
+        compiled = compiled_fwd_split_atomic(case)
+        step = [0]
+
+        def reference_launch():
+            index = step[0]
+            slot = index % ref_slots
+            if slot == 0 and index:
+                block.zero_()
+            step[0] = index + 1
+            compiled(
+                case["k2q_row_ptr"],
+                case["k2q_q_indices"],
+                case["scheduler_metadata"],
+                case["work_count"],
+                case["k2q_qsplit_indices"],
+                views[slot],
+                case["cu_seqlens_q"],
+                case["work_capacity"],
+                case["max_seqlen_q"],
+                case["topk"],
+            )
+
+        # Pay the CuTeDSL compile and first-launch cost, then hand the timed run
+        # a clean rotation -- otherwise slot 0 is already spent on entry.
+        reference_launch()
+        step[0] = 0
+        block.zero_()
+        return reference_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"msa": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/msa/utils/_msa_bench.py
+++ b/tirx_kernels/msa/utils/_msa_bench.py
@@ -52,6 +52,29 @@ def prepare_scheduler_module():
     return _MSA_MODULE
 
 
+def compiled_fwd_split_atomic(case: dict):
+    """Compile (or fetch from MSA's AOT cache) the forward split-slot kernel.
+
+    Returns the compiled callable behind ``prepare_sparse_fwd_schedule_and_split``'s
+    NVTX range, so the timed closure covers the kernel launch alone -- not the
+    host wrapper's shape validation, its ``split_counts.zero_()``, or the
+    flat-schedule kernel it runs first.
+    """
+    module = prepare_scheduler_module()
+    return module._get_sparse_prepare_fwd_split_atomic(
+        case["k2q_row_ptr"],
+        case["k2q_q_indices"],
+        case["scheduler_metadata"],
+        case["work_count"],
+        case["k2q_qsplit_indices"],
+        case["split_counts"],
+        case["cu_seqlens_q"],
+        case["work_capacity"],
+        case["max_seqlen_q"],
+        case["topk"],
+    )
+
+
 def compiled_flat_schedule(case: dict):
     """Compile (or fetch from MSA's AOT cache) the flat-schedule kernel.
 

--- a/tirx_kernels/msa/utils/_scalar_ops.py
+++ b/tirx_kernels/msa/utils/_scalar_ops.py
@@ -1,0 +1,116 @@
+# This file is a TIRx port of code from MSA
+# (https://github.com/MiniMax-AI/MSA @ 80434d7f), Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Scalar memory and synchronization primitives shared by the MSA ports.
+
+The MSA prepare kernels are scalar integer code: they move one int32 at a time
+between registers, global memory and shared memory, and their only cross-thread
+traffic is a device-scope atomic, a warp broadcast and a CTA barrier. Each
+helper below is one PTX instruction of the family the source export uses.
+
+Both scopes go through ``T.ptx.*`` on ``ptr_to`` rather than a native
+``BufferLoad``/``BufferStore``: the repository's low-level IR contract
+(:mod:`tirx_kernels.low_level_ir`) rejects the native form for ``global`` and
+``shared`` alike.
+
+Upstream source: python/fmha_sm100/cute/src/common/copy_utils.py,
+python/fmha_sm100/cute/src/sm100/prepare_scheduler.py.
+"""
+
+from tvm.script import tirx as T
+
+
+# --- global memory ----------------------------------------------------------
+def ld_global_i32(buffer, index):
+    """``ld.global.b32``; the source's plain scalar load."""
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.global_.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def st_global_i32(buffer, index, value):
+    """``st.global.b32``; one scalar field."""
+    T.evaluate(T.ptx.st.global_.b32(buffer.ptr_to([index]), value))
+
+
+def atom_add_global_i32(buffer, index, value):
+    """``atom.global.add.u32``; returns the value held before the addition.
+
+    Relaxed ordering and device scope are PTX's defaults for ``atom.global``, so
+    this short encoding -- no ``.relaxed``, no ``.gpu``, no surrounding fence --
+    is what both MSA prepare kernels emit, whether they spell the qualifiers out
+    (``cute.arch.atomic_add(..., sem="relaxed", scope="gpu")``) or write the
+    instruction directly (``copy_utils.atomic_add_i32``).
+    """
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.atom.global_.add.u32(out[0], buffer.ptr_to([index]), value))
+    return T.reinterpret("int32", out[0])
+
+
+# --- shared memory ----------------------------------------------------------
+def ld_shared_i32(buffer, index):
+    """``ld.shared.b32``."""
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.ld.shared.b32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def st_shared_i32(buffer, index, value):
+    """``st.shared.b32``."""
+    T.evaluate(T.ptx.st.shared.b32(buffer.ptr_to([index]), value))
+
+
+# --- synchronization --------------------------------------------------------
+def bar_sync():
+    """``bar.sync 0`` -- what ``cute.arch.barrier()`` / ``__syncthreads()`` lowers to."""
+    T.evaluate(T.ptx.bar.sync(T.uint32(0)))
+
+
+def shfl_idx_i32(value, source_lane):
+    """``shfl.sync.idx.b32 d, a, src, 31, -1``; a full-warp broadcast."""
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.idx.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(source_lane),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("int32", out[0])
+
+
+# --- integer division -------------------------------------------------------
+def udiv_i32(x, d):
+    """``x / d`` for a non-negative ``x`` and positive ``d``, without the sign fixup.
+
+    These quotients divide a count by a block size or a head count, so no operand
+    can be negative -- but they arrive from signed int32 globals and kernel
+    arguments, which gives the compiler no such proof, and a signed ``//`` then
+    carries the full floordiv correction chain. Routing through unsigned keeps
+    the same quotient and drops the correction; the divisors stay runtime values,
+    so a real integer divide is still issued.
+    """
+    return T.cast(T.cast(x, "uint32") // T.cast(d, "uint32"), "int32")
+
+
+def uceil_div_i32(x, d):
+    """``ceil(x / d)`` under the same non-negativity argument as :func:`udiv_i32`."""
+    numerator: T.uint32 = T.cast(x, "uint32") + T.cast(d, "uint32") - T.uint32(1)
+    return T.cast(numerator // T.cast(d, "uint32"), "int32")
+
+
+__all__ = [
+    "atom_add_global_i32",
+    "bar_sync",
+    "ld_global_i32",
+    "ld_shared_i32",
+    "shfl_idx_i32",
+    "st_global_i32",
+    "st_shared_i32",
+    "uceil_div_i32",
+    "udiv_i32",
+]


### PR DESCRIPTION
Ports `SparseAttentionPrepareFwdSplitAtomicSm100` (`prepare_scheduler.py:432-481`), the stage that hands every CSR edge a split slot so the forward attention kernel can write its partial output without a second round of atomics. Sibling of the flat-schedule kernel from #79, and a consumer of that kernel's work list.

## What the kernel does

One CTA per work item. The grid is sized by the work list's **capacity**, not its length — `work_count` is device-resident and never read back — so CTAs past it retire immediately; on `decode_b128_k65536_h4` that is 60% of 262,437 CTAs. A surviving CTA loads its work item, thread 0 publishes the row's CSR base through 12 bytes of shared memory, and after one `bar.sync` the 256 threads stride over the row's edges: each valid edge reserves a slot with a relaxed device-scope atomic on `split_counts` and writes `q_idx | (slot << 24)`.

## Three things the source reads like, and its export shows it is not

Each one changes what the port transcribes, and all three were found by exporting line-info PTX *before* writing the sketch rather than after.

1. **The shared storage is dynamic.** The source declares a `@cute.struct SharedStorage`, which reads like a static `__shared__` array, but `SmemAllocator` takes it from the dynamic pool — the export carries `.extern .shared .align 1024 .b8 __dynamic_shmem__0[]`. So the matching TIRx form is an `SMEMPool` arena plus `tirx.use_dyn_shared_memory`, not `T.alloc_shared`.
2. **nvcc sinks four of the five metadata loads into the `tidx == 0` block.** Only `head_kv_idx` stays for all threads. This overturns the reading that two of the shared slots merely re-broadcast values every thread already holds: after sinking, the other 255 threads never issue those loads, so all three slots are load-bearing and the port must not collapse them.
3. **`cu_seqlens_q[batch_idx]` is re-loaded every iteration** despite being loop-invariant. Its address is hoisted; the load is not, because the atomic's memory clobber blocks it.

Static opcode counts match the source on every key operation: `st.shared.b32`/`ld.shared.b32` ×3 each around one `bar.sync`, one `atom.global.add.u32` in short form (no `.relaxed`, no `.gpu`, no fence), and `shl.b32` + `or.b32` with the `& 0xFF` folded away (zero `and.b32`).

## Correctness

Slots are handed out in atomic-arrival order, so which edge of a `(q_abs, head_kv)` group gets which slot is not reproducible and a bitwise comparison would mean nothing. `run_test` asserts the three properties that *are* defined:

- `split_counts` element-wise against both a host degree table and MSA's own kernel;
- the low 24 bits of every live entry equal that edge's own `q_idx`;
- per group, the slots are exactly `{0..degree-1}` — gapless and duplicate-free.

The third is the consumer's requirement rather than a testing convenience: the forward kernel writes `split_counts` partials into `O_partial[0..count-1]` and combine reduces exactly that many, so a gap would reduce an uninitialized slice and a duplicate would double-count one. Only each head's live CSR range is read, since `k2q_qsplit_indices` arrives uninitialized. Ten configs, all passing.

## Data generation, which the measurement depends on

The CSR is built edge-first so it matches the real index builder in two ways that decide what gets measured:

- **degree per `(q_abs, head)` stays at or below `topk`**, so every valid edge is written. Filling pre-computed row slots by sampling `q_idx` instead would give an expected degree of exactly `topk`, so about half the queries would overshoot and half the stores would silently die — the benchmark would be timing a kernel with no output path.
- **edges ascend by `q_idx` within a row**, as production's sorted scatter produces, so one iteration's 256 threads hit consecutive counter cells rather than scattering across the tensor.

The work list is synthesized on the host in row-head order — the flat-schedule kernel's own indexing — rather than produced by running that kernel, which would redraw its arrival permutation every run and couple this benchmark's input to another kernel.

## Benchmark

Kernel-only: the timed closure holds one launch, with the CSR build, the work list, the allocation and every zeroing outside it — the same line MSA's own instrumentation draws by putting `split_counts.zero_()` in a separate NVTX range.

`split_counts` is read-modify-write and the kernel never resets it, so a second launch against a spent counter finds `split_slot >= topk` everywhere and the store path stops firing. Both sides rotate over pre-zeroed copies and re-zero once per rotation, keeping the reset out of the timed path; the block is sized past L2 so no slice is measured warmer than another.

| config | ours (µs) | msa (µs) | ref/ours |
| --- | ---: | ---: | ---: |
| `prefill_b1_k8192_h2` | 7.15 | 7.31 | 1.023 |
| `prefill_b3_k8192_h2_varlen` | 10.78 | 11.00 | 1.020 |
| `decode_b64_k16384_h4_varlen` | 29.65 | 30.25 | 1.020 |
| `decode_b32_k8192_h4` | 15.11 | 15.41 | 1.020 |
| `prefill_b1_k32768_h2` | 16.56 | 16.84 | 1.017 |
| `edge_b1_k512_h1` | 4.34 | 4.40 | 1.013 |
| `decode_b128_k65536_h4` | 217.28 | 219.68 | 1.011 |
| `prefill_b1_k131072_h1` | 33.25 | 33.43 | 1.005 |

B200, proton timer, 5 rounds, one complete matrix run. The bench-suite config marks the small/medium/large three as defaults.

## Shared helpers

The PTX scalar helpers both MSA kernels use move to `msa/utils/_scalar_ops.py`. The move is inert: the flat-schedule kernel's generated CUDA is byte-identical before and after, so its promoted baseline still holds, and its twelve configs still pass. Both kernels' full config sets — 22 in total — pass on this branch.
