### PR TITLE
feat(kernel): port FlashInfer fused add RMSNorm quant

### DIFF
--- a/.agents/sketch/flashinfer/norm/fused_add_rmsnorm_quant.md
+++ b/.agents/sketch/flashinfer/norm/fused_add_rmsnorm_quant.md
@@ -1,0 +1,659 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+FusedAddRMSNormQuantKernel. See LICENSE, NOTICE, and licenses/ for applicable
+terms.
+-->
+
+# FlashInfer fused add + RMSNorm + FP8 quantization SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the source-shaped
+execution of FlashInfer's CuTe-DSL `FusedAddRMSNormQuantKernel` for
+[`tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py`](../../../../tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py).
+The target becomes executable only after independent source/line-info-PTX
+review; after the first reviewer PASS this file is permanently frozen.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/norm/kernels/fused_add_rmsnorm.py`, SHA256
+  `f6f4a7d9c88996f26c33ed2661f82026e4ee3e747bf12c57febe9f9e68e61435`;
+- inherited launch/layout helpers in `flashinfer/norm/kernels/rmsnorm.py`,
+  SHA256 `b273fe5444aaf86a1600c196817b7a733b18f6f82030a16e1ef2731c784d48f0`;
+- reduction, reciprocal, and FP8 helpers in `flashinfer/norm/utils.py`, SHA256
+  `3f44ac6727c58883420068bf0aa5b239b12d2e86819ad80e54bc1bc016ec881a`;
+- public dispatch in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+The family covers FP16/BF16 input, residual, and weight; E4M3FN/E5M2
+caller-provided output; `weight_bias=0.0`; compact and three independently
+row-strided Int64 tensors; PDL off/on; synchronous and one-group paired
+`cp.async` traffic; sub-warp through cluster reduction; cluster sizes
+1/2/4/8/16; early in-place residual publication; and SM100 hardware FP8
+conversion. Gemma bias, non-quant fused add, plain RMSNormQuant, legacy CUDA,
+pre-SM89 software FP8 conversion, and every tile primitive are out of scope.
+
+## Source dispatch and resource formulae
+
+Cluster selection is inherited from `FusedAddRMSNormKernel` and therefore uses
+the two-tile estimate with the inherited thread count. Only after that choice
+does the quant kernel apply its `H_PER_CTA > 8192` 256-thread override. That
+order is load-bearing: H12288 remains async with two rows, while H16384 and
+clustered H32768 use two rows but become synchronous.
+
+```python
+ELEM_BYTES = 2
+OPTIN_SMEM_BYTES = 232448
+MAX_VEC = 8
+
+def threads_per_row(h):
+    if h <= 64: return 8
+    if h <= 128: return 16
+    if h <= 3072: return 32
+    if h <= 6144: return 64
+    if h <= 16384: return 128
+    return 256
+
+def fused_base(H, cluster_n):
+    h = H // cluster_n
+    tpr = threads_per_row(h)
+    threads = 128 if h <= 16384 else 256
+    rows = threads // tpr
+    warps = max(tpr // 32, 1)
+    vec = min(h & -h, MAX_VEC)
+    blocks = max(1, ceil_div(h // vec, tpr))
+    cols = vec * blocks * tpr
+    estimate = 2 * rows * cols * ELEM_BYTES \
+             + rows * warps * cluster_n * 4 \
+             + (8 if cluster_n > 1 else 0)
+    return estimate
+
+def choose_cluster(H):
+    best_fit = 1
+    for c in (1, 2, 4, 8, 16):
+        if H % c: continue
+        required = fused_base(H, c)
+        if required <= OPTIN_SMEM_BYTES // 2: return c
+        if required <= OPTIN_SMEM_BYTES and best_fit == 1: best_fit = c
+    return best_fit
+
+def source_config(H):
+    cluster_n = choose_cluster(H)
+    h = H // cluster_n
+    tpr = threads_per_row(h)
+    threads = 128 if h <= 16384 else 256
+    if h > 8192 and threads < 256: threads = 256
+    rows = threads // tpr
+    warps = max(tpr // 32, 1)
+    vec = min(h & -h, MAX_VEC)
+    copy_bits = 16 * vec
+    blocks = max(1, ceil_div(h // vec, tpr))
+    cols = vec * blocks * tpr
+    two_tile_bytes = 2 * rows * cols * ELEM_BYTES
+    use_async = copy_bits >= 32 and two_tile_bytes <= OPTIN_SMEM_BYTES // 2
+    reduce_bytes = rows * warps * cluster_n * 4
+    smem_bytes = (two_tile_bytes if use_async else 0) + reduce_bytes \
+                 + (8 if cluster_n > 1 else 0)
+    rolled = vec * blocks > 512
+    return cluster_n, h, tpr, threads, rows, warps, vec, blocks, cols, \
+           use_async, smem_bytes, rolled
+```
+
+The host selects compact only when Y, X, and residual are all contiguous and
+`M*H <= 2**31-1`. Otherwise the runtime ABI appends independent
+`y_row_stride`, `x_row_stride`, and `residual_row_stride` Int64 element
+strides, each divisible by VEC. Weight stays compact and scale is a compact
+device FP32 tensor of shape one. Every tensor has unit inner stride. Compact Y
+has assumed alignment `gcd(128,H*1)` bytes, compact X/residual have assumed
+alignment `gcd(128,H*2)` bytes, strided Y/X/residual each have assumed
+alignment 16 bytes, weight has assumed alignment 16 bytes, and scale has
+assumed alignment 4 bytes.
+
+`TOTAL_VALUES=VEC*VEC_BLOCKS` is source-constexpr. TIRx uses static unrolling
+through 512 values and a serial `unroll=False` loop above 512. This changes
+only physical expansion, not ownership, source order, association, predicates,
+or instruction family. H131070 and H131073 freeze the 512/513 boundary;
+H1048576 is the rolled cluster-1 synchronous fallback guard.
+
+## Pipeline at a glance
+
+| lanes / CTA role | source-owned work | publication or reuse edge |
+| --- | --- | --- |
+| every thread at entry | optional PDL wait, load `scale[0]`, form FTZ approximate reciprocal | `inv_scale` remains live through FP8 stores |
+| each contiguous TPR-thread group | one logical row and one cluster H partition; each thread owns VEC adjacent columns per vector block | X, residual, W, and FP32 h remain thread-private |
+| every thread before reduction | load X/R, widen, packed-add to h, narrow/store h to residual, square h | early residual store is source-ordered before reduction |
+| each row sub-warp/full warp | ordered local sum then width-8/16/32 butterfly stages | row-warp partial is replicated |
+| lane 0 of each row warp, cluster-1 multi-warp path | publish one partial in shared memory | CTA barrier before final shared loads |
+| lanes `<CLUSTER_N` of each warp, cluster path | remotely publish the warp partial to every peer CTA | two `mapa`, complete-tx store, and peer mbarrier |
+| every row warp after publication | redundantly load and reduce all row partials | replicated sum feeds divide/add/rsqrt |
+| all threads after reduction | cluster arrive/wait or CTA barrier, retain FP32 h and W | unlike RMSNormQuant, there is no post-reduction X reload |
+| each row thread in epilogue | materialize h*rstd, W+0, their product, inverse-scale product, then packed/scalar FP8 stores | output fragment dies after its owned stores |
+
+There is exactly one async group: all X issues precede all residual issues,
+then one commit; W loads occur before one wait; shared X loads precede shared
+residual loads. PDL wait precedes scale and dependency-sensitive global
+traffic; PDL signal follows residual and output stores. Disabled PDL profiles
+contain neither instruction nor launch attribute.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)
+launch(...)
+raw_shared(...)
+view(...)
+reg_tile(...)
+address(...)
+pair_view(...)
+scalar_pair(...)
+```
+
+Key data, arithmetic, conversion, and synchronization operations remain
+primitive:
+
+```python
+copy_g2r(src, dst, bits, predicate=None)
+copy_g2s_async_ca(src, dst, bits, source_bytes)
+copy_s2r(src, dst, bits)
+copy_r2s(src, dst)
+copy_r2g(src, dst, bits, predicate=None)
+fill(dst, value)
+cast(dtype, src, rounding=None)
+add(lhs, rhs, lanes=1)
+mul(lhs, rhs, lanes=1)
+fma(lhs, rhs, acc)
+div(lhs, rhs)
+maximum(lhs, rhs)
+minimum(lhs, rhs)
+rcp_fast(src)
+rsqrt_fast(src)
+shuffle_xor(src, delta, width)
+convert_fp8_pair(lo, hi, dtype)
+pack_two_b16(lo, hi)
+cp_async_commit()
+cp_async_wait(group)
+cta_barrier()
+cluster_arrive_relaxed()
+cluster_wait()
+mbarrier_init(ptr, arrivals)
+mbarrier_init_fence()
+mbarrier_arrive_expect_tx(ptr, bytes)
+map_shared_to_peer(ptr, peer)
+remote_store_complete_tx(value, dst, mbarrier)
+mbarrier_try_wait_parity(ptr, phase, timeout)
+pdl_wait()
+pdl_signal()
+```
+
+Reviewed source PTX fixes vector traffic and output width:
+
+| VEC | X/R/W global and residual store | shared X/R | FP8 output |
+| ---: | --- | --- | --- |
+| 1 | scalar `ld/st.global.b16` | sync only | clamp + pair-convert + `st.global.b8` |
+| 2 | `ld/st.global.v2.b16` | `ld.shared.v2.b16` | pair-convert + `st.global.b16`; scalar tail fallback |
+| 4 | `ld/st.global.v2.b32` | `ld.shared.v4.b16` | two pair-converts + pack + `st.global.b32`; scalar tail fallback |
+| 8 | `ld/st.global.v4.b32` | `ld.shared.v4.b32` | four pair-converts + two packs + `st.global.v2.b32`; scalar tail fallback |
+
+Every async copy is `cp.async.ca.shared.global` with immediate size
+`COPY_BITS/8` and the source-size operand used for column-tail zero fill.
+`add(...,lanes=2)` and `mul(...,lanes=2)` are native packed FP32 operations.
+There is no compound fused-add, RMSNorm, reduction, quantization, tile-copy, or
+tile-compute primitive.
+
+## Complete sketch
+
+```python
+@specialize(
+    INPUT_DTYPE=("f16", "bf16"),
+    OUTPUT_DTYPE=("e4m3fn", "e5m2"),
+    H="positive compile-time integer",
+    LAYOUT=("compact", "strided_i64"),
+    ENABLE_PDL=(False, True),
+    WEIGHT_BIAS=0.0,
+    USE_HW_FP8=True,
+    TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M, ROWS), CLUSTER_N, 1),
+    block=(THREADS, 1, 1),
+    cluster=((1, CLUSTER_N, 1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_fused_add_rmsnorm_quant(
+    out_storage,                 # mutable OUTPUT_DTYPE, inner stride 1;
+                                 # compact align=gcd(128,H), strided align=16
+    input_storage,               # read-only INPUT_DTYPE, inner stride 1;
+                                 # compact align=gcd(128,2*H), strided align=16
+    residual_storage,            # mutable INPUT_DTYPE, same stride/alignment as X
+    weight,                      # compact INPUT_DTYPE [H], stride 1, align=16
+    runtime_M: i64,
+    scale,                       # compact f32 [1], stride 1, align=4
+    runtime_eps: f32,
+    y_row_stride: i64 = H,       # appended only for strided_i64
+    x_row_stride: i64 = H,
+    residual_row_stride: i64 = H,
+):
+    tid = thread_id_x(THREADS)
+    block_x = block_id_x()
+    block_y = block_id_y() if CLUSTER_N > 1 else 0
+    cta_rank = cta_rank_in_cluster() if CLUSTER_N > 1 else 0
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one static site,
+        # executed by every CTA thread
+
+    scale_value = copy_g2r(scale[0], bits=32)
+    # instruction_selection: ld.global.b32; extent: one scalar per thread
+    inv_scale = rcp_fast(scale_value)
+    # instruction_selection: rcp.approx.ftz.f32; extent: one scalar per thread
+
+    row_in_cta = tid // TPR
+    thread_in_row = tid % TPR
+    actual_row = cast_i64(block_x) * cast_i64(ROWS) + cast_i64(row_in_cta)
+    compact_row_i32 = block_x * ROWS + row_in_cta if COMPACT else 0
+    # compact_row_i32 exists only under the host M*H<=INT32_MAX proof.
+    row_valid = actual_row < runtime_M
+    warp = tid // 32
+    lane = tid % 32
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+
+    smem = raw_shared("u8", SMEM_BYTES, alignment=16)
+    cursor = 0
+    if USE_ASYNC:
+        sX = view(smem, INPUT_DTYPE, (ROWS,COLS), byte_offset=cursor,
+                  row_major=True, alignment=16)
+        cursor += ROWS * COLS * 2
+        sR = view(smem, INPUT_DTYPE, (ROWS,COLS), byte_offset=cursor,
+                  row_major=True, alignment=16)
+        cursor += ROWS * COLS * 2
+    if CLUSTER_N == 1:
+        reduction = view(smem, "f32", (ROWS,WARPS_PER_ROW),
+                         stride=(1,ROWS), byte_offset=cursor, alignment=4)
+    else:
+        reduction = view(smem, "f32", (ROWS,(WARPS_PER_ROW,CLUSTER_N)),
+                         stride=(1,(ROWS,ROWS*WARPS_PER_ROW)),
+                         byte_offset=cursor, alignment=4)
+        cursor += ROWS * WARPS_PER_ROW * CLUSTER_N * 4
+        mbar = view(smem, "mbarrier", (1,), byte_offset=cursor, alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar, arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; extent: one per CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; extent: one per CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+
+    x_frag = reg_tile(INPUT_DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    r_frag = reg_tile(INPUT_DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    w_frag = reg_tile(INPUT_DTYPE, (VEC,VEC_BLOCKS), stride=(1,VEC))
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    PAIRS = ceil_div(TOTAL_VALUES, 2)
+    FRAGMENT_RANGE = serial_range(unroll=False) if TOTAL_VALUES > 512 else static_range
+
+    if not USE_ASYNC:
+        for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+            fill(x_frag.flat[flat], zero(INPUT_DTYPE))
+            fill(r_frag.flat[flat], zero(INPUT_DTYPE))
+            # instruction_selection: mov.b16 zero materialization; extent: two values
+
+    # All X issues precede all residual issues.
+    for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        x_offset = (compact_row_i32 * H + absolute_col) if COMPACT else \
+                   (actual_row * x_row_stride + cast_i64(absolute_col))
+        if USE_ASYNC:
+            if row_valid:
+                copy_g2s_async_ca(address(input_storage,x_offset),
+                                  sX[row_in_cta,local_col:local_col+VEC],
+                                  COPY_BITS, (COPY_BITS//8) if col_valid else 0)
+                # instruction_selection: cp.async.ca.shared.global; extent:
+                # one row-gated issue per vb with runtime source size
+        elif row_valid and col_valid:
+            copy_g2r(address(input_storage,x_offset), x_frag[:,vb], COPY_BITS)
+            # instruction_selection: global load from VEC table; extent: one vector
+
+    for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        col_valid = absolute_col < H
+        r_offset = (compact_row_i32 * H + absolute_col) if COMPACT else \
+                   (actual_row * residual_row_stride + cast_i64(absolute_col))
+        if USE_ASYNC:
+            if row_valid:
+                copy_g2s_async_ca(address(residual_storage,r_offset),
+                                  sR[row_in_cta,local_col:local_col+VEC],
+                                  COPY_BITS, (COPY_BITS//8) if col_valid else 0)
+                # instruction_selection: cp.async.ca.shared.global; extent:
+                # one row-gated issue per vb after every X issue
+        elif row_valid and col_valid:
+            copy_g2r(address(residual_storage,r_offset), r_frag[:,vb], COPY_BITS)
+            # instruction_selection: global load from VEC table; extent: one vector
+
+    if USE_ASYNC:
+        cp_async_commit()
+        # instruction_selection: cp.async.commit_group; extent: one per thread
+
+    for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        if absolute_col < H:
+            copy_g2r(weight[absolute_col:absolute_col+VEC], w_frag[:,vb], COPY_BITS)
+            # instruction_selection: global load from VEC table; extent: one vector
+
+    if USE_ASYNC:
+        cp_async_wait(0)
+        # instruction_selection: cp.async.wait_group 0; extent: one per thread
+        for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sX[row_in_cta,local_col:local_col+VEC], x_frag[:,vb], COPY_BITS)
+            # instruction_selection: shared load from VEC table; extent: one vector
+        for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+            local_col = (thread_in_row + vb * TPR) * VEC
+            copy_s2r(sR[row_in_cta,local_col:local_col+VEC], r_frag[:,vb], COPY_BITS)
+            # instruction_selection: shared load from VEC table; extent: one vector
+
+    x_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    r_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+        x_f32[flat] = cast("f32", x_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one X value
+    for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+        r_f32[flat] = cast("f32", r_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one residual value
+
+    h = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in FRAGMENT_RANGE(PAIRS):
+        h.store_pair(pair, add(pair_view(x_f32,pair), pair_view(r_f32,pair), lanes=2))
+        # instruction_selection: add.f32x2; extent: PAIRS packed issues
+
+    h_narrow = reg_tile(INPUT_DTYPE, (TOTAL_VALUES,))
+    if VEC == 1 or (VEC == 2 and VEC_BLOCKS == 3):
+        for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+            h_narrow[flat] = cast(INPUT_DTYPE, h[flat], rounding="rn")
+            # instruction_selection: cvt.rn.{f16,bf16}.f32; extent: one scalar
+    else:
+        for pair in FRAGMENT_RANGE(PAIRS):
+            h_narrow.store_pair(pair, cast(INPUT_DTYPE+"x2", pair_view(h,pair), rounding="rn"))
+            # instruction_selection: cvt.rn.{f16,bf16}x2.f32; extent: one pair
+    for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        r_offset = (compact_row_i32 * H + absolute_col) if COMPACT else \
+                   (actual_row * residual_row_stride + cast_i64(absolute_col))
+        if row_valid and absolute_col < H:
+            copy_r2g(h_narrow.slice(vb,VEC), address(residual_storage,r_offset), COPY_BITS)
+            # instruction_selection: global store from VEC table; extent: one vector
+
+    h_sq = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in FRAGMENT_RANGE(PAIRS):
+        h_sq.store_pair(pair, mul(pair_view(h,pair), pair_view(h,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: PAIRS packed issues
+    local_sum = 0.0
+    for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+        local_sum = add(local_sum, h_sq[flat])
+        # instruction_selection: add.f32; extent: ordered TOTAL_VALUES chain
+
+    for delta in powers_of_two_below(min(TPR,32)):
+        peer = shuffle_xor(local_sum, delta, width=32)
+        # instruction_selection: shfl.sync.bfly.b32; extent: one subgroup stage
+        local_sum = add(local_sum, peer)
+        # instruction_selection: add.f32; extent: one subgroup stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            copy_r2s(warp_sum, reduction[row_warp,warp_in_row])
+            # instruction_selection: st.shared.b32; extent: one per row warp
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: one publication edge
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = copy_s2r(reduction[row_warp,lane])
+            # instruction_selection: ld.shared.b32; extent: one participating lane
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one full-warp stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one full-warp stage
+        sum_sq = final
+    elif CLUSTER_N > 1:
+        if warp == 0 and elect_one():
+            # instruction_selection: elect.sync; extent: one election in warp 0
+            mbarrier_arrive_expect_tx(mbar, ROWS*WARPS_PER_ROW*CLUSTER_N*4)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+            # extent: one elected issue per CTA
+        if lane < CLUSTER_N:
+            peer_reduce = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cta_rank)], lane)
+            peer_mbar = map_shared_to_peer(mbar, lane)
+            # instruction_selection: mapa.shared::cluster.u32; extent: two mappings
+            remote_store_complete_tx(warp_sum, peer_reduce, peer_mbar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # extent: one partial to every peer CTA
+        done = False
+        while not done:
+            done = mbarrier_try_wait_parity(mbar, phase=0, timeout=10000000)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 plus
+            # uniform retry branch; extent: one wait loop per CTA thread
+        final = 0.0
+        for i in static_range(ceil_div(WARPS_PER_ROW*CLUSTER_N,32)):
+            partial = lane + i*32
+            if partial < WARPS_PER_ROW*CLUSTER_N:
+                value = copy_s2r(reduction[row_warp,partial])
+                # instruction_selection: ld.shared.b32; extent: one owned partial
+                final = add(final, value)
+                # instruction_selection: add.f32; extent: one loaded partial
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final, delta, width=32)
+            # instruction_selection: shfl.sync.bfly.b32; extent: one full-warp stage
+            final = add(final, peer)
+            # instruction_selection: add.f32; extent: one full-warp stage
+        sum_sq = final
+    else:
+        sum_sq = warp_sum
+
+    if is_power_of_two(H):
+        shifted = fma(sum_sq, exact_float32_reciprocal(H), runtime_eps)
+        # instruction_selection: fma.rn.f32; extent: one scalar per thread
+    else:
+        mean_sq = div(sum_sq, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+        shifted = add(mean_sq, runtime_eps)
+        # instruction_selection: add.f32; extent: one scalar per thread
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar per thread
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; extent: one per CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; extent: one per CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: one post-reduction edge
+
+    w_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    for flat in FRAGMENT_RANGE(TOTAL_VALUES):
+        w_f32[flat] = cast("f32", w_frag.flat[flat])
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one W value
+
+    normalized = reg_tile("f32", (TOTAL_VALUES,))
+    biased_w = reg_tile("f32", (TOTAL_VALUES,))
+    weighted = reg_tile("f32", (TOTAL_VALUES,))
+    y_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    for pair in FRAGMENT_RANGE(PAIRS):
+        normalized.store_pair(pair, mul(pair_view(h,pair), scalar_pair(rstd,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: complete normalized phase
+    for pair in FRAGMENT_RANGE(PAIRS):
+        biased_w.store_pair(pair, add(pair_view(w_f32,pair), scalar_pair(0.0,pair), lanes=2))
+        # instruction_selection: add.f32x2; extent: complete W-bias phase
+    for pair in FRAGMENT_RANGE(PAIRS):
+        weighted.store_pair(pair, mul(pair_view(normalized,pair), pair_view(biased_w,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: complete weighted phase
+    for pair in FRAGMENT_RANGE(PAIRS):
+        y_f32.store_pair(pair, mul(pair_view(weighted,pair), scalar_pair(inv_scale,pair), lanes=2))
+        # instruction_selection: mul.f32x2; extent: complete inverse-scale phase
+
+    FP8_MAX = 448.0 if OUTPUT_DTYPE == "e4m3fn" else 57344.0
+    for vb in FRAGMENT_RANGE(VEC_BLOCKS):
+        local_col = (thread_in_row + vb * TPR) * VEC
+        absolute_col = block_y * COLS + local_col
+        y_offset = (actual_row * H + absolute_col) if COMPACT else \
+                   (actual_row * y_row_stride + cast_i64(absolute_col))
+        if VEC == 8 and absolute_col + 8 <= H and actual_row < runtime_M:
+            p01 = convert_fp8_pair(y_f32[vb*8+0], y_f32[vb*8+1], OUTPUT_DTYPE)
+            p23 = convert_fp8_pair(y_f32[vb*8+2], y_f32[vb*8+3], OUTPUT_DTYPE)
+            p45 = convert_fp8_pair(y_f32[vb*8+4], y_f32[vb*8+5], OUTPUT_DTYPE)
+            p67 = convert_fp8_pair(y_f32[vb*8+6], y_f32[vb*8+7], OUTPUT_DTYPE)
+            # instruction_selection: four
+            # cvt.rn.satfinite.{e4m3,e5m2}x2.f32; extent: one vec8
+            lo = pack_two_b16(p01,p23)
+            hi = pack_two_b16(p45,p67)
+            # instruction_selection: mov.b32 {b16,b16}; extent: two words
+            copy_r2g((lo,hi), address(out_storage,y_offset), bits=64)
+            # instruction_selection: st.global.v2.b32; extent: one vec8 store
+        elif VEC == 4 and absolute_col + 4 <= H and actual_row < runtime_M:
+            p01 = convert_fp8_pair(y_f32[vb*4+0], y_f32[vb*4+1], OUTPUT_DTYPE)
+            p23 = convert_fp8_pair(y_f32[vb*4+2], y_f32[vb*4+3], OUTPUT_DTYPE)
+            # instruction_selection: two pair converts; extent: one vec4
+            packed = pack_two_b16(p01,p23)
+            # instruction_selection: mov.b32 {b16,b16}; extent: one word
+            copy_r2g(packed, address(out_storage,y_offset), bits=32)
+            # instruction_selection: st.global.b32; extent: one vec4 store
+        elif VEC == 2 and absolute_col + 2 <= H and actual_row < runtime_M:
+            pair = convert_fp8_pair(y_f32[vb*2+0], y_f32[vb*2+1], OUTPUT_DTYPE)
+            # instruction_selection: one pair convert; extent: one vec2
+            copy_r2g(pair, address(out_storage,y_offset), bits=16)
+            # instruction_selection: st.global.b16; extent: one vec2 store
+        else:
+            for e in static_range(VEC):
+                scalar_col = absolute_col + e
+                if scalar_col < H and actual_row < runtime_M:
+                    low = maximum(y_f32[vb*VEC+e], -FP8_MAX)
+                    # instruction_selection: setp.le.f32 + selp.f32; extent: one scalar
+                    clamped = minimum(low, FP8_MAX)
+                    # instruction_selection: setp.ge.f32 + selp.f32; extent: one scalar
+                    pair = convert_fp8_pair(clamped, 0.0, OUTPUT_DTYPE)
+                    # instruction_selection:
+                    # cvt.rn.satfinite.{e4m3,e5m2}x2.f32 with zero high operand;
+                    # extent: one scalar tail value
+                    scalar_offset = (actual_row*H + scalar_col) if COMPACT else \
+                                    (actual_row*y_row_stride + cast_i64(scalar_col))
+                    copy_r2g(pair.low_byte, address(out_storage,scalar_offset), bits=8)
+                    # instruction_selection: st.global.b8; extent: one valid scalar
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; extent: one
+        # static site, executed by every CTA thread
+```
+
+## Export reconciliation and reviewed profiles
+
+- Dynamic shared storage is one raw allocation. H4096 BF16 uses 32784 bytes:
+  sX at 0, sR at 16384, then four FP32 row/warp partials. Its PTX has 16
+  async issues (eight X then eight residual), one commit, eight W vector loads,
+  one wait, 16 shared vector loads, eight residual vectors, and eight FP8 vec8
+  stores.
+- H64 selects VEC8; H66 selects VEC2 with three vector blocks and a source-size
+  tail; H111 selects VEC1 synchronous scalar traffic and scalar FP8 stores;
+  strided H500 selects VEC4 and independent Int64 X/R/Y row products.
+- The quant override makes H12288 two-row async but H16384 two-row sync.
+  H32768/65536/131072/262144 choose cluster 2/4/8/16 and sync after the same
+  override. H524288 remains cluster16 sync; H1048576 falls back to cluster1
+  sync.
+- Cluster PTX contains mbarrier init/fence, two cluster arrive/wait pairs, two
+  `mapa.shared::cluster`, one remote complete-tx store site, and the uniform
+  parity-wait loop. Because `blockIdx.y` is runtime, clustered vec8 PTX retains
+  both packed and scalar-tail output arms even though legal launch coordinates
+  own complete partitions.
+- H131070 has exactly 512 physical values; H131073 has 513 and the source PTX
+  expands all 513. TIRx deliberately rolls the latter and every larger
+  fragment without changing the ordered loop body.
+- PDL-enabled profiles contain exactly one wait and one signal. E4M3 and E5M2
+  exports use their corresponding hardware pair conversion with PTX high/low
+  operands reversed relative to logical `(lo,hi)` helper arguments.
+
+## Addressing, predicates, mutation, and tails
+
+- Runtime ABI order is `(out,input,residual,weight,M:i64,scale:f32[1],eps)`;
+  the strided specialization appends Y/X/residual Int64 row strides. Only out
+  and residual mutate. Input, weight, and scale are read-only.
+- Compact X/R offsets may narrow under the host `M*H<=INT32_MAX` proof.
+  Output begins from explicit `actual_row:Int64`; every strided row product and
+  pointer addition remains Int64 and independent.
+- One column predicate tests each input vector's first coordinate. Async false
+  columns issue zero source bytes; synchronous false columns skip the load.
+  Row validity gates X/R traffic and residual stores but not W, reduction, or
+  synchronization.
+- Residual observes `cast_INPUT_DTYPE(fp32(input)+fp32(residual))` before the
+  reduction. RMSNorm and quantization consume the original FP32 h, never the
+  narrowed residual value.
+- FP8 full vectors rely on `satfinite`; every failed vec8/4/2 guard enters the
+  scalar loop with explicit finite-range max/min clamp and independent row and
+  column guards.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime / reuse rule |
+| --- | --- | --- |
+| compact Y / X / residual | global, unit inner stride | assumed alignment `gcd(128,H) / gcd(128,2H) / gcd(128,2H)` bytes |
+| strided Y / X / residual | global, unit inner stride | independent Int64 row strides divisible by VEC; assumed alignment 16 bytes |
+| weight / scale | global, compact, unit stride | assumed alignment 16 / 4 bytes |
+| scale / `inv_scale` | every thread loads the same element | after PDL wait through FP8 output |
+| `sX`, `sR` | one row-thread vector owner | async issue through one shared reload; dead after h |
+| reduction buffer | row warps; cluster copies remotely publish | warp partial publication through final reduction |
+| cluster mbarrier | thread 0 initializes; elected warp-0 lane expects bytes | init through remote completion wait |
+| X/R fragments | one thread | copy through widening/add |
+| FP32 h | one thread | add through residual store, reduction barrier, and quant epilogue |
+| W fragment | one thread | W load before async wait through biased-W phase |
+| residual output fragment | one thread | h narrowing through early residual store |
+| normalized / biased-W / weighted | one thread | four source-ordered complete epilogue phases |
+| final y FP32 fragment | one thread | inverse-scale phase through FP8 stores |
+| FP8 pairs / packed words | one thread | one vector block's conversion through store |
+
+## Module and verification contract
+
+- Registry name is `flashinfer_fused_add_rmsnorm_quant`, category
+  `flashinfer`, compute capability 10; `get_kernel` is the registered factory.
+- `CONFIGS` contains exactly 1556 unique configurations. The three
+  `BENCH_CONFIGS` are exactly FlashInfer's current BF16→E4M3 source benchmark
+  rows: M32/H4096/PDL0, M64/H8192/PDL0, and M32/H4096/PDL1.
+- Correctness calls the direct public CuTe-DSL path, compares raw FP8 bytes and
+  an independent FP32 quant oracle, compares residual at `rtol=atol=1e-3`,
+  checks finite values, object/stride identity, independent padding and guard
+  regions, Int64 overflow paths, and input/weight/scale immutability.
+- Every specialization undergoes low-level rejection of `TilePrimitiveCall`,
+  `tirx.tile.*`, tile imports/primitives, `T.cuda.func_call`, and
+  `cuda_func_call`.
+- Final performance authority is only `python -m tirx_kernels.bench_suite`.
+  Every one of the three exact `flashinfer_cutedsl_time/tirx_time` ratios must
+  be strictly greater than 0.99 in one complete valid reference-enabled run.
+
+## Instruction selection is a lowering consequence
+
+The port preserves source cluster choice, quant thread override, TV fragment
+order, X-before-residual async issue order, early residual publication,
+ordered FP32 reduction, cluster transaction protocol, live h lifetime, four
+FP32 output phases, FP8 operand order/store width, independent Int64 strides,
+and PDL boundaries. Plain TIRx and typed local PTX may express reviewed
+instructions. They may not use tile or CUDA function-call primitives,
+scalarize a reviewed packed path, reload narrowed residual, reassociate scale
+or weight multiplication, replace FTZ reciprocal/rsqrt, couple strides, move a
+store across the reduction edge, or unroll fragments above the frozen 512-value
+lowering boundary.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
 | `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
+| `flashinfer_fused_add_rmsnorm_quant`    | `norm/fused_add_rmsnorm_quant.py`                   | Fused residual add, RMSNorm, and FP8 quantization with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_qk_rmsnorm`                 | `norm/qk_rmsnorm.py`                                | Shared 3-D QK RMSNorm / Gemma RMSNorm family with arbitrary int64 batch/head strides, PDL, and sync/async copy paths |
 | `selective_state_update_stp_simple`     | `mamba/selective_state_update_stp_simple.py`        | Single-token, `algorithm="simple"` |
 | `selective_state_update_stp_vertical`   | `mamba/selective_state_update_stp_vertical.py`      | Single-token, `algorithm="vertical"` |

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -10,7 +10,7 @@ tree, so a kernel's configs sit at `config/<bucket>/<kernel>.yaml`. With no
 `--workloads`, the flagged configs across all files are assembled into
 `.bench-suite/workloads.generated.yaml` and that is what runs. The generated
 file is the inspectable source of truth for the current representative sweep.
-Every kernel has at most three default small/medium/large representatives; the current tree assembles 133
+Every kernel has at most three default small/medium/large representatives; the current tree assembles 170
 workloads. Widening or narrowing the sweep is a YAML `default`
 flag flip, not a scheduler rule or a second selection file. Multi-GPU configs
 are deliberately absent from the default measured sweep but remain available

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "3df3e86a",
-    "tirx-kernels": "aedd23c2-dirty",
+    "tirx-kernels": "82f32d84-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "30afc5a73ef806d71abc8c58ede9c2af4350a361"
+    "tirx-kernels:tirx_kernels": "43ec928346b60f6b422188dc117c6202da2cb32b"
   },
   "baselines": {
     "torch": {
@@ -2166,6 +2166,48 @@
       "impls": {
         "tirx": 3.8722115224442737,
         "flashinfer_cutedsl": 3.8764929662039616
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm_quant",
+      "config": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1",
+      "label": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.366179520133326,
+        "flashinfer_cutedsl": 3.4006142445911527
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm_quant",
+      "config": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1",
+      "label": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.7141793588824346,
+        "flashinfer_cutedsl": 3.7284191995608156
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_add_rmsnorm_quant",
+      "config": "bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1",
+      "label": "bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.8162779479448434,
+        "flashinfer_cutedsl": 3.898806482512027
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '3df3e86a', 'tirx-kernels': 'aedd23c2-dirty', 'tirx-bench-ci': None}`
-- Workloads: 403 ok, 0 failed
+- Git:       `{'tir': '3df3e86a', 'tirx-kernels': '82f32d84-dirty', 'tirx-bench-ci': None}`
+- Workloads: 406 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -250,6 +250,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `gemma_bf16_m32_h4096_xc_rc_pdl0` | tirx | 3.5710 | flashinfer_cutedsl | 3.5449 | 0.993 | — |
 | `gemma_bf16_m32_h4096_xc_rc_pdl1` | tirx | 3.7241 | flashinfer_cutedsl | 3.7073 | 0.995 | — |
 | `gemma_bf16_m64_h8192_xc_rc_pdl0` | tirx | 3.8722 | flashinfer_cutedsl | 3.8765 | 1.001 | — |
+
+## flashinfer_fused_add_rmsnorm_quant
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1` | tirx | 3.3662 | flashinfer_cutedsl | 3.4006 | 1.010 | — |
+| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1` | tirx | 3.7142 | flashinfer_cutedsl | 3.7284 | 1.004 | — |
+| `bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1` | tirx | 3.8163 | flashinfer_cutedsl | 3.8988 | 1.022 | — |
 
 ## flashinfer_qk_rmsnorm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_fused_add_rmsnorm_quant.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_fused_add_rmsnorm_quant.yaml
@@ -1,0 +1,5 @@
+kernel: flashinfer_fused_add_rmsnorm_quant
+configs:
+  - {config: bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1, default: true}
+  - {config: bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1, default: true}
+  - {config: bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1, default: true}

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
@@ -1,0 +1,1540 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL fused add RMSNorm with FP8 quantization.
+
+The source implementation is ``FusedAddRMSNormQuantKernel`` in
+``flashinfer/norm/kernels/fused_add_rmsnorm.py`` together with RMSNorm and FP8
+helpers from ``flashinfer/norm/kernels/rmsnorm.py`` and
+``flashinfer/norm/utils.py``.  The public dispatch is
+``flashinfer.norm.fused_add_rmsnorm_quant``.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+from .fused_add_rmsnorm import _source_config as _fused_source_config
+from .rmsnorm import (
+    _add_f32,
+    _butterfly_sum_f32,
+    _ceil_div,
+    _cluster_mbarrier_wait,
+    _cvt_from_f32,
+    _cvt_pair_from_f32,
+    _cvt_to_f32,
+    _div_rn_f32,
+    _fma_rn_f32,
+    _load_global_bits,
+    _load_shared_bits,
+    _mapa_u32,
+    _rsqrt_approx_ftz,
+    _store_global_fragment,
+    _threads_per_row,
+)
+from .rmsnorm_quant import (
+    _cvt_fp8_pair,
+    _maximum_f32,
+    _minimum_f32,
+    _pack_b16_pair,
+    _rcp_approx_ftz,
+)
+
+KERNEL_META = {
+    "name": "flashinfer_fused_add_rmsnorm_quant",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_INPUT_DTYPES = ("float16", "bfloat16")
+_OUTPUT_DTYPES = ("float8_e4m3fn", "float8_e5m2")
+_LAYOUTS = ("compact", "strided")
+_SCALES = (0.01, 1.0, 10.0)
+_DEFAULT_EPS = 1e-6
+_INT32_MAX = 2**31 - 1
+_OPTIN_SMEM_BYTES = 232448
+_INPUT_ELEM_BYTES = 2
+
+
+def _derived_config(H: int, cluster_n: int) -> dict[str, int | bool]:
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    if H_per_cta > 8192 and threads < 256:
+        threads = 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec = min(H_per_cta & -H_per_cta, 8)
+    copy_bits = 16 * vec
+    vec_blocks = max(1, _ceil_div(H_per_cta // vec, tpr))
+    cols = vec * vec_blocks * tpr
+    tile_bytes = rows * cols * _INPUT_ELEM_BYTES
+    two_tile_bytes = 2 * tile_bytes
+    use_async = copy_bits >= 32 and two_tile_bytes <= _OPTIN_SMEM_BYTES // 2
+    reduce_bytes = rows * warps_per_row * cluster_n * 4
+    smem_bytes = (two_tile_bytes if use_async else 0) + reduce_bytes
+    if cluster_n > 1:
+        smem_bytes += 8
+    return {
+        "cluster_n": cluster_n,
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec": vec,
+        "copy_bits": copy_bits,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+        "two_tile_bytes": two_tile_bytes,
+        "use_async": use_async,
+        "smem_bytes": smem_bytes,
+    }
+
+
+def _source_config(H: int) -> dict[str, int | bool]:
+    cluster_n = int(_fused_source_config(H)["cluster_n"])
+    return _derived_config(H, cluster_n)
+
+
+def _uses_rolled_fragment_loops(H: int) -> bool:
+    source = _source_config(H)
+    return int(source["vec"]) * int(source["vec_blocks"]) > 512
+
+
+def _short_dtype(dtype: str) -> str:
+    return {"float16": "fp16", "bfloat16": "bf16", "float8_e4m3fn": "e4m3", "float8_e5m2": "e5m2"}[
+        dtype
+    ]
+
+
+def _layout_code(layout: str) -> str:
+    return "c" if layout == "compact" else "s"
+
+
+def _scale_code(scale: float) -> str:
+    return f"{scale:g}".replace(".", "p")
+
+
+def _cfg(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    residual_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    scale: float,
+    *,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    residual_row_stride: int | None = None,
+    y_row_stride: int | None = None,
+    suffix: str | None = None,
+) -> dict[str, Any]:
+    label = (
+        f"{_short_dtype(input_dtype)}_{_short_dtype(output_dtype)}_m{M}_h{H}_"
+        f"x{_layout_code(input_layout)}_r{_layout_code(residual_layout)}_"
+        f"y{_layout_code(output_layout)}_pdl{int(enable_pdl)}_s{_scale_code(scale)}"
+    )
+    if suffix:
+        label += f"_{suffix}"
+    config: dict[str, Any] = {
+        "label": label,
+        "input_dtype": input_dtype,
+        "output_dtype": output_dtype,
+        "M": M,
+        "H": H,
+        "input_layout": input_layout,
+        "residual_layout": residual_layout,
+        "output_layout": output_layout,
+        "enable_pdl": enable_pdl,
+        "scale": scale,
+        "eps": eps,
+    }
+    if x_row_stride is not None:
+        config["x_row_stride"] = x_row_stride
+    if residual_row_stride is not None:
+        config["residual_row_stride"] = residual_row_stride
+    if y_row_stride is not None:
+        config["y_row_stride"] = y_row_stride
+    return config
+
+
+_UPSTREAM_CONFIGS = [
+    _cfg(
+        input_dtype,
+        output_dtype,
+        M,
+        H,
+        input_layout,
+        "compact",
+        "compact",
+        enable_pdl,
+        scale,
+        x_row_stride=2 * H if input_layout == "strided" else None,
+    )
+    for M in (1, 19, 99, 989)
+    for H in (111, 500, 1024, 3072, 3584, 4096, 8192, 16384)
+    for input_dtype in _INPUT_DTYPES
+    for output_dtype in _OUTPUT_DTYPES
+    for scale in _SCALES
+    for enable_pdl in (False, True)
+    for input_layout in _LAYOUTS
+]
+
+_ACTIVE_BENCHMARK_CONFIGS = [
+    _cfg("bfloat16", "float8_e4m3fn", 32, 4096, "compact", "compact", "compact", False, 1.0),
+    _cfg("bfloat16", "float8_e4m3fn", 64, 8192, "compact", "compact", "compact", False, 1.0),
+    _cfg("bfloat16", "float8_e4m3fn", 32, 4096, "compact", "compact", "compact", True, 1.0),
+]
+
+_I64_CONFIGS = [
+    _cfg(
+        "bfloat16",
+        "float8_e4m3fn",
+        2,
+        128,
+        "strided",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        x_row_stride=2**31,
+        suffix="i64_xstride",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        175000,
+        12288,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="compact_overflow_to_strided_i64",
+    ),
+]
+
+_TRACE_CONFIGS = [
+    _cfg("bfloat16", "float8_e4m3fn", M, H, "compact", "compact", "compact", False, 1.0)
+    for M, H in ((32, 2048), (7, 1024), (32, 7168))
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        64,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="vec8_tpr8_async",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        989,
+        66,
+        "compact",
+        "compact",
+        "compact",
+        True,
+        10.0,
+        suffix="vec2",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        16385,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="vec1_sync",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        32768,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="cluster2_sync",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        65536,
+        "compact",
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster4_sync",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        131072,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="cluster8_sync",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        262144,
+        "compact",
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster16_sync",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        524288,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="cluster16_sync_large",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        1048576,
+        "compact",
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="cluster1_sync_fallback",
+    ),
+    _cfg(
+        "float16",
+        "float8_e4m3fn",
+        3,
+        131070,
+        "compact",
+        "compact",
+        "compact",
+        False,
+        1.0,
+        suffix="fragment512",
+    ),
+    _cfg(
+        "bfloat16",
+        "float8_e5m2",
+        3,
+        131073,
+        "compact",
+        "compact",
+        "compact",
+        True,
+        1.0,
+        suffix="fragment513_rolled",
+    ),
+]
+
+_ABI_CONFIGS = [
+    _cfg(
+        "float16",
+        "float8_e5m2",
+        19,
+        500,
+        "strided",
+        "strided",
+        "strided",
+        True,
+        1.0,
+        eps=1e-4,
+        x_row_stride=1000,
+        residual_row_stride=1500,
+        y_row_stride=2000,
+        suffix="eps1e4_full_abi",
+    )
+]
+
+CONFIGS = [
+    *_UPSTREAM_CONFIGS,
+    *_ACTIVE_BENCHMARK_CONFIGS,
+    *_I64_CONFIGS,
+    *_TRACE_CONFIGS,
+    *_STRUCTURE_CONFIGS,
+    *_ABI_CONFIGS,
+]
+BENCH_CONFIGS = list(_ACTIVE_BENCHMARK_CONFIGS)
+
+assert len(_UPSTREAM_CONFIGS) == 1536
+assert len(CONFIGS) == 1556
+assert len(BENCH_CONFIGS) == 3
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+
+
+def _validate(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    residual_layout: str,
+    output_layout: str,
+    scale: float,
+    eps: float,
+) -> None:
+    if input_dtype not in _INPUT_DTYPES:
+        raise ValueError(f"unsupported input dtype: {input_dtype}")
+    if output_dtype not in _OUTPUT_DTYPES:
+        raise ValueError(f"unsupported output dtype: {output_dtype}")
+    for name, layout in (
+        ("input", input_layout),
+        ("residual", residual_layout),
+        ("output", output_layout),
+    ):
+        if layout not in _LAYOUTS:
+            raise ValueError(f"unsupported {name} layout: {layout}")
+    if M <= 0 or H <= 0:
+        raise ValueError(f"M and H must be positive, got M={M}, H={H}")
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError(f"scale must be positive and finite, got {scale}")
+    if not math.isfinite(eps) or eps <= 0.0:
+        raise ValueError(f"eps must be positive and finite, got {eps}")
+
+
+def _uses_compact_specialization(
+    M: int, H: int, input_layout: str, residual_layout: str, output_layout: str
+) -> bool:
+    return input_layout == residual_layout == output_layout == "compact" and M * H <= _INT32_MAX
+
+
+def get_kernel(
+    input_dtype: str,
+    output_dtype: str,
+    M: int,
+    H: int,
+    input_layout: str,
+    residual_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    scale: float,
+    eps: float = _DEFAULT_EPS,
+    **kwargs: Any,
+):
+    """Return the compact or explicit-int64-strided source specialization."""
+    _validate(
+        input_dtype, output_dtype, M, H, input_layout, residual_layout, output_layout, scale, eps
+    )
+    compact = _uses_compact_specialization(M, H, input_layout, residual_layout, output_layout)
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec = int(source["vec"])
+    copy_bits = int(source["copy_bits"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    two_tile_bytes = int(source["two_tile_bytes"])
+    use_async = bool(source["use_async"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = vec * vec_blocks
+    packed_pairs = _ceil_div(total_values, 2)
+    pair_values = packed_pairs * 2
+    packed_narrow = not (vec == 1 or (vec == 2 and vec_blocks == 3))
+    copy_bytes = copy_bits // 8
+    reduce_base = two_tile_bytes if use_async else 0
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+    fp8_max = 448.0 if output_dtype == "float8_e4m3fn" else 57344.0
+    roll_large_fragments = _uses_rolled_fragment_loops(H)
+
+    def fragment_range(extent: int):
+        if roll_large_fragments:
+            return T.serial(extent, unroll=False)
+        return T.unroll(extent)
+
+    x_row_stride_hint = int(kwargs.get("x_row_stride", H))
+    residual_row_stride_hint = int(kwargs.get("residual_row_stride", H))
+    y_row_stride_hint = int(kwargs.get("y_row_stride", H))
+    for name, stride_hint in (
+        ("x", x_row_stride_hint),
+        ("residual", residual_row_stride_hint),
+        ("y", y_row_stride_hint),
+    ):
+        if stride_hint % vec != 0:
+            raise ValueError(f"{name}_row_stride={stride_hint} must be divisible by vec={vec}")
+
+    @T.inline
+    def kernel_body(
+        out,
+        input_buffer,
+        residual,
+        weight,
+        runtime_M,
+        scale_buffer,
+        runtime_eps,
+        y_row_stride,
+        x_row_stride,
+        residual_row_stride,
+    ):
+        # TIRX_TRANSCRIBE_START flashinfer_fused_add_rmsnorm_quant
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int64(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        scale_bits = T.alloc_local((1,), "uint32")
+        T.ptx.ld.global_.b32(scale_bits[0], scale_buffer.ptr_to([0]))
+        scale_value: T.float32 = T.reinterpret("float32", scale_bits[0])
+        inv_scale: T.float32 = _rcp_approx_ftz(scale_value)
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        compact_row_i32: T.int32 = block_x * rows + row_in_cta
+        actual_row: T.int64 = T.cast(block_x, "int64") * T.int64(rows) + T.cast(row_in_cta, "int64")
+        row_valid: T.bool = actual_row < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn")
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        x_bits = T.alloc_local((pair_values,), "uint16")
+        r_bits = T.alloc_local((pair_values,), "uint16")
+        w_bits = T.alloc_local((pair_values,), "uint16")
+        x_f32 = T.alloc_local((pair_values,), "float32")
+        r_f32 = T.alloc_local((pair_values,), "float32")
+        w_f32 = T.alloc_local((pair_values,), "float32")
+        h_f32 = T.alloc_local((pair_values,), "float32")
+        h_sq = T.alloc_local((pair_values,), "float32")
+        undefined_f32 = T.alloc_local((1,), "float32")
+
+        if not use_async:
+            for value in fragment_range(total_values):
+                x_bits[value] = T.uint16(0)
+                r_bits[value] = T.uint16(0)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                x_offset = compact_row_i32 * H + absolute_col
+            else:
+                x_offset = actual_row * x_row_stride + T.cast(absolute_col, "int64")
+            if use_async:
+                if row_valid:
+                    source_bytes: T.uint32 = T.cast(
+                        T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                    )
+                    T.ptx.cp.async_.ca.shared.global_(
+                        shared_raw.ptr_to([(row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES]),
+                        input_buffer.ptr_to([x_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+            else:
+                if row_valid and col_valid:
+                    _load_global_bits(input_buffer, x_offset, x_bits, vb * vec, VEC=vec)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                residual_offset = compact_row_i32 * H + absolute_col
+            else:
+                residual_offset = actual_row * residual_row_stride + T.cast(absolute_col, "int64")
+            if use_async:
+                if row_valid:
+                    source_bytes: T.uint32 = T.cast(
+                        T.if_then_else(col_valid, copy_bytes, 0), "uint32"
+                    )
+                    T.ptx.cp.async_.ca.shared.global_(
+                        shared_raw.ptr_to(
+                            [tile_bytes + (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES]
+                        ),
+                        residual.ptr_to([residual_offset]),
+                        copy_bytes,
+                        source_bytes,
+                    )
+            else:
+                if row_valid and col_valid:
+                    _load_global_bits(residual, residual_offset, r_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.commit_group()
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            if absolute_col < H:
+                _load_global_bits(weight, absolute_col, w_bits, vb * vec, VEC=vec)
+
+        if use_async:
+            T.ptx.cp.async_.wait_group(0)
+            for vb in fragment_range(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                    x_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+            for vb in fragment_range(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+                _load_shared_bits(
+                    shared_raw,
+                    tile_bytes + (row_in_cta * cols + local_col) * _INPUT_ELEM_BYTES,
+                    r_bits,
+                    vb * vec,
+                    VEC=vec,
+                )
+
+        for value in fragment_range(total_values):
+            x_f32[value] = _cvt_to_f32(x_bits[value], input_dtype)
+        for value in fragment_range(total_values):
+            r_f32[value] = _cvt_to_f32(r_bits[value], input_dtype)
+
+        for pair in fragment_range(packed_pairs):
+            x_high: T.float32 = x_f32[pair * 2 + 1]
+            r_high: T.float32 = r_f32[pair * 2 + 1]
+            if pair * 2 + 1 >= total_values:
+                x_high = undefined_f32[0]
+                r_high = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                packed[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_high),
+                T.cuda.make_float2(r_f32[pair * 2], r_high),
+            )
+            T.ptx.mov.b64(h_f32[pair * 2], h_f32[pair * 2 + 1], packed[0])
+
+        residual_bits = T.alloc_local((pair_values,), "uint16")
+        residual_words = T.alloc_local((packed_pairs,), "uint32")
+        if packed_narrow:
+            for pair in fragment_range(packed_pairs):
+                residual_words[pair] = _cvt_pair_from_f32(
+                    h_f32[pair * 2 + 1], h_f32[pair * 2], input_dtype
+                )
+        else:
+            for value in fragment_range(total_values):
+                residual_bits[value] = _cvt_from_f32(h_f32[value], input_dtype)
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if compact:
+                residual_offset = compact_row_i32 * H + absolute_col
+            else:
+                residual_offset = actual_row * residual_row_stride + T.cast(absolute_col, "int64")
+            _store_global_fragment(
+                residual,
+                residual_offset,
+                residual_bits,
+                residual_words,
+                row_valid and col_valid,
+                vb * vec,
+                vb * vec // 2,
+                VEC=vec,
+                PACKED_NARROW=packed_narrow,
+            )
+
+        for pair in fragment_range(packed_pairs):
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(h_sq[pair * 2], h_sq[pair * 2 + 1], packed[0])
+
+        local_sum: T.float32 = T.float32(0.0)
+        for value in fragment_range(total_values):
+            local_sum = _add_f32(local_sum, h_sq[value])
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+            T.evaluate(_cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset])))
+            final_sum = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq = final_sum
+        else:
+            sum_sq = warp_sum
+
+        if H & (H - 1) == 0:
+            shifted: T.float32 = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        for value in fragment_range(total_values):
+            w_f32[value] = _cvt_to_f32(w_bits[value], input_dtype)
+
+        normalized = T.alloc_local((pair_values,), "float32")
+        biased_weight = T.alloc_local((pair_values,), "float32")
+        weighted = T.alloc_local((pair_values,), "float32")
+        y_f32 = T.alloc_local((pair_values,), "float32")
+
+        for pair in fragment_range(packed_pairs):
+            high_scale: T.float32 = rstd
+            if pair * 2 + 1 >= total_values:
+                high_scale = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(h_f32[pair * 2], h_f32[pair * 2 + 1]),
+                T.cuda.make_float2(rstd, high_scale),
+            )
+            T.ptx.mov.b64(normalized[pair * 2], normalized[pair * 2 + 1], packed[0])
+
+        for pair in fragment_range(packed_pairs):
+            high_bias: T.float32 = T.float32(0.0)
+            if pair * 2 + 1 >= total_values:
+                high_bias = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                packed[0],
+                T.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+                T.cuda.make_float2(T.float32(0.0), high_bias),
+            )
+            T.ptx.mov.b64(biased_weight[pair * 2], biased_weight[pair * 2 + 1], packed[0])
+
+        for pair in fragment_range(packed_pairs):
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(normalized[pair * 2], normalized[pair * 2 + 1]),
+                T.cuda.make_float2(biased_weight[pair * 2], biased_weight[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(weighted[pair * 2], weighted[pair * 2 + 1], packed[0])
+
+        for pair in fragment_range(packed_pairs):
+            high_inv_scale: T.float32 = inv_scale
+            if pair * 2 + 1 >= total_values:
+                high_inv_scale = undefined_f32[0]
+            packed = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(
+                packed[0],
+                T.cuda.make_float2(weighted[pair * 2], weighted[pair * 2 + 1]),
+                T.cuda.make_float2(inv_scale, high_inv_scale),
+            )
+            T.ptx.mov.b64(y_f32[pair * 2], y_f32[pair * 2 + 1], packed[0])
+
+        for vb in fragment_range(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * vec
+            absolute_col: T.int32 = block_y * cols + local_col
+            if compact:
+                y_offset = actual_row * T.int64(H) + T.cast(absolute_col, "int64")
+            else:
+                y_offset = actual_row * y_row_stride + T.cast(absolute_col, "int64")
+
+            if vec == 8 and absolute_col + 8 <= H and row_valid:
+                p01: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8], y_f32[vb * 8 + 1], output_dtype)
+                p23: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 2], y_f32[vb * 8 + 3], output_dtype)
+                p45: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 4], y_f32[vb * 8 + 5], output_dtype)
+                p67: T.uint16 = _cvt_fp8_pair(y_f32[vb * 8 + 6], y_f32[vb * 8 + 7], output_dtype)
+                lo_word: T.uint32 = _pack_b16_pair(p01, p23)
+                hi_word: T.uint32 = _pack_b16_pair(p45, p67)
+                T.ptx.st.global_.v2.b32(out.ptr_to([y_offset]), lo_word, hi_word)
+            elif vec == 4 and absolute_col + 4 <= H and row_valid:
+                p01 = _cvt_fp8_pair(y_f32[vb * 4], y_f32[vb * 4 + 1], output_dtype)
+                p23 = _cvt_fp8_pair(y_f32[vb * 4 + 2], y_f32[vb * 4 + 3], output_dtype)
+                packed_word: T.uint32 = _pack_b16_pair(p01, p23)
+                T.ptx.st.global_.b32(out.ptr_to([y_offset]), packed_word)
+            elif vec == 2 and absolute_col + 2 <= H and row_valid:
+                p01 = _cvt_fp8_pair(y_f32[vb * 2], y_f32[vb * 2 + 1], output_dtype)
+                T.ptx.st.global_.b16(out.ptr_to([y_offset]), p01)
+            else:
+                for element in T.unroll(vec):
+                    scalar_col: T.int32 = absolute_col + element
+                    if scalar_col < H and row_valid:
+                        clamped_low: T.float32 = _maximum_f32(
+                            y_f32[vb * vec + element], T.float32(-fp8_max)
+                        )
+                        clamped: T.float32 = _minimum_f32(clamped_low, T.float32(fp8_max))
+                        pair: T.uint16 = _cvt_fp8_pair(clamped, T.float32(0.0), output_dtype)
+                        if compact:
+                            scalar_offset = actual_row * T.int64(H) + T.cast(scalar_col, "int64")
+                        else:
+                            scalar_offset = actual_row * y_row_stride + T.cast(scalar_col, "int64")
+                        T.ptx.st.global_.b8(out.ptr_to([scalar_offset]), T.cast(pair, "uint8"))
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    if compact:
+
+        @T.prim_func
+        def flashinfer_fused_add_rmsnorm_quant_compact(
+            output_handle: T.handle,
+            input_handle: T.handle,
+            residual_handle: T.handle,
+            weight_handle: T.handle,
+            runtime_M: T.int64,
+            scale_handle: T.handle,
+            runtime_eps: T.float32,
+        ):
+            output = T.match_buffer(
+                output_handle, shape=(runtime_M * T.int64(H),), dtype=output_dtype, scope="global"
+            )
+            input_buffer = T.match_buffer(
+                input_handle, shape=(runtime_M * T.int64(H),), dtype=input_dtype, scope="global"
+            )
+            residual = T.match_buffer(
+                residual_handle, shape=(runtime_M * T.int64(H),), dtype=input_dtype, scope="global"
+            )
+            weight = T.match_buffer(weight_handle, shape=(H,), dtype=input_dtype, scope="global")
+            scale_buffer = T.match_buffer(scale_handle, shape=(1,), dtype="float32", scope="global")
+            T.device_entry()
+            kernel_body(
+                output,
+                input_buffer,
+                residual,
+                weight,
+                runtime_M,
+                scale_buffer,
+                runtime_eps,
+                T.int64(H),
+                T.int64(H),
+                T.int64(H),
+            )
+
+        kernel = flashinfer_fused_add_rmsnorm_quant_compact
+    else:
+
+        @T.prim_func
+        def flashinfer_fused_add_rmsnorm_quant_strided(
+            output_handle: T.handle,
+            input_handle: T.handle,
+            residual_handle: T.handle,
+            weight_handle: T.handle,
+            runtime_M: T.int64,
+            scale_handle: T.handle,
+            runtime_eps: T.float32,
+            y_row_stride: T.int64,
+            x_row_stride: T.int64,
+            residual_row_stride: T.int64,
+        ):
+            output = T.match_buffer(
+                output_handle,
+                shape=((runtime_M - T.int64(1)) * y_row_stride + T.int64(H),),
+                dtype=output_dtype,
+                scope="global",
+            )
+            input_buffer = T.match_buffer(
+                input_handle,
+                shape=((runtime_M - T.int64(1)) * x_row_stride + T.int64(H),),
+                dtype=input_dtype,
+                scope="global",
+            )
+            residual = T.match_buffer(
+                residual_handle,
+                shape=((runtime_M - T.int64(1)) * residual_row_stride + T.int64(H),),
+                dtype=input_dtype,
+                scope="global",
+            )
+            weight = T.match_buffer(weight_handle, shape=(H,), dtype=input_dtype, scope="global")
+            scale_buffer = T.match_buffer(scale_handle, shape=(1,), dtype="float32", scope="global")
+            T.device_entry()
+            kernel_body(
+                output,
+                input_buffer,
+                residual,
+                weight,
+                runtime_M,
+                scale_buffer,
+                runtime_eps,
+                y_row_stride,
+                x_row_stride,
+                residual_row_stride,
+            )
+
+        kernel = flashinfer_fused_add_rmsnorm_quant_strided
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return kernel.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Create deterministic source-shaped tensors for the runtime ABI."""
+    data = _prepare_tensors(dict(config))
+    output = _prepare_output(
+        int(config["M"]),
+        int(config["H"]),
+        data["y_row_stride"],
+        str(config["output_dtype"]),
+        initialize_padding=False,
+    )
+    return output["view"], data["input"], data["residual"], data["weight"], data["scale"]
+
+
+_GUARD_ELEMENTS = 64
+_GUARD_VALUE = 1.0
+
+
+def _torch_input_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _torch_output_dtype(dtype: str):
+    import torch
+
+    return {"float8_e4m3fn": torch.float8_e4m3fn, "float8_e5m2": torch.float8_e5m2}[dtype]
+
+
+def _row_strides(config: dict[str, Any]) -> tuple[int, int, int]:
+    H = int(config["H"])
+    x_stride = int(config.get("x_row_stride", 2 * H if config["input_layout"] == "strided" else H))
+    residual_stride = int(
+        config.get("residual_row_stride", 2 * H if config["residual_layout"] == "strided" else H)
+    )
+    y_stride = int(config.get("y_row_stride", 2 * H if config["output_layout"] == "strided" else H))
+    return x_stride, residual_stride, y_stride
+
+
+def _storage_size(M: int, H: int, row_stride: int) -> int:
+    return (M - 1) * row_stride + H
+
+
+def _allocate_strided(M: int, H: int, row_stride: int, dtype) -> dict[str, Any]:
+    import torch
+
+    size = _storage_size(M, H, row_stride)
+    backing = torch.empty(size + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    backing.fill_(_GUARD_VALUE)
+    arg = backing[:size]
+    view = arg.as_strided((M, H), (row_stride, 1))
+    return {
+        "view": view,
+        "arg": arg,
+        "backing": backing,
+        "size": size,
+        "data_ptr": view.data_ptr(),
+        "stride": view.stride(),
+    }
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M = int(config["M"])
+    H = int(config["H"])
+    input_dtype = str(config["input_dtype"])
+    output_dtype = str(config["output_dtype"])
+    scale_value = float(config["scale"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    _validate(
+        input_dtype,
+        output_dtype,
+        M,
+        H,
+        str(config["input_layout"]),
+        str(config["residual_layout"]),
+        str(config["output_layout"]),
+        scale_value,
+        eps,
+    )
+    x_stride, residual_stride, y_stride = _row_strides(config)
+    vec = int(_source_config(H)["vec"])
+    for name, stride in (("x", x_stride), ("residual", residual_stride), ("y", y_stride)):
+        if stride < H:
+            raise ValueError(f"{name} row stride {stride} does not cover H={H}")
+        if stride % vec != 0:
+            raise ValueError(f"{name} row stride {stride} must be divisible by vec={vec}")
+
+    torch_dtype = _torch_input_dtype(input_dtype)
+    generator = torch.Generator(device="cuda").manual_seed(42)
+    x = _allocate_strided(M, H, x_stride, torch_dtype)
+    residual = _allocate_strided(M, H, residual_stride, torch_dtype)
+
+    if (input_dtype == "bfloat16" and H >= 4096) or H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        x_mag = torch.where(columns % 257 < 128, 0.5, 1.0)
+        r_mag = torch.where(columns % 193 < 96, 0.25, 0.75)
+        x_pattern = torch.where(columns % 2 == 0, x_mag, -x_mag).to(torch_dtype)
+        r_pattern = torch.where(columns % 3 == 0, r_mag, -r_mag).to(torch_dtype)
+        x["view"].copy_(x_pattern.expand(M, H))
+        residual["view"].copy_(r_pattern.expand(M, H))
+        x["view"][1::2].neg_()
+        residual["view"][2::3].neg_()
+    else:
+        x["view"].normal_(generator=generator)
+        residual["view"].normal_(generator=generator)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=torch_dtype, device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    if H >= 3:
+        dtype_limit = torch.finfo(torch_dtype).max
+        weight[0] = dtype_limit
+        weight[1] = torch.tensor(1.0546875 * scale_value, dtype=torch_dtype, device="cuda")
+        weight[2] = torch.tensor(1.0703125 * scale_value, dtype=torch_dtype, device="cuda")
+    weight_backing[H:].fill_(_GUARD_VALUE)
+    scale = torch.tensor([scale_value], dtype=torch.float32, device="cuda")
+    return {
+        "input": x["view"],
+        "input_arg": x["arg"],
+        "input_backing": x["backing"],
+        "input_size": x["size"],
+        "input_data_ptr": x["data_ptr"],
+        "input_stride": x["stride"],
+        "residual": residual["view"],
+        "residual_arg": residual["arg"],
+        "residual_backing": residual["backing"],
+        "residual_size": residual["size"],
+        "residual_data_ptr": residual["data_ptr"],
+        "residual_stride": residual["stride"],
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "scale": scale,
+        "x_row_stride": x_stride,
+        "residual_row_stride": residual_stride,
+        "y_row_stride": y_stride,
+    }
+
+
+def _prepare_output(
+    M: int, H: int, row_stride: int, output_dtype: str, *, initialize_padding: bool
+) -> dict[str, Any]:
+    output = _allocate_strided(M, H, row_stride, _torch_output_dtype(output_dtype))
+    if not initialize_padding:
+        output["backing"][output["size"] :].fill_(_GUARD_VALUE)
+    return output
+
+
+def _raw_bytes(tensor):
+    import torch
+
+    return tensor.view(torch.uint8)
+
+
+def _assert_guard(backing, size: int, *, name: str) -> None:
+    import torch
+
+    expected = torch.full(
+        (_GUARD_ELEMENTS,), _GUARD_VALUE, dtype=backing.dtype, device=backing.device
+    )
+    if not torch.equal(_raw_bytes(backing[size:]), _raw_bytes(expected)):
+        raise AssertionError(f"{name} guard was modified")
+
+
+def _padding_sample(backing, M: int, H: int, stride: int):
+    import torch
+
+    if stride == H or M <= 1:
+        return None
+    width = stride - H
+    count = (M - 1) * width
+    if count <= 1_000_000:
+        return backing.as_strided((M - 1, width), (stride, 1), H).reshape(-1)
+    rows = sorted(row for row in {0, 1, (M - 2) // 2, M - 2} if 0 <= row < M - 1)
+    cols = sorted({0, min(1, width - 1), width // 2, width - 1})
+    row_index = torch.tensor(rows, device=backing.device, dtype=torch.int64)
+    col_index = torch.tensor(cols, device=backing.device, dtype=torch.int64)
+    return backing[row_index[:, None] * stride + H + col_index[None, :]].reshape(-1)
+
+
+def _assert_padding(backing, size: int, M: int, H: int, stride: int, *, name: str) -> None:
+    import torch
+
+    _assert_guard(backing, size, name=name)
+    padding = _padding_sample(backing, M, H, stride)
+    if padding is not None:
+        expected = torch.full_like(padding, _GUARD_VALUE)
+        if not torch.equal(_raw_bytes(padding), _raw_bytes(expected)):
+            raise AssertionError(f"{name} row padding was modified")
+
+
+def _overflow_rows(M: int, H: int) -> list[int] | None:
+    if M * H <= _INT32_MAX:
+        return None
+    boundary = _ceil_div(2**31, H)
+    return sorted(
+        {row for row in (0, 1, boundary - 1, boundary, boundary + 1, M - 1) if 0 <= row < M}
+    )
+
+
+def _checked_view(tensor, rows: list[int] | None):
+    return tensor if rows is None else tensor[rows]
+
+
+def _snapshot(data: dict[str, Any], M: int, H: int) -> dict[str, Any]:
+    rows = _overflow_rows(M, H)
+    return {
+        "rows": rows,
+        "input": _checked_view(data["input"], rows).clone(),
+        "residual": _checked_view(data["residual"], rows).clone(),
+        "weight": data["weight"].clone(),
+        "scale": data["scale"].clone(),
+    }
+
+
+def _math_oracle(snapshot: dict[str, Any], eps: float, output_dtype: str):
+    h = snapshot["input"].float() + snapshot["residual"].float()
+    expected_residual = h.to(snapshot["input"].dtype)
+    variance = h.square().mean(dim=-1, keepdim=True)
+    y = (
+        h
+        * variance.add(eps).rsqrt()
+        * snapshot["weight"].float()
+        * snapshot["scale"].float().reciprocal()
+    )
+    fp8_max = 448.0 if output_dtype == "float8_e4m3fn" else 57344.0
+    expected_output = y.clamp(-fp8_max, fp8_max).to(_torch_output_dtype(output_dtype))
+    return expected_output, expected_residual
+
+
+def _assert_raw_equal(actual, expected, *, name: str) -> None:
+    import torch
+
+    if not torch.equal(_raw_bytes(actual), _raw_bytes(expected)):
+        mismatch = _raw_bytes(actual) != _raw_bytes(expected)
+        count = int(mismatch.sum().item())
+        raise AssertionError(f"{name}: {count} FP8 bytes differ")
+
+
+def _assert_residual_close(actual, expected, *, name: str) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual, expected, rtol=1e-3, atol=1e-3, msg=lambda message: f"{name}: {message}"
+    )
+
+
+def _assert_math_close(actual, expected, *, name: str) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual.float(),
+        expected.float(),
+        rtol=1.0,
+        atol=1.0,
+        msg=lambda message: f"{name}: {message}",
+    )
+
+
+def _flashinfer_api(device):
+    import flashinfer.norm as flashinfer_norm
+
+    if flashinfer_norm._use_cuda_norm(device):
+        raise AssertionError("FlashInfer fused add RMSNorm quant oracle dispatched to legacy CUDA")
+    return flashinfer_norm.fused_add_rmsnorm_quant, flashinfer_norm
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]):
+    M = int(config["M"])
+    H = int(config["H"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    compact = _uses_compact_specialization(
+        M,
+        H,
+        str(config["input_layout"]),
+        str(config["residual_layout"]),
+        str(config["output_layout"]),
+    )
+    if compact:
+        return executable(
+            output["arg"],
+            data["input_arg"],
+            data["residual_arg"],
+            data["weight"],
+            M,
+            data["scale"],
+            eps,
+        )
+    return executable(
+        output["arg"],
+        data["input_arg"],
+        data["residual_arg"],
+        data["weight"],
+        M,
+        data["scale"],
+        eps,
+        data["y_row_stride"],
+        data["x_row_stride"],
+        data["residual_row_stride"],
+    )
+
+
+@functools.cache
+def _compiled_test_specialization(
+    input_dtype: str, output_dtype: str, H: int, compact: bool, enable_pdl: bool
+):
+    from tirx_kernels.runner import compile_kernel
+
+    layout = "compact" if compact else "strided"
+    return compile_kernel(
+        get_kernel(
+            input_dtype=input_dtype,
+            output_dtype=output_dtype,
+            M=1,
+            H=H,
+            input_layout=layout,
+            residual_layout=layout,
+            output_layout=layout,
+            enable_pdl=enable_pdl,
+            scale=1.0,
+            eps=_DEFAULT_EPS,
+            x_row_stride=H,
+            residual_row_stride=H,
+            y_row_stride=H,
+        )
+    )
+
+
+def _assert_identity(data: dict[str, Any], output: dict[str, Any]) -> None:
+    for name in ("input", "residual"):
+        if data[name].data_ptr() != data[f"{name}_data_ptr"]:
+            raise AssertionError(f"{name} data pointer changed")
+        if data[name].stride() != data[f"{name}_stride"]:
+            raise AssertionError(f"{name} stride changed")
+    if output["view"].data_ptr() != output["data_ptr"]:
+        raise AssertionError("output data pointer changed")
+    if output["view"].stride() != output["stride"]:
+        raise AssertionError("output stride changed")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate both mutable outputs for one config."""
+    import torch
+
+    config = dict(config)
+    M = int(config["M"])
+    H = int(config["H"])
+    output_dtype = str(config["output_dtype"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    snapshot = _snapshot(data, M, H)
+    output = _prepare_output(M, H, data["y_row_stride"], output_dtype, initialize_padding=True)
+    compact = _uses_compact_specialization(
+        M,
+        H,
+        str(config["input_layout"]),
+        str(config["residual_layout"]),
+        str(config["output_layout"]),
+    )
+    executable = _compiled_test_specialization(
+        str(config["input_dtype"]), output_dtype, H, compact, enable_pdl
+    )
+    returned = _launch_tirx(executable, data, output, config)
+    if returned is not None:
+        raise AssertionError("TIRx fused add RMSNorm quant ABI must return None")
+
+    reference = None
+    reference_output = None
+    if not _uses_rolled_fragment_loops(H):
+        reference = _prepare_tensors(config)
+        reference_output = _prepare_output(
+            M, H, reference["y_row_stride"], output_dtype, initialize_padding=True
+        )
+        api, flashinfer_norm = _flashinfer_api(reference["input"].device)
+        original_cute = flashinfer_norm.fused_add_rmsnorm_quant_cute
+        cute_calls = 0
+
+        def tracked_cute(*args, **kwargs):
+            nonlocal cute_calls
+            cute_calls += 1
+            return original_cute(*args, **kwargs)
+
+        flashinfer_norm.fused_add_rmsnorm_quant_cute = tracked_cute
+        try:
+            reference_returned = api(
+                reference_output["view"],
+                reference["input"],
+                reference["residual"],
+                reference["weight"],
+                reference["scale"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+        finally:
+            flashinfer_norm.fused_add_rmsnorm_quant_cute = original_cute
+        if cute_calls != 1:
+            raise AssertionError(f"expected one CuTe-DSL oracle dispatch, observed {cute_calls}")
+        if reference_returned is not None:
+            raise AssertionError("FlashInfer fused_add_rmsnorm_quant must return None")
+
+    torch.cuda.synchronize()
+    rows = snapshot["rows"]
+    actual_output = _checked_view(output["view"], rows)
+    actual_residual = _checked_view(data["residual"], rows)
+    oracle_output, oracle_residual = _math_oracle(snapshot, eps, output_dtype)
+    if not torch.isfinite(actual_output.float()).all():
+        raise AssertionError("TIRx FP8 output contains non-finite values")
+    if not torch.isfinite(actual_residual.float()).all():
+        raise AssertionError("TIRx residual output contains non-finite values")
+    if reference is not None and reference_output is not None:
+        _assert_raw_equal(
+            actual_output,
+            _checked_view(reference_output["view"], rows),
+            name="FlashInfer raw-byte output oracle",
+        )
+        _assert_residual_close(
+            actual_residual,
+            _checked_view(reference["residual"], rows),
+            name="FlashInfer residual oracle",
+        )
+    _assert_math_close(actual_output, oracle_output, name="independent FP32 output oracle")
+    _assert_residual_close(
+        actual_residual, oracle_residual, name="independent FP32 residual oracle"
+    )
+    if not torch.equal(_checked_view(data["input"], rows), snapshot["input"]):
+        raise AssertionError("TIRx modified input")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError("TIRx modified weight")
+    if not torch.equal(data["scale"], snapshot["scale"]):
+        raise AssertionError("TIRx modified scale")
+    _assert_identity(data, output)
+    _assert_padding(
+        data["input_backing"], data["input_size"], M, H, data["x_row_stride"], name="TIRx input"
+    )
+    _assert_padding(
+        data["residual_backing"],
+        data["residual_size"],
+        M,
+        H,
+        data["residual_row_stride"],
+        name="TIRx residual",
+    )
+    _assert_padding(
+        output["backing"], output["size"], M, H, data["y_row_stride"], name="TIRx output"
+    )
+
+
+def prepare_bench(**config: Any):
+    """Compile the specialization before the bench suite assigns a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    state: dict[str, Any],
+    *,
+    warmup=None,
+    repeat=None,
+    timer=None,
+    rounds=1,
+    cooldown_s=1.0,
+    **kwargs: Any,
+):
+    """Build independent mutable closures and validate them before timing."""
+    import torch
+
+    config = dict(state["config"])
+    config.update(kwargs)
+    M = int(config["M"])
+    H = int(config["H"])
+    output_dtype = str(config["output_dtype"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    enable_pdl = bool(config["enable_pdl"])
+    tirx_data = _prepare_tensors(config)
+    reference_data = _prepare_tensors(config)
+    tirx_output = _prepare_output(
+        M, H, tirx_data["y_row_stride"], output_dtype, initialize_padding=False
+    )
+    reference_output = _prepare_output(
+        M, H, reference_data["y_row_stride"], output_dtype, initialize_padding=False
+    )
+    executable = state["executable"]
+
+    def tirx_launch():
+        return _launch_tirx(executable, tirx_data, tirx_output, config)
+
+    if tirx_launch() is not None:
+        raise AssertionError("TIRx benchmark closure must return None")
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        api, flashinfer_norm = _flashinfer_api(reference_data["input"].device)
+        original_cute = flashinfer_norm.fused_add_rmsnorm_quant_cute
+        cute_calls = 0
+
+        def tracked_cute(*args, **kwargs):
+            nonlocal cute_calls
+            cute_calls += 1
+            return original_cute(*args, **kwargs)
+
+        def flashinfer_launch():
+            return api(
+                reference_output["view"],
+                reference_data["input"],
+                reference_data["residual"],
+                reference_data["weight"],
+                reference_data["scale"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+
+        flashinfer_norm.fused_add_rmsnorm_quant_cute = tracked_cute
+        try:
+            returned = flashinfer_launch()
+        finally:
+            flashinfer_norm.fused_add_rmsnorm_quant_cute = original_cute
+        if cute_calls != 1:
+            raise AssertionError(f"expected one CuTe-DSL benchmark warmup, observed {cute_calls}")
+        if returned is not None:
+            raise AssertionError("FlashInfer benchmark closure must return None")
+        torch.cuda.synchronize()
+        _assert_raw_equal(
+            tirx_output["view"], reference_output["view"], name="benchmark raw-byte output precheck"
+        )
+        _assert_residual_close(
+            tirx_data["residual"], reference_data["residual"], name="benchmark residual precheck"
+        )
+        return flashinfer_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark the implemented kernel against FlashInfer CuTe-DSL."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer `FusedAddRMSNormQuantKernel` to plain TIRx with compact and explicit Int64-strided ABIs
- preserve async/sync copy selection, fused residual update, CTA/cluster reduction, PDL, rolled large-fragment loops, and hardware FP8 vector/tail stores
- add the full correctness matrix, three official bench-suite workloads, baseline rows, kernel documentation, and the reviewed schedule sketch

## Validation

- `python -m tirx_kernels.test --kernel flashinfer_fused_add_rmsnorm_quant`: 1556 passed, 0 failed, 0 skipped
- `python -m tirx_kernels.registry --list --strict`
- `python -m tirx_kernels.bench_suite --check-imports`: 170 workloads, 58 kernels
- `python tests/lint/check_license_headers.py`
- `python tests/lint/check_license_headers.py --self-test`
- `pre-commit run`

Final reference-enabled bench-suite ratios (5 rounds, 1 second cooldown, no interference retries):

- M32/H4096/PDL off: 1.01023x
- M64/H8192/PDL off: 1.02163x
- M32/H4096/PDL on: 1.00383x