### PR TITLE
docs(infra): record codegen tuning entries from the msa forward port

### DIFF
--- a/.agents/skills/tirx-codegen-tuning/references/db/choose-the-l2-eviction-policy-by-reuse-distance.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/choose-the-l2-eviction-policy-by-reuse-distance.md
@@ -1,0 +1,64 @@
+# Choose the L2 eviction policy by reuse distance
+
+**Symptoms:** `excess_dram_read`, `low_dram_throughput`, `cold_cache_regression`, `unsaturated_bandwidth`
+
+## Symptom
+
+DRAM read traffic well above the reference's while every request-side counter
+matches: same global load instructions, same requests, same sectors, same
+stores, same DRAM writes. L2 read sectors only slightly higher, but nearly all
+of the extra ones miss.
+
+## What to change
+
+Bind the TMA cache hint to each tensor's reuse distance instead of using one
+policy for every descriptor. The question is how many CTAs read the same bytes:
+
+- read once by the CTA that owns it and never again -- evict-first, so it does
+  not sit in L2 displacing something that will be read again;
+- read by every CTA that carries the row -- evict-last, so the later CTAs hit.
+
+```python
+# before: one hint for every descriptor, so the streamed tensor and the
+# reused one compete on equal terms.
+_HINT = T.uint64(0x14F0000000000000)
+
+# after: name the policy and bind it to the reuse.
+_EVICT_FIRST = T.uint64(0x12F0000000000000)  # this CTA reads it once
+_EVICT_LAST = T.uint64(0x14F0000000000000)  # every CTA carrying this row reads it
+
+T.ptx[_TMA_G2S_CACHE](..., _EVICT_FIRST)  # the streamed block
+T.ptx[_TMA_GATHER4_CACHE](..., _EVICT_LAST)  # the shared rows
+```
+
+Getting the pairing backwards is easy and silent: both constants differ in one
+nibble, both compile, and every output value is unchanged.
+
+## Rationale
+
+Reversed, the streamed tensor stays resident and pushes the reused one out, so
+each of the later CTAs re-fetches from DRAM what should have been an L2 hit.
+Measured with stores already coalesced and DRAM writes equal at 464.6 against
+463.4 MB, the port read 140.3 MB where the reference read 60.9 MB. The 2.41M
+extra L2 read sectors times 32 B is 77 MB, essentially all of the 79 MB gap:
+the extra L2 reads all missed. Correcting the pairing took the two worst shapes
+from 0.9305 to 1.0227 and 0.9327 to 1.0584.
+
+Cache hit rate alone points the wrong way here. The port's L1 and L2 hit rates
+were *higher* than the reference's while its DRAM traffic was worse, because a
+higher hit rate over far more requests still leaves more misses.
+
+## Boundary
+
+Worth distinguishing only when one tensor genuinely has cross-CTA reuse. With
+nothing reused, uniform evict-first is right; where the whole working set fits,
+the policies stop mattering. Reuse distance is a property of the schedule, not
+of the tensor: the same tensor read by one CTA per block in one dispatch and by
+K CTAs in another wants different policies in the two.
+
+## Verification
+
+Diff `dram__bytes_read`, `dram__bytes_write` and `lts__t_sectors_op_read`
+against the reference. Establish first that the store side matches -- equal
+store sectors and equal DRAM writes localize the whole difference to the read
+side before any code changes.

