### PR TITLE
feat(kernel): port msa sparse attention forward kernel to tirx

### DIFF
--- a/.agents/sketch/msa/sparse_atten_fwd.md
+++ b/.agents/sketch/msa/sparse_atten_fwd.md
@@ -1,0 +1,1686 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of MSA's
+python/fmha_sm100/cute/src/sm100/fwd/atten_fwd.py
+SparseAttentionForwardSm100.
+-->
+
+# msa_sparse_atten_fwd_sm100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, warp roles,
+pipelines, control flow, and PTX-level operations of
+[`tirx_kernels/msa/sparse_atten_fwd.py`](../../../tirx_kernels/msa/sparse_atten_fwd.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **one kernel**: `SparseAttentionForwardSm100.kernel`
+(`atten_fwd.py:637-1235`) with its trace-time launcher `__call__` (`:292-631`)
+and every warp-role helper it dispatches to. This is the attention kernel
+itself: it consumes the work list produced by
+`SparseAttentionPrepareFlatScheduleSm100` and the packed `q_idx | slot<<24`
+metadata produced by `SparseAttentionPrepareFwdSplitAtomicSm100` -- both
+already ported into this package -- and writes the split partials that the
+combine kernel (a separate class, separate compile key, **out of scope**)
+reduces.
+
+## Scope and instantiations
+
+The upstream compile key is a 16-tuple (`interface.py:1714-1731`). Fixed for
+every specialization in this port:
+
+| axis | value | why it is fixed |
+| --- | --- | --- |
+| `head_dim` | 128 | `__init__` raises otherwise (`:75-79`) |
+| `n_block_size` | 128 | the KV block width the schedule is built around |
+| `m_block_size` | 128 | 128 packed Q heads per MMA tile |
+| `causal` | `True` | every upstream test and benchmark sets it; it is a real codegen axis (`:173-181`) |
+| `paged_kv` | `False` | out of scope, see below |
+| `use_prepare_scheduler` | `True` | `__init__` raises otherwise (`:96-98`) |
+
+In scope, i.e. the specializations this module compiles:
+
+| axis | values | what changes in device code |
+| --- | --- | --- |
+| `qheadperkv` | 1, 2, 4 / 8, 16 | selects **the whole Q-load warpgroup program**: `use_q_gather4` (`:81`) picks a raw gather4 descriptor path for 1/2/4 and a CUTE-managed TMA path for 8/16. Also sets `q_tokens_per_group = 128 // qheadperkv` (`:108`) and `tokens_per_gather4 = 4 // qheadperkv` (`:87`). |
+| dtype combination | `bf16`, `fp8`, `bf16q_fp8kv`, `fp8_pvbf16` | resolved at trace time (`:318-364`) into `qk_dtype`/`pv_dtype`, the two `mma_kind` strings, and `k_fp8_to_bf16`/`v_fp8_to_bf16`, which add a shared-memory dequantization pass to the softmax warpgroups |
+| `partial_dtype` | fp32, bf16, fp8 e4m3 | three distinct epilogue store paths: 4-lane, 8-lane, 16-lane 128-bit stores with three different swizzle-inverse column remaps (`:2772-2984`) |
+| temperature LSE | on / off | `mLSE_temperature_partial is not None` adds one scaled row-sum reduction, one `sScaleTemperature` publish and one extra LSE store |
+
+Out of scope, with the predicate that excludes each:
+
+- **paged KV** -- `page_table is not None` at the host entry; requires
+  `page_size == blk_kv` (`:99-105`) and swaps in a rank-4 descriptor plus
+  `PagedKVManager` block indirection.
+- **`seqused_k`** -- `seqused_k is not None`; replaces `_logical_seqlen_k`'s
+  `cu_seqlens_k` difference with a per-batch lookup (`:208-212`).
+- **`causal=False`** -- never exercised upstream; it would change
+  `num_regs_softmax` 176 -> 192, `num_regs_store` 112 -> 80, and
+  `ex2_emu_freq` 16 -> 0, i.e. remove the polynomial exp2 mixing entirely.
+- **fp16 partials** -- accepted by the dtype check at `:372-377` but never
+  exercised upstream; it shares the bf16 8-lane store path.
+- **the NVFP4-KV sibling** `SparseAttentionForwardNvfp4KvSm100`
+  (`atten_fwd_nvfp4_kv.py`) -- a separate class with its own compile key.
+- **the combine kernel** `fwd/combine.py` -- a downstream consumer.
+- Tile (`Tx`) primitives are out of scope everywhere.
+
+## The line-info export this sketch is annotated from
+
+Every `instruction_selection` annotation below is read out of a line-info PTX
+export, not out of the source text. Six exports, one per structurally distinct
+in-scope compile key, are preserved under
+`.porting/sparse_atten_fwd/ptx_lineinfo/<name>/` together with the
+`analysis.txt` each was summarized into; `.porting/sparse_atten_fwd/export_findings.md`
+records the `.loc` file-id table and the eight places where the export
+contradicts the source text. Unqualified counts below are from
+`bf16_tmaq_qh16_fp32`. Counting convention: instruction lines minus predicated
+lines.
+
+Reproduce any export with:
+
+```bash
+mkdir -p .porting/sparse_atten_fwd/ptx_lineinfo/<name>
+MM_SPARSE_ATTN_AOT_DISABLE=1 CUTE_DSL_NO_CACHE=1 CUTE_DSL_KEEP=ptx \
+CUTE_DSL_LINEINFO=1 CUTE_DSL_DUMP_DIR=.porting/sparse_atten_fwd/ptx_lineinfo/<name> \
+python .porting/sparse_atten_fwd/export_driver.py <name>
+```
+
+The reference only compiles under a pinned CuTe-DSL (4.5.3 + `quack-kernels`
+0.5.0, installed at `.reference-deps/msa-cutedsl`). The ambient 4.6.0.dev0
+fails NVVM serialization on every gather4 specialization while compiling the
+TMA-Q ones fine.
+
+## Pipeline at a glance
+
+16 warps, 512 threads, one CTA per work item. Role selection is a flat sequence
+of independent `if` blocks -- **not** an `if/elif` chain -- each ANDed with
+`cta_valid_work`. A warp falls through the blocks it does not match and returns.
+
+| Warps | Role-local tile program | Main publication / reuse edges |
+| --- | --- | --- |
+| 0..3 | softmax warpgroup 0 **with the epilogue fused in**; on `k_fp8_to_bf16` it first dequantizes the whole K tile from `sKFp8` into `sK`. Takes the **even** Q groups. | consumes `mbar_s`; publishes `mbar_p` + `mbar_p_lastsplit` and `sScale`; consumes `mbar_o`; releases `mbar_sm_stats` |
+| 4..7 | softmax warpgroup 1, same body, **odd** Q groups; on `v_fp8_to_bf16` it dequantizes V into `sV` first | same edges, other slot parity |
+| 8..11 | Q-load warpgroup: publishes the packed `sQIdxMeta` ring, then issues either 8 gather4 TMAs per warp per group, or one/two plain TMAs per token | produces `mbar_q`; publishes `sQIdxMeta` (read later by both softmax WGs *and* the epilogue) |
+| 12 | the single MMA-issue warp; also the TMEM allocator warp | waits `mbar_k`/`mbar_v`, consumes `mbar_q`, produces `mbar_s` and `mbar_o`, consumes `mbar_p`/`mbar_p_lastsplit` |
+| 13 | K load: one TMA for this CTA's single KV block | produces `mbar_k` (or `mbar_k_tma` on the fp8 path) |
+| 14 | V load: one TMA for the same block | produces `mbar_v` (or `mbar_v_tma`) |
+| 15 | idle; executes only `setmaxnreg.dec 48` and falls out | none |
+
+**KV is not pipelined.** One CTA owns exactly one KV block, so `mbar_k` and
+`mbar_v` are single-shot barriers with `expect_tx` set once by thread 0 in the
+prologue, and the load warps issue one TMA each and retire. All pipelining runs
+along the **Q-group axis**: `num_q_groups = ceil(count_raw / q_tokens_per_group)`,
+with `q_stage = 2`, `s_stage = 2`, `o_stage = 2` and a 16-deep `sQIdxMeta` ring.
+
+**There is no online rescale.** Because a Q group sees exactly one KV block,
+every softmax step is the first-and-only step: one row max, one exponentiation,
+one row sum, no correction loop, no running accumulator rescale
+(`:2284-2287`).
+
+**The epilogue is fused into the softmax warpgroups**, and the export shows the
+whole softmax+epilogue body is **emitted twice**, once per warpgroup, not
+shared behind a runtime `stage`.
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+tile(...)        # declare storage, dtype, logical shape, placement
+view(...)        # change logical indexing without moving values
+alias(...)       # declare exact storage aliasing and non-overlap lifetime
+slice(...)       # select a logical interval
+reg_tile(...)    # declare a role-local register tile
+tensormap(...)   # declare a TMA descriptor and its encode fields
+```
+
+Copies always state their storage direction:
+
+```python
+copy_g2s(src, dst, bar=None, hint=None)        # global -> shared (TMA)
+copy_g2s_gather4(dst, dst_byte_off, desc, col, r0, r1, r2, r3, bar, hint)
+prefetch_g2s_gather4(desc, col, r0, r1, r2, r3, hint)
+copy_s2r(src, dst)                             # shared -> register
+copy_r2s(src, dst)                             # register -> shared
+copy_t2r(src, dst)                             # tensor memory -> register
+copy_r2t(src, dst)                             # register -> tensor memory
+copy_r2g(ptr, values, cache=None)              # register -> global
+load_shared(smem, idx) -> reg
+store_shared(smem, idx, reg)
+load_global(buf, idx) -> reg
+store_global(buf, idx, reg)
+prefetch_descriptor(desc)
+```
+
+The computational vocabulary:
+
+```python
+fill(dst, value)
+cast(dst, src)                       # includes fp8 -> bf16 and f32 -> narrow
+add(dst, lhs, rhs, lanes=1)          # lanes=2 is one packed f32x2 op
+sub(dst, lhs, rhs, lanes=1)
+mul(dst, lhs, rhs, lanes=1)
+fma(dst, a, b, c, lanes=1)
+max(dst, lhs, rhs)
+exp2(dst, src)                       # MUFU
+exp2_poly(dst, src)                  # degree-3 FFMA emulation
+log2(dst, src)
+rcp(dst, src)
+select(dst, predicate, a, b)
+shuffle_index(dst, src, lane, mask, clamp)
+gemm(dst, lhs, rhs, accumulate=False)
+```
+
+Schedule operations: `pipe`, `init_pipe`, `acquire`, `wait`, `commit`,
+`release`, `expect_tx`, `fence`, `barrier`, `named_barrier`, `elect`,
+`set_register_budget`, TMEM `allocate`/`relinquish`/`free`, and cursor
+(`slot`, `phase`) updates.
+
+`add(..., lanes=2)` is one packed two-lane f32 operation with two ordered
+results, not shorthand for two scalar adds. There are deliberately no
+primitives named `attention`, `softmax`, `mask`, `online_update`, `TMA`,
+`TCGEN05`, `dequantize`, or `epilogue`.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+@specialize(
+    HEAD_DIM=128,
+    M_BLOCK=128,               # 128 packed Q heads per MMA tile
+    N_BLOCK=128,               # KV block width
+    K_TILE=64,                 # UTCMMA bf16 K-tile (:59)
+    QHEADPERKV=(1, 2, 4, 8, 16),
+    USE_Q_GATHER4=QHEADPERKV in (1, 2, 4),          # :81
+    Q_TOKENS_PER_GROUP=128 // QHEADPERKV,           # :108
+    TOKENS_PER_GATHER4=(4 // QHEADPERKV) if USE_Q_GATHER4 else 0,   # :87
+    DTYPE_MODE=("bf16", "fp8", "bf16q_fp8kv", "fp8_pvbf16"),
+    PARTIAL_DTYPE=("f32", "bf16", "fp8e4m3"),
+    RETURN_TEMPERATURE_LSE=(False, True),
+    CAUSAL=True,
+    PAGED_KV=False,
+    HAS_SEQUSED_K=False,
+    Q_STAGE=2, S_STAGE=2, O_STAGE=2, KV_STAGE=1,    # :116-119
+    K_STAGES=2,                                     # Q k-subtiles, :125
+    QIDX_META_STAGES=16,                            # :123
+    SPLIT_P_ARRIVE=96,                              # 128//4*3, floored to 32, :165-167
+    EX2_EMU_FREQ=16,                                # causal only, :180
+    EX2_EMU_START_FRG=1,                            # :181
+    NUM_REGS_SOFTMAX=176, NUM_REGS_STORE=112, NUM_REGS_OTHER=48,   # :173-178
+    CTA_GROUP=1, CLUSTER=(1, 1, 1),                 # :184-188
+    target="sm_100a",
+)
+# instruction_selection: none; extent: compile-time constants only.
+#   QK/PV operand dtypes and the two MMA kind strings are derived, not free:
+#   qk_dtype = q_dtype unless overridden; pv_dtype = bf16 for the legacy
+#   bf16-Q/fp8-KV case, else v_dtype (:321-335). mma_kind is "f8f6f4" when the
+#   operand width is 8, else "f16" (:363-364).
+K_FP8_TO_BF16 = (k_storage is fp8) and (qk_dtype is bf16)    # :354-357
+V_FP8_TO_BF16 = (v_storage is fp8) and (pv_dtype is bf16)    # :358-361
+
+@kernel(
+    grid=(work_capacity, 1, 1),        # :611, :626 -- a RUNTIME extent
+    block=(512, 1, 1),                 # 16 warps, :143
+    num_warps=16,
+    cluster=(1, 1, 1),                 # cta_group::1; no cluster launch attribute
+    dynamic_smem_bytes=max(SharedStorage.size_in_bytes(), 49152),   # :628
+    tmem_columns=512,                  # :161, power-of-two rounded
+    min_blocks_per_sm=1,               # :630
+    target="sm_100a",
+)
+def msa_sparse_atten_fwd_sm100(
+    k,                    # bf16|fp8 [total_k, head_kv, 128], input
+    v,                    # bf16|fp8 [total_k, head_kv, 128], input
+    k2q_q_indices,        # i32 [head_kv, nnz], input; q ascending within a CSR row, -1 past nnz
+    k2q_qsplit_indices,   # i32 [head_kv, nnz], input; q_idx | (slot << 24)
+    k2q_row_ptr,          # i32 [head_kv, total_rows + 1], input
+    scheduler_metadata,   # i32 [work_capacity, 6], input; all six columns read
+    work_count,           # i32 [1], input; the early-out bound
+    o_partial,            # f32|bf16|fp8 [topk*total_q*head_q, 128], OUTPUT, uninitialized
+    lse_partial,          # f32 [topk, total_q, head_q], OUTPUT, uninitialized
+    lse_temperature_partial,   # f32 [topk, total_q, head_q], OUTPUT, optional
+    q_flat,               # bf16|fp8 [total_q*head_q, 128], input
+    cu_seqlens_q,         # i32 [num_batches + 1], input
+    cu_seqlens_k,         # i32 [num_batches + 1], input
+    softmax_scale,        # f32; the kernel forms softmax_scale_log2 at trace time (:514)
+    lse_temperature_inv_scale,   # f32; 1 / lse_temperature_scale
+    num_kv_blocks,        # i32 == total_rows -- DEAD inside the kernel (:681)
+    num_heads_kv,         # i32
+    seq_len_q,            # i32 == max_seqlen_q
+    work_capacity,        # i32 == grid.x
+    total_k, total_q, head_q, nnz, total_rows, num_batches, topk,   # i32 extents
+):
+    # Upstream additionally passes `mQ_gather4_desc`, a host-built uint8[128]
+    # raw CUtensorMap (`interface.py:1682-1688`). The port DROPS that ABI
+    # argument and encodes the identical descriptor in its own launcher
+    # prologue -- see "TensorMap ABI" below. This is the sketch's one
+    # deliberate ABI deviation.
+
+    tid = thread_id()
+    warp = warp_uniform(tid // 32)
+    # instruction_selection: shfl.sync.idx.b32 (:706, 1 static); extent: warp
+    #   broadcast.  `make_warp_uniform` is a real instruction, not a no-op: it
+    #   is what lets ptxas treat every role predicate below as warp-uniform.
+    #   It is emitted at PTX 113, BEFORE the three descriptor prefetches and
+    #   long before either prologue barrier.
+    lane = tid % 32
+    block = block_id_x()
+
+    # -----------------------------------------------------------------------
+    # Work-item decode and the CTA-level early-out
+    # -----------------------------------------------------------------------
+    work_idx = block
+    cta_valid_work = work_idx < load_global(work_count, 0)
+    # instruction_selection: ld.global.u32 (atten_fwd.py:698, 1 static);
+    #   extent: scalar, executed by every thread.
+    # The grid is sized by the work list's CAPACITY, not its length --
+    # work_count lives on the device and is never read back -- so the launch is
+    # deliberately oversized and the tail CTAs fall straight through.
+
+    head_kv_idx = row_linear = work_q_begin = work_q_count = i32(0)
+    batch_idx = kv_block_idx = i32(0)
+    if cta_valid_work:
+        head_kv_idx  = load_global(scheduler_metadata, (work_idx, 0))
+        row_linear   = load_global(scheduler_metadata, (work_idx, 1))
+        work_q_begin = load_global(scheduler_metadata, (work_idx, 2))
+        work_q_count = load_global(scheduler_metadata, (work_idx, 3))
+        batch_idx    = load_global(scheduler_metadata, (work_idx, 4))
+        kv_block_idx = load_global(scheduler_metadata, (work_idx, 5))
+    # instruction_selection: ld.global.u32 x5 (:700, :702, :703, :704, :705)
+    #   plus ld.global.**s32** for `row_linear` (:701); extent: scalar, all
+    #   threads.  That signed load is the module's only one, and it is the same
+    #   operand-form point the epilogue's :3003 makes: the width and signedness
+    #   follow how the value is consumed downstream, not how it is declared.
+    #   All six columns are consumed, unlike the split-atomic sibling which
+    #   reads only 0..4.
+
+    # =======================================================================
+    # GMEM tiles
+    # =======================================================================
+
+    K = tile("gmem", k, KV_DTYPE, [total_k, num_heads_kv, 128], alignment=16)
+    V = tile("gmem", v, KV_DTYPE, [total_k, num_heads_kv, 128], alignment=16)
+    Qf = tile("gmem", q_flat, Q_DTYPE, [total_q * head_q, 128], alignment=16)
+    # The K/V descriptors see permuted views, built at trace time (:378-387):
+    #   K: [total_k, h, d] -> [total_k, d, h]      (K-major B operand)
+    #   V: [total_k, h, d] -> [d, total_k, h]      (MN-major B operand)
+    K_desc_view = view(K, KV_DTYPE, [total_k, 128, num_heads_kv])
+    V_desc_view = view(V, KV_DTYPE, [128, total_k, num_heads_kv])
+
+    Idx   = tile("gmem", k2q_q_indices,      "i32", [num_heads_kv, nnz])
+    QSpl  = tile("gmem", k2q_qsplit_indices, "i32", [num_heads_kv, nnz])
+    RowPtr= tile("gmem", k2q_row_ptr,        "i32", [num_heads_kv, total_rows + 1])
+    Op    = tile("gmem", o_partial,   PARTIAL_DTYPE, [topk * total_q * head_q, 128])
+    Lp    = tile("gmem", lse_partial, "f32", [topk, total_q, head_q])
+    LpT   = tile("gmem", lse_temperature_partial, "f32", [topk, total_q, head_q])
+    CuQ   = tile("gmem", cu_seqlens_q, "i32", [num_batches + 1])
+    CuK   = tile("gmem", cu_seqlens_k, "i32", [num_batches + 1])
+
+    # =======================================================================
+    # Shared memory: one dynamic pool.  Sizes for BF16 / QHEADPERKV=16.
+    #
+    # The source declares this as `@cute.struct SharedStorage` and allocates it
+    # with `cutlass.utils.SmemAllocator` (:734-735), which reads like a static
+    # __shared__ block.  It is not one: every export carries
+    #   .extern .shared .align 1024 .b8 __dynamic_shmem__0[]
+    # The matching TIRx form is T.SMEMPool() + pool.commit() under the
+    # `tirx.use_dyn_shared_memory` launch tag, never T.alloc_shared.
+    #
+    # Measured SharedStorage.size_in_bytes() per in-scope specialization:
+    #   bf16 TMA-Q  qheadperkv=16 -> 135168     <- the sizes below
+    #   bf16 gather4 qheadperkv=4 -> 138240
+    #   bf16 gather4 qheadperkv=1 -> 146432
+    #   bf16 Q + fp8 KV, gather4, qheadperkv=4 -> 171008  (+16384 +16384 staging)
+    #   all-fp8 TMA-Q qheadperkv=16 -> 69632
+    #   fp8 pv=bf16 TMA-Q qheadperkv=8 -> 103424
+    # The metadata half scales with Q_TOKENS_PER_GROUP = 128 // QHEADPERKV, so
+    # the footprint GROWS as the head group shrinks.  The 49152 floor at :628
+    # never binds.
+    # =======================================================================
+
+    smem = tile("smem", "u8", [dynamic_smem_bytes], byte_offset=0, alignment=1024)
+
+    # --- mbarrier words (:537-548) ---------------------------------------
+    mbar_k        = view(smem, "i64", [2])      # single-shot; only slot 0 used
+    mbar_v        = view(smem, "i64", [2])
+    mbar_k_tma    = view(smem, "i64", [2])      # present only if K_FP8_TO_BF16
+    mbar_v_tma    = view(smem, "i64", [2])      # present only if V_FP8_TO_BF16
+    mbar_q        = view(smem, "i64", [Q_STAGE, 2])     # full/empty
+    mbar_s        = view(smem, "i64", [S_STAGE, 2])
+    mbar_p        = view(smem, "i64", [S_STAGE, 2])
+    mbar_p_last   = view(smem, "i64", [S_STAGE, 2])
+    mbar_o        = view(smem, "i64", [O_STAGE, 2])
+    mbar_sm_stats = view(smem, "i64", [O_STAGE, 2])
+    tmem_dealloc_mbar = view(smem, "i64", [1])
+    tmem_holding      = view(smem, "i32", [1])
+
+    # --- scalar metadata (:554-587) --------------------------------------
+    sScale       = view(smem, "f32", [O_STAGE, 256])
+    #   slot s: [0:128) row_sum per M row, [128:256) row_max per M row
+    sScaleTemp   = view(smem, "f32", [O_STAGE, 128])          # temperature only
+    sSplitIdx    = view(smem, "i32", [O_STAGE, Q_TOKENS_PER_GROUP])
+    sQIdx        = view(smem, "i32", [O_STAGE, Q_TOKENS_PER_GROUP])
+    sDiagQCount  = view(smem, "i32", [1])
+    sRowMeta     = view(smem, "i32", [8])
+    #   0 batch, 1 kv_block, 2 row_start, 3 count_raw, 4 kv_valid_cols,
+    #   5 q_batch_off, 6 k_batch_off, 7 causal_q_offset
+    sPagedKvIdx  = view(smem, "i32", [1])                    # unused, PAGED_KV=False
+    sQLoadMIdx   = view(smem, "i32", [Q_STAGE, Q_TOKENS_PER_GROUP])
+    #   Allocated unconditionally (:582-583) even though only the TMA-Q body
+    #   reads it; its bytes are part of every footprint above.
+    sQIdxMeta    = view(smem, "i32", [QIDX_META_STAGES, Q_TOKENS_PER_GROUP])
+    #   The packed qsplit ring.  Deliberately deeper (16) than the in-flight
+    #   group distance so the epilogue can re-read q_idx/split without touching
+    #   global memory again (:120-123).
+
+    # --- the big tiles, 1024-byte aligned (:588-608) ----------------------
+    sK = view(smem, MMA_KV_DTYPE, [128, 128], alignment=1024,
+              layout="SM100-B-K-major", lifetime="one KV block, whole CTA life")
+    sV = view(smem, MMA_KV_DTYPE, [128, 128], alignment=1024,
+              layout="SM100-B-MN-major", lifetime="one KV block, whole CTA life")
+    sKFp8 = view(smem, "fp8e4m3", [128, 128], alignment=1024)   # K_FP8_TO_BF16 only
+    sVFp8 = view(smem, "fp8e4m3", [128, 128], alignment=1024)   # V_FP8_TO_BF16 only
+    sQ = view(smem, Q_DTYPE, [Q_STAGE, 128, 128], alignment=1024,
+              layout="SM100-A-K-major", lifetime="Q load until MMA release")
+    sQ_load = alias(sQ, Q_DTYPE,
+                    [Q_STAGE * Q_TOKENS_PER_GROUP * (128 // Q_LOAD_TILE),
+                     QHEADPERKV, Q_LOAD_TILE],
+                    layout="per-token sub-tile view of the same bytes",
+                    lifetime="identical to sQ")
+    #   Q_LOAD_TILE = 128 for fp8 Q, else K_TILE=64 (:427-429).
+    #   sQ and sQ_load are THE SAME BYTES with two layouts (:744-745): the MMA
+    #   sees one monolithic A tile, the loader sees q_tokens x k_subtiles boxes.
+
+    # =======================================================================
+    # TMEM: 512 columns.  P OVERLAYS the upper part of each S tile.
+    # =======================================================================
+
+    S = tile("tmem", "f32", [S_STAGE, 128, 128], base_col=0, columns=256)
+    #   S0 -> cols [0,128), S1 -> cols [128,256); stage stride = N_BLOCK = 128.
+    O = tile("tmem", "f32", [O_STAGE, 128, 128], base_col=256, columns=256)
+    #   O0 -> cols [256,384), O1 -> cols [384,512); stage stride = 128.
+    TMEM_S_TO_P = 128 - 128 * P_DTYPE_WIDTH // 32      # 64 for bf16 P, 96 for fp8 P (:369-371)
+    P = alias(S, P_DTYPE, [S_STAGE, 128, 128],
+              base_col=TMEM_S_TO_P,
+              lifetime="written after row_max/row_sum are extracted from the "
+                       "same columns; the tail of S is destroyed by the P store "
+                       "and that is safe only because of that ordering")
+    assert tmem_column_end(O) == 512
+
+    # =======================================================================
+    # Pipes.  Slot/phase arithmetic is explicit everywhere in this kernel:
+    #   slot = i % stages;  phase = (i // stages) & 1;  producer phase = phase ^ 1
+    # =======================================================================
+
+    q_pipe = pipe("q", stages=Q_STAGE, words=mbar_q,
+                  producers=1, consumers=1, tx_count=q_tma_bytes,
+                  kind="tma->umma")
+    #   expect_tx is set at PRODUCER ACQUIRE, and the several sub-tile TMAs the
+    #   Q-load warpgroup issues for that stage sum to exactly q_tma_bytes.
+    s_pipe = pipe("s", stages=S_STAGE, words=mbar_s,
+                  producers=1, consumers=128, kind="umma->async")
+    p_pipe = pipe("p", stages=S_STAGE, words=mbar_p,
+                  producers=128, consumers=1, kind="async->umma")
+    p_last_pipe = pipe("p_last", stages=S_STAGE, words=mbar_p_last,
+                       producers=128, consumers=1, kind="async->umma")
+    #   p_pipe carries the FIRST 3/4 of P; p_last_pipe carries the last quarter
+    #   and is consumed from INSIDE the PV MMA instruction sequence.
+    o_pipe = pipe("o", stages=O_STAGE, words=mbar_o,
+                  producers=1, consumers=128, kind="umma->async")
+    sm_stats_pipe = pipe("sm_stats", stages=O_STAGE, words=mbar_sm_stats,
+                         producers=128, consumers=128, kind="async")
+    #   Only the EMPTY half of sm_stats is live: the softmax warpgroup acquires
+    #   it (:2331) and the epilogue releases it (:3019); nothing ever commits or
+    #   waits on its full half.  Its sole job is to stop softmax from
+    #   overwriting sScale_slot before the epilogue two groups back has drained
+    #   it.  The port keeps the pipe object and both halves' storage, because
+    #   removing the dead half would change the barrier word layout.
+
+    # Named barriers.  MSA's NamedBarrierFwdSm100 emits its raw enum values with
+    # no user-barrier bias -- the export's physical ids are 2 (TmemPtr), 11
+    # (LoadWG), 12/13 (StoreEpilogue + stage), 13 (KvLoad), 14/15 (dequant) --
+    # which produces a real collision (see below).  The port renumbers from 8
+    # upward, the convention this repository documents at
+    # `tirx_kernels/flashmla/sparse_decode_head64.py:36-39`.
+    tmem_alloc_bar   = named_barrier(id=8,  threads=32 * (4 * 2 + 1))   # 288: both softmax WGs + MMA warp
+    load_wg_bar      = named_barrier(id=9,  threads=32 * 4)             # the Q-load warpgroup
+    kv_load_bar      = named_barrier(id=10, threads=32 * 2)             # fp8 paths only
+    kv_dequant_k_bar = named_barrier(id=11, threads=32 * 4)
+    kv_dequant_v_bar = named_barrier(id=12, threads=32 * 4)
+    epilogue_bar     = named_barrier(id=13, threads=32 * 4, indexed=2)  # id 13 + stage
+    #   DEVIATION, recorded: upstream uses StoreEpilogue=12 with `barrier_id +
+    #   stage`, so stage 1 resolves to id 13 -- which is also KvLoad's id.  The
+    #   export shows the collision physically: `bar.sync 13, 128` at :2554 (the
+    #   stage-1 epilogue) and `bar.sync 13, 64` at :1485 (KvLoad), the same
+    #   barrier id issued with two different participant counts in one kernel.
+    #   Upstream is safe only by accident of timing: kv_load_bar fires once,
+    #   very early, before any epilogue runs.  The port keeps the identical
+    #   synchronization structure and gives the indexed epilogue barrier its own
+    #   pair of ids.
+    sm_stats_bar     = named_barrier(id=15, threads=32 * 2)
+    #   DEAD: `signal_stats_barrier=False` at both `_softmax_step` call sites
+    #   (:2518, :2552) and `use_stats_barrier=False` in the epilogue (:2584),
+    #   so no arrive is ever emitted.  Declared to keep the id space aligned.
+```
+
+```python
+    # =======================================================================
+    # Prologue.  Descriptor prefetch, thread-0 metadata publish, mbarrier init.
+    # =======================================================================
+
+    if warp == 0:
+        prefetch_descriptor(K_map)
+        # instruction_selection: prefetch.tensormap (:721, 1 static);
+        #   extent: scalar, warp-wide (no elect -- the whole warp issues it).
+        prefetch_descriptor(V_map)
+        # instruction_selection: prefetch.tensormap (:722, 1 static); extent: scalar.
+        if not USE_Q_GATHER4:
+            prefetch_descriptor(Q_map)
+            # instruction_selection: prefetch.tensormap (:724, 1 static); extent: scalar.
+        else:
+            with elect():
+                prefetch_descriptor(Q_gather4_map)
+                # instruction_selection: prefetch.tensormap under elect.sync
+                #   (:727); extent: scalar, one lane.
+
+    # The cluster handshake.  The source comments it "no-op for 1CTA cluster";
+    # the export disagrees and emits a real fence and a real CTA barrier.
+    fence("mbarrier_init_release_cluster")
+    # instruction_selection: fence.mbarrier_init.release.cluster (:841, 1 static);
+    #   extent: scalar.
+    barrier()
+    # instruction_selection: bar.sync (:842, 1 static); extent: CTA-wide.
+
+    if tid == 0:
+        base_row_start = load_global(RowPtr, (head_kv_idx, row_linear))
+        # instruction_selection: ld.global.u32 (:860, 1 static); extent: scalar,
+        #   thread 0 only.  The source also computes `count_raw` from
+        #   RowPtr[.., row_linear+1] (:862-865) and then immediately overwrites
+        #   both with the work item's own slice (:866-867), so that second CSR
+        #   load is dead and the export carries no instruction for it.
+        row_start = base_row_start + work_q_begin
+        count_raw = work_q_count
+
+        # kv_valid_cols = clamp(seqlen_k - kv_block*128, 0, 128)   (:215-229)
+        seqlen_k = load_global(CuK, batch_idx + 1) - load_global(CuK, batch_idx)
+        # instruction_selection: ld.global.u32 x2 (:212, 2 static); extent: scalar.
+        kv_valid_cols = min(max(seqlen_k - kv_block_idx * 128, 0), 128)
+        q_batch_offset = load_global(CuQ, batch_idx)
+        # instruction_selection: ld.global.u32 (:198, 1 static); extent: scalar.
+        k_batch_offset = load_global(CuK, batch_idx)
+        # instruction_selection: none -- CSE'd into the :212 pair above, which
+        #   already loads CuK[batch_idx].  The module's ld.global count is
+        #   exactly 14 with no instruction for :883.
+
+        store_shared(sRowMeta, 0..6,
+                     [batch_idx, kv_block_idx, row_start, count_raw,
+                      kv_valid_cols, q_batch_offset, k_batch_offset])
+        # instruction_selection: st.shared.v4.u32 (:888, 1 static); extent: one
+        #   4-word vector store.  The source writes seven separate scalar
+        #   `sRowMeta[i] = ...` statements (:885-891); the backend merges them.
+
+        # causal_q_offset = seqlen_k - seqlen_q, needed by the mask (:892-901)
+        seqlen_q = load_global(CuQ, batch_idx + 1) - q_batch_offset
+        # instruction_selection: ld.global.u32 (:894, 1 static); extent: scalar.
+        causal_q_offset = seqlen_k - seqlen_q
+
+        store_shared(sRowMeta, 7, causal_q_offset)
+        # instruction_selection: st.shared.v4.u32 (:902, 1 static); extent: a
+        #   second 4-word vector store, ORDERED AFTER the :894 global load --
+        #   the two v4 stores are separated by it, so a port that merges all
+        #   eight fields into one store would have to sink the seqlen_q load
+        #   above them and change the dependence order.
+
+        init_pipe(mbar_k[0], arrivals=1)
+        # instruction_selection: mbarrier.init.shared.b64 (:907, 1 static); extent: scalar.
+        init_pipe(mbar_v[0], arrivals=1)
+        # instruction_selection: mbarrier.init.shared.b64 (:908, 1 static); extent: scalar.
+        if K_FP8_TO_BF16:
+            init_pipe(mbar_k_tma[0], arrivals=1)
+            expect_tx(mbar_k_tma[0], k_tma_bytes)
+        else:
+            expect_tx(mbar_k[0], k_tma_bytes)
+            # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared::cta.b64
+            #   (:913, 1 static); extent: scalar.  Note the K/V barriers take
+            #   their expect_tx HERE, in the prologue, not at the load warp --
+            #   the opposite of the Q pipe, which sets it at producer acquire.
+        if V_FP8_TO_BF16:
+            init_pipe(mbar_v_tma[0], arrivals=1)
+            expect_tx(mbar_v_tma[0], v_tma_bytes)
+        else:
+            expect_tx(mbar_v[0], v_tma_bytes)
+            # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared::cta.b64
+            #   (:918, 1 static); extent: scalar.
+
+        # The causal diagonal split point: how many of this row's tokens still
+        # need per-column causal masking.  A 32-step binary search over the CSR
+        # row, which is sorted by q_idx (:259-285).
+        diag_q_count = 0
+        if count_raw > 0 and kv_valid_cols > 0:
+            q_threshold = (kv_block_idx * 128 + kv_valid_cols) - causal_q_offset
+            left, right = 0, count_raw
+            for _ in range(32):                    # `unroll=1`, and it stays rolled
+                if left < right:
+                    mid = (left + right) // 2
+                    probe = load_global(Idx, (head_kv_idx, row_start + mid))
+                    # instruction_selection: ld.global.u32 (:239, 1 static);
+                    #   extent: scalar, ONE instruction inside a rolled loop.
+                    #   The single static occurrence is the evidence the loop
+                    #   was not unrolled and the probe was not hoisted: the port
+                    #   must express this as a rolled loop with the load in the
+                    #   body, not as 32 straight-line probes.
+                    left, right = (mid + 1, right) if probe < q_threshold else (left, mid)
+            diag_q_count = left
+        store_shared(sDiagQCount, 0, diag_q_count)
+        # instruction_selection: st.shared.u32 (:935, 1 static); extent: scalar.
+
+    fence("mbarrier_init_release_cluster")
+    # instruction_selection: fence.mbarrier_init.release.cluster (:936, 1 static);
+    #   extent: scalar.  This is the SECOND such fence in the prologue; the
+    #   first (:841) belongs to the cluster handshake.
+    barrier()
+    # instruction_selection: bar.sync (:937, 1 static); extent: CTA-wide.
+    #   Every warp reaches this, including the CTAs whose `cta_valid_work` is
+    #   false and every warp that matches no role below.
+
+    # The pipes' own barrier words are initialized by the pipeline objects
+    # rather than by this thread-0 block:
+    # instruction_selection: mbarrier.init.shared.b64 (pipeline.py:62 x4,
+    #   :169 x4, :269 x8, :324 x8; 24 static total); extent: one per stage per
+    #   half across the six pipes.
+
+    if warp == 15:
+        set_register_budget("decrease", NUM_REGS_OTHER)     # 48
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:992, 1 static);
+        #   extent: warp-wide.  NOT gated on cta_valid_work.
+        return
+
+    # =======================================================================
+    # ROLE: Q-load warpgroup, warps 8..11.  Independent `if` on a THREAD range.
+    # =======================================================================
+    if 8 * 32 <= tid < 12 * 32 and cta_valid_work:
+        set_register_budget("decrease", NUM_REGS_STORE)     # 112 on the causal path
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:1001, 1 static);
+        #   extent: warpgroup.  `store_reg_decrease` is True whenever
+        #   NUM_REGS_STORE <= 128 (:179), which the causal specialization is.
+
+        row_start, count_raw = load_shared(sRowMeta, 2..3)
+        # instruction_selection: ld.shared.v2.u32 (:1004, 1 static); extent: two
+        #   adjacent words in one instruction.  The source reads sRowMeta[2] and
+        #   sRowMeta[3] as separate statements; the backend merges them.
+        q_batch_offset = load_shared(sRowMeta, 5)
+        # instruction_selection: ld.shared.u32 (:1006, 1 static); extent: scalar.
+        has_work = count_raw > 0
+        num_q_groups = ceil_div(count_raw, Q_TOKENS_PER_GROUP)
+        # Deliberately NOT gated on KV validity: a sparse entry past seqused_k
+        # still has to run the all-masked path so its partial is neutral
+        # (:1007-1009).
+
+        if USE_Q_GATHER4:
+            q_load_gather4(...)      # warps 8..11, body below
+        else:
+            q_load_tma(...)          # warps 8..11, body below
+
+    # -----------------------------------------------------------------------
+    # Q-load body A: the raw gather4 path (QHEADPERKV in {1, 2, 4})
+    # -----------------------------------------------------------------------
+    def q_load_gather4():
+        warp_in_wg = shuffle_index(local_warp, lane=0, mask=31, clamp=-1)
+        lane_idx = (tid - 8 * 32) % 32
+        # mQ_2d.shape[0] // QHEADPERKV = total_q * num_heads_kv: one past the
+        # last Q *tile*, not the last Q row.  The gather arm below scales it by
+        # QHEADPERKV to get one past the last Q *row*, so the TMA lands out of
+        # bounds and the descriptor's OOB fill supplies the data.  `total_q`
+        # alone is an IN-RANGE row whenever num_heads_kv > 1 (:1647).
+        q_oob_m_idx = total_q * num_heads_kv
+        GATHERS_PER_WARP = 128 // (4 * 4)           # = 8 (:1648-1649)
+
+        if not has_work:
+            return
+        for qi_group in range(num_q_groups):        # rolled
+            slot = qi_group % Q_STAGE
+            phase = (qi_group // Q_STAGE) & 1
+            producer_phase = phase ^ 1
+            if warp_in_wg == 0:
+                acquire(q_pipe.producer, slot, producer_phase)
+                # instruction_selection: mbarrier.try_wait.parity.shared.b64 then
+                #   mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 (the
+                #   TMA-Q variant of this same call is at :1867, 1 static each);
+                #   extent: scalar, one thread.  The expect_tx is issued HERE,
+                #   at acquire, and the gather4 TMAs below sum to exactly
+                #   q_tma_bytes for the stage.
+            named_barrier_arrive_and_wait(load_wg_bar)
+            # instruction_selection: bar.sync with a named id (the TMA-Q twin is
+            #   at :1869, 1 static); extent: 128 threads.
+
+            qidx_meta_slot = (qi_group & (QIDX_META_STAGES - 1)) * Q_TOKENS_PER_GROUP
+            # Publish this group's packed qsplit words.  Q_TOKENS_PER_GROUP is
+            # 32/64/128 on this path, so it takes `meta_iters` sweeps of the
+            # whole warpgroup (:1671-1690).
+            for meta_iter in range(meta_iters):     # constexpr, fully unrolled
+                tok = (meta_iter * 4 + warp_in_wg) * 32 + lane_idx
+                if tok < Q_TOKENS_PER_GROUP:
+                    qi = qi_group * Q_TOKENS_PER_GROUP + tok
+                    if qi < count_raw:
+                        word = load_global(QSpl, (head_kv_idx, row_start + qi))
+                        # instruction_selection: ld.global.u32 (:249, 1 static);
+                        #   extent: scalar.
+                        store_shared(sQIdxMeta, qidx_meta_slot + tok, word)
+                        # instruction_selection: st.shared.u32 (:1686, 1 static);
+                        #   extent: scalar.
+                    else:
+                        store_shared(sQIdxMeta, qidx_meta_slot + tok, 0)
+                        # instruction_selection: st.shared.u32 (:1690, 1 static);
+                        #   extent: scalar.  The two arms stay two separate
+                        #   stores in the export, exactly as on the TMA-Q path --
+                        #   they are not folded into a select plus one store.
+            named_barrier_arrive_and_wait(load_wg_bar)
+            # instruction_selection: bar.sync, named; extent: 128 threads.
+            #   Two barriers per group bracket the metadata publish: the ring
+            #   slot must be acquired before anyone writes it, and every writer
+            #   must be done before any lane reads a neighbour's token.
+
+            with elect():
+                for gather_slot in range(GATHERS_PER_WARP):   # constexpr, unrolled
+                    gather_idx = gather_slot * 4 + warp_in_wg
+                    tok_base = gather_idx * TOKENS_PER_GATHER4
+
+                    # Resolve the four GMEM row indices this gather4 pulls.
+                    # The three QHEADPERKV cases differ only in how many
+                    # distinct tokens the four rows come from (:1702-1763):
+                    #   1 -> four tokens, one head row each
+                    #   2 -> two tokens, two consecutive head rows each
+                    #   4 -> one token, four consecutive head rows
+                    # A token past `count_raw` uses q_oob_m_idx, so the gather
+                    # lands on an out-of-range row instead of being predicated
+                    # off -- the mask makes its contribution neutral later.
+                    q_idx = decode_q_idx(load_shared(sQIdxMeta, qidx_meta_slot + tok_base))
+                    # instruction_selection: ld.shared.u32 (:1755, 8 static on
+                    #   the QHEADPERKV=4 export); extent: scalar, one per gather
+                    #   slot -- the metadata word is re-read per gather, not
+                    #   hoisted across the eight.
+                    r0 = (q_batch_offset + q_idx) * num_heads_kv + head_kv_idx
+                    r0, r1, r2, r3 = expand_rows(r0, QHEADPERKV)
+
+                    if Q_DTYPE is fp8:
+                        copy_g2s_gather4(sQ, slot * Q_STAGE_STRIDE_BYTES
+                                             + gather_idx * 4 * 128 * 1,
+                                         Q_gather4_map, col=0,
+                                         r0, r1, r2, r3,
+                                         bar=q_pipe.full[slot],
+                                         hint=TMA_CACHE_EVICT_LAST)
+                        # instruction_selection:
+                        #   cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4
+                        #   .mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint;
+                        #   extent: one 4-row gather per slot, 8 per warp.
+                    else:
+                        for ks in range(K_STAGES):        # constexpr, unrolled
+                            if ks + 1 < K_STAGES:
+                                prefetch_g2s_gather4(Q_gather4_map,
+                                                     col=(ks + 1) * K_TILE,
+                                                     r0, r1, r2, r3,
+                                                     hint=TMA_CACHE_EVICT_LAST)
+                                # instruction_selection:
+                                #   cp.async.bulk.prefetch.tensor.2d.L2.global
+                                #   .tile::gather4.L2::cache_hint (:1789, 8
+                                #   static); extent: one per gather slot -- only
+                                #   ks=0 satisfies the guard, so the second
+                                #   k-subtile is prefetched while the first is
+                                #   still in flight.
+                            copy_g2s_gather4(sQ,
+                                             (slot * K_STAGES + ks) * K_TILE_STRIDE_BYTES
+                                                 + gather_idx * 4 * K_TILE * 2,
+                                             Q_gather4_map, col=ks * K_TILE,
+                                             r0, r1, r2, r3,
+                                             bar=q_pipe.full[slot],
+                                             hint=TMA_CACHE_EVICT_LAST)
+                            # instruction_selection:
+                            #   cp.async.bulk.tensor.2d.shared::cta.global
+                            #   .tile::gather4.mbarrier::complete_tx::bytes
+                            #   .cta_group::1.L2::cache_hint (:1798, 16 static);
+                            #   extent: 8 gather slots x 2 k-subtiles per warp.
+            named_barrier_arrive_and_wait(load_wg_bar)
+            # instruction_selection: bar.sync, named; extent: 128 threads.
+
+        if warp_in_wg == 0:
+            # One extra acquire past the end so the ring's empty half is left in
+            # the state the next work item would expect (:1812-1817).
+            acquire(q_pipe.producer,
+                    num_q_groups % Q_STAGE,
+                    ((num_q_groups // Q_STAGE) & 1) ^ 1)
+
+    # -----------------------------------------------------------------------
+    # Q-load body B: the CUTE-managed TMA path (QHEADPERKV in {8, 16})
+    # -----------------------------------------------------------------------
+    def q_load_tma():
+        warp_in_wg = warp - 8
+        q_oob_m_idx = total_q * num_heads_kv    # = mQ_2d.shape[0] // QHEADPERKV (:1855)
+        TOKENS_PER_WARP = ceil_div(Q_TOKENS_PER_GROUP, 4)
+        SUBTILES_PER_TOKEN = 1 if Q_DTYPE is fp8 else K_STAGES
+
+        if not has_work:
+            return
+        for qi_group in range(num_q_groups):        # rolled
+            slot = qi_group % Q_STAGE
+            phase = (qi_group // Q_STAGE) & 1
+            if warp_in_wg == 0:
+                acquire(q_pipe.producer, slot, phase ^ 1)
+                # instruction_selection: mbarrier.try_wait.parity.shared.b64 +
+                #   mbarrier.arrive.expect_tx.release.cta.shared::cta.b64
+                #   (:1867, 1 static each); extent: scalar, one thread.
+            named_barrier_arrive_and_wait(load_wg_bar)
+            # instruction_selection: bar.sync, named (:1869, 1 static);
+            #   extent: 128 threads.
+
+            load_meta_slot  = slot * Q_TOKENS_PER_GROUP
+            qidx_meta_slot  = (qi_group & (QIDX_META_STAGES - 1)) * Q_TOKENS_PER_GROUP
+            sub_stage_base  = slot * Q_TOKENS_PER_GROUP * SUBTILES_PER_TOKEN
+
+            # With QHEADPERKV >= 8 the group is at most 16 tokens, so ONE warp's
+            # low lanes publish the whole group (:1883-1898).
+            if warp_in_wg == 0 and lane < Q_TOKENS_PER_GROUP:
+                qi = qi_group * Q_TOKENS_PER_GROUP + lane
+                if qi < count_raw:
+                    word = load_global(QSpl, (head_kv_idx, row_start + qi))
+                    # instruction_selection: ld.global.u32 (:249, 1 static); extent: scalar.
+                    store_shared(sQIdxMeta, qidx_meta_slot + lane, word)
+                    # instruction_selection: st.shared.u32 (:1892, 1 static); extent: scalar.
+                    store_shared(sQLoadMIdx, load_meta_slot + lane,
+                                 (q_batch_offset + decode_q_idx(word)) * num_heads_kv
+                                     + head_kv_idx)
+                    # instruction_selection: st.shared.u32 (:1893, 1 static); extent: scalar.
+                else:
+                    store_shared(sQIdxMeta, qidx_meta_slot + lane, 0)
+                    # instruction_selection: st.shared.u32 (:1897, 1 static); extent: scalar.
+                    store_shared(sQLoadMIdx, load_meta_slot + lane, q_oob_m_idx)
+                    # instruction_selection: st.shared.u32 (:1898, 1 static); extent: scalar.
+                    #   The two arms stay separate stores in the export; they are
+                    #   not merged into a select plus one store.
+            named_barrier_arrive_and_wait(load_wg_bar)
+            # instruction_selection: bar.sync, named (:1899, 1 static); extent: 128 threads.
+
+            for qi_slot in range(TOKENS_PER_WARP):        # constexpr, unrolled
+                tok = warp_in_wg * TOKENS_PER_WARP + qi_slot
+                if tok < Q_TOKENS_PER_GROUP:
+                    m_tile = load_shared(sQLoadMIdx, load_meta_slot + tok)
+                    # instruction_selection: ld.shared.u32 (:1907, 2 static);
+                    #   extent: scalar, once per token slot.
+                    if Q_DTYPE is fp8:
+                        copy_g2s(Qf[m_tile], sQ_load[sub_stage_base + tok],
+                                 bar=q_pipe.full[slot])
+                    else:
+                        copy_g2s(Qf_k0[m_tile], sQ_load[sub_stage_base + tok],
+                                 bar=q_pipe.full[slot])
+                        # instruction_selection: cp.async.bulk.tensor.2d
+                        #   .shared::cluster.global.tile
+                        #   .mbarrier::complete_tx::bytes.L2::cache_hint under
+                        #   elect.sync (:1915, 2 static each); extent: one
+                        #   (QHEADPERKV x 64) box.
+                        copy_g2s(Qf_k1[m_tile],
+                                 sQ_load[sub_stage_base + Q_TOKENS_PER_GROUP + tok],
+                                 bar=q_pipe.full[slot])
+                        # instruction_selection: cp.async.bulk.tensor.2d
+                        #   .shared::cluster.global.tile
+                        #   .mbarrier::complete_tx::bytes.L2::cache_hint under
+                        #   elect.sync (:1920, 2 static each); extent: the second
+                        #   64-column k-subtile of the same token.
+
+        if warp_in_wg == 0:
+            acquire(q_pipe.producer,
+                    num_q_groups % Q_STAGE,
+                    ((num_q_groups // Q_STAGE) & 1) ^ 1)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 +
+            #   mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 (:1935,
+            #   1 static each); extent: scalar.
+
+    # =======================================================================
+    # ROLE: KV load, warps 13 and 14.  One TMA each; there is no KV ring.
+    # =======================================================================
+    if 13 <= warp < 15 and cta_valid_work:
+        set_register_budget("decrease", NUM_REGS_OTHER)     # 48
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:1054, 1 static);
+        #   extent: warp-wide.
+        kv_block = load_shared(sRowMeta, 1)
+        # instruction_selection: ld.shared.u32 (:1055, 1 static); extent: scalar.
+        k_batch_offset = load_shared(sRowMeta, 6)
+        # instruction_selection: ld.shared.u32 (:1056, 1 static); extent: scalar.
+        has_work = load_shared(sRowMeta, 3) > 0
+        # instruction_selection: ld.shared.u32 (:1057, 1 static); extent: scalar.
+        #   These three stay three separate scalar loads -- unlike the Q-load
+        #   warpgroup's sRowMeta[2..3], which the backend merged into a v2.
+
+        if not has_work:
+            return
+        warp_in_role = warp - 13
+        if warp_in_role == 0:
+            if K_FP8_TO_BF16:
+                copy_g2s(K_desc_view[kv_block, :, head_kv_idx], sKFp8,
+                         bar=mbar_k_tma[0])
+                with elect():
+                    commit(mbar_k_tma[0])
+            else:
+                copy_g2s(K_desc_view[kv_block, :, head_kv_idx], sK, bar=mbar_k[0])
+                # instruction_selection: cp.async.bulk.tensor.**3d**
+                #   .shared::cluster.global.tile.mbarrier::complete_tx::bytes
+                #   .L2::cache_hint under elect.sync (:1571, 2 static each);
+                #   extent: the CTA's single 128x128 K tile, issued as TWO
+                #   instructions.  Rank 3, not 2: the KV-head axis stays in the
+                #   descriptor rather than being folded into the base address.
+                with elect():
+                    commit(mbar_k[0])
+                    # instruction_selection: mbarrier.arrive.release.cta
+                    #   .shared::cta.b64 (:1580, 1 static); extent: scalar, one
+                    #   lane.  The transaction-byte count was already promised
+                    #   by thread 0's prologue expect_tx, so this is a plain
+                    #   arrive, not an arrive-and-expect.
+        if warp_in_role == 1:
+            if V_FP8_TO_BF16:
+                copy_g2s(V_desc_view[:, kv_block, head_kv_idx], sVFp8,
+                         bar=mbar_v_tma[0])
+                with elect():
+                    commit(mbar_v_tma[0])
+            else:
+                copy_g2s(V_desc_view[:, kv_block, head_kv_idx], sV, bar=mbar_v[0])
+                # instruction_selection: cp.async.bulk.tensor.3d
+                #   .shared::cluster.global.tile.mbarrier::complete_tx::bytes
+                #   .L2::cache_hint under elect.sync (:1612, 2 static each);
+                #   extent: the CTA's single 128x128 V tile, MN-major.
+                with elect():
+                    commit(mbar_v[0])
+                    # instruction_selection: mbarrier.arrive.release.cta
+                    #   .shared::cta.b64 (:1621, 1 static); extent: scalar.
+        if K_FP8_TO_BF16 or V_FP8_TO_BF16:
+            named_barrier_arrive_and_wait(kv_load_bar)
+            # instruction_selection: bar.sync, named, 64 threads (:1485);
+            #   extent: the two KV load warps.  Present only on the fp8 paths.
+```
+
+```python
+    # =======================================================================
+    # ROLE: the single MMA-issue warp, warp 12.  Also the TMEM allocator warp.
+    # =======================================================================
+    if warp == 12 and cta_valid_work:
+        set_register_budget("decrease", NUM_REGS_OTHER)     # 48
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:1089, 1 static);
+        #   extent: warp-wide.
+        count_raw = load_shared(sRowMeta, 3)
+        has_work = count_raw > 0
+        num_q_groups = ceil_div(count_raw, Q_TOKENS_PER_GROUP)
+
+        tmem.allocate(columns=512)
+        # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned
+        #   .shared::cta.b32 (:1095, 1 static); extent: scalar.
+        tmem.wait_for_alloc()
+        # instruction_selection: bar.sync, named, 288 threads (:1096, 1 static);
+        #   extent: the TMEM retrieve barrier.
+        # The retrieve barrier spans 288 threads = both softmax warpgroups plus
+        # this warp (:767-772).  On the fp8 paths that means the MMA warp is
+        # gated on the softmax warpgroups having finished dequantizing K and V
+        # into sK/sV -- the dequant is upstream of the first QK by construction,
+        # not by an extra edge.
+
+        # Descriptor state, hoisted into named PTX registers before the loop.
+        # `declare_ptx_smem_desc` materializes the Q A-operand descriptors as
+        # persistent `.reg .b64 lean_q_desc_<k>` and `declare_ptx_idesc` the
+        # instruction descriptor as `.reg .b32 lean_qk_idesc` (:1982-1989).
+        # Four QK partials are pre-bound: {S slot 0, S slot 1} x {wrap, advance}
+        # (:1996-2043), where `advance` adds +sQ_stage_stride to the A
+        # descriptor and `wrap` adds -(Q_STAGE-1)*stride.  The Q ring is walked
+        # inside PTX registers, never re-derived per iteration.
+        q_desc  = reg_tile([], "u64", name="lean_q_desc_k", persistent=True)
+        qk_idesc = reg_tile([], "u32", name="lean_qk_idesc", persistent=True)
+
+        if not has_work:
+            return
+
+        wait(mbar_k[0], phase=0)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2069,
+        #   1 static); extent: scalar.
+
+        # Issue order (:2070-2077):  Q0K, Q1K, P0V, Q2K, P1V, Q3K, ...
+        #   QK(qi) consumes S slot qi&1; PV(qi-2) frees that same slot before
+        #   QK(qi) reuses it, so a 2-slot S ring is safe and the phase toggles
+        #   every two groups per slot.
+
+        # --- prologue: up to two QK tiles ---------------------------------
+        wait(q_pipe.full, slot=0, phase=0)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2081, 1 static);
+        #   extent: scalar.
+        acquire(s_pipe.producer, slot=0, phase=1)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2082, 1 static);
+        #   extent: scalar.
+        gemm(S[0], sQ[0], sK, accumulate=False)
+        # instruction_selection: tcgen05.mma.cta_group::1.kind::f16 (48 static
+        #   across the whole kernel, all reported at :291 because the chain is
+        #   built inside blackwell_helpers' PTX string builder); extent: one
+        #   128x128x128 QK tile issued as a K-loop of same-family instructions
+        #   over the pre-bound descriptors.  `mma_kind` becomes "f8f6f4" when
+        #   the QK operand width is 8.
+        commit(s_pipe, slot=0)
+        # instruction_selection: tcgen05.commit.cta_group::1
+        #   .mbarrier::arrive::one.shared::cluster.b64 (:2084, 1 static);
+        #   extent: scalar.
+        release(q_pipe.consumer, slot=0)
+        # instruction_selection: tcgen05.commit.cta_group::1
+        #   .mbarrier::arrive::one.shared::cluster.b64 (:2085, 1 static);
+        #   extent: scalar.  A TMA->UMMA pipe releases its empty half with a
+        #   tcgen05 commit, not a plain mbarrier arrive, so the release is
+        #   ordered behind the MMA that consumed the stage.
+
+        if num_q_groups > 1:
+            wait(q_pipe.full, slot=1, phase=0)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2088, 1 static).
+            acquire(s_pipe.producer, slot=1, phase=1)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2089, 1 static).
+            gemm(S[1], sQ[1], sK, accumulate=False)
+            # instruction_selection: tcgen05.mma.cta_group::1.kind::f16; extent:
+            #   one QK tile, the `advance` partial (A descriptor +stride).
+            commit(s_pipe, slot=1)
+            # instruction_selection: tcgen05.commit... (:2091, 1 static).
+            release(q_pipe.consumer, slot=1)
+            # instruction_selection: tcgen05.commit... (:2092, 1 static).
+
+        wait(mbar_v[0], phase=0)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2094, 1 static);
+        #   extent: scalar.  V is waited AFTER the two prologue QKs, so the V
+        #   TMA overlaps them.
+
+        # --- steady state: PV(qi-2) then QK(qi) ---------------------------
+        for qi in range(2, num_q_groups):           # rolled (`unroll=1`)
+            pv_qi   = qi - 2
+            pv_slot = pv_qi & 1
+            pv_phase = (pv_qi // 2) & 1
+            wait(p_pipe.full, pv_slot, pv_phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2104,
+            #   1 static); extent: scalar.  This is the EARLY-P edge: softmax
+            #   has published only the first 3/4 of P.
+            acquire(o_pipe.producer, pv_slot, pv_phase ^ 1)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2105,
+            #   1 static); extent: scalar.
+            gemm(O[pv_slot], P[pv_slot], sV, accumulate=False)
+            # instruction_selection: an 8-instruction
+            #   tcgen05.mma.cta_group::1.kind::f16 chain (PTX 1120-1147) with an
+            #   embedded mbarrier.try_wait.parity.shared::cta.b64 (2 static,
+            #   reported at :291) partway through it; extent: one 128x128x128 PV
+            #   tile, issued as two batches of the same instruction family with
+            #   the late-P wait between them.  `split_arrive = 96` means the
+            #   first 3/4 of the K extent is issued against the early-P barrier
+            #   and the sequence then blocks on p_last before the final quarter.
+            #   Unlike the QK issue below, the `pv_slot` test does NOT duplicate
+            #   the chain: it collapses to an address select feeding one chain,
+            #   because the two arms differ only in their TMEM addresses.  The A
+            #   operand lives in TMEM, so its address is passed explicitly
+            #   (tA_addr = tmem_p_offset) rather than read from the tensor.
+            commit(o_pipe, pv_slot)
+            # instruction_selection: tcgen05.commit.cta_group::1
+            #   .mbarrier::arrive::one.shared::cluster.b64 (:2127, 1 static);
+            #   extent: scalar.
+            release(p_last_pipe.consumer, pv_slot)
+            # instruction_selection: tcgen05.commit.cta_group::1
+            #   .mbarrier::arrive::one.shared::cluster.b64 (:2129, 1 static);
+            #   extent: scalar.
+            release(p_pipe.consumer, pv_slot)
+            # instruction_selection: tcgen05.commit.cta_group::1
+            #   .mbarrier::arrive::one.shared::cluster.b64 (:2130, 1 static);
+            #   extent: scalar.  Note that p_pipe and p_last_pipe are
+            #   softmax-PRODUCED pipes, yet their consumer release is still a
+            #   tcgen05 commit -- the rule is about who issues the arrival, not
+            #   who produced the data.
+
+            q_slot  = qi % Q_STAGE
+            q_phase = (qi // Q_STAGE) & 1
+            s_slot  = qi & 1
+            s_phase = (qi // 2) & 1
+            wait(q_pipe.full, q_slot, q_phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2136,
+            #   1 static); extent: scalar.
+            acquire(s_pipe.producer, s_slot, s_phase ^ 1)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2137,
+            #   1 static); extent: scalar.
+            if s_slot == 0:
+                gemm(S[0], sQ[q_slot], sK, accumulate=False)
+            else:
+                gemm(S[1], sQ[q_slot], sK, accumulate=False)
+            # instruction_selection: two separate 8-instruction
+            #   tcgen05.mma.cta_group::1.kind::f16 chains at PTX 1264-1271 and
+            #   1335-1342, selected by a RUNTIME branch --
+            #   `setp.ne.s32 %p90, %r62, 0` at PTX 1181 (.loc 1 2107) and
+            #   `@%p90 bra $L__BB0_74` at PTX 1209; extent: one QK tile per arm.
+            #   `s_slot` and `q_slot` are runtime values in a rolled loop, so
+            #   this is NOT a compile-time choice: the S-slot test costs a real
+            #   branch and duplicates the chain, while the (q_slot 0 -> `wrap`,
+            #   q_slot 1 -> `advance`) descriptor choice collapses into an
+            #   address select feeding the chain.  Whole-kernel census: 48
+            #   tcgen05.mma = 6 chains x 8 instructions (2 prologue QK, 2 steady
+            #   QK behind this branch, 1 steady PV, 1 drain PV); an f8f6f4
+            #   specialization emits 24 = 6 x 4.
+            commit(s_pipe, s_slot)
+            # instruction_selection: tcgen05.commit.cta_group::1
+            #   .mbarrier::arrive::one.shared::cluster.b64 (:2149, 1 static);
+            #   extent: scalar.
+            release(q_pipe.consumer, q_slot)
+            # instruction_selection: tcgen05.commit.cta_group::1
+            #   .mbarrier::arrive::one.shared::cluster.b64 (:2150, 1 static);
+            #   extent: scalar.
+
+        # --- drain the last one or two PV tiles ---------------------------
+        drain_begin = 0 if num_q_groups == 1 else num_q_groups - 2
+        for pv_qi in range(drain_begin, num_q_groups):     # rolled
+            pv_slot  = pv_qi & 1
+            pv_phase = (pv_qi // 2) & 1
+            wait(p_pipe.full, pv_slot, pv_phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2157,
+            #   1 static); extent: scalar.
+            acquire(o_pipe.producer, pv_slot, pv_phase ^ 1)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2158,
+            #   1 static); extent: scalar.
+            gemm(O[pv_slot], P[pv_slot], sV, accumulate=False)
+            # instruction_selection: the sixth and last 8-instruction
+            #   tcgen05.mma.cta_group::1.kind::f16 chain, with the same embedded
+            #   late-P wait; extent: one PV tile.
+            commit(o_pipe, pv_slot)
+            # instruction_selection: tcgen05.commit... (:2180, 1 static); extent: scalar.
+            release(p_last_pipe.consumer, pv_slot)
+            # instruction_selection: tcgen05.commit... (:2182, 1 static); extent: scalar.
+            release(p_pipe.consumer, pv_slot)
+            # instruction_selection: tcgen05.commit... (:2183, 1 static); extent: scalar.
+
+        tmem.relinquish_alloc_permit()
+        # instruction_selection: tcgen05.relinquish_alloc_permit.cta_group::1
+        #   .sync.aligned (:1108, 1 static); extent: scalar.
+        named_barrier_arrive_and_wait(tmem_alloc_bar)
+        # instruction_selection: bar.sync, named, 288 threads (:1109, 1 static);
+        #   extent: both softmax warpgroups plus this warp.
+        tmem.free(columns=512)
+        # instruction_selection: tcgen05.dealloc.cta_group::1.sync.aligned.b32
+        #   (:1110, 1 static); extent: scalar.
+        griddepcontrol_launch_dependents()
+        # instruction_selection: griddepcontrol.launch_dependents (:1111, 1 static);
+        #   extent: scalar.  There is no matching griddepcontrol.wait anywhere in
+        #   this kernel, so no launch attribute is required -- only a kernel that
+        #   waits needs `tirx.use_programtic_dependent_launch`.
+
+    # =======================================================================
+    # ROLE: softmax warpgroup 0 (warps 0..3) and 1 (warps 4..7).
+    #
+    # The export shows this whole body -- softmax step AND fused epilogue -- is
+    # emitted TWICE, once per warpgroup, not shared behind a runtime `stage`.
+    # Every single-site operation inside it has exactly 2 static occurrences.
+    # =======================================================================
+    if (0 <= warp < 4 or 4 <= warp < 8) and cta_valid_work:
+        stage = 0 if warp < 4 else 1                # a COMPILE-TIME constant
+        set_register_budget("increase", NUM_REGS_SOFTMAX)   # 176 on the causal path
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 (:1118 for WG0,
+        #   :1180 for WG1, 1 static each); extent: warpgroup.
+
+        kv_block_idx, count_raw = load_shared(sRowMeta, 1..3)
+        # instruction_selection: ld.shared.v4.u32 (:1119 / :1181, 1 static each);
+        #   extent: four adjacent metadata words in one instruction.  The source
+        #   reads sRowMeta[1] and sRowMeta[3] as separate statements.
+        kv_valid_cols     = load_shared(sRowMeta, 4)
+        # instruction_selection: ld.shared.u32 (:1121 / :1183, 1 static); extent: scalar.
+        causal_q_offset   = load_shared(sRowMeta, 7)
+        # instruction_selection: ld.shared.u32 (:1122 / :1184, 1 static); extent: scalar.
+        diag_q_count      = load_shared(sDiagQCount, 0)
+        # instruction_selection: ld.shared.u32 (:1127 / :1189, 1 static); extent: scalar.
+        q_batch_offset    = load_shared(sRowMeta, 5)
+        # instruction_selection: ld.shared.u32 (:1170 / :1232, 1 static); extent: scalar.
+        has_work = count_raw > 0
+        num_q_groups = ceil_div(count_raw, Q_TOKENS_PER_GROUP)
+
+        # -------------------------------------------------------------------
+        # FP8 staging, before the main loop.  WG0 dequantizes K, WG1 V.
+        # -------------------------------------------------------------------
+        if stage == 0 and K_FP8_TO_BF16:
+            dequant_kv(sKFp8, sK, mbar_k_tma, mbar_k, kv_dequant_k_bar, is_v=False)
+        if stage == 1 and V_FP8_TO_BF16:
+            dequant_kv(sVFp8, sV, mbar_v_tma, mbar_v, kv_dequant_v_bar, is_v=True)
+
+        tmem.wait_for_alloc()
+        # instruction_selection: bar.sync, named, 288 threads (:1140 / :1202,
+        #   1 static each); extent: the TMEM retrieve barrier.
+
+        # ... the per-group loop, below ...
+
+        named_barrier_arrive(tmem_alloc_bar)
+        # instruction_selection: bar.arrive, named (reported at :291, 2 static);
+        #   extent: warpgroup.  Arrive-only: the MMA warp is the one that waits
+        #   before freeing TMEM.
+
+    # -----------------------------------------------------------------------
+    # FP8 -> BF16 shared-memory staging (:1255-1303, :1488-1516)
+    #
+    # This is NOT in the load warps.  The KV load warps only land the fp8 bytes
+    # in sKFp8/sVFp8; a whole softmax warpgroup then converts them into the bf16
+    # tile the MMA reads, before entering its own loop.
+    # -----------------------------------------------------------------------
+    def dequant_kv(sFp8, sBf16, mbar_tma, mbar_ready, dequant_bar, is_v):
+        if not has_work:
+            return
+        wait(mbar_tma[0], phase=0)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1504,
+        #   2 static across both warpgroups); extent: scalar.
+
+        CHUNKS_PER_ROW = 128 // 16
+        TOTAL_TASKS = 128 * CHUNKS_PER_ROW          # 1024 sixteen-element chunks
+        task = warp_in_wg * 32 + lane
+        for task_idx in range(task, TOTAL_TASKS, 4 * 32):     # rolled (`unroll=1`)
+            row   = task_idx // CHUNKS_PER_ROW
+            chunk = task_idx - row * CHUNKS_PER_ROW
+            r_fp8 = reg_tile([16], "fp8e4m3")
+            copy_s2r(sFp8[row, chunk * 16 : chunk * 16 + 16], r_fp8)
+            # instruction_selection: ld.shared.v4.u32 (:1287, 2 static -- one per
+            #   warpgroup copy); extent: 16 fp8 values as four 32-bit words in
+            #   ONE instruction, inside a rolled loop.
+            r_bf16 = reg_tile([16], "bf16")
+            cast(r_bf16, r_fp8)
+            # instruction_selection: prmt.b32 + fma.rn.bf16x2 (utils.py:540's
+            #   cvt_fp8x4_e4m3_bf16x4, four words per task); extent: a 16-element
+            #   register tile.  MSA does NOT use the hardware
+            #   cvt.rn.bf16x2.e4m3x2 here; it uses the byte-permute plus packed
+            #   FMA trick, and the port has to select the same one.
+            for v in range(2):                      # constexpr, unrolled
+                copy_r2s(r_bf16[v * 8 : v * 8 + 8], sBf16_dst_view(row, chunk, v, is_v))
+                # instruction_selection: st.shared.v4.u32 (:1302, 4 static = 2
+                #   per warpgroup copy); extent: 8 bf16 values per instruction.
+                #   `is_v` selects the MN-major destination view (:1289-1298),
+                #   which is an indexing difference only -- the instruction is
+                #   the same.
+        fence("view_async_shared")
+        # instruction_selection: fence.proxy.async.shared::cta (:1303, 2 static);
+        #   extent: scalar.
+        named_barrier_arrive_and_wait(dequant_bar)
+        # instruction_selection: bar.sync, named, 128 threads (:1513, 2 static);
+        #   extent: warpgroup.
+        if warp_in_wg == 0:
+            with elect():
+                commit(mbar_ready[0])
+                # instruction_selection: mbarrier.arrive.release.cta
+                #   .shared::cta.b64 (:1516, 2 static); extent: scalar.  This is
+                #   what makes the MMA warp's `wait(mbar_k)` mean "the bf16 tile
+                #   is ready" rather than "the fp8 bytes landed".
+
+    # -----------------------------------------------------------------------
+    # The per-group loop inside a softmax warpgroup (:2460-2586)
+    # -----------------------------------------------------------------------
+    def softmax_wg_loop(stage):
+        group_tidx = tid - stage * 128              # 0..127; this thread's M row
+        kv_block_col_start = kv_block_idx * 128     # causal only
+        num_stage_groups = (num_q_groups + (1 - stage)) // 2
+        # WG0 takes Q groups 0, 2, 4, ...; WG1 takes 1, 3, 5, ...
+
+        for qi_iter in range(num_stage_groups):     # rolled (`unroll=1`)
+            qi_group = qi_iter * 2 + stage
+            phase = qi_iter & 1
+            producer_phase = phase ^ 1
+            qidx_meta_slot = (qi_group & (QIDX_META_STAGES - 1)) * Q_TOKENS_PER_GROUP
+
+            softmax_reset()                         # row_max = -inf, row_sum = 0
+
+            # How many of this group's tokens still sit on the causal diagonal.
+            qi_group_start = qi_group * Q_TOKENS_PER_GROUP
+            masked_tok_count = clamp(diag_q_count - qi_group_start,
+                                     0, Q_TOKENS_PER_GROUP)
+
+            softmax_step(stage, phase, producer_phase, masked_tok_count, ...)
+
+            named_barrier_arrive_and_wait(epilogue_bar, index=stage)
+            # instruction_selection: bar.sync, named, id = base + stage, 128
+            #   threads (:2554); extent: warpgroup.  This is the barrier whose
+            #   upstream id collides with KvLoad -- see the declaration above.
+
+            epilogue_step(qi_group, stage, ...)
+
+    # -----------------------------------------------------------------------
+    # One softmax step (:2186-2352).  One M row per thread, 128 S columns.
+    # -----------------------------------------------------------------------
+    def softmax_step(stage, phase, producer_phase, masked_tok_count, ...):
+        wait(s_pipe.full, slot=stage, phase=phase)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2222,
+        #   2 static); extent: scalar.
+
+        rS = reg_tile([128], "f32")
+        copy_t2r(S[stage][group_tidx, :], rS)
+        # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x32.b32 (:2227,
+        #   8 static = 4 per warpgroup copy); extent: this thread's 128 fp32 S
+        #   elements arrive as four 32-register loads.
+
+        # --- masking (mask.py:71-121) -------------------------------------
+        # Column-limit masking always runs: any column >= kv_valid_cols is
+        # forced to -inf through an r2p bitmask built from 32-bit chunks.
+        # Causal masking runs only for the first `masked_tok_count` tokens of
+        # the group, and it needs this thread's SPARSE q_idx, not its row index.
+        if masked_tok_count > 0:
+            tok = group_tidx // QHEADPERKV
+            q_idx = decode_q_idx(load_shared(sQIdxMeta, qidx_meta_slot + tok))
+            # instruction_selection: ld.shared.u32 (:2251, 2 static); extent: scalar.
+            causal_col_limit = q_idx + causal_q_offset - kv_block_col_start + 1
+            select(rS, col < min(kv_valid_cols, causal_col_limit), rS, -inf)
+            # instruction_selection: shl.b32 to build the r2p chunk bitmask, then
+            #   and.b32 per element (mask.py:40, 124 per warpgroup copy = four
+            #   32-element r2p chunks x 31 emitted bit tests -- the one whose
+            #   `1 << i` folds is free; 248 across the two copies), then
+            #   selp.b32/selp.f32 for the -inf substitution; extent: a
+            #   128-element register tile.  `and.b32` at mask.py:40 is the
+            #   largest single .loc-attributed opcode group in the whole module
+            #   -- the mask, not the softmax, dominates this step's static count.
+        else:
+            select(rS, col < kv_valid_cols, rS, -inf)
+            # instruction_selection: none of its own -- this arm SHARES the r2p
+            #   body above.  `const_expr(self.causal and apply_causal_mask)` at
+            #   :2246 is a compile-time true, so `need_causal_mask` at :2247 is a
+            #   runtime branch (`@%p121 bra $L__BB0_96`, PTX 1649): the causal
+            #   arm falls through into the body at `$L__BB0_95` (PTX 1678) and
+            #   this arm branches back into the same body (PTX 2480), both
+            #   joining at `$L__BB0_97`.  Only the `col_limit` computation and
+            #   its own `< 128` guard are duplicated per arm -- the bit-test and
+            #   select tile is emitted ONCE per warpgroup copy.  A port that
+            #   emits the masking tile per arm doubles the module's hottest
+            #   instruction group.
+
+        # --- row max, then scale-and-subtract ------------------------------
+        # Always is_first=True: a Q group sees exactly one KV block, so this is
+        # the first and only online-softmax step and there is no rescale of a
+        # running accumulator (:2284-2287).
+        row_max = max_reduce(rS)
+        # instruction_selection: max.f32 (utils.py:262-276, 132 static = 66 per
+        #   warpgroup copy); extent: an intra-thread binary tree over 128
+        #   elements -- NO shuffles: each thread owns a whole M row, so the
+        #   reduction never crosses lanes.  The module's other 32 max.f32 are
+        #   the exp2 polynomial's clamp at utils.py:993, counted with exp2_poly
+        #   below, not here.
+        fma(rS, rS, softmax_scale_log2, -row_max * softmax_scale_log2, lanes=2)
+        # instruction_selection: fma.rn.f32x2 (softmax.py:354, 128 static = 64
+        #   per warpgroup copy); extent: 64 packed pairs.  The scale and the
+        #   row-max subtraction are one fused packed FMA, not a multiply
+        #   followed by a subtract.  The module's other 48 fma.rn.f32x2 belong
+        #   to the exp2 polynomial at utils.py:924.
+
+        if RETURN_TEMPERATURE_LSE:
+            temp_row_sum = scaled_exp2_row_sum(rS, lse_temperature_scale)
+            # instruction_selection: ex2.approx.ftz.f32 plus add.rn.f32x2;
+            #   extent: a second full pass over the 128-element tile, needed
+            #   because the temperature LSE is a differently-scaled sum, not a
+            #   rescaling of the main one.
+
+        # --- publish P in two pieces ---------------------------------------
+        if SPLIT_P_ARRIVE > 0:
+            acquire(p_last_pipe.producer, stage, producer_phase)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2297,
+            #   2 static); extent: scalar.
+        acquire(p_pipe.producer, stage, producer_phase)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2299,
+        #   2 static); extent: scalar.
+
+        rP = reg_tile([128], P_DTYPE)
+        exp2(rP, rS)
+        # instruction_selection: ex2.approx.ftz.f32 (softmax.py:389 and :390,
+        #   112 static each = 112 per warpgroup copy) MIXED WITH exp2_poly
+        #   (utils.py:924 fma.rn.f32x2 x48, :993 max.f32 x32, :995
+        #   add.rm.f32x2 x16, :998/:1001 sub.rn.f32x2 x16 each); extent: 128 elements
+        #   per thread, of which 112 go through MUFU and 16 through the
+        #   degree-3 FFMA polynomial.  That ratio is `ex2_emu_freq = 16` counted
+        #   in ELEMENTS -- one emulated pair per sixteen -- and it exists only
+        #   because this specialization is causal.  A port that sends all 128
+        #   through MUFU has a different instruction mix and a different MUFU
+        #   pressure profile.
+        cast(rP, rS)
+        # instruction_selection: cvt.rn.bf16x2.f32 (softmax.py:398, 128 static
+        #   = 64 per warpgroup copy); extent: 128 elements as 64 packed
+        #   conversions.  On an fp8 P the same site becomes the fp8 packed
+        #   conversion instead.
+
+        for k in range(4):                          # constexpr, unrolled
+            copy_r2t(rP[k], P[stage][group_tidx, k])
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32
+            #   (:2315, 8 static = 4 per warpgroup copy); extent: one quarter of
+            #   this thread's P row.  Repetition is dtype-aware: 16 for bf16 P,
+            #   8 for fp8 P, chosen so that k==split_idx lands exactly on the
+            #   3/4 column boundary (:2429-2439).
+            if k + 1 == SPLIT_IDX:                  # SPLIT_IDX = 4 * 96 // 128 = 3
+                fence("view_async_tmem_store")
+                # instruction_selection: tcgen05.wait::st.sync.aligned (:2324,
+                #   2 static); extent: scalar.
+                commit(p_pipe, stage)
+                # instruction_selection: mbarrier.arrive.release.cta
+                #   .shared::cta.b64 (:2325, 2 static); extent: scalar.  This is
+                #   the EARLY publish: the MMA warp starts PV on 3/4 of P.
+        fence("view_async_tmem_store")
+        # instruction_selection: tcgen05.wait::st.sync.aligned (:2326, 2 static);
+        #   extent: scalar.
+        commit(p_last_pipe, stage)
+        # instruction_selection: mbarrier.arrive.release.cta.shared::cta.b64
+        #   (:2330, 2 static); extent: scalar.  The PV instruction sequence is
+        #   already running and blocks on this barrier partway through.
+
+        acquire(sm_stats_pipe.producer, stage, producer_phase)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2331,
+        #   2 static); extent: scalar.  Only the EMPTY half of this pipe is
+        #   live; it is a credit on sScale_slot, nothing more.
+
+        row_sum = add_reduce(rP_as_f32)
+        # instruction_selection: add.rn.f32x2 (126 static); extent: an
+        #   intra-thread packed tree over 128 elements.
+        store_shared(sScale, stage * 256 + group_tidx, row_sum)
+        # instruction_selection: st.shared.f32 (:2339, 2 static); extent: scalar.
+        store_shared(sScale, stage * 256 + 128 + group_tidx, row_max)
+        # instruction_selection: st.shared.f32 (:2340, 2 static); extent: scalar.
+        if RETURN_TEMPERATURE_LSE:
+            store_shared(sScaleTemp, stage * 128 + group_tidx, temp_row_sum)
+            # instruction_selection: st.shared.f32 (:2347); extent: scalar.
+        fence("view_async_shared")
+        # instruction_selection: fence.proxy.async.shared::cta (:2348, 2 static);
+        #   extent: scalar.
+        release(s_pipe.consumer, stage)
+        # instruction_selection: mbarrier.arrive.release.cta.shared::cta.b64
+        #   (:2352, 2 static); extent: scalar.
+```
+
+```python
+    # -----------------------------------------------------------------------
+    # The fused epilogue (:2659-3020), running in the same warpgroup.
+    # -----------------------------------------------------------------------
+    def epilogue_step(qi_group, stage, ...):
+        slot = qi_group & 1
+        phase = (qi_group // 2) & 1
+        wait(o_pipe.full, slot, phase)
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2716,
+        #   2 static); extent: scalar.  The sibling acquire at :2692 emits
+        #   nothing -- both static occurrences report :2716.
+
+        # --- decode the packed qsplit words into the 2-deep caches ---------
+        # Threads 0..Q_TOKENS_PER_GROUP-1 split each word once; everyone else
+        # reads the result back after the barrier.
+        if group_tidx < Q_TOKENS_PER_GROUP:
+            word = load_shared(sQIdxMeta, qidx_meta_slot + group_tidx)
+            # instruction_selection: ld.shared.u32 (:2725, 2 static); extent: scalar.
+            store_shared(sQIdx,     slot * Q_TOKENS_PER_GROUP + group_tidx, word & 0x00FFFFFF)
+            # instruction_selection: and.b32 (`_decode_q_idx_from_qsplit`, :253,
+            #   5 static module-wide, 2 of them here) then st.shared.u32 (:2727,
+            #   2 static); extent: scalar.
+            store_shared(sSplitIdx, slot * Q_TOKENS_PER_GROUP + group_tidx, (word >> 24) & 0xFF)
+            # instruction_selection: shr.u32 (`_decode_split_idx_from_qsplit`,
+            #   :257, 2 static -- the `& 0xFF` folds into it) then st.shared.u32
+            #   (:2728, 2 static); extent: scalar.  The decode
+            #   happens once per group here; every per-store read below comes out
+            #   of these two caches, never out of sQIdxMeta again.
+        named_barrier_arrive_and_wait(epilogue_bar, index=stage)
+        # instruction_selection: bar.sync, named, id = base + stage (:2729,
+        #   2 static); extent: warpgroup.
+
+        # --- read O out of TMEM in two 64-column passes -------------------
+        rO = reg_tile([64], "f32")
+        for col_pass in range(2):                   # written `unroll=1`; emitted STRAIGHT-LINE
+            copy_t2r(O[slot][:, col_pass * 64 : col_pass * 64 + 64], rO[col_pass])
+            # instruction_selection: the TMEM copy-partition address math at
+            #   :2751 (and.b32 x8, add.s32 x8, shr.u32 x4, shl.b32 x4,
+            #   cvt.u64.u32 x2, or.b64 x2, or.b32 x2), then
+            #   tcgen05.ld.sync.aligned.16x256b.x8.b32
+            #   (:2758, 4 static = 2 per warpgroup copy), 32 registers each;
+            #   extent: half of this thread's 64 fp32 O values.  The two loads
+            #   are ADJACENT in the emitted code -- the source's `unroll=1`
+            #   annotation did not survive, and a port that keeps the loop
+            #   rolled would issue one load in a loop instead of two in a row.
+
+        # --- scale and store, four values at a time ------------------------
+        for r in range(NUM_ROWS):                   # constexpr, unrolled
+            for c4 in range(NUM_COLS // 4):         # constexpr, unrolled
+                row = frag_row(r, c4)
+                col = frag_col(r, c4) + col_pass * 64
+                if row < 128:
+                    tok        = row // QHEADPERKV
+                    row_in_tok = row % QHEADPERKV
+                    qi = qi_group * Q_TOKENS_PER_GROUP + tok
+                    if qi < count_raw:
+                        q_idx = load_shared(sQIdx, slot * Q_TOKENS_PER_GROUP + tok)
+                        # instruction_selection: ld.shared.u32 (:2785, 32 static
+                        #   = 16 per warpgroup copy); extent: scalar, ONE PER
+                        #   128-BIT STORE.  This is not hoisted out of the c4
+                        #   loop, and the port must not hoist it either.
+                        split = load_shared(sSplitIdx, slot * Q_TOKENS_PER_GROUP + tok)
+                        # instruction_selection: ld.shared.u32 (:2786, 32 static);
+                        #   extent: scalar, one per store.
+                        q_abs = q_batch_offset + q_idx
+                        flat_row = (split * total_q * head_q
+                                    + q_abs * head_q
+                                    + head_kv_idx * QHEADPERKV
+                                    + row_in_tok)
+                        row_sum = load_shared(sScale, slot * 256 + row)
+                        # instruction_selection: ld.shared.f32 (:2796, 32 static);
+                        #   extent: scalar, one per store.
+                        row_scale = rcp(select(row_sum == 0 or isnan(row_sum),
+                                               1.0, row_sum))
+                        # instruction_selection: rcp.approx.ftz.f32 (:2800, 32
+                        #   static = 16 per warpgroup copy) preceded by
+                        #   setp.ne.f32 (34 static) and selp.f32 (36 static);
+                        #   extent: scalar, one reciprocal per 128-bit store.
+                        #   The guard substitutes 1.0 for a zero or NaN row sum
+                        #   -- an all-masked row -- before the reciprocal, not
+                        #   after.
+                        mul(o0..o3, o0..o3, row_scale, lanes=2)
+                        # instruction_selection: mul.rn.f32x2 (64 static);
+                        #   extent: two packed pairs per store.
+                        fake_col = real_col_to_stg128_fake_col(col)
+                        # instruction_selection: and.b32 + or.b32 (copy_utils
+                        #   :854 and :858, 32 static each); extent: scalar index
+                        #   math.  This is the INVERSE of the shared-memory
+                        #   swizzle: it is what makes the four values contiguous
+                        #   in global memory, and an oracle that ignores it sees
+                        #   a shuffled row rather than a wrong one.
+                        copy_r2g(Op[flat_row * 128 + fake_col], (o0, o1, o2, o3),
+                                 cache="streaming")
+                        # instruction_selection: st.global.cs.v4.f32 (:2597, 32
+                        #   static = 16 per warpgroup copy); extent: 4 fp32 in
+                        #   one 128-bit store.  The bf16/f16 partial path becomes
+                        #   st.global.cs.v4.b32 of 8 packed halves (:2613-2615)
+                        #   with `real_col_to_stg128_half_fake_col`; the fp8 path
+                        #   becomes st.global.cs.v4.b32 of 16 packed bytes
+                        #   (:2638, 8 static on the fp8-partial export) with
+                        #   `real_col_to_stg128_fp8_fake_col`.  Three different
+                        #   remaps, three different lane counts, one instruction
+                        #   family.
+
+        fence("view_async_tmem_load")
+        # instruction_selection: tcgen05.wait::ld.sync.aligned (:2985, 2 static);
+        #   extent: scalar.
+
+        # --- LSE: one row per thread --------------------------------------
+        tok_local = group_tidx // QHEADPERKV
+        h_local   = group_tidx % QHEADPERKV
+        if qi_group * Q_TOKENS_PER_GROUP + tok_local < count_raw:
+            row_sum = load_shared(sScale, slot * 256 + group_tidx)
+            # instruction_selection: ld.shared.f32 (:2991, 2 static); extent: scalar.
+            row_max = load_shared(sScale, slot * 256 + 128 + group_tidx)
+            # instruction_selection: ld.shared.f32 (:2992, 2 static); extent: scalar.
+            lse = (row_max * softmax_scale_log2 + log2(row_sum)) * LN2
+            # instruction_selection: lg2.approx.ftz.f32 (:2999, 2 static) plus
+            #   fma.rn.f32 and mul; extent: scalar.  `-inf` replaces it when the
+            #   row sum is zero or NaN.
+            q_idx = load_shared(sQIdx, slot * Q_TOKENS_PER_GROUP + tok_local)
+            # instruction_selection: ld.shared.u32 (:3001, 2 static); extent: scalar.
+            split = load_shared(sSplitIdx, slot * Q_TOKENS_PER_GROUP + tok_local)
+            # instruction_selection: ld.shared.s32 (:3003, 2 static); extent:
+            #   scalar.  Note the SIGNED load here against the unsigned load of
+            #   the same cache at :2786 -- the operand form follows how the
+            #   value is consumed downstream, and the port has to match both.
+            h_abs = head_kv_idx * QHEADPERKV + h_local
+            store_global(Lp, (split, q_batch_offset + q_idx, h_abs), lse)
+            # instruction_selection: st.global.f32 (:3005, 2 static); extent:
+            #   scalar.  LSE is indexed in three dimensions, unlike O_partial,
+            #   which is indexed through the flattened row.
+            if RETURN_TEMPERATURE_LSE:
+                temp_sum = load_shared(sScaleTemp, slot * 128 + group_tidx)
+                lse_t = (row_max * lse_temperature_scale_log2 + log2(temp_sum)) * LN2
+                store_global(LpT, (split, q_batch_offset + q_idx, h_abs), lse_t)
+                # instruction_selection: lg2.approx.ftz.f32 + st.global.f32
+                #   (:3013, :3015); extent: scalar.
+
+        named_barrier_arrive_and_wait(epilogue_bar, index=stage)
+        # instruction_selection: bar.sync, named, id = base + stage (:3017);
+        #   extent: warpgroup.
+        release(sm_stats_pipe.consumer, slot)
+        # instruction_selection: mbarrier.arrive.release.cta.shared::cta.b64
+        #   (:3019); extent: scalar.  This is the empty-half credit that lets
+        #   softmax overwrite sScale_slot two groups later.
+        release(o_pipe.consumer, slot)
+        # instruction_selection: mbarrier.arrive.release.cta.shared::cta.b64
+        #   (:3020); extent: scalar.
+```
+
+## Logical GEMM ownership
+
+| GEMM | shape | A operand | B operand | accumulator | issued by | consumed by |
+| --- | --- | --- | --- | --- | --- | --- |
+| QK | 128 x 128 x 128 | `sQ[q_slot]`, SMEM, K-major, descriptor walked in PTX registers | `sK`, SMEM, K-major | `S[s_slot]`, TMEM f32 | warp 12 | softmax WG `s_slot & 1` |
+| PV | 128 x 128 x 128 | `P[pv_slot]`, **TMEM**, address passed explicitly because a TMEM iterator reports 0 | `sV`, SMEM, MN-major | `O[pv_slot]`, TMEM f32 | warp 12 | the epilogue in the same softmax WG |
+
+Both are `tcgen05.mma.cta_group::1`, `kind::f16` for bf16 operands and
+`kind::f8f6f4` when the operand width is 8. 48 static MMA instructions in the
+bf16/TMA-Q export. Neither GEMM ever accumulates across calls: `zero_init=True`
+at every issue site, because a CTA owns one KV block and each Q group is
+computed once.
+
+## TensorMap ABI
+
+| map | rank | box | swizzle | built where | notes |
+| --- | --- | --- | --- | --- | --- |
+| K | 3 | `(128, 128)` over `[total_k, 128, head_kv]` | 128B | launcher prologue | `cp.async.bulk.tensor.3d`; the KV-head axis stays in the descriptor |
+| V | 3 | `(128, 128)` MN-major | 128B | launcher prologue | same, after the `[1,0,2]` swap |
+| Q (TMA path) | 2 | `(QHEADPERKV, Q_LOAD_TILE)` | 128B | launcher prologue | `Q_LOAD_TILE` = 128 for fp8 Q, else 64 |
+| Q (gather4 path) | 2 | `(box_x, 1)`, `box_x` = 128 for fp8 Q else 64 | 128B | **launcher prologue in the port; a host-built `uint8[128]` kernel argument upstream** | `INTERLEAVE_NONE`, `L2_PROMOTION_256B`, `OOB_FILL_NONE` |
+
+The gather4 descriptor deserves the note that it is **a plain tiled map**:
+`create_q_gather4_tma_desc` (`tma_utils.py:332-407`) is one
+`cuTensorMapEncodeTiled` call with no gather-specific field. The gather-ness
+lives entirely in the PTX instruction
+(`cp.async.bulk.tensor.2d...tile::gather4`), which takes four independent row
+coordinates against an ordinary rank-2 map. That is why the port can drop
+upstream's descriptor-tensor ABI argument and encode the identical descriptor
+in its own prologue like every other TIRx kernel in this repository, and why
+`prepare_bench` never needs a device.
+
+## Storage aliases and lifetimes
+
+| alias | over | why it is safe |
+| --- | --- | --- |
+| `sQ_load` over `sQ` | the same bytes, two layouts | the MMA reads one monolithic K-major A tile while the loader writes `q_tokens x k_subtiles` boxes; the two views never disagree because the loader completes a stage before the MMA acquires it |
+| `P` over the upper columns of `S` | `TMEM_S_TO_P = 128 - 128 * P_WIDTH / 32` columns in | the P store destroys the tail of S, which is safe **only because** `row_max` and `row_sum` have already been extracted from the register copy of S; the ordering is load-bearing, not incidental |
+| `sKFp8` / `sVFp8` beside `sK` / `sV` | separate allocations, not aliases | the fp8 staging tiles and their bf16 destinations are live at the same time during the dequantization pass, so they cannot overlap; this is what takes the `bf16 Q + fp8 KV` gather4 build from 138240 to 171008 bytes -- exactly 16384 + 16384 more |
+
+## Static specialization boundary
+
+| decided at compile time | decided at runtime |
+| --- | --- |
+| `QHEADPERKV` and therefore the entire Q-load program, `Q_TOKENS_PER_GROUP`, `TOKENS_PER_GATHER4`, `GATHERS_PER_WARP`, `meta_iters`, `TOKENS_PER_WARP` | `work_capacity` (the grid extent), `num_heads_kv`, `seq_len_q`, all tensor extents and strides |
+| every dtype: Q/K/V storage, `qk_dtype`, `pv_dtype`, `p_dtype`, `o_dtype`, and from them `K_FP8_TO_BF16`, `V_FP8_TO_BF16`, both `mma_kind` strings, `store_rep`, `TMEM_S_TO_P` | `head_kv_idx`, `row_linear`, `work_q_begin`, `work_q_count`, `batch_idx`, `kv_block_idx` -- the whole work item |
+| `CAUSAL`, and through it the register budgets and `EX2_EMU_FREQ` | `count_raw`, `num_q_groups`, `diag_q_count`, `masked_tok_count`, `kv_valid_cols`, `causal_q_offset` |
+| `RETURN_TEMPERATURE_LSE` (presence of the third output buffer) | `softmax_scale_log2`, `lse_temperature_scale_log2` |
+| every stage count, `SPLIT_P_ARRIVE`, `SPLIT_IDX`, the TMEM column map, every named-barrier id and participant count | slot and phase cursors, which are derived from runtime group indices |
+
+Shapes are **not** in the compile key upstream and are not in the port's
+either: `to_cute_tensor` marks every layout dynamic, so a single binary per
+compile key serves every shape.
+
+## TIRx module and benchmark contract
+
+- `get_kernel(**config)` specializes on `(qhead_per_kv, causal, dtype_mode,
+  partial_dtype)` and removes the temperature output handle when it is absent,
+  then attaches `("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")`.
+- `prepare_data` reuses the split-atomic module's CSR and work-list builders and
+  adds Q/K/V plus a **frozen** qsplit assignment: slots `0..degree-1` in CSR
+  order per `(q_abs, head_kv)` group. Upstream assigns those slots with a device
+  atomic in arrival order, so re-running the producer would hand this kernel a
+  different permutation every call. Freezing an equivalent instance of the same
+  contract is what makes the forward reproducible and therefore comparable
+  element by element.
+- Correctness compares `O_partial` and `LSE_partial` against MSA's own compiled
+  kernel on identical frozen inputs, **masked to `split < degrees[q_abs, h]`**
+  because both buffers arrive uninitialized and a query of degree `d` never
+  touches slots `d..topk-1`.
+- The benchmark is kernel-only against the compiled CuTe-DSL callable. Unlike
+  the two preparation kernels, this one needs no counter rotation: it reads its
+  inputs without mutating them and overwrites -- never accumulates into -- the
+  partial slots it owns, so the hundredth launch does exactly the work the first
+  one did.
+
+## Instruction-selection summary
+
+How placement, layout, shape and schedule select the emitted instruction:
+
+- **Placement selects the copy family.** GMEM to SMEM is always TMA, never
+  `cp.async`: `cp.async.bulk.tensor.3d` for the K and V tiles (the head axis is
+  a descriptor mode), `cp.async.bulk.tensor.2d` for the TMA-Q sub-tiles, and
+  `cp.async.bulk.tensor.2d...tile::gather4` when four independent rows have to
+  be pulled into one box. TMEM to registers is `tcgen05.ld`, registers to TMEM
+  `tcgen05.st`; SMEM to registers in the dequantization pass is a plain
+  `ld.shared.v4.u32` because 16 fp8 values are exactly four words.
+- **Layout selects the vector width, and the swizzle selects the index math.**
+  The epilogue stores 128 bits per instruction in every partial dtype -- 4 fp32,
+  8 halves or 16 fp8 bytes -- and each width needs its own inverse-swizzle
+  column remap so the packed values land contiguously. The same 128-bit budget
+  is why the shared metadata stores merge into `st.shared.v4.u32` and the
+  `sRowMeta` reads into `ld.shared.v4.u32` / `ld.shared.v2.u32`.
+- **Shape selects the TMEM access shape.** 128 fp32 S elements per thread arrive
+  as four `32x32b.x32` loads; P leaves as four `32x32b.x16` stores with a
+  repetition chosen so the 3/4 publish boundary falls on an instruction edge;
+  64 fp32 O values arrive as two `16x256b.x8` loads of 32 registers each.
+- **Schedule selects where the synchronization instruction goes.** The Q pipe
+  sets `expect_tx` at producer acquire (`mbarrier.arrive.expect_tx`) because a
+  stage is filled by several TMAs; the single-shot K and V barriers take their
+  `expect_tx` in the prologue instead and their load warps issue a bare
+  `mbarrier.arrive`. Any pipe half **whose arrival the MMA warp issues** is
+  released with `tcgen05.commit` rather than `mbarrier.arrive`, so the release
+  is ordered behind the MMA -- that covers the UMMA-produced `s`/`o` pipes and
+  equally the softmax-produced `p`/`p_last` pipes, whose consumer release at
+  :2129/:2130/:2182/:2183 is also a commit. The split-P
+  handoff puts an `mbarrier.try_wait.parity` **inside** the PV instruction
+  sequence, which is what lets PV start on three quarters of P.
+- **`causal` selects the arithmetic mix.** `EX2_EMU_FREQ = 16` sends one element
+  pair in sixteen through a degree-3 FFMA polynomial instead of MUFU: 112
+  `ex2.approx.ftz.f32` and 48 `fma.rn.f32x2` of polynomial per warpgroup copy,
+  per 128 elements. Turning causal off removes the polynomial entirely and
+  changes three register budgets.
+- **Counts are evidence, not derivation.** For `bf16_tmaq_qh16_fp32`, as
+  counted by `.porting/sparse_atten_fwd/analyze_export.py`: 5737 instruction
+  lines, 153 of them predicated, 5584 net. 248 `and.b32` at `mask.py:40`
+  (the largest single `.loc` group), 48 `tcgen05.mma` in six 8-instruction
+  chains, 224 `ex2.approx.ftz.f32`, 176 `fma.rn.f32x2` (128 softmax + 48
+  polynomial), 164 `max.f32` (132 reduction + 32 polynomial clamp), 128
+  `cvt.rn.bf16x2.f32`, 126 `add.rn.f32x2`, 64 `mul.rn.f32x2`, 32
+  `st.global.cs.v4.f32`, 32 `rcp.approx.ftz.f32`, 26 `mbarrier.init.shared.b64`
+  (24 from the six pipes plus `:907` and `:908`), 8
+  `tcgen05.ld...32x32b.x32`, 8 `tcgen05.st...32x32b.x16`, 4
+  `tcgen05.ld...16x256b.x8`. The
+  `bf16_gather4_qh4_fp32` export runs 5952 instruction lines / 157 predicated /
+  5795 net against 5737 / 153 / 5584 -- a delta of 215 lines -- and differs in
+  about 25 opcodes -- 16 `...tile::gather4...cache_hint` and 8
+  `cp.async.bulk.prefetch...gather4` replacing the four 2-D Q TMAs, one extra
+  `bar.sync` per group (the gather4 body takes `load_wg_bar` three times per
+  group at :1659/:1691/:1810 against the TMA path's two), a net +6
+  `ld.shared.u32` (+8 at :1755, -2 at :1907), and roughly 180 more
+  address-arithmetic instructions (`add.s32` 347->393, `mad.lo.s32` 3->10,
+  `cvt.u32.u64` 0->32, and so on).
+
+  What **is** identical between the two exports is the softmax and epilogue
+  opcode profile, to the instruction: `ex2.approx` 224, `fma.rn.f32x2` 176,
+  `max.f32` 164, `cvt.rn.bf16x2.f32` 128, `add.rn.f32x2` 126, `mul.rn.f32x2`
+  64, `rcp.approx` 32, `st.global.cs.v4.f32` 32, `selp.b32` 263, `selp.f32` 36,
+  `ld.shared.f32` 36, `sub.rn.f32x2` 32, `add.rm.f32x2` 16, `st.global.f32` 2,
+  `lg2.approx` 2, and all 89 `tcgen05.*`. That is the measurement that says the
+  two Q paths differ only in the load warpgroup -- stated over the subset it
+  actually covers, not over the whole module.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | ------------------------------------------ | ----------------------------------- | ---------- |
 | `msa_sparse_prepare_flat_schedule_sm100`   | `sparse_prepare_flat_schedule.py`   | Flat work-list preparation for sparse attention |
 | `msa_sparse_prepare_fwd_split_atomic_sm100` | `sparse_prepare_fwd_split_atomic.py` | Forward split-slot preparation (packed `q_idx`/slot metadata) |
+| `msa_sparse_atten_fwd_sm100`               | `sparse_atten_fwd.py`               | CSR block-sparse attention forward, split-partial output |
 
 ## Performance
 

--- a/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_sm100.yaml
@@ -1,0 +1,13 @@
+kernel: msa_sparse_atten_fwd_sm100
+selection_rationale: The two Q-load programs are separate device code, so a default set that exercised only one would leave half the kernel unmeasured; the defaults pair MSA's ring-attention shape (TMA Q, BF16) with a varlen gather4 shape and the FP8 family at ring scale, which also brings in the BF16 partial store and the temperature LSE.
+configs:
+  - {config: ring48k_bf16_qh16_t16, default: true, selection_role: large}
+  - {config: ulysses384k_bf16_qh2_t4, default: false}
+  - {config: long96k_bf16_qh2_t16, default: false}
+  - {config: varlen_b3_s8192_qh4_t16, default: true, selection_role: medium}
+  - {config: varlen_b3_s4096_qh8_t8, default: false}
+  - {config: qh1_s8192_bf16_t16, default: false}
+  - {config: ring48k_fp8_qh16_t16, default: true, selection_role: small}
+  - {config: fp8kv_s16384_qh4_t16, default: false}
+  - {config: fp8_pvbf16_s8192_qh8_t8, default: false}
+  - {config: edge_b1_s1024_bf16_t4, default: false}

--- a/tirx_kernels/msa/sparse_atten_fwd.py
+++ b/tirx_kernels/msa/sparse_atten_fwd.py
@@ -1,0 +1,2984 @@
+# This file is a TIRx port of code from MSA
+# (https://github.com/MiniMax-AI/MSA @ 80434d7f), Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""MSA sparse attention forward, split-partial form.
+
+Ports ``SparseAttentionForwardSm100``: the attention kernel itself, consuming
+the work list and the packed split slots that the two preparation kernels in
+this package produce.
+
+One CTA owns one work item, which is one KV block crossed with a run of the
+query rows that attend it. The CTA loads that KV block once, walks its query
+rows in groups, and writes each group's result to the split slot the
+preparation stage reserved for it -- so the partials of a query never collide
+and no atomics appear anywhere in this kernel. A separate combine kernel,
+outside this port, reduces the partials of each query.
+
+Upstream source: python/fmha_sm100/cute/src/sm100/fwd/atten_fwd.py:56.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from tirx_kernels.msa.utils._scalar_ops import (
+    ld_global_i32,
+    ld_shared_i32,
+    st_shared_i32,
+    uceil_div_i32,
+    udiv_i32,
+)
+from tvm.script import tirx as T
+from tvm.tirx.lang.pipeline import MBarrier, TCGen05Bar, TMABar
+from tvm.tirx.lang.smem_desc import SmemDescriptor
+
+KERNEL_META = {"name": "msa_sparse_atten_fwd_sm100", "category": "msa", "compute_capability": 10}
+
+# `__init__` restricts both to a single supported value (:75-79, :99-107).
+HEAD_DIM = 128
+BLK_KV = 128
+M_BLOCK = 128
+N_BLOCK = 128
+# `k_tile = 64` (:59): the UTCMMA bf16 K-tile, and the bf16 Q sub-tile width.
+K_TILE = 64
+
+# `warps_per_group=4`, `total_warps=16` (:130-143).
+NUM_THREADS = 512
+WARP_SIZE = 32
+TOTAL_WARPS = 16
+WARPS_PER_GROUP = 4
+SOFTMAX0_WARP_BASE = 0
+SOFTMAX1_WARP_BASE = 4
+Q_LOAD_WARP_BASE = 8
+MMA_WARP_ID = 12
+KV_LOAD_WARP_BASE = 13
+NUM_KV_LOAD_WARPS = 2
+NUM_Q_LOAD_WARPS = 4
+SOFTMAX_THREADS = WARP_SIZE * WARPS_PER_GROUP
+
+# Chunks each dequantizing thread owns: sixteen FP8 per 128-bit shared load.
+# Module scope, because a bare assignment inside a traced body binds a TIR
+# variable and the staging buffer would stop being a constant-size allocation.
+DEQUANT_ITERS = N_BLOCK * (HEAD_DIM // 16) // SOFTMAX_THREADS
+DEQUANT_BATCH = 4
+
+# Pipeline depths (:116-125).
+Q_STAGE = 2
+S_STAGE = 2
+O_STAGE = 2
+K_STAGES = 2
+QIDX_META_STAGES = 16
+
+# `tmem_total` (:156-161), power-of-two rounded.
+TMEM_TOTAL = 512
+
+# `split_P_arrive = n_block // 4 * 3`, floored to a multiple of 32 (:165-167).
+SPLIT_P_ARRIVE = 96
+
+# Register budgets on the causal path (:173-181).
+NUM_REGS_SOFTMAX = 176
+NUM_REGS_STORE = 112
+NUM_REGS_OTHER = 48
+EX2_EMU_FREQ = 16
+EX2_EMU_START_FRG = 1
+
+# cuTensorMapEncodeTiled enum values.
+_SWIZZLE_128B = 3
+_L2_PROMOTION_256B = 3
+
+_DTYPE_BYTES = {"bfloat16": 2, "float16": 2, "float32": 4, "float8_e4m3": 1}
+
+# `scheduler_metadata` columns; the forward reads all six.
+WORK_FIELDS = 6
+
+# `q_idx | ((split_slot & 0xFF) << 24)`, decoded at :242-257.
+SLOT_SHIFT = 24
+SLOT_MASK = 0xFF
+Q_IDX_MASK = (1 << SLOT_SHIFT) - 1
+
+
+def _tirx_dtype(name: str) -> str:
+    """The dtype TIRx declares a buffer with.
+
+    CUDA codegen has no fp8 scalar type, and MSA does not want one either: it
+    recasts its fp8 tiles to 32-bit words and converts them with a byte-permute
+    plus a packed FMA. So an fp8 buffer is declared as raw ``uint8`` and every
+    conversion goes through PTX on the bit pattern, which is what
+    ``flashmla/sparse_decode_head64.py`` does too. ``cuTensorMapEncodeTiled``
+    maps both spellings onto ``CU_TENSOR_MAP_DATA_TYPE_UINT8`` anyway.
+    """
+    return "uint8" if name == "float8_e4m3" else name
+
+
+def _swizzle_elems(elem_bytes: int) -> int:
+    """Elements spanned by one 128-byte swizzle atom, i.e. the TMA box width."""
+    return 128 // elem_bytes
+
+
+def USE_GATHER4(qheadperkv: int) -> bool:
+    """`use_q_gather4` (:81): 1, 2 and 4 take the raw gather4 Q path."""
+    return qheadperkv in (1, 2, 4)
+
+
+def KV_SUBTILES(elem_bytes: int) -> int:
+    """128-byte swizzle atoms across a 128-wide KV tile, i.e. TMA issues per tile."""
+    return HEAD_DIM // _swizzle_elems(elem_bytes)
+
+
+def Q_SUBTILES(elem_bytes: int) -> int:
+    """Q sub-tiles per token: 1 for fp8 Q, `k_stages` = 2 for bf16 (:1872-1875)."""
+    return HEAD_DIM // _swizzle_elems(elem_bytes)
+
+
+def TOKENS_PER_WARP(qheadperkv: int) -> int:
+    """`tokens_per_warp` (:1856-1859) on the TMA-Q path."""
+    q_tokens_per_group = M_BLOCK // qheadperkv
+    return (q_tokens_per_group + NUM_Q_LOAD_WARPS - 1) // NUM_Q_LOAD_WARPS
+
+
+# Named-barrier ids. MSA emits `NamedBarrierFwdSm100`'s raw enum values with no
+# user-barrier bias, which collides: `StoreEpilogue + stage` is 13 at stage 1
+# and `KvLoad` is also 13, with 128 and 64 participants respectively. The port
+# keeps the synchronization structure and numbers from 8 upward, the convention
+# this repository documents at `flashmla/sparse_decode_head64.py:36-39`.
+BAR_TMEM_ALLOC = 8
+BAR_LOAD_WG = 9
+BAR_KV_LOAD = 10
+BAR_KV_DEQUANT_K = 11
+BAR_KV_DEQUANT_V = 12
+BAR_EPILOGUE = 13  # and 14, indexed by the softmax stage
+
+_TMA_GATHER4_2D_CACHE = (
+    "cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_GATHER4_PREFETCH = "cp.async.bulk.prefetch.tensor.2d.L2.global.tile::gather4.L2::cache_hint"
+_TMA_G2S_2D_CACHE = (
+    "cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_G2S_3D_CACHE = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+# L2 eviction policies, per the reference's own defaults (tma_utils.py:23-24,
+# :204, :251). Which tensor gets which is load-bearing, not cosmetic: a KV block
+# belongs to exactly one CTA and is never read again, while a Q row is read by
+# every one of the topK CTAs that carry it. Marking the streamed KV evict-last
+# keeps it resident and pushes the Q rows out, so those CTAs re-fetch Q from
+# DRAM instead of hitting L2.
+_TMA_CACHE_EVICT_FIRST = T.uint64(0x12F0000000000000)
+_TMA_CACHE_EVICT_LAST = T.uint64(0x14F0000000000000)
+_Q_TMA_CACHE_HINT = _TMA_CACHE_EVICT_LAST
+_KV_TMA_CACHE_HINT = _TMA_CACHE_EVICT_FIRST
+
+
+_MMA_KIND = {"bfloat16": "f16", "float16": "f16", "float8_e4m3": "f8f6f4"}
+# `mma_kind` (:363-364) is "f8f6f4" whenever the operand width is 8.
+_MMA_CHAIN = {kind: f"tcgen05.mma.cta_group::1.kind::{kind}" for kind in ("f16", "f8f6f4")}
+# K elements consumed by one tcgen05.mma instruction, so 128 // this is the
+# chain length: 8 for f16, 4 for f8f6f4 -- which is the 48 = 6 x 8 and
+# 24 = 6 x 4 census in the export.
+_MMA_K = {"f16": 16, "f8f6f4": 32}
+
+
+def _instr_desc(operand_dtype: str, trans_b: bool = False) -> int:
+    """The tcgen05.mma instruction descriptor for a 128x128 f32-accumulating tile.
+
+    Computed, not copied: the immediate encodes the operand dtype, so bf16 and
+    f16 differ (0x08200490 against 0x08200010) even though both are
+    ``kind::f16`` chains. Taking a neighbouring kernel's magic number is how a
+    bf16 port ends up issuing an f16 descriptor.
+
+    ``trans_b`` is the operand's major-ness: False for QK, where both operands
+    are K-major, and True for PV, whose B tile is MN-major. Both were pinned
+    against torch -- a wrong value here does not fault, it silently returns the
+    wrong product.
+    """
+    from tvm.backend.cuda.cpp.descriptors import encode_instr_descriptor_dense_uint32
+
+    torch_name = {"bfloat16": "bfloat16", "float16": "float16", "float8_e4m3": "float8_e4m3fn"}[
+        operand_dtype
+    ]
+    k = 32 if operand_dtype == "float8_e4m3" else 16
+    return encode_instr_descriptor_dense_uint32(
+        M_BLOCK, N_BLOCK, k, "float32", torch_name, torch_name, False, trans_b, cta_group=1
+    )
+
+
+_MMA_ELEM_BYTES = {"f16": 2, "f8f6f4": 1}
+
+# Descriptor offsets, all in 16-byte units, and all identical between the bf16
+# and fp8 geometries because a 128-byte swizzle atom holds twice as many fp8
+# elements as bf16 ones.
+_SWIZZLE_BYTES = 128
+
+
+def _stage_16b(operand_dtype: str) -> int:
+    """One Q pipeline stage, in 16-byte units: 2048 for bf16, 1024 for fp8.
+
+    Element-width dependent, so it cannot be a constant. Hard-coding the bf16
+    value points stage 1's A descriptor past the end of the Q tile, which shows
+    up as an out-of-range shared address from the MMA warp -- and only once a
+    work item has more than one Q group, so small shapes pass.
+    """
+    return M_BLOCK * HEAD_DIM * _MMA_ELEM_BYTES[_MMA_KIND[operand_dtype]] // 16
+
+
+_SUBTILE_16B = 1024  # one 128-byte swizzle atom column band
+_MMA_K_16B = 2  # one tcgen05.mma K step
+# The A operand's TMEM column step: 8 columns per K chunk in both widths.
+# The PV B operand advances 128 sixteen-byte units per 16-element K chunk of
+# a bf16 MN-major V tile, and 256 per 32-element fp8 chunk -- both measured
+# against torch, not derived.
+_PV_K_16B = {"f16": 128, "f8f6f4": 256}
+_PV_A_COL_STEP = {"f16": 8, "f8f6f4": 8}
+
+# The P operand's tcgen05.st repetition (:2429-2439): 16 for a bf16 P, 8 for
+# fp8, chosen so the 3/4 publish boundary falls on an instruction edge.
+_P_STORE_REP = {"bfloat16": 16, "float16": 16, "float8_e4m3": 8}
+
+
+def _smem_desc_add_16b(desc_base, offset):
+    """Advance a descriptor's address lane without carrying into its layout bits."""
+    halves = T.reinterpret("uint32x2", desc_base)
+    lo = T.Shuffle([halves], [0]) + T.cast(offset, "uint32")
+    hi = T.Shuffle([halves], [1])
+    return T.reinterpret("uint64", T.Shuffle([lo, hi], [0, 1]))
+
+
+# `POLY_EX2[3]` (utils.py:24-40): the degree-3 minimax polynomial for
+# 2**frac on [0, 1), evaluated by Horner in packed f32x2.
+_POLY_EX2_3 = (
+    1.0,
+    0.695146143436431884765625,
+    0.227564394474029541015625,
+    0.077119089663028717041015625,
+)
+# `fp32_round_int = 2**23 + 2**22` (utils.py:991): adding it round-down puts the
+# integer floor in the low bits of the mantissa.
+_FP32_ROUND_INT = float(2**23 + 2**22)
+LOG2_E = 1.4426950408889634
+NEG_INF = float("-inf")
+LN_2 = 0.6931471805599453
+# `MASK_R2P_CHUNK_SIZE` (mask.py:15).
+MASK_R2P_CHUNK = 32
+
+
+def _scale_gather(dst, src, cols, scale):
+    """Gather one output group's columns from the O fragment and scale them.
+
+    A plain Python function, so its loop runs at trace time and ``cols`` -- a
+    Python list -- can index the fragment directly. A ``for`` inside a traced
+    body would become a TIR loop and the list index would fail.
+    """
+    for j in range(len(cols) // 2):
+        _packed_f32x2(
+            "mul.rn.f32x2",
+            dst,
+            j * 2,
+            j * 2 + 1,
+            src[cols[j * 2]],
+            src[cols[j * 2 + 1]],
+            scale,
+            scale,
+        )
+
+
+@T.inline
+def _packed_f32x2(op, dst, di, dj, a0, a1, b0, b1, c0=None, c1=None):
+    """One packed two-lane f32 operation.
+
+    The ``.f32x2`` instructions take 64-bit packed operands, so each pair is
+    assembled with ``mov.b64`` and split again afterwards -- the same shape
+    ``flashmla/sparse_prefill_head64_phase1.py`` uses. This is one instruction
+    with two ordered results, not two scalar operations.
+    """
+    pa = T.alloc_local((1,), "uint64")
+    pb = T.alloc_local((1,), "uint64")
+    pd = T.alloc_local((1,), "uint64")
+    T.ptx.mov.b64(pa[0], a0, a1)
+    T.ptx.mov.b64(pb[0], b0, b1)
+    if c0 is None:
+        T.ptx[op](pd[0], pa[0], pb[0])
+    else:
+        pc = T.alloc_local((1,), "uint64")
+        T.ptx.mov.b64(pc[0], c0, c1)
+        T.ptx[op](pd[0], pa[0], pb[0], pc[0])
+    T.ptx.mov.b64(dst[di], dst[dj], pd[0])
+
+
+@T.inline
+def _max3_at(dst, idx, a, b, c):
+    """Three-input ``max.f32``, an SM100 form, writing into ``dst[idx]``.
+
+    The reference's reduction tree is built on it (``utils.fmax`` passes NVVM a
+    third operand), which halves the tree: 66 instructions per 128-element row
+    instead of the 127 a two-input tree would need.
+    """
+    T.ptx.max.f32(dst[idx], a, b, c)
+
+
+@T.inline
+def _row_max_128(regs, out, out_idx):
+    """`fmax_reduce` for arch 100 with a size divisible by 8 (utils.py:258-278).
+
+    Four accumulators seeded from the first eight elements, each absorbing two
+    more per step through a three-input max, then folded pairwise.
+    """
+    acc = T.alloc_local((4,), "float32")
+    T.evaluate(T.ptx.max.f32(acc[0], regs[0], regs[1]))
+    T.evaluate(T.ptx.max.f32(acc[1], regs[2], regs[3]))
+    T.evaluate(T.ptx.max.f32(acc[2], regs[4], regs[5]))
+    T.evaluate(T.ptx.max.f32(acc[3], regs[6], regs[7]))
+    for it in T.unroll(1, N_BLOCK // 8):
+        i: T.int32 = it * 8
+        _max3_at(acc, 0, acc[0], regs[i + 0], regs[i + 1])
+        _max3_at(acc, 1, acc[1], regs[i + 2], regs[i + 3])
+        _max3_at(acc, 2, acc[2], regs[i + 4], regs[i + 5])
+        _max3_at(acc, 3, acc[3], regs[i + 6], regs[i + 7])
+    T.evaluate(T.ptx.max.f32(acc[0], acc[0], acc[1]))
+    _max3_at(out, out_idx, acc[0], acc[2], acc[3])
+
+
+@T.inline
+def _scaled_exp2_row_sum_128(regs, scale, out):
+    """`fadd_exp2_scaled_reduce` for arch 100: sum of 2**(scale * x).
+
+    A second pass over the same 128 elements, not a rescaling of the main row
+    sum: the temperature LSE needs the exponentials at a different scale, so
+    every element is multiplied, exponentiated and accumulated again (:2288-2292).
+    """
+    acc = T.alloc_local((8,), "float32")
+    for j in T.unroll(8):
+        acc[j] = T.float32(0.0)
+    tmp = T.alloc_local((8,), "float32")
+    for it in T.unroll(N_BLOCK // 8):
+        i: T.int32 = it * 8
+        for j in T.unroll(4):
+            _packed_f32x2(
+                "mul.rn.f32x2",
+                tmp,
+                j * 2,
+                j * 2 + 1,
+                regs[i + j * 2],
+                regs[i + j * 2 + 1],
+                scale,
+                scale,
+            )
+        for j in T.unroll(8):
+            T.evaluate(T.ptx.ex2.approx.ftz.f32(tmp[j], tmp[j]))
+        for j in T.unroll(4):
+            _packed_f32x2(
+                "add.rn.f32x2",
+                acc,
+                j * 2,
+                j * 2 + 1,
+                acc[j * 2],
+                acc[j * 2 + 1],
+                tmp[j * 2],
+                tmp[j * 2 + 1],
+            )
+    _packed_f32x2("add.rn.f32x2", acc, 0, 1, acc[0], acc[1], acc[2], acc[3])
+    _packed_f32x2("add.rn.f32x2", acc, 4, 5, acc[4], acc[5], acc[6], acc[7])
+    _packed_f32x2("add.rn.f32x2", acc, 0, 1, acc[0], acc[1], acc[4], acc[5])
+    out[0] = acc[0] + acc[1]
+
+
+@T.inline
+def _row_sum_128(regs, out):
+    """`fadd_reduce` for arch 100 (utils.py:290-303): four packed accumulators."""
+    acc = T.alloc_local((8,), "float32")
+    for j in T.unroll(8):
+        acc[j] = regs[j]
+    for it in T.unroll(1, N_BLOCK // 8):
+        i: T.int32 = it * 8
+        for j in T.unroll(4):
+            _packed_f32x2(
+                "add.rn.f32x2",
+                acc,
+                j * 2,
+                j * 2 + 1,
+                acc[j * 2],
+                acc[j * 2 + 1],
+                regs[i + j * 2],
+                regs[i + j * 2 + 1],
+            )
+    _packed_f32x2("add.rn.f32x2", acc, 0, 1, acc[0], acc[1], acc[2], acc[3])
+    _packed_f32x2("add.rn.f32x2", acc, 4, 5, acc[4], acc[5], acc[6], acc[7])
+    _packed_f32x2("add.rn.f32x2", acc, 0, 1, acc[0], acc[1], acc[4], acc[5])
+    out[0] = acc[0] + acc[1]
+
+
+def _combine_int_frac_ex2(x_rounded, frac_ex2):
+    """`combine_int_frac_ex2` (utils.py:1008-1030): shift the integer part into
+    the exponent field and add it to the polynomial's bits.
+
+    The reference uses ``add.s32`` deliberately -- it lowers to LEA on the ALU
+    pipe, where ``add.u32`` would lower to IMAD and contend with the FMA pipe
+    the polynomial itself is using.
+    """
+    xi = T.alloc_local((1,), "int32")
+    fi = T.alloc_local((1,), "int32")
+    out = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.mov.b32(xi[0], x_rounded))
+    T.evaluate(T.ptx.mov.b32(fi[0], frac_ex2))
+    T.evaluate(T.ptx.shl.b32(xi[0], xi[0], T.uint32(23)))
+    T.evaluate(T.ptx.add.s32(out[0], xi[0], fi[0]))
+    return T.reinterpret("float32", out[0])
+
+
+@T.inline
+def _ex2_emulation_2(regs, i, j):
+    """`ex2_emulation_2` (utils.py:987-1005): 2**x for a pair, without MUFU.
+
+    Clamp, split off the integer part by a round-down add of 2**23 + 2**22,
+    evaluate the fractional part with a degree-3 packed Horner, and reassemble
+    by shifting the integer into the exponent field. The reference mixes one of
+    these in per sixteen elements on the causal path, which is what keeps the
+    MUFU pipe from becoming the softmax bottleneck.
+    """
+    cl = T.alloc_local((2,), "float32")
+    T.evaluate(T.ptx.max.f32(cl[0], regs[i], T.float32(-127.0)))
+    T.evaluate(T.ptx.max.f32(cl[1], regs[j], T.float32(-127.0)))
+    rounded = T.alloc_local((2,), "float32")
+    _packed_f32x2(
+        "add.rm.f32x2",
+        rounded,
+        0,
+        1,
+        cl[0],
+        cl[1],
+        T.float32(_FP32_ROUND_INT),
+        T.float32(_FP32_ROUND_INT),
+    )
+    back = T.alloc_local((2,), "float32")
+    _packed_f32x2(
+        "sub.rn.f32x2",
+        back,
+        0,
+        1,
+        rounded[0],
+        rounded[1],
+        T.float32(_FP32_ROUND_INT),
+        T.float32(_FP32_ROUND_INT),
+    )
+    frac = T.alloc_local((2,), "float32")
+    _packed_f32x2("sub.rn.f32x2", frac, 0, 1, cl[0], cl[1], back[0], back[1])
+    poly = T.alloc_local((2,), "float32")
+    poly[0] = T.float32(_POLY_EX2_3[3])
+    poly[1] = T.float32(_POLY_EX2_3[3])
+    # Horner, unrolled at trace time: the coefficients are Python floats.
+    _packed_f32x2(
+        "fma.rn.f32x2",
+        poly,
+        0,
+        1,
+        poly[0],
+        poly[1],
+        frac[0],
+        frac[1],
+        T.float32(0.22756439447402954),
+        T.float32(0.22756439447402954),
+    )
+    _packed_f32x2(
+        "fma.rn.f32x2",
+        poly,
+        0,
+        1,
+        poly[0],
+        poly[1],
+        frac[0],
+        frac[1],
+        T.float32(0.6951461434364319),
+        T.float32(0.6951461434364319),
+    )
+    _packed_f32x2(
+        "fma.rn.f32x2",
+        poly,
+        0,
+        1,
+        poly[0],
+        poly[1],
+        frac[0],
+        frac[1],
+        T.float32(1.0),
+        T.float32(1.0),
+    )
+    regs[i] = _combine_int_frac_ex2(rounded[0], poly[0])
+    regs[j] = _combine_int_frac_ex2(rounded[1], poly[1])
+
+
+@T.inline
+def _issue_qk(s_slot, q_slot, q_desc, k_desc, kind, operand_dtype, s_col, stage_stride):
+    """One QK tile: a chain of same-family ``tcgen05.mma`` over the K extent.
+
+    The A descriptor is advanced by a compile-time 16-byte offset per Q stage
+    rather than rebuilt, which is the register-resident `wrap`/`advance` walk
+    the source pre-binds in PTX (:1990-1995). Only the first instruction of the
+    chain clears the accumulator; the rest accumulate into it.
+    """
+    mma_k = T.meta_var(_MMA_K[kind])
+    steps = T.meta_var(HEAD_DIM // mma_k)
+    per_subtile = T.meta_var(_SWIZZLE_BYTES // (mma_k * _MMA_ELEM_BYTES[kind]))
+    for ki in T.unroll(steps):
+        sub = T.meta_var(ki // per_subtile)
+        within = T.meta_var(ki % per_subtile)
+        off = T.meta_var(sub * _SUBTILE_16B + within * _MMA_K_16B)
+        if T.cuda.elect_sync():
+            T.ptx[_MMA_CHAIN[kind]](
+                T.cast(s_col + s_slot * stage_stride, "uint32"),
+                q_desc.add_16B_offset(q_slot * _stage_16b(operand_dtype) + off),
+                k_desc.add_16B_offset(off),
+                T.uint32(_instr_desc(operand_dtype)),
+                T.uint32(0),
+                T.uint32(0),
+                T.uint32(0),
+                T.uint32(0),
+                ki != 0,
+            )
+
+
+@T.inline
+def _issue_pv(
+    pv_slot,
+    v_desc,
+    kind,
+    operand_dtype,
+    o_col,
+    o_stage_stride,
+    p_col,
+    p_stage_stride,
+    bar_last,
+    phase,
+):
+    """One PV tile, split around the late-P wait.
+
+    ``split_P_arrive = 96`` means the first three quarters of the K extent are
+    issued against the early-P barrier; the sequence then blocks on the
+    last-split barrier before issuing the final quarter (:2044-2067). The A
+    operand lives in TMEM, so its column address is passed explicitly instead of
+    being read from a tensor.
+    """
+    mma_k = T.meta_var(_MMA_K[kind])
+    steps = T.meta_var(N_BLOCK // mma_k)
+    split_step = T.meta_var(SPLIT_P_ARRIVE // mma_k)
+    for ki in T.unroll(steps):
+        if ki == split_step:
+            bar_last.wait(pv_slot, phase)
+        if T.cuda.elect_sync():
+            T.ptx[_MMA_CHAIN[kind]](
+                T.cast(o_col + pv_slot * o_stage_stride, "uint32"),
+                T.cast(p_col + pv_slot * p_stage_stride + ki * _PV_A_COL_STEP[kind], "uint32"),
+                v_desc.add_16B_offset(ki * _PV_K_16B[kind]),
+                T.uint32(_instr_desc(operand_dtype, trans_b=True)),
+                T.uint32(0),
+                T.uint32(0),
+                T.uint32(0),
+                T.uint32(0),
+                ki != 0,
+            )
+
+
+@T.inline
+def _tcgen05_commit(bar, stage):
+    """Publish an MMA result, or release a stage the MMA warp consumed.
+
+    Any pipe half whose arrival the MMA warp issues is signalled with
+    ``tcgen05.commit`` rather than ``mbarrier.arrive``, so the arrival is
+    ordered behind the MMA -- including the softmax-produced P pipes, whose
+    consumer release the export also shows as a commit (:2129-2130).
+    """
+    if T.cuda.elect_sync():
+        bar.arrive(stage)
+
+
+@T.inline
+def bar_sync_named(bar_id, count):
+    """``bar.sync <id>, <count>`` -- a named barrier over a thread subset."""
+    T.ptx.bar.sync(T.uint32(bar_id), T.uint32(count))
+
+
+@T.inline
+def _dequant_kv(src, dst, bar_tma, bar_ready, bar_id, count_raw, group_tidx, batch):
+    """Convert one staged fp8 KV tile into the bf16 tile the MMA reads.
+
+    A strided task loop over ``n_block * (head_dim / 16)`` chunks: sixteen fp8
+    in through one 128-bit shared load, sixteen bf16 out through two, with the
+    reference's byte-permute conversion between them. Both tiles carry the same
+    logical (kv, head_dim) indexing in this port, so K and V differ only in
+    which buffers they name.
+
+    The two forms below differ only in how the loads are scheduled, and
+    ``batch`` picks between them at trace time.
+    """
+    if batch == 1:
+        # Both warpgroups are dequantizing -- BF16 Q over FP8 KV, WG0 on K and
+        # WG1 on V. Batching the loads only makes 256 threads burst into the
+        # same shared memory at once, and the rolled loop measured faster. A
+        # `While`, because a counted loop gets no no-unroll pragma from TVM.
+        if count_raw > 0:
+            bar_tma.wait(0, 0)
+            chunks_per_row = T.meta_var(HEAD_DIM // 16)
+            it = T.alloc_local((1,), "int32")
+            it[0] = 0
+            while it[0] < DEQUANT_ITERS:
+                task: T.int32 = it[0] * SOFTMAX_THREADS + group_tidx
+                row: T.int32 = udiv_i32(task, chunks_per_row)
+                chunk: T.int32 = task - row * chunks_per_row
+                src_words = T.alloc_local((4,), "uint32")
+                T.evaluate(
+                    T.ptx.ld.shared.v4.b32(
+                        src_words[0],
+                        src_words[1],
+                        src_words[2],
+                        src_words[3],
+                        src.ptr_to([row, chunk * 16]),
+                    )
+                )
+                out_words = T.alloc_local((8,), "uint32")
+                # Inlined rather than factored into a helper: nesting `@T.inline` calls
+                # turns the trace-time `w`/`half` into runtime variables and the register
+                # file into indexed local memory.
+                #
+                # Four packed e4m3 bytes become two packed bf16x2 words. Not the hardware
+                # `cvt.rn.bf16x2.e4m3x2`: the reference reassembles sign and mantissa by
+                # hand and lets one `fma.rn.bf16x2` against the constant 0x7b807b80 apply
+                # the exponent bias, keeping the conversion on the FMA pipe (utils.py:540).
+                for w in range(4):
+                    for half in range(2):
+                        q = T.alloc_local((1,), "uint32")
+                        mant = T.alloc_local((1,), "uint32")
+                        acc = T.alloc_local((1,), "uint32")
+                        T.evaluate(
+                            T.ptx.prmt.b32(q[0], src_words[w], src_words[w], T.uint32(0x1302))
+                        )
+                        if half == 1:
+                            T.evaluate(T.ptx.shl.b32(q[0], q[0], T.uint32(8)))
+                        T.evaluate(T.ptx.and_.b32(acc[0], q[0], T.uint32(0x80008000)))
+                        T.evaluate(T.ptx.and_.b32(mant[0], q[0], T.uint32(0x7F007F00)))
+                        T.evaluate(T.ptx.shr.u32(mant[0], mant[0], T.uint32(4)))
+                        T.evaluate(T.ptx.or_.b32(acc[0], acc[0], mant[0]))
+                        T.evaluate(
+                            T.ptx.fma.rn.bf16x2(
+                                out_words[w * 2 + half], acc[0], T.uint32(0x7B807B80), T.uint32(0)
+                            )
+                        )
+                for half in range(2):
+                    T.evaluate(
+                        T.ptx.st.shared.v4.b32(
+                            dst.ptr_to([row, chunk * 16 + half * 8]),
+                            out_words[half * 4],
+                            out_words[half * 4 + 1],
+                            out_words[half * 4 + 2],
+                            out_words[half * 4 + 3],
+                        )
+                    )
+                it[0] = it[0] + 1
+            T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
+            bar_sync_named(bar_id, SOFTMAX_THREADS)
+            if group_tidx == 0:
+                bar_ready.arrive(0)
+    else:
+        # One warpgroup at work: issue a batch of loads before converting any of
+        # them, so the conversion chain -- eight dependent integer ops before
+        # the FMA -- stops sitting on the critical path of the next load.
+        staged = T.alloc_local((4 * batch,), "uint32")
+        if count_raw > 0:
+            bar_tma.wait(0, 0)
+            chunks_per_row = T.meta_var(HEAD_DIM // 16)
+            for chunk_group in range(DEQUANT_ITERS // batch):
+                for bi in range(batch):
+                    task_l: T.int32 = (chunk_group * batch + bi) * SOFTMAX_THREADS + group_tidx
+                    row_l: T.int32 = udiv_i32(task_l, chunks_per_row)
+                    chunk_l: T.int32 = task_l - row_l * chunks_per_row
+                    T.evaluate(
+                        T.ptx.ld.shared.v4.b32(
+                            staged[bi * 4],
+                            staged[bi * 4 + 1],
+                            staged[bi * 4 + 2],
+                            staged[bi * 4 + 3],
+                            src.ptr_to([row_l, chunk_l * 16]),
+                        )
+                    )
+                for bi in range(batch):
+                    task: T.int32 = (chunk_group * batch + bi) * SOFTMAX_THREADS + group_tidx
+                    row: T.int32 = udiv_i32(task, chunks_per_row)
+                    chunk: T.int32 = task - row * chunks_per_row
+                    out_words = T.alloc_local((8,), "uint32")
+                    # Inlined rather than factored into a helper: nesting `@T.inline` calls
+                    # turns the trace-time `w`/`half` into runtime variables and the register
+                    # file into indexed local memory.
+                    #
+                    # Four packed e4m3 bytes become two packed bf16x2 words. Not the hardware
+                    # `cvt.rn.bf16x2.e4m3x2`: the reference reassembles sign and mantissa by
+                    # hand and lets one `fma.rn.bf16x2` against the constant 0x7b807b80 apply
+                    # the exponent bias, keeping the conversion on the FMA pipe (utils.py:540).
+                    for w in range(4):
+                        for half in range(2):
+                            q = T.alloc_local((1,), "uint32")
+                            mant = T.alloc_local((1,), "uint32")
+                            acc = T.alloc_local((1,), "uint32")
+                            T.evaluate(
+                                T.ptx.prmt.b32(
+                                    q[0], staged[bi * 4 + w], staged[bi * 4 + w], T.uint32(0x1302)
+                                )
+                            )
+                            if half == 1:
+                                T.evaluate(T.ptx.shl.b32(q[0], q[0], T.uint32(8)))
+                            T.evaluate(T.ptx.and_.b32(acc[0], q[0], T.uint32(0x80008000)))
+                            T.evaluate(T.ptx.and_.b32(mant[0], q[0], T.uint32(0x7F007F00)))
+                            T.evaluate(T.ptx.shr.u32(mant[0], mant[0], T.uint32(4)))
+                            T.evaluate(T.ptx.or_.b32(acc[0], acc[0], mant[0]))
+                            T.evaluate(
+                                T.ptx.fma.rn.bf16x2(
+                                    out_words[w * 2 + half],
+                                    acc[0],
+                                    T.uint32(0x7B807B80),
+                                    T.uint32(0),
+                                )
+                            )
+                    for half in range(2):
+                        T.evaluate(
+                            T.ptx.st.shared.v4.b32(
+                                dst.ptr_to([row, chunk * 16 + half * 8]),
+                                out_words[half * 4],
+                                out_words[half * 4 + 1],
+                                out_words[half * 4 + 2],
+                                out_words[half * 4 + 3],
+                            )
+                        )
+            T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
+            bar_sync_named(bar_id, SOFTMAX_THREADS)
+            if group_tidx == 0:
+                bar_ready.arrive(0)
+
+
+@T.inline
+def _pack_p_words(words, regs, j, pv_dtype):
+    """Convert one 32-element fragment of P into packed words.
+
+    bf16 packs two values per word with ``cvt.rn.bf16x2.f32``; fp8 packs four,
+    two at a time through ``cvt.rn.satfinite.e4m3x2.f32`` and then combined.
+    Element assignment needs a traced body, so this is ``@T.inline`` with
+    ``T.unroll``; every index is arithmetic, so nothing here needs a Python
+    loop variable.
+    """
+    if pv_dtype == "float8_e4m3":
+        for w in T.unroll(8):
+            lo = T.alloc_local((1,), "uint16")
+            hi = T.alloc_local((1,), "uint16")
+            T.evaluate(
+                T.ptx.cvt.rn.satfinite.e4m3x2.f32(
+                    lo[0], regs[j * 32 + w * 4 + 1], regs[j * 32 + w * 4]
+                )
+            )
+            T.evaluate(
+                T.ptx.cvt.rn.satfinite.e4m3x2.f32(
+                    hi[0], regs[j * 32 + w * 4 + 3], regs[j * 32 + w * 4 + 2]
+                )
+            )
+            words[j * 8 + w] = T.bitwise_or(
+                T.cast(lo[0], "uint32"), T.shift_left(T.cast(hi[0], "uint32"), T.uint32(16))
+            )
+    else:
+        for w in T.unroll(16):
+            T.evaluate(
+                T.ptx.cvt.rn.bf16x2.f32(
+                    words[j * 16 + w], regs[j * 32 + w * 2 + 1], regs[j * 32 + w * 2]
+                )
+            )
+
+
+_TMEM_LD_32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_16 = "tcgen05.ld.sync.aligned.16x256b.x8.b32"
+_TMEM_ST = {
+    16: "tcgen05.st.sync.aligned.32x32b.x16.b32",
+    8: "tcgen05.st.sync.aligned.32x32b.x8.b32",
+}
+
+# Values per 128-bit store, per partial dtype (:2772-2984).
+_STORE_LANES = {"float32": 4, "bfloat16": 8, "float16": 8, "float8_e4m3": 16}
+
+
+def _fake_col(partial_dtype: str, col):
+    """``real_col_to_stg128{,_half,_fp8}_fake_col`` (copy_utils.py:852, :869, :888).
+
+    ``O_partial`` is laid out in "fake column" order: the reference stores
+    through this map and the combine kernel reads it back that way, so the
+    permutation is part of the ABI. It exists to make the epilogue's 128-bit
+    stores contiguous -- it undoes the column permutation the 16x256b fragment
+    already carries, so a warp's stores land in whole sectors.
+
+    Pure index math; ``col`` may be a runtime value, as it is in the reference.
+    """
+    if partial_dtype == "float32":
+        nt, c16 = col // 16, col % 16
+        pair = c16 // 2
+        return nt * 16 + (pair % 4) * 4 + (pair // 4) * 2 + (c16 % 2)
+    if partial_dtype in ("bfloat16", "float16"):
+        nt, c32 = col // 32, col % 32
+        return nt * 32 + ((c32 % 8) // 2) * 8 + (c32 // 8) * 2 + (c32 % 2)
+    nt, c64 = col // 64, col % 64
+    return nt * 64 + ((c64 % 8) // 2) * 16 + (c64 // 8) * 2 + (c64 % 2)
+
+
+_KS_PER_STORE = {name: lanes // 2 for name, lanes in _STORE_LANES.items()}
+_GROUPS_PER_PARITY = {name: 8 // ks for name, ks in _KS_PER_STORE.items()}
+
+
+def _tmem16_store_groups(partial_dtype: str) -> list[tuple[int, int, list[int]]]:
+    """Register groups of one ``16x256b.x8`` instruction, one per 128-bit store.
+
+    That instruction hands a thread 32 registers whose tile coordinates are
+
+        row = warp*32 + lane_base + (lane%32)//4 + 8*((r//2) % 2)
+        col = col_base + (lane%4)*2 + (r%2) + 8*(r//4)
+
+    so registers split into two row groups by ``(r//2) % 2`` -- call it the
+    parity ``p``, which selects row or row+8 -- and inside a parity the columns
+    run ``8k + j`` for ``k`` in 0..7 and ``j`` in 0..1. Consecutive ``k`` pairs
+    map to consecutive fake columns, so one store takes ``lanes//2`` values of
+    ``k`` starting at ``kb``: four registers for fp32, eight for bf16/f16,
+    all sixteen for fp8.
+
+    Returns ``(parity, kb, registers)`` per store.
+    """
+    ks_per_store = _STORE_LANES[partial_dtype] // 2
+    return [
+        (p, kb, [4 * k + 2 * p + j for k in range(kb, kb + ks_per_store) for j in (0, 1)])
+        for p in (0, 1)
+        for kb in range(0, 8, ks_per_store)
+    ]
+
+
+def ld_shared_f32(buffer, index):
+    """``ld.shared.f32``."""
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.shared.f32(out[0], buffer.ptr_to([index])))
+    return out[0]
+
+
+def st_shared_f32(buffer, index, value):
+    """``st.shared.f32``."""
+    T.evaluate(T.ptx.st.shared.f32(buffer.ptr_to([index]), value))
+
+
+@T.inline
+def _store_o_partial(buf, elem_offset, vals, partial_dtype):
+    """One 128-bit ``st.global.cs`` of the partial output.
+
+    fp32 stores four lanes directly; bf16/f16 pack eight into four words; fp8
+    packs sixteen into four (:2589-2656).
+    """
+    if partial_dtype == "float32":
+        T.ptx.st.global_.cs.v4.f32(buf.ptr_to([elem_offset]), vals[0], vals[1], vals[2], vals[3])
+    elif partial_dtype in ("bfloat16", "float16"):
+        words = T.alloc_local((4,), "uint32")
+        for w in T.unroll(4):
+            if partial_dtype == "bfloat16":
+                T.ptx.cvt.rn.bf16x2.f32(words[w], vals[w * 2 + 1], vals[w * 2])
+            else:
+                T.ptx.cvt.rn.f16x2.f32(words[w], vals[w * 2 + 1], vals[w * 2])
+        T.ptx.st.global_.cs.v4.b32(
+            buf.ptr_to([elem_offset]), words[0], words[1], words[2], words[3]
+        )
+    else:
+        words = T.alloc_local((4,), "uint32")
+        for w in T.unroll(4):
+            lo = T.alloc_local((1,), "uint16")
+            hi = T.alloc_local((1,), "uint16")
+            T.ptx.cvt.rn.satfinite.e4m3x2.f32(lo[0], vals[w * 4 + 1], vals[w * 4])
+            T.ptx.cvt.rn.satfinite.e4m3x2.f32(hi[0], vals[w * 4 + 3], vals[w * 4 + 2])
+            words[w] = T.bitwise_or(
+                T.cast(lo[0], "uint32"), T.shift_left(T.cast(hi[0], "uint32"), T.uint32(16))
+            )
+        T.ptx.st.global_.cs.v4.b32(
+            buf.ptr_to([elem_offset]), words[0], words[1], words[2], words[3]
+        )
+
+
+@T.inline
+def _resolve_gather4_rows(
+    rows,
+    meta,
+    meta_slot,
+    tok_base,
+    qi_base,
+    count_raw,
+    q_batch_off,
+    num_heads_kv,
+    head_kv_idx,
+    q_oob_m_idx,
+    qheadperkv,
+):
+    """The four GMEM row coordinates one gather4 pulls (:1702-1763).
+
+    The three head-group sizes differ only in how many distinct tokens the four
+    rows come from: one head row each from four tokens at ``qheadperkv == 1``,
+    two consecutive head rows from each of two tokens at 2, and four
+    consecutive head rows from a single token at 4. A token past ``count_raw``
+    resolves to an out-of-range row so the gather takes the descriptor's OOB
+    fill rather than being predicated off.
+    """
+    if qheadperkv == 1:
+        for j in range(4):
+            qi = qi_base + tok_base + j
+            rows[j] = q_oob_m_idx
+            if qi < count_raw:
+                q_idx = T.bitwise_and(ld_shared_i32(meta, meta_slot + tok_base + j), Q_IDX_MASK)
+                rows[j] = (q_batch_off + q_idx) * num_heads_kv + head_kv_idx
+    elif qheadperkv == 2:
+        for t in range(2):
+            qi = qi_base + tok_base + t
+            base = q_oob_m_idx * qheadperkv
+            if qi < count_raw:
+                q_idx = T.bitwise_and(ld_shared_i32(meta, meta_slot + tok_base + t), Q_IDX_MASK)
+                base = ((q_batch_off + q_idx) * num_heads_kv + head_kv_idx) * qheadperkv
+            rows[t * 2] = base
+            rows[t * 2 + 1] = base + 1
+    else:
+        qi = qi_base + tok_base
+        base = q_oob_m_idx * qheadperkv
+        if qi < count_raw:
+            q_idx = T.bitwise_and(ld_shared_i32(meta, meta_slot + tok_base), Q_IDX_MASK)
+            base = ((q_batch_off + q_idx) * num_heads_kv + head_kv_idx) * qheadperkv
+        for j in range(4):
+            rows[j] = base + j
+
+
+@T.inline
+def _mbar_expect_tx(bar, stage, tx_bytes):
+    """``mbarrier.expect_tx``: promise bytes without arriving.
+
+    The single-shot K/V barriers take their transaction count in the prologue
+    from thread 0 (:911-918) and are arrived on later by the load warp, so this
+    has to stay separate from the arrive -- the barrier's arrival count is 1.
+    """
+    T.ptx.mbarrier.expect_tx.relaxed.cta.shared__cta.b64(bar.ptr_to([stage]), T.uint32(tx_bytes))
+
+
+LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
+
+# The four in-scope dtype combinations, named by the storage dtypes plus the
+# MMA operand dtypes they resolve to at :318-364. `qk`/`pv` narrower than the
+# storage dtype is not a thing; `qk`/`pv` *wider* is the fp8 -> bf16 staging
+# path, which dequantizes K or V in shared memory before the MMA sees it.
+DTYPE_MODES: dict[str, dict[str, str]] = {
+    "bf16": {"q": "bfloat16", "k": "bfloat16", "v": "bfloat16", "qk": "bfloat16", "pv": "bfloat16"},
+    "fp8": {
+        "q": "float8_e4m3",
+        "k": "float8_e4m3",
+        "v": "float8_e4m3",
+        "qk": "float8_e4m3",
+        "pv": "float8_e4m3",
+    },
+    "bf16q_fp8kv": {
+        "q": "bfloat16",
+        "k": "float8_e4m3",
+        "v": "float8_e4m3",
+        "qk": "bfloat16",
+        "pv": "bfloat16",
+    },
+    "fp8_pvbf16": {
+        "q": "float8_e4m3",
+        "k": "float8_e4m3",
+        "v": "float8_e4m3",
+        "qk": "float8_e4m3",
+        "pv": "bfloat16",
+    },
+}
+
+# `mO_partial.element_type`, validated at :372-377. fp16 is accepted upstream
+# but never exercised there, so it stays out of this port's domain.
+PARTIAL_DTYPES = ("float32", "bfloat16", "float8_e4m3")
+
+_TORCH_DTYPES = {
+    "bfloat16": "bfloat16",
+    "float16": "float16",
+    "float32": "float32",
+    "float8_e4m3": "float8_e4m3fn",
+}
+
+
+def _torch_dtype(name: str):
+    import torch
+
+    return getattr(torch, _TORCH_DTYPES[name])
+
+
+# ---------------------------------------------------------------------------
+# Target entry.
+# ---------------------------------------------------------------------------
+@T.jit
+def _kernel(
+    k_h: T.handle,
+    v_h: T.handle,
+    k2q_q_indices_h: T.handle,
+    k2q_qsplit_indices_h: T.handle,
+    k2q_row_ptr_h: T.handle,
+    scheduler_metadata_h: T.handle,
+    work_count_h: T.handle,
+    o_partial_h: T.handle,
+    lse_partial_h: T.handle,
+    lse_temperature_partial_h: T.Optional(T.handle),
+    q_flat_h: T.handle,
+    cu_seqlens_q_h: T.handle,
+    cu_seqlens_k_h: T.handle,
+    softmax_scale_log2: T.float32,
+    lse_temperature_scale_log2: T.float32,
+    lse_temperature_inv_scale: T.float32,
+    num_kv_blocks: T.int32,
+    num_heads_kv: T.int32,
+    seq_len_q: T.int32,
+    work_capacity: T.int32,
+    total_k: T.int32,
+    total_q: T.int32,
+    head_q: T.int32,
+    nnz: T.int32,
+    total_rows: T.int32,
+    num_batches: T.int32,
+    topk: T.int32,
+    *,
+    qheadperkv: T.constexpr,
+    causal: T.constexpr,
+    dtype_mode: T.constexpr,
+    partial_dtype: T.constexpr,
+):
+    mode = T.meta_var(DTYPE_MODES[dtype_mode])
+    q_dtype = T.meta_var(mode["q"])
+    k_dtype = T.meta_var(mode["k"])
+    v_dtype = T.meta_var(mode["v"])
+    qk_dtype = T.meta_var(mode["qk"])
+    pv_dtype = T.meta_var(mode["pv"])
+    # `k_fp8_to_bf16` / `v_fp8_to_bf16` (:354-361): an fp8 tile that the MMA has
+    # to see as bf16 is staged through a second shared buffer and dequantized by
+    # a softmax warpgroup.
+    k_stage_fp8 = T.meta_var(k_dtype != qk_dtype)
+    v_stage_fp8 = T.meta_var(v_dtype != pv_dtype)
+    q_ty = T.meta_var(_tirx_dtype(q_dtype))
+    k_ty = T.meta_var(_tirx_dtype(k_dtype))
+    v_ty = T.meta_var(_tirx_dtype(v_dtype))
+    qk_ty = T.meta_var(_tirx_dtype(qk_dtype))
+    pv_ty = T.meta_var(_tirx_dtype(pv_dtype))
+    partial_ty = T.meta_var(_tirx_dtype(partial_dtype))
+    qk_mma_kind = T.meta_var(_MMA_KIND[qk_dtype])
+    pv_mma_kind = T.meta_var(_MMA_KIND[pv_dtype])
+    q_bytes = T.meta_var(_DTYPE_BYTES[q_dtype])
+    k_bytes = T.meta_var(_DTYPE_BYTES[k_dtype])
+    v_bytes = T.meta_var(_DTYPE_BYTES[v_dtype])
+    # `q_load_tile` (:427-429): fp8 Q loads a full 128-wide row per token, bf16
+    # Q loads two 64-wide k-subtiles.
+    q_load_tile = T.meta_var(HEAD_DIM if q_bytes == 1 else K_TILE)
+    q_tokens_per_group = T.meta_var(M_BLOCK // qheadperkv)
+
+    k = T.match_buffer(k_h, (total_k, num_heads_kv, HEAD_DIM), k_ty, scope="global")
+    v = T.match_buffer(v_h, (total_k, num_heads_kv, HEAD_DIM), v_ty, scope="global")
+    k2q_q_indices = T.match_buffer(k2q_q_indices_h, (num_heads_kv * nnz,), "int32", scope="global")
+    k2q_qsplit_indices = T.match_buffer(
+        k2q_qsplit_indices_h, (num_heads_kv * nnz,), "int32", scope="global"
+    )
+    k2q_row_ptr = T.match_buffer(
+        k2q_row_ptr_h, (num_heads_kv * (total_rows + 1),), "int32", scope="global"
+    )
+    scheduler_metadata = T.match_buffer(
+        scheduler_metadata_h, (work_capacity * WORK_FIELDS,), "int32", scope="global"
+    )
+    work_count = T.match_buffer(work_count_h, (1,), "int32", scope="global")
+    o_partial = T.match_buffer(
+        o_partial_h, (topk * total_q * head_q * HEAD_DIM,), partial_ty, scope="global"
+    )
+    lse_partial = T.match_buffer(
+        lse_partial_h, (topk * total_q * head_q,), "float32", scope="global"
+    )
+    if lse_temperature_partial_h is not None:
+        lse_temperature_partial = T.match_buffer(
+            lse_temperature_partial_h, (topk * total_q * head_q,), "float32", scope="global"
+        )
+    q_flat = T.match_buffer(q_flat_h, (total_q * head_q, HEAD_DIM), q_ty, scope="global")
+    cu_seqlens_q = T.match_buffer(cu_seqlens_q_h, (num_batches + 1,), "int32", scope="global")
+    cu_seqlens_k = T.match_buffer(cu_seqlens_k_h, (num_batches + 1,), "int32", scope="global")
+
+    # -----------------------------------------------------------------------
+    # TMA descriptors, encoded in the launcher prologue.
+    #
+    # MSA hands the gather4 Q descriptor in as a `uint8[128]` kernel argument
+    # built on the host (`interface.py:1682-1688`). Every TIRx kernel in this
+    # repository encodes its own instead, and the descriptor is a plain rank-2
+    # tiled map either way -- the gather is in the instruction, not the map --
+    # so the port drops that argument and encodes all of them here.
+    #
+    # K and V keep the KV-head axis as a descriptor mode, which is what makes
+    # their loads `cp.async.bulk.tensor.3d` rather than 2-D over a pre-permuted
+    # tensor. Both boxes are one 128-byte swizzle atom wide, so a 128-wide tile
+    # takes two issues.
+    # -----------------------------------------------------------------------
+    k_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        k_map,
+        k_ty,
+        3,
+        k.data,
+        HEAD_DIM,
+        num_heads_kv,
+        total_k,
+        HEAD_DIM * k_bytes,
+        num_heads_kv * HEAD_DIM * k_bytes,
+        _swizzle_elems(k_bytes),
+        1,
+        N_BLOCK,
+        1,
+        1,
+        1,
+        0,
+        _SWIZZLE_128B,
+        _L2_PROMOTION_256B,
+        0,
+    )
+    v_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        v_map,
+        v_ty,
+        3,
+        v.data,
+        HEAD_DIM,
+        num_heads_kv,
+        total_k,
+        HEAD_DIM * v_bytes,
+        num_heads_kv * HEAD_DIM * v_bytes,
+        _swizzle_elems(v_bytes),
+        1,
+        N_BLOCK,
+        1,
+        1,
+        1,
+        0,
+        _SWIZZLE_128B,
+        _L2_PROMOTION_256B,
+        0,
+    )
+    # The fp8 staging path lands in a PLAIN buffer, so its descriptor must carry
+    # no swizzle. The reference builds a separate `cpasync.make_tiled_tma_atom`
+    # over a row-major box for exactly this reason (:474-479); reusing the
+    # swizzled MMA descriptor writes permuted bytes that the dequantization then
+    # reads back in logical order, which silently scrambles every row.
+    if k_stage_fp8 or v_stage_fp8:
+        k_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            k_stage_map,
+            k_ty,
+            3,
+            k.data,
+            HEAD_DIM,
+            num_heads_kv,
+            total_k,
+            HEAD_DIM * k_bytes,
+            num_heads_kv * HEAD_DIM * k_bytes,
+            HEAD_DIM,
+            1,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
+        v_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            v_stage_map,
+            v_ty,
+            3,
+            v.data,
+            HEAD_DIM,
+            num_heads_kv,
+            total_k,
+            HEAD_DIM * v_bytes,
+            num_heads_kv * HEAD_DIM * v_bytes,
+            HEAD_DIM,
+            1,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
+
+    # The TMA-Q box is one token group of `qheadperkv` rows; the gather4 box is
+    # a single row, because the instruction supplies four row coordinates.
+    q_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    T.call_packed(
+        "runtime.cuTensorMapEncodeTiled",
+        q_map,
+        q_ty,
+        2,
+        q_flat.data,
+        HEAD_DIM,
+        total_q * head_q,
+        HEAD_DIM * q_bytes,
+        _swizzle_elems(q_bytes),
+        qheadperkv if not USE_GATHER4(qheadperkv) else 1,
+        1,
+        1,
+        0,
+        _SWIZZLE_128B,
+        _L2_PROMOTION_256B,
+        0,
+    )
+
+    T.device_entry()
+    T.attr({"tirx.launch_bounds_min_blocks_per_sm": 1})
+
+    # CUDA TRANSCRIPTION START
+    block = T.cta_id([work_capacity])
+    tidx = T.thread_id([NUM_THREADS])
+    # `make_warp_uniform(warp_idx())` (:706) lowers to a lane-0 shfl broadcast.
+    # `T.warp_id` is warp-uniform by construction, so the broadcast is redundant
+    # here rather than load-bearing.
+    warp_idx = T.warp_id([TOTAL_WARPS])
+    lane_idx = T.lane_id([WARP_SIZE])
+
+    # Work-item decode and the CTA-level early-out (:689-705).
+    # The grid is sized by the work list's CAPACITY, so the tail CTAs retire.
+    work_count_val = ld_global_i32(work_count, 0)
+    cta_valid_work: T.int32 = T.cast(block < work_count_val, "int32")
+    head_kv_idx = T.alloc_local((1,), "int32")
+    row_linear = T.alloc_local((1,), "int32")
+    work_q_begin = T.alloc_local((1,), "int32")
+    work_q_count = T.alloc_local((1,), "int32")
+    batch_idx = T.alloc_local((1,), "int32")
+    kv_block_idx = T.alloc_local((1,), "int32")
+    head_kv_idx[0] = 0
+    row_linear[0] = 0
+    work_q_begin[0] = 0
+    work_q_count[0] = 0
+    batch_idx[0] = 0
+    kv_block_idx[0] = 0
+    if cta_valid_work != 0:
+        head_kv_idx[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 0)
+        row_linear[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 1)
+        work_q_begin[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 2)
+        work_q_count[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 3)
+        batch_idx[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 4)
+        kv_block_idx[0] = ld_global_i32(scheduler_metadata, block * WORK_FIELDS + 5)
+
+    # -----------------------------------------------------------------------
+    # Shared memory. The source's `@cute.struct SharedStorage` reads static but
+    # is handed out by `SmemAllocator` from the dynamic pool; the export carries
+    # `.extern .shared .align 1024 .b8 __dynamic_shmem__0[]`, so the matching
+    # TIRx form is a pool allocation under `tirx.use_dyn_shared_memory`.
+    # -----------------------------------------------------------------------
+    pool = T.SMEMPool()
+    s_k = pool.alloc_tcgen05_mma_AB((N_BLOCK, HEAD_DIM), qk_ty, swizzle_mode="auto")
+    # Same shape as sK: the TMA box's fastest dim is head_dim, so the tile
+    # lands (kv rows, head_dim cols) with head_dim contiguous. For the PV
+    # B operand that means N = head_dim is the contiguous axis, which is what
+    # "MN-major" names (:386-387).
+    s_v = pool.alloc_tcgen05_mma_AB((N_BLOCK, HEAD_DIM), pv_ty, swizzle_mode="auto")
+    s_q = pool.alloc_tcgen05_mma_AB((Q_STAGE * M_BLOCK, HEAD_DIM), q_ty, swizzle_mode="auto")
+    if k_stage_fp8:
+        s_k_fp8 = pool.alloc((N_BLOCK, HEAD_DIM), k_ty, align=1024)
+    if v_stage_fp8:
+        s_v_fp8 = pool.alloc((N_BLOCK, HEAD_DIM), v_ty, align=1024)
+
+    s_scale = pool.alloc((O_STAGE * M_BLOCK * 2,), "float32", align=16)
+    if lse_temperature_partial_h is not None:
+        s_scale_temp = pool.alloc((O_STAGE * M_BLOCK,), "float32", align=16)
+    s_split_idx = pool.alloc((O_STAGE * q_tokens_per_group,), "int32", align=16)
+    s_q_idx = pool.alloc((O_STAGE * q_tokens_per_group,), "int32", align=16)
+    s_row_meta = pool.alloc((8,), "int32", align=16)
+    s_diag_q_count = pool.alloc((1,), "int32", align=16)
+    s_q_load_m_idx = pool.alloc((Q_STAGE * q_tokens_per_group,), "int32", align=16)
+    s_qidx_meta = pool.alloc((QIDX_META_STAGES * q_tokens_per_group,), "int32", align=16)
+
+    bar_k = MBarrier(pool, 1)
+    bar_v = MBarrier(pool, 1)
+    if k_stage_fp8:
+        bar_k_tma = MBarrier(pool, 1)
+    if v_stage_fp8:
+        bar_v_tma = MBarrier(pool, 1)
+    bar_q_full = TMABar(pool, Q_STAGE)
+    bar_q_empty = TCGen05Bar(pool, Q_STAGE)
+    bar_s_full = TCGen05Bar(pool, S_STAGE)
+    bar_s_empty = MBarrier(pool, S_STAGE)
+    bar_p_full = MBarrier(pool, S_STAGE)
+    bar_p_empty = TCGen05Bar(pool, S_STAGE)
+    bar_p_last_full = MBarrier(pool, S_STAGE)
+    bar_p_last_empty = TCGen05Bar(pool, S_STAGE)
+    bar_o_full = TCGen05Bar(pool, O_STAGE)
+    bar_o_empty = MBarrier(pool, O_STAGE)
+    # Only the empty half of the stats pipe is live upstream: it is a credit on
+    # `s_scale`, and nothing ever commits or waits on its full half (:2331,
+    # :3019). The full half is still allocated so the word layout matches.
+    bar_stats_full = MBarrier(pool, O_STAGE)
+    bar_stats_empty = MBarrier(pool, O_STAGE)
+    tmem_start_addr = pool.alloc((1,), "uint32", align=4)
+    pool.commit()
+
+    # The 128-row datapath-D accumulator takes a 2-D (m, N) shape only, so each
+    # stage is its own allocation. The resulting column map is the source's:
+    # S0 [0,128), S1 [128,256), O0 [256,384), O1 [384,512) (:145-161).
+    tmem_pool = T.TMEMPool(pool, total_cols=TMEM_TOTAL, cta_group=1, tmem_addr=tmem_start_addr)
+    tmem_s_col = T.meta_var(tmem_pool.offset)
+    _tmem_s0 = tmem_pool.alloc_tcgen05_mma_D((M_BLOCK, N_BLOCK), "float32", M=M_BLOCK, cta_group=1)
+    _tmem_s1 = tmem_pool.alloc_tcgen05_mma_D((M_BLOCK, N_BLOCK), "float32", M=M_BLOCK, cta_group=1)
+    tmem_o_col = T.meta_var(tmem_pool.offset)
+    _tmem_o0 = tmem_pool.alloc_tcgen05_mma_D((M_BLOCK, HEAD_DIM), "float32", M=M_BLOCK, cta_group=1)
+    _tmem_o1 = tmem_pool.alloc_tcgen05_mma_D((M_BLOCK, HEAD_DIM), "float32", M=M_BLOCK, cta_group=1)
+    tmem_stage_stride = T.meta_var(N_BLOCK)
+    tmem_o_stage_stride = T.meta_var(HEAD_DIM)
+    # P overlays the upper columns of each S tile (:369-371): the P store
+    # destroys the tail of S, which is safe only because row_max and row_sum are
+    # already out of it by then.
+    p_width = T.meta_var(_DTYPE_BYTES[pv_dtype] * 8)
+    tmem_s_to_p = T.meta_var(N_BLOCK - N_BLOCK * p_width // 32)
+    tmem_p_col = T.meta_var(tmem_s_col + tmem_s_to_p)
+
+    # -----------------------------------------------------------------------
+    # Prologue: descriptor prefetch, thread-0 metadata publish, barrier init.
+    # -----------------------------------------------------------------------
+    if warp_idx == 0:
+        # One issue, not thirty-two: the prefetch is warp-uniform and rides the
+        # memory pipeline, so letting the whole warp issue it costs L1TEX slots
+        # for nothing. The reference elects a single lane (:663-669).
+        if T.cuda.elect_sync():
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(k_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(v_map)))
+            T.evaluate(T.ptx.prefetch.tensormap(T.address_of(q_map)))
+
+    if tidx == 0:
+        base_row_start = ld_global_i32(
+            k2q_row_ptr, head_kv_idx[0] * (total_rows + 1) + row_linear[0]
+        )
+        row_start: T.int32 = base_row_start + work_q_begin[0]
+        count_raw: T.int32 = work_q_count[0]
+        seqlen_k: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0] + 1) - ld_global_i32(
+            cu_seqlens_k, batch_idx[0]
+        )
+        kv_valid_cols: T.int32 = T.min(T.max(seqlen_k - kv_block_idx[0] * N_BLOCK, 0), N_BLOCK)
+        q_batch_offset: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0])
+        k_batch_offset: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0])
+        st_shared_i32(s_row_meta, 0, batch_idx[0])
+        st_shared_i32(s_row_meta, 1, kv_block_idx[0])
+        st_shared_i32(s_row_meta, 2, row_start)
+        st_shared_i32(s_row_meta, 3, count_raw)
+        st_shared_i32(s_row_meta, 4, kv_valid_cols)
+        st_shared_i32(s_row_meta, 5, q_batch_offset)
+        st_shared_i32(s_row_meta, 6, k_batch_offset)
+        seqlen_q: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0] + 1) - q_batch_offset
+        causal_q_offset: T.int32 = seqlen_k - seqlen_q
+        st_shared_i32(s_row_meta, 7, causal_q_offset)
+
+        # The causal diagonal split point: a 32-step binary search over the CSR
+        # row, which is sorted by q_idx (:259-285, :919-935). The export keeps
+        # the loop rolled with exactly one probe load in the body.
+        diag_q_count = T.alloc_local((1,), "int32")
+        diag_q_count[0] = 0
+        if count_raw > 0 and kv_valid_cols > 0:
+            q_threshold: T.int32 = (kv_block_idx[0] * N_BLOCK + kv_valid_cols) - causal_q_offset
+            lo = T.alloc_local((1,), "int32")
+            hi = T.alloc_local((1,), "int32")
+            lo[0] = 0
+            hi[0] = count_raw
+            # A `While`, not a counted loop: TVM's C codegen consults no loop
+            # annotation, so `T.serial(..., unroll=False)` still leaves nvcc free
+            # to unroll, and several copies of a body that is one dependent
+            # global load cost more than the loop overhead they remove. The
+            # condition also retires the search as soon as it converges instead
+            # of predicating off the remaining fixed steps, which is most of them
+            # whenever the CSR row is short.
+            while lo[0] < hi[0]:
+                mid: T.int32 = udiv_i32(lo[0] + hi[0], 2)
+                probe: T.int32 = ld_global_i32(
+                    k2q_q_indices, head_kv_idx[0] * nnz + row_start + mid
+                )
+                if probe < q_threshold:
+                    lo[0] = mid + 1
+                else:
+                    hi[0] = mid
+            diag_q_count[0] = lo[0]
+        st_shared_i32(s_diag_q_count, 0, diag_q_count[0])
+
+        bar_k.init(1)
+        bar_v.init(1)
+        if k_stage_fp8:
+            bar_k_tma.init(1)
+            _mbar_expect_tx(bar_k_tma, 0, N_BLOCK * HEAD_DIM * k_bytes)
+        else:
+            _mbar_expect_tx(bar_k, 0, N_BLOCK * HEAD_DIM * k_bytes)
+        if v_stage_fp8:
+            bar_v_tma.init(1)
+            _mbar_expect_tx(bar_v_tma, 0, N_BLOCK * HEAD_DIM * v_bytes)
+        else:
+            _mbar_expect_tx(bar_v, 0, N_BLOCK * HEAD_DIM * v_bytes)
+
+    # Warp 1, not warp 0: thread 0 is already serialising the whole CTA behind
+    # its metadata chain, whose binary search is 32 dependent global loads, and
+    # every other thread is waiting at the barrier below. The pipe mbarriers do
+    # not depend on any of that, so initialising them from another warp puts the
+    # two on top of each other. The fence and CTA barrier that follow order both
+    # against every consumer, so visibility is unchanged.
+    if warp_idx == 1:
+        if T.cuda.elect_sync():
+            for stage in T.unroll(Q_STAGE):
+                T.ptx.mbarrier.init.shared.b64(bar_q_full.ptr_to([stage]), T.uint32(1))
+                T.ptx.mbarrier.init.shared.b64(bar_q_empty.ptr_to([stage]), T.uint32(1))
+            for stage in T.unroll(S_STAGE):
+                T.ptx.mbarrier.init.shared.b64(bar_s_full.ptr_to([stage]), T.uint32(1))
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_s_empty.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_p_full.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+                T.ptx.mbarrier.init.shared.b64(bar_p_empty.ptr_to([stage]), T.uint32(1))
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_p_last_full.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+                T.ptx.mbarrier.init.shared.b64(bar_p_last_empty.ptr_to([stage]), T.uint32(1))
+            for stage in T.unroll(O_STAGE):
+                T.ptx.mbarrier.init.shared.b64(bar_o_full.ptr_to([stage]), T.uint32(1))
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_o_empty.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_stats_full.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+                T.ptx.mbarrier.init.shared.b64(
+                    bar_stats_empty.ptr_to([stage]), T.uint32(SOFTMAX_THREADS)
+                )
+
+    T.ptx.fence.mbarrier_init.release.cluster()
+    T.cuda.cta_sync()
+
+    # -----------------------------------------------------------------------
+    # Role dispatch. A flat sequence of independent `if` blocks, each ANDed
+    # with `cta_valid_work` -- not an if/elif chain (:991-1235).
+    # -----------------------------------------------------------------------
+    if warp_idx == TOTAL_WARPS - 1:
+        # Warp 15 is idle and is NOT gated on cta_valid_work (:991-992).
+        T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_OTHER)))
+
+    # -----------------------------------------------------------------------
+    # ROLE: Q-load warpgroup, warps 8..11 (:994-1047).
+    # -----------------------------------------------------------------------
+    if tidx >= Q_LOAD_WARP_BASE * WARP_SIZE and tidx < MMA_WARP_ID * WARP_SIZE:
+        if cta_valid_work != 0:
+            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_STORE)))
+            q_row_start: T.int32 = ld_shared_i32(s_row_meta, 2)
+            q_count_raw: T.int32 = ld_shared_i32(s_row_meta, 3)
+            q_batch_off: T.int32 = ld_shared_i32(s_row_meta, 5)
+            # Deliberately NOT gated on KV validity: a sparse entry past the
+            # sequence still runs the all-masked path so its partial is neutral
+            # (:1007-1009).
+            if q_count_raw > 0:
+                num_q_groups_load: T.int32 = uceil_div_i32(q_count_raw, q_tokens_per_group)
+                warp_in_wg: T.int32 = warp_idx - Q_LOAD_WARP_BASE
+                # `q_oob_m_idx = mQ_2d.shape[0] // qheadperkv` (:1855) -- one
+                # past the last Q *tile*, so an absent token gathers out of
+                # bounds and takes the descriptor's OOB fill. `total_q` alone
+                # would be an in-range row whenever num_heads_kv > 1.
+                q_oob_m_idx: T.int32 = total_q * num_heads_kv
+
+                if not USE_GATHER4(qheadperkv):
+                    for qi_group in T.serial(0, num_q_groups_load, unroll=False):
+                        slot: T.int32 = qi_group % Q_STAGE
+                        phase: T.int32 = udiv_i32(qi_group, Q_STAGE) & 1
+                        if warp_in_wg == 0:
+                            bar_q_empty.wait(slot, phase ^ 1)
+                            if T.cuda.elect_sync():
+                                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                    bar_q_full.ptr_to([slot]),
+                                    T.uint32(M_BLOCK * HEAD_DIM * q_bytes),
+                                )
+                        bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
+
+                        load_meta_slot: T.int32 = slot * q_tokens_per_group
+                        qidx_meta_slot: T.int32 = (
+                            qi_group & (QIDX_META_STAGES - 1)
+                        ) * q_tokens_per_group
+                        # One warp's low lanes publish the whole group: with
+                        # qheadperkv >= 8 a group is at most 16 tokens
+                        # (:1883-1898).
+                        if warp_in_wg == 0 and lane_idx < q_tokens_per_group:
+                            qi: T.int32 = qi_group * q_tokens_per_group + lane_idx
+                            if qi < q_count_raw:
+                                word: T.int32 = ld_global_i32(
+                                    k2q_qsplit_indices, head_kv_idx[0] * nnz + q_row_start + qi
+                                )
+                                st_shared_i32(s_qidx_meta, qidx_meta_slot + lane_idx, word)
+                                st_shared_i32(
+                                    s_q_load_m_idx,
+                                    load_meta_slot + lane_idx,
+                                    (q_batch_off + T.bitwise_and(word, Q_IDX_MASK)) * num_heads_kv
+                                    + head_kv_idx[0],
+                                )
+                            else:
+                                st_shared_i32(s_qidx_meta, qidx_meta_slot + lane_idx, 0)
+                                st_shared_i32(
+                                    s_q_load_m_idx, load_meta_slot + lane_idx, q_oob_m_idx
+                                )
+                        bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
+
+                        for qi_slot in T.unroll(TOKENS_PER_WARP(qheadperkv)):
+                            tok: T.int32 = warp_in_wg * TOKENS_PER_WARP(qheadperkv) + qi_slot
+                            if tok < q_tokens_per_group:
+                                m_tile: T.int32 = ld_shared_i32(
+                                    s_q_load_m_idx, load_meta_slot + tok
+                                )
+                                if T.cuda.elect_sync():
+                                    for ks in T.unroll(Q_SUBTILES(q_bytes)):
+                                        T.evaluate(
+                                            T.ptx[_TMA_G2S_2D_CACHE](
+                                                T.ptr_byte_offset(
+                                                    s_q.ptr_to([0, 0]),
+                                                    slot * M_BLOCK * HEAD_DIM * q_bytes
+                                                    + ks * M_BLOCK * q_load_tile * q_bytes
+                                                    + tok * qheadperkv * q_load_tile * q_bytes,
+                                                    q_ty,
+                                                ),
+                                                T.address_of(q_map),
+                                                T.int32(ks * q_load_tile),
+                                                m_tile * qheadperkv,
+                                                T.cuda.cvta_generic_to_shared(
+                                                    bar_q_full.ptr_to([slot])
+                                                ),
+                                                _Q_TMA_CACHE_HINT,
+                                            )
+                                        )
+
+                    if warp_in_wg == 0:
+                        # One acquire past the end leaves the ring's empty half
+                        # in the state the next work item expects (:1930-1935).
+                        bar_q_empty.wait(
+                            num_q_groups_load % Q_STAGE,
+                            (udiv_i32(num_q_groups_load, Q_STAGE) & 1) ^ 1,
+                        )
+                        if T.cuda.elect_sync():
+                            T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                bar_q_full.ptr_to([num_q_groups_load % Q_STAGE]),
+                                T.uint32(M_BLOCK * HEAD_DIM * q_bytes),
+                            )
+                else:
+                    # ---- gather4 Q path, qheadperkv in {1, 2, 4} (:1624-1817) ----
+                    # Each gather4 pulls four GMEM rows into one box, so a
+                    # 128-row Q tile takes 8 gathers per warp.
+                    gathers_per_warp = T.meta_var(M_BLOCK // (NUM_Q_LOAD_WARPS * 4))
+                    tokens_per_gather4 = T.meta_var(4 // qheadperkv)
+                    meta_iters = T.meta_var(
+                        (q_tokens_per_group + NUM_Q_LOAD_WARPS * WARP_SIZE - 1)
+                        // (NUM_Q_LOAD_WARPS * WARP_SIZE)
+                    )
+                    for qi_group in T.serial(0, num_q_groups_load, unroll=False):
+                        slot: T.int32 = qi_group % Q_STAGE
+                        phase: T.int32 = udiv_i32(qi_group, Q_STAGE) & 1
+                        if warp_in_wg == 0:
+                            bar_q_empty.wait(slot, phase ^ 1)
+                            if T.cuda.elect_sync():
+                                T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                    bar_q_full.ptr_to([slot]),
+                                    T.uint32(M_BLOCK * HEAD_DIM * q_bytes),
+                                )
+                        bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
+
+                        qidx_meta_slot: T.int32 = (
+                            T.bitwise_and(qi_group, QIDX_META_STAGES - 1) * q_tokens_per_group
+                        )
+                        # This path's groups hold 32, 64 or 128 tokens, so the
+                        # publish takes several sweeps of the whole warpgroup
+                        # (:1671-1690).
+                        for meta_iter in T.unroll(meta_iters):
+                            tok_g4: T.int32 = (
+                                meta_iter * NUM_Q_LOAD_WARPS + warp_in_wg
+                            ) * WARP_SIZE + lane_idx
+                            if tok_g4 < q_tokens_per_group:
+                                qi_g4: T.int32 = qi_group * q_tokens_per_group + tok_g4
+                                if qi_g4 < q_count_raw:
+                                    st_shared_i32(
+                                        s_qidx_meta,
+                                        qidx_meta_slot + tok_g4,
+                                        ld_global_i32(
+                                            k2q_qsplit_indices,
+                                            head_kv_idx[0] * nnz + q_row_start + qi_g4,
+                                        ),
+                                    )
+                                else:
+                                    st_shared_i32(s_qidx_meta, qidx_meta_slot + tok_g4, 0)
+                        bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
+
+                        if T.cuda.elect_sync():
+                            for gather_slot in T.unroll(gathers_per_warp):
+                                gather_idx: T.int32 = gather_slot * NUM_Q_LOAD_WARPS + warp_in_wg
+                                tok_base: T.int32 = gather_idx * tokens_per_gather4
+                                rows = T.alloc_local((4,), "int32")
+                                _resolve_gather4_rows(
+                                    rows,
+                                    s_qidx_meta,
+                                    qidx_meta_slot,
+                                    tok_base,
+                                    qi_base=qi_group * q_tokens_per_group,
+                                    count_raw=q_count_raw,
+                                    q_batch_off=q_batch_off,
+                                    num_heads_kv=num_heads_kv,
+                                    head_kv_idx=head_kv_idx[0],
+                                    q_oob_m_idx=q_oob_m_idx,
+                                    qheadperkv=qheadperkv,
+                                )
+                                for ks in T.unroll(Q_SUBTILES(q_bytes)):
+                                    if ks + 1 < Q_SUBTILES(q_bytes):
+                                        T.evaluate(
+                                            T.ptx[_TMA_GATHER4_PREFETCH](
+                                                T.address_of(q_map),
+                                                T.int32((ks + 1) * q_load_tile),
+                                                rows[0],
+                                                rows[1],
+                                                rows[2],
+                                                rows[3],
+                                                _Q_TMA_CACHE_HINT,
+                                            )
+                                        )
+                                    T.evaluate(
+                                        T.ptx[_TMA_GATHER4_2D_CACHE](
+                                            T.ptr_byte_offset(
+                                                s_q.ptr_to([0, 0]),
+                                                slot * M_BLOCK * HEAD_DIM * q_bytes
+                                                + ks * M_BLOCK * q_load_tile * q_bytes
+                                                + gather_idx * 4 * q_load_tile * q_bytes,
+                                                q_ty,
+                                            ),
+                                            T.address_of(q_map),
+                                            T.int32(ks * q_load_tile),
+                                            rows[0],
+                                            rows[1],
+                                            rows[2],
+                                            rows[3],
+                                            T.cuda.cvta_generic_to_shared(
+                                                bar_q_full.ptr_to([slot])
+                                            ),
+                                            _Q_TMA_CACHE_HINT,
+                                        )
+                                    )
+                        bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
+
+                    if warp_in_wg == 0:
+                        bar_q_empty.wait(
+                            num_q_groups_load % Q_STAGE,
+                            (udiv_i32(num_q_groups_load, Q_STAGE) & 1) ^ 1,
+                        )
+                        if T.cuda.elect_sync():
+                            T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                bar_q_full.ptr_to([num_q_groups_load % Q_STAGE]),
+                                T.uint32(M_BLOCK * HEAD_DIM * q_bytes),
+                            )
+
+    # -----------------------------------------------------------------------
+    # ROLE: KV load, warps 13 and 14. One TMA each; there is no KV ring
+    # (:1049-1086, :1519-1621).
+    # -----------------------------------------------------------------------
+    if warp_idx >= KV_LOAD_WARP_BASE and warp_idx < KV_LOAD_WARP_BASE + NUM_KV_LOAD_WARPS:
+        if cta_valid_work != 0:
+            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_OTHER)))
+            kv_block_load: T.int32 = ld_shared_i32(s_row_meta, 1)
+            k_batch_off: T.int32 = ld_shared_i32(s_row_meta, 6)
+            kv_has_work: T.int32 = T.cast(ld_shared_i32(s_row_meta, 3) > 0, "int32")
+            if kv_has_work != 0:
+                kv_row_start: T.int32 = k_batch_off + kv_block_load * N_BLOCK
+                if warp_idx == KV_LOAD_WARP_BASE:
+                    if T.cuda.elect_sync():
+                        for sub in T.unroll(KV_SUBTILES(k_bytes)):
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_3D_CACHE](
+                                    T.ptr_byte_offset(
+                                        (s_k_fp8 if k_stage_fp8 else s_k).ptr_to([0, 0]),
+                                        sub * N_BLOCK * _swizzle_elems(k_bytes) * k_bytes,
+                                        k_ty,
+                                    ),
+                                    T.address_of(k_stage_map if k_stage_fp8 else k_map),
+                                    T.int32(sub * _swizzle_elems(k_bytes)),
+                                    head_kv_idx[0],
+                                    kv_row_start,
+                                    T.cuda.cvta_generic_to_shared(
+                                        (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0])
+                                    ),
+                                    _KV_TMA_CACHE_HINT,
+                                )
+                            )
+                        T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
+                            (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0]), T.uint32(1)
+                        )
+                if warp_idx == KV_LOAD_WARP_BASE + 1:
+                    if T.cuda.elect_sync():
+                        for sub in T.unroll(KV_SUBTILES(v_bytes)):
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_3D_CACHE](
+                                    T.ptr_byte_offset(
+                                        (s_v_fp8 if v_stage_fp8 else s_v).ptr_to([0, 0]),
+                                        sub * N_BLOCK * _swizzle_elems(v_bytes) * v_bytes,
+                                        v_ty,
+                                    ),
+                                    T.address_of(v_stage_map if v_stage_fp8 else v_map),
+                                    T.int32(sub * _swizzle_elems(v_bytes)),
+                                    head_kv_idx[0],
+                                    kv_row_start,
+                                    T.cuda.cvta_generic_to_shared(
+                                        (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0])
+                                    ),
+                                    _KV_TMA_CACHE_HINT,
+                                )
+                            )
+                        T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
+                            (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0]), T.uint32(1)
+                        )
+                if k_stage_fp8 or v_stage_fp8:
+                    bar_sync_named(BAR_KV_LOAD, WARP_SIZE * NUM_KV_LOAD_WARPS)
+
+    # -----------------------------------------------------------------------
+    # ROLE: the single MMA-issue warp, warp 12; also the TMEM allocator warp
+    # (:1088-1111, :1938-2183).
+    # -----------------------------------------------------------------------
+    if warp_idx == MMA_WARP_ID:
+        if cta_valid_work != 0:
+            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_OTHER)))
+            T.evaluate(
+                T.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                    T.address_of(tmem_start_addr[0]), T.uint32(TMEM_TOTAL)
+                )
+            )
+            # The retrieve barrier spans both softmax warpgroups plus this warp
+            # (:767-772). On the fp8 paths that also makes the first QK wait for
+            # the shared-memory dequantization, without a separate edge.
+            bar_sync_named(BAR_TMEM_ALLOC, WARP_SIZE * (WARPS_PER_GROUP * 2 + 1))
+
+            mma_count_raw: T.int32 = ld_shared_i32(s_row_meta, 3)
+            if mma_count_raw > 0:
+                num_q_groups_mma: T.int32 = uceil_div_i32(mma_count_raw, q_tokens_per_group)
+
+                # Operand descriptors. The Q ring is walked by adding a
+                # compile-time 16-byte offset to the A descriptor rather than
+                # rebuilding it, which is what the source's `wrap`/`advance`
+                # pre-bound partials do in PTX registers (:1990-1995).
+                q_desc = SmemDescriptor()
+                q_desc.init(s_q.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+                q_desc.make_lo_uniform()
+                k_desc = SmemDescriptor()
+                k_desc.init(s_k.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+                k_desc.make_lo_uniform()
+                v_desc = SmemDescriptor()
+                v_desc.init(s_v.ptr_to([0, 0]), ldo=1024, sdo=64, swizzle=3)
+                v_desc.make_lo_uniform()
+
+                bar_k.wait(0, 0)
+
+                # Issue order (:2070-2077): Q0K, Q1K, P0V, Q2K, P1V, ...
+                # QK(qi) consumes S slot qi&1; PV(qi-2) frees that slot before
+                # QK(qi) reuses it, so a 2-slot S ring is safe.
+                bar_q_full.wait(0, 0)
+                bar_s_empty.wait(0, 1)
+                _issue_qk(
+                    0, 0, q_desc, k_desc, qk_mma_kind, qk_dtype, tmem_s_col, tmem_stage_stride
+                )
+                _tcgen05_commit(bar_s_full, 0)
+                _tcgen05_commit(bar_q_empty, 0)
+
+                if num_q_groups_mma > 1:
+                    bar_q_full.wait(1, 0)
+                    bar_s_empty.wait(1, 1)
+                    _issue_qk(
+                        1, 1, q_desc, k_desc, qk_mma_kind, qk_dtype, tmem_s_col, tmem_stage_stride
+                    )
+                    _tcgen05_commit(bar_s_full, 1)
+                    _tcgen05_commit(bar_q_empty, 1)
+
+                # V is waited only after the two prologue QKs, so its TMA
+                # overlaps them (:2094).
+                bar_v.wait(0, 0)
+
+                for qi in T.serial(2, num_q_groups_mma, unroll=False):
+                    pv_qi: T.int32 = qi - 2
+                    pv_slot: T.int32 = T.bitwise_and(pv_qi, 1)
+                    pv_phase: T.int32 = udiv_i32(pv_qi, 2) & 1
+                    bar_p_full.wait(pv_slot, pv_phase)
+                    bar_o_empty.wait(pv_slot, pv_phase ^ 1)
+                    _issue_pv(
+                        pv_slot,
+                        v_desc,
+                        pv_mma_kind,
+                        pv_dtype,
+                        tmem_o_col,
+                        tmem_o_stage_stride,
+                        tmem_p_col,
+                        tmem_stage_stride,
+                        bar_p_last_full,
+                        pv_phase,
+                    )
+                    _tcgen05_commit(bar_o_full, pv_slot)
+                    _tcgen05_commit(bar_p_last_empty, pv_slot)
+                    _tcgen05_commit(bar_p_empty, pv_slot)
+
+                    q_slot: T.int32 = qi % Q_STAGE
+                    q_phase: T.int32 = udiv_i32(qi, Q_STAGE) & 1
+                    s_slot: T.int32 = T.bitwise_and(qi, 1)
+                    s_phase: T.int32 = udiv_i32(qi, 2) & 1
+                    bar_q_full.wait(q_slot, q_phase)
+                    bar_s_empty.wait(s_slot, s_phase ^ 1)
+                    # The S-slot test is a runtime branch that duplicates the
+                    # whole 8-instruction chain in the emitted code; the Q-slot
+                    # choice collapses into an address select (export: two
+                    # chains behind `@%p bra`, one PV chain).
+                    if s_slot == 0:
+                        _issue_qk(
+                            0,
+                            q_slot,
+                            q_desc,
+                            k_desc,
+                            qk_mma_kind,
+                            qk_dtype,
+                            tmem_s_col,
+                            tmem_stage_stride,
+                        )
+                    else:
+                        _issue_qk(
+                            1,
+                            q_slot,
+                            q_desc,
+                            k_desc,
+                            qk_mma_kind,
+                            qk_dtype,
+                            tmem_s_col,
+                            tmem_stage_stride,
+                        )
+                    _tcgen05_commit(bar_s_full, s_slot)
+                    _tcgen05_commit(bar_q_empty, q_slot)
+
+                # Drain the last one or two PV tiles (:2152-2183).
+                drain_begin: T.int32 = T.if_then_else(
+                    num_q_groups_mma == 1, 0, num_q_groups_mma - 2
+                )
+                for pv_qi2 in T.serial(drain_begin, num_q_groups_mma, unroll=False):
+                    pv_slot2: T.int32 = T.bitwise_and(pv_qi2, 1)
+                    pv_phase2: T.int32 = udiv_i32(pv_qi2, 2) & 1
+                    bar_p_full.wait(pv_slot2, pv_phase2)
+                    bar_o_empty.wait(pv_slot2, pv_phase2 ^ 1)
+                    _issue_pv(
+                        pv_slot2,
+                        v_desc,
+                        pv_mma_kind,
+                        pv_dtype,
+                        tmem_o_col,
+                        tmem_o_stage_stride,
+                        tmem_p_col,
+                        tmem_stage_stride,
+                        bar_p_last_full,
+                        pv_phase2,
+                    )
+                    _tcgen05_commit(bar_o_full, pv_slot2)
+                    _tcgen05_commit(bar_p_last_empty, pv_slot2)
+                    _tcgen05_commit(bar_p_empty, pv_slot2)
+
+            T.evaluate(T.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned())
+            bar_sync_named(BAR_TMEM_ALLOC, WARP_SIZE * (WARPS_PER_GROUP * 2 + 1))
+            # The contract forbids a native load on a shared buffer, so the
+            # allocated base comes back through an explicit ld.shared.
+            tmem_base = T.alloc_local((1,), "uint32")
+            T.evaluate(T.ptx.ld.shared.u32(tmem_base[0], tmem_start_addr.ptr_to([0])))
+            T.evaluate(
+                T.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                    tmem_base[0], T.uint32(TMEM_TOTAL)
+                )
+            )
+            # No matching griddepcontrol.wait anywhere in this kernel, so no
+            # launch attribute is needed -- only a waiting kernel needs one.
+            T.evaluate(T.ptx.griddepcontrol.launch_dependents())
+
+    # -----------------------------------------------------------------------
+    # ROLE: softmax warpgroups 0 and 1, with the epilogue fused in
+    # (:1113-1235, :2186-2352, :2659-3020).
+    #
+    # `stage` is a compile-time constant, so this body is emitted once per
+    # warpgroup -- which is what the export shows, every single-site operation
+    # inside it appearing exactly twice.
+    # -----------------------------------------------------------------------
+    @T.inline
+    def epilogue_step(
+        stage, qi_group, qidx_meta_slot, group_tidx, count_raw, q_batch_off, scale_log2
+    ):
+        """Scale O by 1/row_sum and store it, then store LSE (:2659-3020).
+
+        This departs from the reference, which reads O with
+        ``Ld16x256bOp(Repetition(8))``. That shape's register map on SM100 is
+        ``row = warp*32 + lane//4 + 8*((r//2)%2)``,
+        ``col = pass*64 + (lane%4)*2 + (r//4)*8 + r%2`` -- one instruction
+        covering a strided 64-row subset, whose 128-row bookkeeping has no
+        counterpart in the reference to transcribe. This port reads with
+        ``32x32b.x32`` instead, whose map is the identity (thread = M row,
+        register = column). That is the shape all
+        three merged flashmla epilogues use. The stored values are unchanged;
+        the load instruction count per warpgroup goes from 2 to 4, and the
+        swizzle-inverse column remap drops out, because it exists only to undo
+        the 16x256b fragment's permutation.
+        """
+        slot: T.int32 = T.bitwise_and(qi_group, 1)
+        phase: T.int32 = udiv_i32(qi_group, 2) & 1
+        bar_o_full.wait(slot, phase)
+
+        # Decode the packed qsplit once per group into the 2-deep caches; every
+        # per-store read below comes out of these, never out of s_qidx_meta.
+        if group_tidx < q_tokens_per_group:
+            word: T.int32 = ld_shared_i32(s_qidx_meta, qidx_meta_slot + group_tidx)
+            st_shared_i32(
+                s_q_idx, slot * q_tokens_per_group + group_tidx, T.bitwise_and(word, Q_IDX_MASK)
+            )
+            st_shared_i32(
+                s_split_idx,
+                slot * q_tokens_per_group + group_tidx,
+                T.bitwise_and(T.shift_right(word, SLOT_SHIFT), SLOT_MASK),
+            )
+        bar_sync_named(BAR_EPILOGUE + stage, SOFTMAX_THREADS)
+
+        # Four `16x256b.x8` reads tile the 128x128 accumulator: the lane half
+        # picks rows `lane_base + 0..15` of each warp's 32, the column half
+        # picks 64 of the 128 columns. Each hands the thread 32 registers.
+        #
+        # This shape, not `32x32b`, is what makes the stores coalesce. Here
+        # lanes 0-3 of a warp hold four columns of ONE row, so a store
+        # instruction covers eight rows in contiguous 64-byte runs -- 16
+        # sectors for 512 bytes, the minimum. Under `32x32b` the thread IS the
+        # row, so every lane of a store lands on a different row 512 bytes
+        # away: the same bytes at twice the sectors.
+        warp_in_wg: T.int32 = group_tidx // WARP_SIZE
+        lane_in_warp: T.int32 = group_tidx - warp_in_wg * WARP_SIZE
+        row_of_lane: T.int32 = warp_in_wg * 32 + lane_in_warp // 4
+        col_of_lane: T.int32 = (lane_in_warp % 4) * 2
+
+        # `lane_base` and `col_base` stay Python ints through the inline call,
+        # which keeps the TMEM address and the group's column base constant.
+        @T.inline
+        def load_o_instruction(o_regs, lane_base, col_base):
+            T.evaluate(
+                T.ptx[_TMEM_LD_16](
+                    *[o_regs[i] for i in range(32)],
+                    T.cast(tmem_o_col + slot * tmem_o_stage_stride + col_base, "uint32")
+                    + T.uint32(lane_base << 16),
+                )
+            )
+
+        @T.inline
+        def store_o_instruction(o_regs, lane_base, col_base):
+            # Derived arithmetically rather than looked up: the loop variable is
+            # a TIR var here, and the unroller folds these to constants. Indexing
+            # a Python list with it would fail while tracing, before that.
+            # Derived arithmetically rather than looked up: the loop variable is
+            # a TIR var here, and the unroller folds these to constants. Indexing
+            # a Python list with it would fail while tracing, before that.
+            for grp in range(2 * _GROUPS_PER_PARITY[partial_dtype]):
+                parity = grp // _GROUPS_PER_PARITY[partial_dtype]
+                kb = (grp % _GROUPS_PER_PARITY[partial_dtype]) * _KS_PER_STORE[partial_dtype]
+                regs = [
+                    4 * (kb + t) + 2 * parity + j
+                    for t in range(_KS_PER_STORE[partial_dtype])
+                    for j in (0, 1)
+                ]
+                # `tok` is the token within the group, `row_in_tok` the head
+                # inside that token.
+                row: T.int32 = row_of_lane + lane_base + 8 * parity
+                tok: T.int32 = udiv_i32(row, qheadperkv)
+                row_in_tok: T.int32 = row - tok * qheadperkv
+                qi: T.int32 = qi_group * q_tokens_per_group + tok
+                if qi < count_raw:
+                    # Re-read per store, as the reference does: nothing here is
+                    # hoisted out of the column loop, the reciprocal included
+                    # (:2785-2800, measured one of each per 128-bit store).
+                    q_idx_e: T.int32 = ld_shared_i32(s_q_idx, slot * q_tokens_per_group + tok)
+                    split_e: T.int32 = ld_shared_i32(s_split_idx, slot * q_tokens_per_group + tok)
+                    row_sum_e: T.float32 = ld_shared_f32(s_scale, slot * M_BLOCK * 2 + row)
+                    safe_sum: T.float32 = T.if_then_else(
+                        T.Or(row_sum_e == T.float32(0.0), row_sum_e != row_sum_e),
+                        T.float32(1.0),
+                        row_sum_e,
+                    )
+                    row_scale = T.alloc_local((1,), "float32")
+                    T.evaluate(T.ptx.rcp.approx.ftz.f32(row_scale[0], safe_sum))
+                    q_abs_e: T.int32 = q_batch_off + q_idx_e
+                    flat_row: T.int64 = (
+                        T.cast(split_e, "int64")
+                        * T.cast(total_q, "int64")
+                        * T.cast(head_q, "int64")
+                        + T.cast(q_abs_e, "int64") * T.cast(head_q, "int64")
+                        + T.cast(head_kv_idx[0] * qheadperkv + row_in_tok, "int64")
+                    )
+                    # The group's first register sits at column
+                    # `col_base + (lane%4)*2 + 8*kb`; the fake-column map turns
+                    # that into the contiguous output address.
+                    store_col: T.int32 = _fake_col(partial_dtype, col_base + col_of_lane + 8 * kb)
+                    scaled = T.alloc_local((_STORE_LANES[partial_dtype],), "float32")
+                    _scale_gather(scaled, o_regs, regs, row_scale[0])
+                    _store_o_partial(
+                        o_partial,
+                        flat_row * T.int64(HEAD_DIM) + T.cast(store_col, "int64"),
+                        scaled,
+                        partial_dtype,
+                    )
+
+        # All four reads are issued before the single wait. `wait::ld` drains
+        # every TMEM load this thread has outstanding, so one after the last
+        # issue still orders all four ahead of the first store that reads them
+        # -- and the four now overlap instead of draining one at a time.
+        o_frag_0 = T.alloc_tcgen05_ldst_frag("16x256b", (M_BLOCK // 2, 64), "float32")
+        o_frag_1 = T.alloc_tcgen05_ldst_frag("16x256b", (M_BLOCK // 2, 64), "float32")
+        o_frag_2 = T.alloc_tcgen05_ldst_frag("16x256b", (M_BLOCK // 2, 64), "float32")
+        o_frag_3 = T.alloc_tcgen05_ldst_frag("16x256b", (M_BLOCK // 2, 64), "float32")
+        o_regs_0 = o_frag_0.local()
+        o_regs_1 = o_frag_1.local()
+        o_regs_2 = o_frag_2.local()
+        o_regs_3 = o_frag_3.local()
+        load_o_instruction(o_regs_0, 0, 0)
+        load_o_instruction(o_regs_1, 0, 64)
+        load_o_instruction(o_regs_2, 16, 0)
+        load_o_instruction(o_regs_3, 16, 64)
+        T.evaluate(T.ptx.tcgen05.wait__ld.sync.aligned())
+        store_o_instruction(o_regs_0, 0, 0)
+        store_o_instruction(o_regs_1, 0, 64)
+        store_o_instruction(o_regs_2, 16, 0)
+        store_o_instruction(o_regs_3, 16, 64)
+
+        # LSE: one row per thread (:2987-3016).
+        tok_l: T.int32 = udiv_i32(group_tidx, qheadperkv)
+        h_local: T.int32 = group_tidx - tok_l * qheadperkv
+        if qi_group * q_tokens_per_group + tok_l < count_raw:
+            row_sum_l: T.float32 = ld_shared_f32(s_scale, slot * M_BLOCK * 2 + group_tidx)
+            row_max_l: T.float32 = ld_shared_f32(s_scale, slot * M_BLOCK * 2 + M_BLOCK + group_tidx)
+            lg = T.alloc_local((1,), "float32")
+            T.evaluate(T.ptx.lg2.approx.ftz.f32(lg[0], row_sum_l))
+            lse_val: T.float32 = T.if_then_else(
+                T.Or(row_sum_l == T.float32(0.0), row_sum_l != row_sum_l),
+                -T.infinity("float32"),
+                (row_max_l * scale_log2 + lg[0]) * T.float32(LN_2),
+            )
+            q_idx_l: T.int32 = ld_shared_i32(s_q_idx, slot * q_tokens_per_group + tok_l)
+            split_l: T.int32 = ld_shared_i32(s_split_idx, slot * q_tokens_per_group + tok_l)
+            h_abs: T.int32 = head_kv_idx[0] * qheadperkv + h_local
+            lse_flat: T.int64 = (
+                T.cast(split_l, "int64") * T.cast(total_q, "int64") * T.cast(head_q, "int64")
+                + T.cast(q_batch_off + q_idx_l, "int64") * T.cast(head_q, "int64")
+                + T.cast(h_abs, "int64")
+            )
+            T.evaluate(T.ptx.st.global_.f32(lse_partial.ptr_to([lse_flat]), lse_val))
+            if lse_temperature_partial_h is not None:
+                temp_sum: T.float32 = ld_shared_f32(s_scale_temp, slot * M_BLOCK + group_tidx)
+                lgt = T.alloc_local((1,), "float32")
+                T.evaluate(T.ptx.lg2.approx.ftz.f32(lgt[0], temp_sum))
+                lse_t: T.float32 = T.if_then_else(
+                    T.Or(temp_sum == T.float32(0.0), temp_sum != temp_sum),
+                    NEG_INF,
+                    (row_max_l * lse_temperature_scale_log2 + lgt[0]) * T.float32(LN_2),
+                )
+                T.evaluate(T.ptx.st.global_.f32(lse_temperature_partial.ptr_to([lse_flat]), lse_t))
+
+        bar_sync_named(BAR_EPILOGUE + stage, SOFTMAX_THREADS)
+        bar_stats_empty.arrive(slot)
+        bar_o_empty.arrive(slot)
+
+    @T.inline
+    def softmax_warpgroup(stage):
+        group_tidx: T.int32 = tidx - stage * SOFTMAX_THREADS
+        kv_block_sm: T.int32 = ld_shared_i32(s_row_meta, 1)
+        count_raw_sm: T.int32 = ld_shared_i32(s_row_meta, 3)
+        kv_valid_cols: T.int32 = ld_shared_i32(s_row_meta, 4)
+        q_batch_off_sm: T.int32 = ld_shared_i32(s_row_meta, 5)
+        causal_q_off: T.int32 = ld_shared_i32(s_row_meta, 7)
+        diag_q_count_sm: T.int32 = ld_shared_i32(s_diag_q_count, 0)
+
+        # FP8 staging (:1255-1303, :1488-1516). This is NOT in the load warps:
+        # the TMA lands raw fp8 in the staging tile and a whole softmax
+        # warpgroup converts it into the tile the MMA reads, before entering its
+        # own loop. WG0 takes K, WG1 takes V.
+        if stage == 0 and k_stage_fp8:
+            _dequant_kv(
+                s_k_fp8,
+                s_k,
+                bar_k_tma,
+                bar_k,
+                BAR_KV_DEQUANT_K,
+                count_raw_sm,
+                tidx - stage * SOFTMAX_THREADS,
+                1 if v_stage_fp8 else DEQUANT_BATCH,
+            )
+        if stage == 1 and v_stage_fp8:
+            _dequant_kv(
+                s_v_fp8,
+                s_v,
+                bar_v_tma,
+                bar_v,
+                BAR_KV_DEQUANT_V,
+                count_raw_sm,
+                tidx - stage * SOFTMAX_THREADS,
+                1 if k_stage_fp8 else DEQUANT_BATCH,
+            )
+
+        bar_sync_named(BAR_TMEM_ALLOC, WARP_SIZE * (WARPS_PER_GROUP * 2 + 1))
+
+        if count_raw_sm > 0:
+            num_q_groups_sm: T.int32 = uceil_div_i32(count_raw_sm, q_tokens_per_group)
+            kv_block_col_start: T.int32 = kv_block_sm * N_BLOCK
+            # WG0 takes the even Q groups, WG1 the odd ones (:2465-2468).
+            num_stage_groups: T.int32 = udiv_i32(num_q_groups_sm + (1 - stage), 2)
+
+            for qi_iter in T.serial(0, num_stage_groups, unroll=False):
+                qi_group: T.int32 = qi_iter * 2 + stage
+                phase: T.int32 = T.bitwise_and(qi_iter, 1)
+                producer_phase: T.int32 = phase ^ 1
+                qidx_meta_slot: T.int32 = (
+                    T.bitwise_and(qi_group, QIDX_META_STAGES - 1) * q_tokens_per_group
+                )
+                # How many of this group's tokens still sit on the causal
+                # diagonal and therefore need per-column masking (:2478-2486).
+                qi_group_start: T.int32 = qi_group * q_tokens_per_group
+                masked_tok_count: T.int32 = T.max(
+                    0, T.min(q_tokens_per_group, diag_q_count_sm - qi_group_start)
+                )
+
+                # ---------------- softmax step (:2186-2352) ----------------
+                bar_s_full.wait(stage, phase)
+                s_frag = T.alloc_tcgen05_ldst_frag("32x32b", (M_BLOCK, N_BLOCK), "float32")
+                s_regs = s_frag.local()
+                for chunk in T.unroll(4):
+                    T.evaluate(
+                        T.ptx[_TMEM_LD_32](
+                            *[s_regs[chunk * 32 + i] for i in range(32)],
+                            T.cuda.get_tmem_addr(
+                                tmem_s_col + stage * tmem_stage_stride + chunk * 32, 0, 0
+                            ),
+                        )
+                    )
+                T.evaluate(T.ptx.tcgen05.wait__ld.sync.aligned())
+
+                # Column-limit masking, and causal masking for the tokens on
+                # the diagonal. Both arms feed one r2p bit-test body, which is
+                # how the reference emits it too (mask.py:36-46, :71-121).
+                col_limit = T.alloc_local((1,), "int32")
+                col_limit[0] = kv_valid_cols
+                if masked_tok_count > 0:
+                    tok_of_row: T.int32 = udiv_i32(group_tidx, qheadperkv)
+                    q_idx_mask: T.int32 = T.bitwise_and(
+                        ld_shared_i32(s_qidx_meta, qidx_meta_slot + tok_of_row), Q_IDX_MASK
+                    )
+                    causal_col_limit: T.int32 = q_idx_mask + causal_q_off - kv_block_col_start + 1
+                    col_limit[0] = T.min(kv_valid_cols, causal_col_limit)
+                if col_limit[0] < N_BLOCK:
+                    for chunk in T.unroll(N_BLOCK // MASK_R2P_CHUNK):
+                        shift: T.int32 = T.max((chunk + 1) * MASK_R2P_CHUNK - col_limit[0], 0)
+                        # `shr.u32` clamps a shift of 32 or more to zero, which
+                        # is exactly what `r2p_bitmask_below` relies on for the
+                        # chunks entirely past the column limit. A TIR-level
+                        # shift is undefined there and leaves the chunk
+                        # unmasked, which shows up as too-large row sums on the
+                        # early query rows.
+                        bits_reg = T.alloc_local((1,), "uint32")
+                        T.evaluate(
+                            T.ptx.shr.u32(
+                                bits_reg[0], T.uint32(0xFFFFFFFF), T.cast(shift, "uint32")
+                            )
+                        )
+                        bits: T.uint32 = bits_reg[0]
+                        signed_bits: T.int32 = T.reinterpret("int32", bits)
+                        for i in range(MASK_R2P_CHUNK):
+                            # The same bit pattern as the reference's
+                            # `mask & (1 << i)`, spelled signed so bit 31 fits
+                            # an int32 literal and stays one `and.b32` with an
+                            # immediate rather than a shift plus a test.
+                            imm = (1 << i) if i < 31 else -(1 << 31)
+                            if T.bitwise_and(signed_bits, T.int32(imm)) == T.int32(0):
+                                s_regs[chunk * MASK_R2P_CHUNK + i] = NEG_INF
+
+                # One KV block per Q group, so this is always the first and
+                # only online-softmax step: no rescale of a running accumulator
+                # (:2284-2287).
+                row_max = T.alloc_local((1,), "float32")
+                _row_max_128(s_regs, row_max, 0)
+                # `row_max_safe` (:246-247): a fully masked row has row_max
+                # -inf, and subtracting it would make every element NaN. The
+                # reference substitutes 0.0 before the scale-subtract; the
+                # row's sum then comes out 0 and the epilogue's zero guard
+                # turns it into a neutral partial.
+                row_max[0] = T.if_then_else(row_max[0] != NEG_INF, row_max[0], T.float32(0.0))
+                # Taken as a scalar, not recomputed: the reference folds
+                # `softmax_scale * log2(e)` on the host in double precision
+                # (:514), and redoing it in f32 here differs by one ULP, which
+                # propagates straight into every LSE.
+                scale_log2: T.float32 = softmax_scale_log2
+                neg_max_scaled: T.float32 = -(row_max[0] * scale_log2)
+                for ii in T.unroll(N_BLOCK // 2):
+                    i: T.int32 = ii * 2
+                    _packed_f32x2(
+                        "fma.rn.f32x2",
+                        s_regs,
+                        i,
+                        i + 1,
+                        s_regs[i],
+                        s_regs[i + 1],
+                        scale_log2,
+                        scale_log2,
+                        neg_max_scaled,
+                        neg_max_scaled,
+                    )
+
+                if lse_temperature_partial_h is not None:
+                    temp_row_sum = T.alloc_local((1,), "float32")
+                    _scaled_exp2_row_sum_128(s_regs, lse_temperature_inv_scale, temp_row_sum)
+
+                bar_p_last_empty.wait(stage, producer_phase)
+                bar_p_empty.wait(stage, producer_phase)
+
+                # exp2 with the reference's MUFU / polynomial mix, then the
+                # packed conversion into the P operand dtype (:2307-2312).
+                # 128 P values pack into 64 words as bf16, 32 as fp8; the
+                # store repetition follows (:2429-2439).
+                p_words = T.alloc_local((N_BLOCK * _DTYPE_BYTES[pv_dtype] * 8 // 32,), "uint32")
+                # Python loops: the MUFU/polynomial choice is a trace-time
+                # decision on (j, k), so both indices have to be Python ints.
+                for j in range(4):
+                    for k in range(0, 32, 2):
+                        use_mufu = T.meta_var(
+                            (k % EX2_EMU_FREQ) < (EX2_EMU_FREQ - 4)
+                            or j >= 3
+                            or j < EX2_EMU_START_FRG
+                        )
+                        if use_mufu:
+                            T.evaluate(
+                                T.ptx.ex2.approx.ftz.f32(s_regs[j * 32 + k], s_regs[j * 32 + k])
+                            )
+                            T.evaluate(
+                                T.ptx.ex2.approx.ftz.f32(
+                                    s_regs[j * 32 + k + 1], s_regs[j * 32 + k + 1]
+                                )
+                            )
+                        else:
+                            _ex2_emulation_2(s_regs, j * 32 + k, j * 32 + k + 1)
+                    _pack_p_words(p_words, s_regs, j, pv_dtype)
+
+                # Publish P in two pieces: the first three quarters early, so
+                # the MMA warp can start PV, and the last quarter on the
+                # separate barrier its instruction sequence blocks on.
+                split_idx = T.meta_var(4 * SPLIT_P_ARRIVE // N_BLOCK)
+                rep = T.meta_var(_P_STORE_REP[pv_dtype])
+                st_chain = T.meta_var(_TMEM_ST[rep])
+                for k in range(4):
+                    T.evaluate(
+                        T.ptx[st_chain](
+                            T.cuda.get_tmem_addr(
+                                tmem_p_col + stage * tmem_stage_stride + k * rep, 0, 0
+                            ),
+                            *[p_words[k * rep + i] for i in range(rep)],
+                        )
+                    )
+                    if k + 1 == split_idx:
+                        T.evaluate(T.ptx.tcgen05.wait__st.sync.aligned())
+                        bar_p_full.arrive(stage)
+                T.evaluate(T.ptx.tcgen05.wait__st.sync.aligned())
+                bar_p_last_full.arrive(stage)
+
+                # The stats pipe's empty half is a credit on s_scale: it stops
+                # this group from overwriting the slot the epilogue two groups
+                # back has not drained (:2331).
+                bar_stats_empty.wait(stage, producer_phase)
+                row_sum = T.alloc_local((1,), "float32")
+                _row_sum_128(s_regs, row_sum)
+                st_shared_f32(s_scale, stage * M_BLOCK * 2 + group_tidx, row_sum[0])
+                st_shared_f32(s_scale, stage * M_BLOCK * 2 + M_BLOCK + group_tidx, row_max[0])
+                if lse_temperature_partial_h is not None:
+                    st_shared_f32(s_scale_temp, stage * M_BLOCK + group_tidx, temp_row_sum[0])
+                T.evaluate(T.ptx.fence.proxy.async_.shared__cta())
+                bar_s_empty.arrive(stage)
+
+                # ---------------- epilogue (:2659-3020) ----------------
+                bar_sync_named(BAR_EPILOGUE + stage, SOFTMAX_THREADS)
+                epilogue_step(
+                    stage,
+                    qi_group,
+                    qidx_meta_slot,
+                    group_tidx,
+                    count_raw_sm,
+                    q_batch_off_sm,
+                    scale_log2,
+                )
+
+        bar_sync_named(BAR_TMEM_ALLOC, WARP_SIZE * (WARPS_PER_GROUP * 2 + 1))
+
+    if warp_idx < SOFTMAX1_WARP_BASE:
+        if cta_valid_work != 0:
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            softmax_warpgroup(0)
+
+    if warp_idx >= SOFTMAX1_WARP_BASE and warp_idx < Q_LOAD_WARP_BASE:
+        if cta_valid_work != 0:
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            softmax_warpgroup(1)
+
+
+def get_kernel(**config):
+    """Return the TIRx specialization for one compile key."""
+    config.pop("label", None)
+    kernel = _kernel.specialize(
+        qheadperkv=int(config["qhead_per_kv"]),
+        causal=bool(config.get("causal", True)),
+        dtype_mode=str(config.get("dtype", "bf16")),
+        partial_dtype=str(config.get("partial_dtype", "float32")),
+        **({} if config.get("temperature") else {"lse_temperature_partial_h": None}),
+    )
+    return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+#
+# `qhead_per_kv` is the axis that picks the Q-load program: 1, 2 and 4 use the
+# raw gather4 descriptor path, 8 and 16 the plain TMA path (:81-87), so both
+# appear in the benchmark matrix rather than only in correctness.
+# ---------------------------------------------------------------------------
+def _case(
+    *,
+    batch: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    head_kv: int,
+    qhead_per_kv: int,
+    topk: int,
+    label: str,
+    dtype: str = "bf16",
+    partial_dtype: str = "float32",
+    temperature: float | None = None,
+    causal: bool = True,
+    blk_kv: int = BLK_KV,
+    seqlen_pattern: str = "uniform",
+) -> dict:
+    return {
+        "label": label,
+        "batch": batch,
+        "seqlen_q": seqlen_q,
+        "seqlen_k": seqlen_k,
+        "head_kv": head_kv,
+        "qhead_per_kv": qhead_per_kv,
+        "topk": topk,
+        "dtype": dtype,
+        "partial_dtype": partial_dtype,
+        "temperature": temperature,
+        "causal": causal,
+        "blk_kv": blk_kv,
+        "seqlen_pattern": seqlen_pattern,
+    }
+
+
+BENCH_CONFIGS = [
+    # MSA's own ring-attention benchmark shape, verbatim.
+    _case(
+        label="ring48k_bf16_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        seqlen_k=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+    ),
+    # MSA's ulysses shape at its own sweep's lowest topk: the full 384K sequence
+    # with topk=16 needs 6.4 GB for O_partial alone, and the geometry -- not the
+    # slot count -- is what makes this shape interesting.
+    _case(
+        label="ulysses384k_bf16_qh2_t4",
+        batch=1,
+        seqlen_q=393216,
+        seqlen_k=393216,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+    ),
+    # The long-sequence x high-topk regime, at a length whose partials fit.
+    _case(
+        label="long96k_bf16_qh2_t16",
+        batch=1,
+        seqlen_q=98304,
+        seqlen_k=98304,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=16,
+    ),
+    _case(
+        label="varlen_b3_s8192_qh4_t16",
+        batch=3,
+        seqlen_q=8192,
+        seqlen_k=8192,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="varlen_b3_s4096_qh8_t8",
+        batch=3,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        seqlen_pattern="varlen",
+    ),
+    # qhead_per_kv=1 is the gather4 path's extreme: one token per gather.
+    _case(
+        label="qh1_s8192_bf16_t16",
+        batch=1,
+        seqlen_q=8192,
+        seqlen_k=8192,
+        head_kv=2,
+        qhead_per_kv=1,
+        topk=16,
+    ),
+    _case(
+        label="ring48k_fp8_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        seqlen_k=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+    ),
+    _case(
+        label="fp8kv_s16384_qh4_t16",
+        batch=1,
+        seqlen_q=16384,
+        seqlen_k=16384,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        dtype="bf16q_fp8kv",
+    ),
+    _case(
+        label="fp8_pvbf16_s8192_qh8_t8",
+        batch=1,
+        seqlen_q=8192,
+        seqlen_k=8192,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        dtype="fp8_pvbf16",
+    ),
+    _case(
+        label="edge_b1_s1024_bf16_t4",
+        batch=1,
+        seqlen_q=1024,
+        seqlen_k=1024,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+    ),
+]
+
+# Correctness runs at test scale: a full reference for the marquee shapes would
+# need tens of GB live, and the axes those shapes carry -- both Q paths, all
+# four dtype modes, all three partial dtypes -- are covered here at sizes that
+# fit alongside their reference.
+CONFIGS = [
+    *[case for case in BENCH_CONFIGS if case["seqlen_k"] <= 16384 and case["dtype"] != "fp8"],
+    _case(
+        label="corr_fp8_s4096_qh16_t8",
+        batch=1,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=8,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+    ),
+    _case(
+        label="corr_fp8_partial_s2048_qh8_t8",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        dtype="fp8",
+        partial_dtype="float8_e4m3",
+        temperature=2.0,
+    ),
+    # FP8 Q through the gather4 descriptor. The gather4 box width is derived
+    # from the Q element size (:1699), so an FP8 Q is a different descriptor and
+    # a different per-instruction byte count than the BF16 Q the other gather4
+    # cases load; the FP8 cases above all sit on the TMA-Q side of :81-87.
+    _case(
+        label="corr_fp8_gather4_qh2_s2048",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=2,
+        topk=8,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+    ),
+    # The staged FP8-KV dequant (:1255/:1488) runs in the softmax warpgroups and
+    # the Q program runs in its own, so the two compose independently; the other
+    # staged case is gather4, this one pairs the same dequant with TMA Q.
+    _case(
+        label="corr_fp8kv_tma_qh16_s2048",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=8,
+        dtype="bf16q_fp8kv",
+    ),
+    # PV in BF16 while QK stays FP8 selects a different MMA kind for the second
+    # GEMM (:1938 issue order); the other pv=bf16 case is TMA Q.
+    _case(
+        label="corr_fp8_pvbf16_gather4_qh4_s2048",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=8,
+        dtype="fp8_pvbf16",
+    ),
+    _case(
+        label="corr_bf16_qh2_varlen_b2",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=2,
+        topk=8,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="corr_bf16_qh16_s2048_t4",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=4,
+    ),
+    _case(
+        label="corr_decode_b8_qh16_t8",
+        batch=8,
+        seqlen_q=8,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=8,
+    ),
+    _case(
+        label="corr_tiny_b2_s512_qh1_t2",
+        batch=2,
+        seqlen_q=512,
+        seqlen_k=512,
+        head_kv=1,
+        qhead_per_kv=1,
+        topk=2,
+        seqlen_pattern="varlen",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Data preparation.
+#
+# The CSR payload, the work list and the schedule sizing come from the
+# split-atomic module, which builds exactly the inputs this kernel consumes.
+# What that module cannot supply is the packed split slots: it produces them
+# with a device atomic, in arrival order, so re-running it would hand this
+# kernel a different slot permutation on every call. The assignment below is a
+# valid instance of the same contract -- per `(q_abs, head_kv)` group the slots
+# are exactly `{0 .. degree-1}` -- fixed to CSR order so the forward becomes
+# reproducible run to run, which is what makes an element-wise oracle possible.
+# ---------------------------------------------------------------------------
+_CSR_CONFIG_KEYS = (
+    "batch",
+    "seqlen_q",
+    "seqlen_k",
+    "head_kv",
+    "qhead_per_kv",
+    "topk",
+    "blk_kv",
+    "seqlen_pattern",
+)
+
+
+def _frozen_qsplit(csr: dict[str, Any]):
+    """Assign each CSR edge the slot the split-atomic kernel would reserve for it."""
+    import torch
+
+    from tirx_kernels.msa.sparse_prepare_flat_schedule import row_coords
+
+    head_kv = csr["head_kv"]
+    total_rows = csr["total_rows"]
+    row_ptr = csr["k2q_row_ptr"].view(head_kv, total_rows + 1)
+    q_indices = csr["k2q_q_indices"].view(head_kv, -1)
+    device = q_indices.device
+
+    batch_of_row, _ = row_coords(csr["seqlens_k"], csr["config"]["blk_kv"])
+    batch_of_row = torch.tensor(batch_of_row, dtype=torch.int64, device=device)
+    q_offset = torch.zeros(len(csr["seqlens_q"]) + 1, dtype=torch.int64, device=device)
+    q_offset[1:] = torch.tensor(csr["seqlens_q"], dtype=torch.int64, device=device).cumsum(0)
+
+    qsplit = torch.full_like(q_indices, -1)
+    q_abs_all = torch.zeros_like(q_indices, dtype=torch.int64)
+    rows = torch.arange(total_rows, device=device)
+    for h in range(head_kv):
+        counts = (row_ptr[h, 1:] - row_ptr[h, :-1]).to(torch.int64)
+        live = int(row_ptr[h, total_rows].item())
+        row_of_edge = torch.repeat_interleave(rows, counts)
+        q_idx = q_indices[h, :live].to(torch.int64)
+        q_abs = q_idx + q_offset[batch_of_row[row_of_edge]]
+        q_abs_all[h, :live] = q_abs
+
+        # Slots in CSR order within each `q_abs` group: sort the edges by group
+        # (stably, so CSR order survives inside a group), number each group
+        # 0..degree-1, and scatter the numbering back to edge positions.
+        order = q_abs.argsort(stable=True)
+        degrees = torch.bincount(q_abs, minlength=csr["total_q"])
+        starts = torch.cumsum(degrees, 0) - degrees
+        ranks = torch.arange(live, device=device) - starts[q_abs[order]]
+        slots = torch.empty(live, dtype=torch.int64, device=device)
+        slots[order] = ranks
+        qsplit[h, :live] = (q_indices[h, :live] | (slots.to(torch.int32) << SLOT_SHIFT)).to(
+            torch.int32
+        )
+    return qsplit.contiguous(), q_abs_all
+
+
+def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
+    """Build Q/K/V, the CSR payload, the work list and the frozen split slots."""
+    import torch
+
+    from tirx_kernels.msa.sparse_prepare_fwd_split_atomic import prepare_data as prepare_csr
+
+    config.pop("label", None)
+    csr_config = {key: config[key] for key in _CSR_CONFIG_KEYS if key in config}
+    csr = prepare_csr(seed=seed, **csr_config)
+
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(9871 + seed)
+    head_kv = config["head_kv"]
+    qhead_per_kv = config["qhead_per_kv"]
+    head_q = head_kv * qhead_per_kv
+    topk = config["topk"]
+    total_q = csr["total_q"]
+    total_k = int(sum(csr["seqlens_k"]))
+    mode = DTYPE_MODES[config.get("dtype", "bf16")]
+    partial_dtype = config.get("partial_dtype", "float32")
+
+    def draw(shape):
+        return torch.randn(shape, dtype=torch.bfloat16, device=device, generator=generator)
+
+    q_bf16 = draw((total_q, head_q, HEAD_DIM))
+    k_bf16 = draw((total_k, head_kv, HEAD_DIM))
+    v_bf16 = draw((total_k, head_kv, HEAD_DIM))
+    q = q_bf16.to(_torch_dtype(mode["q"])).contiguous()
+    k = k_bf16.to(_torch_dtype(mode["k"])).contiguous()
+    v = v_bf16.to(_torch_dtype(mode["v"])).contiguous()
+
+    cu_seqlens_k = torch.zeros(len(csr["seqlens_k"]) + 1, dtype=torch.int32, device=device)
+    cu_seqlens_k[1:] = torch.tensor(csr["seqlens_k"], dtype=torch.int32, device=device).cumsum(0)
+
+    qsplit, q_abs_of_edge = _frozen_qsplit(csr)
+
+    return {
+        "config": dict(config),
+        "csr": csr,
+        "q": q,
+        "q_flat": q.reshape(-1, HEAD_DIM),
+        "k": k,
+        "v": v,
+        # The bf16 twins the fp8-KV path's exact-match oracle re-runs against.
+        "k_dequantized": k.to(torch.bfloat16).contiguous(),
+        "v_dequantized": v.to(torch.bfloat16).contiguous(),
+        "k2q_row_ptr": csr["k2q_row_ptr"].view(head_kv, -1),
+        "k2q_q_indices": csr["k2q_q_indices"].view(head_kv, -1),
+        "k2q_qsplit_indices": qsplit,
+        "q_abs_of_edge": q_abs_of_edge,
+        "scheduler_metadata": csr["scheduler_metadata"],
+        "work_count": csr["work_count"],
+        "degrees": csr["degrees"].to(torch.int32),
+        "cu_seqlens_q": csr["cu_seqlens_q"],
+        "cu_seqlens_k": cu_seqlens_k,
+        "seqlens_q": csr["seqlens_q"],
+        "seqlens_k": csr["seqlens_k"],
+        "softmax_scale": 1.0 / math.sqrt(HEAD_DIM),
+        "lse_temperature_scale": config.get("temperature"),
+        "head_dim": HEAD_DIM,
+        "blk_kv": config["blk_kv"],
+        "head_kv": head_kv,
+        "head_q": head_q,
+        "qhead_per_kv": qhead_per_kv,
+        "topk": topk,
+        "total_q": total_q,
+        "total_k": total_k,
+        "total_rows": csr["total_rows"],
+        "nnz": csr["nnz_capacity"],
+        "num_batches": len(csr["seqlens_k"]),
+        "max_seqlen_q": csr["max_seqlen_q"],
+        "work_capacity": csr["work_capacity"],
+        "causal": config.get("causal", True),
+        "partial_dtype": partial_dtype,
+        "qk_dtype": mode["qk"],
+        "pv_dtype": mode["pv"],
+    }
+
+
+def make_outputs(data: dict[str, Any]) -> dict[str, Any]:
+    """Fresh partial buffers, uninitialized exactly as the host allocates them."""
+    import torch
+
+    shape = (data["topk"], data["total_q"], data["head_q"])
+    outputs = {
+        "o_partial": torch.empty(
+            (*shape, HEAD_DIM), dtype=_torch_dtype(data["partial_dtype"]), device="cuda"
+        ),
+        "lse_partial": torch.empty(shape, dtype=torch.float32, device="cuda"),
+    }
+    if data["lse_temperature_scale"] is not None:
+        outputs["lse_temperature_partial"] = torch.empty(shape, dtype=torch.float32, device="cuda")
+    return outputs
+
+
+def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
+    """The launch ABI, bound once outside any timed region."""
+    import torch
+
+    def as_bits(t):
+        """fp8 reaches the kernel as raw ``uint8``; see ``_tirx_dtype``."""
+        return t.view(torch.uint8) if t.dtype == torch.float8_e4m3fn else t
+
+    # The kernel declares the index and output buffers flat; only K, V and Q
+    # keep their real shape, and only because their base pointer reaches a
+    # tensor map.
+    args = [
+        as_bits(data["k"]),
+        as_bits(data["v"]),
+        data["k2q_q_indices"].reshape(-1),
+        data["k2q_qsplit_indices"].reshape(-1),
+        data["k2q_row_ptr"].reshape(-1),
+        data["scheduler_metadata"].reshape(-1),
+        data["work_count"],
+        as_bits(outputs["o_partial"].reshape(-1)),
+        outputs["lse_partial"].reshape(-1),
+    ]
+    if data["lse_temperature_scale"] is not None:
+        args.append(outputs["lse_temperature_partial"].reshape(-1))
+    args += [
+        as_bits(data["q_flat"]),
+        data["cu_seqlens_q"],
+        data["cu_seqlens_k"],
+        data["softmax_scale"] * math.log2(math.e),
+        data["softmax_scale"] * math.log2(math.e) / (data["lse_temperature_scale"] or 1.0),
+        1.0 / (data["lse_temperature_scale"] or 1.0),
+        data["total_rows"],
+        data["head_kv"],
+        data["max_seqlen_q"],
+        data["work_capacity"],
+        data["total_k"],
+        data["total_q"],
+        data["head_q"],
+        data["nnz"],
+        data["total_rows"],
+        data["num_batches"],
+        data["topk"],
+    ]
+    return tuple(args)
+
+
+def reference_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, Any]:
+    """The argument bundle MSA's own compiled forward takes."""
+    return {
+        "k": data["k"],
+        "v": data["v"],
+        "k2q_q_indices": data["k2q_q_indices"],
+        "k2q_qsplit_indices": data["k2q_qsplit_indices"],
+        "k2q_row_ptr": data["k2q_row_ptr"],
+        "scheduler_metadata": data["scheduler_metadata"],
+        "work_count": data["work_count"],
+        "o_partial_flat": outputs["o_partial"].reshape(-1, HEAD_DIM),
+        "lse_partial": outputs["lse_partial"],
+        "lse_temperature_partial": outputs.get("lse_temperature_partial"),
+        "q_flat": data["q_flat"],
+        "cu_seqlens_q": data["cu_seqlens_q"],
+        "cu_seqlens_k": data["cu_seqlens_k"],
+        "softmax_scale": data["softmax_scale"],
+        "lse_temperature_inv_scale": 1.0 / (data["lse_temperature_scale"] or 1.0),
+        "num_kv_blocks": data["total_rows"],
+        "head_kv": data["head_kv"],
+        "max_seqlen_q": data["max_seqlen_q"],
+        "work_capacity": data["work_capacity"],
+        "head_dim": HEAD_DIM,
+        "blk_kv": data["blk_kv"],
+        "qhead_per_kv": data["qhead_per_kv"],
+        "causal": data["causal"],
+        "qk_dtype": _torch_dtype(data["qk_dtype"]),
+        "pv_dtype": _torch_dtype(data["pv_dtype"]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Correctness.
+# ---------------------------------------------------------------------------
+def live_partial_mask(data: dict[str, Any]):
+    """`split < split_counts[q_abs, head_kv]`, broadcast over the partial shape.
+
+    Both partial buffers arrive uninitialized, and a query with degree `d`
+    leaves slots `d .. topk-1` untouched, so every comparison has to be masked
+    to the slots the schedule actually assigns.
+    """
+    import torch
+
+    degrees = data["degrees"]  # [total_q, head_kv]
+    per_head_q = degrees.repeat_interleave(data["qhead_per_kv"], dim=1)
+    splits = torch.arange(data["topk"], device=degrees.device).view(-1, 1, 1)
+    return splits < per_head_q.unsqueeze(0)
+
+
+def assert_partials_match(
+    data: dict[str, Any],
+    outputs: dict[str, Any],
+    expected: dict[str, Any],
+    *,
+    rtol: float = 0.0,
+    atol: float = 0.0,
+) -> None:
+    """Compare the live slots of both partial buffers."""
+    import torch
+
+    mask = live_partial_mask(data)
+    o_mask = mask.unsqueeze(-1).expand_as(outputs["o_partial"])
+    torch.testing.assert_close(
+        outputs["o_partial"][o_mask].float(),
+        expected["o_partial"][o_mask].float(),
+        rtol=rtol,
+        atol=atol,
+    )
+    torch.testing.assert_close(
+        outputs["lse_partial"][mask], expected["lse_partial"][mask], rtol=rtol, atol=atol
+    )
+    if "lse_temperature_partial" in outputs:
+        torch.testing.assert_close(
+            outputs["lse_temperature_partial"][mask],
+            expected["lse_temperature_partial"][mask],
+            rtol=rtol,
+            atol=atol,
+        )
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against MSA's own kernel."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    config.pop("label", None)
+    data = prepare_data(**config)
+
+    try:
+        from tirx_kernels.msa.utils._msa_bench import compiled_sparse_atten_fwd
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+
+    expected = make_outputs(data)
+    try:
+        compiled_sparse_atten_fwd(reference_case(data, expected))()
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+    torch.cuda.synchronize()
+
+    executable = compile_kernel(get_kernel(**config))
+    outputs = make_outputs(data)
+    executable(*tirx_args(data, outputs))
+    torch.cuda.synchronize()
+    assert_partials_match(data, outputs, expected)
+
+
+def prepare_bench(**config):
+    """Compile the TIRx specialization without initializing CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config.pop("label", None)
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+#
+# Unlike the two preparation kernels, this one needs no rotation: it reads its
+# inputs without touching them and overwrites -- never accumulates into -- the
+# partial slots it owns, so the hundredth launch does exactly the work the
+# first one did.
+# ---------------------------------------------------------------------------
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    """Kernel-only comparison against MSA's compiled forward launch."""
+    from tirx_kernels.runner import bench
+
+    config = {**prepared["config"], **config}
+    config.pop("label", None)
+    data = prepare_data(**config)
+    executable = prepared["executable"]
+
+    tirx_outputs = make_outputs(data)
+    tirx_bound = tirx_args(data, tirx_outputs)
+
+    def tirx_launch():
+        executable(*tirx_bound)
+
+    def build_reference():
+        from tirx_kernels.msa.utils._msa_bench import compiled_sparse_atten_fwd
+
+        launch = compiled_sparse_atten_fwd(reference_case(data, make_outputs(data)))
+        launch()  # pay the CuTeDSL compile and first-launch cost outside timing
+        return launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"msa": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/msa/utils/_msa_bench.py
+++ b/tirx_kernels/msa/utils/_msa_bench.py
@@ -35,16 +35,99 @@ def msa_root() -> Path:
     raise ImportError(f"no MSA checkout found (set MSA_PATH); tried: {tried}")
 
 
+def cutedsl_paths() -> list[str]:
+    """Import roots for the CuTe-DSL build MSA's sources need, or an empty list.
+
+    MSA's CuTe-DSL sources are written against ``cutlass.cute``. CuTe-DSL 4.6
+    renamed that package to ``iket``, so 4.6 releases cannot run them at all,
+    and the 4.6.0 development build that still carries ``cutlass.cute`` fails
+    NVVM serialization on the forward kernel's gather4 Q specializations
+    (``qhead_per_kv`` 1, 2 and 4) -- the reference simply will not compile for
+    a third of this kernel's dispatch domain. 4.5.3 compiles all of them, and
+    ``quack-kernels`` has to match it: 0.5.1 and newer import
+    ``cutlass._mlir_helpers``, which 4.5 does not have.
+
+    Install the pair with::
+
+        python -m pip install --no-deps --target .reference-deps/msa-cutedsl \\
+          nvidia-cutlass-dsl==4.5.3 nvidia-cutlass-dsl-libs-base==4.5.3 \\
+          nvidia-cutlass-dsl-libs-cu13==4.5.3 quack-kernels==0.5.0
+
+    ``MSA_CUTEDSL_PATH`` overrides the location. When neither the override nor
+    the default prefix exists, the ambient install is used unchanged.
+    """
+    override = os.environ.get("MSA_CUTEDSL_PATH")
+    prefix = Path(override) if override else _REPO_ROOT / ".reference-deps" / "msa-cutedsl"
+    packages = prefix / "nvidia_cutlass_dsl" / "python_packages"
+    if not packages.is_dir():
+        return []
+    return [str(prefix), str(packages)]
+
+
+def _drop_interrupted_imports() -> None:
+    """Forget modules whose import was cut off partway through.
+
+    The bench suite stops a worker mid-flight when it sees another process on
+    the GPU, then retries the measurement inside that same worker. If the stop
+    lands inside one of the reference's heavy imports -- ``quack.__init__``
+    pulls in CuTe-DSL, and CuTe-DSL pulls in ``sympy`` -- the package stays in
+    ``sys.modules`` with its body only partly executed. The retry then reads a
+    missing attribute off it (``quack`` with no ``copy_utils``, ``sympy`` with
+    no ``core``) instead of importing it again, and the workload is reported as
+    a baseline error even though nothing is wrong with either implementation.
+
+    A module still marked ``_initializing`` here is stale by construction: this
+    runs from the reference builder, not from inside anyone's import.
+
+    That flag does not catch every case -- a package can be left incomplete with
+    the flag already cleared -- so the packages that have actually been seen to
+    break are probed for an attribute their own ``__init__`` defines, and their
+    whole subtree is dropped when the probe fails. Re-importing costs seconds,
+    but only on a retry, and it happens outside the timed region.
+    """
+    for name, module in list(sys.modules.items()):
+        if name.startswith(("tirx_kernels", "tvm")):
+            continue
+        spec = getattr(module, "__spec__", None)
+        if spec is not None and getattr(spec, "_initializing", False):
+            del sys.modules[name]
+
+    for package, attribute in (("sympy", "core"), ("quack", "rounding")):
+        module = sys.modules.get(package)
+        if module is not None and not hasattr(module, attribute):
+            for name in [n for n in sys.modules if n == package or n.startswith(package + ".")]:
+                del sys.modules[name]
+
+
+def ensure_msa_importable() -> None:
+    """Put MSA's two import roots -- and its pinned CuTe-DSL -- on ``sys.path``."""
+    _drop_interrupted_imports()
+    if "cutlass" in sys.modules:
+        pinned = cutedsl_paths()
+        search_path = getattr(sys.modules["cutlass"], "__path__", None)
+        loaded = str(next(iter(search_path))) if search_path else None
+        if pinned and loaded and not loaded.startswith(pinned[0]):
+            raise RuntimeError(
+                "cutlass was imported before the MSA reference pinned its CuTe-DSL "
+                f"build; loaded from {loaded}, expected under {pinned[0]}"
+            )
+    for entry in reversed(cutedsl_paths()):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+
+    root = msa_root()
+    for entry in (str(root / "python" / "fmha_sm100" / "cute"), str(root / "python")):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+
+
 def prepare_scheduler_module():
     """Import ``src.sm100.prepare_scheduler`` from the MSA checkout, once."""
     global _MSA_MODULE
     if _MSA_MODULE is not None:
         return _MSA_MODULE
 
-    root = msa_root()
-    for entry in (str(root / "python" / "fmha_sm100" / "cute"), str(root / "python")):
-        if entry not in sys.path:
-            sys.path.insert(0, entry)
+    ensure_msa_importable()
 
     import src.sm100.prepare_scheduler as prepare_scheduler
 
@@ -73,6 +156,138 @@ def compiled_fwd_split_atomic(case: dict):
         case["max_seqlen_q"],
         case["topk"],
     )
+
+
+_FWD_CACHE: dict = {}
+
+
+def compiled_sparse_atten_fwd(case: dict):
+    """Compile (or fetch) ``SparseAttentionForwardSm100`` and return the launchable.
+
+    This mirrors the compile step of ``_call_sparse_forward_sm100_csr_varlen``
+    (interface.py:1714-1780) instead of calling that host entry, so the timed
+    closure covers the kernel launch alone: the host entry would also validate
+    shapes, copy ``O_partial`` through ``reshape(-1, head_dim).contiguous()``,
+    build a gather4 tensor map, and -- when handed no prebuilt schedule -- run
+    the two preparation kernels first.
+
+    Every tensor is wrapped **before** ``cute.compile``. Wrapping one afterwards
+    binds this process to a host ``cuTensorMapEncodeTiled`` path that unrelated
+    kernels then fail on, long after the call that caused it.
+    """
+    ensure_msa_importable()
+
+    import cutlass
+    import cutlass.cute as cute
+    import torch
+    from cutlass import Float32, Int32
+    from src.common.cute_dsl_utils import to_cute_tensor
+    from src.common.tma_utils import create_q_gather4_tma_desc
+    from src.sm100.fwd.atten_fwd import SparseAttentionForwardSm100
+
+    qhead_per_kv = case["qhead_per_kv"]
+    q_flat = case["q_flat"]
+    o_partial_flat = case["o_partial_flat"]
+    lse_temperature = case.get("lse_temperature_partial")
+    gather4_desc = (
+        create_q_gather4_tma_desc(q_flat, box_x=128 if q_flat.dtype == torch.float8_e4m3fn else 64)
+        if qhead_per_kv in (1, 2, 4)
+        else None
+    )
+
+    key = (
+        "sparse_forward_sm100_csr_varlen",
+        case["head_dim"],
+        case["blk_kv"],
+        qhead_per_kv,
+        q_flat.dtype,
+        case["k"].dtype,
+        case["v"].dtype,
+        case["qk_dtype"],
+        case["pv_dtype"],
+        o_partial_flat.dtype,
+        bool(case["causal"]),
+        False,  # paged_kv
+        True,  # use_prepare_scheduler
+        None,  # page_size
+        False,  # seqused_k
+        lse_temperature is not None,
+    )
+    if key not in _FWD_CACHE:
+        cutlass_dtype = {
+            torch.bfloat16: cutlass.BFloat16,
+            torch.float16: cutlass.Float16,
+            torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        }
+        kernel = SparseAttentionForwardSm100(
+            head_dim=case["head_dim"],
+            qheadperkv=qhead_per_kv,
+            n_block_size=case["blk_kv"],
+            paged_kv=False,
+            page_size=None,
+            has_seqused_k=False,
+            causal=bool(case["causal"]),
+            use_prepare_scheduler=True,
+            qk_dtype=cutlass_dtype[case["qk_dtype"]],
+            pv_dtype=cutlass_dtype[case["pv_dtype"]],
+        )
+        _FWD_CACHE[key] = cute.compile(
+            kernel,
+            to_cute_tensor(case["k"]),
+            to_cute_tensor(case["v"]),
+            to_cute_tensor(case["k2q_q_indices"]),
+            to_cute_tensor(case["k2q_qsplit_indices"]),
+            to_cute_tensor(case["k2q_row_ptr"]),
+            to_cute_tensor(case["scheduler_metadata"]),
+            to_cute_tensor(case["work_count"]),
+            to_cute_tensor(o_partial_flat),
+            to_cute_tensor(case["lse_partial"]),
+            None if lse_temperature is None else to_cute_tensor(lse_temperature),
+            to_cute_tensor(q_flat),
+            None if gather4_desc is None else to_cute_tensor(gather4_desc),
+            None,  # page_table
+            None,  # seqused_k
+            to_cute_tensor(case["cu_seqlens_q"]),
+            to_cute_tensor(case["cu_seqlens_k"]),
+            Float32(case["softmax_scale"]),
+            Float32(case["lse_temperature_inv_scale"]),
+            Int32(case["num_kv_blocks"]),
+            Int32(case["head_kv"]),
+            Int32(case["max_seqlen_q"]),
+            Int32(case["work_capacity"]),
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+            options="--enable-tvm-ffi",
+        )
+
+    compiled = _FWD_CACHE[key]
+
+    def launch() -> None:
+        compiled(
+            case["k"],
+            case["v"],
+            case["k2q_q_indices"],
+            case["k2q_qsplit_indices"],
+            case["k2q_row_ptr"],
+            case["scheduler_metadata"],
+            case["work_count"],
+            o_partial_flat,
+            case["lse_partial"],
+            lse_temperature,
+            q_flat,
+            gather4_desc,
+            None,
+            None,
+            case["cu_seqlens_q"],
+            case["cu_seqlens_k"],
+            case["softmax_scale"],
+            case["lse_temperature_inv_scale"],
+            case["num_kv_blocks"],
+            case["head_kv"],
+            case["max_seqlen_q"],
+            case["work_capacity"],
+        )
+
+    return launch
 
 
 def compiled_flat_schedule(case: dict):


### PR DESCRIPTION
Ports `SparseAttentionForwardSm100` (MSA @ `80434d7f`): the attention kernel itself, consuming the work list and the packed split slots that the two preparation kernels in this package (#79, #80) produce.

## Scope

Causal, non-paged, `blk_kv=128`, `head_dim=128`, over:

- four dtype combos — all-BF16; all-FP8; BF16 Q with FP8 KV staged to BF16; FP8 with a BF16 PV operand
- both Q-load programs — the raw gather4 descriptor path (`qhead_per_kv` 1/2/4) and the plain TMA path (8/16)
- FP32 / BF16 / FP8 partial stores, and the temperature LSE

Out of scope, each excluded by a predicate named in the sketch: paged KV, `causal=False`, FP16 partials, the NVFP4 sibling class, and the combine kernel.

## Correctness

Bitwise against the compiled reference on frozen inputs (`rtol=0, atol=0`), masked to the live partial slots. 15/15 configs, covering every dtype × Q-path combination, all three partial widths, and both temperature settings.

The reference needs CuTe-DSL 4.5.3: 4.6 releases rename `cutlass.cute` to `iket` and cannot run MSA at all, and the 4.6.0 development build fails NVVM serialization on the gather4 Q specializations. `_msa_bench.py` pins it under `.reference-deps/msa-cutedsl` (`MSA_CUTEDSL_PATH` overrides).

## Two mechanisms that are invisible in the output values

Both of these produce byte-identical results while costing roughly 2x, so the correctness gate cannot see them.

- **The epilogue reads O with `16x256b`, not `32x32b`.** That fragment puts four columns of one row in lanes 0-3, so a warp's 128-bit stores cover contiguous 64-byte runs. Under `32x32b` the thread *is* the row, and every lane of a store instruction lands on a different row 512 bytes away — same bytes, twice the sectors. The `real_col_to_stg128*_fake_col` permutation exists to serve the first layout; applying its inverse to the second is bit-exact and destroys the access pattern the map was built for.
- **The TMA L2 eviction policies are not interchangeable.** A KV block is read by exactly one CTA and never again, so it is evict-first; a Q row is read by every one of the topK CTAs that carry it, so it is evict-last. Reversed, the streamed KV stays resident and pushes the reusable Q out, costing 2.3x the DRAM reads.

Two loops are rolled with `While` rather than a counted loop — the causal-diagonal binary search, and the KV dequant when both warpgroups run it. `T.serial(..., unroll=False)` does not keep a loop rolled, since TVM's C codegen consults no loop annotation and nvcc unrolls bodies the reference leaves rolled.

## Performance

`bench_suite` over the ten-shape matrix, reference / tirx:

| shape | tirx | reference | ratio |
| --- | ---: | ---: | ---: |
| `varlen_b3_s8192_qh4_t16` | 266.3 µs | 263.9 µs | 0.9909 |
| `long96k_bf16_qh2_t16` | 401.7 | 409.3 | 1.0190 |
| `fp8kv_s16384_qh4_t16` | 241.3 | 246.6 | 1.0221 |
| `ring48k_fp8_qh16_t16` | 1332.2 | 1366.2 | 1.0255 |
| `ring48k_bf16_qh16_t16` | 1351.1 | 1393.0 | 1.0310 |
| `ulysses384k_bf16_qh2_t4` | 565.8 | 584.3 | 1.0327 |
| `qh1_s8192_bf16_t16` | 49.3 | 51.0 | 1.0343 |
| `fp8_pvbf16_s8192_qh8_t8` | 110.7 | 116.4 | 1.0516 |
| `edge_b1_s1024_bf16_t4` | 9.53 | 10.13 | 1.0632 |
| `varlen_b3_s4096_qh8_t8` | 127.6 | 136.6 | 1.0704 |

min 0.9909, mean 1.0341.

`varlen_b3_s8192_qh4_t16` is worth calling out: 0.9909 is a thin margin, and it is not noise. Across three complete matrices it measured 0.9904 / 0.9918 / 0.9909, with our time stable at ~266.2 µs against the reference's ~263.7 µs. Paired profiling on that shape shows identical global store sectors, identical DRAM writes, 8.6% fewer instructions executed and marginally fewer cycles under NCU, so there is no mechanism difference left to point at — the remaining ~1% is diffuse.

The committed bench-suite config keeps the repo's three-default curation; the full ten-shape matrix runs through `--workloads`.

## Notes for review

The kernel keeps the source's own warts where they are load-bearing to the structure: the dead `sm_stats` full half, the dead `num_kv_blocks` argument, and warps 8-11 named for a store role they no longer have. Two deliberate deviations are documented in place — named barriers are renumbered from 8 under the CUTLASS user-ID convention because the source's `epilogue_barrier + stage` collides with `KvLoad` (benign only by timing), and TMA descriptors are encoded in the PrimFunc host prologue instead of taking the source's prebuilt `uint8[128]` descriptor-tensor argument.
