### PR TITLE
feat(kernel): port FlashInfer LayerNorm

### DIFF
--- a/.agents/sketch/flashinfer/norm/layernorm.md
+++ b/.agents/sketch/flashinfer/norm/layernorm.md
@@ -1,0 +1,497 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+LayerNormKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer LayerNorm SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the implementation
+shape of FlashInfer's CuTe-DSL `LayerNormKernel` for the paired target
+[`tirx_kernels/flashinfer/norm/layernorm.py`](../../../../tirx_kernels/flashinfer/norm/layernorm.py).
+The target may become executable only after this sketch passes independent
+source/PTX review; after the first PASS this file is permanently frozen.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/norm/kernels/layernorm.py`, SHA256
+  `123dd99aa37202ee499654e80c39c2edef5517b5b8b1e46c70885619c885fff0`;
+- reduction, predicate, vector, and layout helpers in
+  `flashinfer/norm/utils.py`, SHA256
+  `3f44ac6727c58883420068bf0aa5b239b12d2e86819ad80e54bc1bc016ec881a`;
+- public dispatch in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+The port covers the source's public two-dimensional BF16 input/output and
+FP32 gamma/beta specialization, independent Int64 input/output row strides,
+runtime FP32 epsilon, vector widths 1/2/4/8, one- and multi-warp rows, one or
+more vector blocks per thread, column tails, and the internal PDL off/on
+branch. FP16 template instantiations, non-FP32 affine parameters, legacy CUDA,
+RMSNorm, quantization, clusters, asynchronous copies, and every tile primitive
+are out of scope.
+
+## Source dispatch and resource formulae
+
+These compile-time formulae are source policy rather than tuning choices:
+
+```python
+ELEM_BITS = 16
+MAX_VEC = 128 // ELEM_BITS                             # 8 BF16 values
+
+def source_vec(H):
+    for candidate in (8, 4, 2, 1):
+        if H % candidate == 0 and H // candidate >= 32:
+            return candidate
+    return gcd(8, H)
+
+def source_config(H):
+    VEC = source_vec(H)
+    TPR = min(1024, max(32, pow2_ceil(ceil_div(H, VEC))))
+    WARPS = max(TPR // 32, 1)
+    VEC_BLOCKS = max(1, ceil_div(H // VEC, TPR))
+    COLS = VEC * VEC_BLOCKS * TPR
+    SMEM_BYTES = 2 * WARPS * 4
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    # Fresh PTX selects the mixed BF16 accumulator chain for a complete
+    # physical row tile or a >8-value fragment. Predicated short fragments are
+    # first widened and use ordinary f32 adds.
+    MIXED_LOCAL_SUM = TOTAL_VALUES > 1 and (COLS == H or TOTAL_VALUES > 8)
+    return VEC, TPR, WARPS, VEC_BLOCKS, COLS, SMEM_BYTES, MIXED_LOCAL_SUM
+```
+
+The compiled fake-tensor ABI always retains independent symbolic Int64 X and Y
+row strides, including compact callers. Both row strides are divisible by
+`VEC`; X/Y bases and compact FP32 gamma/beta bases have 16-byte assumed
+alignment. There is no separate compact PrimFunc and no Int32 flat-offset
+shortcut.
+
+Reviewed anchor specializations are:
+
+| `H` | `VEC` | `TPR` | `WARPS` | `VEC_BLOCKS` | `COLS` | relevant branch |
+| ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 66 | 2 | 64 | 2 | 1 | 128 | vector tail, multi-warp, PDL |
+| 128 | 4 | 32 | 1 | 1 | 128 | full vector, one warp |
+| 129 | 1 | 256 | 8 | 1 | scalar tail, multi-warp |
+| 500 | 4 | 128 | 4 | 1 | vector tail, independent strides |
+| 1024 | 8 | 128 | 4 | 1 | full 128-bit vector |
+| 12288 | 8 | 1024 | 32 | 2 | two vector blocks plus tail |
+| 16384 | 8 | 1024 | 32 | 2 | two full vector blocks |
+
+## Pipeline at a glance
+
+There is no producer/consumer pipeline. Every CTA is one row, and every thread
+performs all three source phases in order.
+
+| CTA/lane role | source-owned work | publication or reuse edge |
+| --- | --- | --- |
+| every thread | synchronously load its disjoint BF16 column vectors into logically zero-initialized registers | X feeds the first reduction and difference construction; the resulting FP32 difference stays live through the second reduction and affine epilogue |
+| every thread | ordered local BF16 sum, then warp butterfly sum | one scalar partial per warp |
+| lane 0 of each warp when `WARPS>1` | publish first-pass partial to `sum_smem[warp]` | CTA barrier publishes all warp sums |
+| lanes `<WARPS` when `WARPS>1` | load one first-pass partial and full-warp reduce | replicated row sum feeds mean |
+| every thread | subtract mean, square, and explicitly zero invalid physical fragment values | masked difference-square stays private until variance reduction |
+| lane 0 / lanes `<WARPS` when `WARPS>1` | repeat publication/load using distinct `var_smem` | second CTA barrier publishes variance partials |
+| every thread | form variance and approximate reciprocal standard deviation, then execute the source's explicit CTA barrier | barrier separates both reductions from affine loads/stores |
+| every thread | scalar-load its FP32 gamma/beta values, apply packed/scalar affine math, narrow, and store its BF16 vectors | each valid output element has one owner |
+
+The only publications are the two multi-warp reductions. The two shared
+buffers never alias. PDL wait precedes all data traffic and PDL signal follows
+all stores; disabled specializations contain neither instruction nor launch
+attribute.
+
+## Primitive vocabulary
+
+Structural operations do not move or compute values:
+
+```python
+specialize(...)       # compile-time H and PDL family member
+launch(...)           # exact grid, block, dynamic shared, and PDL attribute
+raw_shared(...)       # dynamic shared allocation
+view(...)             # typed linear view at a byte offset
+reg_tile(...)         # thread-private fragment
+address(...)          # logical tensor element under an Int64 row stride
+pair_view(...)        # adjacent f32 registers consumed as one f32x2 value
+```
+
+Data movement, arithmetic, and synchronization remain primitive:
+
+```python
+fill(dst, value)
+copy_g2r(src, dst, bits, predicate=None)
+copy_r2s(src, dst)
+copy_s2r(src, dst, predicate=None)
+copy_r2g(src, dst, bits, predicate=None)
+cast(dtype, src, rounding=None)
+add(lhs, rhs, lanes=1, mixed_bf16=False)
+sub(lhs, rhs, lanes=1)
+mul(lhs, rhs, lanes=1)
+fma(lhs, rhs, acc, lanes=1)
+div(lhs, rhs)
+rsqrt_fast(src)
+shuffle_xor(src, delta)
+cta_barrier()
+pdl_wait()
+pdl_signal()
+```
+
+One vector copy is one reviewed instruction. Fresh SM100a line-info exports
+select:
+
+| `VEC` | X load | Y store | narrowing |
+| ---: | --- | --- | --- |
+| 1 | `ld.global.b16` | `st.global.b16` | `cvt.rn.bf16.f32` |
+| 2 | `ld.global.v2.b16` | `st.global.b32` | `cvt.rn.bf16x2.f32` |
+| 4 | `ld.global.v4.b16` | `st.global.v2.b32` | two `cvt.rn.bf16x2.f32` |
+| 8 | `ld.global.v4.b32` | `st.global.v4.b32` | four `cvt.rn.bf16x2.f32` |
+
+Every gamma/beta element is a scalar `ld.global.b32`, including full-vector
+profiles. Packed difference, square, normalize, scale, and bias operations use
+the reviewed `*.f32x2` forms. No op below hides a row reduction, normalization,
+affine epilogue, tile copy, or tile computation.
+
+## Complete sketch
+
+```python
+@specialize(
+    INPUT_DTYPE="bf16",
+    AFFINE_DTYPE="f32",
+    H="positive compile-time integer",
+    ENABLE_PDL=(False, True),
+    TARGET="sm_100a",
+)
+@launch(
+    grid=(runtime_M, 1, 1),
+    block=(TPR, 1, 1),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_layernorm(
+    out_storage,                  # BF16, row stride y_row_stride
+    input_storage,                # BF16, row stride x_row_stride
+    gamma,                        # compact FP32 [H]
+    beta,                         # compact FP32 [H]
+    runtime_M: i64,
+    runtime_eps: f32,
+    y_row_stride: i64,            # elements, divisible by VEC
+    x_row_stride: i64,            # elements, independently divisible by VEC
+):
+    tid = thread_id_x(TPR)
+    row = cta_id_x(runtime_M)
+    lane = tid % 32
+    warp = tid // 32
+
+    smem = raw_shared("u8", SMEM_BYTES, alignment=1024)
+    sum_smem = view(smem, "f32", (WARPS,), byte_offset=0, alignment=4)
+    var_smem = view(smem, "f32", (WARPS,),
+                    byte_offset=WARPS*4, alignment=4)
+    # For WARPS>1, fresh PTX materializes and broadcasts the dynamic-shared
+    # base in the mechanical prologue before the PDL wait.
+    # instruction_selection: shfl.sync.idx.b32; extent: one shared-base
+    # broadcast per CTA thread. One-warp profiles eliminate both shared views.
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one issue per CTA,
+        # after shared-address setup but before every global-memory/data operation
+
+    TOTAL_VALUES = VEC * VEC_BLOCKS
+    x_bits = reg_tile("bf16", (TOTAL_VALUES,))
+    x_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    fill(x_bits, 0)
+    # instruction_selection: source-logical fill; full-column profiles DCE it
+    # completely, while a possibly partial vector block materializes only its
+    # zero seed as mov.b32/mov.b64 before the predicated global load
+
+    # Source TV layout: each thread owns VEC consecutive columns in each block;
+    # successive vector blocks are VEC*TPR columns apart.
+    for vb in static_range(VEC_BLOCKS):
+        col = (tid + vb * TPR) * VEC
+        col_valid = col < H
+        x_offset = cast_i64(row) * x_row_stride + cast_i64(col)
+        if col_valid:
+            copy_g2r(address(input_storage,x_offset),
+                     x_bits[vb*VEC:(vb+1)*VEC], 16*VEC)
+            # instruction_selection: exact X load from the VEC table; extent:
+            # one first-column-predicated vector per vector block
+
+    for value in static_range(TOTAL_VALUES):
+        x_f32[value] = cast("f32", x_bits[value])
+        # instruction_selection: cvt.f32.bf16; extent: one physical value
+
+    # The source reduction starts from the first widened value. Fresh BF16 PTX
+    # folds later conversions into mixed-input adds for complete physical row
+    # tiles and >8-value fragments. Predicated short fragments (reviewed H66,
+    # H320, H500, and H768) keep ordinary f32 adds instead.
+    local_sum = add(x_f32[0], 0.0)
+    # instruction_selection: add.f32; extent: one initial accumulator issue
+    for value in static_range(1, TOTAL_VALUES):
+        if MIXED_LOCAL_SUM:
+            local_sum = add(local_sum, x_bits[value], mixed_bf16=True)
+            # instruction_selection: add.rn.f32.bf16; extent: one ordered issue
+            # per remaining physical BF16 value
+        else:
+            local_sum = add(local_sum, x_f32[value])
+            # instruction_selection: add.f32; extent: one ordered issue per
+            # remaining widened value in a predicated short fragment
+
+    for delta in (1, 2, 4, 8, 16):
+        peer = shuffle_xor(local_sum, delta)
+        # instruction_selection: shfl.sync.bfly.b32, clamp 31, full mask;
+        # extent: one scalar issue per stage
+        local_sum = add(local_sum, peer)
+        # instruction_selection: add.f32; extent: one scalar issue per stage
+    warp_sum = local_sum
+
+    if WARPS > 1:
+        if lane == 0:
+            copy_r2s(warp_sum, sum_smem[warp])
+            # instruction_selection: st.shared.b32; extent: one scalar per warp
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: first publication edge
+        block_sum = 0.0
+        if lane < WARPS:
+            block_sum = copy_s2r(sum_smem[lane])
+            # instruction_selection: ld.shared.b32; extent: one participating
+            # lane in every warp
+        for delta in (1, 2, 4, 8, 16):
+            peer = shuffle_xor(block_sum, delta)
+            # instruction_selection: shfl.sync.bfly.b32, clamp 31, full mask;
+            # extent: one scalar issue per stage
+            block_sum = add(block_sum, peer)
+            # instruction_selection: add.f32; extent: one scalar issue per stage
+        sum_x = block_sum
+    else:
+        sum_x = warp_sum
+
+    # Preserve the source/compiler split. Power-of-two H uses a reciprocal
+    # multiply. General H with a packed fragment keeps positive mean and packed
+    # subtraction; the scalar-fragment branch folds the sign into the divisor
+    # so its subsequent difference is an add.
+    if is_power_of_two(H):
+        mean = mul(sum_x, exact_float32_reciprocal(H))
+        # instruction_selection: mul.f32; extent: one scalar per thread
+    elif TOTAL_VALUES > 1:
+        mean = div(sum_x, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+    else:
+        negative_mean = div(sum_x, float32(-H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+
+    diff = reg_tile("f32", (TOTAL_VALUES,))
+    diff_sq = reg_tile("f32", (TOTAL_VALUES,))
+    if TOTAL_VALUES == 1:
+        if is_power_of_two(H):
+            diff[0] = sub(x_f32[0], mean)
+            # instruction_selection: sub.f32; extent: one scalar value
+        else:
+            diff[0] = add(x_f32[0], negative_mean)
+            # instruction_selection: add.f32; extent: one scalar value
+        diff_sq[0] = mul(diff[0], diff[0])
+        # instruction_selection: mul.f32; extent: one scalar value
+    else:
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            diff_pair = sub(pair_view(x_f32,pair), pair(mean,mean), lanes=2)
+            # instruction_selection: sub.f32x2; extent: one packed pair
+            diff.store_pair(pair, diff_pair)
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            square_pair = mul(pair_view(diff,pair), pair_view(diff,pair), lanes=2)
+            # instruction_selection: mul.f32x2; extent: one packed pair
+            diff_sq.store_pair(pair, square_pair)
+
+    # A zero-filled invalid X lane has diff=-mean, so source semantics require
+    # this second mask before the variance reduction.
+    for vb in static_range(VEC_BLOCKS):
+        vector_col = (tid + vb * TPR) * VEC
+        if vector_col >= H:
+            for e in static_range(VEC):
+                diff_sq[vb*VEC+e] = 0.0
+            # instruction_selection: one CSE'd setp.gt.u32 per possibly partial
+            # vector block, then scalar selp.f32 for VEC=1 or shared-predicate
+            # selp.b64/mov sequences for VEC=2/4/8; extent: the complete
+            # invalid physical vector, not one independent predicate per value
+
+    local_var = add(diff_sq[0], 0.0)
+    # instruction_selection: add.f32; extent: one initial accumulator issue
+    for value in static_range(1, TOTAL_VALUES):
+        local_var = add(local_var, diff_sq[value])
+        # instruction_selection: add.f32; extent: one ordered issue per value
+
+    for delta in (1, 2, 4, 8, 16):
+        peer = shuffle_xor(local_var, delta)
+        # instruction_selection: shfl.sync.bfly.b32, clamp 31, full mask;
+        # extent: one scalar issue per stage
+        local_var = add(local_var, peer)
+        # instruction_selection: add.f32; extent: one scalar issue per stage
+    warp_var = local_var
+
+    if WARPS > 1:
+        if lane == 0:
+            copy_r2s(warp_var, var_smem[warp])
+            # instruction_selection: st.shared.b32; extent: one scalar per warp
+        cta_barrier()
+        # instruction_selection: bar.sync 0; extent: second publication edge
+        block_var = 0.0
+        if lane < WARPS:
+            block_var = copy_s2r(var_smem[lane])
+            # instruction_selection: ld.shared.b32; extent: one participating
+            # lane in every warp
+        for delta in (1, 2, 4, 8, 16):
+            peer = shuffle_xor(block_var, delta)
+            # instruction_selection: shfl.sync.bfly.b32, clamp 31, full mask;
+            # extent: one scalar issue per stage
+            block_var = add(block_var, peer)
+            # instruction_selection: add.f32; extent: one scalar issue per stage
+        sum_diff_sq = block_var
+    else:
+        sum_diff_sq = warp_var
+
+    if is_power_of_two(H):
+        shifted_var = fma(sum_diff_sq, exact_float32_reciprocal(H), runtime_eps)
+        # instruction_selection: fma.rn.f32; extent: one scalar per thread
+    else:
+        variance = div(sum_diff_sq, float32(H))
+        # instruction_selection: div.rn.f32; extent: one scalar per thread
+        shifted_var = add(variance, runtime_eps)
+        # instruction_selection: add.f32; extent: one scalar per thread
+    rstd = rsqrt_fast(shifted_var)
+    # instruction_selection: rsqrt.approx.ftz.f32; extent: one scalar per thread
+
+    cta_barrier()
+    # instruction_selection: bar.sync 0; extent: one source-ordered edge after
+    # the reciprocal standard deviation and before affine loads
+
+    gamma_frag = reg_tile("f32", (TOTAL_VALUES,))
+    beta_frag = reg_tile("f32", (TOTAL_VALUES,))
+    fill(gamma_frag, 0.0)
+    fill(beta_frag, 0.0)
+    # instruction_selection: source-logical fills; full-column profiles DCE
+    # both fills, while possibly partial vector blocks materialize only the
+    # required mov.b32/mov.b64 zero seeds before predicated scalar loads
+    for vb in static_range(VEC_BLOCKS):
+        for e in static_range(VEC):
+            value = vb * VEC + e
+            col = tid * VEC + vb * TPR * VEC + e
+            if col < H:
+                gamma_frag[value] = copy_g2r(gamma[col])
+                # instruction_selection: ld.global.b32; extent: one scalar f32
+                beta_frag[value] = copy_g2r(beta[col])
+                # instruction_selection: ld.global.b32; extent: one scalar f32
+
+    y_f32 = reg_tile("f32", (TOTAL_VALUES,))
+    if TOTAL_VALUES == 1:
+        normalized = mul(diff[0], rstd)
+        # instruction_selection: mul.f32; extent: one scalar value
+        y_f32[0] = fma(normalized, gamma_frag[0], beta_frag[0])
+        # instruction_selection: fma.rn.f32; extent: one scalar value
+    else:
+        normalized = reg_tile("f32", (TOTAL_VALUES,))
+        scaled = reg_tile("f32", (TOTAL_VALUES,))
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            normalized_pair = mul(pair_view(diff,pair), pair(rstd,rstd), lanes=2)
+            # instruction_selection: mul.f32x2; extent: one packed pair
+            normalized.store_pair(pair, normalized_pair)
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            scaled_pair = mul(pair_view(normalized,pair),
+                              pair_view(gamma_frag,pair), lanes=2)
+            # instruction_selection: mul.f32x2; extent: one packed pair
+            scaled.store_pair(pair, scaled_pair)
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            y_pair = add(pair_view(scaled,pair), pair_view(beta_frag,pair), lanes=2)
+            # instruction_selection: add.f32x2; extent: one packed pair
+            y_f32.store_pair(pair, y_pair)
+
+    y_bits = reg_tile("bf16", (TOTAL_VALUES,))
+    if TOTAL_VALUES == 1:
+        y_bits[0] = cast("bf16", y_f32[0], rounding="rn")
+        # instruction_selection: cvt.rn.bf16.f32; extent: one scalar value
+    else:
+        for pair in static_range(ceil_div(TOTAL_VALUES,2)):
+            y_bits.store_pair(pair,
+                cast("bf16x2",
+                     high=y_f32[pair*2+1], low=y_f32[pair*2], rounding="rn"))
+            # instruction_selection: cvt.rn.bf16x2.f32 with PTX operands
+            # high-address value then low-address value; extent: one packed
+            # pair whose low 16 bits belong at the lower output address
+
+    for vb in static_range(VEC_BLOCKS):
+        col = (tid + vb * TPR) * VEC
+        col_valid = col < H
+        y_offset = cast_i64(row) * y_row_stride + cast_i64(col)
+        if col_valid:
+            copy_r2g(y_bits[vb*VEC:(vb+1)*VEC],
+                     address(out_storage,y_offset), 16*VEC)
+            # instruction_selection: exact Y store from the VEC table; extent:
+            # one first-column-predicated vector per vector block
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; extent:
+        # one issue per CTA after all output stores
+```
+
+## Addressing, predicates, and tails
+
+- Grid extent equals runtime M, so no row predicate exists. `row` is widened
+  before either row-stride multiplication; both element offsets remain Int64.
+- The source TV layout owns `VEC` adjacent values and strides successive vector
+  blocks by `VEC*TPR`. All supported vector widths divide H, so testing the
+  first column proves an entire in-range vector.
+- X invalid physical values remain zero because the fragment is filled before
+  predicated loads. They participate harmlessly in the first sum.
+- Invalid difference squares must be zeroed explicitly before the second sum.
+  This is a distinct predicate and may not be inferred from the X fill.
+- Gamma/beta loads are scalar and individually predicated. Output reuses the
+  vector first-column predicate and never touches row padding or the trailing
+  backing-store guard.
+- Every fragment loop is a compile-time unrolled loop in reviewed required
+  profiles, including the 16-value-per-thread H12288/H16384 branches. No
+  runtime or source-size loop is introduced.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime / reuse rule |
+| --- | --- | --- |
+| X/Y/gamma/beta GMEM | caller | X/gamma/beta read-only; Y is the only mutable tensor |
+| `sum_smem[WARPS]` | lane 0 writers, lanes `<WARPS` readers | first reduction publication through its full-warp completion |
+| `var_smem[WARPS]` | lane 0 writers, lanes `<WARPS` readers | second reduction publication through its full-warp completion; never aliases sum buffer |
+| BF16 X fragment | one thread | logical zero-fill/load through widening and the optional mixed-BF16 first-sum chain; dead after difference inputs are available |
+| FP32 X fragment | one thread | widening through difference construction; the affine path consumes the retained difference instead |
+| difference / square fragment | one thread | mean through masked second local sum; difference remains live for affine |
+| gamma/beta fragments | one thread | post-reduction scalar loads through affine add |
+| normalized/scaled fragments | one thread | three explicit packed affine phases; lifetimes end at consumption |
+| BF16 Y fragment | one thread | narrowing through one predicated vector store per block |
+
+## Module and verification contract
+
+- Registry name is `flashinfer_layernorm`, category `flashinfer`, compute
+  capability 10. Runtime ABI is
+  `out,input,gamma,beta,M:int64,eps:f32,y_row_stride:int64,x_row_stride:int64`.
+- The supported tensor domain is BF16 X/Y, FP32 gamma/beta, positive M/H,
+  inner stride one, independent row strides divisible by the selected vector.
+- `CONFIGS` includes the exact upstream 16-case matrix, trace/example cases,
+  Int64 overflow regression, PDL/vec2 tail, independent-stride/full-ABI guard,
+  input/parameter immutability, output padding, and finite-value checks.
+- The complete required performance matrix is the upstream 16-case matrix
+  `M in {1,2,3,128}` by `H in {128,129,1024,16384}`. Each row must satisfy
+  `flashinfer_cutedsl_time / tirx_time > 0.99` in one valid reference-enabled
+  `bench_suite` artifact; no other timer is a retention or PASS criterion.
+- Every specialization undergoes low-level IR rejection of
+  `TilePrimitiveCall`, `tirx.tile.*`, tile primitives, `T.cuda.func_call`, and
+  `cuda_func_call`.
+
+## Instruction selection is a lowering consequence
+
+The port preserves source vector selection, one-CTA-per-row topology, symbolic
+Int64 strides, zero-fill and both column predicates, mixed BF16 local summation,
+two non-aliasing shared reductions, power-of-two versus general-H arithmetic,
+fast reciprocal square root, explicit post-reduction barrier, scalar affine
+loads, packed affine phase order, BF16 store width, full compile-time unrolling,
+and PDL boundaries. Plain TIRx and typed/local PTX may express reviewed
+instructions; they may not use tile primitives, replace the two-pass
+difference-of-squares with `E[x^2]-mean^2`, reuse one shared buffer, hoist
+gamma/beta loads before the source barrier, vectorize those scalar FP32 loads,
+contract packed multiply/add into a different arithmetic order, or weaken the
+Int64 addressing and tail predicates.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `mxfp4_quantize`                        | `quantization/mxfp4_quantize.py`                    | Block quantization with UE8M0 scales |
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
 | `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
+| `flashinfer_layernorm`                  | `norm/layernorm.py`                                 | BF16 LayerNorm with FP32 affine parameters, independent int64 row strides, and optional PDL |
 | `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_fused_add_rmsnorm_quant`    | `norm/fused_add_rmsnorm_quant.py`                   | Fused residual add, RMSNorm, and FP8 quantization with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_qk_rmsnorm`                 | `norm/qk_rmsnorm.py`                                | Shared 3-D QK RMSNorm / Gemma RMSNorm family with arbitrary int64 batch/head strides, PDL, and sync/async copy paths |

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -10,7 +10,7 @@ tree, so a kernel's configs sit at `config/<bucket>/<kernel>.yaml`. With no
 `--workloads`, the flagged configs across all files are assembled into
 `.bench-suite/workloads.generated.yaml` and that is what runs. The generated
 file is the inspectable source of truth for the current representative sweep.
-Every kernel has at most three default small/medium/large representatives; the current tree assembles 170
+Every kernel has at most three default small/medium/large representatives; the current tree assembles 173
 workloads. Widening or narrowing the sweep is a YAML `default`
 flag flip, not a scheduler rule or a second selection file. Multi-GPU configs
 are deliberately absent from the default measured sweep but remain available

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "3df3e86a",
-    "tirx-kernels": "82f32d84-dirty",
+    "tirx-kernels": "521f16bf-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "43ec928346b60f6b422188dc117c6202da2cb32b"
+    "tirx-kernels:tirx_kernels": "14fcbbf2fb46caaa36472e199bf91c3350a22ec5"
   },
   "baselines": {
     "torch": {
@@ -2208,6 +2208,230 @@
       "impls": {
         "tirx": 3.8162779479448434,
         "flashinfer_cutedsl": 3.898806482512027
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m128_h1024_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m128_h1024_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.078044790176154,
+        "flashinfer_cutedsl": 3.0617348327678933
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m128_h128_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m128_h128_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.4434706360235405,
+        "flashinfer_cutedsl": 2.4455248950463506
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m128_h129_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m128_h129_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.8534939835927684,
+        "flashinfer_cutedsl": 2.8579195937745405
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m128_h16384_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m128_h16384_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.948368212843627,
+        "flashinfer_cutedsl": 8.942759484215717
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m1_h1024_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m1_h1024_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.9720230571507775,
+        "flashinfer_cutedsl": 2.968002248222724
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m1_h128_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m1_h128_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.049317271435883,
+        "flashinfer_cutedsl": 2.0524189789453113
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m1_h129_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m1_h129_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.7931047184268443,
+        "flashinfer_cutedsl": 2.796024503594549
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m1_h16384_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m1_h16384_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.25753044039432,
+        "flashinfer_cutedsl": 8.250688795963889
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m2_h1024_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m2_h1024_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.796584245962813,
+        "flashinfer_cutedsl": 2.808288917696446
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m2_h128_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m2_h128_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.035999937686912,
+        "flashinfer_cutedsl": 2.0559761592891403
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m2_h129_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m2_h129_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.0461868868557516,
+        "flashinfer_cutedsl": 3.044687034878098
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m2_h16384_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m2_h16384_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.609502131257391,
+        "flashinfer_cutedsl": 7.624619378887564
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m3_h1024_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m3_h1024_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 3.1946847040140542,
+        "flashinfer_cutedsl": 3.188364216401223
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m3_h128_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m3_h128_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.244549753506697,
+        "flashinfer_cutedsl": 2.2462553695363647
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m3_h129_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m3_h129_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.811327220719155,
+        "flashinfer_cutedsl": 2.8114798688863067
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_layernorm",
+      "config": "bf16_m3_h16384_xc_yc_pdl0_eps1e6",
+      "label": "bf16_m3_h16384_xc_yc_pdl0_eps1e6",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.021095590241375,
+        "flashinfer_cutedsl": 8.060368782716147
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '3df3e86a', 'tirx-kernels': '82f32d84-dirty', 'tirx-bench-ci': None}`
-- Workloads: 406 ok, 0 failed
+- Git:       `{'tir': '3df3e86a', 'tirx-kernels': '521f16bf-dirty', 'tirx-bench-ci': None}`
+- Workloads: 422 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -258,6 +258,27 @@ Grouped workloads show one row per config and one timing column per implementati
 | `bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1` | tirx | 3.3662 | flashinfer_cutedsl | 3.4006 | 1.010 | — |
 | `bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1` | tirx | 3.7142 | flashinfer_cutedsl | 3.7284 | 1.004 | — |
 | `bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1` | tirx | 3.8163 | flashinfer_cutedsl | 3.8988 | 1.022 | — |
+
+## flashinfer_layernorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_m128_h1024_xc_yc_pdl0_eps1e6` | tirx | 3.0780 | flashinfer_cutedsl | 3.0617 | 0.995 | — |
+| `bf16_m128_h128_xc_yc_pdl0_eps1e6` | tirx | 2.4435 | flashinfer_cutedsl | 2.4455 | 1.001 | — |
+| `bf16_m128_h129_xc_yc_pdl0_eps1e6` | tirx | 2.8535 | flashinfer_cutedsl | 2.8579 | 1.002 | — |
+| `bf16_m128_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.9484 | flashinfer_cutedsl | 8.9428 | 0.999 | — |
+| `bf16_m1_h1024_xc_yc_pdl0_eps1e6` | tirx | 2.9720 | flashinfer_cutedsl | 2.9680 | 0.999 | — |
+| `bf16_m1_h128_xc_yc_pdl0_eps1e6` | tirx | 2.0493 | flashinfer_cutedsl | 2.0524 | 1.002 | — |
+| `bf16_m1_h129_xc_yc_pdl0_eps1e6` | tirx | 2.7931 | flashinfer_cutedsl | 2.7960 | 1.001 | — |
+| `bf16_m1_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.2575 | flashinfer_cutedsl | 8.2507 | 0.999 | — |
+| `bf16_m2_h1024_xc_yc_pdl0_eps1e6` | tirx | 2.7966 | flashinfer_cutedsl | 2.8083 | 1.004 | — |
+| `bf16_m2_h128_xc_yc_pdl0_eps1e6` | tirx | 2.0360 | flashinfer_cutedsl | 2.0560 | 1.010 | — |
+| `bf16_m2_h129_xc_yc_pdl0_eps1e6` | tirx | 3.0462 | flashinfer_cutedsl | 3.0447 | 1.000 | — |
+| `bf16_m2_h16384_xc_yc_pdl0_eps1e6` | tirx | 7.6095 | flashinfer_cutedsl | 7.6246 | 1.002 | — |
+| `bf16_m3_h1024_xc_yc_pdl0_eps1e6` | tirx | 3.1947 | flashinfer_cutedsl | 3.1884 | 0.998 | — |
+| `bf16_m3_h128_xc_yc_pdl0_eps1e6` | tirx | 2.2445 | flashinfer_cutedsl | 2.2463 | 1.001 | — |
+| `bf16_m3_h129_xc_yc_pdl0_eps1e6` | tirx | 2.8113 | flashinfer_cutedsl | 2.8115 | 1.000 | — |
+| `bf16_m3_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.0211 | flashinfer_cutedsl | 8.0604 | 1.005 | — |
 
 ## flashinfer_qk_rmsnorm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_layernorm.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_layernorm.yaml
@@ -1,0 +1,19 @@
+kernel: flashinfer_layernorm
+selection_rationale: The default rows anchor the one-warp launch floor, a saturated one-vector-block multi-warp case, and the largest two-vector-block source specialization.
+configs:
+  - {config: bf16_m1_h128_xc_yc_pdl0_eps1e6, default: true, selection_role: small}
+  - {config: bf16_m1_h129_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m1_h1024_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m1_h16384_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m2_h128_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m2_h129_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m2_h1024_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m2_h16384_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m3_h128_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m3_h129_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m3_h1024_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m3_h16384_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m128_h128_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m128_h129_xc_yc_pdl0_eps1e6, default: false}
+  - {config: bf16_m128_h1024_xc_yc_pdl0_eps1e6, default: true, selection_role: medium}
+  - {config: bf16_m128_h16384_xc_yc_pdl0_eps1e6, default: true, selection_role: large}

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -792,12 +792,7 @@ class _PreparedAttempt:
 
 
 def _prepared_child_command(
-    workload: dict,
-    *,
-    control_fd: int,
-    rounds: int,
-    cooldown: float,
-    with_references: bool,
+    workload: dict, *, control_fd: int, rounds: int, cooldown: float, with_references: bool
 ) -> list[str]:
     command = [
         sys.executable,
@@ -1497,7 +1492,7 @@ def _finalize_bench_record(
         return
     protocol_cooldown = protocol.get("cooldown_s", protocol.get("round_cooldown_s"))
     if (
-        not isinstance(protocol_cooldown, (int, float))
+        not isinstance(protocol_cooldown, int | float)
         or isinstance(protocol_cooldown, bool)
         or not math.isclose(float(protocol_cooldown), cooldown, rel_tol=0.0, abs_tol=1e-9)
     ):
@@ -1541,7 +1536,7 @@ def _finalize_bench_record(
         impl: value
         for impl, values in samples.items()
         for value in values
-        if not isinstance(value, (int, float))
+        if not isinstance(value, int | float)
         or isinstance(value, bool)
         or not math.isfinite(value)
         or value <= 0
@@ -1649,10 +1644,7 @@ def run_scheduled_jobs(
     ) -> None:
         if item.state not in ("ASSIGNED", "RUNNING_GPU") or item.pending_interference:
             return
-        item.pending_interference = {
-            "intruder_pids": intruders,
-            "detail": detail[:240],
-        }
+        item.pending_interference = {"intruder_pids": intruders, "detail": detail[:240]}
         item.interference_stop_deadline = time.monotonic() + 30.0
         item.state = "STOPPING_INTERFERED_GPU"
         log(
@@ -1682,6 +1674,7 @@ def run_scheduled_jobs(
         release_gpus(item)
         item.gpus = ()
         item.physical_gpu_uuids = ()
+        item.gpu_affinity = ()
         item.pending_interference = None
         item.interference_stop_deadline = None
         item.attempt += 1
@@ -1909,7 +1902,9 @@ def run_scheduled_jobs(
                         records.append(record)
                         completed += 1
                         impls = record.get("impls") or {}
-                        impl_str = ", ".join(f"{name}={value:.3f}µs" for name, value in impls.items())
+                        impl_str = ", ".join(
+                            f"{name}={value:.3f}µs" for name, value in impls.items()
+                        )
                         log(
                             f"[bench-suite] {record['finished_at']} "
                             f"gpus={record.get('gpu') or '-'} {record.get('status', 'ok'):4s} "

--- a/tirx_kernels/flashinfer/norm/layernorm.py
+++ b/tirx_kernels/flashinfer/norm/layernorm.py
@@ -1,0 +1,853 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL LayerNorm port.
+
+The source implementation is ``LayerNormKernel`` in
+``flashinfer/norm/kernels/layernorm.py`` together with the public dispatch in
+``flashinfer/norm/__init__.py`` and reduction helpers in
+``flashinfer/norm/utils.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {"name": "flashinfer_layernorm", "category": "flashinfer", "compute_capability": 10}
+
+_DEFAULT_EPS = 1e-6
+_LAYOUTS = ("compact", "strided")
+_GUARD_ELEMENTS = 64
+_GUARD_VALUE = 123.0
+
+
+def _ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def _source_vec(H: int) -> int:
+    for vec in (8, 4, 2, 1):
+        if H % vec == 0 and H // vec >= 32:
+            return vec
+    return 8 if H % 8 == 0 else 4 if H % 4 == 0 else 2 if H % 2 == 0 else 1
+
+
+def _source_config(H: int) -> dict[str, int | bool]:
+    vec = _source_vec(H)
+    threads = 32
+    while threads < _ceil_div(H, vec) and threads < 1024:
+        threads *= 2
+    threads = min(threads, 1024)
+    warps = max(threads // 32, 1)
+    vec_blocks = max(1, _ceil_div(H // vec, threads))
+    cols = vec * vec_blocks * threads
+    total_values = vec * vec_blocks
+    return {
+        "vec": vec,
+        "threads": threads,
+        "warps": warps,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "total_values": total_values,
+        "smem_bytes": 2 * warps * 4,
+        "mixed_local_sum": total_values > 1 and (cols == H or total_values > 8),
+    }
+
+
+def _ptx_unary(chain: str, value, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _ptx_ternary(chain: str, lhs, rhs, acc, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _add_bf16_to_f32(bits, value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.add.rn.f32.bf16(out[0], T.cast(bits, "uint16"), value))
+    return out[0]
+
+
+def _sub_f32(lhs, rhs):
+    return _ptx_binary("sub.f32", lhs, rhs)
+
+
+def _mul_f32(lhs, rhs):
+    return _ptx_binary("mul.f32", lhs, rhs)
+
+
+def _div_rn_f32(lhs, rhs):
+    return _ptx_binary("div.rn.f32", lhs, rhs)
+
+
+def _fma_rn_f32(lhs, rhs, acc):
+    return _ptx_ternary("fma.rn.f32", lhs, rhs, acc)
+
+
+def _rsqrt_approx_ftz(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _cvt_bf16_to_f32(bits):
+    return _ptx_unary("cvt.f32.bf16", T.cast(bits, "uint16"))
+
+
+def _cvt_f32_to_bf16(value):
+    return _ptx_unary("cvt.rn.bf16.f32", value, dtype="uint16")
+
+
+def _cvt_pair_f32_to_bf16(high, low):
+    return _ptx_binary("cvt.rn.bf16x2.f32", high, low, dtype="uint32")
+
+
+def _shfl_bfly_f32(value, lane_xor: int):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _butterfly_sum_f32(value):
+    for lane_xor in (1, 2, 4, 8, 16):
+        value = _add_f32(value, _shfl_bfly_f32(value, lane_xor))
+    return value
+
+
+@T.inline
+def _load_x(buffer, index, values, value_offset, VEC: T.constexpr):
+    if VEC == 1:
+        T.ptx.ld.global_.b16(values[value_offset], buffer.ptr_to([index]))
+    elif VEC == 2:
+        T.ptx.ld.global_.v2.b16(
+            values[value_offset], values[value_offset + 1], buffer.ptr_to([index])
+        )
+    elif VEC == 4:
+        T.ptx.ld.global_.v4.b16(
+            values[value_offset],
+            values[value_offset + 1],
+            values[value_offset + 2],
+            values[value_offset + 3],
+            buffer.ptr_to([index]),
+        )
+    else:
+        words = T.alloc_local((4,), "uint32")
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+        for pair in T.unroll(4):
+            T.ptx.mov.b32(
+                values[value_offset + pair * 2], values[value_offset + pair * 2 + 1], words[pair]
+            )
+
+
+@T.inline
+def _store_y(buffer, index, bits, words, value_offset, word_offset, VEC: T.constexpr):
+    if VEC == 1:
+        T.ptx.st.global_.b16(buffer.ptr_to([index]), bits[value_offset])
+    elif VEC == 2:
+        T.ptx.st.global_.b32(buffer.ptr_to([index]), words[word_offset])
+    elif VEC == 4:
+        T.ptx.st.global_.v2.b32(buffer.ptr_to([index]), words[word_offset], words[word_offset + 1])
+    else:
+        T.ptx.st.global_.v4.b32(
+            buffer.ptr_to([index]),
+            words[word_offset],
+            words[word_offset + 1],
+            words[word_offset + 2],
+            words[word_offset + 3],
+        )
+
+
+def _short_layout(layout: str) -> str:
+    return "c" if layout == "compact" else "s"
+
+
+def _cfg(
+    M: int,
+    H: int,
+    input_layout: str = "compact",
+    output_layout: str = "compact",
+    enable_pdl: bool = False,
+    *,
+    eps: float = _DEFAULT_EPS,
+    x_row_stride: int | None = None,
+    y_row_stride: int | None = None,
+    suffix: str = "",
+) -> dict[str, Any]:
+    eps_label = "eps1e6" if eps == _DEFAULT_EPS else "eps1e4"
+    label = (
+        f"bf16_m{M}_h{H}_x{_short_layout(input_layout)}_y{_short_layout(output_layout)}_"
+        f"pdl{int(enable_pdl)}_{eps_label}"
+    )
+    if suffix:
+        label += f"_{suffix}"
+    config: dict[str, Any] = {
+        "label": label,
+        "M": M,
+        "H": H,
+        "input_layout": input_layout,
+        "output_layout": output_layout,
+        "enable_pdl": enable_pdl,
+        "eps": eps,
+    }
+    if x_row_stride is not None:
+        config["x_row_stride"] = x_row_stride
+    if y_row_stride is not None:
+        config["y_row_stride"] = y_row_stride
+    return config
+
+
+_UPSTREAM_CONFIGS = [_cfg(M, H) for M in (1, 2, 3, 128) for H in (128, 129, 1024, 16384)]
+BENCH_CONFIGS = [dict(config) for config in _UPSTREAM_CONFIGS]
+_TRACE_CONFIGS = [
+    _cfg(8, 256, suffix="trace"),
+    _cfg(3, 320, suffix="trace"),
+    _cfg(32, 768, suffix="public_example"),
+]
+_OVERFLOW_CONFIGS = [_cfg(175000, 12288, suffix="i64_overflow")]
+_STRUCTURE_CONFIGS = [
+    _cfg(3, 66, enable_pdl=True, suffix="vec2_tail"),
+    _cfg(3, 1025, suffix="vec1_two_blocks"),
+    _cfg(
+        19,
+        500,
+        "strided",
+        "strided",
+        eps=1e-4,
+        x_row_stride=1000,
+        y_row_stride=1500,
+        suffix="full_abi",
+    ),
+]
+CONFIGS = [*_UPSTREAM_CONFIGS, *_TRACE_CONFIGS, *_OVERFLOW_CONFIGS, *_STRUCTURE_CONFIGS]
+
+assert len(CONFIGS) == 23
+assert len(BENCH_CONFIGS) == 16
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+
+
+def _validate(M: int, H: int, input_layout: str, output_layout: str, eps: float) -> None:
+    if M <= 0 or H <= 0:
+        raise ValueError(f"M and H must be positive, got M={M}, H={H}")
+    if input_layout not in _LAYOUTS or output_layout not in _LAYOUTS:
+        raise ValueError(f"unsupported layouts: input={input_layout}, output={output_layout}")
+    if eps <= 0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+
+def get_kernel(
+    M: int,
+    H: int,
+    input_layout: str,
+    output_layout: str,
+    enable_pdl: bool,
+    eps: float = _DEFAULT_EPS,
+    **kwargs: Any,
+):
+    """Return the source-faithful dynamic-Int64-stride specialization."""
+    _validate(M, H, input_layout, output_layout, eps)
+    source = _source_config(H)
+    vec = int(source["vec"])
+    threads = int(source["threads"])
+    warps = int(source["warps"])
+    vec_blocks = int(source["vec_blocks"])
+    total_values = int(source["total_values"])
+    smem_bytes = int(source["smem_bytes"])
+    mixed_local_sum = bool(source["mixed_local_sum"])
+    packed_pairs = _ceil_div(total_values, 2)
+    pair_values = packed_pairs * 2
+
+    x_stride_hint = int(kwargs.get("x_row_stride", H if input_layout == "compact" else 2 * H))
+    y_stride_hint = int(kwargs.get("y_row_stride", H if output_layout == "compact" else 2 * H))
+    if x_stride_hint < H or y_stride_hint < H:
+        raise ValueError(f"row strides must cover H={H}: x={x_stride_hint}, y={y_stride_hint}")
+    if x_stride_hint % vec != 0 or y_stride_hint % vec != 0:
+        raise ValueError(
+            f"row strides must be divisible by vec={vec}: x={x_stride_hint}, y={y_stride_hint}"
+        )
+
+    @T.prim_func
+    def flashinfer_layernorm(
+        out_ptr: T.handle,
+        input_ptr: T.handle,
+        gamma_ptr: T.handle,
+        beta_ptr: T.handle,
+        runtime_M: T.int64,
+        runtime_eps: T.float32,
+        y_row_stride: T.int64,
+        x_row_stride: T.int64,
+    ):
+        T.func_attr({"tir.is_entry_func": True})
+        out = T.match_buffer(
+            out_ptr,
+            shape=((runtime_M - T.int64(1)) * y_row_stride + T.int64(H),),
+            dtype="bfloat16",
+            scope="global",
+        )
+        x = T.match_buffer(
+            input_ptr,
+            shape=((runtime_M - T.int64(1)) * x_row_stride + T.int64(H),),
+            dtype="bfloat16",
+            scope="global",
+        )
+        gamma = T.match_buffer(gamma_ptr, shape=(H,), dtype="float32", scope="global")
+        beta = T.match_buffer(beta_ptr, shape=(H,), dtype="float32", scope="global")
+        T.device_entry()
+        # TIRX_TRANSCRIBE_START flashinfer_layernorm
+        row_raw = T.cta_id([T.cast(runtime_M, "int32")])
+        tid = T.thread_id([threads])
+        row: T.int64 = T.cast(row_raw, "int64")
+        lane: T.int32 = tid % 32
+        warp: T.int32 = tid // 32
+
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+        if warps > 1:
+            shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn", align=1024)
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        x_bits = T.alloc_local((pair_values,), "uint16")
+        x_f32 = T.alloc_local((pair_values,), "float32")
+        for value in T.unroll(total_values):
+            x_bits[value] = T.uint16(0)
+        for vb in T.unroll(vec_blocks):
+            col: T.int32 = (tid + vb * threads) * vec
+            x_offset: T.int64 = row * x_row_stride + T.cast(col, "int64")
+            if col < H:
+                _load_x(x, x_offset, x_bits, vb * vec, VEC=vec)
+        for value in T.unroll(total_values):
+            x_f32[value] = _cvt_bf16_to_f32(x_bits[value])
+
+        local_sum: T.float32 = _add_f32(x_f32[0], T.float32(0.0))
+        if total_values > 1:
+            for step in T.unroll(total_values - 1):
+                value: T.int32 = step + 1
+                if mixed_local_sum:
+                    local_sum = _add_bf16_to_f32(x_bits[value], local_sum)
+                else:
+                    local_sum = _add_f32(local_sum, x_f32[value])
+        warp_sum: T.float32 = _butterfly_sum_f32(local_sum)
+        if warps > 1:
+            if lane == 0:
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([warp * 4]), T.reinterpret("uint32", warp_sum)
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            block_sum: T.float32 = T.float32(0.0)
+            if lane < warps:
+                sum_word = T.alloc_local((1,), "uint32")
+                T.ptx.ld.shared.b32(sum_word[0], shared_raw.ptr_to([lane * 4]))
+                block_sum = T.reinterpret("float32", sum_word[0])
+            sum_x: T.float32 = _butterfly_sum_f32(block_sum)
+        else:
+            sum_x: T.float32 = warp_sum
+
+        if H & (H - 1) == 0:
+            mean: T.float32 = _mul_f32(sum_x, T.float32(1.0 / H))
+        elif total_values > 1:
+            mean: T.float32 = _div_rn_f32(sum_x, T.float32(H))
+        else:
+            negative_mean: T.float32 = _div_rn_f32(sum_x, T.float32(-H))
+
+        diff = T.alloc_local((pair_values,), "float32")
+        diff_sq = T.alloc_local((pair_values,), "float32")
+        if total_values == 1:
+            if H & (H - 1) == 0:
+                diff[0] = _sub_f32(x_f32[0], mean)
+            else:
+                diff[0] = _add_f32(x_f32[0], negative_mean)
+            diff_sq[0] = _mul_f32(diff[0], diff[0])
+        else:
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.sub.f32x2(
+                    packed[0],
+                    T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                    T.cuda.make_float2(mean, mean),
+                )
+                T.ptx.mov.b64(diff[pair * 2], diff[pair * 2 + 1], packed[0])
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                diff_pair: T.uint64 = T.cuda.make_float2(diff[pair * 2], diff[pair * 2 + 1])
+                T.ptx.mul.f32x2(packed[0], diff_pair, diff_pair)
+                T.ptx.mov.b64(diff_sq[pair * 2], diff_sq[pair * 2 + 1], packed[0])
+
+        for vb in T.unroll(vec_blocks):
+            col: T.int32 = (tid + vb * threads) * vec
+            if col >= H:
+                for e in T.unroll(vec):
+                    diff_sq[vb * vec + e] = T.float32(0.0)
+
+        local_var: T.float32 = _add_f32(diff_sq[0], T.float32(0.0))
+        if total_values > 1:
+            for step in T.unroll(total_values - 1):
+                value: T.int32 = step + 1
+                local_var = _add_f32(local_var, diff_sq[value])
+        warp_var: T.float32 = _butterfly_sum_f32(local_var)
+        if warps > 1:
+            if lane == 0:
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([warps * 4 + warp * 4]), T.reinterpret("uint32", warp_var)
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            block_var: T.float32 = T.float32(0.0)
+            if lane < warps:
+                var_word = T.alloc_local((1,), "uint32")
+                T.ptx.ld.shared.b32(var_word[0], shared_raw.ptr_to([warps * 4 + lane * 4]))
+                block_var = T.reinterpret("float32", var_word[0])
+            sum_diff_sq: T.float32 = _butterfly_sum_f32(block_var)
+        else:
+            sum_diff_sq: T.float32 = warp_var
+        if H & (H - 1) == 0:
+            shifted_var: T.float32 = _fma_rn_f32(sum_diff_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            variance: T.float32 = _div_rn_f32(sum_diff_sq, T.float32(H))
+            shifted_var: T.float32 = _add_f32(variance, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted_var)
+        T.ptx.bar.sync(T.uint32(0))
+
+        gamma_frag = T.alloc_local((pair_values,), "float32")
+        beta_frag = T.alloc_local((pair_values,), "float32")
+        for value in T.unroll(total_values):
+            gamma_frag[value] = T.float32(0.0)
+            beta_frag[value] = T.float32(0.0)
+        for vb in T.unroll(vec_blocks):
+            for e in T.unroll(vec):
+                value: T.int32 = vb * vec + e
+                col: T.int32 = tid * vec + vb * threads * vec + e
+                if col < H:
+                    T.ptx.ld.global_.b32(gamma_frag[value], gamma.ptr_to([col]))
+                    T.ptx.ld.global_.b32(beta_frag[value], beta.ptr_to([col]))
+
+        y_f32 = T.alloc_local((pair_values,), "float32")
+        if total_values == 1:
+            normalized: T.float32 = _mul_f32(diff[0], rstd)
+            y_f32[0] = _fma_rn_f32(normalized, gamma_frag[0], beta_frag[0])
+        else:
+            normalized = T.alloc_local((pair_values,), "float32")
+            scaled = T.alloc_local((pair_values,), "float32")
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(
+                    packed[0],
+                    T.cuda.make_float2(diff[pair * 2], diff[pair * 2 + 1]),
+                    T.cuda.make_float2(rstd, rstd),
+                )
+                T.ptx.mov.b64(normalized[pair * 2], normalized[pair * 2 + 1], packed[0])
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.mul.f32x2(
+                    packed[0],
+                    T.cuda.make_float2(normalized[pair * 2], normalized[pair * 2 + 1]),
+                    T.cuda.make_float2(gamma_frag[pair * 2], gamma_frag[pair * 2 + 1]),
+                )
+                T.ptx.mov.b64(scaled[pair * 2], scaled[pair * 2 + 1], packed[0])
+            for pair in T.unroll(packed_pairs):
+                packed = T.alloc_local((1,), "uint64")
+                T.ptx.add.f32x2(
+                    packed[0],
+                    T.cuda.make_float2(scaled[pair * 2], scaled[pair * 2 + 1]),
+                    T.cuda.make_float2(beta_frag[pair * 2], beta_frag[pair * 2 + 1]),
+                )
+                T.ptx.mov.b64(y_f32[pair * 2], y_f32[pair * 2 + 1], packed[0])
+
+        y_bits = T.alloc_local((pair_values,), "uint16")
+        y_words = T.alloc_local((max(packed_pairs, 1),), "uint32")
+        if vec == 1:
+            for value in T.unroll(total_values):
+                y_bits[value] = _cvt_f32_to_bf16(y_f32[value])
+        else:
+            for pair in T.unroll(packed_pairs):
+                y_words[pair] = _cvt_pair_f32_to_bf16(y_f32[pair * 2 + 1], y_f32[pair * 2])
+        for vb in T.unroll(vec_blocks):
+            col: T.int32 = (tid + vb * threads) * vec
+            y_offset: T.int64 = row * y_row_stride + T.cast(col, "int64")
+            if col < H:
+                _store_y(out, y_offset, y_bits, y_words, vb * vec, vb * vec // 2, VEC=vec)
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    launch_params = ["blockIdx.x", "threadIdx.x"]
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return flashinfer_layernorm.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def _row_strides(config: dict[str, Any]) -> tuple[int, int]:
+    H = int(config["H"])
+    x_stride = int(config.get("x_row_stride", H if config["input_layout"] == "compact" else 2 * H))
+    y_stride = int(config.get("y_row_stride", H if config["output_layout"] == "compact" else 2 * H))
+    return x_stride, y_stride
+
+
+def _storage_size(M: int, H: int, row_stride: int) -> int:
+    return (M - 1) * row_stride + H
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    eps = float(config.get("eps", _DEFAULT_EPS))
+    _validate(M, H, str(config["input_layout"]), str(config["output_layout"]), eps)
+    x_stride, y_stride = _row_strides(config)
+    vec = int(_source_config(H)["vec"])
+    if x_stride < H or y_stride < H or x_stride % vec or y_stride % vec:
+        raise ValueError(f"invalid row strides for H={H}, vec={vec}: x={x_stride}, y={y_stride}")
+
+    x_size = _storage_size(M, H, x_stride)
+    x_backing = torch.full(
+        (x_size + _GUARD_ELEMENTS,), _GUARD_VALUE, dtype=torch.bfloat16, device="cuda"
+    )
+    x_arg = x_backing[:x_size]
+    x = x_arg.as_strided((M, H), (x_stride, 1))
+    if H >= 4096:
+        columns = torch.arange(H, device="cuda")
+        magnitude = torch.where(columns % 257 < 128, 0.5, 1.0)
+        pattern = torch.where(columns % 2 == 0, magnitude, -magnitude).to(torch.bfloat16)
+        x.copy_(pattern.expand(M, H))
+        x[1::2].neg_()
+    else:
+        generator = torch.Generator(device="cuda")
+        generator.manual_seed(42)
+        x.normal_(generator=generator)
+
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(43)
+    gamma_backing = torch.full(
+        (H + _GUARD_ELEMENTS,), _GUARD_VALUE, dtype=torch.float32, device="cuda"
+    )
+    beta_backing = torch.full(
+        (H + _GUARD_ELEMENTS,), _GUARD_VALUE, dtype=torch.float32, device="cuda"
+    )
+    gamma, beta = gamma_backing[:H], beta_backing[:H]
+    gamma.normal_(generator=generator)
+    beta.normal_(generator=generator)
+    return {
+        "x": x,
+        "x_arg": x_arg,
+        "x_backing": x_backing,
+        "x_size": x_size,
+        "gamma": gamma,
+        "gamma_backing": gamma_backing,
+        "beta": beta,
+        "beta_backing": beta_backing,
+        "x_row_stride": x_stride,
+        "y_row_stride": y_stride,
+    }
+
+
+def prepare_data(**config: Any):
+    """Create deterministic LayerNorm inputs."""
+    data = _prepare_tensors(dict(config))
+    return data["x"], data["gamma"], data["beta"]
+
+
+def _prepare_output(M: int, H: int, row_stride: int, *, initialize_padding: bool):
+    import torch
+
+    size = _storage_size(M, H, row_stride)
+    backing = torch.empty(size + _GUARD_ELEMENTS, dtype=torch.bfloat16, device="cuda")
+    if initialize_padding:
+        backing.fill_(_GUARD_VALUE)
+    else:
+        backing[size:].fill_(_GUARD_VALUE)
+    arg = backing[:size]
+    return {
+        "view": arg.as_strided((M, H), (row_stride, 1)),
+        "arg": arg,
+        "backing": backing,
+        "size": size,
+    }
+
+
+def _assert_guard(values, *, name: str) -> None:
+    import torch
+
+    if values.numel() and not torch.equal(values, torch.full_like(values, _GUARD_VALUE)):
+        raise AssertionError(f"{name} padding or guard was modified")
+
+
+def _assert_output_padding(output, M: int, H: int, row_stride: int, *, name: str) -> None:
+    backing = output["backing"]
+    _assert_guard(backing[output["size"] :], name=f"{name} terminal")
+    if row_stride > H and M > 1:
+        padding = backing.as_strided((M - 1, row_stride - H), (row_stride, 1), storage_offset=H)
+        _assert_guard(padding, name=f"{name} row")
+
+
+def _overflow_rows(M: int, H: int) -> list[int] | None:
+    if M * H <= 2**31 - 1:
+        return None
+    boundary = _ceil_div(2**31, H)
+    return sorted(
+        {row for row in (0, 1, boundary - 1, boundary, boundary + 1, M - 1) if 0 <= row < M}
+    )
+
+
+def _checked_view(tensor, rows: list[int] | None):
+    return tensor if rows is None else tensor[rows]
+
+
+def _math_oracle(x, gamma, beta, eps: float, rows: list[int] | None):
+    import torch
+    import torch.nn.functional as F
+
+    checked = _checked_view(x, rows).float()
+    return F.layer_norm(checked, (x.shape[-1],), gamma, beta, eps).to(torch.bfloat16)
+
+
+def _assert_close(actual, expected, *, name: str, rtol: float, atol: float) -> None:
+    import torch
+
+    torch.testing.assert_close(
+        actual, expected, rtol=rtol, atol=atol, msg=lambda message: f"{name}: {message}"
+    )
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]) -> None:
+    executable(
+        output["arg"],
+        data["x_arg"],
+        data["gamma"],
+        data["beta"],
+        int(config["M"]),
+        float(config.get("eps", _DEFAULT_EPS)),
+        data["y_row_stride"],
+        data["x_row_stride"],
+    )
+
+
+def _flashinfer_cute(device):
+    import flashinfer.norm as flashinfer_norm
+
+    if flashinfer_norm._use_cuda_norm(device):
+        raise AssertionError("FlashInfer LayerNorm oracle dispatched to legacy CUDA")
+    return flashinfer_norm, flashinfer_norm.layernorm_cute
+
+
+def _snapshot_inputs(data, M: int, H: int):
+    rows = _overflow_rows(M, H)
+    if rows is None:
+        x_values = data["x"].clone()
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        x_values = data["x"][rows][:, columns].clone()
+    return {
+        "rows": rows,
+        "x": x_values,
+        "gamma": data["gamma"].clone(),
+        "beta": data["beta"].clone(),
+    }
+
+
+def _assert_inputs_unchanged(data, snapshot, M: int, H: int) -> None:
+    import torch
+
+    rows = snapshot["rows"]
+    if rows is None:
+        observed = data["x"]
+    else:
+        columns = sorted({0, H // 2, H - 1})
+        observed = data["x"][rows][:, columns]
+    if not torch.equal(observed, snapshot["x"]):
+        raise AssertionError("input tensor was modified")
+    if not torch.equal(data["gamma"], snapshot["gamma"]):
+        raise AssertionError("gamma tensor was modified")
+    if not torch.equal(data["beta"], snapshot["beta"]):
+        raise AssertionError("beta tensor was modified")
+    _assert_guard(data["x_backing"][data["x_size"] :], name="input terminal")
+    _assert_guard(data["gamma_backing"][H:], name="gamma terminal")
+    _assert_guard(data["beta_backing"][H:], name="beta terminal")
+
+
+def _check_public_dispatch(data, eps: float) -> None:
+    import flashinfer
+
+    flashinfer_norm, original_cute = _flashinfer_cute(data["x"].device)
+    calls = 0
+
+    def tracked_cute(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_cute(*args, **kwargs)
+
+    flashinfer_norm.layernorm_cute = tracked_cute
+    try:
+        public_out = flashinfer.layernorm(data["x"], data["gamma"], data["beta"], eps)
+    finally:
+        flashinfer_norm.layernorm_cute = original_cute
+    if calls != 1:
+        raise AssertionError(f"expected one CuTe-DSL public dispatch, observed {calls}")
+    if public_out.shape != data["x"].shape or public_out.dtype != data["x"].dtype:
+        raise AssertionError("FlashInfer public LayerNorm returned an incompatible output")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one LayerNorm specialization."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = dict(config)
+    M, H = int(config["M"]), int(config["H"])
+    eps, enable_pdl = float(config.get("eps", _DEFAULT_EPS)), bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    snapshot = _snapshot_inputs(data, M, H)
+    output = _prepare_output(M, H, data["y_row_stride"], initialize_padding=True)
+    reference = _prepare_output(M, H, data["y_row_stride"], initialize_padding=True)
+
+    executable = compile_kernel(get_kernel(**config))
+    _launch_tirx(executable, data, output, config)
+    _, layernorm_cute = _flashinfer_cute(data["x"].device)
+    returned = layernorm_cute(
+        reference["view"], data["x"], data["gamma"], data["beta"], eps, enable_pdl=enable_pdl
+    )
+    if returned is not None:
+        raise AssertionError("FlashInfer layernorm_cute must return None")
+    if M == 32 and H == 768:
+        _check_public_dispatch(data, eps)
+
+    torch.cuda.synchronize()
+    rows = _overflow_rows(M, H)
+    actual_checked = _checked_view(output["view"], rows)
+    reference_checked = _checked_view(reference["view"], rows)
+    math = _math_oracle(data["x"], data["gamma"], data["beta"], eps, rows)
+    if not torch.isfinite(actual_checked).all():
+        raise AssertionError("TIRx output contains non-finite values")
+    _assert_close(
+        actual_checked, reference_checked, name="FlashInfer CuTe-DSL", rtol=1e-3, atol=1e-3
+    )
+    _assert_close(actual_checked, math, name="FP32 math oracle", rtol=1e-2, atol=1e-2)
+    _assert_inputs_unchanged(data, snapshot, M, H)
+    _assert_output_padding(output, M, H, data["y_row_stride"], name="TIRx output")
+    _assert_output_padding(reference, M, H, data["y_row_stride"], name="FlashInfer output")
+
+
+def prepare_bench(**config: Any):
+    """Compile the selected TIRx specialization before GPU assignment."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Construct and validate both timed closures before benchmarking."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    M, H = int(config["M"]), int(config["H"])
+    eps, enable_pdl = float(config.get("eps", _DEFAULT_EPS)), bool(config["enable_pdl"])
+    data = _prepare_tensors(config)
+    tirx_output = _prepare_output(M, H, data["y_row_stride"], initialize_padding=False)
+    flashinfer_output = _prepare_output(M, H, data["y_row_stride"], initialize_padding=False)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        _launch_tirx(executable, data, tirx_output, config)
+
+    tirx_launch()
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        flashinfer_norm, layernorm_cute = _flashinfer_cute(data["x"].device)
+        calls = 0
+
+        def tracked_cute(*args, **call_kwargs):
+            nonlocal calls
+            calls += 1
+            return layernorm_cute(*args, **call_kwargs)
+
+        flashinfer_norm.layernorm_cute = tracked_cute
+        try:
+            public_out = flashinfer_norm.layernorm(data["x"], data["gamma"], data["beta"], eps)
+        finally:
+            flashinfer_norm.layernorm_cute = layernorm_cute
+        if calls != 1:
+            raise AssertionError(
+                f"expected one CuTe-DSL benchmark dispatch proof, observed {calls}"
+            )
+        del public_out
+
+        def flashinfer_launch():
+            return layernorm_cute(
+                flashinfer_output["view"],
+                data["x"],
+                data["gamma"],
+                data["beta"],
+                eps,
+                enable_pdl=enable_pdl,
+            )
+
+        returned = flashinfer_launch()
+        if returned is not None:
+            raise AssertionError("FlashInfer benchmark LayerNorm must return None")
+        torch.cuda.synchronize()
+        _assert_close(
+            tirx_output["view"],
+            flashinfer_output["view"],
+            name="benchmark precheck",
+            rtol=1e-3,
+            atol=1e-3,
+        )
+        return flashinfer_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark a TIRx specialization against FlashInfer CuTe-DSL."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer CuTeDSL LayerNorm to plain TIRx for BF16 input/output with FP32 gamma and beta
- preserve the one-CTA-per-row schedule, two ordered reductions, independent int64 row strides, vectorized load/store paths, tail masking, and optional PDL
- add the reviewed kernel sketch, 23 correctness configurations, 16 official benchmark configurations, documentation, and promoted baseline rows
- allow interference retries to late-bind a different eligible GPU by clearing stale prepared-child affinity

## Validation

- `python -m tirx_kernels.test --kernel flashinfer_layernorm`: 23/23 passed, 0 failed, 0 skipped
- reference-enabled bench-suite: 16/16 workloads passed with five rounds and one-second cooldown; minimum `flashinfer_cutedsl / tirx` ratio was `0.994701196`
- `python -m tirx_kernels.registry --strict --format json`
- `python -m tirx_kernels.bench_suite --check-imports`
- license checker and self-test
- `pre-commit run`