### PR TITLE
feat(kernel): port FlashInfer fused add RMSNorm

### DIFF
--- a/.agents/sketch/flashinfer/norm/fused_add_rmsnorm.md
+++ b/.agents/sketch/flashinfer/norm/fused_add_rmsnorm.md
@@ -1,0 +1,609 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+FusedAddRMSNormKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer fused add + RMSNorm / Gemma RMSNorm SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the implementation
+shape of FlashInfer's CuTe-DSL `FusedAddRMSNormKernel` for the paired target
+[`tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py`](../../../../tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py).
+The target may become executable only after this sketch passes independent
+source/PTX review; after the first PASS this file is permanently frozen.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/norm/kernels/fused_add_rmsnorm.py`, SHA256
+  `f6f4a7d9c88996f26c33ed2661f82026e4ee3e747bf12c57febe9f9e68e61435`;
+- inherited launch/layout helpers in `flashinfer/norm/kernels/rmsnorm.py`,
+  SHA256 `b273fe5444aaf86a1600c196817b7a733b18f6f82030a16e1ef2731c784d48f0`;
+- reduction and predicate helpers in `flashinfer/norm/utils.py`, SHA256
+  `3f44ac6727c58883420068bf0aa5b239b12d2e86819ad80e54bc1bc016ec881a`;
+- public dispatch in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+The family covers FP16/BF16, ordinary fused-add RMSNorm with
+`weight_bias=0.0` and Gemma fused-add RMSNorm with `weight_bias=1.0`, compact
+and explicit independent Int64 row strides, PDL off/on, synchronous and paired
+`cp.async` input/residual traffic, sub-warp, one-warp, multi-warp, and cluster
+reduction, and cluster sizes 1/2/4/8/16. Only the two-dimensional in-place
+fused-add body is in scope. Quantization, plain RMSNorm, legacy CUDA, and every
+tile primitive are out of scope.
+
+## Source dispatch and resource formulae
+
+These compile-time formulae are the source policy, not tuning choices:
+
+```python
+ELEM_BYTES = 2
+OPTIN_SMEM_BYTES = 232448
+MAX_VEC = 128 // 8 // ELEM_BYTES                         # 8 elements
+
+def threads_per_row(h_per_cta):
+    if h_per_cta <= 64: return 8
+    if h_per_cta <= 128: return 16
+    if h_per_cta <= 3072: return 32
+    if h_per_cta <= 6144: return 64
+    if h_per_cta <= 16384: return 128
+    return 256
+
+def num_threads(h_per_cta):
+    return 128 if h_per_cta <= 16384 else 256
+
+def derived(H, cluster_n):
+    H_PER_CTA = H // cluster_n
+    TPR = threads_per_row(H_PER_CTA)
+    THREADS = num_threads(H_PER_CTA)
+    ROWS = THREADS // TPR
+    WARPS_PER_ROW = max(TPR // 32, 1)
+    VEC = min(H_PER_CTA & -H_PER_CTA, MAX_VEC)
+    COPY_BITS = 16 * VEC
+    VEC_BLOCKS = max(1, ceil_div(H_PER_CTA // VEC, TPR))
+    COLS = VEC * VEC_BLOCKS * TPR
+    TWO_TILE_BYTES = 2 * ROWS * COLS * ELEM_BYTES
+    USE_ASYNC = COPY_BITS >= 32 and TWO_TILE_BYTES <= OPTIN_SMEM_BYTES // 2
+    REDUCE_BYTES = ROWS * WARPS_PER_ROW * cluster_n * 4
+    SMEM_BYTES = (TWO_TILE_BYTES if USE_ASYNC else 0) + REDUCE_BYTES
+    if cluster_n > 1: SMEM_BYTES += 8
+    return (...)
+
+def estimate_smem(H, cluster_n):
+    # The estimate always includes both X and residual tiles, even if the
+    # eventual body uses synchronous register loads.
+    d = derived_without_async_elision(H, cluster_n)
+    return 2 * d.ROWS * d.COLS * ELEM_BYTES \
+           + d.ROWS * d.WARPS_PER_ROW * cluster_n * 4 \
+           + (8 if cluster_n > 1 else 0)
+
+def source_config(H):
+    best_fit = 1
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate != 0:
+            continue
+        required = estimate_smem(H, candidate)
+        if required <= OPTIN_SMEM_BYTES // 2:
+            return derived(H, candidate)
+        if required <= OPTIN_SMEM_BYTES and best_fit == 1:
+            best_fit = candidate
+    return derived(H, best_fit)
+```
+
+The host chooses the compact ABI only when both mutable tensors are contiguous
+and `M*H <= 2**31-1`. Otherwise it passes independent
+`x_row_stride:int64` and `residual_row_stride:int64`, both in elements. The
+weight is always compact. Compact X/R fake tensors carry
+`assumed_align=gcd(128,H*ELEM_BYTES)` bytes. Strided X/R bases each carry
+`assumed_align=16` bytes and their independent symbolic row strides each carry
+`divisibility=VEC`; weight carries `assumed_align=16` bytes. This predicate,
+alignment, stride-divisibility, and stride independence are fixed.
+
+## Pipeline at a glance
+
+| lanes / CTA role | source-owned work | publication or reuse edge |
+| --- | --- | --- |
+| each contiguous group of `TPR` threads | one logical row and one cluster H partition; each thread owns `VEC` adjacent columns per vector block | X, residual, and weight fragments remain thread-private |
+| every thread before reduction | widen X/R, pairwise add to FP32 `h`, narrow and publish `h` to residual global memory, then square `h` | residual update is source-ordered before reduction and remains independent of the later input store |
+| each sub-warp/full warp within a row | ordered local sum followed by butterfly stages at widths 8/16/32 | subgroup-replicated partial |
+| lane 0 of every row warp, cluster-1 multi-warp branch | publish one row-warp partial to shared | one CTA barrier before redundant final loads |
+| lanes `<CLUSTER_N` of every warp, clustered branch | send that warp's partial to the corresponding slot on every peer CTA | remote async shared store completes the peer mbarrier transaction |
+| every row warp after publication | load and full-warp reduce `WARPS_PER_ROW*CLUSTER_N` partials | replicated row sum feeds mean and approximate rsqrt |
+| all threads after reduction | cluster arrive/wait or CTA barrier, use still-live FP32 `h` and weight, narrow and write input | final barrier is the reduction completion edge, not an X reload edge |
+
+There is one paired `cp.async` group, not a staged pipeline. Each thread issues
+all X copies then all residual copies, commits once, loads weight synchronously,
+waits once, and loads both shared fragments. PDL wait is the first body-side
+dependency instruction and PDL signal is the last. Disabled specializations
+contain neither instruction nor launch attribute.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)       # compile-time family member
+launch(...)           # exact grid, block, cluster, dynamic shared, PDL attrs
+raw_shared(...)       # one dynamic shared allocation
+view(...)             # typed view at an explicit byte offset
+reg_tile(...)         # thread-private register fragment
+address(...)          # compact or explicit Int64 backing-store address
+pair_view(...)        # adjacent flattened f32 register values
+scalar_pair(...)      # duplicated scalar, with unused high lane for an odd tail
+```
+
+Data movement, arithmetic, and synchronization remain primitive:
+
+```python
+copy_g2r(src, dst, bits, predicate=None)
+copy_g2s_async_ca(src, dst, bits, source_bytes)
+copy_s2r(src, dst, bits)
+copy_r2g(src, dst, bits, predicate=None)
+cast(dtype, src, rounding=None)
+add(lhs, rhs, lanes=1)
+mul(lhs, rhs, lanes=1)
+fma(lhs, rhs, acc)
+div(lhs, rhs)
+rsqrt_fast(src)
+shuffle_xor(src, delta, width)
+elect_one()
+cp_async_commit()
+cp_async_wait(group)
+cta_barrier()
+cluster_arrive_relaxed()
+cluster_wait()
+mbarrier_init(ptr, arrivals)
+mbarrier_init_fence()
+mbarrier_arrive_expect_tx(ptr, bytes)
+map_shared_to_peer(ptr, peer)
+remote_store_complete_tx(value, dst, mbarrier)
+mbarrier_try_wait_parity(ptr, phase, timeout)
+pdl_wait()
+pdl_signal()
+```
+
+One vector copy is one reviewed instruction. The source exports select:
+
+| `VEC` | global X/R/W load and X/R store | shared X/R load | reviewed narrowing |
+| ---: | --- | --- | --- |
+| 1 | scalar `ld/st.global.b16` | synchronous reviewed profile | scalar `cvt.rn.{f16,bf16}.f32` |
+| 2 | `ld/st.global.v2.b16` | `ld.shared.v2.b16` | scalar converts for reviewed `(VEC=2,VEC_BLOCKS=3)` H66 profile |
+| 4 | `ld/st.global.v2.b32` | `ld.shared.v4.b16` | `cvt.rn.{f16,bf16}x2.f32` |
+| 8 | `ld/st.global.v4.b32` | `ld.shared.v4.b32` | `cvt.rn.{f16,bf16}x2.f32` |
+
+Every async copy is `cp.async.ca.shared.global`, with immediate size
+`COPY_BITS/8` and a runtime source-size operand for column-tail zero fill.
+`add(...,lanes=2)` and `mul(...,lanes=2)` each denote one native packed-FP32
+instruction. There is no compound fused-add, RMSNorm, row/CTA/cluster
+reduction, tile-copy, or tile-compute operation.
+
+## Complete sketch
+
+```python
+@specialize(
+    VARIANT_WEIGHT_BIAS=(("fused_add_rmsnorm", 0.0),
+                         ("gemma_fused_add_rmsnorm", 1.0)),
+    DTYPE=("f16", "bf16"),
+    H="positive compile-time integer",
+    LAYOUT=("compact", "strided_i64"),
+    ENABLE_PDL=(False, True),
+    TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M, ROWS), CLUSTER_N, 1),
+    block=(THREADS, 1, 1),
+    cluster=((1, CLUSTER_N, 1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_fused_add_rmsnorm(
+    input_storage,                    # mutable DTYPE backing storage; compact
+                                      # align=gcd(128,H*2), strided align=16
+    residual_storage,                 # same base-alignment contract as input
+    weight,                           # compact DTYPE [H], align=16
+    runtime_M: i64,
+    runtime_eps: f32,
+    x_row_stride: i64 = H,            # strided_i64 only; divisible by VEC
+    residual_row_stride: i64 = H,     # strided_i64 only; independently
+                                      # divisible by VEC
+):
+    tid = thread_id_x(THREADS)
+    block_x = block_id_x()
+    block_y = 0
+    cta_rank = 0
+    if CLUSTER_N > 1:
+        block_y = block_id_y()
+        cta_rank = cta_rank_in_cluster()
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one issue per CTA
+
+    # CuTe TV layout shape=((TPR,ROWS),(VEC,VEC_BLOCKS)) and
+    # stride=((VEC*ROWS,1),(ROWS,ROWS*VEC*TPR)).
+    row_in_cta = tid // TPR
+    thread_in_row = tid % TPR
+    row_i32 = block_x * ROWS + row_in_cta
+    row_i64 = cast_i64(row_i32)
+    row_valid = row_i64 < runtime_M
+    warp = tid // 32
+    lane = tid % 32
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+
+    smem = raw_shared("u8", SMEM_BYTES, alignment=16)
+    cursor = 0
+    if USE_ASYNC:
+        sX = view(smem, DTYPE, (ROWS,COLS), byte_offset=cursor,
+                  row_major=True, alignment=16)
+        cursor += ROWS * COLS * ELEM_BYTES
+        sR = view(smem, DTYPE, (ROWS,COLS), byte_offset=cursor,
+                  row_major=True, alignment=16)
+        cursor += ROWS * COLS * ELEM_BYTES
+    if CLUSTER_N == 1:
+        reduction = view(smem, "f32", (ROWS,WARPS_PER_ROW),
+                         stride=(1,ROWS), byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * 4
+    else:
+        reduction = view(smem, "f32", (ROWS,(WARPS_PER_ROW,CLUSTER_N)),
+                         stride=(1,(ROWS,ROWS*WARPS_PER_ROW)),
+                         byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+        mbar = view(smem, "mbarrier", (1,), byte_offset=cursor, alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar, arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; extent: one per CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; extent: one per CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+
+    x_frag = reg_tile(DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    r_frag = reg_tile(DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_frag = reg_tile(DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    PAIRS = ceil_div(TOTAL_VALUES, 2)
+
+    if not USE_ASYNC:
+        for flat in static_range(TOTAL_VALUES):
+            x_frag.flat[flat] = zero(DTYPE)
+            r_frag.flat[flat] = zero(DTYPE)
+            # instruction_selection: mov.b16 zero initialization; extent: two
+            # complete fragments before any predicated synchronous load
+
+    # Input copies precede residual copies in the one source async group.
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        x_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                   (row_i64 * x_row_stride + absolute_col)
+        if USE_ASYNC:
+            if row_valid:
+                copy_g2s_async_ca(address(input_storage,x_offset),
+                                  sX[row_in_cta,local_col:local_col+VEC],
+                                  COPY_BITS, (COPY_BITS//8) if col_valid else 0)
+                # instruction_selection: cp.async.ca.shared.global; extent:
+                # one row-gated issue per vb with runtime tail source size
+        else:
+            if row_valid and col_valid:
+                copy_g2r(address(input_storage,x_offset), x_frag[:,vb], COPY_BITS)
+                # instruction_selection: exact global load from the VEC table;
+                # extent: one row-and-column-predicated vector per vb
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        r_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                   (row_i64 * residual_row_stride + absolute_col)
+        if USE_ASYNC:
+            if row_valid:
+                copy_g2s_async_ca(address(residual_storage,r_offset),
+                                  sR[row_in_cta,local_col:local_col+VEC],
+                                  COPY_BITS, (COPY_BITS//8) if col_valid else 0)
+                # instruction_selection: cp.async.ca.shared.global; extent:
+                # one row-gated issue per vb after every input issue
+        else:
+            if row_valid and col_valid:
+                copy_g2r(address(residual_storage,r_offset), r_frag[:,vb], COPY_BITS)
+                # instruction_selection: exact global load from the VEC table;
+                # extent: one row-and-column-predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_commit()
+        # instruction_selection: cp.async.commit_group; extent: one per CTA thread
+
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        if absolute_col < H:
+            copy_g2r(weight[absolute_col:absolute_col+VEC], w_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact global load from the VEC table;
+            # extent: one column-predicated vector per vb
+
+    if USE_ASYNC:
+        cp_async_wait(0)
+        # instruction_selection: cp.async.wait_group 0; extent: one per CTA thread
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact shared load from the VEC table;
+            # extent: one vector per vb
+        for vb in static_range(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sR[row_in_cta,local_col:local_col+VEC], r_frag[:,vb], COPY_BITS)
+            # instruction_selection: exact shared load from the VEC table;
+            # extent: one vector per vb after every input shared load
+
+    x_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    r_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    w_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    for flat in static_range(TOTAL_VALUES):
+        x_f32[flat] = cast("f32", x_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one per X value
+    for flat in static_range(TOTAL_VALUES):
+        r_f32[flat] = cast("f32", r_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one per residual value
+
+    h = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in static_range(PAIRS):
+        h_pair = add(pair_view(x_f32,pair,unused_high_if_odd=True),
+                     pair_view(r_f32,pair,unused_high_if_odd=True), lanes=2)
+        # instruction_selection: add.f32x2; extent: PAIRS packed issues
+        h.store_pair(pair, h_pair)
+
+    # The source narrows and publishes residual before forming h squared.
+    h_narrow = reg_tile(DTYPE, (TOTAL_VALUES,))
+    if VEC == 1 or (VEC == 2 and VEC_BLOCKS == 3):
+        for flat in static_range(TOTAL_VALUES):
+            h_narrow[flat] = cast(DTYPE, h[flat], rounding="rn")
+            # instruction_selection: cvt.rn.{f16,bf16}.f32; extent: scalar
+    else:
+        for pair in static_range(PAIRS):
+            h_narrow.store_pair(pair, cast(DTYPE+"x2", pair_view(h,pair), rounding="rn"))
+            # instruction_selection: cvt.rn.{f16,bf16}x2.f32; extent: one per pair
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        r_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                   (row_i64 * residual_row_stride + absolute_col)
+        if row_valid and col_valid:
+            copy_r2g(h_narrow.slice(vb,VEC), address(residual_storage,r_offset), COPY_BITS)
+            # instruction_selection: exact global store from the VEC table;
+            # extent: one predicated residual vector per vb
+
+    h_sq = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in static_range(PAIRS):
+        h_sq.store_pair(pair, mul(pair_view(h,pair), pair_view(h,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: PAIRS packed issues
+    local_sum = 0.0
+    for flat in static_range(TOTAL_VALUES):
+        local_sum = add(local_sum, h_sq[flat])
+        # instruction_selection: add.f32; extent: TOTAL_VALUES ordered scalar
+        # issues per thread, including zero-filled column-tail fragment entries
+
+    WARP_WIDTH = min(TPR, 32)
+    for delta in powers_of_two_below(WARP_WIDTH):
+        peer = shuffle_xor(local_sum, delta, width=32)
+        # instruction_selection: shfl.sync.bfly.b32; extent: one scalar per stage
+        local_sum = add(local_sum, peer)
+        # instruction_selection: add.f32; extent: one scalar per stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            reduction[row_warp,warp_in_row] = warp_sum
+            # instruction_selection: st.shared.b32; extent: one per row warp
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: one CTA publication edge
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = reduction[row_warp,lane]
+            # instruction_selection: ld.shared.b32; extent: one scalar per participating lane
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one scalar per stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+
+    elif CLUSTER_N > 1:
+        if warp == 0 and elect_one():
+            # instruction_selection: elect.sync; extent: one election in warp 0
+            mbarrier_arrive_expect_tx(
+                mbar, ROWS * WARPS_PER_ROW * CLUSTER_N * 4)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+            # extent: one elected issue per CTA
+        if lane < CLUSTER_N:
+            peer_reduce = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cta_rank)], lane)
+            peer_mbar = map_shared_to_peer(mbar, lane)
+            # instruction_selection: mapa.shared::cluster.u32; extent: two mappings
+            remote_store_complete_tx(warp_sum, peer_reduce, peer_mbar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # extent: one partial to each peer selected by an active lane
+        done = False
+        while not done:
+            done = mbarrier_try_wait_parity(mbar, phase=0, timeout=10000000)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 plus
+            # bra.uni retry; extent: one uniform wait loop per CTA thread
+        total_partials = WARPS_PER_ROW * CLUSTER_N
+        final = 0.0
+        for i in static_range(ceil_div(total_partials,32)):
+            partial = lane + i * 32
+            if partial < total_partials:
+                value = reduction[row_warp,partial]
+                # instruction_selection: ld.shared.b32; extent: one owned partial
+                final = add(final, value)
+                # instruction_selection: add.f32; extent: one per loaded partial
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one scalar per stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one scalar per stage
+        sum_sq = final
+    else:
+        sum_sq = warp_sum
+
+    if is_power_of_two(H):
+        shifted = fma(sum_sq, exact_float32_reciprocal(H), runtime_eps)
+        # instruction_selection: fma.rn.f32; extent: one scalar per thread
+    else:
+        mean_sq = div(sum_sq, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+        shifted = add(mean_sq, runtime_eps)
+        # instruction_selection: add.f32; extent: one scalar per thread
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar per thread
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: one post-reduction CTA edge
+
+    for flat in static_range(TOTAL_VALUES):
+        w_f32[flat] = cast("f32", w_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one per weight value
+    normalized = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in static_range(PAIRS):
+        normalized.store_pair(
+            pair, mul(pair_view(h,pair), scalar_pair(rstd,pair,TOTAL_VALUES), lanes=2))
+        # instruction_selection: mul.f32x2; extent: PAIRS packed issues
+    biased_w = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in static_range(PAIRS):
+        biased_w.store_pair(
+            pair, add(pair_view(w_f32,pair),
+                      scalar_pair(WEIGHT_BIAS,pair,TOTAL_VALUES), lanes=2))
+        # instruction_selection: add.f32x2; extent: PAIRS packed issues for both variants
+    y = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in static_range(PAIRS):
+        y.store_pair(pair, mul(pair_view(normalized,pair),
+                               pair_view(biased_w,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: PAIRS packed issues
+
+    y_narrow = reg_tile(DTYPE, (TOTAL_VALUES,))
+    if VEC == 1 or (VEC == 2 and VEC_BLOCKS == 3):
+        for flat in static_range(TOTAL_VALUES):
+            y_narrow[flat] = cast(DTYPE, y[flat], rounding="rn")
+            # instruction_selection: cvt.rn.{f16,bf16}.f32; extent: scalar
+    else:
+        for pair in static_range(PAIRS):
+            y_narrow.store_pair(pair, cast(DTYPE+"x2", pair_view(y,pair), rounding="rn"))
+            # instruction_selection: cvt.rn.{f16,bf16}x2.f32; extent: one per pair
+    for vb in static_range(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        x_offset = (row_i32 * H + absolute_col) if COMPACT else \
+                   (row_i64 * x_row_stride + absolute_col)
+        if row_valid and col_valid:
+            copy_r2g(y_narrow.slice(vb,VEC), address(input_storage,x_offset), COPY_BITS)
+            # instruction_selection: exact global store from the VEC table;
+            # extent: one predicated input vector per vb
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; extent: one issue per CTA
+```
+
+## Export reconciliation and reviewed profiles
+
+- Dynamic shared memory is one raw allocation; the generated PTX broadcasts
+  its base with `shfl.sync.idx.b32`. Async H4096 places `sX` at byte 0, `sR`
+  after 16384 bytes, and reduction after 32768 bytes.
+- BF16 M32 H4096 emits 16 `cp.async` issues (eight X then eight residual), one
+  commit, eight weight `ld.global.v4.b32`, one wait, 16
+  `ld.shared.v4.b32`, eight residual and eight input `st.global.v4.b32`.
+- BF16 H66 emits six 4-byte async issues, three weight loads, six shared loads,
+  and three vector stores to each mutable tensor. FP16 H111 selects the fully
+  synchronous scalar branch: seven loads from each of X/R/W and seven stores
+  to each mutable tensor.
+- FP16 strided M19 H500 emits `mad.lo.s64` addressing for independent X and
+  residual rows; its four X plus four residual async issues have tail source
+  sizes and its stores remain separately predicated.
+- Cluster H32768/H131072/H262144 and sync H524288 exports contain the explicit
+  mbarrier init/fence, cluster arrive/wait pairs, two peer address mappings,
+  one remote complete-tx store site, uniform parity wait, and ten butterfly
+  stages. H1048576 follows the source fallback to cluster 1 and synchronous
+  loads. PDL-enabled profiles contain exactly one wait and one signal.
+
+## Addressing, predicates, mutation, and tails
+
+- Compact row offsets are Int32 after the host proves `M*H` fits signed Int32;
+  only comparison with `runtime_M:i64` widens the row. Strided row products and
+  pointer additions remain Int64 independently for input and residual.
+- One source `predicate_k` predicate covers each vector block by testing its
+  first absolute hidden coordinate. Alignment and `VEC` selection make an
+  accepted vector wholly in range.
+- Row validity gates X/R traffic and both mutable stores. In an async valid row,
+  an invalid column becomes a zero source size rather than a skipped async
+  instruction. Weight traffic depends only on the column predicate.
+- `h` is computed in FP32. Residual observes `cast_DTYPE(h)` before the
+  reduction; input observes `cast_DTYPE(h*rstd*(weight+WEIGHT_BIAS))` after the
+  reduction. The normalization uses FP32 `h`, not the narrowed residual value.
+- Out-of-range row groups still execute weight loads, reduction, mbarrier, and
+  CTA/cluster synchronization. Cluster CTAs own disjoint H ranges and publish
+  partials to every peer before any input result is stored.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime / reuse rule |
+| --- | --- | --- |
+| `sX`, `sR` | each thread writes and reads its own `(row,local_col)` vectors | one async issue/commit/wait/load epoch; dead after FP32 `h` is formed |
+| cluster-1 reduction | lane 0 of each row warp publishes one scalar | CTA publication barrier through final shared load |
+| clustered reduction | every source warp sends a partial to every peer; slot includes source CTA rank | complete-tx remote store through local mbarrier wait and final load |
+| cluster mbarrier | thread 0 initializes; one elected lane expects all peer-store bytes | initialization barrier through the single reduction transaction |
+| X/R fragments | one thread | load through FP32 add; source fragments die after `h` is formed |
+| FP32 `h` | one thread | add through early residual store, square/reduction, barrier, and final input multiply |
+| weight fragment | one thread | global load before async wait through post-reduction bias/multiply |
+| residual output fragment | one thread | `h` narrowing through the early predicated residual store |
+| input output fragment | one thread | post-reduction multiplies and narrowing through final predicated input store |
+
+No race depends on scheduling: each vector has one owner, residual publication
+does not feed the reduction, every source partial completes exactly one byte
+counted cluster transaction per peer, all participants execute the wait, and
+cluster CTAs write disjoint hidden-column ranges.
+
+## Module and verification contract
+
+- Registry name is `flashinfer_fused_add_rmsnorm`, category `flashinfer`, and
+  compute capability 10; `get_kernel` is the only registered factory.
+- `CONFIGS` contains exactly 281 unique configurations and `BENCH_CONFIGS`
+  contains the six frozen BF16 source workloads, including PDL and both public
+  variants.
+- Correctness checks both in-place outputs against the direct public
+  FlashInfer CuTe-DSL path and an independent FP32 oracle at
+  `rtol=atol=1e-3`, checks finite values, mutation/object behavior, independent
+  row padding and guard regions, and sampled Int64 overflow boundary rows.
+- Static verification rejects `TilePrimitiveCall`, `tirx.tile.*`, imports of
+  `tvm.script.tirx.tile`, and tile primitives in every generated PrimFunc.
+- The only final performance authority is `python -m
+  tirx_kernels.bench_suite`; every exact `flashinfer_cutedsl_time / tirx_time`
+  ratio in the complete six-shape matrix must be strictly greater than 0.99.
+  PTX, SASS, NCU, and any other timing API are diagnostic only.
+
+## Instruction selection is a lowering consequence
+
+The port preserves source row ownership, TV fragment order, vector width,
+paired copy issue order, early residual publication, ordered FP32 reduction,
+shared offsets, cluster transaction protocol, live `h` lifetime, and barriers
+before relying on local typed PTX. It may not use a tile primitive, substitute a
+different reduction, scalarize reviewed vector traffic, reload narrowed
+residual for normalization, move residual publication after reduction, merge or
+reassociate the two post-reduction multiplies, replace
+`rsqrt.approx.ftz.f32`, couple the two row strides, or emit PDL operations in a
+disabled specialization.

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -149,6 +149,24 @@ non-protocol path but moved the dependency-protocol path from 3.386 to 3.425
 microseconds, so the shared rewrite was reverted. Match the source topology,
 then retain the hoist only on the paths where the gate confirms it.
 
+The grouping width itself is a scheduling parameter. In one asynchronous-copy
+path, merging guards across the complete copy group reduced control and address
+instructions but regressed every guarded shape by roughly 4.6-8.1%. Grouping
+only two adjacent copies still removed dynamic instructions and preserved
+logical memory traffic, but regressed the affected shapes by roughly 5.3-10.3%
+because more addresses and predicates stayed live together. Compare the
+smallest legal group, intermediate groups, and the original per-issue form;
+fewer reconvergence instructions do not prove that a broader branch is useful.
+
+Encoding a row predicate as an asynchronous copy's zero-fill source size is
+also path-sensitive. One measured rewrite removed more than two million dynamic
+warp instructions, removed more than sixty million predicated-on thread
+instructions, and lowered the allocation without spilling, yet both
+dependency-protocol shapes fell to about 0.987x while their non-protocol guards
+held. Source-size predication changes issue and dependency behavior, not just
+branch syntax, so preserve protocol-on and protocol-off shapes as separate
+performance guards.
+
 ## Verification
 
 Confirm predicate polarity and inactive-lane memory behavior, then compare BRA,

--- a/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/specialize-static-register-caps-by-execution-path.md
@@ -54,6 +54,14 @@ changing the mathematical kernel: the dependency-protocol path moved from
 1.001x in the final complete matrix. A static cap is a contract with the
 current allocator and scheduler, not a stable source-level constant.
 
+The requested cap and the realized allocation need not move together or by one
+register. In one neighboring sweep, declared caps 128 and 127 both realized 127
+registers, 126 realized 126, and 125 jumped to 123; every candidate was
+spill-free, yet their scheduled binaries and affected timings differed. The
+125 cap was the only member of that sweep to clear the complete required-shape
+matrix. Treat each distinct final binary as an independent schedule candidate,
+including adjacent caps that land on the same realized allocation.
+
 An underfilled launch isolated the scheduling effect from occupancy. With only
 16 CTAs on 148 SMs, lowering realized allocation from 96 to 80 registers could
 not reduce actual CTA occupancy; it kept the complete opcode vectors identical
@@ -84,9 +92,20 @@ cap matching the reference's 56-register dependency path improved the target
 only slightly without clearing the gate. The two instruction streams can need
 different budgets to realize comparable schedules.
 
+Do not infer a family-wide cap from one operation mode. A cap that initially
+helped one dependency-protocol specialization failed a sibling mode in a later
+complete matrix; applying the cap to both modes produced another distinct
+schedule rather than a guaranteed transfer. Select the scope from compile-time
+live-range and protocol identity, then guard every affected sibling.
+
 ## Verification
 
 Confirm that CUDA and PTX contain the requested `__maxnreg__` and `.maxnreg`,
 then read the realized register allocation, stack size, local-memory traffic,
 and scheduled SASS rather than trusting the declaration. Run correctness plus
 the affected performance shapes and guard shapes on every retained cap.
+
+Hash or normalize the final cubin before labeling neighboring caps duplicate.
+Zero spill, equal realized registers, or equal static instruction totals are not
+enough: ptxas can reorder the same-count stream, and that schedule difference
+is exactly what the cap sweep is testing.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `mxfp4_quantize`                        | `quantization/mxfp4_quantize.py`                    | Block quantization with UE8M0 scales |
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
 | `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
+| `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_qk_rmsnorm`                 | `norm/qk_rmsnorm.py`                                | Shared 3-D QK RMSNorm / Gemma RMSNorm family with arbitrary int64 batch/head strides, PDL, and sync/async copy paths |
 | `selective_state_update_stp_simple`     | `mamba/selective_state_update_stp_simple.py`        | Single-token, `algorithm="simple"` |
 | `selective_state_update_stp_vertical`   | `mamba/selective_state_update_stp_vertical.py`      | Single-token, `algorithm="vertical"` |

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "0d695aa0",
-    "tirx-kernels": "db0958ea-dirty",
+    "tir": "3df3e86a",
+    "tirx-kernels": "aedd23c2-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "75f7a5c54e09bd808690a85e1ed985c30df760f8"
+    "tirx-kernels:tirx_kernels": "30afc5a73ef806d71abc8c58ede9c2af4350a361"
   },
   "baselines": {
     "torch": {
@@ -2082,6 +2082,90 @@
       "impls": {
         "tir": 5549.111992647058,
         "flashattn_sm100": 5662.155411764706
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "fused_bf16_m32_h4096_xc_rc_pdl0",
+      "label": "fused_bf16_m32_h4096_xc_rc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.6032831305010378,
+        "flashinfer_cutedsl": 3.6118395209343883
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "fused_bf16_m32_h4096_xc_rc_pdl1",
+      "label": "fused_bf16_m32_h4096_xc_rc_pdl1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.7216245682399927,
+        "flashinfer_cutedsl": 3.702989458777208
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "fused_bf16_m64_h8192_xc_rc_pdl0",
+      "label": "fused_bf16_m64_h8192_xc_rc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.7879947375304193,
+        "flashinfer_cutedsl": 3.7898716428934125
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "gemma_bf16_m32_h4096_xc_rc_pdl0",
+      "label": "gemma_bf16_m32_h4096_xc_rc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.571021015346193,
+        "flashinfer_cutedsl": 3.5449109046493725
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "gemma_bf16_m32_h4096_xc_rc_pdl1",
+      "label": "gemma_bf16_m32_h4096_xc_rc_pdl1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.724107989166657,
+        "flashinfer_cutedsl": 3.7072597055790313
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm",
+      "config": "gemma_bf16_m64_h8192_xc_rc_pdl0",
+      "label": "gemma_bf16_m64_h8192_xc_rc_pdl0",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.8722115224442737,
+        "flashinfer_cutedsl": 3.8764929662039616
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '0d695aa0', 'tirx-kernels': 'db0958ea-dirty', 'tirx-bench-ci': None}`
-- Workloads: 397 ok, 0 failed
+- Git:       `{'tir': '3df3e86a', 'tirx-kernels': 'aedd23c2-dirty', 'tirx-bench-ci': None}`
+- Workloads: 403 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -239,6 +239,17 @@ Grouped workloads show one row per config and one timing column per implementati
 | `b2_s4096_h16_causal` | tir | 388.0339 | flashattn_sm100 | 390.3185 | 1.006 | — |
 | `b4_s8192_h16_causal` | tir | 2473.1056 | flashattn_sm100 | 2496.3857 | 1.009 | — |
 | `b4_s8192_h16_noncausal` | tir | 5549.1120 | flashattn_sm100 | 5662.1554 | 1.020 | — |
+
+## flashinfer_fused_add_rmsnorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `fused_bf16_m32_h4096_xc_rc_pdl0` | tirx | 3.6033 | flashinfer_cutedsl | 3.6118 | 1.002 | — |
+| `fused_bf16_m32_h4096_xc_rc_pdl1` | tirx | 3.7216 | flashinfer_cutedsl | 3.7030 | 0.995 | — |
+| `fused_bf16_m64_h8192_xc_rc_pdl0` | tirx | 3.7880 | flashinfer_cutedsl | 3.7899 | 1.000 | — |
+| `gemma_bf16_m32_h4096_xc_rc_pdl0` | tirx | 3.5710 | flashinfer_cutedsl | 3.5449 | 0.993 | — |
+| `gemma_bf16_m32_h4096_xc_rc_pdl1` | tirx | 3.7241 | flashinfer_cutedsl | 3.7073 | 0.995 | — |
+| `gemma_bf16_m64_h8192_xc_rc_pdl0` | tirx | 3.8722 | flashinfer_cutedsl | 3.8765 | 1.001 | — |
 
 ## flashinfer_qk_rmsnorm
 

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
@@ -1,0 +1,1155 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL fused add RMSNorm family.
+
+The source implementation is ``FusedAddRMSNormKernel`` and its 2-D host
+dispatch in ``flashinfer/norm/kernels/fused_add_rmsnorm.py``.  The public entry
+points are ``fused_add_rmsnorm`` and ``gemma_fused_add_rmsnorm`` in
+``flashinfer/norm/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+from .rmsnorm import (
+    _add_f32,
+    _butterfly_sum_f32,
+    _ceil_div,
+    _cluster_mbarrier_wait,
+    _cvt_from_f32,
+    _cvt_pair_from_f32,
+    _cvt_to_f32,
+    _div_rn_f32,
+    _fma_rn_f32,
+    _load_global_bits,
+    _load_shared_bits,
+    _mapa_u32,
+    _rsqrt_approx_ftz,
+    _store_global_fragment,
+    _threads_per_row,
+)
+
+KERNEL_META = {
+    "name": "flashinfer_fused_add_rmsnorm",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_VARIANTS = ("fused_add_rmsnorm", "gemma_fused_add_rmsnorm")
+_DTYPES = ("float16", "bfloat16")
+_LAYOUTS = ("compact", "strided")
+_INT32_MAX = 2**31 - 1
+_DEFAULT_EPS = 1e-6
+_OPTIN_SMEM_BYTES = 232448
+_ELEM_BYTES = 2
+
+
+def _derived_config(H: int, cluster_n: int) -> dict[str, int | bool]:
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, 8)
+    copy_bits = 16 * vec
+    vec_blocks = max(1, _ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    tile_bytes = rows * cols * _ELEM_BYTES
+    two_tile_bytes = 2 * tile_bytes
+    use_async = copy_bits >= 32 and two_tile_bytes <= _OPTIN_SMEM_BYTES // 2
+    reduce_bytes = rows * warps_per_row * cluster_n * 4
+    smem_bytes = (two_tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return {
+        "cluster_n": cluster_n,
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec": vec,
+        "copy_bits": copy_bits,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+        "two_tile_bytes": two_tile_bytes,
+        "use_async": use_async,
+        "smem_bytes": smem_bytes,
+    }
+
+
+def _estimate_smem(H: int, cluster_n: int) -> int:
+    config = _derived_config(H, cluster_n)
+    return (
+        2 * int(config["tile_bytes"])
+        + int(config["rows"]) * int(config["warps_per_row"]) * cluster_n * 4
+        + (8 if cluster_n > 1 else 0)
+    )
+
+
+def _source_config(H: int) -> dict[str, int | bool]:
+    best_fit = 1
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate != 0:
+            continue
+        required = _estimate_smem(H, candidate)
+        if required <= _OPTIN_SMEM_BYTES // 2:
+            return _derived_config(H, candidate)
+        if required <= _OPTIN_SMEM_BYTES and best_fit == 1:
+            best_fit = candidate
+    return _derived_config(H, best_fit)
+
+
+def _uses_rolled_fragment_loops(H: int) -> bool:
+    source = _source_config(H)
+    return int(source["vec"]) * int(source["vec_blocks"]) > 512
+
+
+def _short_variant(variant: str) -> str:
+    return "fused" if variant == "fused_add_rmsnorm" else "gemma"
+
+
+def _short_dtype(dtype: str) -> str:
+    return "fp16" if dtype == "float16" else "bf16"
+
+
+def _layout_code(layout: str) -> str:
+    return "c" if layout == "compact" else "s"
+
+
+def _cfg(
+    variant: str,
+    dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    residual_layout: str,
+    enable_pdl: bool,
+    *,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    residual_row_stride: int | None = None,
+    suffix: str | None = None,
+) -> dict[str, Any]:
+    label = (
+        f"{_short_variant(variant)}_{_short_dtype(dtype)}_m{M}_h{H}_"
+        f"x{_layout_code(input_layout)}_r{_layout_code(residual_layout)}_"
+        f"pdl{int(enable_pdl)}"
+    )
+    if suffix:
+        label += f"_{suffix}"
+    config: dict[str, Any] = {
+        "label": label,
+        "variant": variant,
+        "dtype": dtype,
+        "M": M,
+        "H": H,
+        "input_layout": input_layout,
+        "residual_layout": residual_layout,
+        "enable_pdl": enable_pdl,
+        "eps": eps,
+    }
+    if x_row_stride is not None:
+        config["x_row_stride"] = x_row_stride
+    if residual_row_stride is not None:
+        config["residual_row_stride"] = residual_row_stride
+    return config
+
+
+_UPSTREAM_CONFIGS = [
+    _cfg(
+        variant,
+        "float16",
+        M,
+        H,
+        layout,
+        layout,
+        enable_pdl,
+        x_row_stride=2 * H if layout == "strided" else None,
+        residual_row_stride=2 * H if layout == "strided" else None,
+    )
+    for variant in _VARIANTS
+    for M in (1, 19, 99, 989)
+    for H in (111, 500, 1024, 3072, 3584, 4096, 8192, 16384)
+    for layout in _LAYOUTS
+    for enable_pdl in (False, True)
+]
+
+BENCH_CONFIGS = [
+    _cfg("fused_add_rmsnorm", "bfloat16", 32, 4096, "compact", "compact", False),
+    _cfg("fused_add_rmsnorm", "bfloat16", 64, 8192, "compact", "compact", False),
+    _cfg("fused_add_rmsnorm", "bfloat16", 32, 4096, "compact", "compact", True),
+    _cfg("gemma_fused_add_rmsnorm", "bfloat16", 32, 4096, "compact", "compact", False),
+    _cfg("gemma_fused_add_rmsnorm", "bfloat16", 64, 8192, "compact", "compact", False),
+    _cfg("gemma_fused_add_rmsnorm", "bfloat16", 32, 4096, "compact", "compact", True),
+]
+
+_I64_CONFIGS = [
+    _cfg(
+        "fused_add_rmsnorm",
+        "bfloat16",
+        2,
+        128,
+        "strided",
+        "compact",
+        False,
+        x_row_stride=2**31,
+        suffix="i64_xstride",
+    ),
+    _cfg(
+        "fused_add_rmsnorm",
+        "float16",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        False,
+        suffix="compact_overflow_strided_abi",
+    ),
+    _cfg(
+        "gemma_fused_add_rmsnorm",
+        "float16",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        False,
+        suffix="compact_overflow_strided_abi",
+    ),
+]
+
+_TRACE_CONFIGS = [
+    _cfg(variant, "bfloat16", M, H, "compact", "compact", False)
+    for variant in _VARIANTS
+    for M, H in ((8, 256), (3, 320))
+] + [
+    _cfg("fused_add_rmsnorm", "bfloat16", 32, 5120, "compact", "compact", False),
+    _cfg("gemma_fused_add_rmsnorm", "bfloat16", 32, 4608, "compact", "compact", False),
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg("fused_add_rmsnorm", "float16", 3, 64, "compact", "compact", False, suffix="tpr8"),
+    _cfg("gemma_fused_add_rmsnorm", "bfloat16", 3, 66, "compact", "compact", True, suffix="vec2"),
+    _cfg("fused_add_rmsnorm", "float16", 3, 16385, "compact", "compact", False, suffix="sync_vec1"),
+    _cfg("fused_add_rmsnorm", "float16", 3, 32768, "compact", "compact", False, suffix="cluster2"),
+    _cfg(
+        "gemma_fused_add_rmsnorm",
+        "bfloat16",
+        3,
+        65536,
+        "compact",
+        "compact",
+        True,
+        suffix="cluster4",
+    ),
+    _cfg("fused_add_rmsnorm", "float16", 3, 131072, "compact", "compact", False, suffix="cluster8"),
+    _cfg(
+        "gemma_fused_add_rmsnorm",
+        "bfloat16",
+        3,
+        262144,
+        "compact",
+        "compact",
+        True,
+        suffix="cluster16",
+    ),
+    _cfg(
+        "fused_add_rmsnorm",
+        "float16",
+        3,
+        524288,
+        "compact",
+        "compact",
+        False,
+        suffix="cluster16_sync",
+    ),
+    _cfg(
+        "gemma_fused_add_rmsnorm",
+        "bfloat16",
+        3,
+        1048576,
+        "compact",
+        "compact",
+        True,
+        suffix="cluster1_sync_fallback",
+    ),
+]
+
+_ABI_CONFIGS = [
+    _cfg(
+        "fused_add_rmsnorm",
+        "float16",
+        19,
+        500,
+        "strided",
+        "strided",
+        True,
+        eps=1e-4,
+        x_row_stride=1000,
+        residual_row_stride=1500,
+        suffix="eps1e4_full_abi",
+    )
+]
+
+CONFIGS = [
+    *_UPSTREAM_CONFIGS,
+    *BENCH_CONFIGS,
+    *_I64_CONFIGS,
+    *_TRACE_CONFIGS,
+    *_STRUCTURE_CONFIGS,
+    *_ABI_CONFIGS,
+]
+
+assert len(CONFIGS) == 281
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+assert len(BENCH_CONFIGS) == 6
+
+
+def _validate(
+    variant: str, dtype: str, M: int, H: int, input_layout: str, residual_layout: str, eps: float
+) -> None:
+    if variant not in _VARIANTS:
+        raise ValueError(f"unsupported variant: {variant}")
+    if dtype not in _DTYPES:
+        raise ValueError(f"unsupported dtype: {dtype}")
+    if input_layout not in _LAYOUTS or residual_layout not in _LAYOUTS:
+        raise ValueError(f"unsupported layouts: input={input_layout}, residual={residual_layout}")
+    if M <= 0 or H <= 0:
+        raise ValueError(f"M and H must be positive, got M={M}, H={H}")
+    if eps <= 0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+
+def _uses_compact_specialization(M: int, H: int, input_layout: str, residual_layout: str) -> bool:
+    return input_layout == "compact" and residual_layout == "compact" and M * H <= _INT32_MAX
+
+
+def get_kernel(
+    variant: str,
+    dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    residual_layout: str,
+    enable_pdl: bool,
+    eps: float = _DEFAULT_EPS,
+    **kwargs: Any,
+):
+    """Return the compact or explicit-i64-strided runtime-M specialization."""
+    _validate(variant, dtype, M, H, input_layout, residual_layout, eps)
+    compact = _uses_compact_specialization(M, H, input_layout, residual_layout)
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec = int(source["vec"])
+    copy_bits = int(source["copy_bits"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    two_tile_bytes = int(source["two_tile_bytes"])
+    use_async = bool(source["use_async"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = vec * vec_blocks
+    packed_pairs = _ceil_div(total_values, 2)
+    pair_values = packed_pairs * 2
+    roll_large_fragments = _uses_rolled_fragment_loops(H)
+    packed_narrow = not (vec == 1 or (vec == 2 and vec_blocks == 3))
+    weight_bias = 0.0 if variant == "fused_add_rmsnorm" else 1.0
+    copy_bytes = copy_bits // 8
+    reduce_base = two_tile_bytes if use_async else 0
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+
+    def fragment_range(extent: int):
+        if roll_large_fragments:
+            return T.serial(extent, unroll=False)
+        return T.unroll(extent)
+
+    x_row_stride_hint = kwargs.get("x_row_stride", H)
+    residual_row_stride_hint = kwargs.get("residual_row_stride", H)
+    if x_row_stride_hint is not None and int(x_row_stride_hint) % vec != 0:
+        raise ValueError(f"x_row_stride={x_row_stride_hint} must be divisible by vec={vec}")
+    if residual_row_stride_hint is not None and int(residual_row_stride_hint) % vec != 0:
+        raise ValueError(
+            f"residual_row_stride={residual_row_stride_hint} must be divisible by vec={vec}"
+        )
+
+    @T.inline
+    def kernel_body(
+        input_buffer, residual, weight, runtime_M, runtime_eps, x_row_stride, residual_row_stride
+    ):
+        # TIRX_TRANSCRIBE_START flashinfer_fused_add_rmsnorm
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        row_i32: T.int32 = block_x * rows + row_in_cta
+        row_i64: T.int64 = T.cast(row_i32, "int64")
+        row_valid: T.bool = row_i64 < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+        if compact and enable_pdl and H == 4096:
+            T.attr({"tirx.max_registers": 125})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        x_bits = T.alloc_local((pair_values,), "uint16")
+        r_bits = T.alloc_local((pair_values,), "uint16")
+        w_bits = T.alloc_local((pair_values,), "uint16")
+        x_f32 = T.alloc_local((pair_values,), "float32")
+        r_f32 = T.alloc_local((pair_values,), "float32")
+        w_f32 = T.alloc_local((pair_values,), "float32")
+        h_f32 = T.alloc_local((pair_values,), "float32")
+        h_sq = T.alloc_local((pair_values,), "float32")
+        undefined_f32 = T.alloc_local((1,), "float32")
+
+        if not use_async:
+            for value in fragment_range(total_values):
+                x_bits[value] = T.uint16(0)
+                r_bits[value] = T.uint16(0)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                x_offset = row_i32 * H + absolute_col
+            else:
+                x_offset = row_i64 * x_row_stride + T.cast(absolute_col, "int64")
+            if use_async:
+                if row_valid:
+                    source_bytes: T.uint32 = T.cast(
+                        T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                    )
+                    T.ptx.cp.async_.ca.shared.global_(
+                        shared_raw.ptr_to([(row_in_cta * cols + local_col) * _ELEM_BYTES]),
+                        input_buffer.ptr_to([x_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+            else:
+                if row_valid and col_valid:
+                    _load_global_bits(input_buffer, x_offset, x_bits, vb * vec, VEC=vec)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                residual_offset = row_i32 * H + absolute_col
+            else:
+                residual_offset = row_i64 * residual_row_stride + T.cast(absolute_col, "int64")
+            if use_async:
+                if row_valid:
+                    source_bytes: T.uint32 = T.cast(
+                        T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                    )
+                    T.ptx.cp.async_.ca.shared.global_(
+                        shared_raw.ptr_to(
+                            [tile_bytes + (row_in_cta * cols + local_col) * _ELEM_BYTES]
+                        ),
+                        residual.ptr_to([residual_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+            else:
+                if row_valid and col_valid:
+                    _load_global_bits(residual, residual_offset, r_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.commit_group()
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            if absolute_col < H:
+                _load_global_bits(weight, absolute_col, w_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.wait_group(0)
+            for vb in fragment_range(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    (row_in_cta * cols + local_col) * _ELEM_BYTES,
+                    x_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+            for vb in fragment_range(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    tile_bytes + (row_in_cta * cols + local_col) * _ELEM_BYTES,
+                    r_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+
+        for value in fragment_range(total_values):
+            x_f32[value] = _cvt_to_f32(x_bits[value], dtype)
+        for value in fragment_range(total_values):
+            r_f32[value] = _cvt_to_f32(r_bits[value], dtype)
+
+        for pair in fragment_range(packed_pairs):
+            x_high: T.float32 = x_f32[pair * 2 + 1]
+            r_high: T.float32 = r_f32[pair * 2 + 1]
+            if pair * 2 + 1 >= total_values:
+                x_high = undefined_f32[0]
+                r_high = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                packed[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_high),
+                T.cuda.make_float2(r_f32[pair * 2], r_high),
+            )
+            T.ptx.mov.b64(h_f32[pair * 2], h_f32[pair * 2 + 1], packed[0])
+
+        residual_bits = T.alloc_local((pair_values,), "uint16")
+        residual_words = T.alloc_local((packed_pairs,), "uint32")
+        if packed_narrow:
+            for pair in fragment_range(packed_pairs):
+                residual_words[pair] = _cvt_pair_from_f32(
+                    h_f32[pair * 2 + 1], h_f32[pair * 2], dtype
+                )
+        else:
+            for value in fragment_range(total_values):
+                residual_bits[value] = _cvt_from_f32(h_f32[value], dtype)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                residual_offset = row_i32 * H + absolute_col
+            else:
+                residual_offset = row_i64 * residual_row_stride + T.cast(absolute_col, "int64")
+            _store_global_fragment(
+                residual,
+                residual_offset,
+                residual_bits,
+                residual_words,
+                row_valid and col_valid,
+                vb * vec,
+                vb * vec // 2,
+                VEC=vec,
+                PACKED_NARROW=packed_narrow,
+            )
+
+        for pair in fragment_range(packed_pairs):
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(h_sq[pair * 2], h_sq[pair * 2 + 1], packed[0])
+
+        local_sum: T.float32 = T.float32(0.0)
+        for value in fragment_range(total_values):
+            local_sum = _add_f32(local_sum, h_sq[value])
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+            T.evaluate(_cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset])))
+            final_sum: T.float32 = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        else:
+            sum_sq: T.float32 = warp_sum
+
+        if H & (H - 1) == 0:
+            shifted: T.float32 = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted: T.float32 = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        for value in fragment_range(total_values):
+            w_f32[value] = _cvt_to_f32(w_bits[value], dtype)
+
+        normalized = T.alloc_local((pair_values,), "float32")
+        biased_weight = T.alloc_local((pair_values,), "float32")
+        for pair in fragment_range(packed_pairs):
+            high_scale: T.float32 = rstd
+            if pair * 2 + 1 >= total_values:
+                high_scale = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+                T.cuda.make_float2(rstd, high_scale),
+            )
+            T.ptx.mov.b64(normalized[pair * 2], normalized[pair * 2 + 1], packed[0])
+
+        for pair in fragment_range(packed_pairs):
+            high_bias: T.float32 = T.float32(weight_bias)
+            if pair * 2 + 1 >= total_values:
+                high_bias = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                packed[0],
+                T.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+                T.cuda.make_float2(T.float32(weight_bias), high_bias),
+            )
+            T.ptx.mov.b64(biased_weight[pair * 2], biased_weight[pair * 2 + 1], packed[0])
+
+        for pair in fragment_range(packed_pairs):
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(normalized[pair * 2], normalized[pair * 2 + 1]),
+                T.cuda.make_float2(biased_weight[pair * 2], biased_weight[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(normalized[pair * 2], normalized[pair * 2 + 1], packed[0])
+
+        output_bits = T.alloc_local((pair_values,), "uint16")
+        output_words = T.alloc_local((packed_pairs,), "uint32")
+        if packed_narrow:
+            for pair in fragment_range(packed_pairs):
+                output_words[pair] = _cvt_pair_from_f32(
+                    normalized[pair * 2 + 1], normalized[pair * 2], dtype
+                )
+        else:
+            for value in fragment_range(total_values):
+                output_bits[value] = _cvt_from_f32(normalized[value], dtype)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                x_offset = row_i32 * H + absolute_col
+            else:
+                x_offset = row_i64 * x_row_stride + T.cast(absolute_col, "int64")
+            _store_global_fragment(
+                input_buffer,
+                x_offset,
+                output_bits,
+                output_words,
+                row_valid and col_valid,
+                vb * vec,
+                vb * vec // 2,
+                VEC=vec,
+                PACKED_NARROW=packed_narrow,
+            )
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    if compact:
+
+        @T.prim_func
+        def flashinfer_fused_add_rmsnorm_compact(
+            input_handle: T.handle,
+            residual_handle: T.handle,
+            weight_handle: T.handle,
+            runtime_M: T.int64,
+            runtime_eps: T.float32,
+        ):
+            input_buffer = T.match_buffer(
+                input_handle, shape=(runtime_M * T.int64(H),), dtype=dtype, scope="global"
+            )
+            residual = T.match_buffer(
+                residual_handle, shape=(runtime_M * T.int64(H),), dtype=dtype, scope="global"
+            )
+            weight = T.match_buffer(weight_handle, shape=(H,), dtype=dtype, scope="global")
+            T.device_entry()
+            kernel_body(
+                input_buffer, residual, weight, runtime_M, runtime_eps, T.int64(H), T.int64(H)
+            )
+
+        kernel = flashinfer_fused_add_rmsnorm_compact
+    else:
+
+        @T.prim_func
+        def flashinfer_fused_add_rmsnorm_strided(
+            input_handle: T.handle,
+            residual_handle: T.handle,
+            weight_handle: T.handle,
+            runtime_M: T.int64,
+            runtime_eps: T.float32,
+            x_row_stride: T.int64,
+            residual_row_stride: T.int64,
+        ):
+            input_buffer = T.match_buffer(
+                input_handle,
+                shape=((runtime_M - T.int64(1)) * x_row_stride + T.int64(H),),
+                dtype=dtype,
+                scope="global",
+            )
+            residual = T.match_buffer(
+                residual_handle,
+                shape=((runtime_M - T.int64(1)) * residual_row_stride + T.int64(H),),
+                dtype=dtype,
+                scope="global",
+            )
+            weight = T.match_buffer(weight_handle, shape=(H,), dtype=dtype, scope="global")
+            T.device_entry()
+            kernel_body(
+                input_buffer,
+                residual,
+                weight,
+                runtime_M,
+                runtime_eps,
+                x_row_stride,
+                residual_row_stride,
+            )
+
+        kernel = flashinfer_fused_add_rmsnorm_strided
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return kernel.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Create deterministic input, residual, and weight tensors."""
+    data = _prepare_tensors(dict(config))
+    return data["input"], data["residual"], data["weight"]
+
+
+_GUARD_ELEMENTS = 64
+_GUARD_VALUE = 123.0
+
+
+def _torch_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _row_strides(config: dict[str, Any]) -> tuple[int, int]:
+    H = int(config["H"])
+    x_stride = int(config.get("x_row_stride", 2 * H if config["input_layout"] == "strided" else H))
+    residual_stride = int(
+        config.get("residual_row_stride", 2 * H if config["residual_layout"] == "strided" else H)
+    )
+    return x_stride, residual_stride
+
+
+def _storage_size(M: int, H: int, row_stride: int) -> int:
+    return (M - 1) * row_stride + H
+
+
+def _allocate_strided(M: int, H: int, row_stride: int, dtype: str) -> dict[str, Any]:
+    import torch
+
+    size = _storage_size(M, H, row_stride)
+    backing = torch.empty(size + _GUARD_ELEMENTS, dtype=_torch_dtype(dtype), device="cuda")
+    backing.fill_(_GUARD_VALUE)
+    arg = backing[:size]
+    view = arg.as_strided((M, H), (row_stride, 1))
+    return {"view": view, "arg": arg, "backing": backing, "size": size}
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M = int(config["M"])
+    H = int(config["H"])
+    dtype = str(config["dtype"])
+    variant = str(config["variant"])
+    input_layout = str(config["input_layout"])
+    residual_layout = str(config["residual_layout"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    _validate(variant, dtype, M, H, input_layout, residual_layout, eps)
+    x_stride, residual_stride = _row_strides(config)
+    vec = int(_source_config(H)["vec"])
+    if x_stride < H or residual_stride < H:
+        raise ValueError(f"row strides must cover H={H}: x={x_stride}, residual={residual_stride}")
+    if x_stride % vec != 0 or residual_stride % vec != 0:
+        raise ValueError(
+            f"row strides must be divisible by vec={vec}: x={x_stride}, residual={residual_stride}"
+        )
+
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(42)
+    x = _allocate_strided(M, H, x_stride, dtype)
+    residual = _allocate_strided(M, H, residual_stride, dtype)
+
+    # Large reductions use exactly representable, nonuniform patterns. This
+    # keeps the independent FP32 oracle stable around the source's approximate
+    # reciprocal square root while still exposing row/column/cluster mistakes.
+    if (dtype == "bfloat16" and H >= 4096) or H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        x_mag = torch.where(columns % 257 < 128, 0.5, 1.0)
+        r_mag = torch.where(columns % 193 < 96, 0.25, 0.75)
+        x_pattern = torch.where(columns % 2 == 0, x_mag, -x_mag).to(_torch_dtype(dtype))
+        r_pattern = torch.where(columns % 3 == 0, r_mag, -r_mag).to(_torch_dtype(dtype))
+        x["view"].copy_(x_pattern.expand(M, H))
+        residual["view"].copy_(r_pattern.expand(M, H))
+        x["view"][1::2].neg_()
+        residual["view"][2::3].neg_()
+    else:
+        x["view"].normal_(generator=generator)
+        residual["view"].normal_(generator=generator)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=_torch_dtype(dtype), device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    weight_backing[H:].fill_(_GUARD_VALUE)
+    return {
+        "input": x["view"],
+        "input_arg": x["arg"],
+        "input_backing": x["backing"],
+        "input_size": x["size"],
+        "residual": residual["view"],
+        "residual_arg": residual["arg"],
+        "residual_backing": residual["backing"],
+        "residual_size": residual["size"],
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "x_row_stride": x_stride,
+        "residual_row_stride": residual_stride,
+    }
+
+
+def _assert_guard(backing, size: int, *, name: str) -> None:
+    import torch
+
+    expected = torch.full(
+        (_GUARD_ELEMENTS,), _GUARD_VALUE, dtype=backing.dtype, device=backing.device
+    )
+    if not torch.equal(backing[size:], expected):
+        raise AssertionError(f"{name} guard was modified")
+
+
+def _assert_padding(data: dict[str, Any], M: int, H: int, *, prefix: str) -> None:
+    import torch
+
+    for name, stride_key in (("input", "x_row_stride"), ("residual", "residual_row_stride")):
+        backing = data[f"{name}_backing"]
+        size = int(data[f"{name}_size"])
+        stride = int(data[stride_key])
+        _assert_guard(backing, size, name=f"{prefix} {name}")
+        if stride > H:
+            for row in range(M - 1):
+                padding = backing[row * stride + H : (row + 1) * stride]
+                if not torch.equal(padding, torch.full_like(padding, _GUARD_VALUE)):
+                    raise AssertionError(f"{prefix} {name} row {row} padding was modified")
+
+
+def _overflow_rows(M: int, H: int) -> list[int] | None:
+    if M * H <= _INT32_MAX:
+        return None
+    boundary = _ceil_div(2**31, H)
+    return sorted(
+        {row for row in (0, 1, boundary - 1, boundary, boundary + 1, M - 1) if 0 <= row < M}
+    )
+
+
+def _checked_view(tensor, rows: list[int] | None):
+    return tensor if rows is None else tensor[rows]
+
+
+def _input_snapshot(data: dict[str, Any], M: int, H: int) -> dict[str, Any]:
+    rows = _overflow_rows(M, H)
+    return {
+        "rows": rows,
+        "input": _checked_view(data["input"], rows).clone(),
+        "residual": _checked_view(data["residual"], rows).clone(),
+        "weight": data["weight"].clone(),
+    }
+
+
+def _math_oracle(snapshot: dict[str, Any], variant: str, eps: float):
+    h = snapshot["input"].float() + snapshot["residual"].float()
+    residual = h.to(snapshot["input"].dtype)
+    variance = h.square().mean(dim=-1, keepdim=True)
+    bias = 0.0 if variant == "fused_add_rmsnorm" else 1.0
+    output = h * variance.add(eps).rsqrt() * (snapshot["weight"].float() + bias)
+    return output.to(snapshot["input"].dtype), residual
+
+
+def _assert_close(actual, expected, *, name: str) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual, expected, rtol=1e-3, atol=1e-3, msg=lambda message: f"{name}: {message}"
+    )
+
+
+def _flashinfer_api(variant: str, device):
+    import flashinfer
+    import flashinfer.norm as flashinfer_norm
+
+    if flashinfer_norm._use_cuda_norm(device):
+        raise AssertionError("FlashInfer fused add RMSNorm oracle dispatched to legacy CUDA")
+    return getattr(flashinfer, variant), flashinfer_norm
+
+
+def _launch_tirx(executable, data: dict[str, Any], config: dict[str, Any]) -> None:
+    M = int(config["M"])
+    H = int(config["H"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    compact = _uses_compact_specialization(
+        M, H, str(config["input_layout"]), str(config["residual_layout"])
+    )
+    if compact:
+        executable(data["input_arg"], data["residual_arg"], data["weight"], M, eps)
+    else:
+        executable(
+            data["input_arg"],
+            data["residual_arg"],
+            data["weight"],
+            M,
+            eps,
+            data["x_row_stride"],
+            data["residual_row_stride"],
+        )
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate both in-place outputs for one config."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = dict(config)
+    M = int(config["M"])
+    H = int(config["H"])
+    variant = str(config["variant"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    # CuTe materializes the million-column fallback as a multi-gigabyte host
+    # compilation.  Its cluster-1 synchronous path is compared directly at
+    # H=16385; the extreme rolled-loop specialization uses the FP32 oracle.
+    use_cute_reference = not _uses_rolled_fragment_loops(H)
+    reference = _prepare_tensors(config) if use_cute_reference else None
+    snapshot = _input_snapshot(data, M, H)
+    executable = compile_kernel(get_kernel(**config))
+    _launch_tirx(executable, data, config)
+
+    if reference is not None:
+        api, flashinfer_norm = _flashinfer_api(variant, reference["input"].device)
+        original_cute = flashinfer_norm.fused_add_rmsnorm_cute
+        cute_calls = 0
+
+        def tracked_cute(*args, **kwargs):
+            nonlocal cute_calls
+            cute_calls += 1
+            return original_cute(*args, **kwargs)
+
+        flashinfer_norm.fused_add_rmsnorm_cute = tracked_cute
+        try:
+            returned = api(
+                reference["input"],
+                reference["residual"],
+                reference["weight"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+        finally:
+            flashinfer_norm.fused_add_rmsnorm_cute = original_cute
+        if returned is not None:
+            raise AssertionError("FlashInfer in-place fused add RMSNorm returned a value")
+        if cute_calls != 1:
+            raise AssertionError(f"expected one CuTe-DSL oracle dispatch, observed {cute_calls}")
+
+    torch.cuda.synchronize()
+    rows = snapshot["rows"]
+    actual_input = _checked_view(data["input"], rows)
+    actual_residual = _checked_view(data["residual"], rows)
+    oracle_input, oracle_residual = _math_oracle(snapshot, variant, eps)
+    if not torch.isfinite(actual_input).all() or not torch.isfinite(actual_residual).all():
+        raise AssertionError("TIRx fused add RMSNorm produced non-finite values")
+    if reference is not None:
+        reference_input = _checked_view(reference["input"], rows)
+        reference_residual = _checked_view(reference["residual"], rows)
+        _assert_close(actual_input, reference_input, name="FlashInfer input output")
+        _assert_close(actual_residual, reference_residual, name="FlashInfer residual output")
+    _assert_close(actual_input, oracle_input, name="FP32 input oracle")
+    _assert_close(actual_residual, oracle_residual, name="FP32 residual oracle")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError("TIRx modified weight")
+    _assert_guard(data["weight_backing"], H, name="TIRx weight")
+    _assert_padding(data, M, H, prefix="TIRx")
+    if reference is not None:
+        if not torch.equal(reference["weight"], snapshot["weight"]):
+            raise AssertionError("FlashInfer modified weight")
+        _assert_guard(reference["weight_backing"], H, name="FlashInfer weight")
+        _assert_padding(reference, M, H, prefix="FlashInfer")
+
+
+def prepare_bench(**config: Any):
+    """Compile the selected specialization before GPU assignment."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Construct and validate independent mutable timed closures."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    variant = str(config["variant"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    tirx_data = _prepare_tensors(config)
+    reference_data = _prepare_tensors(config)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        _launch_tirx(executable, tirx_data, config)
+
+    tirx_launch()
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        api, _ = _flashinfer_api(variant, reference_data["input"].device)
+
+        def flashinfer_launch():
+            return api(
+                reference_data["input"],
+                reference_data["residual"],
+                reference_data["weight"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+
+        returned = flashinfer_launch()
+        if returned is not None:
+            raise AssertionError("FlashInfer benchmark in-place API returned a value")
+        torch.cuda.synchronize()
+        _assert_close(tirx_data["input"], reference_data["input"], name="benchmark input precheck")
+        _assert_close(
+            tirx_data["residual"], reference_data["residual"], name="benchmark residual precheck"
+        )
+        return flashinfer_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark the TIRx specialization against FlashInfer CuTe-DSL."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer FusedAddRMSNormKernel and Gemma fused add RMSNorm to TIRx
- preserve compact and strided ABIs, PDL, asynchronous copies, multi-warp reduction, and cluster fallback paths
- record reusable register-cap and predication scheduling findings in the codegen tuning database
- add the six validated benchmark workloads to the baseline

## Validation

- correctness: 281/281 configurations passed
- staged pre-commit checks passed
- license checker and all 18 license self-tests passed
- strict benchmark reference import check passed
- final bench-suite confirmation: 6/6 workloads passed with FlashInfer CuTeDSL / TIRx ratios of 1.002375, 0.994993, 1.000495, 0.992688, 0.995476, and 1.001106

The final performance result uses bench-suite run 113 with five rounds and a one-second cooldown. All detected interference was rejected and retried before the accepted measurements.