### PR TITLE
feat(kernel): add FlashInfer RMSNormQuant

### DIFF
--- a/.agents/sketch/flashinfer/norm/rmsnorm_quant.md
+++ b/.agents/sketch/flashinfer/norm/rmsnorm_quant.md
@@ -1,0 +1,706 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+RMSNormQuantKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer 2-D RMSNorm FP8 quantization SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the implementation
+shape of FlashInfer's CuTe-DSL `RMSNormQuantKernel` for the paired target
+[`tirx_kernels/flashinfer/norm/rmsnorm_quant.py`](../../../../tirx_kernels/flashinfer/norm/rmsnorm_quant.py).
+The target becomes executable only after this sketch passes independent
+source/line-info-PTX review; after the first PASS this file is permanently
+frozen.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/norm/kernels/rmsnorm.py`, SHA256
+  `b273fe5444aaf86a1600c196817b7a733b18f6f82030a16e1ef2731c784d48f0`;
+- `flashinfer/norm/utils.py`, SHA256
+  `3f44ac6727c58883420068bf0aa5b239b12d2e86819ad80e54bc1bc016ec881a`;
+- public dispatch in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+The family covers FP16/BF16 X and W, E4M3FN/E5M2 caller-provided Y,
+`weight_bias=0.0`, compact and explicit Int64 row-strided addressing, PDL
+off/on, synchronous and one-group `cp.async` input traffic, sub-warp through
+cluster reduction, and cluster sizes 1/2/4/8/16. SM100 always uses hardware
+FP8 conversion. Gemma, fused-add, FP4, legacy CUDA, the pre-SM89 software-FP8
+path, and every tile primitive are out of scope.
+
+## Source dispatch and resource formulae
+
+These compile-time formulae are copied mechanically from
+`RMSNormQuantKernel` and the inherited `RMSNormKernel` helpers. They are not
+tuning choices:
+
+```python
+ELEM_BYTES = 2
+MAX_VEC = 128 // 8 // ELEM_BYTES                         # 8 input elements
+
+def threads_per_row(h_per_cta):
+    if h_per_cta <= 64: return 8
+    if h_per_cta <= 128: return 16
+    if h_per_cta <= 3072: return 32
+    if h_per_cta <= 6144: return 64
+    if h_per_cta <= 16384: return 128
+    return 256
+
+def rmsnorm_num_threads(h_per_cta):
+    return 128 if h_per_cta <= 16384 else 256
+
+def estimate_smem(H, cluster_n):
+    # Cluster selection deliberately uses RMSNormKernel's estimate, before the
+    # quant-only 256-thread override. It always includes the complete X tile.
+    h_per_cta = H // cluster_n
+    tpr = threads_per_row(h_per_cta)
+    threads = rmsnorm_num_threads(h_per_cta)
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(h_per_cta & -h_per_cta, MAX_VEC)
+    vec_blocks = max(1, ceil_div(h_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    bytes_ = rows * cols * ELEM_BYTES
+    bytes_ += rows * warps_per_row * cluster_n * 4
+    return bytes_ + (8 if cluster_n > 1 else 0)
+
+def source_config(H):
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and estimate_smem(H, candidate) <= 232448:
+            cluster_n = candidate
+            break
+    else:
+        cluster_n = 16
+
+    h_per_cta = H // cluster_n
+    tpr = threads_per_row(h_per_cta)
+    threads = rmsnorm_num_threads(h_per_cta)
+    if h_per_cta > 8192 and threads < 256:
+        threads = 256                                # quant-only override
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(h_per_cta & -h_per_cta, MAX_VEC)
+    copy_bits = 16 * vec
+    vec_blocks = max(1, ceil_div(h_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    tile_bytes = rows * cols * ELEM_BYTES
+    use_async = copy_bits >= 32 and tile_bytes <= 232448 // 2
+    reduce_bytes = rows * warps_per_row * 4
+    if cluster_n > 1:
+        reduce_bytes *= cluster_n
+    smem_bytes = (tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return cluster_n, h_per_cta, tpr, threads, rows, warps_per_row, \
+           vec, copy_bits, vec_blocks, cols, use_async, smem_bytes
+```
+
+The public host selects compact only when X and Y are both contiguous and
+`M*H <= 2**31-1`. Otherwise it compiles and passes symbolic
+`x_row_stride:int64` and `y_row_stride:int64`, in elements and divisible by
+the input `VEC`. The runtime scale remains a device FP32 tensor of shape one.
+
+## Pipeline at a glance
+
+| lanes / CTA role | source-owned work | publication or reuse edge |
+| --- | --- | --- |
+| every CTA thread at entry | optional PDL wait, then load the one device scale and form its FTZ approximate reciprocal | replicated `inv_scale` remains live through the FP8 epilogue |
+| each contiguous `TPR`-thread group | one logical row; each thread owns `VEC` adjacent H columns in each vector block | X and W load without communication |
+| each row sub-warp/full warp | ordered fragment sum then width-8/16/32 butterfly reduction | row-warp partial is replicated |
+| lane 0 of each row warp, non-cluster multi-warp path | publish one partial to shared `(row,warp_in_row)` | CTA barrier before final shared loads |
+| lanes `<CLUSTER_N` of each warp, clustered path | remotely publish the warp partial to the matching slot on every peer CTA | two `mapa`, remote async store, and mbarrier completion |
+| every row warp after publication | redundantly load and reduce all row partials | replicated sum feeds FP32 divide/add/rsqrt |
+| all threads after reduction | cluster arrive/wait or CTA barrier, then reload staged X on async profiles | X reload intentionally shortens FP32 register lifetime |
+| each row thread in the epilogue | apply X*rstd, W+bias, their product, and inverse-scale product | each complete FP32 fragment feeds one packed-or-scalar FP8 store loop |
+
+There is exactly one `cp.async` group, not a multi-stage pipeline. W loads are
+issued between X async commit and wait. PDL wait follows CTA/thread-ID and any
+compiler-hoisted pure-local initialization, but precedes the scale load and all
+dependency-sensitive global traffic; PDL signal follows every output store.
+PDL-disabled specializations contain neither PDL instruction nor launch
+attribute.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)
+launch(...)
+raw_shared(...)
+view(...)
+reg_tile(...)
+address(...)
+pair_view(...)
+scalar_pair(...)
+```
+
+Every data, arithmetic, conversion, and synchronization operation remains
+primitive:
+
+```python
+copy_g2r(src, dst, bits, predicate=None)
+copy_g2s_async_ca(src, dst, bits, source_bytes)
+copy_s2r(src, dst, bits)
+copy_r2s(src, dst)
+copy_r2g(src, dst, bits, predicate=None)
+fill(dst, value)
+cast(dtype, src)
+mul(lhs, rhs, lanes=1)
+add(lhs, rhs, lanes=1)
+fma(lhs, rhs, acc)
+fma_half_inputs_to_f32(lhs, rhs, acc)
+div(lhs, rhs)
+maximum(lhs, rhs)
+minimum(lhs, rhs)
+rcp_fast(src)
+rsqrt_fast(src)
+shuffle_xor(src, delta, width)
+convert_fp8_pair(lo, hi, dtype)
+pack_two_b16(lo, hi)
+cp_async_commit()
+cp_async_wait(group)
+cta_barrier()
+cluster_arrive_relaxed()
+cluster_wait()
+mbarrier_init(ptr, arrivals)
+mbarrier_init_fence()
+mbarrier_arrive_expect_tx(ptr, bytes)
+map_shared_to_peer(ptr, peer)
+remote_store_complete_tx(value, dst, mbarrier)
+mbarrier_try_wait_parity(ptr, phase, timeout)
+pdl_wait()
+pdl_signal()
+```
+
+Input traffic uses the source 128-bit-copy layout:
+
+| `VEC` | global X/W load | shared X load |
+| ---: | --- | --- |
+| 1 | `ld.global.b16` | async disabled |
+| 2 | `ld.global.v2.b16` | `ld.shared.v2.b16` |
+| 4 | `ld.global.v2.b32` | `ld.shared.v4.b16` |
+| 8 | `ld.global.v4.b32` | `ld.shared.v4.b32` |
+
+Every async X issue is `cp.async.ca.shared.global`, with immediate copy size
+`COPY_BITS/8` and the same runtime source-size operand for tail zero-fill.
+`mul(...,lanes=2)` and `add(...,lanes=2)` each denote one native packed-FP32
+instruction. There is no compound RMSNorm, row/block/cluster reduction,
+quantization, tile-copy, or tile-compute primitive.
+
+The hardware FP8 store families are fixed by the source inline PTX:
+
+| path | conversions | packing | store |
+| --- | --- | --- | --- |
+| full vec8 | four `cvt.rn.satfinite.{e4m3,e5m2}x2.f32` | two `mov.b32` from adjacent b16 pairs | one `st.global.v2.b32` |
+| full vec4 | two pair converts | one `mov.b32` | one `st.global.b32` |
+| full vec2 | one pair convert | none | one `st.global.b16` |
+| vec1 or any tail | explicit scalar max/min clamp, one pair convert with zero in the unused high byte | none | one `st.global.b8` per valid value |
+
+## Complete sketch
+
+```python
+@specialize(
+    INPUT_DTYPE=("f16", "bf16"),
+    OUTPUT_DTYPE=("e4m3fn", "e5m2"),
+    H="positive compile-time integer",
+    LAYOUT=("compact", "strided_i64"),
+    ENABLE_PDL=(False, True),
+    WEIGHT_BIAS=0.0,
+    USE_HW_FP8=True,
+    TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M, ROWS), CLUSTER_N, 1),
+    block=(NUM_THREADS, 1, 1),
+    cluster=((1, CLUSTER_N, 1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_rmsnorm_quant(
+    x_storage,                 # INPUT_DTYPE one-dimensional backing storage
+    weight,                    # INPUT_DTYPE [H], compact
+    out_storage,               # OUTPUT_DTYPE backing storage, caller provided
+    runtime_M: i64,
+    scale,                     # f32 [1], device resident
+    runtime_eps: f32,
+    x_row_stride: i64 = H,     # appended only for strided_i64
+    y_row_stride: i64 = H,     # appended only for strided_i64
+):
+    tid = thread_id_x(NUM_THREADS)
+    block_x = block_id_x()
+    block_y = 0
+    cta_rank = 0
+    if CLUSTER_N > 1:
+        block_y = block_id_y()
+        cta_rank = cta_rank_in_cluster()
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one issue per CTA
+
+    scale_value = copy_g2r(scale[0], bits=32)
+    # instruction_selection: ld.global.b32; extent: one scalar load per thread
+    inv_scale = rcp_fast(scale_value)
+    # instruction_selection: rcp.approx.ftz.f32; extent: one scalar per thread
+
+    # CuTe TV layout:
+    # shape=((TPR,ROWS),(VEC,VEC_BLOCKS))
+    # stride=((VEC*ROWS,1),(ROWS,ROWS*VEC*TPR)).
+    row_in_cta = tid // TPR
+    thread_in_row = tid % TPR
+    row_i64 = cast_i64(block_x) * ROWS + cast_i64(row_in_cta)
+    row_valid = row_i64 < runtime_M
+    warp = tid // 32
+    lane = tid % 32
+    WARPS_PER_ROW = max(TPR // 32, 1)
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+
+    smem = raw_shared("u8", SMEM_BYTES, alignment=16)
+    cursor = 0
+    if USE_ASYNC:
+        sX = view(smem, INPUT_DTYPE, (ROWS,COLS_PER_TILE),
+                  byte_offset=cursor, row_major=True, alignment=16)
+        cursor += ROWS * COLS_PER_TILE * 2
+    if CLUSTER_N == 1:
+        reduction = view(smem, "f32", (ROWS,WARPS_PER_ROW),
+                         stride=(1,ROWS), byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * 4
+    else:
+        reduction = view(
+            smem, "f32", (ROWS,(WARPS_PER_ROW,CLUSTER_N)),
+            stride=(1,(ROWS,ROWS*WARPS_PER_ROW)),
+            byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+        mbar = view(smem, "mbarrier", (1,), byte_offset=cursor, alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar, arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; extent: one per CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; extent: one per CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+
+    # Source fragment layout is (VEC,VEC_BLOCKS):(1,VEC); flat=v+VEC*vb.
+    x_frag = reg_tile(INPUT_DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_frag = reg_tile(INPUT_DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    x_f32 = reg_tile("f32", (VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_f32 = reg_tile("f32", (VEC,VEC_BLOCKS), stride=(1,VEC))
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    PACKED_PAIRS = ceil_div(TOTAL_VALUES, 2)
+
+    # ------------------------------------------------------------------
+    # Pass 1: X issue, optional async commit, W issue, optional wait/reload.
+    # ------------------------------------------------------------------
+    if not USE_ASYNC:
+        for flat in static_range(TOTAL_VALUES):
+            fill(x_frag[flat], zero(INPUT_DTYPE))
+            # instruction_selection: mov.b16 zero materialization; extent:
+            # one logical value, subject only to reviewed backend coalescing
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        col_valid = absolute_col < H
+        # Compact flat-offset narrowing is legal only under the host proof
+        # runtime_M*H<=INT32_MAX; the logical row itself remains i64.
+        x_offset = compact_safe_offset(row_i64,H,absolute_col) if COMPACT else \
+                   (row_i64 * x_row_stride + cast_i64(absolute_col))
+        if USE_ASYNC:
+            if row_valid:
+                source_bytes = (COPY_BITS // 8) if col_valid else 0
+                copy_g2s_async_ca(
+                    address(x_storage,x_offset),
+                    sX[row_in_cta,local_col:local_col+VEC],
+                    bits=COPY_BITS,
+                    source_bytes=source_bytes)
+                # instruction_selection: cp.async.ca.shared.global with
+                # immediate COPY_BITS/8 and runtime source-size; extent: one
+                # issue per vb for each in-bounds row
+        else:
+            if row_valid and col_valid:
+                copy_g2r(address(x_storage,x_offset), x_frag[:,vb], COPY_BITS)
+                # instruction_selection: ld.global from the VEC table;
+                # extent: one predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_commit()
+        # instruction_selection: cp.async.commit_group; extent: one per thread
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        if absolute_col < H:
+            copy_g2r(weight[absolute_col:absolute_col+VEC], w_frag[:,vb], COPY_BITS)
+            # instruction_selection: ld.global from the VEC table; extent:
+            # one column-predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_wait(0)
+        # instruction_selection: cp.async.wait_group 0; extent: one per thread
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: shared load from the VEC table; extent:
+            # one vector per vb
+
+    for flat in static_range(TOTAL_VALUES):
+        x_f32[flat] = cast("f32", x_frag[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one scalar per
+        # physical fragment value in flattened source order
+
+    if TOTAL_VALUES == 1:
+        local_sum = fma_half_inputs_to_f32(x_frag[0],x_frag[0],0.0)
+        # instruction_selection: fma.rn.f32.{f16,bf16}; extent: exactly one
+        # fused square/initial-reduction issue. The earlier scalar X-to-FP32
+        # cast remains live for the later epilogue.
+    else:
+        x_sq = reg_tile("f32", (TOTAL_VALUES,))
+        for pair in static_range(PACKED_PAIRS):
+            square_pair = mul(
+                pair_view(x_f32,pair,unused_high_if_odd=True),
+                pair_view(x_f32,pair,unused_high_if_odd=True), lanes=2)
+            # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues,
+            # including an unused high lane for an odd fragment
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    x_sq[flat] = square_pair[packed_lane]
+
+        local_sum = 0.0
+        for flat in static_range(TOTAL_VALUES):
+            local_sum = add(local_sum, x_sq[flat])
+            # instruction_selection: add.f32; extent: one ordered scalar issue
+            # per valid physical fragment value
+
+    # ------------------------------------------------------------------
+    # Expanded row_reduce_sum_multirow.
+    # ------------------------------------------------------------------
+    WARP_WIDTH = min(TPR, 32)
+    for delta in powers_of_two_below(WARP_WIDTH):
+        peer = shuffle_xor(local_sum, delta, width=32)
+        # instruction_selection: shfl.sync.bfly.b32 with full mask and clamp
+        # 31; extent: one scalar per explicit subgroup stage
+        local_sum = add(local_sum, peer)
+        # instruction_selection: add.f32; extent: one scalar per stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            copy_r2s(warp_sum, reduction[row_warp,warp_in_row])
+            # instruction_selection: st.shared.b32; extent: one per row warp
+        cta_barrier()
+        # instruction_selection: bar.sync; extent: one CTA publication edge
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = copy_s2r(reduction[row_warp,lane])
+            # instruction_selection: ld.shared.b32; extent: one scalar per
+            # participating lane in every row warp
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one scalar
+            # at each full-warp stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+
+    elif CLUSTER_N > 1:
+        if warp == 0 and elect_one():
+            # instruction_selection: elect.sync; extent: one election in warp 0
+            EXPECTED_BYTES = ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+            mbarrier_arrive_expect_tx(mbar, EXPECTED_BYTES)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+            # extent: one elected issue per CTA
+        if lane < CLUSTER_N:
+            peer_reduction = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cta_rank)], lane)
+            peer_mbar = map_shared_to_peer(mbar, lane)
+            # instruction_selection: mapa.shared::cluster.u32; extent: two
+            # address maps per sending lane
+            remote_store_complete_tx(warp_sum, peer_reduction, peer_mbar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # extent: one partial from every warp to every peer CTA
+        wait_done = False
+        while not wait_done:
+            wait_done = mbarrier_try_wait_parity(mbar, phase=0, timeout=10000000)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 plus
+            # uniform retry branch; extent: one retry loop per CTA thread
+        total_partials = WARPS_PER_ROW * CLUSTER_N
+        final = 0.0
+        for i in static_range(ceil_div(total_partials,32)):
+            partial = lane + i * 32
+            if partial < total_partials:
+                partial_value = copy_s2r(reduction[row_warp,partial])
+                # instruction_selection: ld.shared.b32; extent: one scalar
+                # for every partial owned by this lane
+                final = add(final, partial_value)
+                # instruction_selection: add.f32; extent: one scalar per load
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one scalar
+            # at each full-warp stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+    else:
+        sum_sq = warp_sum
+
+    if H == 1:
+        shifted = add(sum_sq, runtime_eps)
+        # instruction_selection: add.f32 after multiply-by-one folding;
+        # extent: one scalar per thread
+    elif is_power_of_two(H):
+        shifted = fma(sum_sq, exact_float32_reciprocal(H), runtime_eps)
+        # instruction_selection: fma.rn.f32; extent: one scalar per thread
+    else:
+        mean_sq = div(sum_sq, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+        shifted = add(mean_sq, runtime_eps)
+        # instruction_selection: add.f32; extent: one scalar per thread
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar per thread
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync; extent: one post-reduction CTA edge
+
+    # ------------------------------------------------------------------
+    # Pass 2: source async reload, FP32 multiply phases, FP8 output paths.
+    # ------------------------------------------------------------------
+    if USE_ASYNC:
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: shared load from the VEC table; extent:
+            # one vector per vb after the post-reduction synchronization
+        for flat in static_range(TOTAL_VALUES):
+            x_f32[flat] = cast("f32", x_frag[flat])
+            # instruction_selection: cvt.f32.{f16,bf16}; extent: every X value
+
+    for flat in static_range(TOTAL_VALUES):
+        w_f32[flat] = cast("f32", w_frag[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: every W value
+
+    normalized = reg_tile("f32", (TOTAL_VALUES,))
+    biased_w = reg_tile("f32", (TOTAL_VALUES,))
+    weighted = reg_tile("f32", (TOTAL_VALUES,))
+    y_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    if TOTAL_VALUES == 1:
+        normalized[0] = mul(x_f32[0],rstd)
+        # instruction_selection: mul.f32; extent: one scalar normalization
+        biased_w[0] = add(w_f32[0],0.0)
+        # instruction_selection: add.f32; extent: one scalar W-bias operation
+        weighted[0] = mul(normalized[0],biased_w[0])
+        # instruction_selection: mul.f32; extent: one scalar weighted product
+        y_f32[0] = mul(weighted[0],inv_scale)
+        # instruction_selection: mul.f32; extent: one scalar inverse-scale product
+    else:
+        # Phase 2a: materialize the complete normalized fragment.
+        for pair in static_range(PACKED_PAIRS):
+            normalized_pair = mul(
+                pair_view(x_f32,pair,unused_high_if_odd=True),
+                scalar_pair(rstd,pair,TOTAL_VALUES,undefined_high_if_odd=True),
+                lanes=2)
+            # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues
+            # over the complete fragment before any W-bias operation
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    normalized[flat] = normalized_pair[packed_lane]
+
+        # Phase 2b: materialize the complete biased-W fragment.
+        for pair in static_range(PACKED_PAIRS):
+            biased_pair = add(
+                pair_view(w_f32,pair,unused_high_if_odd=True),
+                scalar_pair(0.0,pair,TOTAL_VALUES,undefined_high_if_odd=True),
+                lanes=2)
+            # instruction_selection: add.f32x2; extent: PACKED_PAIRS issues
+            # for the source's explicit weight_bias=0.0 expression
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    biased_w[flat] = biased_pair[packed_lane]
+
+        # Phase 2c: consume normalized and biased_w into the complete weighted
+        # fragment; their lifetimes end after this loop.
+        for pair in static_range(PACKED_PAIRS):
+            weighted_pair = mul(
+                pair_view(normalized,pair,unused_high_if_odd=True),
+                pair_view(biased_w,pair,unused_high_if_odd=True), lanes=2)
+            # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues
+            # after the complete bias phase and before inverse-scale work
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    weighted[flat] = weighted_pair[packed_lane]
+
+        # Phase 2d: consume weighted into the final output fragment; only
+        # y_f32 remains live for FP8 conversion and stores.
+        for pair in static_range(PACKED_PAIRS):
+            y_pair = mul(
+                pair_view(weighted,pair,unused_high_if_odd=True),
+                scalar_pair(inv_scale,pair,TOTAL_VALUES,undefined_high_if_odd=True),
+                lanes=2)
+            # instruction_selection: mul.f32x2; extent: PACKED_PAIRS issues
+            # after every weighted-fragment issue
+            for packed_lane in static_range(2):
+                flat = pair * 2 + packed_lane
+                if flat < TOTAL_VALUES:
+                    y_f32[flat] = y_pair[packed_lane]
+
+    actual_row = row_i64
+    col_offset = thread_in_row * VEC
+    FP8_MAX = 448.0 if OUTPUT_DTYPE == "e4m3fn" else 57344.0
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = col_offset + vb * TPR * VEC
+        absolute_col = block_y * COLS_PER_TILE + local_col
+        y_offset = (actual_row * H + absolute_col) if COMPACT else \
+                   (actual_row * y_row_stride + cast_i64(absolute_col))
+
+        if VEC == 8 and absolute_col + 8 <= H and actual_row < runtime_M:
+            p01 = convert_fp8_pair(y_f32[vb*8+0], y_f32[vb*8+1], OUTPUT_DTYPE)
+            p23 = convert_fp8_pair(y_f32[vb*8+2], y_f32[vb*8+3], OUTPUT_DTYPE)
+            p45 = convert_fp8_pair(y_f32[vb*8+4], y_f32[vb*8+5], OUTPUT_DTYPE)
+            p67 = convert_fp8_pair(y_f32[vb*8+6], y_f32[vb*8+7], OUTPUT_DTYPE)
+            # instruction_selection: four
+            # cvt.rn.satfinite.{e4m3,e5m2}x2.f32 issues, each PTX pair ordered
+            # high operand then low operand; extent: one complete vec8 fragment
+            lo = pack_two_b16(p01,p23)
+            hi = pack_two_b16(p45,p67)
+            # instruction_selection: mov.b32 {b16,b16}; extent: two packed words
+            copy_r2g((lo,hi), address(out_storage,y_offset), bits=64)
+            # instruction_selection: st.global.v2.b32; extent: one vec8 store
+
+        elif VEC == 4 and absolute_col + 4 <= H and actual_row < runtime_M:
+            p01 = convert_fp8_pair(y_f32[vb*4+0], y_f32[vb*4+1], OUTPUT_DTYPE)
+            p23 = convert_fp8_pair(y_f32[vb*4+2], y_f32[vb*4+3], OUTPUT_DTYPE)
+            # instruction_selection: two
+            # cvt.rn.satfinite.{e4m3,e5m2}x2.f32 issues; extent: one vec4 fragment
+            packed = pack_two_b16(p01,p23)
+            # instruction_selection: mov.b32 {b16,b16}; extent: one packed word
+            copy_r2g(packed, address(out_storage,y_offset), bits=32)
+            # instruction_selection: st.global.b32; extent: one vec4 store
+
+        elif VEC == 2 and absolute_col + 2 <= H and actual_row < runtime_M:
+            p01 = convert_fp8_pair(y_f32[vb*2+0], y_f32[vb*2+1], OUTPUT_DTYPE)
+            # instruction_selection:
+            # cvt.rn.satfinite.{e4m3,e5m2}x2.f32; extent: one vec2 fragment
+            copy_r2g(p01, address(out_storage,y_offset), bits=16)
+            # instruction_selection: st.global.b16; extent: one vec2 store
+
+        else:
+            for e in static_range(VEC):
+                scalar_col = absolute_col + e
+                if scalar_col < H and actual_row < runtime_M:
+                    clamped_low = maximum(y_f32[vb*VEC+e], -FP8_MAX)
+                    # instruction_selection: setp.le.f32 + selp.f32; extent:
+                    # one compare-select pair per valid scalar tail value
+                    clamped = minimum(clamped_low, FP8_MAX)
+                    # instruction_selection: setp.ge.f32 + selp.f32; extent:
+                    # one compare-select pair per valid scalar tail value
+                    pair = convert_fp8_pair(clamped, 0.0, OUTPUT_DTYPE)
+                    # instruction_selection:
+                    # cvt.rn.satfinite.{e4m3,e5m2}x2.f32 with PTX operands
+                    # zero,clamped so the valid result occupies the stored byte;
+                    # extent: one scalar tail value
+                    scalar_offset = (actual_row * H + scalar_col) if COMPACT else \
+                                    (actual_row * y_row_stride + cast_i64(scalar_col))
+                    copy_r2g(pair.low_byte, address(out_storage,scalar_offset), bits=8)
+                    # instruction_selection: st.global.b8; extent: one valid scalar
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; extent:
+        # one issue per CTA after all stores
+```
+
+## Addressing, predicates, tails, and excluded software conversion
+
+- Compact X addressing may use the source constexpr row stride only because
+  the host proves `M*H <= INT32_MAX`. The strided ABI keeps the row, stride
+  product, H-column addition, and final pointer offset Int64. Output addressing
+  begins from the source's explicit `actual_row:Int64` on both paths.
+- X and Y are one-dimensional backing buffers in TIRx. Strides are independent
+  and measured in elements; an FP8 Y element is one byte.
+- `predicate_k` tests the first column of each input vector. Legal H partitions
+  and stride divisibility make a true predicate cover the complete vector.
+  Async false columns issue zero source bytes rather than skip the instruction.
+- Output full-vector checks use `absolute_col+VEC<=H` and Int64 row bounds.
+  Every failed vec8/4/2 check enters the scalar loop, where row and each column
+  are checked again before clamp/convert/store.
+- Out-of-range rows still execute scale load/reciprocal, W loads, async
+  commit/wait, reduction, every barrier, and PDL signal; synchronization is not
+  nested under the row predicate.
+- The source software E4M3/E5M2 converters are recorded as an unreachable
+  pre-SM89 alternative. They are not transcribed because SM100 fixes
+  `USE_HW_FP8=True`.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime / reuse rule |
+| --- | --- | --- |
+| device scale scalar / `inv_scale` | every thread loads the same element | immediately after PDL wait through the final FP8 conversion phase |
+| `sX` | each row-thread writes and reads its `(row,local_col)` vectors | async issue through the post-reduction reload |
+| reduction buffer | row warps; clustered copies are remotely published | publication through replicated final reduction and post-reduction sync |
+| cluster mbarrier | one per CTA, initialized by thread 0 | cluster initialization through remote-store completion wait |
+| X fragment | one thread | sync: load through epilogue; async: first load through square, then post-sync reload |
+| W fragment | one thread | global load before async wait through complete weighted normalization |
+| widened X / squares | one thread | X widening through ordered local sum; async X widening is recreated after sync |
+| widened W | one thread | W widening through completion of the biased-W phase |
+| normalized fragment | one thread | complete normalization phase through its consumption by the weighted phase |
+| biased-W fragment | one thread | complete bias phase through its consumption by the weighted phase |
+| weighted fragment | one thread | complete weighted phase through its consumption by inverse-scale phase |
+| final `y_f32` fragment | one thread | complete inverse-scale phase through FP8 conversion/store |
+| FP8 b16 pairs / b32 words | one thread | one vector block's conversion through its single packed store |
+
+Each row group owns one output row and each `(cluster_y,thread,vb,e)` owns a
+disjoint H element after predicates. Cluster CTAs communicate only reduction
+partials; X, W, scale, and Y traffic is otherwise independent.
+
+## Module and verification contract
+
+- Registry name is `flashinfer_rmsnorm_quant`, category `flashinfer`, compute
+  capability 10; the factory supports every positive-H source specialization.
+- Compact ABI is `x,weight,out,M:int64,scale:f32[1],eps:f32`; strided ABI appends
+  `x_row_stride:int64,y_row_stride:int64`. The public API returns `None` and
+  preserves the caller-provided output object and stride.
+- `CONFIGS` contains exactly 1552 unique rows; the eight `BENCH_CONFIGS` are
+  direct selections from that same closure and the suite YAML lists all eight.
+- Correctness must prove public `rmsnorm_quant_cute` dispatch, compare raw FP8
+  bytes against FlashInfer, compare dequantized values against an independent
+  FP32 oracle with `rtol=atol=1`, preserve X/W/scale, and protect output padding
+  and tails. Large-H inputs are periodic and non-constant.
+- Every specialization undergoes low-level IR rejection of `TilePrimitiveCall`,
+  `tirx.tile.*`, tile primitives, `T.cuda.func_call`, and `cuda_func_call`.
+- Performance passes only when all eight suite rows have both `tirx` and
+  `flashinfer_cutedsl`, no unresolved error/interference, and each individual
+  `flashinfer_cutedsl_time/tirx_time` ratio is strictly above 0.99.
+
+## Instruction selection is a lowering consequence
+
+The port preserves source cluster selection, quant-only thread override, TV
+layout, vector width, copy branch, fragment order, scale-load position,
+reduction publication, post-reduction synchronization, async-X reload, four
+FP32 epilogue phases, FP8 pair operand order, store width, and PDL boundaries.
+Plain TIRx and typed/local PTX may express reviewed instructions. They may not
+scalarize a full packed FP8 path, retain X FP32 registers instead of reloading
+shared X, reassociate inverse-scale multiplication ahead of weighting, weaken
+Int64 addressing or predicates, replace FTZ reciprocal/rsqrt, or emit any tile
+or CUDA function-call primitive.

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -1,6 +1,6 @@
 # Expose predication and uniform control
 
-**Symptoms:** `branch_reconvergence`, `warp_divergence`, `excess_control_instructions`, `branch_in_hot_loop`, `serialized_stores`
+**Symptoms:** `branch_reconvergence`, `excess_control_instructions`, `branch_in_hot_loop`, `excess_guard_math`, `serialized_stores`
 
 ## Symptom
 
@@ -26,6 +26,23 @@ no spill.
 
 - For a loop-invariant uniform condition, hoist it and duplicate the hot loop
   only when that exposes a dense path without changing recurrence state.
+- When compile-time launch and tiling facts prove complete rows and vectors,
+  expose a separate guard-free specialization instead of carrying the generic
+  row, column, and zero-byte-copy predicates into every unrolled issue. Keep the
+  guarded path for partial rows and columns.
+
+  ```python
+  # before: the complete-vector specialization still materializes both guards.
+  source_bytes = T.if_then_else(row_valid and col_valid, COPY_BYTES, 0)
+  _copy_async(src, dst, source_bytes)
+
+  # after: launch and tiling proofs make the complete path literal.
+  if ROWS_PER_CTA == 1 and FULL_COLUMNS:
+      _copy_async(src, dst, T.uint32(COPY_BYTES))
+  else:
+      source_bytes = T.if_then_else(row_valid and col_valid, COPY_BYTES, 0)
+      _copy_async(src, dst, source_bytes)
+  ```
 - When the condition is runtime at kernel entry but constant throughout the CTA,
   an inline TIRx helper with a `T.constexpr` mode can force the two branch
   bodies to specialize independently: dispatch once on the runtime condition,
@@ -91,6 +108,13 @@ no spill.
   tensor pipe from 67.3% to 74.2% of cycles against the reference's 73.5%. On
   the gate the mainloop half is what moved the family, from 0.939-0.983x to
   0.995-1.035x.
+- In a rows-one, full-vector specialization, making the launch proof explicit
+  removed eight asynchronous-copy row/source-byte guards, eight weight-column
+  guards, and eight output-row guards. Static SASS fell from 693 to 669
+  instructions, `BRA` from 9 to 1, and `ISETP` from 17 to 1 while the eight
+  copies, eight loads, and eight stores were unchanged. Two affected ratios
+  moved from 0.9794 to 0.9895 and from 0.9869 to 0.9955; a neighboring multi-row
+  shape stayed flat at 0.9836 to 0.9834.
 
 The reference's source text does not reveal whether it wants this. nvcc
 routinely duplicates a loop around a store predicate the reference wrote per
@@ -103,6 +127,13 @@ duplicated, and matching that multiple is the target.
 
 Do not predicate substantial computation or duplicate a body that causes
 instruction-cache pressure, spills, or lower occupancy.
+
+A complete-row proof must follow from the specialization's launch identity, not
+only from a favorite runtime sample. Preserve the generic guards for tail rows,
+partial vectors, strided layouts, and any ABI whose runtime extent can differ
+from the compile-time tile. Removing guard instructions is mechanism evidence,
+not a timing result: a separate divisible-row proof removed control and address
+instructions but still failed its affected performance shape.
 
 Not every predicate is worth rewriting. Rebuilding an integer-materialized
 condition as a boolean conjunction, aimed at an excess of logic ops and

--- a/.agents/skills/tirx-codegen-tuning/references/db/measure-elided-warp-synchronization.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/measure-elided-warp-synchronization.md
@@ -1,6 +1,6 @@
 # Measure elided warp synchronization as a scheduling constraint
 
-**Symptoms:** `warp_sync_schedule_shift`, `small_shape_regression`, `bar_warp_elided`
+**Symptoms:** `warp_sync_schedule_shift`, `bar_warp_elided`, `long_scoreboard`, `exposed_load_latency`, `small_shape_regression`
 
 ## Symptom
 
@@ -11,13 +11,32 @@ specialization.
 
 ## What to change
 
-Nothing is automatically safe to add or drop here. Treat the added or removed
-sync as a scheduling change and A/B the complete dispatch matrix even when the
-machine barrier is elided.
+When paired SASS shows independent loads hoisted before asynchronous-copy issue
+or sunk behind its wait, use full-mask warp synchronization as a scheduling
+boundary. Bracket only the prefix of independent loads that should remain in the
+wait window; the prefix length and both boundary positions are compile-time
+specialization choices.
 
 ```python
-T.cuda.warp_sync()  # may emit no SASS barrier and still move time
+# before: ptxas is free to move the entire load group across issue and wait.
+T.ptx.cp.async_.commit_group()
+for i in T.unroll(PREFETCHES):
+    _load_independent_fragment(i)
+T.ptx.cp.async_.wait_group(0)
+
+# after: keep exactly the intended prefix between async issue and wait.
+T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
+T.ptx.cp.async_.commit_group()
+for i in T.unroll(PREFETCHES):
+    _load_independent_fragment(i)
+    if i == WAIT_WINDOW_LOADS - 1:
+        T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
+T.ptx.cp.async_.wait_group(0)
 ```
+
+Adding or dropping one of these constraints is never automatically safe. The
+barrier can become a `NOP` or disappear as a machine barrier while its ordering
+constraint still changes the schedule.
 
 ## Rationale
 
@@ -26,12 +45,27 @@ SASS barrier, and kept registers and spills unchanged. Cold-L2 time nevertheless
 moved by +2.07%, -0.76%, and -1.17% across its small, medium, and large default
 shapes; both benchmark orderings agreed.
 
+In an asynchronous-copy path, moving the independent-load source block alone
+produced byte-equivalent scheduled SASS. A single warp boundary did change the
+schedule, but placed all eight loads after `DEPBAR` and the first shared loads.
+Keeping a boundary at asynchronous issue and adding a second after four of the
+eight independent loads placed exactly that prefix between `LDGDEPBAR` and
+`DEPBAR`; the only opcode-vector change was one extra `NOP` per warp. Extending
+the same two-boundary shape to a neighboring specialization moved its complete-
+matrix ratio from 0.9862 to 0.9931, and the resulting eight-shape matrix cleared
+the strict gate.
+
 ## Boundary
 
 Treat the movement as specialization-specific scheduling, not as a fixed barrier
-latency: the sign differs per shape.
+latency: the sign differs per shape. A boundary immediately before or after the
+wrong pipeline operation can sink every independent load behind the wait and be
+worse than no boundary. Use a full mask only where every named lane converges;
+this idiom is not permission to weaken a synchronization required for
+correctness.
 
 ## Verification
 
-Inspect PTX, SASS, and resources for every affected shape, then A/B the complete
-dispatch matrix.
+Inspect PTX, final SASS, and resources for every affected shape. Confirm the
+intended load prefix lies between asynchronous issue and wait, then check
+registers, spills, the affected workloads, and their guard shapes.

--- a/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
@@ -1,6 +1,6 @@
 # Specialize static register caps by execution path
 
-**Symptoms:** `register_budget_mismatch`, `schedule_regression`, `dispatch_specific_deficit`, `low_occupancy`
+**Symptoms:** `register_budget_mismatch`, `schedule_regression`, `dispatch_specific_deficit`, `low_occupancy`, `small_grid`
 
 ## Symptom
 
@@ -54,6 +54,15 @@ changing the mathematical kernel: the dependency-protocol path moved from
 1.001x in the final complete matrix. A static cap is a contract with the
 current allocator and scheduler, not a stable source-level constant.
 
+An underfilled launch isolated the scheduling effect from occupancy. With only
+16 CTAs on 148 SMs, lowering realized allocation from 96 to 80 registers could
+not reduce actual CTA occupancy; it kept the complete opcode vectors identical
+and introduced no spill, yet moved the ratio from 0.983 to 0.972. Raising the
+allocation to 104 registers reduced dynamic instructions and long-scoreboard
+stall from about 2.69 to 2.34 cycles per issued instruction, also without spill,
+but still measured only 0.975. Matching the reference allocation or improving a
+stall counter did not select the useful cap.
+
 ## Boundary
 
 `tirx.max_registers` and `tirx.launch_bounds_*` are alternative static codegen
@@ -63,6 +72,11 @@ that is too low can introduce spills or recomputation; a cap that is too high
 can reduce occupancy or produce a worse schedule. Re-sweep after any change to
 fragment lifetime, instruction ordering, launch protocol, compiler, or codegen
 pipeline.
+
+A grid too small to fill the machine does not make a cap change free. Even when
+the launch geometry proves occupancy cannot fall, retain a cap only when its
+scheduled SASS and affected/guard timings improve; realized register parity and
+stall counters alone are diagnostic evidence.
 
 Do not copy the reference's realized register count into the cap. One
 source-like cap of 74 moved a wide-fragment path to 4.7-4.9 microseconds, and a

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm_quant.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm_quant.yaml
@@ -1,0 +1,11 @@
+kernel: flashinfer_rmsnorm_quant
+selection_rationale: The default small and medium rows preserve both active FlashInfer benchmarks, while the largest structural row guards PDL, synchronous copy, and the cluster-16 capacity branch.
+configs:
+  - {config: bf16_e4m3_m32_h4096_xc_yc_pdl0_s1, default: true, selection_role: small}
+  - {config: bf16_e4m3_m64_h8192_xc_yc_pdl0_s1, default: true, selection_role: medium}
+  - {config: fp16_e5m2_m989_h500_xc_yc_pdl0_s0p01, default: false}
+  - {config: bf16_e5m2_m989_h66_xc_yc_pdl1_s10_vec2, default: false}
+  - {config: fp16_e4m3_m989_h111_xs_yc_pdl0_s1, default: false}
+  - {config: fp16_e5m2_m989_h500_xc_ys_pdl1_s1_eps1e4_full_abi, default: false}
+  - {config: fp16_e4m3_m3_h65536_xc_yc_pdl0_s1_cluster1_sync_capacity, default: false}
+  - {config: bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync, default: true, selection_role: large}

--- a/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
@@ -1,0 +1,1704 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL 2-D RMSNorm with FP8 quantization.
+
+The source implementation is ``RMSNormQuantKernel`` and its shared helpers in
+``flashinfer/norm/kernels/rmsnorm.py`` and ``flashinfer/norm/utils.py``.  The
+public dispatch is ``rmsnorm_quant`` in ``flashinfer/norm/__init__.py``.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "flashinfer_rmsnorm_quant",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_INPUT_DTYPES = ("float16", "bfloat16")
+_OUTPUT_DTYPES = ("float8_e4m3fn", "float8_e5m2")
+_LAYOUTS = ("compact", "strided")
+_INT32_MAX = 2**31 - 1
+_DEFAULT_EPS = 1e-6
+_SCALES = (0.01, 1.0, 10.0)
+_OPTIN_SMEM_BYTES = 232448
+_INPUT_ELEM_BYTES = 2
+
+
+def _ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def _threads_per_row(H_per_cta: int) -> int:
+    if H_per_cta <= 64:
+        return 8
+    if H_per_cta <= 128:
+        return 16
+    if H_per_cta <= 3072:
+        return 32
+    if H_per_cta <= 6144:
+        return 64
+    if H_per_cta <= 16384:
+        return 128
+    return 256
+
+
+def _rmsnorm_derived_config(H: int, cluster_n: int) -> dict[str, int]:
+    """Return the inherited RMSNorm launch terms used by the smem estimate."""
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, 8)
+    vec_blocks = max(1, _ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    return {
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec": vec,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+    }
+
+
+def _estimate_smem(H: int, cluster_n: int) -> int:
+    source = _rmsnorm_derived_config(H, cluster_n)
+    rows = source["rows"]
+    warps_per_row = source["warps_per_row"]
+    cols = source["cols"]
+    return (
+        rows * cols * _INPUT_ELEM_BYTES
+        + rows * warps_per_row * cluster_n * 4
+        + (8 if cluster_n > 1 else 0)
+    )
+
+
+def _source_config(H: int) -> dict[str, int | bool]:
+    cluster_n = 16
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and _estimate_smem(H, candidate) <= _OPTIN_SMEM_BYTES:
+            cluster_n = candidate
+            break
+
+    source = _rmsnorm_derived_config(H, cluster_n)
+    H_per_cta = source["H_per_cta"]
+    tpr = source["tpr"]
+    threads = source["threads"]
+    if H_per_cta > 8192 and threads < 256:
+        threads = 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = source["vec"]
+    copy_bits = 16 * vec
+    vec_blocks = source["vec_blocks"]
+    cols = source["cols"]
+    tile_bytes = rows * cols * _INPUT_ELEM_BYTES
+    use_async = copy_bits >= 32 and tile_bytes <= _OPTIN_SMEM_BYTES // 2
+    reduce_bytes = rows * warps_per_row * 4 * (cluster_n if cluster_n > 1 else 1)
+    smem_bytes = (tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return {
+        "cluster_n": cluster_n,
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec": vec,
+        "copy_bits": copy_bits,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+        "use_async": use_async,
+        "smem_bytes": smem_bytes,
+    }
+
+
+def _ptx_unary(chain: str, value, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _ptx_ternary(chain: str, lhs, rhs, acc, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _mul_f32(lhs, rhs):
+    return _ptx_binary("mul.f32", lhs, rhs)
+
+
+def _div_rn_f32(lhs, rhs):
+    return _ptx_binary("div.rn.f32", lhs, rhs)
+
+
+def _fma_rn_f32(lhs, rhs, acc):
+    return _ptx_ternary("fma.rn.f32", lhs, rhs, acc)
+
+
+def _fma_half_inputs_to_f32(lhs, rhs, input_dtype: str):
+    out = T.alloc_local((1,), "float32")
+    if input_dtype == "float16":
+        T.evaluate(T.ptx.fma.rn.f32.f16(out[0], lhs, rhs, T.float32(0.0)))
+    else:
+        T.evaluate(T.ptx.fma.rn.f32.bf16(out[0], lhs, rhs, T.float32(0.0)))
+    return out[0]
+
+
+def _rcp_approx_ftz(value):
+    return _ptx_unary("rcp.approx.ftz.f32", value)
+
+
+def _rsqrt_approx_ftz(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _cvt_to_f32(bits, input_dtype: str):
+    if input_dtype == "float16":
+        return _ptx_unary("cvt.f32.f16", T.cast(bits, "uint16"))
+    return _ptx_unary("cvt.f32.bf16", T.cast(bits, "uint16"))
+
+
+def _cvt_fp8_pair(low, high, output_dtype: str):
+    pair = T.alloc_local((1,), "uint16")
+    if output_dtype == "float8_e4m3fn":
+        T.evaluate(T.ptx.cvt.rn.satfinite.e4m3x2.f32(pair[0], high, low))
+    else:
+        T.evaluate(T.ptx.cvt.rn.satfinite.e5m2x2.f32(pair[0], high, low))
+    return pair[0]
+
+
+def _pack_b16_pair(low, high):
+    word = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.mov.b32(word[0], low, high))
+    return word[0]
+
+
+def _maximum_f32(value, lower):
+    predicate = T.local_scalar("uint32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.setp.le.f32(predicate, value, lower))
+    T.evaluate(T.ptx.selp.f32(out[0], lower, value, T.ptx.pred(predicate)))
+    return out[0]
+
+
+def _minimum_f32(value, upper):
+    predicate = T.local_scalar("uint32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.setp.ge.f32(predicate, value, upper))
+    T.evaluate(T.ptx.selp.f32(out[0], upper, value, T.ptx.pred(predicate)))
+    return out[0]
+
+
+def _shfl_bfly_f32(value, lane_xor: int):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _butterfly_sum_f32(value, lane_xors: tuple[int, ...]):
+    for lane_xor in lane_xors:
+        value = _add_f32(value, _shfl_bfly_f32(value, lane_xor))
+    return value
+
+
+def _mapa_u32(pointer, peer):
+    mapped = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.mapa.shared__cluster.u32(
+            mapped[0], T.cuda.cvta_generic_to_shared(pointer), T.cast(peer, "uint32")
+        )
+    )
+    return mapped[0]
+
+
+def _cluster_mbarrier_wait(pointer):
+    return T.cuda.mbarrier_wait(pointer, T.int32(0))
+
+
+@T.inline
+def _load_global_bits(buffer, index, values, value_offset, VEC: T.constexpr):
+    if VEC == 1:
+        T.ptx.ld.global_.b16(values[value_offset], buffer.ptr_to([index]))
+    elif VEC == 2:
+        T.ptx.ld.global_.v2.b16(
+            values[value_offset], values[value_offset + 1], buffer.ptr_to([index])
+        )
+    else:
+        words = T.alloc_local((VEC // 2,), "uint32")
+        if VEC == 4:
+            T.ptx.ld.global_.v2.b32(words[0], words[1], buffer.ptr_to([index]))
+        else:
+            T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+        for pair in T.unroll(VEC // 2):
+            T.ptx.mov.b32(
+                values[value_offset + pair * 2], values[value_offset + pair * 2 + 1], words[pair]
+            )
+
+
+@T.inline
+def _load_shared_bits(shared_raw, byte_offset, values, value_offset, VEC: T.constexpr):
+    if VEC == 2:
+        T.ptx.ld.shared.v2.b16(
+            values[value_offset], values[value_offset + 1], shared_raw.ptr_to([byte_offset])
+        )
+    else:
+        words = T.alloc_local((VEC // 2,), "uint32")
+        if VEC == 4:
+            halves = T.alloc_local((4,), "uint16")
+            T.ptx.ld.shared.v4.b16(
+                halves[0], halves[1], halves[2], halves[3], shared_raw.ptr_to([byte_offset])
+            )
+            for value in T.unroll(4):
+                values[value_offset + value] = halves[value]
+        else:
+            T.ptx.ld.shared.v4.b32(
+                words[0], words[1], words[2], words[3], shared_raw.ptr_to([byte_offset])
+            )
+            for pair in T.unroll(4):
+                T.ptx.mov.b32(
+                    values[value_offset + pair * 2],
+                    values[value_offset + pair * 2 + 1],
+                    words[pair],
+                )
+
+
+@T.inline
+def _load_global_words(buffer, index, words, word_offset, VEC: T.constexpr):
+    if VEC == 2:
+        T.ptx.ld.global_.b32(words[word_offset], buffer.ptr_to([index]))
+    elif VEC == 4:
+        T.ptx.ld.global_.v2.b32(words[word_offset], words[word_offset + 1], buffer.ptr_to([index]))
+    else:
+        T.ptx.ld.global_.v4.b32(
+            words[word_offset],
+            words[word_offset + 1],
+            words[word_offset + 2],
+            words[word_offset + 3],
+            buffer.ptr_to([index]),
+        )
+
+
+@T.inline
+def _load_shared_words(shared_raw, byte_offset, words, word_offset, VEC: T.constexpr):
+    if VEC == 2:
+        T.ptx.ld.shared.b32(words[word_offset], shared_raw.ptr_to([byte_offset]))
+    elif VEC == 4:
+        T.ptx.ld.shared.v2.b32(
+            words[word_offset], words[word_offset + 1], shared_raw.ptr_to([byte_offset])
+        )
+    else:
+        T.ptx.ld.shared.v4.b32(
+            words[word_offset],
+            words[word_offset + 1],
+            words[word_offset + 2],
+            words[word_offset + 3],
+            shared_raw.ptr_to([byte_offset]),
+        )
+
+
+def _short_dtype(dtype: str) -> str:
+    return {"float16": "fp16", "bfloat16": "bf16", "float8_e4m3fn": "e4m3", "float8_e5m2": "e5m2"}[
+        dtype
+    ]
+
+
+def _layout_code(layout: str) -> str:
+    return {"compact": "c", "strided": "s"}[layout]
+
+
+def _scale_code(scale: float) -> str:
+    return {0.01: "0p01", 1.0: "1", 10.0: "10"}[scale]
+
+
+def _cfg(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    scale: float,
+    *,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    y_row_stride: int | None = None,
+    suffix: str | None = None,
+) -> dict[str, Any]:
+    label = (
+        f"{_short_dtype(input_dtype)}_{_short_dtype(output_dtype)}_m{M}_h{H}_"
+        f"x{_layout_code(input_layout)}_y{_layout_code(output_layout)}_"
+        f"pdl{int(enable_pdl)}_s{_scale_code(scale)}"
+    )
+    if suffix:
+        label += f"_{suffix}"
+    config: dict[str, Any] = {
+        "label": label,
+        "input_dtype": input_dtype,
+        "output_dtype": output_dtype,
+        "M": M,
+        "H": H,
+        "input_layout": input_layout,
+        "output_layout": output_layout,
+        "enable_pdl": enable_pdl,
+        "scale": scale,
+        "eps": eps,
+    }
+    if x_row_stride is not None:
+        config["x_row_stride"] = x_row_stride
+    if y_row_stride is not None:
+        config["y_row_stride"] = y_row_stride
+    return config
+
+
+_UPSTREAM_CONFIGS = [
+    _cfg(
+        input_dtype,
+        output_dtype,
+        M,
+        H,
+        input_layout,
+        "compact",
+        enable_pdl,
+        scale,
+        x_row_stride=2 * H if input_layout == "strided" else None,
+    )
+    for M in (1, 19, 99, 989)
+    for H in (111, 500, 1024, 3072, 3584, 4096, 8192, 16384)
+    for input_dtype in _INPUT_DTYPES
+    for output_dtype in _OUTPUT_DTYPES
+    for scale in _SCALES
+    for enable_pdl in (False, True)
+    for input_layout in _LAYOUTS
+]
+
+_ACTIVE_BENCHMARK_CONFIGS = [
+    _cfg("bfloat16", "float8_e4m3fn", 32, 4096, "compact", "compact", False, 1.0),
+    _cfg("bfloat16", "float8_e4m3fn", 64, 8192, "compact", "compact", False, 1.0),
+]
+
+_I64_CONFIGS = [
+    _cfg(
+        "bfloat16",
+        "float8_e4m3fn",
+        2,
+        128,
+        "strided",
+        "compact",
+        False,
+        1.0,
+        x_row_stride=2**31,
+        suffix="i64_xstride",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="compact_overflow_to_strided_i64",
+    ),
+]
+
+_TRACE_CONFIGS = [
+    _cfg("bfloat16", "float8_e4m3fn", M, H, "compact", "compact", False, 1.0)
+    for M, H in ((32, 2048), (7, 1024), (32, 7168))
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        64,
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="vec8_tpr8_async",
+    ),
+    _cfg("bfloat16", "float8_e5m2", 989, 66, "compact", "compact", True, 10.0, suffix="vec2"),
+    _cfg(
+        "float16", "float8_e4m3fn", 3, 16385, "compact", "compact", False, 1.0, suffix="vec1_sync"
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        65536,
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="cluster1_sync_capacity",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        131072,
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster2_sync",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        262144,
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="cluster4_sync",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        524288,
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster8_sync",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        1048576,
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster16_sync",
+    ),
+]
+
+_ABI_CONFIGS = [
+    _cfg(
+        "float16",
+        "float8_e5m2",
+        989,
+        500,
+        "compact",
+        "strided",
+        True,
+        1.0,
+        eps=1e-4,
+        y_row_stride=1000,
+        suffix="eps1e4_full_abi",
+    )
+]
+
+CONFIGS = [
+    *_UPSTREAM_CONFIGS,
+    *_ACTIVE_BENCHMARK_CONFIGS,
+    *_I64_CONFIGS,
+    *_TRACE_CONFIGS,
+    *_STRUCTURE_CONFIGS,
+    *_ABI_CONFIGS,
+]
+
+assert len(_UPSTREAM_CONFIGS) == 1536
+assert len(CONFIGS) == 1552
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+
+_CONFIG_BY_LABEL = {config["label"]: config for config in CONFIGS}
+_BENCH_LABELS = (
+    "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1",
+    "bf16_e4m3_m64_h8192_xc_yc_pdl0_s1",
+    "fp16_e5m2_m989_h500_xc_yc_pdl0_s0p01",
+    "bf16_e5m2_m989_h66_xc_yc_pdl1_s10_vec2",
+    "fp16_e4m3_m989_h111_xs_yc_pdl0_s1",
+    "fp16_e5m2_m989_h500_xc_ys_pdl1_s1_eps1e4_full_abi",
+    "fp16_e4m3_m3_h65536_xc_yc_pdl0_s1_cluster1_sync_capacity",
+    "bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync",
+)
+BENCH_CONFIGS = [_CONFIG_BY_LABEL[label] for label in _BENCH_LABELS]
+
+
+def _validate(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    scale: float,
+    eps: float,
+    x_row_stride: int | None,
+    y_row_stride: int | None,
+) -> None:
+    if input_dtype not in _INPUT_DTYPES:
+        raise ValueError(f"unsupported input dtype: {input_dtype}")
+    if output_dtype not in _OUTPUT_DTYPES:
+        raise ValueError(f"unsupported output dtype: {output_dtype}")
+    if input_layout not in _LAYOUTS or output_layout not in _LAYOUTS:
+        raise ValueError(f"unsupported layouts: input={input_layout}, output={output_layout}")
+    if M <= 0 or H <= 0:
+        raise ValueError(f"M and H must be positive, got M={M}, H={H}")
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError(f"scale must be positive and finite, got {scale}")
+    if not math.isfinite(eps) or eps <= 0.0:
+        raise ValueError(f"eps must be positive and finite, got {eps}")
+    for name, layout, stride in (
+        ("x_row_stride", input_layout, x_row_stride),
+        ("y_row_stride", output_layout, y_row_stride),
+    ):
+        if layout == "strided" and stride is not None and stride < H:
+            raise ValueError(f"{name} must be at least H={H}, got {stride}")
+
+
+def _uses_compact_specialization(M: int, H: int, input_layout: str, output_layout: str) -> bool:
+    return input_layout == "compact" and output_layout == "compact" and M * H <= _INT32_MAX
+
+
+def get_kernel(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    scale: float,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    y_row_stride: int | None = None,
+    **kwargs: Any,
+):
+    """Return the compact or explicit-i64-strided source specialization."""
+    _validate(
+        input_dtype,
+        output_dtype,
+        M,
+        H,
+        input_layout,
+        output_layout,
+        scale,
+        eps,
+        x_row_stride,
+        y_row_stride,
+    )
+    compact = _uses_compact_specialization(M, H, input_layout, output_layout)
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec = int(source["vec"])
+    copy_bits = int(source["copy_bits"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    use_async = bool(source["use_async"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = vec * vec_blocks
+    packed_pairs = _ceil_div(total_values, 2)
+    copy_bytes = copy_bits // 8
+    reduce_base = tile_bytes if use_async else 0
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    full_columns = H == cluster_n * cols
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+    fp8_max = 448.0 if output_dtype == "float8_e4m3fn" else 57344.0
+
+    del kwargs
+    x_row_stride_hint = H if x_row_stride is None else int(x_row_stride)
+    y_row_stride_hint = H if y_row_stride is None else int(y_row_stride)
+    if x_row_stride_hint % vec != 0:
+        raise ValueError(f"x_row_stride={x_row_stride_hint} must be divisible by vec={vec}")
+    if y_row_stride_hint % vec != 0:
+        raise ValueError(f"y_row_stride={y_row_stride_hint} must be divisible by vec={vec}")
+
+    @T.inline
+    def kernel_body(x, weight, out, runtime_M, scale_buffer, runtime_eps, x_stride, y_stride):
+        # TIRX_TRANSCRIBE_START flashinfer_rmsnorm_quant
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        scale_bits = T.alloc_local((1,), "uint32")
+        T.ptx.ld.global_.b32(scale_bits[0], scale_buffer.ptr_to([0]))
+        scale_value: T.float32 = T.reinterpret("float32", scale_bits[0])
+        inv_scale: T.float32 = _rcp_approx_ftz(scale_value)
+
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        row_i64: T.int64 = T.cast(block_x, "int64") * T.int64(rows) + T.cast(row_in_cta, "int64")
+        row_valid: T.bool = row_i64 < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+        if threads == 128:
+            if enable_pdl:
+                T.attr({"tirx.max_registers": 64})
+            elif H == 4096:
+                T.attr({"tirx.max_registers": 93})
+            elif H == 8192:
+                T.attr({"tirx.max_registers": 80})
+            else:
+                T.attr({"tirx.max_registers": 93})
+        else:
+            T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        x_bits = T.alloc_local((total_values if vec == 1 else 1,), "uint16")
+        w_bits = T.alloc_local((total_values if vec == 1 else 1,), "uint16")
+        x_words = T.alloc_local((packed_pairs if vec > 1 else 1,), "uint32")
+        w_words = T.alloc_local((packed_pairs if vec > 1 else 1,), "uint32")
+        x_f32_pairs = T.alloc_local((packed_pairs,), "uint64")
+        w_f32_pairs = T.alloc_local((packed_pairs,), "uint64")
+        x_f32_scalar = T.alloc_local((1,), "float32")
+        w_f32_scalar = T.alloc_local((1,), "float32")
+        undefined_f32 = T.alloc_local((1,), "float32")
+
+        if not use_async:
+            if vec == 1:
+                for value in T.unroll(total_values):
+                    x_bits[value] = T.uint16(0)
+            else:
+                for pair in T.unroll(packed_pairs):
+                    x_words[pair] = T.uint32(0)
+
+        if use_async and not enable_pdl and H == 8192:
+            if rows == 1 or row_valid:
+                for vb in T.unroll(vec_blocks):
+                    local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                    absolute_col: T.int32 = block_y * cols + local_col
+                    col_valid: T.bool = absolute_col < H
+                    if compact:
+                        x_offset = T.cast(
+                            row_i64 * T.int64(H) + T.cast(absolute_col, "int64"), "int32"
+                        )
+                    else:
+                        x_offset = row_i64 * x_stride + T.cast(absolute_col, "int64")
+                    if full_columns:
+                        source_bytes: T.uint32 = T.uint32(copy_bytes)
+                    else:
+                        source_bytes = T.cast(T.if_then_else(col_valid, copy_bytes, 0), "uint32")
+                    T.ptx["cp.async.ca.shared.global"](
+                        shared_raw.ptr_to([(row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES]),
+                        x.ptr_to([x_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+        else:
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                absolute_col: T.int32 = block_y * cols + local_col
+                col_valid: T.bool = absolute_col < H
+                if compact:
+                    x_offset = T.cast(row_i64 * T.int64(H) + T.cast(absolute_col, "int64"), "int32")
+                else:
+                    x_offset = row_i64 * x_stride + T.cast(absolute_col, "int64")
+
+                if use_async:
+                    if rows == 1 or row_valid:
+                        if full_columns:
+                            source_bytes: T.uint32 = T.uint32(copy_bytes)
+                        else:
+                            source_bytes = T.cast(
+                                T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                            )
+                        T.ptx["cp.async.ca.shared.global"](
+                            shared_raw.ptr_to(
+                                [(row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES]
+                            ),
+                            x.ptr_to([x_offset]),
+                            copy_bytes,
+                            source_bytes,
+                        )
+                else:
+                    if (rows == 1 and full_columns) or (row_valid and col_valid):
+                        if vec == 1:
+                            _load_global_bits(x, x_offset, x_bits, vb, VEC=vec)
+                        else:
+                            _load_global_words(x, x_offset, x_words, vb * (vec // 2), VEC=vec)
+
+        if use_async and not enable_pdl and compact and full_columns and (H == 4096 or H == 8192):
+            T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
+
+        if use_async:
+            T.ptx.cp.async_.commit_group()
+
+        if use_async and full_columns and compact and H == 4096:
+            weight_base_col: T.int32 = block_y * cols + thread_in_row * vec
+            for vb in T.unroll(vec_blocks):
+                T.ptx.ld.global_.v4.b32(
+                    w_words[vb * 4],
+                    w_words[vb * 4 + 1],
+                    w_words[vb * 4 + 2],
+                    w_words[vb * 4 + 3],
+                    T.ptx.addr(
+                        weight.ptr_to([weight_base_col]), vb * tpr * vec * _INPUT_ELEM_BYTES
+                    ),
+                )
+                if vb == vec_blocks // 2 - 1:
+                    T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
+        else:
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                absolute_col: T.int32 = block_y * cols + local_col
+                if full_columns or absolute_col < H:
+                    if vec == 1:
+                        _load_global_bits(weight, absolute_col, w_bits, vb, VEC=vec)
+                    else:
+                        _load_global_words(weight, absolute_col, w_words, vb * (vec // 2), VEC=vec)
+                if (
+                    use_async
+                    and not enable_pdl
+                    and compact
+                    and full_columns
+                    and H == 8192
+                    and vb == vec_blocks // 2 - 1
+                ):
+                    T.ptx.bar.warp.sync(T.uint32(0xFFFFFFFF))
+
+        if use_async:
+            T.ptx.cp.async_.wait_group(0)
+            if full_columns and compact and H == 4096:
+                shared_load_base: T.int32 = (
+                    row_in_cta * cols + thread_in_row * vec
+                ) * _INPUT_ELEM_BYTES
+                for vb in T.unroll(vec_blocks):
+                    T.ptx.ld.shared.v4.b32(
+                        x_words[vb * 4],
+                        x_words[vb * 4 + 1],
+                        x_words[vb * 4 + 2],
+                        x_words[vb * 4 + 3],
+                        T.ptx.addr(
+                            shared_raw.ptr_to([shared_load_base]),
+                            vb * tpr * vec * _INPUT_ELEM_BYTES,
+                        ),
+                    )
+            else:
+                for vb in T.unroll(vec_blocks):
+                    local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                    if vec == 1:
+                        _load_shared_bits(
+                            shared_raw,
+                            (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                            x_bits,
+                            vb,
+                            VEC=vec,
+                        )
+                    else:
+                        _load_shared_words(
+                            shared_raw,
+                            (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                            x_words,
+                            vb * (vec // 2),
+                            VEC=vec,
+                        )
+
+        if total_values == 1:
+            x_f32_scalar[0] = _cvt_to_f32(x_bits[0], input_dtype)
+            local_sum: T.float32 = _fma_half_inputs_to_f32(x_bits[0], x_bits[0], input_dtype)
+        else:
+            if vec == 1:
+                for pair in T.unroll(packed_pairs):
+                    low_x: T.float32 = _cvt_to_f32(x_bits[pair * 2], input_dtype)
+                    high_x: T.float32 = undefined_f32[0]
+                    if pair * 2 + 1 < total_values:
+                        high_x = _cvt_to_f32(x_bits[pair * 2 + 1], input_dtype)
+                    T.ptx.mov.b64(x_f32_pairs[pair], low_x, high_x)
+            else:
+                for pair in T.unroll(packed_pairs):
+                    low_bits = T.alloc_local((1,), "uint16")
+                    high_bits = T.alloc_local((1,), "uint16")
+                    T.ptx.mov.b32(low_bits[0], high_bits[0], x_words[pair])
+                    low_x = _cvt_to_f32(low_bits[0], input_dtype)
+                    high_x = _cvt_to_f32(high_bits[0], input_dtype)
+                    T.ptx.mov.b64(x_f32_pairs[pair], low_x, high_x)
+
+            x_sq = T.alloc_local((total_values,), "float32")
+            for reverse_pair in T.unroll(packed_pairs):
+                pair: T.int32 = packed_pairs - reverse_pair - 1
+                product = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(product[0], x_f32_pairs[pair], x_f32_pairs[pair])
+                if pair * 2 + 1 < total_values:
+                    T.ptx.mov.b64(x_sq[pair * 2], x_sq[pair * 2 + 1], product[0])
+                else:
+                    discarded = T.alloc_local((1,), "float32")
+                    T.ptx.mov.b64(x_sq[pair * 2], discarded[0], product[0])
+
+            local_sum = T.float32(0.0)
+            for value in T.unroll(total_values):
+                local_sum = _add_f32(local_sum, x_sq[value])
+
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+
+            T.evaluate(_cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset])))
+
+            final_sum = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq = final_sum
+        else:
+            sum_sq = warp_sum
+
+        if H == 1:
+            shifted: T.float32 = _add_f32(sum_sq, runtime_eps)
+        elif H & (H - 1) == 0:
+            shifted = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        if use_async:
+            if full_columns and compact and H == 4096:
+                shared_reload_base: T.int32 = (
+                    row_in_cta * cols + thread_in_row * vec
+                ) * _INPUT_ELEM_BYTES
+                for vb in T.unroll(vec_blocks):
+                    T.ptx.ld.shared.v4.b32(
+                        x_words[vb * 4],
+                        x_words[vb * 4 + 1],
+                        x_words[vb * 4 + 2],
+                        x_words[vb * 4 + 3],
+                        T.ptx.addr(
+                            shared_raw.ptr_to([shared_reload_base]),
+                            vb * tpr * vec * _INPUT_ELEM_BYTES,
+                        ),
+                    )
+            else:
+                for vb in T.unroll(vec_blocks):
+                    local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                    if vec == 1:
+                        _load_shared_bits(
+                            shared_raw,
+                            (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                            x_bits,
+                            vb,
+                            VEC=vec,
+                        )
+                    else:
+                        _load_shared_words(
+                            shared_raw,
+                            (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                            x_words,
+                            vb * (vec // 2),
+                            VEC=vec,
+                        )
+        if total_values == 1:
+            if use_async:
+                x_f32_scalar[0] = _cvt_to_f32(x_bits[0], input_dtype)
+            w_f32_scalar[0] = _cvt_to_f32(w_bits[0], input_dtype)
+        else:
+            if use_async:
+                if vec == 1:
+                    for pair in T.unroll(packed_pairs):
+                        low_x: T.float32 = _cvt_to_f32(x_bits[pair * 2], input_dtype)
+                        high_x: T.float32 = undefined_f32[0]
+                        if pair * 2 + 1 < total_values:
+                            high_x = _cvt_to_f32(x_bits[pair * 2 + 1], input_dtype)
+                        T.ptx.mov.b64(x_f32_pairs[pair], low_x, high_x)
+                else:
+                    for pair in T.unroll(packed_pairs):
+                        low_bits = T.alloc_local((1,), "uint16")
+                        high_bits = T.alloc_local((1,), "uint16")
+                        T.ptx.mov.b32(low_bits[0], high_bits[0], x_words[pair])
+                        low_x = _cvt_to_f32(low_bits[0], input_dtype)
+                        high_x = _cvt_to_f32(high_bits[0], input_dtype)
+                        T.ptx.mov.b64(x_f32_pairs[pair], low_x, high_x)
+            if vec == 1:
+                for pair in T.unroll(packed_pairs):
+                    low_w: T.float32 = _cvt_to_f32(w_bits[pair * 2], input_dtype)
+                    high_w: T.float32 = undefined_f32[0]
+                    if pair * 2 + 1 < total_values:
+                        high_w = _cvt_to_f32(w_bits[pair * 2 + 1], input_dtype)
+                    T.ptx.mov.b64(w_f32_pairs[pair], low_w, high_w)
+            else:
+                for pair in T.unroll(packed_pairs):
+                    low_bits = T.alloc_local((1,), "uint16")
+                    high_bits = T.alloc_local((1,), "uint16")
+                    T.ptx.mov.b32(low_bits[0], high_bits[0], w_words[pair])
+                    low_w = _cvt_to_f32(low_bits[0], input_dtype)
+                    high_w = _cvt_to_f32(high_bits[0], input_dtype)
+                    T.ptx.mov.b64(w_f32_pairs[pair], low_w, high_w)
+
+        if total_values == 1:
+            x_f32_scalar[0] = _mul_f32(x_f32_scalar[0], rstd)
+            w_f32_scalar[0] = _add_f32(w_f32_scalar[0], T.float32(0.0))
+            x_f32_scalar[0] = _mul_f32(x_f32_scalar[0], w_f32_scalar[0])
+            x_f32_scalar[0] = _mul_f32(x_f32_scalar[0], inv_scale)
+        else:
+            for pair in T.unroll(packed_pairs):
+                high_scale: T.float32 = undefined_f32[0]
+                if pair * 2 + 1 < total_values:
+                    high_scale = rstd
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(packed[0], x_f32_pairs[pair], T.cuda.make_float2(rstd, high_scale))
+                x_f32_pairs[pair] = packed[0]
+
+            for pair in T.unroll(packed_pairs):
+                high_bias: T.float32 = undefined_f32[0]
+                if pair * 2 + 1 < total_values:
+                    high_bias = T.float32(0.0)
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.add.f32x2(
+                    packed[0], w_f32_pairs[pair], T.cuda.make_float2(T.float32(0.0), high_bias)
+                )
+                w_f32_pairs[pair] = packed[0]
+
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(packed[0], x_f32_pairs[pair], w_f32_pairs[pair])
+                x_f32_pairs[pair] = packed[0]
+
+            for pair in T.unroll(packed_pairs):
+                high_inv_scale: T.float32 = undefined_f32[0]
+                if pair * 2 + 1 < total_values:
+                    high_inv_scale = inv_scale
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(
+                    packed[0], x_f32_pairs[pair], T.cuda.make_float2(inv_scale, high_inv_scale)
+                )
+                x_f32_pairs[pair] = packed[0]
+
+        y_f32 = T.alloc_local((total_values,), "float32")
+        if total_values == 1:
+            y_f32[0] = x_f32_scalar[0]
+        else:
+            for pair in T.unroll(packed_pairs):
+                if pair * 2 + 1 < total_values:
+                    T.ptx.mov.b64(y_f32[pair * 2], y_f32[pair * 2 + 1], x_f32_pairs[pair])
+                else:
+                    discarded = T.alloc_local((1,), "float32")
+                    T.ptx.mov.b64(y_f32[pair * 2], discarded[0], x_f32_pairs[pair])
+
+        col_offset: T.int32 = thread_in_row * vec
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = col_offset + vb * tpr * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            if compact:
+                y_offset = row_i64 * T.int64(H) + T.cast(absolute_col, "int64")
+            else:
+                y_offset = row_i64 * y_stride + T.cast(absolute_col, "int64")
+
+            if vec == 8 and full_columns:
+                if rows == 1 or row_i64 < runtime_M:
+                    p01: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8], y_f32[vb * 8 + 1], output_dtype)
+                    p23: T.uint16 = _cvt_fp8_pair(
+                        y_f32[vb * 8 + 2], y_f32[vb * 8 + 3], output_dtype
+                    )
+                    p45: T.uint16 = _cvt_fp8_pair(
+                        y_f32[vb * 8 + 4], y_f32[vb * 8 + 5], output_dtype
+                    )
+                    p67: T.uint16 = _cvt_fp8_pair(
+                        y_f32[vb * 8 + 6], y_f32[vb * 8 + 7], output_dtype
+                    )
+                    lo_word: T.uint32 = _pack_b16_pair(p01, p23)
+                    hi_word: T.uint32 = _pack_b16_pair(p45, p67)
+                    T.ptx.st.global_.v2.b32(out.ptr_to([y_offset]), lo_word, hi_word)
+            elif vec == 8 and absolute_col + 8 <= H and (rows == 1 or row_i64 < runtime_M):
+                p01: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8], y_f32[vb * 8 + 1], output_dtype)
+                p23: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 2], y_f32[vb * 8 + 3], output_dtype)
+                p45: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 4], y_f32[vb * 8 + 5], output_dtype)
+                p67: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 6], y_f32[vb * 8 + 7], output_dtype)
+                lo_word: T.uint32 = _pack_b16_pair(p01, p23)
+                hi_word: T.uint32 = _pack_b16_pair(p45, p67)
+                T.ptx.st.global_.v2.b32(out.ptr_to([y_offset]), lo_word, hi_word)
+            elif vec == 4 and absolute_col + 4 <= H and (rows == 1 or row_i64 < runtime_M):
+                p01 = _cvt_fp8_pair(y_f32[vb * 4], y_f32[vb * 4 + 1], output_dtype)
+                p23 = _cvt_fp8_pair(y_f32[vb * 4 + 2], y_f32[vb * 4 + 3], output_dtype)
+                packed_word: T.uint32 = _pack_b16_pair(p01, p23)
+                T.ptx.st.global_.b32(out.ptr_to([y_offset]), packed_word)
+            elif vec == 2 and absolute_col + 2 <= H and (rows == 1 or row_i64 < runtime_M):
+                p01 = _cvt_fp8_pair(y_f32[vb * 2], y_f32[vb * 2 + 1], output_dtype)
+                T.ptx.st.global_.b16(out.ptr_to([y_offset]), p01)
+            else:
+                for element in T.unroll(vec):
+                    scalar_col: T.int32 = absolute_col + element
+                    if scalar_col < H and (rows == 1 or row_i64 < runtime_M):
+                        clamped_low: T.float32 = _maximum_f32(
+                            y_f32[vb * vec + element], T.float32(-fp8_max)
+                        )
+                        clamped: T.float32 = _minimum_f32(clamped_low, T.float32(fp8_max))
+                        pair: T.uint16 = _cvt_fp8_pair(clamped, T.float32(0.0), output_dtype)
+                        if compact:
+                            scalar_offset = row_i64 * T.int64(H) + T.cast(scalar_col, "int64")
+                        else:
+                            scalar_offset = row_i64 * y_stride + T.cast(scalar_col, "int64")
+                        T.ptx.st.global_.b8(out.ptr_to([scalar_offset]), T.cast(pair, "uint8"))
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    if compact:
+
+        @T.prim_func
+        def flashinfer_rmsnorm_quant_compact(
+            x_ptr: T.handle,
+            weight_ptr: T.handle,
+            out_ptr: T.handle,
+            runtime_M: T.int64,
+            scale_ptr: T.handle,
+            runtime_eps: T.float32,
+        ):
+            x = T.match_buffer(
+                x_ptr, shape=(runtime_M * T.int64(H),), dtype=input_dtype, scope="global"
+            )
+            weight = T.match_buffer(weight_ptr, shape=(H,), dtype=input_dtype, scope="global")
+            out = T.match_buffer(
+                out_ptr, shape=(runtime_M * T.int64(H),), dtype=output_dtype, scope="global"
+            )
+            scale_buffer = T.match_buffer(scale_ptr, shape=(1,), dtype="float32", scope="global")
+            T.device_entry()
+            kernel_body(
+                x, weight, out, runtime_M, scale_buffer, runtime_eps, T.int64(H), T.int64(H)
+            )
+
+        kernel = flashinfer_rmsnorm_quant_compact
+    else:
+
+        @T.prim_func
+        def flashinfer_rmsnorm_quant_strided(
+            x_ptr: T.handle,
+            weight_ptr: T.handle,
+            out_ptr: T.handle,
+            runtime_M: T.int64,
+            scale_ptr: T.handle,
+            runtime_eps: T.float32,
+            runtime_x_row_stride: T.int64,
+            runtime_y_row_stride: T.int64,
+        ):
+            x = T.match_buffer(
+                x_ptr,
+                shape=((runtime_M - T.int64(1)) * runtime_x_row_stride + T.int64(H),),
+                dtype=input_dtype,
+                scope="global",
+            )
+            weight = T.match_buffer(weight_ptr, shape=(H,), dtype=input_dtype, scope="global")
+            out = T.match_buffer(
+                out_ptr,
+                shape=((runtime_M - T.int64(1)) * runtime_y_row_stride + T.int64(H),),
+                dtype=output_dtype,
+                scope="global",
+            )
+            scale_buffer = T.match_buffer(scale_ptr, shape=(1,), dtype="float32", scope="global")
+            T.device_entry()
+            kernel_body(
+                x,
+                weight,
+                out,
+                runtime_M,
+                scale_buffer,
+                runtime_eps,
+                runtime_x_row_stride,
+                runtime_y_row_stride,
+            )
+
+        kernel = flashinfer_rmsnorm_quant_strided
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return kernel.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Create deterministic tensors, including the caller-owned FP8 output."""
+    data = _prepare_tensors(dict(config))
+    output = _prepare_output(
+        int(config["M"]),
+        int(config["H"]),
+        data["y_row_stride"],
+        str(config["output_dtype"]),
+        initialize_padding=False,
+    )
+    return data["x"], data["weight"], output["view"], data["scale"]
+
+
+_GUARD_ELEMENTS = 64
+_GUARD_VALUE = 1.0
+
+
+def _torch_input_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _torch_output_dtype(dtype: str):
+    import torch
+
+    return {"float8_e4m3fn": torch.float8_e4m3fn, "float8_e5m2": torch.float8_e5m2}[dtype]
+
+
+def _row_strides(config: dict[str, Any]) -> tuple[int, int]:
+    H = int(config["H"])
+    x_stride = int(config.get("x_row_stride", 2 * H if config["input_layout"] == "strided" else H))
+    y_stride = int(config.get("y_row_stride", 2 * H if config["output_layout"] == "strided" else H))
+    return x_stride, y_stride
+
+
+def _storage_size(M: int, H: int, row_stride: int) -> int:
+    return (M - 1) * row_stride + H
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M = int(config["M"])
+    H = int(config["H"])
+    input_dtype = str(config["input_dtype"])
+    output_dtype = str(config["output_dtype"])
+    input_layout = str(config["input_layout"])
+    output_layout = str(config["output_layout"])
+    scale_value = float(config["scale"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    x_stride, y_stride = _row_strides(config)
+    _validate(
+        input_dtype,
+        output_dtype,
+        M,
+        H,
+        input_layout,
+        output_layout,
+        scale_value,
+        eps,
+        x_stride,
+        y_stride,
+    )
+    vec = int(_source_config(H)["vec"])
+    if x_stride < H or y_stride < H:
+        raise ValueError(f"row strides must cover H={H}: x={x_stride}, y={y_stride}")
+    if x_stride % vec != 0 or y_stride % vec != 0:
+        raise ValueError(f"row strides must be divisible by vec={vec}: x={x_stride}, y={y_stride}")
+
+    torch_dtype = _torch_input_dtype(input_dtype)
+    generator = torch.Generator(device="cuda").manual_seed(42)
+    x_storage_size = _storage_size(M, H, x_stride)
+    x_backing = torch.empty(x_storage_size + _GUARD_ELEMENTS, dtype=torch_dtype, device="cuda")
+    x_arg = x_backing[:x_storage_size]
+    x = x_arg.as_strided((M, H), (x_stride, 1))
+    if H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        magnitude = torch.where(columns % 257 < 128, 0.5, 1.0)
+        pattern = torch.where(columns % 2 == 0, magnitude, -magnitude).to(torch_dtype)
+        x.copy_(pattern.expand(M, H))
+        x[1::2].neg_()
+    else:
+        x.normal_(generator=generator)
+    x_backing[x_storage_size:].fill_(_GUARD_VALUE)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=torch_dtype, device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    if H >= 3:
+        dtype_limit = torch.finfo(torch_dtype).max
+        weight[0] = dtype_limit
+        weight[1] = torch.tensor(1.0546875 * scale_value, dtype=torch_dtype, device="cuda")
+        weight[2] = torch.tensor(1.0703125 * scale_value, dtype=torch_dtype, device="cuda")
+    weight_backing[H:].fill_(_GUARD_VALUE)
+
+    scale = torch.tensor([scale_value], dtype=torch.float32, device="cuda")
+    return {
+        "x": x,
+        "x_arg": x_arg,
+        "x_backing": x_backing,
+        "x_storage_size": x_storage_size,
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "scale": scale,
+        "x_row_stride": x_stride,
+        "y_row_stride": y_stride,
+    }
+
+
+def _prepare_output(
+    M: int, H: int, row_stride: int, output_dtype: str, *, initialize_padding: bool
+) -> dict[str, Any]:
+    import torch
+
+    size = _storage_size(M, H, row_stride)
+    backing = torch.empty(
+        size + _GUARD_ELEMENTS, dtype=_torch_output_dtype(output_dtype), device="cuda"
+    )
+    if initialize_padding:
+        backing.fill_(_GUARD_VALUE)
+    else:
+        backing[size:].fill_(_GUARD_VALUE)
+    arg = backing[:size]
+    view = arg.as_strided((M, H), (row_stride, 1))
+    return {
+        "view": view,
+        "arg": arg,
+        "backing": backing,
+        "size": size,
+        "data_ptr": view.data_ptr(),
+        "stride": view.stride(),
+    }
+
+
+def _raw_bytes(tensor):
+    import torch
+
+    return tensor.view(torch.uint8)
+
+
+def _assert_guard(backing, size: int, *, name: str) -> None:
+    import torch
+
+    expected = torch.full(
+        (_GUARD_ELEMENTS,), _GUARD_VALUE, dtype=backing.dtype, device=backing.device
+    )
+    if not torch.equal(_raw_bytes(backing[size:]), _raw_bytes(expected)):
+        raise AssertionError(f"{name} guard was modified")
+
+
+def _assert_output_padding(
+    output: dict[str, Any], M: int, H: int, row_stride: int, *, name: str
+) -> None:
+    import torch
+
+    _assert_guard(output["backing"], output["size"], name=name)
+    if row_stride > H:
+        for row in range(M - 1):
+            padding = output["backing"][row * row_stride + H : (row + 1) * row_stride]
+            expected = torch.full_like(padding, _GUARD_VALUE)
+            if not torch.equal(_raw_bytes(padding), _raw_bytes(expected)):
+                raise AssertionError(f"{name} row {row} padding was modified")
+
+
+def _overflow_rows(M: int, H: int) -> list[int] | None:
+    if M * H <= _INT32_MAX:
+        return None
+    boundary = _ceil_div(2**31, H)
+    return sorted(
+        {row for row in (0, 1, boundary - 1, boundary, boundary + 1, M - 1) if 0 <= row < M}
+    )
+
+
+def _checked_view(tensor, rows: list[int] | None):
+    return tensor if rows is None else tensor[rows]
+
+
+def _math_oracle(x, weight, scale, eps: float, output_dtype: str, rows: list[int] | None):
+    x_checked = _checked_view(x, rows).float()
+    variance = x_checked.square().mean(dim=-1, keepdim=True)
+    normalized = x_checked * variance.add(eps).rsqrt()
+    quantized = normalized * weight.float() * scale.float().reciprocal()
+    fp8_max = 448.0 if output_dtype == "float8_e4m3fn" else 57344.0
+    return quantized.clamp(-fp8_max, fp8_max).to(_torch_output_dtype(output_dtype))
+
+
+def _assert_raw_equal(actual, expected, *, name: str) -> None:
+    import torch
+
+    if not torch.equal(_raw_bytes(actual), _raw_bytes(expected)):
+        mismatch = _raw_bytes(actual) != _raw_bytes(expected)
+        count = int(mismatch.sum().item())
+        raise AssertionError(f"{name}: {count} FP8 bytes differ")
+
+
+def _assert_math_close(actual, expected, *, name: str) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual.float(),
+        expected.float(),
+        rtol=1.0,
+        atol=1.0,
+        msg=lambda message: f"{name}: {message}",
+    )
+
+
+def _flashinfer_api(device):
+    import flashinfer.norm as flashinfer_norm
+
+    if flashinfer_norm._use_cuda_norm(device):
+        raise AssertionError("FlashInfer RMSNormQuant oracle dispatched to legacy CUDA")
+    return flashinfer_norm.rmsnorm_quant, flashinfer_norm
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]):
+    M = int(config["M"])
+    H = int(config["H"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    compact = _uses_compact_specialization(
+        M, H, str(config["input_layout"]), str(config["output_layout"])
+    )
+    if compact:
+        return executable(data["x_arg"], data["weight"], output["arg"], M, data["scale"], eps)
+    return executable(
+        data["x_arg"],
+        data["weight"],
+        output["arg"],
+        M,
+        data["scale"],
+        eps,
+        data["x_row_stride"],
+        data["y_row_stride"],
+    )
+
+
+@functools.cache
+def _compiled_test_specialization(
+    input_dtype: str, output_dtype: str, H: int, compact: bool, enable_pdl: bool
+):
+    """Compile each runtime-M test specialization once per test process."""
+    from tirx_kernels.runner import compile_kernel
+
+    layout = "compact" if compact else "strided"
+    return compile_kernel(
+        get_kernel(
+            input_dtype=input_dtype,
+            output_dtype=output_dtype,
+            M=1,
+            H=H,
+            input_layout=layout,
+            output_layout=layout,
+            enable_pdl=enable_pdl,
+            scale=1.0,
+            eps=_DEFAULT_EPS,
+            x_row_stride=H,
+            y_row_stride=H,
+        )
+    )
+
+
+def _input_snapshot(data, M: int, H: int) -> dict[str, Any]:
+    rows = _overflow_rows(M, H)
+    if rows is None:
+        values = data["x"].clone()
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        values = data["x"][rows][:, columns].clone()
+    return {
+        "rows": rows,
+        "values": values,
+        "weight": data["weight"].clone(),
+        "scale": data["scale"].clone(),
+    }
+
+
+def _assert_inputs_unchanged(data, snapshot, M: int, H: int) -> None:
+    import torch
+
+    rows = snapshot["rows"]
+    if rows is None:
+        observed = data["x"]
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        observed = data["x"][rows][:, columns]
+    if not torch.equal(observed, snapshot["values"]):
+        raise AssertionError("input tensor was modified")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError("weight tensor was modified")
+    if not torch.equal(data["scale"], snapshot["scale"]):
+        raise AssertionError("scale tensor was modified")
+    _assert_guard(data["x_backing"], data["x_storage_size"], name="input")
+    _assert_guard(data["weight_backing"], H, name="weight")
+
+
+def _assert_output_identity(output: dict[str, Any], *, name: str) -> None:
+    if output["view"].data_ptr() != output["data_ptr"]:
+        raise AssertionError(f"{name} data pointer changed")
+    if output["view"].stride() != output["stride"]:
+        raise AssertionError(f"{name} stride changed")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one RMSNorm-quant specialization."""
+    import torch
+
+    config = dict(config)
+    M = int(config["M"])
+    H = int(config["H"])
+    output_dtype = str(config["output_dtype"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    snapshot = _input_snapshot(data, M, H)
+    output = _prepare_output(M, H, data["y_row_stride"], output_dtype, initialize_padding=True)
+    reference_output = _prepare_output(
+        M, H, data["y_row_stride"], output_dtype, initialize_padding=True
+    )
+
+    compact = _uses_compact_specialization(
+        M, H, str(config["input_layout"]), str(config["output_layout"])
+    )
+    executable = _compiled_test_specialization(
+        str(config["input_dtype"]), output_dtype, H, compact, enable_pdl
+    )
+    returned = _launch_tirx(executable, data, output, config)
+    if returned is not None:
+        raise AssertionError("TIRx RMSNormQuant ABI must return None")
+
+    api, flashinfer_norm = _flashinfer_api(data["x"].device)
+    original_cute = flashinfer_norm.rmsnorm_quant_cute
+    cute_calls = 0
+
+    def tracked_cute(*args, **kwargs):
+        nonlocal cute_calls
+        cute_calls += 1
+        return original_cute(*args, **kwargs)
+
+    flashinfer_norm.rmsnorm_quant_cute = tracked_cute
+    try:
+        reference_returned = api(
+            reference_output["view"],
+            data["x"],
+            data["weight"],
+            data["scale"],
+            eps,
+            enable_pdl=enable_pdl,
+        )
+    finally:
+        flashinfer_norm.rmsnorm_quant_cute = original_cute
+    if cute_calls != 1:
+        raise AssertionError(f"expected one CuTe-DSL oracle dispatch, observed {cute_calls}")
+    if reference_returned is not None:
+        raise AssertionError("FlashInfer rmsnorm_quant must return None")
+
+    torch.cuda.synchronize()
+    rows = _overflow_rows(M, H)
+    actual_checked = _checked_view(output["view"], rows)
+    reference_checked = _checked_view(reference_output["view"], rows)
+    oracle = _math_oracle(data["x"], data["weight"], data["scale"], eps, output_dtype, rows)
+    if not torch.isfinite(actual_checked.float()).all():
+        raise AssertionError("TIRx FP8 output contains non-finite values")
+    _assert_raw_equal(actual_checked, reference_checked, name="FlashInfer raw-byte oracle")
+    _assert_math_close(actual_checked, oracle, name="independent FP32 math oracle")
+    _assert_inputs_unchanged(data, snapshot, M, H)
+    _assert_output_identity(output, name="TIRx output")
+    _assert_output_identity(reference_output, name="FlashInfer output")
+    _assert_output_padding(output, M, H, data["y_row_stride"], name="TIRx output")
+    _assert_output_padding(reference_output, M, H, data["y_row_stride"], name="FlashInfer output")
+
+
+def prepare_bench(**config: Any):
+    """Compile the specialization before the bench suite assigns a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Build two single-launch closures and validate them before timing."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    M = int(config["M"])
+    H = int(config["H"])
+    output_dtype = str(config["output_dtype"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    tirx_output = _prepare_output(
+        M, H, data["y_row_stride"], output_dtype, initialize_padding=False
+    )
+    flashinfer_output = _prepare_output(
+        M, H, data["y_row_stride"], output_dtype, initialize_padding=False
+    )
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        return _launch_tirx(executable, data, tirx_output, config)
+
+    if tirx_launch() is not None:
+        raise AssertionError("TIRx benchmark closure must return None")
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        api, flashinfer_norm = _flashinfer_api(data["x"].device)
+        original_cute = flashinfer_norm.rmsnorm_quant_cute
+        cute_calls = 0
+
+        def tracked_cute(*args, **kwargs):
+            nonlocal cute_calls
+            cute_calls += 1
+            return original_cute(*args, **kwargs)
+
+        def flashinfer_launch():
+            return api(
+                flashinfer_output["view"],
+                data["x"],
+                data["weight"],
+                data["scale"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+
+        flashinfer_norm.rmsnorm_quant_cute = tracked_cute
+        try:
+            returned = flashinfer_launch()
+        finally:
+            flashinfer_norm.rmsnorm_quant_cute = original_cute
+        if cute_calls != 1:
+            raise AssertionError(f"expected one CuTe-DSL benchmark warmup, observed {cute_calls}")
+        if returned is not None:
+            raise AssertionError("FlashInfer benchmark closure must return None")
+        torch.cuda.synchronize()
+        _assert_raw_equal(
+            tirx_output["view"], flashinfer_output["view"], name="benchmark raw-byte precheck"
+        )
+        return flashinfer_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark one specialization against the lazy FlashInfer CuTe-DSL reference."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- Add an SM100 TIRx port of FlashInfer RMSNormQuant with caller-provided FP8 output and runtime scaling.
- Cover FP16/BF16 input, E4M3/E5M2 output, compact and explicit int64-strided layouts, PDL, asynchronous copy, and cluster reduction paths.
- Add the frozen implementation sketch and curated bench-suite coverage for small, medium, guard, and large structural workloads.
- Record measured codegen guidance for static guard elimination, warp-sync scheduling constraints, and execution-path-specific register caps.

## Validation

- `python -m tirx_kernels.test --kernel flashinfer_rmsnorm_quant` — 1552/1552 passed, including low-level IR, no-tile, and no-function-call checks.
- `python -m tirx_kernels.bench_suite --check-imports` — 54 kernels imported successfully from 158 default workloads.
- `pre-commit run --files .agents/sketch/flashinfer/norm/rmsnorm_quant.md tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm_quant.yaml tirx_kernels/flashinfer/norm/rmsnorm_quant.py` — passed.
- `pre-commit run --files .agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md .agents/skills/tirx-codegen-tuning/references/db/measure-elided-warp-synchronization.md .agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md` — passed.
- `python tests/lint/check_license_headers.py --self-test` — 13/13 cases passed.

## Performance status

- Current implementation SHA256: `2c7db3e4216fc4208d2405e465f6391d902b26f64e97fc9f8b8a786cdfc7087d`.
- The latest valid current-byte targeted run produced FlashInfer CuTeDSL / TIRx ratios of 0.98455 at H=4096, 0.99421 at H=8192, and 1.00156 at H=1048576.
- A complete current-byte eight-workload performance run remains pending because repeated attempts detected unresolved external GPU interference. No baseline update is included.