### PR TITLE
fix(topk): order multi-CTA state handoffs

### DIFF
--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -514,11 +514,6 @@ def get_kernel(
         _threshold(hist, scal, tid, warp, lane, rank, phase, k_rem, True)
         bin_t = T.alloc_local((1,), "int32")
         bin_t[0] = T.cast(R.ld_shared_u32(scal, THR), "int32")
-        if nc > 1 and t < rounds - 1:
-            # Skipped on the final round: no further threshold() means no
-            # further peer read of this bank (:260-263).
-            T.evaluate(T.ptx.barrier.cluster.arrive())
-
         raw = T.alloc_local((1,), "int32")
         raw[0] = T.cast(R.ld_shared_u32(scal, NCACHED + (phase ^ 1)), "int32")
         n_sh = T.alloc_local((1,), "int32")
@@ -573,6 +568,13 @@ def get_kernel(
                 ring_base,
                 tid,
             )
+
+        if nc > 1 and t < rounds - 1:
+            # Publish only after every thread has consumed the previous
+            # ping-pong bank.  Arriving immediately after threshold selection
+            # lets the next round overwrite that bank while another warp is
+            # still reading its cached candidates.
+            T.evaluate(T.ptx.barrier.cluster.arrive())
 
     @T.macro
     def _emit(logits, out_idx, out_val, seq_lens_g, aux, ovf):

--- a/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
@@ -487,6 +487,12 @@ def get_kernel(
                     # One fenced arrival from thread 0 (:176), an acquire spin to the
                     # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                     # one (:133) and the phase bump is followed by another (:182).
+                    # Complete every CTA-local state update before thread 0
+                    # publishes the group arrival.  The following acquire
+                    # spin is the inter-CTA handoff; without this CTA
+                    # rendezvous, another warp could still be folding its
+                    # histogram when the consumer observes the arrival.
+                    bar_sync()
                     if tx == 0:
                         red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                     bar_target0: T.int32 = (barrier_phase + T.int32(1)) * T.int32(ctas_per_group)
@@ -545,6 +551,7 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
+                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target1: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -676,6 +683,7 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
+                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target2: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -720,6 +728,7 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
+                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target3: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -883,6 +892,7 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
+                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target4: T.int32 = (barrier_phase + T.int32(1)) * T.int32(


### PR DESCRIPTION
## Summary
- move the cluster arrival in fast_topk_clusters after candidate consumption
- add CTA rendezvous before multi-CTA radix Top-K publishes each phase

## Validation
- cherry-picked on current origin/main (cf37b72)
- canonical NumSim/Synccheck/Racecheck and full tirx_tools gates will run after the merge and exact repin