### PR TITLE
feat(kernel): add FlashInfer RMSNorm FP4 quantization

### DIFF
--- a/.agents/sketch/flashinfer/norm/rmsnorm_fp4quant.md
+++ b/.agents/sketch/flashinfer/norm/rmsnorm_fp4quant.md
@@ -1,0 +1,807 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+RMSNormFP4QuantKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer RMSNorm FP4 quantization SM100: execution sketch
+
+This non-executable sketch freezes the implementation shape of FlashInfer's
+CuTe-DSL `RMSNormFP4QuantKernel` for
+[`tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py`](../../../../tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py).
+It records the source execution skeleton, not a mathematically equivalent
+replacement. The target is implemented only after independent source/PTX
+review, and this file is permanently frozen after its first reviewer PASS.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/cute_dsl/rmsnorm_fp4quant.py`, SHA256
+  `ec32fae9254adb9b888c0affd99822c89806a5881de04db0b0a755d81f6f90a3`;
+- `flashinfer/cute_dsl/fp4_common.py`, SHA256
+  `ff490c11853603634fd19c4558021b03db08b409dc54d24146f1bdc66a6b784f`;
+- public alias and wrapper in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+Writer-owned fresh line-info exports are under
+`.porting/flashinfer_rmsnorm_fp4quant/source_exports/`; their opcode and loop
+audit is `.porting/flashinfer_rmsnorm_fp4quant/source_ptx_audit.md`. They cover
+FP16/BF16, NVFP4/MXFP4, linear/swizzled scales, PDL, every launch threshold,
+the 7-to-8 scale-loop boundary, and cluster sizes 2/16. The reviewer must
+independently export through the normal public CuTeDSL build path.
+
+The supported family is compact FP16/BF16 X and W, packed E2M1 Y bytes,
+block size 16 or 32, E4M3 or UE8M0 scale bytes, linear or 128x4 swizzled scale
+layout, 2-D or host-flattened 3-D input, PDL off/on, and clusters 1/2/4/8/16.
+There is no strided device specialization. Tile primitives, TMA, W shared
+staging, a second `cp.async` stage, and post-reduction X shared reload are out
+of scope.
+
+## Source dispatch and resource formulae
+
+These are source formulae, not tuning choices. `MAX_SMEM=232448` is the B200
+opt-in value used by the pinned export and validation environment.
+
+```python
+COPY_BITS = 128
+ELEM_BYTES = 2
+VEC = 8
+
+def threads_per_row(h_per_cta):
+    if h_per_cta <= 64: return 8
+    if h_per_cta <= 128: return 16
+    if h_per_cta <= 3072: return 32
+    if h_per_cta <= 6144: return 64
+    if h_per_cta <= 16384: return 128
+    return 256
+
+def num_threads(h_per_cta):
+    return 128 if h_per_cta <= 16384 else 256
+
+def estimate_smem(H, cluster_n):
+    hcta = H // cluster_n
+    tpr = threads_per_row(hcta)
+    threads = num_threads(hcta)
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec_blocks = max(1, ceil_div(hcta // VEC, tpr))
+    cols = VEC * vec_blocks * tpr
+    tile_bytes = rows * cols * ELEM_BYTES
+    if cluster_n == 1:
+        # Deliberately conservative selection estimate: source counts sX+sW.
+        return 2 * tile_bytes + rows * warps_per_row * 4
+    return tile_bytes + rows * warps_per_row * cluster_n * 4 + 8
+
+def source_config(H):
+    cluster_n = next(
+        (c for c in (1,2,4,8,16)
+         if H % c == 0 and estimate_smem(H,c) <= MAX_SMEM),
+        16,
+    )
+    hcta = H // cluster_n
+    tpr = threads_per_row(hcta)
+    threads = num_threads(hcta)
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec_blocks = max(1, ceil_div(hcta // VEC, tpr))
+    cols = VEC * vec_blocks * tpr
+    tile_bytes = rows * cols * ELEM_BYTES
+    reduction_bytes = rows * warps_per_row * 4
+    if cluster_n > 1:
+        reduction_bytes *= cluster_n
+    smem_bytes = tile_bytes + reduction_bytes + (8 if cluster_n > 1 else 0)
+    num_sf = H // BLOCK_SIZE
+    sf_per_thread = ceil_div(num_sf, tpr)
+    return cluster_n,hcta,tpr,threads,rows,warps_per_row,vec_blocks,cols, \
+           smem_bytes,num_sf,sf_per_thread
+```
+
+The actual shared allocation always contains one X tile, not the conservative
+two-tile cluster-selection estimate. Launch is
+`grid=(ceil_div(M,ROWS),CLUSTER_N,1)`, `block=(THREADS,1,1)`, optional cluster
+`(1,CLUSTER_N,1)`, with exact dynamic shared size above. The PTX has
+`.reqntid` and `.extern .shared .align 1024`, and no `.maxnreg` or launch-bound
+directive.
+
+Runtime device ABI is `(X,W,Y,S,global_scale,M:i32,eps:f32)`. X/W are compact
+input dtype; Y is compact packed bytes `[M,H/2]`; S is `[M,H/BLOCK]` linear or
+the padded swizzled backing allocation; global scale is device FP32 `[1]`.
+The public 3-D case flattens its leading two axes into runtime M before launch.
+
+## Source-proven loop shape
+
+| phase | compile-time extent | source/PTX structure |
+| --- | ---: | --- |
+| X `cp.async` and shared load | `VEC_BLOCKS` | always statically expanded, including large H |
+| row fragment square/sum | `8*VEC_BLOCKS` | statically expanded |
+| phase-3 SF loop | `SF_PER_THREAD <= 7` | completely expanded |
+| phase-3 SF loop | `SF_PER_THREAD >= 8` | backward `while` loop, two SF blocks per body, cursor `+=2`, second block guarded |
+| block16 payload | 16 values | one source-exact group, no inner runtime loop |
+| block32 payload | 2 x 16 values | both groups loaded before either group is consumed |
+
+Fresh adjacent evidence is H14336/block16 (`SF_PER_THREAD=7`, seven static
+stores, no backedge) and H16384/block16 (`SF_PER_THREAD=8`, two static blocks
+inside a loop whose backedge maps to source line 498). This is a loop-trip
+boundary, not a hard-coded H boundary.
+
+## CTA roles, publication edges, and storage
+
+| owner | source-owned work | publication/reuse edge |
+| --- | --- | --- |
+| every CTA thread | optional PDL wait; phase-1 X issue, square contribution; phase-3 assigned SF blocks | one row group per contiguous TPR lanes |
+| each TPR lane group | one logical row, one CTA column slice during reduction | replicated rstd after row/cluster reduction |
+| lane 0 of each row warp, non-cluster multiwarp | publish one warp partial to CTA shared | CTA barrier, then all row warps redundantly finish the reduction |
+| lanes `<CLUSTER_N`, clustered CTA | remotely publish each warp partial to every peer CTA | two `mapa`, remote complete-tx store, mbarrier wait |
+| every cluster CTA in phase 3 | process the complete row's scale-block space | intentionally redundant full-H Y/S stores; no `cluster_y` offset |
+
+Raw shared storage is aligned to 1024 bytes:
+
+1. `sX`: input dtype `[ROWS,COLS]`, row-major/order `(1,0)`, alignment 16;
+2. reduction: FP32 `[ROWS,WARPS_PER_ROW]` for one CTA, or
+   `[ROWS,(WARPS_PER_ROW,CLUSTER_N)]` for clustered execution, alignment 4;
+3. one 8-byte mbarrier only for `CLUSTER_N>1`.
+
+X shared lifetime starts at async issue and ends after the single phase-2
+shared load. The FP32 X fragment lives only through square/reduction. Phase 3
+reloads X and W directly from global into packed register words. The reduction
+buffer is reused only by the row-reduction protocol; clustered phase 3 begins
+after the second cluster barrier. Scale is stored before its Y payload for each
+SF block. Inputs/global scale are read-only; Y/S are the two mutable outputs.
+
+## Primitive vocabulary
+
+Structural vocabulary does not move or compute values:
+
+```python
+specialize(...)  launch(...)  raw_shared(...)  view(...)  reg_fragment(...)
+address(...)     swizzled_scale_offset(...)     logical_pair_view(...)
+```
+
+All copy, compute, conversion, and synchronization work remains primitive:
+
+```python
+pdl_wait()  pdl_signal()
+cp_async_ca_128(src,dst,source_bytes)  cp_async_commit()  cp_async_wait(0)
+load_shared_128(src)  load_global_128(src)  store_global_b8(dst,v)
+store_global_u64(dst,v)
+mul_input2(a,b,dtype)  abs_input2(v,dtype)  max_input2(a,b,dtype)
+widen_input_scalar(v,dtype)  mul_f32(a,b)  mul_f32x2(a,b)
+add_f32(a,b)  div_f32(a,b)  max_f32(a,b)
+rsqrt_fast(v)  rcp_fast(v)  min_f32(a,b)  lg2_fast(v)  ex2_fast(v)
+shuffle_xor(v,delta,width)  copy_r2s(v,dst)  copy_s2r(src)
+cvt_e4m3_pair(hi,lo)  cvt_e2m1_pair(hi,lo)  cvt_f16x2_e4m3x2(v)
+cvt_f32_f16(v)  cvt_s32_f32_rpi(v)  cvt_f32_s32_rn(v)
+and_b32(a,mask)  shift_left_b32(v,n)  shift_right_b32(v,n)
+mov_b32_pair(lo,hi)  mov_b32_bytes(b0,b1,b2,b3)
+setp(...)  select(...)  add_s32(...)  sub_s32(...)  cvt_u64_u32(...)
+shift_left_b64(v,n)  or_b64(a,b)
+cta_barrier()  cluster_arrive_relaxed()  cluster_wait()
+mbarrier_init(...)  mbarrier_init_fence()  mbarrier_arrive_expect_tx(...)
+map_shared_to_peer(...)  remote_store_complete_tx(...)  mbarrier_try_wait(...)
+```
+
+There is no compound RMSNorm, reduction, scale, FP4 quantize, tiled copy, or
+tile compute primitive.
+
+## Complete execution sketch
+
+```python
+@specialize(
+    INPUT_DTYPE=("f16","bf16"),
+    H="compile-time positive multiple of BLOCK_SIZE, at least 64",
+    BLOCK_SIZE=(16,32), SCALE_FORMAT=("e4m3","ue8m0"),
+    SWIZZLED=(False,True), ENABLE_PDL=(False,True), TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M,ROWS),CLUSTER_N,1),
+    block=(THREADS,1,1),
+    cluster=((1,CLUSTER_N,1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_rmsnorm_fp4quant(
+    X, W, Y_u8, S_u8, global_scale, runtime_M:i32, runtime_eps:f32,
+):
+    tid = thread_id_x()
+    block_x = block_id_x()
+    cluster_y = block_id_y() if CLUSTER_N > 1 else 0
+    lane_in_row = tid % TPR
+    row_in_cta = tid // TPR
+    warp = tid // 32
+    lane = tid % 32
+    WARPS_PER_ROW = max(TPR // 32,1)
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one CTA issue
+
+    fp4_max_rcp = rcp_fast(6.0)
+    # instruction_selection: rcp.approx.ftz.f32; extent: one scalar/thread
+
+    smem = raw_shared("u8",SMEM_BYTES,alignment=1024)
+    sX = view(smem,INPUT_DTYPE,(ROWS,COLS),row_major=True,
+              byte_offset=0,alignment=16)
+    reduce_offset = ROWS * COLS * 2
+    if CLUSTER_N == 1:
+        reduction = view(smem,"f32",(ROWS,WARPS_PER_ROW),
+                         byte_offset=reduce_offset,alignment=4)
+    else:
+        reduction = view(smem,"f32",(ROWS,(WARPS_PER_ROW,CLUSTER_N)),
+                         byte_offset=reduce_offset,alignment=4)
+        mbar = view(smem,"mbarrier",(1,),
+                    byte_offset=reduce_offset + ROWS*WARPS_PER_ROW*CLUSTER_N*4,
+                    alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar,arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; one/CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; one/CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; one/CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; one/CTA
+
+    # TV layout shape ((TPR,ROWS),(8,VEC_BLOCKS)); stride
+    # ((8*ROWS,1),(ROWS,ROWS*8*TPR)). Each lane owns eight adjacent values
+    # at every vb, and cluster_y selects the reduction column slice.
+    actual_row = block_x * ROWS + row_in_cta
+    row_valid = actual_row < runtime_M
+    x_frag = reg_fragment(INPUT_DTYPE,8*VEC_BLOCKS)
+
+    # --------------------------------------------------------------
+    # Phase 1: one async group, X global -> shared.
+    # --------------------------------------------------------------
+    for vb in static_unroll(VEC_BLOCKS):
+        local_col = (lane_in_row + vb*TPR) * 8
+        absolute_col = cluster_y * COLS + local_col
+        col_valid = absolute_col < H
+        if row_valid:
+            source_bytes = 16 if col_valid else 0
+            cp_async_ca_128(
+                X + actual_row*H + absolute_col,
+                sX[row_in_cta,local_col], source_bytes)
+            # instruction_selection: cp.async.ca.shared.global, immediate 16
+            # bytes plus source-size 16/0; extent: one issue/vb/thread
+    cp_async_commit()
+    # instruction_selection: cp.async.commit_group; one/thread
+    cp_async_wait(0)
+    # instruction_selection: cp.async.wait_group 0; one/thread
+
+    for vb in static_unroll(VEC_BLOCKS):
+        local_col = (lane_in_row + vb*TPR) * 8
+        x_frag[vb] = load_shared_128(sX[row_in_cta,local_col])
+        # instruction_selection: ld.shared.v4.b32; one 128-bit issue/vb/thread
+
+    # Source widens all physical values, squares adjacent pairs with packed
+    # FP32 instructions, then performs an ordered scalar ADD over the fragment.
+    x_f32 = reg_fragment("f32",8*VEC_BLOCKS)
+    x_sq = reg_fragment("f32",8*VEC_BLOCKS)
+    for flat in static_unroll(8*VEC_BLOCKS):
+        x_f32[flat] = widen_input_scalar(x_frag,flat,INPUT_DTYPE)
+        # instruction_selection: cvt.f32.{f16,bf16}; one scalar/value
+    for pair in static_unroll(4*VEC_BLOCKS):
+        x_sq[2*pair:2*pair+2] = mul_f32x2(
+            x_f32[2*pair:2*pair+2],x_f32[2*pair:2*pair+2])
+        # instruction_selection: mul.f32x2; exactly 4*VEC_BLOCKS issues
+    local_sum = 0.0
+    for flat in static_unroll(8*VEC_BLOCKS):
+        local_sum = add_f32(local_sum,x_sq[flat])
+        # instruction_selection: add.f32; ordered extent one/value
+
+    # --------------------------------------------------------------
+    # Expanded source row_reduce protocol.
+    # --------------------------------------------------------------
+    WARP_WIDTH = min(TPR,32)
+    for delta in powers_of_two_below(WARP_WIDTH):
+        peer = shuffle_xor(local_sum,delta,width=32)
+        # instruction_selection: shfl.sync.bfly.b32 full mask/clamp31;
+        # one issue per explicit subgroup stage
+        local_sum = add_f32(local_sum,peer)
+        # instruction_selection: add.f32; one/stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            copy_r2s(warp_sum,reduction[row_warp,warp_in_row])
+            # instruction_selection: st.shared.b32; one/row warp
+        cta_barrier()
+        # instruction_selection: bar.sync; one publication edge/CTA
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = copy_s2r(reduction[row_warp,lane])
+            # instruction_selection: ld.shared.b32; one participating lane
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final,delta,width=32)
+            # instruction_selection: shfl.sync.bfly.b32; one/stage
+            final = add_f32(final,peer)
+            # instruction_selection: add.f32; one/stage
+        sum_sq = final
+
+    elif CLUSTER_N > 1:
+        if warp == 0 and elect_one():
+            # instruction_selection: elect.sync; one election/CTA
+            expected = ROWS*WARPS_PER_ROW*CLUSTER_N*4
+            mbarrier_arrive_expect_tx(mbar,expected)
+            # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+            # one elected issue/CTA with exact expected byte count
+        if lane < CLUSTER_N:
+            peer_value = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cluster_rank())],lane)
+            peer_bar = map_shared_to_peer(mbar,lane)
+            # instruction_selection: mapa.shared::cluster.u32; two maps/lane
+            remote_store_complete_tx(warp_sum,peer_value,peer_bar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # one partial from every row warp to every peer CTA
+        done = False
+        while not done:
+            done = mbarrier_try_wait(mbar,phase=0,timeout=10000000)
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 plus
+            # uniform retry branch; one completion loop/thread
+        total = WARPS_PER_ROW*CLUSTER_N
+        final = 0.0
+        for i in static_unroll(ceil_div(total,32)):
+            partial = lane + i*32
+            if partial < total:
+                v = copy_s2r(reduction[row_warp,partial])
+                # instruction_selection: ld.shared.b32; one owned partial
+                final = add_f32(final,v)
+                # instruction_selection: add.f32; one loaded partial
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final,delta,width=32)
+            # instruction_selection: shfl.sync.bfly.b32; one/stage
+            final = add_f32(final,peer)
+            # instruction_selection: add.f32; one/stage
+        sum_sq = final
+    else:
+        sum_sq = warp_sum
+
+    mean_sq = div_f32(sum_sq,float32(H))
+    # instruction_selection: div.rn.f32, or source-compiler folded reciprocal
+    # multiply for exactly representable power-of-two H; one/thread
+    shifted = add_f32(mean_sq,runtime_eps)
+    # instruction_selection: add.f32, possibly fused with a folded reciprocal
+    # as fma.rn.f32 for a power-of-two H; one/thread
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; one/thread
+
+    # The source expression reads global_scale before this edge. In canonical
+    # UE8M0 PTX the unused load is DCE; E4M3 branches retain ld.global.b32.
+    if BLOCK_SIZE == 16 or SCALE_FORMAT == "e4m3":
+        global_scale_value = load_global_f32(global_scale[0])
+        # instruction_selection: ld.global.b32; one scalar/thread in E4M3
+        # specializations, absent after DCE in canonical UE8M0
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; one/CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; one/CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync; one post-reduction edge/CTA
+
+    # --------------------------------------------------------------
+    # Phase 3: all cluster CTAs intentionally revisit the complete H row.
+    # SF cursor never includes cluster_y.
+    # --------------------------------------------------------------
+    if row_valid:
+        SF_PER_THREAD = ceil_div(H//BLOCK_SIZE,TPR)
+
+        def process_one_sf(sf_idx):
+            if sf_idx < H//BLOCK_SIZE:
+                block_start = sf_idx*BLOCK_SIZE
+
+                if BLOCK_SIZE == 16:
+                    # Issue all four 128-bit loads before packed arithmetic.
+                    x_words = reg_fragment("u32",8)
+                    w_words = reg_fragment("u32",8)
+                    x_words[0:4] = load_global_128(
+                        X+actual_row*H+block_start)
+                    # instruction_selection: ld.global.v4.u32; X values 0..7
+                    x_words[4:8] = load_global_128(
+                        X+actual_row*H+block_start+8)
+                    # instruction_selection: ld.global.v4.u32; X values 8..15
+                    w_words[0:4] = load_global_128(W+block_start)
+                    # instruction_selection: ld.global.v4.u32; W values 0..7
+                    w_words[4:8] = load_global_128(W+block_start+8)
+                    # instruction_selection: ld.global.v4.u32; W values 8..15
+                    # Extent is exactly two X then two W 128-bit issues/SF.
+
+                    xw = reg_fragment(INPUT_DTYPE+"x2",8)
+                    for pair in static_unroll(8):
+                        xw[pair] = mul_input2(x_words,w_words,pair,INPUT_DTYPE)
+                        # instruction_selection: mul.f16x2 or mul.bf16x2;
+                        # eight packed issues, preserving input-dtype rounding
+                    abs_xw = reg_fragment("u32",8)
+                    for pair in static_unroll(8):
+                        abs_xw[pair] = and_b32(xw[pair],0x7fff7fff)
+                        # instruction_selection: and.b32 with 0x7fff7fff;
+                        # exactly eight packed absolute-value issues/SF
+                    max01 = max_input2(abs_xw[0],abs_xw[1],INPUT_DTYPE)
+                    max23 = max_input2(abs_xw[2],abs_xw[3],INPUT_DTYPE)
+                    max45 = max_input2(abs_xw[4],abs_xw[5],INPUT_DTYPE)
+                    max67 = max_input2(abs_xw[6],abs_xw[7],INPUT_DTYPE)
+                    max03 = max_input2(max01,max23,INPUT_DTYPE)
+                    max47 = max_input2(max45,max67,INPUT_DTYPE)
+                    pair_max = max_input2(max03,max47,INPUT_DTYPE)
+                    # instruction_selection: max.f16x2 or max.bf16x2;
+                    # exactly seven issues in the source 8->4->2->1 tree
+                    if INPUT_DTYPE == "f16":
+                        max_lo16,max_hi16 = mov_b32_pair(pair_max)
+                        # instruction_selection: mov.b32 {b16,b16}; one/SF
+                        max_lo = cvt_f32_f16(max_lo16)
+                        max_hi = cvt_f32_f16(max_hi16)
+                        # instruction_selection: cvt.f32.f16; two/SF
+                    else:
+                        max_lo32 = and_b32(pair_max,0xffff)
+                        max_hi32 = shift_right_b32(pair_max,16)
+                        # instruction_selection: and.b32 then shr.b32; one each/SF
+                        max_lo32 = shift_left_b32(max_lo32,16)
+                        max_hi32 = shift_left_b32(max_hi32,16)
+                        # instruction_selection: shl.b32; two/SF
+                        max_lo = mov_b32_as_f32(max_lo32)
+                        max_hi = mov_b32_as_f32(max_hi32)
+                        # instruction_selection: mov.b32 to f32; two/SF
+                    max_xw = max_f32(max_lo,max_hi)
+                    # instruction_selection: max.f32; one horizontal max/SF
+                    y_f32 = reg_fragment("f32",16)
+                    for pair in static_unroll(8):
+                        if INPUT_DTYPE == "f16":
+                            lo16,hi16 = mov_b32_pair(xw[pair])
+                            # instruction_selection: mov.b32 {b16,b16}; one/pair
+                            lo = cvt_f32_f16(lo16)
+                            hi = cvt_f32_f16(hi16)
+                            # instruction_selection: cvt.f32.f16; two/pair
+                        else:
+                            lo32 = and_b32(xw[pair],0xffff)
+                            hi32 = shift_right_b32(xw[pair],16)
+                            lo32 = shift_left_b32(lo32,16)
+                            hi32 = shift_left_b32(hi32,16)
+                            # instruction_selection: and.b32, shr.b32, and two
+                            # shl.b32 issues per packed BF16 pair
+                            lo = mov_b32_as_f32(lo32)
+                            hi = mov_b32_as_f32(hi32)
+                            # instruction_selection: mov.b32 to f32; two/pair
+                        y_f32[2*pair] = mul_f32(lo,rstd)
+                        y_f32[2*pair+1] = mul_f32(hi,rstd)
+                        # instruction_selection: mul.f32; sixteen values/SF
+                    max_abs = mul_f32(max_xw,rstd)
+                    # instruction_selection: mul.f32; one/SF
+
+                    scale_float = mul_f32(
+                        mul_f32(global_scale_value,max_abs),fp4_max_rcp)
+                    # instruction_selection: mul.f32 chain; two issues/SF
+                    scale_float = min_f32(scale_float,448.0)
+                    # instruction_selection: min.f32; one/SF
+                    fp8_zero = mov_f32(0.0)
+                    # instruction_selection: mov.f32 zero; one/SF
+                    scale_pair16 = cvt_e4m3_pair(fp8_zero,scale_float)
+                    # instruction_selection: cvt.rn.satfinite.e4m3x2.f32;
+                    # zero is high mate and scale is low mate, one/SF
+                    scale_word = cvt_u32_u16(scale_pair16)
+                    # instruction_selection: cvt.u32.u16; one/SF
+                    scale_byte = scale_word & 0xff
+                    # instruction_selection: source low-byte view is DCE;
+                    # zero standalone instructions before st.global.b8
+                    decode_pair16 = cvt_u16_u32(scale_word)
+                    # instruction_selection: cvt.u16.u32; one/SF
+                    decoded_h2 = cvt_f16x2_e4m3x2(decode_pair16)
+                    # instruction_selection: cvt.rn.f16x2.e4m3x2; one/SF
+                    decoded_lo16,_ = mov_b32_pair(decoded_h2)
+                    # instruction_selection: mov.b32 {b16,b16}; one/SF
+                    decoded = cvt_f32_f16(decoded_lo16)
+                    # instruction_selection: cvt.f32.f16; one/SF
+                    reciprocal = rcp_fast(decoded)
+                    # instruction_selection: rcp.approx.ftz.f32; one/SF
+                    decoded_zero = setp_eq_f32(decoded,0.0)
+                    # instruction_selection: setp.eq.f32; one/SF
+                    decoded_rcp = select_f32(0.0,reciprocal,decoded_zero)
+                    # instruction_selection: selp.f32; one/SF, zero stays zero
+                    inv_scale = mul_f32(decoded_rcp,global_scale_value)
+                    # instruction_selection: mul.f32; one/SF
+
+                    s_offset = swizzled_scale_offset(actual_row,sf_idx) \
+                               if SWIZZLED else actual_row*(H//16)+sf_idx
+                    store_global_b8(S_u8+s_offset,scale_byte)
+                    # instruction_selection: st.global.b8; one/SF, before Y
+
+                    scaled = reg_fragment("f32",16)
+                    for value in static_unroll(16):
+                        scaled[value] = mul_f32(y_f32[value],inv_scale)
+                        # instruction_selection: mul.f32; sixteen values/SF
+                    pair_bytes = reg_fragment("u8",8)
+                    for pair in static_unroll(8):
+                        pair_bytes[pair] = cvt_e2m1_pair(
+                            scaled[2*pair+1],scaled[2*pair])
+                        # instruction_selection:
+                        # cvt.rn.satfinite.e2m1x2.f32 to b8; eight/SF, PTX high then
+                        # low so logical element 0 occupies the low nibble
+                    packed_lo32 = mov_b32_bytes(
+                        pair_bytes[0],pair_bytes[1],pair_bytes[2],pair_bytes[3])
+                    packed_hi32 = mov_b32_bytes(
+                        pair_bytes[4],pair_bytes[5],pair_bytes[6],pair_bytes[7])
+                    # instruction_selection: mov.b32 {b8,b8,b8,b8}; two/SF
+                    packed_lo64 = cvt_u64_u32(packed_lo32)
+                    packed_hi64 = cvt_u64_u32(packed_hi32)
+                    # instruction_selection: cvt.u64.u32; two/SF
+                    packed_hi64 = shift_left_b64(packed_hi64,32)
+                    # instruction_selection: shl.b64; one/SF
+                    packed64 = or_b64(packed_hi64,packed_lo64)
+                    # instruction_selection: or.b64; one/SF
+                    store_global_u64(
+                        Y_u8 + actual_row*(H//2) + block_start//2,packed64)
+                    # instruction_selection: st.global.u64; one/SF
+
+                else:  # BLOCK_SIZE == 32
+                    # Source issues both 16-value chunks' X/W loads before
+                    # consuming either chunk.
+                    x0 = reg_fragment("u32",8)
+                    w0 = reg_fragment("u32",8)
+                    x1 = reg_fragment("u32",8)
+                    w1 = reg_fragment("u32",8)
+                    x0[0:4] = load_global_128(X+actual_row*H+block_start)
+                    x0[4:8] = load_global_128(X+actual_row*H+block_start+8)
+                    w0[0:4] = load_global_128(W+block_start)
+                    w0[4:8] = load_global_128(W+block_start+8)
+                    x1[0:4] = load_global_128(X+actual_row*H+block_start+16)
+                    x1[4:8] = load_global_128(X+actual_row*H+block_start+24)
+                    w1[0:4] = load_global_128(W+block_start+16)
+                    w1[4:8] = load_global_128(W+block_start+24)
+                    # instruction_selection: ld.global.v4.u32; exactly eight
+                    # issues ordered X0,X0,W0,W0,X1,X1,W1,W1 before arithmetic
+                    xw0 = reg_fragment("u32",8)
+                    xw1 = reg_fragment("u32",8)
+                    for pair in static_unroll(8):
+                        xw0[pair] = mul_input2(x0[pair],w0[pair],INPUT_DTYPE)
+                        # instruction_selection: mul.f16x2 or mul.bf16x2;
+                        # eight chunk0 packed issues before chunk1 begins
+                    for pair in static_unroll(8):
+                        xw1[pair] = mul_input2(x1[pair],w1[pair],INPUT_DTYPE)
+                        # instruction_selection: mul.f16x2 or mul.bf16x2;
+                        # eight chunk1 packed issues after all chunk0 multiplies
+                    abs0 = reg_fragment("u32",8)
+                    abs1 = reg_fragment("u32",8)
+                    for pair in static_unroll(8):
+                        abs0[pair] = and_b32(xw0[pair],0x7fff7fff)
+                        # instruction_selection: and.b32 0x7fff7fff;
+                        # eight chunk0 packed absolute-value issues
+                    m0_01 = max_input2(abs0[0],abs0[1],INPUT_DTYPE)
+                    m0_23 = max_input2(abs0[2],abs0[3],INPUT_DTYPE)
+                    m0_45 = max_input2(abs0[4],abs0[5],INPUT_DTYPE)
+                    m0_67 = max_input2(abs0[6],abs0[7],INPUT_DTYPE)
+                    m0_03 = max_input2(m0_01,m0_23,INPUT_DTYPE)
+                    m0_47 = max_input2(m0_45,m0_67,INPUT_DTYPE)
+                    max0 = max_input2(m0_03,m0_47,INPUT_DTYPE)
+                    # instruction_selection: max.f16x2 or max.bf16x2;
+                    # complete seven-issue chunk0 tree before chunk1 abs work
+                    for pair in static_unroll(8):
+                        abs1[pair] = and_b32(xw1[pair],0x7fff7fff)
+                        # instruction_selection: and.b32 0x7fff7fff;
+                        # eight chunk1 packed absolute-value issues
+                    m1_01 = max_input2(abs1[0],abs1[1],INPUT_DTYPE)
+                    m1_23 = max_input2(abs1[2],abs1[3],INPUT_DTYPE)
+                    m1_45 = max_input2(abs1[4],abs1[5],INPUT_DTYPE)
+                    m1_67 = max_input2(abs1[6],abs1[7],INPUT_DTYPE)
+                    m1_03 = max_input2(m1_01,m1_23,INPUT_DTYPE)
+                    m1_47 = max_input2(m1_45,m1_67,INPUT_DTYPE)
+                    max1 = max_input2(m1_03,m1_47,INPUT_DTYPE)
+                    # instruction_selection: max.f16x2 or max.bf16x2;
+                    # complete seven-issue chunk1 tree after all chunk1 abs work
+                    max_pair = max_input2(max0,max1,INPUT_DTYPE)
+                    # instruction_selection: max.f16x2 or max.bf16x2;
+                    # one final cross-chunk issue; fifteen max issues total
+                    if INPUT_DTYPE == "f16":
+                        max_lo16,max_hi16 = mov_b32_pair(max_pair)
+                        # instruction_selection: mov.b32 {b16,b16}; one/SF
+                        max_lo = cvt_f32_f16(max_lo16)
+                        max_hi = cvt_f32_f16(max_hi16)
+                        # instruction_selection: cvt.f32.f16; two/SF
+                    else:
+                        max_lo32 = and_b32(max_pair,0xffff)
+                        max_hi32 = shift_right_b32(max_pair,16)
+                        max_lo32 = shift_left_b32(max_lo32,16)
+                        max_hi32 = shift_left_b32(max_hi32,16)
+                        # instruction_selection: and.b32, shr.b32, then two
+                        # shl.b32 issues/SF
+                        max_lo = mov_b32_as_f32(max_lo32)
+                        max_hi = mov_b32_as_f32(max_hi32)
+                        # instruction_selection: mov.b32 to f32; two/SF
+                    max_xw = max_f32(max_lo,max_hi)
+                    # instruction_selection: max.f32; one horizontal max/SF
+                    y = reg_fragment("f32",(2,16))
+                    for chunk in static_unroll(2):
+                        words = xw0 if chunk == 0 else xw1
+                        for pair in static_unroll(8):
+                            if INPUT_DTYPE == "f16":
+                                lo16,hi16 = mov_b32_pair(words[pair])
+                                # instruction_selection: mov.b32 pair; one/pair
+                                lo = cvt_f32_f16(lo16)
+                                hi = cvt_f32_f16(hi16)
+                                # instruction_selection: cvt.f32.f16; two/pair
+                            else:
+                                lo32 = and_b32(words[pair],0xffff)
+                                hi32 = shift_right_b32(words[pair],16)
+                                lo32 = shift_left_b32(lo32,16)
+                                hi32 = shift_left_b32(hi32,16)
+                                # instruction_selection: and.b32, shr.b32,
+                                # two shl.b32 issues/pair
+                                lo = mov_b32_as_f32(lo32)
+                                hi = mov_b32_as_f32(hi32)
+                                # instruction_selection: mov.b32 to f32; two/pair
+                            y[chunk,2*pair] = mul_f32(lo,rstd)
+                            y[chunk,2*pair+1] = mul_f32(hi,rstd)
+                            # instruction_selection: mul.f32; 32 values/SF
+                    max_abs = mul_f32(max_xw,rstd)
+                    # instruction_selection: mul.f32; one/SF
+
+                    if SCALE_FORMAT == "ue8m0":
+                        scale_float = mul_f32(max_abs,fp4_max_rcp)
+                        # instruction_selection: mul.f32; one/SF
+                        nonpositive = setp_le_f32(scale_float,0.0)
+                        # instruction_selection: setp.le.f32; one/SF
+                        log2_value = lg2_fast(scale_float)
+                        # instruction_selection: lg2.approx.f32; one/SF
+                        exponent = cvt_s32_f32_rpi(log2_value)
+                        # instruction_selection: cvt.rpi.s32.f32; one/SF
+                        biased = add_s32(exponent,127)
+                        # instruction_selection: add.s32; one/SF
+                        negative = setp_lt_s32(biased,0)
+                        overflow = setp_gt_s32(biased,255)
+                        # instruction_selection: setp.lt.s32 and setp.gt.s32;
+                        # one each/SF
+                        biased = select_s32(0,biased,negative)
+                        biased = select_s32(255,biased,overflow)
+                        scale_word = select_s32(0,biased,nonpositive)
+                        # instruction_selection: selp.s32; three/SF in this order
+                        scale_byte = scale_word & 0xff
+                        # instruction_selection: source low-byte view is DCE;
+                        # zero standalone instructions before st.global.b8
+                        scale_zero = setp_eq_u32(scale_word,0)
+                        # instruction_selection: setp.eq.u32; one/SF
+                        negative_exponent = sub_s32(127,scale_word)
+                        # instruction_selection: sub.s32; one/SF
+                        negative_exponent_f32 = cvt_f32_s32_rn(negative_exponent)
+                        # instruction_selection: cvt.rn.f32.s32; one/SF
+                        inverse_candidate = ex2_fast(negative_exponent_f32)
+                        # instruction_selection: ex2.approx.f32; one/SF
+                        inv_scale = select_f32(0.0,inverse_candidate,scale_zero)
+                        # instruction_selection: selp.f32; one/SF
+                    else:
+                        scale_float = mul_f32(
+                            mul_f32(global_scale_value,max_abs),fp4_max_rcp)
+                        # instruction_selection: mul.f32 chain; two/SF
+                        scale_float = min_f32(scale_float,448.0)
+                        # instruction_selection: min.f32; one/SF
+                        fp8_zero = mov_f32(0.0)
+                        # instruction_selection: mov.f32 zero; one/SF
+                        scale_pair16 = cvt_e4m3_pair(fp8_zero,scale_float)
+                        # instruction_selection:
+                        # cvt.rn.satfinite.e4m3x2.f32; one/SF
+                        scale_word = cvt_u32_u16(scale_pair16)
+                        # instruction_selection: cvt.u32.u16; one/SF
+                        scale_byte = scale_word & 0xff
+                        # instruction_selection: source low-byte view is DCE;
+                        # zero standalone instructions before st.global.b8
+                        decode_pair16 = cvt_u16_u32(scale_word)
+                        # instruction_selection: cvt.u16.u32; one/SF
+                        decoded_h2 = cvt_f16x2_e4m3x2(decode_pair16)
+                        # instruction_selection: cvt.rn.f16x2.e4m3x2; one/SF
+                        decoded_lo16,_ = mov_b32_pair(decoded_h2)
+                        # instruction_selection: mov.b32 pair; one/SF
+                        decoded = cvt_f32_f16(decoded_lo16)
+                        # instruction_selection: cvt.f32.f16; one/SF
+                        reciprocal = rcp_fast(decoded)
+                        # instruction_selection: rcp.approx.ftz.f32; one/SF
+                        decoded_zero = setp_eq_f32(decoded,0.0)
+                        # instruction_selection: setp.eq.f32; one/SF
+                        decoded_rcp = select_f32(0.0,reciprocal,decoded_zero)
+                        # instruction_selection: selp.f32; one/SF
+                        inv_scale = mul_f32(decoded_rcp,global_scale_value)
+                        # instruction_selection: mul.f32; one/SF
+
+                    s_offset = swizzled_scale_offset(actual_row,sf_idx) \
+                               if SWIZZLED else actual_row*(H//32)+sf_idx
+                    store_global_b8(S_u8+s_offset,scale_byte)
+                    # instruction_selection: st.global.b8; one/SF, before Y
+                    for chunk in static_unroll(2):
+                        scaled = reg_fragment("f32",16)
+                        for value in static_unroll(16):
+                            scaled[value] = mul_f32(y[chunk,value],inv_scale)
+                            # instruction_selection: mul.f32; sixteen/chunk
+                        pair_bytes = reg_fragment("u8",8)
+                        for pair in static_unroll(8):
+                            pair_bytes[pair] = cvt_e2m1_pair(
+                                scaled[2*pair+1],scaled[2*pair])
+                            # instruction_selection:
+                            # cvt.rn.satfinite.e2m1x2.f32 to b8; eight/chunk
+                        packed_lo32 = mov_b32_bytes(
+                            pair_bytes[0],pair_bytes[1],
+                            pair_bytes[2],pair_bytes[3])
+                        packed_hi32 = mov_b32_bytes(
+                            pair_bytes[4],pair_bytes[5],
+                            pair_bytes[6],pair_bytes[7])
+                        # instruction_selection: mov.b32 {b8,b8,b8,b8};
+                        # two/chunk
+                        packed_lo64 = cvt_u64_u32(packed_lo32)
+                        packed_hi64 = cvt_u64_u32(packed_hi32)
+                        # instruction_selection: cvt.u64.u32; two/chunk
+                        packed_hi64 = shift_left_b64(packed_hi64,32)
+                        # instruction_selection: shl.b64; one/chunk
+                        packed64 = or_b64(packed_hi64,packed_lo64)
+                        # instruction_selection: or.b64; one/chunk
+                        store_global_u64(
+                            Y_u8+actual_row*(H//2)
+                            +(block_start+chunk*16)//2,packed64)
+                        # instruction_selection: st.global.u64; chunk0 then chunk1
+
+        if SF_PER_THREAD <= 7:
+            for sf_iter in static_unroll(SF_PER_THREAD):
+                process_one_sf(lane_in_row + sf_iter*TPR)
+        else:
+            sf_iter = 0
+            while sf_iter < SF_PER_THREAD:
+                process_one_sf(lane_in_row + sf_iter*TPR)
+                process_one_sf(lane_in_row + (sf_iter+1)*TPR)
+                # second call retains its sf_idx < H/BLOCK_SIZE predicate
+                sf_iter += 2
+            # instruction_selection: add.s32 cursor by 2, setp.ne.b32 against
+            # SF_PER_THREAD, then predicated `@p bra` backedge; two static SF
+            # payloads/body and the second payload retains its sf bound guard
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; one CTA issue
+```
+
+## Scale addressing and literal source behavior
+
+Linear S offset is `row*(H/BLOCK_SIZE)+sf`. Swizzled offset is exactly
+
+```text
+(row//128) * (ceil((H/BLOCK_SIZE)/4) * 512)
++ (sf//4) * 512
++ (row%32) * 16
++ ((row%128)//32) * 4
++ (sf%4)
+```
+
+The swizzled allocation is padded to
+`ceil(M/128)*ceil((H/BLOCK_SIZE)/4)*512` bytes; only valid logical positions
+are written. Phase 3 uses full-H `sf_idx` in every cluster CTA. The redundant
+cluster stores are literal pinned-source behavior and are not deduplicated.
+
+Block16 always executes E4M3 scaling even if the cache key says UE8M0.
+Block32 chooses UE8M0 or E4M3. The public canonical pairs are block16/E4M3
+and block32/UE8M0, but the reachable block32/E4M3 class specialization remains
+in the correctness domain. The global scale is part of the E4M3 scale and
+inverse-scale topology; it is not applied as a separate normalization factor.
+UE8M0 ignores it, so its load may disappear from emitted PTX.
+
+The packed multiply happens in FP16x2/BF16x2 before widening; replacing it
+with FP32 multiplication changes both max-abs and raw output bytes. E2M1
+conversion uses native saturating round-to-nearest pair instructions. Scale
+bytes are computed and stored before packed Y bytes, preserving source order.
+
+## Verification locked into the module
+
+The module's validation manifest covers the full upstream 1007-case logical
+matrix plus structural guards for both input dtypes, both canonical formats,
+reachable block32/E4M3, zero and explicit global scales, block/tile/thread
+thresholds, row tails, 2-D/3-D flattening, swizzled M/K padding, PDL, the
+7-to-8 loop boundary, and cluster 2/16. Every specialization passes the
+low-level no-tile/no-call gate before execution. Correctness compares raw Y
+bytes and logical S bytes with the CuTeDSL kernel, checks dequantized RMSNorm
+against an independent FP32 oracle, verifies input/weight/global-scale
+immutability, output identity and untouched padding/guards.
+
+The required performance matrix is exactly the six pinned FlashInfer sample
+rows. Only one reference-enabled `tirx_kernels.bench_suite` artifact may decide
+performance retention; diagnostic timing or profiler duration is not a gate.

--- a/.agents/skills/tirx-codegen-tuning/references/db/declare-the-block-shape-the-reference-declares.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/declare-the-block-shape-the-reference-declares.md
@@ -1,6 +1,6 @@
 # Declare the block shape the reference declares
 
-**Symptoms:** `special_register_reads`, `instruction_count_bloat`, `slow_latency_bound_shape`
+**Symptoms:** `special_register_reads`, `instruction_count_bloat`, `slow_latency_bound_shape`, `launch_config_drift`, `instruction_variant_mismatch`
 
 ## Symptom
 
@@ -25,6 +25,20 @@ lane: T.int32 = tid % 32
 lane_quad: T.int32 = lane % 4
 ```
 
+Match the strength of the declaration too. A static thread extent ordinarily
+lowers through a launch bound and permits any block no larger than `.maxntid`.
+When fresh reference PTX instead requires `.reqntid`, request the exact block
+contract explicitly.
+
+```python
+# before: the extent can still lower to __launch_bounds__ and .maxntid.
+tid = T.thread_id([THREADS])
+
+# after: require the declared thread and cluster extents exactly.
+T.attr({"tirx.required_block_size": 1})
+tid = T.thread_id([THREADS])
+```
+
 ## Rationale
 
 A multi-dimensional `thread_id` costs a special-register read per component at
@@ -35,6 +49,27 @@ specified a flat one. It cost 4608 dynamic `S2R` plus 4608 `S2UR`; flattening
 moved the worst shape from 0.864x to 1.016x and removed 48 static instructions,
 all in the affected phase.
 
+The exact-block case is a separate contract, not a stronger spelling of the
+same launch bound. A CUDA 13 probe showed that `__block_size__` changed
+`.maxntid` to `.reqntid`, but also emitted `.reqnctapercluster` and
+`.blocksareclusters`. The matching runtime therefore launched with the CUDA
+required-block sentinel, omitted a duplicate runtime cluster attribute, and
+converted the logical CTA grid to a cluster grid. Cluster-1, cluster-2, and
+cluster-16 correctness all passed, as did 1,025 source-domain configurations;
+the complete measured matrix retained 1.018-1.046x reference/port ratios.
+
+## Boundary
+
+Use the required-block contract only when fresh reference PTX requires exact
+dimensions. It needs CUDA 13 or newer, static thread and cluster extents, and a
+runtime that understands CUDA's cluster-grid launch semantics. Do not replace a
+register-budget launch bound with it: `.maxntid` and `.reqntid` promise different
+things, and the measured result above establishes source-contract matching, not
+an isolated speedup from strengthening the directive.
+
 ## Verification
 
-Confirm with dynamic special-register counts on the worst shape.
+Confirm flat-versus-dimensional declarations with dynamic special-register
+counts on the worst shape. For an exact declaration, inspect final PTX for
+`.reqntid`, inspect the accompanying cluster directives, and launch guards at
+cluster 1 and greater than 1 before accepting the performance matrix.

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-conversion-and-packing-idioms.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-conversion-and-packing-idioms.md
@@ -41,6 +41,24 @@ chains, or store width diverges from the reference's transaction width.
   in another kernel instead of inventing a new lowering.
 - Match shuffle masks and saturation/rounding modifiers exactly.
 
+When one source helper converts four pairs and packs the four byte results with
+the four-input form of `mov.b32`, keep the conversion results inside one typed
+compound intrinsic. Returning each byte through an ordinary scalar helper can
+force a shift/or pack even though the final PTX idiom is native.
+
+```python
+# before: four separately returned byte carriers are shifted and ORed.
+for pair in T.unroll(4):
+    byte[pair] = _cvt_pair_to_byte(values[2 * pair], values[2 * pair + 1])
+packed = _shift_or_four_bytes(byte)
+
+# after: the helper owns four paired conversions and one four-input mov.b32.
+packed = T.cuda.cvt_e2m1x8_f32(
+    values[0], values[1], values[2], values[3],
+    values[4], values[5], values[6], values[7],
+)
+```
+
 The store keeps its own width independent of both:
 
 ```python
@@ -61,6 +79,19 @@ else:
     if PACKED_STORE:
         for pair in T.unroll(NUM_VALUES // 2):
             T.ptx.mov.b32(words[pair], halves[2 * pair], halves[2 * pair + 1])
+```
+
+The PTX store's data carrier is independent as well. If the reference feeds the
+low byte of a word directly to `st.global.b8`, preserve the word carrier instead
+of inserting a TIR-level narrowing operation.
+
+```python
+# before: narrowing is introduced only to satisfy the wrapper's source dtype.
+byte = T.cast(scale_word, "uint8")
+T.ptx.st.global_.b8(address, byte)
+
+# after: the certified overload consumes the low byte of the uint32 carrier.
+T.ptx.st.global_.b8(address, scale_word)
 ```
 
 Derive both selectors from fresh reference PTX for the complete static fragment
@@ -84,6 +115,13 @@ scalar-narrowed eight-element path still repacked its results for a
 correctness matrix and retained a final 1.003-1.010x three-shape benchmark
 matrix.
 
+In a second measured packed-4-bit family, one eight-value group became exactly
+four `cvt.rn.satfinite.e2m1x2.f32` plus one `mov.b32` instead of separate byte
+returns and a shift/or chain. Its scale byte also flowed from a uint32 word to
+one `st.global.b8` without a narrowing instruction. Exact packed-output and
+scale-byte comparison passed 1,025 configurations, and all six measured shapes
+retained 1.018-1.046x reference/port ratios.
+
 ## Boundary
 
 The exact packed/scalar selector is a property of the source fragment layout
@@ -91,10 +129,17 @@ and compiler version, not a universal power-of-two or vector-width rule. Record
 the observed selector as compile-time specialization data and re-probe its
 boundary when either changes.
 
+Only add a wider source-carrier overload after ptxas certifies that exact PTX
+operand class. A byte store consuming the low byte of a uint32 register does not
+justify weakening every b8 operation's dtype contract. Likewise, use a compound
+intrinsic for a native multi-output packing idiom, not as a container for an
+arbitrary workload-specific instruction sequence.
+
 ## Verification
 
 Confirm packed words bitwise before judging instruction count. Trace the
 conversion-to-store def-use chain in SASS instead of comparing conversion
 mnemonics in isolation. Probe adjacent fragment extents and both dtypes, then
 count scalar conversions, packed conversions, explicit packs, and final store
-transactions independently.
+transactions independently. For low-byte stores, also check that final PTX has
+no cast or narrowing instruction between the producing word and `st.global.b8`.

--- a/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
@@ -55,6 +55,25 @@ while cursor[0] < num_items:
     cursor[0] = cursor[0] + 1
 ```
 
+When the reference itself changes policy at a compile-time trip count, branch
+on that derived count rather than using one blanket loop form. Preserve any
+partial unroll visible inside the rolled body.
+
+```python
+# The threshold and body unroll come from adjacent fresh reference profiles.
+if trips < ROLL_THRESHOLD:
+    for u in T.unroll(trips):
+        consume(u)
+else:
+    cursor: T.int32 = T.int32(0)
+    while True:
+        consume(cursor)
+        consume(cursor + 1)
+        cursor = cursor + 2
+        if cursor >= trips:
+            break
+```
+
 ## Rationale
 
 The unrolled body is the same dynamic work, but several copies of it on a grid
@@ -100,6 +119,17 @@ with the fewest search iterations moved 0.9727 to 1.0631 and the next 0.9902 to
 1.0343, while the long-sequence shapes, which run the search deepest and
 amortize it over the most work, moved by under half a percent.
 
+One source-exact quantization loop provided a sharp adjacent-profile boundary.
+Seven scale groups per thread were fully expanded: the PTX was 98,957 bytes,
+had no backward branch, and contained seven static output stores. At eight
+groups the source switched to a two-group rolled body: PTX fell to 47,230 bytes
+and one backedge, with two static stores in the body. Branching on the derived
+group count and using `While` on the rolled side reproduced both structures;
+the surrounding port passed 1,025 correctness configurations and its complete
+six-shape performance matrix. Those timings do not isolate the large-trip loop,
+so the reusable result is the measured structural boundary, not a claimed
+speedup at eight groups.
+
 ## Boundary
 
 Only where the reference's loop is genuinely rolled -- whether it says so with a
@@ -107,6 +137,11 @@ Only where the reference's loop is genuinely rolled -- whether it says so with a
 on a counted loop. If it unrolls its own loop, match that instead. Rolling is
 not a general win: it trades code size against loop overhead, and a loop whose
 body is small relative to its trip count can prefer the unrolled form.
+
+A source threshold is specific to its compiler version and the derived trip
+count, not to a convenient tensor dimension. Re-export adjacent profiles when
+the source compiler changes, and do not extrapolate the seven-to-eight boundary
+to a different loop body.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `mxfp4_quantize`                        | `quantization/mxfp4_quantize.py`                    | Block quantization with UE8M0 scales |
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
 | `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
+| `flashinfer_rmsnorm_fp4quant`           | `norm/rmsnorm_fp4quant.py`                          | RMSNorm fused with packed E2M1 FP4 quantization, E4M3 or UE8M0 block scales, optional scale swizzling, PDL, and cluster reduction |
 | `flashinfer_layernorm`                  | `norm/layernorm.py`                                 | BF16 LayerNorm with FP32 affine parameters, independent int64 row strides, and optional PDL |
 | `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_fused_add_rmsnorm_quant`    | `norm/fused_add_rmsnorm_quant.py`                   | Fused residual add, RMSNorm, and FP8 quantization with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -10,7 +10,7 @@ tree, so a kernel's configs sit at `config/<bucket>/<kernel>.yaml`. With no
 `--workloads`, the flagged configs across all files are assembled into
 `.bench-suite/workloads.generated.yaml` and that is what runs. The generated
 file is the inspectable source of truth for the current representative sweep.
-Every kernel has at most three default small/medium/large representatives; the current tree assembles 173
+Every kernel has at most three default small/medium/large representatives; the current tree assembles 179
 workloads. Widening or narrowing the sweep is a YAML `default`
 flag flip, not a scheduler rule or a second selection file. Multi-GPU configs
 are deliberately absent from the default measured sweep but remain available

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -2,13 +2,13 @@
   "timestamp": "14",
   "label": "post-refactor",
   "git": {
-    "tir": "3df3e86a",
-    "tirx-kernels": "521f16bf-dirty",
+    "tir": "135a054f",
+    "tirx-kernels": "b405c5cb",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "14fcbbf2fb46caaa36472e199bf91c3350a22ec5"
+    "tirx-kernels:tirx_kernels": "44b38022bd0b8643153e5c8de42da53d998e704c"
   },
   "baselines": {
     "torch": {
@@ -2544,6 +2544,90 @@
       "impls": {
         "tirx": 3.4584417197769426,
         "flashinfer_cutedsl": 3.4412295032725257
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.001454621638744,
+        "flashinfer_cutedsl": 4.073269817270862
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.648938698993347,
+        "flashinfer_cutedsl": 2.737106204933017
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.568517369546825,
+        "flashinfer_cutedsl": 4.751573483387964
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random",
+      "label": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.647691026547789,
+        "flashinfer_cutedsl": 4.8623331023772165
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.834194894089477,
+        "flashinfer_cutedsl": 5.034695922873405
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_fp4quant",
+      "config": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 4.671817443687989,
+        "flashinfer_cutedsl": 4.757455522012428
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '3df3e86a', 'tirx-kernels': '521f16bf-dirty', 'tirx-bench-ci': None}`
-- Workloads: 422 ok, 0 failed
+- Git:       `{'tir': '135a054f', 'tirx-kernels': 'b405c5cb', 'tirx-bench-ci': None}`
+- Workloads: 428 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -297,6 +297,17 @@ Grouped workloads show one row per config and one timing column per implementati
 | `rms_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.3644 | flashinfer_cutedsl | 3.4527 | 1.026 | — |
 | `rms_bf16_m32_h4096_xc_yc_pdl1` | tirx | 3.3516 | flashinfer_cutedsl | 3.3558 | 1.001 | — |
 | `rms_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4584 | flashinfer_cutedsl | 3.4412 | 0.995 | — |
+
+## flashinfer_rmsnorm_fp4quant
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.0015 | flashinfer_cutedsl | 4.0733 | 1.018 | — |
+| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.6489 | flashinfer_cutedsl | 2.7371 | 1.033 | — |
+| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.5685 | flashinfer_cutedsl | 4.7516 | 1.040 | — |
+| `bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 4.6477 | flashinfer_cutedsl | 4.8623 | 1.046 | — |
+| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.8342 | flashinfer_cutedsl | 5.0347 | 1.041 | — |
+| `bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.6718 | flashinfer_cutedsl | 4.7575 | 1.018 | — |
 
 ## flashkda_bf16_fused_m128
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm_fp4quant.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_rmsnorm_fp4quant.yaml
@@ -1,0 +1,9 @@
+kernel: flashinfer_rmsnorm_fp4quant
+selection_rationale: The defaults cover the flattened 3-D launch, the primary NVFP4 shape, and the largest active shape; global-scale, swizzled-scale, and MXFP4 variants remain available on request.
+configs:
+  - {config: bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: medium}
+  - {config: bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: large}
+  - {config: bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random, default: false}
+  - {config: bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: small}

--- a/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
@@ -1,0 +1,1476 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL RMSNorm with packed FP4 quantization.
+
+The source implementation is ``RMSNormFP4QuantKernel`` in
+``flashinfer/cute_dsl/rmsnorm_fp4quant.py`` with inline PTX helpers from
+``flashinfer/cute_dsl/fp4_common.py``.  The public entry is
+``flashinfer.norm.rmsnorm_fp4quant``.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+from tirx_kernels.flashinfer.utils.fp_quant import (
+    absmax_8,
+    hmax2,
+    pack_u32x2_to_u64,
+    sf_offset_128x4,
+)
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "flashinfer_rmsnorm_fp4quant",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_DTYPES = ("float16", "bfloat16")
+_DEFAULT_EPS = 1e-6
+_OPTIN_SMEM_BYTES = 232448
+
+
+def _ptx_unary(chain: str, value, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], value))
+    return out[0]
+
+
+def _ptx_binary(chain: str, lhs, rhs, dtype: str = "float32"):
+    out = T.alloc_local((1,), dtype)
+    T.evaluate(T.ptx[chain](out[0], lhs, rhs))
+    return out[0]
+
+
+def _add_f32(lhs, rhs):
+    return _ptx_binary("add.f32", lhs, rhs)
+
+
+def _mul_f32(lhs, rhs):
+    return _ptx_binary("mul.f32", lhs, rhs)
+
+
+def _add_s32(lhs, rhs):
+    return _ptx_binary("add.s32", lhs, rhs, dtype="int32")
+
+
+def _div_rn_f32(lhs, rhs):
+    return _ptx_binary("div.rn.f32", lhs, rhs)
+
+
+def _fma_rn_f32(lhs, rhs, acc):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.fma.rn.f32(out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _rcp_approx_ftz(value):
+    return _ptx_unary("rcp.approx.ftz.f32", value)
+
+
+def _rsqrt_approx_ftz(value):
+    return _ptx_unary("rsqrt.approx.ftz.f32", value)
+
+
+def _cvt_to_f32(bits, input_dtype: str):
+    chain = "cvt.f32.f16" if input_dtype == "float16" else "cvt.f32.bf16"
+    return _ptx_unary(chain, T.cast(bits, "uint16"))
+
+
+def _shfl_bfly_f32(value, lane_xor: int):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0],
+            T.reinterpret("uint32", value),
+            T.uint32(lane_xor),
+            T.uint32(31),
+            T.uint32(0xFFFFFFFF),
+        )
+    )
+    return T.reinterpret("float32", out[0])
+
+
+def _butterfly_sum_f32(value, lane_xors: tuple[int, ...]):
+    for lane_xor in lane_xors:
+        value = _add_f32(value, _shfl_bfly_f32(value, lane_xor))
+    return value
+
+
+def _mapa_u32(pointer, peer):
+    mapped = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.mapa.shared__cluster.u32(
+            mapped[0], T.cuda.cvta_generic_to_shared(pointer), T.cast(peer, "uint32")
+        )
+    )
+    return mapped[0]
+
+
+@T.inline
+def _cluster_mbarrier_wait(pointer):
+    T.cuda.mbarrier_wait_relaxed(pointer)
+
+
+def _mul_input2(lhs, rhs, input_dtype: str):
+    chain = "mul.f16x2" if input_dtype == "float16" else "mul.bf16x2"
+    return _ptx_binary(chain, lhs, rhs, dtype="uint32")
+
+
+def _minimum_f32(lhs, rhs):
+    return _ptx_binary("min.f32", lhs, rhs)
+
+
+def _cvt_f32_to_e4m3(value):
+    pair = T.alloc_local((1,), "uint16")
+    word = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.cvt.rn.satfinite.e4m3x2.f32(pair[0], T.float32(0.0), value))
+    T.evaluate(T.ptx.cvt.u32.u16(word[0], pair[0]))
+    return word[0]
+
+
+def _e4m3_to_f32_rcp(value):
+    pair = T.alloc_local((1,), "uint16")
+    halves = T.alloc_local((1,), "uint32")
+    half_bits = T.alloc_local((2,), "uint16")
+    decoded = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.cvt.u16.u32(pair[0], value))
+    T.evaluate(T.ptx.cvt.rn.f16x2.e4m3x2(halves[0], pair[0]))
+    T.evaluate(T.ptx.mov.b32(half_bits[0], half_bits[1], halves[0]))
+    T.evaluate(T.ptx.cvt.f32.f16(decoded[0], half_bits[0]))
+    reciprocal = _rcp_approx_ftz(decoded[0])
+    return T.Select(decoded[0] == T.float32(0.0), T.float32(0.0), reciprocal)
+
+
+def _cvt_f32_to_ue8m0(value):
+    predicate_zero = T.local_scalar("uint32")
+    predicate_negative = T.local_scalar("uint32")
+    predicate_overflow = T.local_scalar("uint32")
+    log2_value = T.alloc_local((1,), "float32")
+    exponent = T.alloc_local((1,), "int32")
+    result = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.setp.le.f32(predicate_zero, value, T.float32(0.0)))
+    T.evaluate(T.ptx.lg2.approx.f32(log2_value[0], value))
+    T.evaluate(T.ptx["cvt.rpi.s32.f32"](exponent[0], log2_value[0]))
+    T.evaluate(T.ptx.add.s32(result[0], exponent[0], T.int32(127)))
+    T.evaluate(T.ptx.setp.lt.s32(predicate_negative, result[0], T.int32(0)))
+    T.evaluate(T.ptx.setp.gt.s32(predicate_overflow, result[0], T.int32(255)))
+    T.evaluate(T.ptx.selp.s32(result[0], T.int32(0), result[0], T.ptx.pred(predicate_negative)))
+    T.evaluate(T.ptx.selp.s32(result[0], T.int32(255), result[0], T.ptx.pred(predicate_overflow)))
+    T.evaluate(T.ptx.selp.s32(result[0], T.int32(0), result[0], T.ptx.pred(predicate_zero)))
+    return T.cast(result[0], "uint32")
+
+
+def _ue8m0_to_output_scale(value):
+    predicate_zero = T.local_scalar("uint32")
+    negative_exponent = T.alloc_local((1,), "int32")
+    negative_exponent_f32 = T.alloc_local((1,), "float32")
+    candidate = T.alloc_local((1,), "float32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.setp.eq.u32(predicate_zero, value, T.uint32(0)))
+    T.evaluate(T.ptx.sub.s32(negative_exponent[0], T.int32(127), T.cast(value, "int32")))
+    T.evaluate(T.ptx["cvt.rn.f32.s32"](negative_exponent_f32[0], negative_exponent[0]))
+    T.evaluate(T.ptx.ex2.approx.f32(candidate[0], negative_exponent_f32[0]))
+    T.evaluate(T.ptx.selp.f32(out[0], T.float32(0.0), candidate[0], T.ptx.pred(predicate_zero)))
+    return out[0]
+
+
+def _load_16_input_words(buffer, base_index):
+    words = T.alloc_local((8,), "uint32")
+    T.evaluate(
+        T.ptx.ld.global_.v4.u32(
+            words[0], words[1], words[2], words[3], T.address_of(buffer[base_index])
+        )
+    )
+    T.evaluate(
+        T.ptx.ld.global_.v4.u32(
+            words[4], words[5], words[6], words[7], T.address_of(buffer[base_index + 8])
+        )
+    )
+    return words
+
+
+def _multiply_8_pairs(lhs, rhs, input_dtype: str):
+    products = T.alloc_local((8,), "uint32")
+    chain = T.ptx.mul.f16x2 if input_dtype == "float16" else T.ptx.mul.bf16x2
+    for pair in range(8):
+        T.evaluate(chain(products[pair], lhs[pair], rhs[pair]))
+    return products
+
+
+def _pair_max_to_f32(word, input_dtype: str):
+    out = T.alloc_local((1,), "float32")
+    if input_dtype == "float16":
+        bits = T.alloc_local((2,), "uint16")
+        values = T.alloc_local((2,), "float32")
+        T.evaluate(T.ptx.mov.b32(bits[0], bits[1], word))
+        T.evaluate(T.ptx.cvt.f32.f16(values[0], bits[0]))
+        T.evaluate(T.ptx.cvt.f32.f16(values[1], bits[1]))
+        T.evaluate(T.ptx.max.f32(out[0], values[0], values[1]))
+    else:
+        low_bits = T.bitwise_and(word, T.uint32(0xFFFF))
+        high_bits = T.shift_right(word, T.uint32(16))
+        low = T.reinterpret("float32", T.shift_left(low_bits, T.uint32(16)))
+        high = T.reinterpret("float32", T.shift_left(high_bits, T.uint32(16)))
+        T.evaluate(T.ptx.max.f32(out[0], low, high))
+    return out[0]
+
+
+def _widen_and_scale_16(words, scale, input_dtype: str):
+    values = T.alloc_local((16,), "float32")
+    for pair in range(8):
+        bits = T.alloc_local((2,), "uint16")
+        widened = T.alloc_local((2,), "float32")
+        T.evaluate(T.ptx.mov.b32(bits[0], bits[1], words[pair]))
+        if input_dtype == "float16":
+            T.evaluate(T.ptx.cvt.f32.f16(widened[0], bits[0]))
+            T.evaluate(T.ptx.cvt.f32.f16(widened[1], bits[1]))
+        else:
+            T.evaluate(T.ptx.cvt.f32.bf16(widened[0], bits[0]))
+            T.evaluate(T.ptx.cvt.f32.bf16(widened[1], bits[1]))
+        T.evaluate(T.ptx.mul.f32(values[pair * 2], widened[0], scale))
+        T.evaluate(T.ptx.mul.f32(values[pair * 2 + 1], widened[1], scale))
+    return values
+
+
+def _store_global_u64(pointer, value):
+    T.evaluate(T.ptx.st.global_.u64(pointer, value))
+
+
+def _quantize_and_pack_16(values, output_scale):
+    scaled = T.alloc_local((16,), "float32")
+    for value in range(16):
+        T.evaluate(T.ptx.mul.f32(scaled[value], values[value], output_scale))
+    low = T.cuda.cvt_e2m1x8_f32(
+        scaled[0], scaled[1], scaled[2], scaled[3], scaled[4], scaled[5], scaled[6], scaled[7]
+    )
+    high = T.cuda.cvt_e2m1x8_f32(
+        scaled[8], scaled[9], scaled[10], scaled[11], scaled[12], scaled[13], scaled[14], scaled[15]
+    )
+    return pack_u32x2_to_u64(low, high)
+
+
+def _scale_offset(actual_row, sf_index, H: int, block_size: int, swizzled: bool):
+    scale_columns = H // block_size
+    if swizzled:
+        return sf_offset_128x4(actual_row, sf_index, _ceil_div(scale_columns, 4) * 4)
+    return actual_row * scale_columns + sf_index
+
+
+@T.inline
+def _process_scale_block(
+    x,
+    weight,
+    y,
+    scales,
+    actual_row,
+    sf_index,
+    rstd,
+    global_scale_value,
+    fp4_max_rcp,
+    *,
+    H: T.constexpr,
+    block_size: T.constexpr,
+    scale_format: T.constexpr,
+    swizzled: T.constexpr,
+    input_dtype: T.constexpr,
+):
+    num_scale_blocks = H // block_size
+    if sf_index < num_scale_blocks:
+        block_start = sf_index * block_size
+        x_base = actual_row * H + block_start
+
+        x0 = _load_16_input_words(x, x_base)
+        w0 = _load_16_input_words(weight, block_start)
+
+        if block_size == 16:
+            products0 = _multiply_8_pairs(x0, w0, input_dtype)
+            pair_max = absmax_8(products0, input_dtype)
+            max_xw = _pair_max_to_f32(pair_max, input_dtype)
+            values0 = _widen_and_scale_16(products0, rstd, input_dtype)
+            max_abs = _mul_f32(max_xw, rstd)
+            scale_value = _mul_f32(_mul_f32(global_scale_value, max_abs), fp4_max_rcp)
+            scale_value = _minimum_f32(scale_value, T.float32(448.0))
+            scale_word = _cvt_f32_to_e4m3(scale_value)
+            output_scale = _mul_f32(_e4m3_to_f32_rcp(scale_word), global_scale_value)
+            scale_offset = _scale_offset(actual_row, sf_index, H, block_size, swizzled)
+            T.ptx.st.global_.b8(T.address_of(scales[scale_offset]), scale_word)
+            packed0 = _quantize_and_pack_16(values0, output_scale)
+            y_offset = T.cast(actual_row, "int64") * (H // 2) + block_start // 2
+            _store_global_u64(T.address_of(y[y_offset]), packed0)
+        else:
+            x1 = _load_16_input_words(x, x_base + 16)
+            w1 = _load_16_input_words(weight, block_start + 16)
+            products0 = _multiply_8_pairs(x0, w0, input_dtype)
+            products1 = _multiply_8_pairs(x1, w1, input_dtype)
+            max0 = absmax_8(products0, input_dtype)
+            max1 = absmax_8(products1, input_dtype)
+            pair_max = hmax2(max0, max1, input_dtype)
+            max_xw = _pair_max_to_f32(pair_max, input_dtype)
+            values0 = _widen_and_scale_16(products0, rstd, input_dtype)
+            values1 = _widen_and_scale_16(products1, rstd, input_dtype)
+            max_abs = _mul_f32(max_xw, rstd)
+            if scale_format == "ue8m0":
+                scale_word = _cvt_f32_to_ue8m0(_mul_f32(max_abs, fp4_max_rcp))
+                output_scale = _ue8m0_to_output_scale(scale_word)
+            else:
+                scale_value = _mul_f32(_mul_f32(global_scale_value, max_abs), fp4_max_rcp)
+                scale_value = _minimum_f32(scale_value, T.float32(448.0))
+                scale_word = _cvt_f32_to_e4m3(scale_value)
+                output_scale = _mul_f32(_e4m3_to_f32_rcp(scale_word), global_scale_value)
+            scale_offset = _scale_offset(actual_row, sf_index, H, block_size, swizzled)
+            T.ptx.st.global_.b8(T.address_of(scales[scale_offset]), scale_word)
+            packed0 = _quantize_and_pack_16(values0, output_scale)
+            packed1 = _quantize_and_pack_16(values1, output_scale)
+            y_offset = T.cast(actual_row, "int64") * (H // 2) + block_start // 2
+            _store_global_u64(T.address_of(y[y_offset]), packed0)
+            _store_global_u64(T.address_of(y[y_offset + 8]), packed1)
+
+
+def _ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def _threads_per_row(H_per_cta: int) -> int:
+    if H_per_cta <= 64:
+        return 8
+    if H_per_cta <= 128:
+        return 16
+    if H_per_cta <= 3072:
+        return 32
+    if H_per_cta <= 6144:
+        return 64
+    if H_per_cta <= 16384:
+        return 128
+    return 256
+
+
+def _derived_config(H: int, cluster_n: int) -> dict[str, int]:
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec_blocks = max(1, _ceil_div(H_per_cta // 8, tpr))
+    cols = 8 * vec_blocks * tpr
+    tile_bytes = rows * cols * 2
+    return {
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+    }
+
+
+def _estimate_smem(H: int, cluster_n: int) -> int:
+    config = _derived_config(H, cluster_n)
+    reduction = config["rows"] * config["warps_per_row"] * 4
+    if cluster_n == 1:
+        return 2 * config["tile_bytes"] + reduction
+    return config["tile_bytes"] + reduction * cluster_n + 8
+
+
+def _source_config(H: int) -> dict[str, int]:
+    cluster_n = 16
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and _estimate_smem(H, candidate) <= _OPTIN_SMEM_BYTES:
+            cluster_n = candidate
+            break
+    config = _derived_config(H, cluster_n)
+    config["cluster_n"] = cluster_n
+    config["smem_bytes"] = (
+        config["tile_bytes"]
+        + config["rows"] * config["warps_per_row"] * cluster_n * 4
+        + (8 if cluster_n > 1 else 0)
+    )
+    return config
+
+
+def _dtype_code(dtype: str) -> str:
+    return {"float16": "fp16", "bfloat16": "bf16"}[dtype]
+
+
+def _eps_code(eps: float) -> str:
+    return {1e-4: "1e4", 1e-5: "1e5", 1e-6: "1e6"}[eps]
+
+
+def _cfg(
+    case: str,
+    dtype: str,
+    H: int,
+    *,
+    M: int | None = None,
+    B: int | None = None,
+    S: int | None = None,
+    block_size: int = 16,
+    scale_format: str = "e4m3",
+    swizzled: bool = False,
+    enable_pdl: bool = False,
+    eps: float = _DEFAULT_EPS,
+    global_scale_mode: str = "computed",
+    allocation: str = "preallocated",
+    data_mode: str = "random",
+) -> dict[str, Any]:
+    if M is None:
+        if B is None or S is None:
+            raise ValueError("either M or both B/S must be provided")
+        M = B * S
+        shape = f"b{B}_s{S}"
+        input_ndim = 3
+    else:
+        if B is not None or S is not None:
+            raise ValueError("M and B/S are mutually exclusive")
+        shape = f"m{M}"
+        input_ndim = 2
+    label = (
+        f"{case}_{_dtype_code(dtype)}_{shape}_h{H}_b{block_size}_{scale_format}_"
+        f"sw{int(swizzled)}_pdl{int(enable_pdl)}_eps{_eps_code(eps)}_"
+        f"gs{global_scale_mode}_{allocation}_{data_mode}"
+    )
+    return {
+        "label": label,
+        "case": case,
+        "input_dtype": dtype,
+        "input_ndim": input_ndim,
+        "M": M,
+        "B": B,
+        "S": S,
+        "H": H,
+        "block_size": block_size,
+        "scale_format": scale_format,
+        "swizzled": swizzled,
+        "enable_pdl": enable_pdl,
+        "eps": eps,
+        "global_scale_mode": global_scale_mode,
+        "allocation": allocation,
+        "data_mode": data_mode,
+    }
+
+
+_NV2D_CONFIGS = [
+    _cfg("nv2d", dtype, H, M=M, eps=eps)
+    for M in (1, 4, 16, 32, 7, 13, 33, 100, 128, 8192, 16384)
+    for H in (64, 128, 256, 512, 1024, 1536, 2048, 4096, 8192)
+    for dtype in _DTYPES
+    for eps in (1e-5, 1e-6)
+]
+
+_NV3D_CONFIGS = [
+    _cfg("nv3d", dtype, H, B=B, S=S, eps=1e-5)
+    for B in (1, 4, 3, 7, 128)
+    for S in (16, 64, 128, 37, 99)
+    for H in (128, 256, 1536, 4096, 8192)
+    for dtype in _DTYPES
+]
+
+_LARGE_BATCH_CONFIGS = [
+    _cfg("large_batch", "float16", H, M=M) for M, H in ((512, 4096), (1024, 4096))
+]
+
+_MX_BASIC_CONFIGS = [
+    _cfg("mx_basic", dtype, H, M=M, block_size=32, scale_format="ue8m0", global_scale_mode="none")
+    for M in (1, 4, 16, 7, 25, 128, 8192)
+    for H in (128, 256, 512, 1536, 2048, 4096)
+    for dtype in _DTYPES
+]
+
+_CROSS_CONFIGS = [
+    *[
+        _cfg("fused_vs_separate", "float16", H, M=M)
+        for M in (4, 16, 128, 512, 8192)
+        for H in (256, 512, 1024, 1536, 4096, 8192)
+    ],
+    *[
+        _cfg("nv_matches_separate", dtype, H, M=M)
+        for M in (1, 4, 16, 128)
+        for H in (64, 256, 512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg(
+            "mx_matches_separate",
+            dtype,
+            H,
+            M=M,
+            block_size=32,
+            scale_format="ue8m0",
+            global_scale_mode="none",
+        )
+        for M in (1, 4, 16, 128)
+        for H in (128, 256, 512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("global_scale_consistency", "float16", H, M=M, global_scale_mode="nonunit")
+        for M in (1, 16, 64)
+        for H in (256, 1024, 4096)
+    ],
+]
+
+_LARGE_H_CONFIGS = [
+    *[
+        _cfg("large_h_nv", dtype, H, M=M)
+        for M in (1, 16, 128, 1024)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg(
+            "large_h_mx",
+            dtype,
+            H,
+            M=M,
+            block_size=32,
+            scale_format="ue8m0",
+            global_scale_mode="none",
+        )
+        for M in (1, 16, 128, 1024)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+]
+
+_SWIZZLED_CONFIGS = [
+    *[
+        _cfg("swizzled_nv", dtype, H, M=M, swizzled=True)
+        for M in (1, 16, 128, 256)
+        for H in (512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg(
+            "swizzled_mx",
+            dtype,
+            H,
+            M=M,
+            block_size=32,
+            scale_format="ue8m0",
+            swizzled=True,
+            global_scale_mode="none",
+        )
+        for M in (1, 16, 128, 256)
+        for H in (512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+]
+
+_ALLOCATION_CONFIGS = [
+    *[
+        _cfg("auto2d_nv", dtype, H, M=M, allocation="auto")
+        for M in (1, 16, 128)
+        for H in (256, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("auto3d_nv", "float16", H, B=B, S=S, allocation="auto")
+        for B in (1, 4, 16)
+        for S in (16, 64)
+        for H in (256, 1024)
+    ],
+    *[
+        _cfg(
+            "auto_mx",
+            "float16",
+            H,
+            M=M,
+            block_size=32,
+            scale_format="ue8m0",
+            global_scale_mode="none",
+            allocation="auto",
+        )
+        for M in (1, 16, 128)
+        for H in (256, 1024)
+    ],
+    *[
+        _cfg("auto_swizzled", "float16", H, M=M, swizzled=True, allocation="auto")
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    *[
+        _cfg("auto_matches_preallocated", "float16", H, M=M, allocation="compare")
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+]
+
+_UPSTREAM_CONFIGS = [
+    *_NV2D_CONFIGS,
+    *_NV3D_CONFIGS,
+    *_LARGE_BATCH_CONFIGS,
+    *_MX_BASIC_CONFIGS,
+    *_CROSS_CONFIGS,
+    *_LARGE_H_CONFIGS,
+    *_SWIZZLED_CONFIGS,
+    *_ALLOCATION_CONFIGS,
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg("subwarp_rows_tail", "float16", 64, M=17),
+    _cfg(
+        "subwarp_mx",
+        "bfloat16",
+        64,
+        M=17,
+        block_size=32,
+        scale_format="ue8m0",
+        global_scale_mode="none",
+    ),
+    _cfg("column_tail_nv", "bfloat16", 80, M=129, swizzled=True),
+    _cfg(
+        "column_tail_mx",
+        "float16",
+        160,
+        M=3,
+        block_size=32,
+        scale_format="ue8m0",
+        global_scale_mode="none",
+    ),
+    *[
+        _cfg("thread_threshold", "bfloat16", H, M=3)
+        for H in (3072, 3088, 6144, 6160, 14336, 16384, 16400)
+    ],
+    _cfg("cluster2", "bfloat16", 65536, M=1),
+    _cfg("cluster16", "bfloat16", 1048576, M=1, enable_pdl=True),
+    _cfg("pdl", "bfloat16", 4096, M=3, enable_pdl=True),
+    _cfg(
+        "block32_e4m3",
+        "float16",
+        4096,
+        M=3,
+        block_size=32,
+        scale_format="e4m3",
+        global_scale_mode="nonunit",
+    ),
+    _cfg("block16_requested_ue8", "float16", 4096, M=3, block_size=16, scale_format="ue8m0"),
+    _cfg("zero_input", "bfloat16", 4096, M=3, data_mode="zero"),
+    _cfg("zero_global_scale", "float16", 4096, M=3, global_scale_mode="zero"),
+]
+
+CONFIGS = [*_UPSTREAM_CONFIGS, *_STRUCTURE_CONFIGS]
+
+assert len(_NV2D_CONFIGS) == 396
+assert len(_NV3D_CONFIGS) == 250
+assert len(_LARGE_BATCH_CONFIGS) == 2
+assert len(_MX_BASIC_CONFIGS) == 84
+assert len(_CROSS_CONFIGS) == 135
+assert len(_LARGE_H_CONFIGS) == 32
+assert len(_SWIZZLED_CONFIGS) == 64
+assert len(_ALLOCATION_CONFIGS) == 44
+assert len(_UPSTREAM_CONFIGS) == 1007
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+
+BENCH_CONFIGS = [
+    _cfg("bench_nv", "bfloat16", 4096, M=32, global_scale_mode="none"),
+    _cfg("bench_nv_large", "bfloat16", 8192, M=64, global_scale_mode="none"),
+    _cfg("bench_nv_global", "bfloat16", 4096, M=32, global_scale_mode="one"),
+    _cfg("bench_nv_swizzled", "bfloat16", 4096, M=32, swizzled=True, global_scale_mode="none"),
+    _cfg(
+        "bench_mx",
+        "bfloat16",
+        4096,
+        M=32,
+        block_size=32,
+        scale_format="ue8m0",
+        global_scale_mode="none",
+    ),
+    _cfg("bench_nv_3d", "bfloat16", 128, B=32, S=32, global_scale_mode="none"),
+]
+
+
+def _validate(input_dtype: str, H: int, block_size: int, scale_format: str, M: int) -> None:
+    if input_dtype not in _DTYPES:
+        raise ValueError(f"unsupported input_dtype={input_dtype!r}")
+    if H < 64 or H % block_size != 0:
+        raise ValueError(f"H={H} must be >=64 and divisible by block_size={block_size}")
+    if block_size not in (16, 32):
+        raise ValueError(f"unsupported block_size={block_size}")
+    if scale_format not in ("e4m3", "ue8m0"):
+        raise ValueError(f"unsupported scale_format={scale_format!r}")
+    if M <= 0:
+        raise ValueError(f"M must be positive, got {M}")
+
+
+def get_kernel(
+    input_dtype: str,
+    M: int,
+    H: int,
+    block_size: int,
+    scale_format: str,
+    swizzled: bool,
+    enable_pdl: bool,
+    **kwargs: Any,
+):
+    """Return the compact source-faithful RMSNorm/FP4 specialization."""
+    _validate(input_dtype, H, block_size, scale_format, M)
+    del kwargs
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = 8 * vec_blocks
+    packed_pairs = total_values // 2
+    reduce_base = tile_bytes
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    full_columns = H == cluster_n * cols
+    num_scale_blocks = H // block_size
+    scale_blocks_per_thread = _ceil_div(num_scale_blocks, tpr)
+    use_e4m3_scale = block_size == 16 or scale_format == "e4m3"
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+    scale_columns = H // block_size
+
+    @T.inline
+    def kernel_body(x, weight, y, scales, global_scale, runtime_M, runtime_eps):
+        # TIRX_TRANSCRIBE_START flashinfer_rmsnorm_fp4quant
+        T.attr({"tirx.required_block_size": 1})
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int32(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int32(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        fp4_max_rcp: T.float32 = _rcp_approx_ftz(T.float32(6.0))
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        actual_row: T.int32 = block_x * rows + row_in_cta
+        row_valid: T.bool = actual_row < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn", align=1024)
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            if row_valid:
+                source_bytes: T.uint32 = T.uint32(16)
+                if not full_columns:
+                    source_bytes = T.cast(T.if_then_else(col_valid, 16, 0), "uint32")
+                x_offset: T.int64 = T.cast(actual_row, "int64") * T.int64(H) + T.cast(
+                    absolute_col, "int64"
+                )
+                T.ptx["cp.async.ca.shared.global"](
+                    shared_raw.ptr_to([(row_in_cta * cols + local_col) * 2]),
+                    x.ptr_to([x_offset]),
+                    16,
+                    source_bytes,
+                )
+        T.ptx.cp.async_.commit_group()
+        T.ptx.cp.async_.wait_group(0)
+
+        x_words = T.alloc_local((packed_pairs,), "uint32")
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+            T.ptx.ld.shared.v4.b32(
+                x_words[vb * 4],
+                x_words[vb * 4 + 1],
+                x_words[vb * 4 + 2],
+                x_words[vb * 4 + 3],
+                shared_raw.ptr_to([(row_in_cta * cols + local_col) * 2]),
+            )
+
+        x_f32_pairs = T.alloc_local((packed_pairs,), "uint64")
+        for pair in T.unroll(packed_pairs):
+            low_bits = T.alloc_local((1,), "uint16")
+            high_bits = T.alloc_local((1,), "uint16")
+            T.ptx.mov.b32(low_bits[0], high_bits[0], x_words[pair])
+            low_x: T.float32 = _cvt_to_f32(low_bits[0], input_dtype)
+            high_x: T.float32 = _cvt_to_f32(high_bits[0], input_dtype)
+            T.ptx.mov.b64(x_f32_pairs[pair], low_x, high_x)
+
+        x_sq = T.alloc_local((total_values,), "float32")
+        for pair in T.unroll(packed_pairs):
+            product = T.alloc_local((1,), "uint64")
+            T.ptx.mul.f32x2(product[0], x_f32_pairs[pair], x_f32_pairs[pair])
+            T.ptx.mov.b64(x_sq[pair * 2], x_sq[pair * 2 + 1], product[0])
+
+        local_sum: T.float32 = T.float32(0.0)
+        for value in T.unroll(total_values):
+            local_sum = _add_f32(local_sum, x_sq[value])
+
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+            _cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset]))
+
+            final_sum = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq = final_sum
+        else:
+            sum_sq = warp_sum
+
+        if H & (H - 1) == 0:
+            shifted: T.float32 = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        global_scale_value: T.float32 = T.float32(0.0)
+        if use_e4m3_scale:
+            scale_bits = T.alloc_local((1,), "uint32")
+            T.ptx.ld.global_.b32(scale_bits[0], global_scale.ptr_to([0]))
+            global_scale_value = T.reinterpret("float32", scale_bits[0])
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        if row_valid:
+            if scale_blocks_per_thread <= 7:
+                for scale_iteration in T.unroll(scale_blocks_per_thread):
+                    sf_index: T.int32 = thread_in_row + scale_iteration * tpr
+                    _process_scale_block(
+                        x,
+                        weight,
+                        y,
+                        scales,
+                        actual_row,
+                        sf_index,
+                        rstd,
+                        global_scale_value,
+                        fp4_max_rcp,
+                        H=H,
+                        block_size=block_size,
+                        scale_format=scale_format,
+                        swizzled=swizzled,
+                        input_dtype=input_dtype,
+                    )
+            else:
+                scale_iteration: T.int32 = T.int32(0)
+                while True:
+                    sf_index0: T.int32 = thread_in_row + scale_iteration * tpr
+                    _process_scale_block(
+                        x,
+                        weight,
+                        y,
+                        scales,
+                        actual_row,
+                        sf_index0,
+                        rstd,
+                        global_scale_value,
+                        fp4_max_rcp,
+                        H=H,
+                        block_size=block_size,
+                        scale_format=scale_format,
+                        swizzled=swizzled,
+                        input_dtype=input_dtype,
+                    )
+                    sf_index1: T.int32 = thread_in_row + (scale_iteration + 1) * tpr
+                    _process_scale_block(
+                        x,
+                        weight,
+                        y,
+                        scales,
+                        actual_row,
+                        sf_index1,
+                        rstd,
+                        global_scale_value,
+                        fp4_max_rcp,
+                        H=H,
+                        block_size=block_size,
+                        scale_format=scale_format,
+                        swizzled=swizzled,
+                        input_dtype=input_dtype,
+                    )
+                    scale_iteration = _add_s32(scale_iteration, T.int32(2))
+                    if scale_blocks_per_thread % 2 == 0:
+                        if scale_iteration == scale_blocks_per_thread:
+                            break
+                    else:
+                        if scale_iteration >= scale_blocks_per_thread:
+                            break
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    @T.prim_func
+    def flashinfer_rmsnorm_fp4quant(
+        x_ptr: T.handle,
+        weight_ptr: T.handle,
+        y_ptr: T.handle,
+        scale_ptr: T.handle,
+        global_scale_ptr: T.handle,
+        runtime_M: T.int32,
+        runtime_eps: T.float32,
+    ):
+        x = T.match_buffer(
+            x_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H),),
+            dtype=input_dtype,
+            scope="global",
+        )
+        weight = T.match_buffer(weight_ptr, shape=(H,), dtype=input_dtype, scope="global")
+        y = T.match_buffer(
+            y_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H // 2),),
+            dtype="uint8",
+            scope="global",
+        )
+        if swizzled:
+            scales = T.match_buffer(
+                scale_ptr,
+                shape=(
+                    T.cast(T.ceildiv(runtime_M, T.int32(128)), "int64")
+                    * T.int64(_ceil_div(scale_columns, 4) * 512),
+                ),
+                dtype="uint8",
+                scope="global",
+            )
+        else:
+            scales = T.match_buffer(
+                scale_ptr,
+                shape=(T.cast(runtime_M, "int64") * T.int64(scale_columns),),
+                dtype="uint8",
+                scope="global",
+            )
+        global_scale = T.match_buffer(global_scale_ptr, shape=(1,), dtype="float32", scope="global")
+        T.device_entry()
+        kernel_body(x, weight, y, scales, global_scale, runtime_M, runtime_eps)
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return flashinfer_rmsnorm_fp4quant.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Prepare deterministic inputs and caller-owned packed outputs."""
+    data = _prepare_tensors(dict(config))
+    output = _prepare_output(dict(config), initialize=True)
+    return data["x"], data["weight"], output["y"], output["scale"], data["global_scale"]
+
+
+_GUARD_ELEMENTS = 128
+_GUARD_BYTE = 0xA5
+
+
+def _torch_input_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _logical_shape(config: dict[str, Any]) -> tuple[int, ...]:
+    H = int(config["H"])
+    if int(config["input_ndim"]) == 3:
+        return int(config["B"]), int(config["S"]), H
+    return int(config["M"]), H
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    dtype = _torch_input_dtype(str(config["input_dtype"]))
+    generator = torch.Generator(device="cuda").manual_seed(42)
+
+    x_backing = torch.empty(M * H + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    x = x_backing[: M * H].view(_logical_shape(config))
+    if config.get("data_mode") == "zero":
+        x.zero_()
+    elif H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        magnitude = torch.where(columns % 257 < 128, 0.5, 1.0)
+        pattern = torch.where(columns % 2 == 0, magnitude, -magnitude).to(dtype)
+        x.view(M, H).copy_(pattern.expand(M, H))
+    else:
+        x.normal_(generator=generator)
+    x_backing[M * H :].fill_(1.0)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    weight_backing[H:].fill_(1.0)
+
+    mode = str(config.get("global_scale_mode", "computed"))
+    if mode == "computed":
+        x_f32 = x.view(M, H).float()
+        rms = x_f32 * torch.rsqrt(x_f32.square().mean(dim=-1, keepdim=True) + float(config["eps"]))
+        rms = (rms * weight.float()).to(dtype)
+        max_abs = rms.float().abs().amax().clamp_min(torch.finfo(torch.float32).tiny)
+        scale_value = 448.0 * 6.0 / float(max_abs.item())
+    elif mode in ("none", "one"):
+        scale_value = 1.0
+    elif mode == "nonunit":
+        scale_value = 3.25
+    elif mode == "zero":
+        scale_value = 0.0
+    else:
+        raise ValueError(f"unsupported global_scale_mode={mode!r}")
+    global_scale = torch.tensor([scale_value], dtype=torch.float32, device="cuda")
+
+    return {
+        "x": x,
+        "x2d": x.view(M, H),
+        "x_arg": x_backing[: M * H],
+        "x_backing": x_backing,
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "global_scale": global_scale,
+    }
+
+
+def _scale_storage_size(config: dict[str, Any]) -> int:
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    if bool(config["swizzled"]):
+        return _ceil_div(M, 128) * _ceil_div(columns, 4) * 512
+    return M * columns
+
+
+def _prepare_output(config: dict[str, Any], *, initialize: bool) -> dict[str, Any]:
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    y_size = M * (H // 2)
+    scale_size = _scale_storage_size(config)
+    y_backing = torch.empty(y_size + _GUARD_ELEMENTS, dtype=torch.uint8, device="cuda")
+    scale_backing = torch.empty(scale_size + _GUARD_ELEMENTS, dtype=torch.uint8, device="cuda")
+    if initialize:
+        y_backing.fill_(_GUARD_BYTE)
+        scale_backing.fill_(_GUARD_BYTE)
+    else:
+        y_backing[y_size:].fill_(_GUARD_BYTE)
+        scale_backing[scale_size:].fill_(_GUARD_BYTE)
+    y = y_backing[:y_size].view(M, H // 2)
+    if bool(config["swizzled"]):
+        scale = scale_backing[:scale_size]
+    else:
+        scale = scale_backing[:scale_size].view(M, H // int(config["block_size"]))
+    return {
+        "y": y,
+        "scale": scale,
+        "y_arg": y_backing[:y_size],
+        "scale_arg": scale_backing[:scale_size],
+        "y_backing": y_backing,
+        "scale_backing": scale_backing,
+        "y_size": y_size,
+        "scale_size": scale_size,
+        "y_ptr": y.data_ptr(),
+        "scale_ptr": scale.data_ptr(),
+        "y_stride": y.stride(),
+        "scale_stride": scale.stride(),
+    }
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]):
+    return executable(
+        data["x_arg"],
+        data["weight"],
+        output["y_arg"],
+        output["scale_arg"],
+        data["global_scale"],
+        int(config["M"]),
+        float(config["eps"]),
+    )
+
+
+@functools.cache
+def _compiled_test_specialization(
+    input_dtype: str, H: int, block_size: int, scale_format: str, swizzled: bool, enable_pdl: bool
+):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(
+        get_kernel(
+            input_dtype=input_dtype,
+            M=1,
+            H=H,
+            block_size=block_size,
+            scale_format=scale_format,
+            swizzled=swizzled,
+            enable_pdl=enable_pdl,
+        )
+    )
+
+
+@functools.cache
+def _flashinfer_compiled(
+    H: int, block_size: int, input_dtype: str, scale_format: str, swizzled: bool, enable_pdl: bool
+):
+    from flashinfer.cute_dsl.rmsnorm_fp4quant import _get_compiled_kernel
+
+    return _get_compiled_kernel(
+        H, block_size, input_dtype == "float16", 100, scale_format, swizzled, enable_pdl
+    )
+
+
+def _launch_flashinfer(data, output, config: dict[str, Any]):
+    kernel = _flashinfer_compiled(
+        int(config["H"]),
+        int(config["block_size"]),
+        str(config["input_dtype"]),
+        str(config["scale_format"]),
+        bool(config["swizzled"]),
+        bool(config["enable_pdl"]),
+    )
+    return kernel(
+        data["x2d"],
+        data["weight"],
+        output["y"],
+        output["scale"],
+        data["global_scale"],
+        int(config["M"]),
+        float(config["eps"]),
+    )
+
+
+def _snapshot_inputs(data):
+    return {
+        "x": data["x"].clone(),
+        "weight": data["weight"].clone(),
+        "global_scale": data["global_scale"].clone(),
+    }
+
+
+def _assert_inputs_unchanged(data, snapshot, config: dict[str, Any]) -> None:
+    import torch
+
+    if not torch.equal(data["x"], snapshot["x"]):
+        raise AssertionError("input tensor was modified")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError("weight tensor was modified")
+    if not torch.equal(data["global_scale"], snapshot["global_scale"]):
+        raise AssertionError("global-scale tensor was modified")
+    M, H = int(config["M"]), int(config["H"])
+    if not torch.equal(data["x_backing"][M * H :], torch.ones_like(data["x_backing"][M * H :])):
+        raise AssertionError("input guard was modified")
+    if not torch.equal(data["weight_backing"][H:], torch.ones_like(data["weight_backing"][H:])):
+        raise AssertionError("weight guard was modified")
+
+
+def _assert_output_integrity(output, *, name: str) -> None:
+    import torch
+
+    if output["y"].data_ptr() != output["y_ptr"] or output["y"].stride() != output["y_stride"]:
+        raise AssertionError(f"{name} packed-output identity changed")
+    if (
+        output["scale"].data_ptr() != output["scale_ptr"]
+        or output["scale"].stride() != output["scale_stride"]
+    ):
+        raise AssertionError(f"{name} scale-output identity changed")
+    if not torch.all(output["y_backing"][output["y_size"] :] == _GUARD_BYTE):
+        raise AssertionError(f"{name} packed-output guard was modified")
+    if not torch.all(output["scale_backing"][output["scale_size"] :] == _GUARD_BYTE):
+        raise AssertionError(f"{name} scale-output guard was modified")
+
+
+def _logical_scale_bytes(output, config: dict[str, Any]):
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    if not bool(config["swizzled"]):
+        return output["scale"].view(M, columns)
+    rows = torch.arange(M, device="cuda", dtype=torch.int64)[:, None]
+    cols = torch.arange(columns, device="cuda", dtype=torch.int64)[None, :]
+    offsets = (
+        (rows // 128) * (_ceil_div(columns, 4) * 512)
+        + (cols // 4) * 512
+        + (rows % 32) * 16
+        + ((rows % 128) // 32) * 4
+        + (cols % 4)
+    )
+    return output["scale"].view(-1)[offsets]
+
+
+def _dequantize(output, data, config: dict[str, Any]):
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    packed = output["y"].view(M, H // 2)
+    low = packed & 0x0F
+    high = packed >> 4
+    nibbles = torch.stack((low, high), dim=-1).reshape(M, H).long()
+    table = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    fp4 = table[nibbles]
+    scale_bytes = _logical_scale_bytes(output, config)
+    if int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3":
+        scales = scale_bytes.view(torch.float8_e4m3fn).float()
+        scales = scales / data["global_scale"].float()
+    else:
+        scales = torch.pow(2.0, scale_bytes.int() - 127)
+    return (fp4.view(M, -1, int(config["block_size"])) * scales[..., None]).reshape(M, H)
+
+
+def _math_oracle(data, config: dict[str, Any]):
+    M, H = int(config["M"]), int(config["H"])
+    x = data["x2d"].float()
+    normalized = x * (x.square().mean(dim=-1, keepdim=True) + float(config["eps"])).rsqrt()
+    return (
+        (normalized * data["weight"].float()).to(_torch_input_dtype(config["input_dtype"])).float()
+    )
+
+
+def _assert_raw_equal(actual, expected, config: dict[str, Any], *, name: str) -> None:
+    import torch
+
+    if not torch.equal(actual["y"], expected["y"]):
+        count = int((actual["y"] != expected["y"]).sum().item())
+        raise AssertionError(f"{name}: {count} packed FP4 bytes differ")
+    actual_scales = _logical_scale_bytes(actual, config)
+    expected_scales = _logical_scale_bytes(expected, config)
+    if not torch.equal(actual_scales, expected_scales):
+        count = int((actual_scales != expected_scales).sum().item())
+        raise AssertionError(f"{name}: {count} logical scale bytes differ")
+
+
+def _assert_math(output, data, config: dict[str, Any]) -> None:
+    import torch
+
+    if (int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3") and float(
+        data["global_scale"].item()
+    ) == 0.0:
+        if torch.count_nonzero(output["y"] & 0x77) or torch.count_nonzero(
+            _logical_scale_bytes(output, config)
+        ):
+            raise AssertionError("zero global scale must produce signed-zero FP4 values and scales")
+        return
+
+    dequantized = _dequantize(output, data, config)
+    oracle = _math_oracle(data, config)
+    if not torch.isfinite(dequantized).all():
+        raise AssertionError("dequantized TIRx output contains non-finite values")
+    torch.testing.assert_close(
+        dequantized,
+        oracle,
+        rtol=0.5,
+        atol=2.0,
+        msg=lambda message: f"independent FP32 RMSNorm oracle: {message}",
+    )
+
+
+def _check_public_allocation(data, reference, config: dict[str, Any]) -> None:
+    import torch
+    from flashinfer.norm import rmsnorm_fp4quant
+
+    if str(config.get("allocation")) not in ("auto", "compare"):
+        return
+    y, scales = rmsnorm_fp4quant(
+        data["x"],
+        data["weight"],
+        global_scale=(None if config.get("global_scale_mode") == "none" else data["global_scale"]),
+        eps=float(config["eps"]),
+        block_size=int(config["block_size"]),
+        scale_format=str(config["scale_format"]),
+        is_sf_swizzled_layout=bool(config["swizzled"]),
+        enable_pdl=bool(config["enable_pdl"]),
+    )
+    if tuple(y.shape) != (*_logical_shape(config)[:-1], int(config["H"]) // 2):
+        raise AssertionError(f"unexpected public packed output shape {tuple(y.shape)}")
+    if not torch.equal(y.view(torch.uint8).view(reference["y"].shape), reference["y"]):
+        raise AssertionError("public auto-allocated packed output differs from kernel oracle")
+    if bool(config["swizzled"]):
+        public_scale = {**reference, "scale": scales.view(torch.uint8)}
+        public_logical = _logical_scale_bytes(public_scale, config)
+    else:
+        public_logical = scales.view(torch.uint8).view_as(reference["scale"])
+    if not torch.equal(public_logical, _logical_scale_bytes(reference, config)):
+        raise AssertionError("public auto-allocated scale output differs from kernel oracle")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one source-domain specialization."""
+    import torch
+
+    config = dict(config)
+    _validate(
+        str(config["input_dtype"]),
+        int(config["H"]),
+        int(config["block_size"]),
+        str(config["scale_format"]),
+        int(config["M"]),
+    )
+    data = _prepare_tensors(config)
+    snapshot = _snapshot_inputs(data)
+    output = _prepare_output(config, initialize=True)
+    reference = _prepare_output(config, initialize=True)
+    executable = _compiled_test_specialization(
+        str(config["input_dtype"]),
+        int(config["H"]),
+        int(config["block_size"]),
+        str(config["scale_format"]),
+        bool(config["swizzled"]),
+        bool(config["enable_pdl"]),
+    )
+    if _launch_tirx(executable, data, output, config) is not None:
+        raise AssertionError("TIRx RMSNormFP4Quant ABI must return None")
+    if _launch_flashinfer(data, reference, config) is not None:
+        raise AssertionError("FlashInfer RMSNormFP4Quant ABI must return None")
+    torch.cuda.synchronize()
+    _assert_raw_equal(output, reference, config, name="FlashInfer raw-byte oracle")
+    _assert_math(output, data, config)
+    _assert_inputs_unchanged(data, snapshot, config)
+    _assert_output_integrity(output, name="TIRx output")
+    _assert_output_integrity(reference, name="FlashInfer output")
+    _check_public_allocation(data, reference, config)
+
+
+def prepare_bench(**config: Any):
+    """Compile the specialization before the bench suite assigns a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Build and prevalidate source and TIRx single-launch closures."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    data = _prepare_tensors(config)
+    tirx_output = _prepare_output(config, initialize=False)
+    source_output = _prepare_output(config, initialize=False)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        return _launch_tirx(executable, data, tirx_output, config)
+
+    if tirx_launch() is not None:
+        raise AssertionError("TIRx benchmark closure must return None")
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        def source_launch():
+            return _launch_flashinfer(data, source_output, config)
+
+        if source_launch() is not None:
+            raise AssertionError("FlashInfer benchmark closure must return None")
+        torch.cuda.synchronize()
+        _assert_raw_equal(tirx_output, source_output, config, name="benchmark raw-byte precheck")
+        return source_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark one specialization against the CuTeDSL kernel reference."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer RMSNormFP4QuantKernel to plain TIRx with source-faithful async copy, row/cluster reduction, FP4 packing, E4M3 and UE8M0 scale generation, scale swizzling, PDL, and rolled large-H quantization
- add 1,025 source-domain correctness configurations, six official benchmark configurations, registry documentation, and the promoted bench-suite baseline
- preserve the exact CUDA block-size contract and source PTX conversion/store idioms through the companion TVM change
- document the reusable required-block, conversion/packing, and source-derived loop-boundary findings in the symptom-indexed codegen tuning database

## TVM dependency

This PR requires spectrometerHBH/tvm@135a054f17 on top of the workspace agent/tirx-cuda-launch-controls branch. That change adds tirx.required_block_size lowering through CUDA 13 __block_size__, the required-block launch path, and the exact FP4 CUDA operations used by this kernel.

https://github.com/spectrometerHBH/tvm/commit/135a054f17

## Validation

- python -m tirx_kernels.test --kernel flashinfer_rmsnorm_fp4quant: 1,025 passed, 0 failed, 0 skipped
- all specializations pass the low-level IR gate with no tile primitives or function calls
- registry strict check, bench-suite import check, license checker, license self-test, and pre-commit pass
- companion TVM tests: 271 passed, 32 skipped
- codegen database field notes pass pre-commit and structural heading/index checks

Final performance command:

    python -m tirx_kernels.bench_suite --with-references --filter flashinfer_rmsnorm_fp4quant --rounds 5 --cooldown 1 --workloads .porting/flashinfer_rmsnorm_fp4quant/perf_gate/workloads/all6.yaml

All six rows passed the strict flashinfer_cutedsl / tirx > 0.99 gate:

| Configuration | Ratio |
|---|---:|
| MXFP4 M32 H4096 | 1.018x |
| NVFP4 3D M1024 H128 | 1.033x |
| NVFP4 M32 H4096 | 1.040x |
| NVFP4 M32 H4096 with global scale | 1.046x |
| NVFP4 M64 H8192 | 1.041x |
| NVFP4 M32 H4096 with swizzled scales | 1.018x |