--- a/.agents/skills/tirx-codegen-tuning/references/db/merge-waits-with-a-protocol-proof.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/merge-waits-with-a-protocol-proof.md
@@ -42,6 +42,24 @@ if STAGES == 8:
     )
 ```
 
+A drain that waits on everything the thread has outstanding merges the same
+way. Where an epilogue reads a tile with several `tcgen05.ld` instructions and
+waits after each, one wait after the last issue still orders all of them ahead
+of the first consuming store, and the reads then overlap instead of draining
+one at a time:
+
+```python
+# before: each read drains before the next is issued.
+for chunk in range(CHUNKS):
+    _tmem_load(frag[chunk], addr(chunk))
+    _tmem_wait_ld()
+
+# after: issue them all, drain once.
+for chunk in range(CHUNKS):
+    _tmem_load(frag[chunk], addr(chunk))
+_tmem_wait_ld()
+```
+
 ## Rationale
 
 Before editing, write the producer-consumer happens-before argument; the merge
@@ -52,6 +70,16 @@ contribution.
 
 Do not merge visibility domains, permit ring overwrite, remove a release
 witness, or weaken cross-stream ordering.
+
+A wait that looks like a pure release may still be load-bearing. Where a named
+barrier is reused across phases by several warpgroups, replacing its trailing
+`bar.sync` with `bar.arrive` -- on the argument that the warpgroup only needs
+to release another warp and never needs the return trip -- deadlocked: the
+arrival counts fall out of phase with the matching `bar.sync` elsewhere. Match
+the reference's instruction only after the phase argument holds for the port's
+own barrier assignment, which may differ if the barrier ids were renumbered.
+The merged form above is safe by contrast because the drain is per-thread, with
+no other participant to fall out of step with.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/pick-the-tmem-load-shape-by-the-stores-it-implies.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/pick-the-tmem-load-shape-by-the-stores-it-implies.md
@@ -1,0 +1,68 @@
+# Pick the TMEM load shape by the stores it implies
+
+**Symptoms:** `uncoalesced_store`, `excessive_sectors`, `slow_epilogue`, `unsaturated_bandwidth`
+
+## Symptom
+
+An epilogue that is bit-exact and writes exactly the reference's bytes, while
+issuing twice its sectors. Fewer instructions than the reference and more time,
+with the gap in the store path rather than the GEMM. The profiler names it
+outright: uncoalesced global accesses, N excessive sectors, roughly half the
+total.
+
+## What to change
+
+Choose the `tcgen05.ld` shape by which thread ends up holding which element, not
+by which shape is easiest to index. The shape fixes the register-to-element map,
+and the map fixes whether a warp's 128-bit stores are contiguous.
+
+`32x32b` makes the thread the M row and the register the column -- an identity
+map, and the obvious choice when transcribing. Every lane of one store
+instruction then lands on a different row, one row stride apart. `16x256b` puts
+four columns of ONE row in lanes 0-3, so a store covers eight rows in contiguous
+64-byte runs: 16 sectors for 512 bytes, the minimum.
+
+Measured `16x256b` map, seeded through a `32x32b.st` whose map is the identity:
+
+```text
+address = (lane_base << 16) | col_base
+row = warp*32 + lane_base + (lane % 32)//4 + 8*((r//2) % 2)
+col = col_base + (lane % 4)*2 + (r % 2) + 8*(r//4)
+```
+
+One instruction is 32 registers covering 64 rows by 64 columns, so a 128x128
+tile takes four, over `(lane_base, col_base)` in `{0,16} x {0,64}`. The second
+row half is reached through the **lane field of the address**, not through the
+repetition suffix and not through the column field: `.x8` and `.x16` cover the
+same rows, and a column offset alone leaves half the tile unread.
+
+Where the reference permutes columns before storing, that permutation belongs to
+its fragment layout. Applying the inverse permutation to a different fragment
+reproduces the bytes exactly while destroying the contiguity the permutation
+existed to create.
+
+## Rationale
+
+The permuted store address is not an ABI curiosity to be undone; it is what
+makes the stores whole-sector. One epilogue read with `32x32b` and the inverse
+map issued 16,127,606 excessive sectors, 50% of 32,433,928, against 5,750 (0%)
+for the reference, whose total sector count was exactly half for identical
+bytes written. Switching the read shape and using the reference's own forward
+map took two shapes from 0.538 to 0.929 and 0.486 to 0.931.
+
+## Boundary
+
+Only where the fragment feeds global stores. A fragment consumed in registers,
+or written to shared memory where a swizzle absorbs the layout, should take
+whichever shape indexes most simply. The wide-fragment live-range cost still
+applies: reading the whole tile before storing any of it trades sectors for
+registers.
+
+## Verification
+
+Compare `l1tex__t_sectors_pipe_lsu_mem_global_op_st` and `dram__bytes_write`
+against the reference together. Equal bytes with unequal sectors is the tell,
+and it survives every value-level correctness check, so no amount of bitwise
+agreement rules it out. Seed a tile with `row * K + col` through the shape whose
+map is already known and dump the registers to recover an unfamiliar map rather
+than deriving it.

--- a/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
@@ -79,6 +79,27 @@ load and divide traffic of the serial chain the kernel's latency sat on.
 | `div.s32` | 6 | 24 | 6 |
 | `.pragma "nounroll"` | 4, one per scan | 5, none on a scan | 6, all four scans |
 
+A search converges, which a counted loop cannot exploit. Where the loop is a
+binary search transcribed as a fixed step count with the body predicated off
+after convergence, writing the `While` on the search's own condition also
+retires it as soon as it converges instead of running out the remaining steps:
+
+```python
+# before: a fixed step count, predicated off once converged.
+for _step in T.serial(0, SEARCH_STEPS, unroll=False):
+    if lo[0] < hi[0]:
+        ...one probe load, then narrow...
+
+# after: rolled, and it exits when the interval closes.
+while lo[0] < hi[0]:
+    ...one probe load, then narrow...
+```
+
+That is the same predicted profile from the other end of the range: the shape
+with the fewest search iterations moved 0.9727 to 1.0631 and the next 0.9902 to
+1.0343, while the long-sequence shapes, which run the search deepest and
+amortize it over the most work, moved by under half a percent.
+
 ## Boundary
 
 Only where the reference's loop is genuinely rolled -- whether it says so with a

--- a/.agents/skills/tirx-codegen-tuning/references/db/scale-a-shared-prefetch-to-the-warpgroups-contending-for-it.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/scale-a-shared-prefetch-to-the-warpgroups-contending-for-it.md
@@ -1,0 +1,74 @@
+# Scale a shared prefetch to the warpgroups contending for it
+
+**Symptoms:** `short_scoreboard`, `insufficient_memory_parallelism`, `dispatch_specific_deficit`, `schedule_regression`
+
+## Symptom
+
+Batching a shared-memory pass into load-then-convert helps one dispatch and
+regresses a sibling. The two differ only in how many warpgroups run the same
+pass at the same time.
+
+## What to change
+
+Treat the prefetch depth as a property of the concurrency on that memory, not
+of the pass, and take it from the same compile-time predicate that decides how
+many warpgroups run it. One warpgroup converting a tile wants its loads batched
+so the dependent conversion chain stops sitting on the critical path of the next
+load; two warpgroups converting different tiles at once do not, because the
+batch only makes twice the threads burst into the same shared memory.
+
+Keep the contended form rolled. A batched rewrite normally replaces a rolled
+loop with a counted one over the batch, which unrolls -- so the two forms differ
+in prefetch depth *and* in code size unless the rolled path is written back with
+a `While`.
+
+```python
+# `batch` comes from the dispatch predicate, not from a global constant.
+def _convert_tile(src, dst, batch, iters):
+    if batch == 1:
+        i = T.alloc_local((1,), "int32")
+        i[0] = 0
+        while i[0] < iters:                 # contended: stays rolled
+            words = _load_chunk(src, i[0])
+            _convert_and_store(dst, words, i[0])
+            i[0] = i[0] + 1
+    else:
+        staged = T.alloc_local((4 * batch,), "uint32")
+        for group in range(iters // batch):  # uncontended: batch, then convert
+            for b in range(batch):
+                _load_chunk_into(staged, src, group * batch + b, b)
+            for b in range(batch):
+                _convert_and_store_from(staged, dst, group * batch + b, b)
+```
+
+The staging buffer's extent must be a module-level constant. A bare assignment
+inside a traced body binds a TIR variable, and the allocation stops being a
+constant-size one -- which only shows up on the dispatch that instantiates the
+path.
+
+## Rationale
+
+Batching every chunk load before converting any took the single-warpgroup
+dispatch from 0.9862 to 1.0410 and the two-warpgroup sibling from 1.0210 to
+0.9868. Cutting the depth from the whole tile to four did not recover the
+sibling (0.9857), and passing it depth 1 did not either (0.9864) -- so neither
+register pressure nor depth was the cause. What remained was the loop form: the
+batched rewrite iterated with a counted `range`, which unrolls, where the
+original was rolled. Giving each dispatch the form it measured best in recovered
+both, at 1.0421 and 1.0208.
+
+## Boundary
+
+The depth is not transferable between kernels or between passes. Concurrency is
+one axis among several that set it: the per-thread trip count sets how much
+parallelism there is to extract, and the live range of the staged registers sets
+a ceiling above which the depth costs more than it returns. All three can bind
+at once, and only a sweep separates them.
+
+## Verification
+
+When one rewrite changes two things, vary each alone before believing either
+explanation. Two cheap variants -- depth first, then loop form -- separated
+them here, and the first two attributions were both wrong. Measure the sibling
+dispatches together: a change keyed to a compile-time predicate can only be
+judged on the configs that take each branch.

--- a/.agents/skills/tirx-codegen-tuning/references/db/spread-the-prologues-independent-work-off-one-thread.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/spread-the-prologues-independent-work-off-one-thread.md
@@ -1,0 +1,63 @@
+# Spread the prologue's independent work off one thread
+
+**Symptoms:** `serialized_prologue`, `fixed_overhead`, `slow_small_shape`, `barrier_stall`
+
+## Symptom
+
+A per-CTA cost that the long shapes amortize and the short ones do not, so the
+deficit tracks kernel length rather than any tile-level metric. One thread runs
+a dependent chain -- work-item decode, a search, a metadata publish -- while the
+rest of the CTA waits at the barrier that follows.
+
+## What to change
+
+Work out which prologue blocks share no data dependence and give them different
+warps, keeping one fence and one CTA barrier after all of them. Pipeline
+mbarrier initialization is the usual candidate: it depends on nothing the
+metadata chain produces, yet transcription tends to put both on thread 0
+because the source writes them as consecutive `if tid == 0` blocks.
+
+```python
+# before: one thread owns the dependent metadata chain AND the barrier init,
+# and everyone else waits for the sum of the two.
+if tidx == 0:
+    ...dependent global loads, search, publish to shared...
+if warp_idx == 0:
+    if T.cuda.elect_sync():
+        ...init the pipeline mbarriers...
+
+# after: the init runs on another warp, under the same fence and barrier.
+if tidx == 0:
+    ...dependent global loads, search, publish to shared...
+if warp_idx == 1:
+    if T.cuda.elect_sync():
+        ...init the pipeline mbarriers...
+T.ptx.fence.mbarrier_init.release.cluster()
+T.cuda.cta_sync()
+```
+
+## Rationale
+
+The fence and CTA barrier already order both blocks against every consumer, so
+splitting them costs nothing and removes one of the two from the critical path.
+Measured, moving about thirty mbarrier initializations off the thread that also
+owned a dependent-load metadata chain took the shortest shape from 0.9570 to
+0.9931 and the next from 0.9822 to 0.9906, while the long-sequence shapes moved
+by less than a tenth of that -- the signature of a fixed per-CTA cost.
+
+At one block per SM there is no second block to hide the prologue behind, so
+the whole chain is exposed. That is also why the effect is invisible on the
+shapes that motivate most tuning.
+
+## Boundary
+
+Only for blocks with no data dependence, and only while the prologue runs
+before role dispatch, so the warp taking the work has not yet specialized.
+Splitting an mbarrier init from the `expect_tx` that arms the same barrier is
+not safe -- keep an init and its transaction count together.
+
+## Verification
+
+Measure across the trip-count range rather than on one shape: the gain
+concentrates where the kernel is shortest and disappears where it is longest,
+so a single long-shape measurement will report no change.


### PR DESCRIPTION
Four new `tirx-codegen-tuning` entries and two extensions, each from a measured experiment during the performance gate of the MSA sparse attention forward port (#84). Every one changed the generated code and moved the bench-suite ratio; the two that did not are not here.

## New entries

**Pick the TMEM load shape by the stores it implies** — the `tcgen05.ld` shape fixes the register-to-element map, and that map decides whether a warp's 128-bit stores are contiguous. `32x32b` makes the thread the M row, so every lane of one store instruction lands on a different row: identical bytes at twice the sectors (16,127,606 excessive, 50% of the total, against the reference's 0%). Carries the measured `16x256b` map, including the part that cost the most to find — the second row half is reached through the **lane field of the address**, not the repetition suffix and not the column field.

**Choose the L2 eviction policy by reuse distance** — a block read once by its owning CTA wants evict-first; a row read by every CTA carrying it wants evict-last. Reversed, the streamed tensor stays resident and displaces the reused one: 140.3 MB of DRAM reads against 60.9 MB with every request-side counter matching exactly. Also records that hit rate points the wrong way here, since a higher rate over far more requests still leaves more misses.

**Spread the prologue's independent work off one thread** — pipeline mbarrier init depends on nothing the metadata chain produces, so it does not belong on the same thread. The gain lands entirely on the shapes short enough not to amortize a fixed per-CTA cost (0.9570 → 0.9931 on the shortest; under a tenth of that on the long ones).

**Scale a shared prefetch to the warpgroups contending for it** — batching a shared-memory pass took one dispatch 0.9862 → 1.0410 and the sibling that runs the same pass in two warpgroups at once 1.0210 → 0.9868. Depth 4 did not recover it and depth 1 did not either, which left the loop form the rewrite had silently changed along the way. Includes the TIRx-specific trap that a bare assignment in a traced body binds a TIR variable, so the staging buffer stops being a constant-size allocation on exactly one dispatch.

## Extensions

**`roll-a-loop-with-while-not-a-counted-loop`** gains a second loop kind. The existing entry covers pass loops; a binary search transcribed as a fixed step count with the body predicated off after convergence is the same failure with an extra term, because the `While` on the search's own condition also retires early. Same predicted profile from the other end of the range: fewest iterations moved most (0.9727 → 1.0631), deepest search barely moved.

**`merge-waits-with-a-protocol-proof`** gains the per-thread drain case (issue N `tcgen05.ld`, wait once) and a boundary paid for with a deadlock: a named barrier reused across phases by several warpgroups cannot have its trailing wait dropped even when it reads as a pure release, because the arrival counts fall out of phase with the matching `bar.sync`. Matching the reference's instruction is not sufficient when the port renumbered the barrier ids.

## Notes

Symptom terms reuse the existing index where one fits; four new terms are introduced (`uncoalesced_store`, `excessive_sectors`, `excess_dram_read`, `serialized_prologue`), each naming something no existing term covers. No entry cross-references another by name, matching the house style that keeps `Symptoms:` the only index.
