### PR TITLE
feat(kernel): add FlashInfer Add RMSNorm FP4 quantization

### DIFF
--- a/.agents/sketch/flashinfer/norm/add_rmsnorm_fp4quant.md
+++ b/.agents/sketch/flashinfer/norm/add_rmsnorm_fp4quant.md
@@ -1,0 +1,845 @@
+<!--
+Copyright (c) 2025 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CuTe-DSL
+AddRMSNormFP4QuantKernel. See LICENSE, NOTICE, and licenses/ for applicable terms.
+-->
+
+# FlashInfer Add RMSNorm FP4 quantization SM100: execution sketch
+
+This non-executable sketch freezes the implementation shape of FlashInfer's
+CuTe-DSL `AddRMSNormFP4QuantKernel` for
+[`tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py`](../../../../tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py).
+It records the source execution skeleton rather than a mathematically equivalent
+replacement and is frozen after its first independent reviewer PASS.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `flashinfer/cute_dsl/add_rmsnorm_fp4quant.py`, SHA256
+  `1d034042a6b31c4f7301626a3d6ee7cff7cfbd67715d95ae3f0918f70b62d881`;
+- `flashinfer/cute_dsl/fp4_common.py`, SHA256
+  `ff490c11853603634fd19c4558021b03db08b409dc54d24146f1bdc66a6b784f`;
+- public alias/wrapper in `flashinfer/norm/__init__.py`, SHA256
+  `226a88f5fb14e78e06e1be79020edcae01bfa9e53e677bd485373ea4d51cffcb`.
+
+Writer-owned fresh line-info PTX and clean MLIR are under
+`.porting/flashinfer_add_rmsnorm_fp4quant/source_exports/writer/`. The accepted
+profiles explicitly pass PDL false unless their name contains `pdl`; directories
+ending `_invalid_auto_pdl` are preserved dispatch-diagnostic artifacts and are not
+instruction-selection evidence. The accepted matrix covers FP16/BF16, 2-D/3-D,
+column and row tails, linear/swizzled/dual scale layouts, optional YNorm, NV/MX
+scale paths, the Add-specific rolled-loop boundaries, cluster2/16, and PDL.
+
+The supported device family is compact FP16/BF16 X/residual/W, packed E2M1 Y,
+block size 16/32, E4M3/UE8M0 scale bytes, row-major or padded 128x4 swizzled
+scales, optional simultaneous swizzled+row-major scales, optional input-dtype
+YNorm, PDL off/on, host-flattened 3-D, and cluster sizes 1/2/4/8/16. There is no
+strided device ABI, tile primitive, TMA, additional pipeline stage, max-register
+cap, or launch bound.
+
+## Source dispatch and launch formulae
+
+```python
+VEC = 8
+ELEM_BYTES = 2
+MAX_SMEM = 232448  # B200 opt-in value of the reviewed environment
+
+def threads_per_row(hcta):
+    if hcta <= 64: return 8
+    if hcta <= 128: return 16
+    if hcta <= 3072: return 32
+    if hcta <= 6144: return 64
+    if hcta <= 16384: return 128
+    return 256
+
+def source_config(H, cluster_n):
+    hcta = H // cluster_n
+    tpr = threads_per_row(hcta)
+    threads = 128 if hcta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec_blocks = max(1, ceil_div(hcta // VEC, tpr))
+    cols = VEC * vec_blocks * tpr
+    tile_bytes = rows * cols * ELEM_BYTES
+    if cluster_n == 1:
+        smem = 4 * tile_bytes + rows * warps_per_row * 4
+    else:
+        smem = 2 * tile_bytes + rows * warps_per_row * cluster_n * 4 + 8
+    return hcta,tpr,threads,rows,warps_per_row,vec_blocks,cols,tile_bytes,smem
+
+CLUSTER_N = next(
+    (c for c in (1,2,4,8,16)
+     if H % c == 0 and source_config(H,c).smem <= MAX_SMEM),
+    16,
+)
+```
+
+Launch is `grid=(ceil_div(runtime_M,ROWS),CLUSTER_N,1)`,
+`block=(THREADS,1,1)`, and cluster `(1,CLUSTER_N,1)` iff clustered. Runtime ABI
+is `(X,R,W,Y,S,S_linear,YNorm,global_scale,M:i32,eps:f32)`. Disabled optional
+outputs still occupy fixed dummy-buffer slots but are never accessed. PTX has
+`.reqntid`, `.extern .shared .align 1024`, and no `.maxnreg`/minimum-CTA directive.
+
+On B200, H16384 is cluster1, H32768 is cluster2, and H524288 is cluster16.
+H1048576 falls back to cluster16 but its Add-specific shared allocation exceeds
+the opt-in limit, so it is not a launchable validation profile.
+
+## Source-proven loop shape
+
+| phase | specialization | PTX structure |
+| --- | --- | --- |
+| X/R/W async issue and X/R shared load | `VEC_BLOCKS` | always statically expanded |
+| H add, narrow, square, local reduction | `8*VEC_BLOCKS` values | statically expanded; add/square use `*.f32x2` per adjacent pair |
+| block16, no YNorm | `SF_PER_THREAD <= 2` | completely expanded |
+| block16, no YNorm, cluster1 shared path | `SF_PER_THREAD >= 3` | one-SF rolled body, cursor `+=1` |
+| block16 with YNorm | `SF_PER_THREAD == 1` | expanded |
+| block16 with YNorm, cluster1 shared path | `SF_PER_THREAD >= 2` | one-SF rolled body, cursor `+=1` |
+| block32 | `SF_PER_THREAD == 1` | expanded |
+| block32, cluster1 shared path | `SF_PER_THREAD >= 2` | one-SF rolled body, cursor `+=1` |
+| any clustered global-reload path | reachable rolled trips | two-SF static body, cursor `+=2`, second SF tail-guarded |
+
+Fresh adjacent evidence is H1024/H1536 for block16 without YNorm,
+H512/H1024 with YNorm, and H1024/H2048 for block32. The cluster1 backedges map
+to source line 647/648 and contain one scale store and one 16-value FP4 store.
+Dual-layout alone leaves the block16 trip-two case expanded; dual-layout plus
+YNorm follows the YNorm threshold. Independently exported cluster2 H30720
+(odd trip 15) and H32768 (trip 16) show the distinct global-reload body: two
+scale blocks are statically emitted, the cursor increments by two, and the
+second block is guarded for the odd tail. The same two-SF clustered body was
+observed for block16 core, dual-layout, YNorm, and block32 UE8M0. These are
+path-and-trip rules, not hard-coded H cases, and must not be replaced with the
+RMSNormFP4 loop rule.
+
+## CTA roles, publication edges, and storage
+
+| owner | work | publication/reuse edge |
+| --- | --- | --- |
+| every CTA thread | optional PDL wait; assigned X/R/W vector blocks; H add/square; assigned scale blocks | one contiguous TPR-lane group owns one row |
+| each row warp | ordered local sum plus subwarp/full-warp butterfly | scalar warp partial |
+| lane 0 per row warp, cluster1 multiwarp | publish partial to reduction shared | CTA barrier, then lanes `<WARPS_PER_ROW` reload |
+| lanes `<CLUSTER_N`, clustered CTA | remote-store every warp partial to every peer | mapa + complete-tx mbarrier protocol |
+| every clustered CTA | publish its residual H slice, cluster fence/barrier, then quantize the complete row | deliberate identical racing Y/S stores |
+
+One 1024-aligned dynamic shared arena contains:
+
+1. `sX` then `sR`, input dtype `[ROWS,COLS]` each;
+2. cluster1 only: `sW` then `sH`, input dtype `[ROWS,COLS]` each;
+3. FP32 reduction `[ROWS,WARPS_PER_ROW]` or
+   `[ROWS,(WARPS_PER_ROW,CLUSTER_N)]`;
+4. clustered only: one 8-byte mbarrier.
+
+`sH` stores the input-dtype-rounded H values, not FP32. Cluster1 phase 3 scalar
+loads and widens `sH/sW`; clustered phase 3 uses packed global residual/W loads.
+Global scale is read before the first post-reduction barrier in E4M3 branches;
+canonical UE8M0 dead-code-eliminates that load. Residual is written after the
+first post-reduction barrier. Clustered execution then fences and performs a
+second cluster barrier before any full-row global reload.
+
+## Primitive vocabulary
+
+Structural vocabulary does not move or compute data:
+
+```python
+specialize(...)  launch(...)  raw_shared(...)  view(...)  reg_fragment(...)
+address(...)     swizzled_scale_offset(...)    pair_view(...)
+each_static_replica(...)
+```
+
+Primitive data/schedule vocabulary:
+
+```python
+pdl_wait()  pdl_signal()
+cp_async_ca_128(src,dst,source_bytes)  cp_async_commit()  cp_async_wait(0)
+load_shared_128(src)  load_shared_b16(src)  load_shared_b32(src)
+load_global_128(src)  load_global_b32(src)
+store_shared_128(dst,v)  store_shared_b32(dst,v)
+store_global_128(dst,v)  store_global_b8(dst,v)  store_global_u64(dst,v)
+widen_input_scalar(v,dtype)  cvt_input_pair(hi,lo,dtype)
+add_f32(a,b)  add_f32x2(a,b)  mul_f32(a,b)  mul_f32x2(a,b)
+fma_rn_f32(a,b,c)
+mul_input2(a,b,dtype)  abs_input2(v,dtype)  max_input2(a,b,dtype)
+abs_f32(v)  max_f32(a,b)  div_f32(a,b)
+rsqrt_fast(v)  rcp_fast(v)  min_f32(a,b)  lg2_fast(v)  ex2_fast(v)
+shuffle_xor(v,delta,width)
+cvt_e4m3_pair(hi,lo)  cvt_e2m1_pair(hi,lo)  cvt_f16x2_e4m3x2(v)
+cvt_f32_f16(v)  cvt_f16_f32(v)  cvt_f32_bf16(v)
+cvt_s32_f32_rpi(v)  cvt_f32_s32_rn(v)
+and_b32(a,mask)  shift_left_b32(v,n)  shift_right_b32(v,n)
+mov_b32_pair(v)  mov_b32_from_b16(lo,hi)
+mov_b32_bytes(b0,b1,b2,b3)  mov_b32_as_f32(v)
+setp(...)  select(...)  add_s32(...)  sub_s32(...)  cvt_u32_u16(...)
+cvt_u16_u32(...)  cvt_u64_u32(...)  shift_left_b64(v,n)  or_b64(a,b)
+cta_barrier()  cluster_arrive_relaxed()  cluster_wait()
+mbarrier_init(...)  mbarrier_init_fence()  mbarrier_arrive_expect_tx(...)
+map_shared_to_peer(...)  remote_store_complete_tx(...)  mbarrier_try_wait(...)
+fence_cluster_acq_rel()
+elect_one()
+```
+
+There is no compound add-RMSNorm, reduction, scale conversion, FP4 quantize,
+dual-output, or YNorm primitive.
+
+## Complete execution sketch
+
+```python
+@specialize(
+    INPUT_DTYPE=("f16","bf16"), H="compile-time multiple of BLOCK_SIZE, >=64",
+    BLOCK_SIZE=(16,32), SCALE_FORMAT=("e4m3","ue8m0"),
+    SWIZZLED=(False,True), BOTH_SF=(False,True), YNORM=(False,True),
+    ENABLE_PDL=(False,True), TARGET="sm_100a",
+)
+@launch(
+    grid=(ceil_div(runtime_M,ROWS),CLUSTER_N,1), block=(THREADS,1,1),
+    cluster=((1,CLUSTER_N,1) if CLUSTER_N > 1 else None),
+    dynamic_smem_bytes=SMEM_BYTES,
+    use_programmatic_dependent_launch=ENABLE_PDL,
+)
+def flashinfer_add_rmsnorm_fp4quant(
+    X,R,W,Y_u8,S_u8,S_linear_u8,YNorm,global_scale,
+    runtime_M:i32,runtime_eps:f32,
+):
+    tid = thread_id_x()
+
+    if ENABLE_PDL:
+        pdl_wait()
+        # instruction_selection: griddepcontrol.wait; extent: one CTA issue,
+        # immediately after tid acquisition and before every CTA-ID read
+
+    block_x = block_id_x()
+    cluster_y = block_id_y() if CLUSTER_N > 1 else 0
+    lane_in_row = tid % TPR
+    row_in_cta = tid // TPR
+    lane = tid % 32
+    warp = tid // 32
+    row_warp = warp // WARPS_PER_ROW
+    warp_in_row = warp % WARPS_PER_ROW
+    actual_row = block_x * ROWS + row_in_cta
+    row_valid = actual_row < runtime_M
+
+    fp4_max_rcp = rcp_fast(6.0)
+    # instruction_selection: rcp.approx.ftz.f32; extent: one scalar/thread
+
+    smem = raw_shared("u8",SMEM_BYTES,alignment=1024)
+    sX = view(smem,INPUT_DTYPE,(ROWS,COLS),offset=0,alignment=16)
+    sR = view(smem,INPUT_DTYPE,(ROWS,COLS),offset=TILE_BYTES,alignment=16)
+    if CLUSTER_N == 1:
+        sW = view(smem,INPUT_DTYPE,(ROWS,COLS),offset=2*TILE_BYTES,alignment=16)
+        sH = view(smem,INPUT_DTYPE,(ROWS,COLS),offset=3*TILE_BYTES,alignment=16)
+        reduction = view(smem,"f32",(ROWS,WARPS_PER_ROW),
+                         offset=4*TILE_BYTES,alignment=4)
+    else:
+        reduction = view(smem,"f32",(ROWS,(WARPS_PER_ROW,CLUSTER_N)),
+                         offset=2*TILE_BYTES,alignment=4)
+        mbar = view(smem,"mbarrier",(1,),
+                    offset=2*TILE_BYTES+ROWS*WARPS_PER_ROW*CLUSTER_N*4,
+                    alignment=8)
+
+    if CLUSTER_N > 1:
+        if tid == 0:
+            mbarrier_init(mbar,arrivals=1)
+            # instruction_selection: mbarrier.init.shared.b64; extent: one/CTA
+        mbarrier_init_fence()
+        # instruction_selection: fence.mbarrier_init.release.cluster; one/CTA
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; one/CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; one/CTA
+
+    # Phase 1: source TV layout owns eight adjacent values per lane per vb.
+    for vb in static_unroll(VEC_BLOCKS):
+        local_col = (lane_in_row + vb*TPR)*8
+        absolute_col = cluster_y*COLS + local_col
+        col_valid = absolute_col < H
+        if row_valid:
+            cp_async_ca_128(X[actual_row,absolute_col],
+                            sX[row_in_cta,local_col],16 if col_valid else 0)
+            # instruction_selection: cp.async.ca.shared.global 16 bytes with
+            # source-size 16/0; extent: one X issue/vb/thread
+            cp_async_ca_128(R[actual_row,absolute_col],
+                            sR[row_in_cta,local_col],16 if col_valid else 0)
+            # instruction_selection: cp.async.ca.shared.global 16 bytes with
+            # source-size 16/0; extent: one residual issue/vb/thread
+        if CLUSTER_N == 1:
+            cp_async_ca_128(W[absolute_col],sW[row_in_cta,local_col],
+                            16 if col_valid else 0)
+            # instruction_selection: cp.async.ca.shared.global 16 bytes with
+            # source-size 16/0; extent: one W issue/vb/thread, outside row guard
+    cp_async_commit()
+    # instruction_selection: cp.async.commit_group; extent: one/thread
+    cp_async_wait(0)
+    # instruction_selection: cp.async.wait_group 0; extent: one/thread
+
+    x_bits = reg_fragment(INPUT_DTYPE,8*VEC_BLOCKS)
+    r_bits = reg_fragment(INPUT_DTYPE,8*VEC_BLOCKS)
+    for vb in static_unroll(VEC_BLOCKS):
+        local_col = (lane_in_row + vb*TPR)*8
+        x_bits[8*vb:8*vb+8] = load_shared_128(
+            sX[row_in_cta,local_col])
+        # instruction_selection: ld.shared.v4.b32; one 128-bit X issue/vb/thread
+        r_bits[8*vb:8*vb+8] = load_shared_128(
+            sR[row_in_cta,local_col])
+        # instruction_selection: ld.shared.v4.b32; one 128-bit R issue/vb/thread
+
+    x_f32 = reg_fragment("f32",8*VEC_BLOCKS)
+    r_f32 = reg_fragment("f32",8*VEC_BLOCKS)
+    for value in static_unroll(8*VEC_BLOCKS):
+        x_f32[value] = widen_input_scalar(x_bits[value],INPUT_DTYPE)
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one value
+        r_f32[value] = widen_input_scalar(r_bits[value],INPUT_DTYPE)
+        # instruction_selection: cvt.f32.{f16,bf16}; extent: one value
+
+    h_f32 = reg_fragment("f32",8*VEC_BLOCKS)
+    h_sq = reg_fragment("f32",8*VEC_BLOCKS)
+    h_bits = reg_fragment(INPUT_DTYPE,8*VEC_BLOCKS)
+    for pair in static_unroll(4*VEC_BLOCKS):
+        pair_view(h_f32,pair) = add_f32x2(
+            pair_view(x_f32,pair),pair_view(r_f32,pair))
+        # instruction_selection: add.f32x2; extent: one adjacent pair
+        pair_view(h_sq,pair) = mul_f32x2(
+            pair_view(h_f32,pair),pair_view(h_f32,pair))
+        # instruction_selection: mul.f32x2; extent: one adjacent pair
+        h_bits[2*pair:2*pair+2] = cvt_input_pair(
+            h_f32[2*pair+1],h_f32[2*pair],INPUT_DTYPE)
+        # instruction_selection: cvt.rn.{f16x2,bf16x2}.f32; one adjacent pair
+
+    if CLUSTER_N == 1:
+        for vb in static_unroll(VEC_BLOCKS):
+            local_col = (lane_in_row + vb*TPR)*8
+            store_shared_128(
+                sH[row_in_cta,local_col],h_bits[8*vb:8*vb+8])
+            # instruction_selection: st.shared.v4.b32; one 128-bit issue/vb/thread
+
+    local_sum = 0.0
+    for value in static_unroll(8*VEC_BLOCKS):
+        local_sum = add_f32(local_sum,h_sq[value])
+        # instruction_selection: add.f32; ordered extent one/value
+    for delta in powers_of_two_below(min(TPR,32)):
+        peer = shuffle_xor(local_sum,delta)
+        # instruction_selection: shfl.sync.bfly.b32; one/subwarp stage
+        local_sum = add_f32(local_sum,peer)
+        # instruction_selection: add.f32; one/subwarp stage
+    warp_sum = local_sum
+
+    if WARPS_PER_ROW > 1 and CLUSTER_N == 1:
+        if lane == 0:
+            store_shared_b32(reduction[row_warp,warp_in_row],warp_sum)
+            # instruction_selection: st.shared.b32; one/row warp
+        cta_barrier()
+        # instruction_selection: bar.sync 0; one reduction publication edge
+        final = 0.0
+        if lane < WARPS_PER_ROW:
+            final = load_shared_b32(reduction[row_warp,lane])
+            # instruction_selection: ld.shared.b32; one participating lane
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final,delta)
+            # instruction_selection: shfl.sync.bfly.b32; one/full-warp stage
+            final = add_f32(final,peer)
+            # instruction_selection: add.f32; one/full-warp stage
+        sum_sq = final
+    elif CLUSTER_N > 1:
+        if warp == 0:
+            elected = elect_one()
+            # instruction_selection: elect.sync; one invocation in warp 0,
+            # followed by its predicate branch
+            if elected:
+                mbarrier_arrive_expect_tx(
+                    mbar,ROWS*WARPS_PER_ROW*CLUSTER_N*4)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # one elected issue/CTA with exact byte count
+        if lane < CLUSTER_N:
+            peer_value = map_shared_to_peer(
+                reduction[row_warp,(warp_in_row,cluster_rank())],lane)
+            # instruction_selection: mapa.shared::cluster.u32; one value map/lane
+            peer_bar = map_shared_to_peer(mbar,lane)
+            # instruction_selection: mapa.shared::cluster.u32; one barrier map/lane
+            remote_store_complete_tx(warp_sum,peer_value,peer_bar)
+            # instruction_selection:
+            # st.async.shared::cluster.mbarrier::complete_tx::bytes.f32;
+            # one partial from every row warp to each peer
+        while not mbarrier_try_wait(mbar,phase=0,timeout=10000000):
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64 plus
+            # uniform retry branch; one completion loop/thread
+            pass
+        final = 0.0
+        for i in static_unroll(ceil_div(WARPS_PER_ROW*CLUSTER_N,32)):
+            idx = lane + i*32
+            if idx < WARPS_PER_ROW*CLUSTER_N:
+                partial = load_shared_b32(reduction[row_warp,idx])
+                # instruction_selection: ld.shared.b32; one owned partial
+                final = add_f32(final,partial)
+                # instruction_selection: add.f32; one loaded partial
+        for delta in (1,2,4,8,16):
+            peer = shuffle_xor(final,delta)
+            # instruction_selection: shfl.sync.bfly.b32; one/full-warp stage
+            final = add_f32(final,peer)
+            # instruction_selection: add.f32; one/full-warp stage
+        sum_sq = final
+    else:
+        sum_sq = warp_sum
+
+    if H is a power of two:
+        shifted = fma_rn_f32(sum_sq,float32(1.0/H),runtime_eps)
+        # instruction_selection: fma.rn.f32; exactly one/thread
+    else:
+        mean_sq = div_f32(sum_sq,float32(H))
+        # instruction_selection: div.rn.f32; exactly one/thread
+        shifted = add_f32(mean_sq,runtime_eps)
+        # instruction_selection: add.f32; exactly one/thread after the divide
+    rstd = rsqrt_fast(shifted)
+    # instruction_selection: rsqrt.approx.ftz.f32; one/thread
+
+    if BLOCK_SIZE == 16 or SCALE_FORMAT == "e4m3":
+        global_scale_value = load_global_b32(global_scale[0])
+        # instruction_selection: ld.global.b32; one scalar/thread in E4M3;
+        # canonical UE8M0 eliminates it
+
+    if CLUSTER_N > 1:
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; one/CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; one/CTA
+    else:
+        cta_barrier()
+        # instruction_selection: bar.sync 0; one post-reduction shared edge
+
+    if row_valid:
+        for vb in static_unroll(VEC_BLOCKS):
+            local_col = (lane_in_row + vb*TPR)*8
+            absolute_col = cluster_y*COLS + local_col
+            if absolute_col < H:
+                store_global_128(R[actual_row,absolute_col],
+                                 h_bits[8*vb:8*vb+8])
+                # instruction_selection: st.global.v4.b32 with column predicate;
+                # one 128-bit residual issue/vb/thread
+
+    if CLUSTER_N > 1:
+        fence_cluster_acq_rel()
+        # instruction_selection: fence.acq_rel.cluster; one/CTA thread
+        cluster_arrive_relaxed()
+        # instruction_selection: barrier.cluster.arrive.relaxed; one/CTA
+        cluster_wait()
+        # instruction_selection: barrier.cluster.wait; one/CTA
+
+    # Phase 3 uses a static sequence only below the reviewed trip boundary;
+    # otherwise cursor is a true while-loop scalar. Cluster1 instantiates one
+    # lexical scale-block body; clustered global-reload paths instantiate the
+    # exact same primitive sequence twice before the backedge.
+    if row_valid:
+        BODY_SF = 2 if CLUSTER_N > 1 else 1
+        cursor = 0
+        while cursor < SF_PER_THREAD:
+            body_slot = each_static_replica(range(BODY_SF))
+            # structure: compile-time lexical replication only; it emits no op
+            sf_iter = cursor + body_slot
+            sf_idx = lane_in_row + sf_iter*TPR
+            if sf_idx < H//BLOCK_SIZE:
+                block_start = sf_idx*BLOCK_SIZE
+
+                if CLUSTER_N == 1:
+                    # Shared source helper loads all H scalars, then all W scalars.
+                    h0 = reg_fragment("f32",16)
+                    w0 = reg_fragment("f32",16)
+                    for value in static_unroll(16):
+                        bits = load_shared_b16(sH[row_in_cta,block_start+value])
+                        # instruction_selection: ld.shared.b16; one H value
+                        h0[value] = widen_input_scalar(bits,INPUT_DTYPE)
+                        # instruction_selection: cvt.f32.{f16,bf16}; one H value
+                    for value in static_unroll(16):
+                        bits = load_shared_b16(sW[row_in_cta,block_start+value])
+                        # instruction_selection: ld.shared.b16; one W value
+                        w0[value] = widen_input_scalar(bits,INPUT_DTYPE)
+                        # instruction_selection: cvt.f32.{f16,bf16}; one W value
+                    y0 = reg_fragment("f32",16)
+                    y0[0] = mul_f32(mul_f32(h0[0],rstd),w0[0])
+                    # instruction_selection: two mul.f32; first value
+                    max0 = abs_f32(y0[0])
+                    # instruction_selection: abs.f32; first value
+                    for value in static_unroll_range(1,16):
+                        y0[value] = mul_f32(mul_f32(h0[value],rstd),w0[value])
+                        # instruction_selection: two mul.f32; one value
+                        max0 = max_f32(max0,abs_f32(y0[value]))
+                        # instruction_selection: abs.f32 then max.f32; ordered fold
+
+                    if BLOCK_SIZE == 32:
+                        # Source completes chunk0 before beginning chunk1.
+                        h1 = reg_fragment("f32",16)
+                        w1 = reg_fragment("f32",16)
+                        for value in static_unroll(16):
+                            bits = load_shared_b16(
+                                sH[row_in_cta,block_start+16+value])
+                            # instruction_selection: ld.shared.b16; one H1 value
+                            h1[value] = widen_input_scalar(bits,INPUT_DTYPE)
+                            # instruction_selection: one scalar widen
+                        for value in static_unroll(16):
+                            bits = load_shared_b16(
+                                sW[row_in_cta,block_start+16+value])
+                            # instruction_selection: ld.shared.b16; one W1 value
+                            w1[value] = widen_input_scalar(bits,INPUT_DTYPE)
+                            # instruction_selection: one scalar widen
+                        y1 = reg_fragment("f32",16)
+                        y1[0] = mul_f32(mul_f32(h1[0],rstd),w1[0])
+                        # instruction_selection: two mul.f32; first chunk1 value
+                        max1 = abs_f32(y1[0])
+                        # instruction_selection: abs.f32; first chunk1 value
+                        for value in static_unroll_range(1,16):
+                            y1[value] = mul_f32(
+                                mul_f32(h1[value],rstd),w1[value])
+                            # instruction_selection: two mul.f32; one chunk1 value
+                            max1 = max_f32(max1,abs_f32(y1[value]))
+                            # instruction_selection: abs then ordered max; one/value
+                        max_abs = max_f32(max0,max1)
+                        # instruction_selection: max.f32; one cross-chunk issue
+                    else:
+                        max_abs = max0
+                else:
+                    # Cluster path issues every 128-bit H/W load before arithmetic.
+                    h0 = reg_fragment("u32",8)
+                    w0 = reg_fragment("u32",8)
+                    h0[0:4] = load_global_128(R[actual_row,block_start])
+                    h0[4:8] = load_global_128(R[actual_row,block_start+8])
+                    w0[0:4] = load_global_128(W[block_start])
+                    w0[4:8] = load_global_128(W[block_start+8])
+                    # instruction_selection: four ld.global.v4.u32 for chunk0,
+                    # ordered H0,H0,W0,W0
+                    if BLOCK_SIZE == 32:
+                        h1 = reg_fragment("u32",8)
+                        w1 = reg_fragment("u32",8)
+                        h1[0:4] = load_global_128(R[actual_row,block_start+16])
+                        h1[4:8] = load_global_128(R[actual_row,block_start+24])
+                        w1[0:4] = load_global_128(W[block_start+16])
+                        w1[4:8] = load_global_128(W[block_start+24])
+                        # instruction_selection: four more ld.global.v4.u32,
+                        # ordered H1,H1,W1,W1 before any packed multiply
+
+                    xw0 = reg_fragment("u32",8)
+                    for pair in static_unroll(8):
+                        xw0[pair] = mul_input2(h0[pair],w0[pair],INPUT_DTYPE)
+                        # instruction_selection: mul.{f16x2,bf16x2}, no .rn;
+                        # eight chunk0 issues
+                    if BLOCK_SIZE == 32:
+                        xw1 = reg_fragment("u32",8)
+                        for pair in static_unroll(8):
+                            xw1[pair] = mul_input2(h1[pair],w1[pair],INPUT_DTYPE)
+                            # instruction_selection: eight chunk1 packed issues
+
+                    abs0 = reg_fragment("u32",8)
+                    for pair in static_unroll(8):
+                        abs0[pair] = abs_input2(xw0[pair],INPUT_DTYPE)
+                        # instruction_selection: and.b32 0x7fff7fff; eight issues
+                    m0_01 = max_input2(abs0[0],abs0[1],INPUT_DTYPE)
+                    m0_23 = max_input2(abs0[2],abs0[3],INPUT_DTYPE)
+                    m0_45 = max_input2(abs0[4],abs0[5],INPUT_DTYPE)
+                    m0_67 = max_input2(abs0[6],abs0[7],INPUT_DTYPE)
+                    m0_03 = max_input2(m0_01,m0_23,INPUT_DTYPE)
+                    m0_47 = max_input2(m0_45,m0_67,INPUT_DTYPE)
+                    max_pair = max_input2(m0_03,m0_47,INPUT_DTYPE)
+                    # instruction_selection: seven packed max issues for chunk0
+                    if BLOCK_SIZE == 32:
+                        abs1 = reg_fragment("u32",8)
+                        for pair in static_unroll(8):
+                            abs1[pair] = abs_input2(xw1[pair],INPUT_DTYPE)
+                            # instruction_selection: eight chunk1 abs issues,
+                            # all after the complete chunk0 max tree
+                        m1_01 = max_input2(abs1[0],abs1[1],INPUT_DTYPE)
+                        m1_23 = max_input2(abs1[2],abs1[3],INPUT_DTYPE)
+                        m1_45 = max_input2(abs1[4],abs1[5],INPUT_DTYPE)
+                        m1_67 = max_input2(abs1[6],abs1[7],INPUT_DTYPE)
+                        m1_03 = max_input2(m1_01,m1_23,INPUT_DTYPE)
+                        m1_47 = max_input2(m1_45,m1_67,INPUT_DTYPE)
+                        max1_pair = max_input2(m1_03,m1_47,INPUT_DTYPE)
+                        max_pair = max_input2(max_pair,max1_pair,INPUT_DTYPE)
+                        # instruction_selection: eight packed max issues total
+                        # after chunk1 abs, including one cross-chunk maximum
+
+                    if INPUT_DTYPE == "f16":
+                        max_lo16,max_hi16 = mov_b32_pair(max_pair)
+                        # instruction_selection: mov.b32 pair; one/SF
+                        max_lo = cvt_f32_f16(max_lo16)
+                        max_hi = cvt_f32_f16(max_hi16)
+                        # instruction_selection: cvt.f32.f16; two/SF
+                    else:
+                        max_lo32 = and_b32(max_pair,0xffff)
+                        max_hi32 = shift_right_b32(max_pair,16)
+                        max_lo32 = shift_left_b32(max_lo32,16)
+                        max_hi32 = shift_left_b32(max_hi32,16)
+                        # instruction_selection: and, shift-right, two
+                        # shift-left issues for the BF16 maximum pair
+                        max_lo = mov_b32_as_f32(max_lo32)
+                        max_hi = mov_b32_as_f32(max_hi32)
+                        # instruction_selection: mov.b32 to f32; two/SF
+                    max_xw = max_f32(max_lo,max_hi)
+                    # instruction_selection: max.f32; one horizontal issue
+
+                    y0 = reg_fragment("f32",16)
+                    for pair in static_unroll(8):
+                        if INPUT_DTYPE == "f16":
+                            lo16,hi16 = mov_b32_pair(xw0[pair])
+                            lo = cvt_f32_f16(lo16)
+                            hi = cvt_f32_f16(hi16)
+                            # instruction_selection: mov pair + two cvt; one pair
+                        else:
+                            lo32 = shift_left_b32(and_b32(xw0[pair],0xffff),16)
+                            hi32 = shift_left_b32(shift_right_b32(xw0[pair],16),16)
+                            lo = mov_b32_as_f32(lo32)
+                            hi = mov_b32_as_f32(hi32)
+                            # instruction_selection: BF16 unpack/mov chain; one pair
+                        y0[2*pair] = mul_f32(lo,rstd)
+                        y0[2*pair+1] = mul_f32(hi,rstd)
+                        # instruction_selection: two mul.f32; one pair
+                    if BLOCK_SIZE == 32:
+                        y1 = reg_fragment("f32",16)
+                        for pair in static_unroll(8):
+                            if INPUT_DTYPE == "f16":
+                                lo16,hi16 = mov_b32_pair(xw1[pair])
+                                lo = cvt_f32_f16(lo16)
+                                hi = cvt_f32_f16(hi16)
+                                # instruction_selection: mov pair + two cvt
+                            else:
+                                lo32 = shift_left_b32(and_b32(xw1[pair],0xffff),16)
+                                hi32 = shift_left_b32(
+                                    shift_right_b32(xw1[pair],16),16)
+                                lo = mov_b32_as_f32(lo32)
+                                hi = mov_b32_as_f32(hi32)
+                                # instruction_selection: BF16 unpack/mov chain
+                            y1[2*pair] = mul_f32(lo,rstd)
+                            y1[2*pair+1] = mul_f32(hi,rstd)
+                            # instruction_selection: two mul.f32; one pair
+                    max_abs = mul_f32(max_xw,rstd)
+                    # instruction_selection: mul.f32; one scale-block maximum
+
+                if BLOCK_SIZE == 16 or SCALE_FORMAT == "e4m3":
+                    scale_f = mul_f32(global_scale_value,max_abs)
+                    # instruction_selection: mul.f32; one scalar
+                    scale_f = mul_f32(scale_f,fp4_max_rcp)
+                    # instruction_selection: mul.f32; one scalar
+                    scale_f = min_f32(scale_f,448.0)
+                    # instruction_selection: min.f32; one scalar
+                    scale_pair16 = cvt_e4m3_pair(0.0,scale_f)
+                    # instruction_selection: cvt.rn.satfinite.e4m3x2.f32;
+                    # zero is the high mate and scale the low mate, one/SF
+                    scale_word = cvt_u32_u16(scale_pair16)
+                    # instruction_selection: cvt.u32.u16; one/SF
+                    scale_byte = scale_word
+                    # lowering: the source `& 0xff` view is DCE; st.global.b8
+                    # consumes the low byte with no standalone and.b32
+                    decode_pair16 = cvt_u16_u32(scale_word)
+                    # instruction_selection: cvt.u16.u32; one/SF
+                    decoded_h2 = cvt_f16x2_e4m3x2(decode_pair16)
+                    # instruction_selection: cvt.rn.f16x2.e4m3x2; one/SF
+                    decoded_lo16,_ = mov_b32_pair(decoded_h2)
+                    # instruction_selection: mov.b32 {b16,b16}; one/SF
+                    decoded = cvt_f32_f16(decoded_lo16)
+                    # instruction_selection: cvt.f32.f16; one/SF
+                    reciprocal = rcp_fast(decoded)
+                    # instruction_selection: rcp.approx.ftz.f32; one/SF
+                    decoded_zero = setp(decoded == 0.0)
+                    # instruction_selection: setp.eq.f32; one/SF
+                    decoded_rcp = select(decoded_zero,0.0,reciprocal)
+                    # instruction_selection: selp.f32; one/SF
+                    inv_scale = mul_f32(decoded_rcp,global_scale_value)
+                    # instruction_selection: mul.f32; one scale
+                else:
+                    scale_f = mul_f32(max_abs,fp4_max_rcp)
+                    # instruction_selection: mul.f32; one scalar
+                    nonpositive = setp(scale_f <= 0.0)
+                    # instruction_selection: setp.le.f32; one/SF
+                    log_scale = lg2_fast(scale_f)
+                    # instruction_selection: lg2.approx.f32; one scale
+                    exponent = cvt_s32_f32_rpi(log_scale)
+                    # instruction_selection: cvt.rpi.s32.f32; one/SF
+                    biased = add_s32(exponent,127)
+                    # instruction_selection: add.s32; one/SF
+                    negative = setp(biased < 0)
+                    overflow = setp(biased > 255)
+                    # instruction_selection: setp.lt.s32 and setp.gt.s32
+                    biased = select(negative,0,biased)
+                    biased = select(overflow,255,biased)
+                    scale_word = select(nonpositive,0,biased)
+                    # instruction_selection: three ordered selp.s32 issues
+                    scale_byte = scale_word
+                    # lowering: low-byte view is DCE before st.global.b8
+                    scale_zero = setp(scale_word == 0)
+                    # instruction_selection: setp.eq.u32; one/SF
+                    negative_exponent = sub_s32(127,scale_word)
+                    # instruction_selection: sub.s32; one/SF
+                    inv_exponent = cvt_f32_s32_rn(negative_exponent)
+                    # instruction_selection: cvt.rn.f32.s32; one scale
+                    inv_candidate = ex2_fast(inv_exponent)
+                    # instruction_selection: ex2.approx.f32; one/SF
+                    inv_scale = select(scale_zero,0.0,inv_candidate)
+                    # instruction_selection: selp.f32; one/SF
+
+                store_global_b8(S_u8[primary_offset],scale_byte)
+                # instruction_selection: st.global.b8; one primary scale byte;
+                # no preceding `and.b32 0xff` survives PTX
+                if BOTH_SF:
+                    store_global_b8(S_linear_u8[actual_row,sf_idx],scale_byte)
+                    # instruction_selection: st.global.b8; one linear scale byte
+
+                for value in static_unroll(16):
+                    q0[value] = mul_f32(y0[value],inv_scale)
+                    # instruction_selection: mul.f32; one value
+                pair0 = reg_fragment("u8",8)
+                for pair in static_unroll(8):
+                    pair0[pair] = cvt_e2m1_pair(q0[2*pair+1],q0[2*pair])
+                    # instruction_selection:
+                    # cvt.rn.satfinite.e2m1x2.f32; eight/SF, PTX high then low
+                lo32 = mov_b32_bytes(pair0[0],pair0[1],pair0[2],pair0[3])
+                hi32 = mov_b32_bytes(pair0[4],pair0[5],pair0[6],pair0[7])
+                # instruction_selection: mov.b32 {b8,b8,b8,b8}; two/SF
+                lo64 = cvt_u64_u32(lo32)
+                hi64 = shift_left_b64(cvt_u64_u32(hi32),32)
+                # instruction_selection: two cvt.u64.u32 and one shl.b64
+                packed0 = or_b64(hi64,lo64)
+                # instruction_selection: or.b64; one/SF
+                if BLOCK_SIZE == 32:
+                    for value in static_unroll(16):
+                        q1[value] = mul_f32(y1[value],inv_scale)
+                        # instruction_selection: mul.f32; one value
+                    pair1 = reg_fragment("u8",8)
+                    for pair in static_unroll(8):
+                        pair1[pair] = cvt_e2m1_pair(q1[2*pair+1],q1[2*pair])
+                        # instruction_selection: eight E2M1 pair conversions
+                    lo32 = mov_b32_bytes(pair1[0],pair1[1],pair1[2],pair1[3])
+                    hi32 = mov_b32_bytes(pair1[4],pair1[5],pair1[6],pair1[7])
+                    lo64 = cvt_u64_u32(lo32)
+                    hi64 = shift_left_b64(cvt_u64_u32(hi32),32)
+                    packed1 = or_b64(hi64,lo64)
+                    # instruction_selection: two byte-pack moves, two widens,
+                    # one shift, one or
+                # Source finishes every block32 conversion/pack before either
+                # payload store; block16 reaches this store immediately.
+                store_global_u64(Y_u8[actual_row,block_start//2],packed0)
+                # instruction_selection: st.global.u64; first FP4 payload
+                if BLOCK_SIZE == 32:
+                    store_global_u64(Y_u8[actual_row,block_start//2+8],packed1)
+                    # instruction_selection: st.global.u64; second payload
+
+                if YNORM:
+                    for group in static_unroll(4):
+                        if INPUT_DTYPE == "f16":
+                            h0 = cvt_f16_f32(y0[group*4])
+                            h1 = cvt_f16_f32(y0[group*4+1])
+                            # instruction_selection: cvt.rn.f16.f32;
+                            # two scalar conversions for the low pair
+                            norm_lo32 = mov_b32_from_b16(h0,h1)
+                            # instruction_selection: mov.b32 {b16,b16}; one
+                            h2 = cvt_f16_f32(y0[group*4+2])
+                            h3 = cvt_f16_f32(y0[group*4+3])
+                            # instruction_selection: cvt.rn.f16.f32;
+                            # two scalar conversions for the high pair
+                            norm_hi32 = mov_b32_from_b16(h2,h3)
+                            # instruction_selection: mov.b32 {b16,b16}; one
+                        else:
+                            b0 = cvt_f32_bf16(y0[group*4])
+                            b1 = cvt_f32_bf16(y0[group*4+1])
+                            # instruction_selection: cvt.rn.bf16.f32;
+                            # two scalar conversions for the low pair
+                            norm_lo32 = mov_b32_from_b16(b0,b1)
+                            # instruction_selection: mov.b32 {b16,b16}; one
+                            b2 = cvt_f32_bf16(y0[group*4+2])
+                            b3 = cvt_f32_bf16(y0[group*4+3])
+                            # instruction_selection: cvt.rn.bf16.f32;
+                            # two scalar conversions for the high pair
+                            norm_hi32 = mov_b32_from_b16(b2,b3)
+                            # instruction_selection: mov.b32 {b16,b16}; one
+                        norm_lo64 = cvt_u64_u32(norm_lo32)
+                        norm_hi64 = shift_left_b64(cvt_u64_u32(norm_hi32),32)
+                        ynorm_word = or_b64(norm_hi64,norm_lo64)
+                        # instruction_selection: two widens, shift, or
+                        store_global_u64(
+                            YNorm[actual_row,block_start+group*4],ynorm_word)
+                        # instruction_selection: st.global.u64; four input-dtype values
+                    if BLOCK_SIZE == 32:
+                        for group in static_unroll(4):
+                            if INPUT_DTYPE == "f16":
+                                h0 = cvt_f16_f32(y1[group*4])
+                                h1 = cvt_f16_f32(y1[group*4+1])
+                                # instruction_selection: two scalar FP16 cvt
+                                norm_lo32 = mov_b32_from_b16(h0,h1)
+                                # instruction_selection: one mov.b32 pack
+                                h2 = cvt_f16_f32(y1[group*4+2])
+                                h3 = cvt_f16_f32(y1[group*4+3])
+                                # instruction_selection: two scalar FP16 cvt
+                                norm_hi32 = mov_b32_from_b16(h2,h3)
+                                # instruction_selection: one mov.b32 pack
+                            else:
+                                b0 = cvt_f32_bf16(y1[group*4])
+                                b1 = cvt_f32_bf16(y1[group*4+1])
+                                # instruction_selection: two scalar BF16 cvt
+                                norm_lo32 = mov_b32_from_b16(b0,b1)
+                                # instruction_selection: one mov.b32 pack
+                                b2 = cvt_f32_bf16(y1[group*4+2])
+                                b3 = cvt_f32_bf16(y1[group*4+3])
+                                # instruction_selection: two scalar BF16 cvt
+                                norm_hi32 = mov_b32_from_b16(b2,b3)
+                                # instruction_selection: one mov.b32 pack
+                            norm_lo64 = cvt_u64_u32(norm_lo32)
+                            norm_hi64 = shift_left_b64(
+                                cvt_u64_u32(norm_hi32),32)
+                            ynorm_word = or_b64(norm_hi64,norm_lo64)
+                            # instruction_selection: same conversion/pack family
+                            store_global_u64(
+                                YNorm[actual_row,block_start+16+group*4],
+                                ynorm_word)
+                            # instruction_selection: st.global.u64; four values
+            cursor += BODY_SF
+            # instruction_selection: scalar loop-index add in rolled variants;
+            # immediate 1 for cluster1, 2 for clustered paths; absent when the
+            # reviewed trip threshold selects complete static expansion
+
+    if ENABLE_PDL:
+        pdl_signal()
+        # instruction_selection: griddepcontrol.launch_dependents; one CTA issue
+```
+
+The pseudocode writes a `while` for the general phase-3 form. The implementation
+must statically emit its body below the reviewed cluster1 threshold, retain the
+single-SF cluster1 while exactly at/above it, and retain the two-replica
+clustered body with a guard on replica one. `primary_offset` is row-major unless
+`SWIZZLED or BOTH_SF`, in which case it is
+`(row//128)*(ceil_div(SF_COLS,4)*512)+(sf//4)*512+(row%32)*16+((row%128)//32)*4+(sf%4)`.
+
+## Storage ownership and lifetimes
+
+| storage | owner | lifetime |
+| --- | --- | --- |
+| X/W/global-scale | caller | read-only for the whole launch |
+| residual | caller | initial add input, then source-order in-place output; clustered phase 3 reloads it after fence/barrier |
+| Y/S/S-linear/YNorm | caller | independently mutable outputs; optional buffers remain untouched when disabled |
+| sX/sR | each CTA | async publication through phase-1 shared load |
+| sW/sH | each cluster1 CTA | async W/narrowed H publication through complete phase-3 scale loop |
+| reduction/mbarrier | CTA/cluster | row partial publication through rstd completion only |
+| H FP32 and H-square fragments | one thread | add through row reduction; H narrows before publication |
+| packed H/W or scalar FP32 scale block | one thread | one static or rolled phase-3 block |
+
+## Module and verification contract
+
+- Registry name `flashinfer_add_rmsnorm_fp4quant`, category `flashinfer`, compute
+  capability 10. PrimFunc returns `None` and exposes the fixed ten-argument ABI.
+- `CONFIGS` contains 1222 positive upstream device/public cases and 23 structural
+  guards. Three source-wrapper-only negative/trace cases are documented but are
+  not represented as device executions.
+- `BENCH_CONFIGS` is exactly the ten active unified source samples. Every row in
+  one valid reference-enabled `bench_suite` run must satisfy
+  `flashinfer_cutedsl_time / tirx_time > 0.99`; no other timer or API is a PASS
+  criterion.
+- Every specialization is rejected if low-level IR contains any tile primitive,
+  `tirx.tile.*`, `TilePrimitiveCall`, or function call.
+
+## Instruction selection is a lowering consequence
+
+The port preserves the three-input async group in cluster1 and two-input group in
+clusters, input-dtype H publication, ordered FP32 sum, exact row/cluster
+reduction, global-scale load placement, residual-store placement, cluster
+visibility fence, source's redundant full-row clustered quantization, Add-specific
+rolled-loop thresholds, scalar shared phase-3 loads versus packed global loads,
+chunk ordering, E4M3/UE8M0 rounding chains, byte stores without synthetic masks,
+packed E2M1 ordering, dual scale writes, YNorm conversion/store width, and PDL
+boundaries. Plain TIRx/PTX may express these reviewed instructions; it may not use
+tile primitives, change arithmetic precision/order, deduplicate cluster stores,
+reload a different value, move the residual store/fence, adopt RMSNormFP4's loop
+threshold, or fold optional outputs into extra launches.

--- a/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/roll-a-loop-with-while-not-a-counted-loop.md
@@ -130,6 +130,18 @@ six-shape performance matrix. Those timings do not isolate the large-trip loop,
 so the reusable result is the measured structural boundary, not a claimed
 speedup at eight groups.
 
+A second source-exact quantization port showed why that threshold cannot be
+transferred even to a closely related loop. After residual addition enlarged
+the kernel, its single-CTA E4M3-scale epilogue without an extra normalized
+output expanded one or two scale groups but rolled three or more with a
+one-group body; the corresponding UE8M0-scale epilogue expanded one and rolled
+two or more. The earlier async-copy and fragment phase remained fully expanded,
+so one blanket loop policy would have mismatched one phase or the other.
+Adjacent source profiles established the boundaries, 1,245 correctness
+configurations covered both sides, and the source-shaped implementation kept
+all ten measured reference/port ratios at 1.0097-1.0257. The measurements again
+confirm the complete structure rather than isolating a speedup from rolling.
+
 ## Boundary
 
 Only where the reference's loop is genuinely rolled -- whether it says so with a
@@ -141,7 +153,10 @@ body is small relative to its trip count can prefer the unrolled form.
 A source threshold is specific to its compiler version and the derived trip
 count, not to a convenient tensor dimension. Re-export adjacent profiles when
 the source compiler changes, and do not extrapolate the seven-to-eight boundary
-to a different loop body.
+to a different loop body. Do not share a threshold across sibling kernels,
+scale encodings, phases, or compile-time output modes: each changes the body
+size that drives the source compiler's decision. Keep independent selectors
+when one phase stays statically expanded while a later phase rolls.
 
 ## Verification
 
@@ -151,4 +166,6 @@ generated CUDA proves nothing, because the unrolling happens in nvcc -- this
 change was first made, measured, and written up as a win while the loop was
 still being fully unrolled. Matching totals do not prove it either: read the
 loop body, since a port can hit the reference's exact static counts and still
-carry a fatter body.
+carry a fatter body. For specialization-dependent policies, export adjacent
+profiles for every distinct body, record the backedge and static body width,
+and verify each phase independently before running the affected matrix.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `mxfp8_quantize`                        | `quantization/mxfp8_quantize.py`                    | Block quantization with UE8M0 scales |
 | `flashinfer_rmsnorm`                    | `norm/rmsnorm.py`                                   | Shared 2-D RMSNorm / Gemma RMSNorm family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_rmsnorm_fp4quant`           | `norm/rmsnorm_fp4quant.py`                          | RMSNorm fused with packed E2M1 FP4 quantization, E4M3 or UE8M0 block scales, optional scale swizzling, PDL, and cluster reduction |
+| `flashinfer_add_rmsnorm_fp4quant`       | `norm/add_rmsnorm_fp4quant.py`                      | Residual add and RMSNorm fused with packed E2M1 FP4 quantization, optional dual scale layouts and normalized output, PDL, and cluster reduction |
 | `flashinfer_layernorm`                  | `norm/layernorm.py`                                 | BF16 LayerNorm with FP32 affine parameters, independent int64 row strides, and optional PDL |
 | `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_fused_add_rmsnorm_quant`    | `norm/fused_add_rmsnorm_quant.py`                   | Fused residual add, RMSNorm, and FP8 quantization with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -10,7 +10,7 @@ tree, so a kernel's configs sit at `config/<bucket>/<kernel>.yaml`. With no
 `--workloads`, the flagged configs across all files are assembled into
 `.bench-suite/workloads.generated.yaml` and that is what runs. The generated
 file is the inspectable source of truth for the current representative sweep.
-Every kernel has at most three default small/medium/large representatives; the current tree assembles 179
+Every kernel has at most three default small/medium/large representatives; the current tree assembles 182
 workloads. Widening or narrowing the sweep is a YAML `default`
 flag flip, not a scheduler rule or a second selection file. Multi-GPU configs
 are deliberately absent from the default measured sweep but remain available

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "135a054f",
-    "tirx-kernels": "b405c5cb",
+    "tirx-kernels": "359c47fd",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "44b38022bd0b8643153e5c8de42da53d998e704c"
+    "tirx-kernels:tirx_kernels": "95c1d639f26f6c93c475c43a8a2d743a12029361"
   },
   "baselines": {
     "torch": {
@@ -2082,6 +2082,146 @@
       "impls": {
         "tir": 5549.111992647058,
         "flashattn_sm100": 5662.155411764706
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.720722131127593,
+        "flashinfer_cutedsl": 7.886697324960348
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 7.6994118407291845,
+        "flashinfer_cutedsl": 7.875118813744586
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 2.9510970245915575,
+        "flashinfer_cutedsl": 2.998385455950631
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.637615117253418,
+        "flashinfer_cutedsl": 5.775713977805708
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.741885649567213,
+        "flashinfer_cutedsl": 5.889707903937606
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random",
+      "label": "bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.685883698758787,
+        "flashinfer_cutedsl": 5.819831426804824
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 6.099396045275293,
+        "flashinfer_cutedsl": 6.15851926123798
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random",
+      "label": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.635236709029221,
+        "flashinfer_cutedsl": 5.769568938570171
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.963950825946344,
+        "flashinfer_cutedsl": 6.053008608825112
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_add_rmsnorm_fp4quant",
+      "config": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "label": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+      "status": "ok",
+      "impls": {
+        "tirx": 5.689546898829335,
+        "flashinfer_cutedsl": 5.821100472708933
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '135a054f', 'tirx-kernels': 'b405c5cb', 'tirx-bench-ci': None}`
-- Workloads: 428 ok, 0 failed
+- Git:       `{'tir': '135a054f', 'tirx-kernels': '359c47fd', 'tirx-bench-ci': None}`
+- Workloads: 438 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -239,6 +239,21 @@ Grouped workloads show one row per config and one timing column per implementati
 | `b2_s4096_h16_causal` | tir | 388.0339 | flashattn_sm100 | 390.3185 | 1.006 | — |
 | `b4_s8192_h16_causal` | tir | 2473.1056 | flashattn_sm100 | 2496.3857 | 1.009 | — |
 | `b4_s8192_h16_noncausal` | tir | 5549.1120 | flashattn_sm100 | 5662.1554 | 1.020 | — |
+
+## flashinfer_add_rmsnorm_fp4quant
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 7.7207 | flashinfer_cutedsl | 7.8867 | 1.021 | — |
+| `bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 7.6994 | flashinfer_cutedsl | 7.8751 | 1.023 | — |
+| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.9511 | flashinfer_cutedsl | 2.9984 | 1.016 | — |
+| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.6376 | flashinfer_cutedsl | 5.7757 | 1.024 | — |
+| `bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.7419 | flashinfer_cutedsl | 5.8897 | 1.026 | — |
+| `bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 5.6859 | flashinfer_cutedsl | 5.8198 | 1.024 | — |
+| `bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 6.0994 | flashinfer_cutedsl | 6.1585 | 1.010 | — |
+| `bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 5.6352 | flashinfer_cutedsl | 5.7696 | 1.024 | — |
+| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.9640 | flashinfer_cutedsl | 6.0530 | 1.015 | — |
+| `bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.6895 | flashinfer_cutedsl | 5.8211 | 1.023 | — |
 
 ## flashinfer_fused_add_rmsnorm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_add_rmsnorm_fp4quant.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_add_rmsnorm_fp4quant.yaml
@@ -1,0 +1,13 @@
+kernel: flashinfer_add_rmsnorm_fp4quant
+selection_rationale: The defaults cover the flattened 3-D launch, the primary NVFP4 shape, and the largest active shape; global-scale, swizzled-scale, MXFP4, and dual-scale variants remain available on request.
+configs:
+  - {config: bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: medium}
+  - {config: bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: large}
+  - {config: bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random, default: false}
+  - {config: bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: true, selection_role: small}
+  - {config: bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: false}
+  - {config: bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random, default: false}
+  - {config: bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random, default: false}

--- a/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
@@ -1,0 +1,1890 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2025 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer CuTe-DSL fused add/RMSNorm with packed FP4 quantization.
+
+The source implementation is ``AddRMSNormFP4QuantKernel`` in
+``flashinfer/cute_dsl/add_rmsnorm_fp4quant.py`` with inline PTX helpers from
+``flashinfer/cute_dsl/fp4_common.py``. The public entry is
+``flashinfer.norm.add_rmsnorm_fp4quant``.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+from tirx_kernels.flashinfer.norm.rmsnorm import _cvt_from_f32, _cvt_pair_from_f32
+from tirx_kernels.flashinfer.norm.rmsnorm_fp4quant import (
+    _add_f32,
+    _add_s32,
+    _butterfly_sum_f32,
+    _ceil_div,
+    _cluster_mbarrier_wait,
+    _cvt_f32_to_e4m3,
+    _cvt_f32_to_ue8m0,
+    _cvt_to_f32,
+    _div_rn_f32,
+    _fma_rn_f32,
+    _load_16_input_words,
+    _mapa_u32,
+    _minimum_f32,
+    _mul_f32,
+    _multiply_8_pairs,
+    _pair_max_to_f32,
+    _quantize_and_pack_16,
+    _rcp_approx_ftz,
+    _rsqrt_approx_ftz,
+    _scale_offset,
+    _store_global_u64,
+    _threads_per_row,
+    _ue8m0_to_output_scale,
+    _widen_and_scale_16,
+)
+from tirx_kernels.flashinfer.utils.fp_quant import absmax_8, hmax2
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "flashinfer_add_rmsnorm_fp4quant",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_DTYPES = ("float16", "bfloat16")
+_DEFAULT_EPS = 1e-6
+_OPTIN_SMEM_BYTES = 232448
+
+
+def _abs_f32(value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.abs.f32(out[0], value))
+    return out[0]
+
+
+def _maximum_f32(lhs, rhs):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.max.f32(out[0], lhs, rhs))
+    return out[0]
+
+
+def _e4m3_to_f32_rcp_exact(value):
+    pair = T.alloc_local((1,), "uint16")
+    halves = T.alloc_local((1,), "uint32")
+    half_bits = T.alloc_local((2,), "uint16")
+    decoded = T.alloc_local((1,), "float32")
+    predicate_zero = T.local_scalar("uint32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.cvt.u16.u32(pair[0], value))
+    T.evaluate(T.ptx.cvt.rn.f16x2.e4m3x2(halves[0], pair[0]))
+    T.evaluate(T.ptx.mov.b32(half_bits[0], half_bits[1], halves[0]))
+    T.evaluate(T.ptx.cvt.f32.f16(decoded[0], half_bits[0]))
+    reciprocal: T.float32 = _rcp_approx_ftz(decoded[0])
+    T.evaluate(T.ptx.setp.eq.f32(predicate_zero, decoded[0], T.float32(0.0)))
+    T.evaluate(T.ptx.selp.f32(out[0], T.float32(0.0), reciprocal, T.ptx.pred(predicate_zero)))
+    return out[0]
+
+
+def _cluster_bf16_pair_max_to_f32(word):
+    low = T.alloc_local((1,), "uint32")
+    high = T.alloc_local((1,), "uint32")
+    low_shifted = T.alloc_local((1,), "uint32")
+    high_shifted = T.alloc_local((1,), "uint32")
+    values = T.alloc_local((2,), "float32")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.and_.b32(low[0], word, T.uint32(0xFFFF)))
+    T.evaluate(T.ptx.shr.b32(high[0], word, T.uint32(16)))
+    T.evaluate(T.ptx.shl.b32(low_shifted[0], low[0], T.uint32(16)))
+    T.evaluate(T.ptx.shl.b32(high_shifted[0], high[0], T.uint32(16)))
+    T.evaluate(T.ptx.mov.b32(values[0], low_shifted[0]))
+    T.evaluate(T.ptx.mov.b32(values[1], high_shifted[0]))
+    T.evaluate(T.ptx.max.f32(out[0], values[0], values[1]))
+    return out[0]
+
+
+def _cluster_bf16_widen_and_scale_16(words, scale):
+    values = T.alloc_local((16,), "float32")
+    for pair in range(8):
+        low = T.alloc_local((1,), "uint32")
+        high = T.alloc_local((1,), "uint32")
+        low_shifted = T.alloc_local((1,), "uint32")
+        high_shifted = T.alloc_local((1,), "uint32")
+        widened = T.alloc_local((2,), "float32")
+        T.evaluate(T.ptx.and_.b32(low[0], words[pair], T.uint32(0xFFFF)))
+        T.evaluate(T.ptx.shr.b32(high[0], words[pair], T.uint32(16)))
+        T.evaluate(T.ptx.shl.b32(low_shifted[0], low[0], T.uint32(16)))
+        T.evaluate(T.ptx.shl.b32(high_shifted[0], high[0], T.uint32(16)))
+        T.evaluate(T.ptx.mov.b32(widened[0], low_shifted[0]))
+        T.evaluate(T.ptx.mov.b32(widened[1], high_shifted[0]))
+        T.evaluate(T.ptx.mul.f32(values[pair * 2], widened[0], scale))
+        T.evaluate(T.ptx.mul.f32(values[pair * 2 + 1], widened[1], scale))
+    return values
+
+
+def _pack_input_pair_scalar(low, high, input_dtype: str):
+    low_bits: T.uint16 = _cvt_from_f32(low, input_dtype)
+    high_bits: T.uint16 = _cvt_from_f32(high, input_dtype)
+    word = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.mov.b32(word[0], low_bits, high_bits))
+    return word[0]
+
+
+def _store_y_norm_16(y_norm, values, actual_row, block_start, H: int, input_dtype: str):
+    for group in range(4):
+        low_word: T.uint32 = _pack_input_pair_scalar(
+            values[group * 4], values[group * 4 + 1], input_dtype
+        )
+        high_word: T.uint32 = _pack_input_pair_scalar(
+            values[group * 4 + 2], values[group * 4 + 3], input_dtype
+        )
+        low64 = T.alloc_local((1,), "uint64")
+        high64 = T.alloc_local((1,), "uint64")
+        packed = T.alloc_local((1,), "uint64")
+        T.evaluate(T.ptx.cvt.u64.u32(low64[0], low_word))
+        T.evaluate(T.ptx.cvt.u64.u32(high64[0], high_word))
+        T.evaluate(T.ptx.shl.b64(high64[0], high64[0], T.uint32(32)))
+        T.evaluate(T.ptx.or_.b64(packed[0], high64[0], low64[0]))
+        offset: T.int64 = (
+            T.cast(actual_row, "int64") * T.int64(H) + T.cast(block_start, "int64") + group * 4
+        )
+        _store_global_u64(T.address_of(y_norm[offset]), packed[0])
+
+
+@T.inline
+def _process_add_scale_block(
+    shared_raw,
+    residual,
+    weight,
+    y,
+    scales,
+    scales_unswizzled,
+    y_norm,
+    actual_row,
+    row_in_cta,
+    sf_index,
+    rstd,
+    global_scale_value,
+    fp4_max_rcp,
+    *,
+    H: T.constexpr,
+    block_size: T.constexpr,
+    scale_format: T.constexpr,
+    swizzled: T.constexpr,
+    output_both_sf_layouts: T.constexpr,
+    output_norm: T.constexpr,
+    input_dtype: T.constexpr,
+    cluster_n: T.constexpr,
+    cols: T.constexpr,
+    tile_bytes: T.constexpr,
+):
+    num_scale_blocks = H // block_size
+    if sf_index < num_scale_blocks:
+        block_start: T.int32 = sf_index * block_size
+
+        if cluster_n == 1:
+            h0 = T.alloc_local((16,), "float32")
+            w0 = T.alloc_local((16,), "float32")
+            values0 = T.alloc_local((16,), "float32")
+            for value in T.unroll(16):
+                h_bits = T.alloc_local((1,), "uint16")
+                T.ptx.ld.shared.b16(
+                    h_bits[0],
+                    shared_raw.ptr_to(
+                        [tile_bytes * 3 + (row_in_cta * cols + block_start + value) * 2]
+                    ),
+                )
+                h0[value] = _cvt_to_f32(h_bits[0], input_dtype)
+            for value in T.unroll(16):
+                w_bits = T.alloc_local((1,), "uint16")
+                T.ptx.ld.shared.b16(
+                    w_bits[0],
+                    shared_raw.ptr_to(
+                        [tile_bytes * 2 + (row_in_cta * cols + block_start + value) * 2]
+                    ),
+                )
+                w0[value] = _cvt_to_f32(w_bits[0], input_dtype)
+            values0[0] = _mul_f32(_mul_f32(h0[0], rstd), w0[0])
+            max0: T.float32 = _abs_f32(values0[0])
+            for value in T.unroll(15):
+                index = value + 1
+                values0[index] = _mul_f32(_mul_f32(h0[index], rstd), w0[index])
+                max0 = _maximum_f32(max0, _abs_f32(values0[index]))
+            if block_size == 32:
+                h1 = T.alloc_local((16,), "float32")
+                w1 = T.alloc_local((16,), "float32")
+                values1 = T.alloc_local((16,), "float32")
+                for value in T.unroll(16):
+                    h_bits = T.alloc_local((1,), "uint16")
+                    T.ptx.ld.shared.b16(
+                        h_bits[0],
+                        shared_raw.ptr_to(
+                            [tile_bytes * 3 + (row_in_cta * cols + block_start + 16 + value) * 2]
+                        ),
+                    )
+                    h1[value] = _cvt_to_f32(h_bits[0], input_dtype)
+                for value in T.unroll(16):
+                    w_bits = T.alloc_local((1,), "uint16")
+                    T.ptx.ld.shared.b16(
+                        w_bits[0],
+                        shared_raw.ptr_to(
+                            [tile_bytes * 2 + (row_in_cta * cols + block_start + 16 + value) * 2]
+                        ),
+                    )
+                    w1[value] = _cvt_to_f32(w_bits[0], input_dtype)
+                values1[0] = _mul_f32(_mul_f32(h1[0], rstd), w1[0])
+                max1: T.float32 = _abs_f32(values1[0])
+                for value in T.unroll(15):
+                    index = value + 1
+                    values1[index] = _mul_f32(_mul_f32(h1[index], rstd), w1[index])
+                    max1 = _maximum_f32(max1, _abs_f32(values1[index]))
+                max_abs: T.float32 = _maximum_f32(max0, max1)
+            else:
+                max_abs = max0
+        else:
+            residual_base: T.int64 = T.cast(actual_row, "int64") * T.int64(H) + T.cast(
+                block_start, "int64"
+            )
+            h0 = _load_16_input_words(residual, residual_base)
+            w0 = _load_16_input_words(weight, block_start)
+            if block_size == 32:
+                h1 = _load_16_input_words(residual, residual_base + 16)
+                w1 = _load_16_input_words(weight, block_start + 16)
+            products0 = _multiply_8_pairs(h0, w0, input_dtype)
+            if block_size == 32:
+                products1 = _multiply_8_pairs(h1, w1, input_dtype)
+            max_pair = absmax_8(products0, input_dtype)
+            if block_size == 32:
+                max_pair = hmax2(max_pair, absmax_8(products1, input_dtype), input_dtype)
+            if input_dtype == "bfloat16":
+                max_xw: T.float32 = _cluster_bf16_pair_max_to_f32(max_pair)
+                values0 = _cluster_bf16_widen_and_scale_16(products0, rstd)
+                if block_size == 32:
+                    values1 = _cluster_bf16_widen_and_scale_16(products1, rstd)
+            else:
+                max_xw = _pair_max_to_f32(max_pair, input_dtype)
+                values0 = _widen_and_scale_16(products0, rstd, input_dtype)
+                if block_size == 32:
+                    values1 = _widen_and_scale_16(products1, rstd, input_dtype)
+            max_abs = _mul_f32(max_xw, rstd)
+
+        if block_size == 16 or scale_format == "e4m3":
+            scale_value: T.float32 = _mul_f32(_mul_f32(global_scale_value, max_abs), fp4_max_rcp)
+            scale_value = _minimum_f32(scale_value, T.float32(448.0))
+            scale_word: T.uint32 = _cvt_f32_to_e4m3(scale_value)
+            output_scale: T.float32 = _mul_f32(
+                _e4m3_to_f32_rcp_exact(scale_word), global_scale_value
+            )
+        else:
+            scale_word = _cvt_f32_to_ue8m0(_mul_f32(max_abs, fp4_max_rcp))
+            output_scale = _ue8m0_to_output_scale(scale_word)
+
+        primary_offset = _scale_offset(
+            actual_row, sf_index, H, block_size, swizzled or output_both_sf_layouts
+        )
+        T.evaluate(T.ptx.st.global_.b8(T.address_of(scales[primary_offset]), scale_word))
+        if output_both_sf_layouts:
+            linear_offset: T.int64 = T.cast(actual_row, "int64") * T.int64(
+                num_scale_blocks
+            ) + T.cast(sf_index, "int64")
+            T.evaluate(
+                T.ptx.st.global_.b8(T.address_of(scales_unswizzled[linear_offset]), scale_word)
+            )
+
+        packed0: T.uint64 = _quantize_and_pack_16(values0, output_scale)
+        if block_size == 32:
+            packed1: T.uint64 = _quantize_and_pack_16(values1, output_scale)
+        y_offset: T.int64 = T.cast(actual_row, "int64") * T.int64(H // 2) + T.cast(
+            block_start // 2, "int64"
+        )
+        _store_global_u64(T.address_of(y[y_offset]), packed0)
+        if block_size == 32:
+            _store_global_u64(T.address_of(y[y_offset + 8]), packed1)
+
+        if output_norm:
+            _store_y_norm_16(y_norm, values0, actual_row, block_start, H, input_dtype)
+            if block_size == 32:
+                _store_y_norm_16(y_norm, values1, actual_row, block_start + 16, H, input_dtype)
+
+
+def _dtype_code(dtype: str) -> str:
+    return {"float16": "fp16", "bfloat16": "bf16"}[dtype]
+
+
+def _eps_code(eps: float) -> str:
+    return {1e-4: "1e4", 1e-5: "1e5", 1e-6: "1e6"}[eps]
+
+
+def _derived_config(H: int, cluster_n: int) -> dict[str, int]:
+    H_per_cta = H // cluster_n
+    tpr = _threads_per_row(H_per_cta)
+    threads = 128 if H_per_cta <= 16384 else 256
+    rows = threads // tpr
+    warps_per_row = max(tpr // 32, 1)
+    vec_blocks = max(1, _ceil_div(H_per_cta // 8, tpr))
+    cols = 8 * vec_blocks * tpr
+    tile_bytes = rows * cols * 2
+    return {
+        "H_per_cta": H_per_cta,
+        "tpr": tpr,
+        "threads": threads,
+        "rows": rows,
+        "warps_per_row": warps_per_row,
+        "vec_blocks": vec_blocks,
+        "cols": cols,
+        "tile_bytes": tile_bytes,
+    }
+
+
+def _estimate_smem(H: int, cluster_n: int) -> int:
+    source = _derived_config(H, cluster_n)
+    reduction = source["rows"] * source["warps_per_row"] * 4
+    if cluster_n == 1:
+        return 4 * source["tile_bytes"] + reduction
+    return 2 * source["tile_bytes"] + reduction * cluster_n + 8
+
+
+def _source_config(H: int) -> dict[str, int]:
+    cluster_n = 16
+    for candidate in (1, 2, 4, 8, 16):
+        if H % candidate == 0 and _estimate_smem(H, candidate) <= _OPTIN_SMEM_BYTES:
+            cluster_n = candidate
+            break
+    source = _derived_config(H, cluster_n)
+    source["cluster_n"] = cluster_n
+    source["smem_bytes"] = _estimate_smem(H, cluster_n)
+    return source
+
+
+def _cfg(
+    case: str,
+    dtype: str,
+    H: int,
+    *,
+    M: int | None = None,
+    B: int | None = None,
+    S: int | None = None,
+    block_size: int = 16,
+    scale_format: str = "e4m3",
+    swizzled: bool = False,
+    output_both_sf_layouts: bool = False,
+    output_norm: bool = False,
+    enable_pdl: bool = False,
+    eps: float = _DEFAULT_EPS,
+    global_scale_mode: str = "none",
+    allocation: str = "preallocated",
+    data_mode: str = "random",
+) -> dict[str, Any]:
+    if M is None:
+        if B is None or S is None:
+            raise ValueError("either M or both B/S must be provided")
+        M = B * S
+        shape = f"b{B}_s{S}"
+        input_ndim = 3
+    else:
+        if B is not None or S is not None:
+            raise ValueError("M and B/S are mutually exclusive")
+        shape = f"m{M}"
+        input_ndim = 2
+    label = (
+        f"{case}_{_dtype_code(dtype)}_{shape}_h{H}_b{block_size}_{scale_format}_"
+        f"sw{int(swizzled)}_both{int(output_both_sf_layouts)}_"
+        f"yn{int(output_norm)}_pdl{int(enable_pdl)}_eps{_eps_code(eps)}_"
+        f"gs{global_scale_mode}_{allocation}_{data_mode}"
+    )
+    return {
+        "label": label,
+        "case": case,
+        "input_dtype": dtype,
+        "input_ndim": input_ndim,
+        "M": M,
+        "B": B,
+        "S": S,
+        "H": H,
+        "block_size": block_size,
+        "scale_format": scale_format,
+        "swizzled": swizzled,
+        "output_both_sf_layouts": output_both_sf_layouts,
+        "output_norm": output_norm,
+        "enable_pdl": enable_pdl,
+        "eps": eps,
+        "global_scale_mode": global_scale_mode,
+        "allocation": allocation,
+        "data_mode": data_mode,
+    }
+
+
+_NV2D_CONFIGS = [
+    _cfg("nv2d", dtype, H, M=M, eps=eps)
+    for M in (1, 4, 16, 32, 7, 13, 128, 512, 1000, 8192, 16384)
+    for H in (64, 128, 256, 512, 1024, 1536, 2048, 4096, 8192)
+    for dtype in _DTYPES
+    for eps in (1e-5, 1e-6)
+]
+
+_NV3D_CONFIGS = [
+    _cfg("nv3d", dtype, H, B=B, S=S, eps=1e-5)
+    for B in (1, 4, 3, 7, 128)
+    for S in (16, 64, 128, 37)
+    for H in (128, 256, 1536, 4096, 8192)
+    for dtype in _DTYPES
+]
+
+_LARGE_BATCH_CONFIGS = [
+    _cfg("large_batch", "float16", H, M=M) for M, H in ((512, 4096), (1024, 4096))
+]
+
+_MX_BASIC_CONFIGS = [
+    _cfg("mx_basic", dtype, H, M=M, block_size=32, scale_format="ue8m0")
+    for M in (1, 4, 16, 7, 128, 8192)
+    for H in (128, 256, 512, 1536, 2048, 4096)
+    for dtype in _DTYPES
+]
+
+_CROSS_CONFIGS = [
+    *[
+        _cfg("fused_vs_separate", "float16", H, M=M)
+        for M in (4, 16, 128, 512)
+        for H in (256, 512, 1024, 4096, 8192)
+    ],
+    *[
+        _cfg("nv_matches_separate", dtype, H, M=M)
+        for M in (1, 4, 16, 128)
+        for H in (64, 256, 512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("mx_matches_separate", dtype, H, M=M, block_size=32, scale_format="ue8m0")
+        for M in (1, 4, 16, 128)
+        for H in (128, 256, 512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("global_scale_consistency", "float16", H, M=M, global_scale_mode="nonunit")
+        for M in (1, 16, 64)
+        for H in (256, 1024, 4096)
+    ],
+]
+
+_LARGE_H_CONFIGS = [
+    *[
+        _cfg("large_h_nv", dtype, H, M=M)
+        for M in (1, 16, 128, 1024)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("large_h_mx", dtype, H, M=M, block_size=32, scale_format="ue8m0")
+        for M in (1, 16, 128, 1024)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+]
+
+_SWIZZLED_CONFIGS = [
+    *[
+        _cfg("swizzled_nv", dtype, H, M=M, swizzled=True)
+        for M in (1, 16, 128, 256)
+        for H in (512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("swizzled_mx", dtype, H, M=M, block_size=32, scale_format="ue8m0", swizzled=True)
+        for M in (1, 16, 128, 256)
+        for H in (512, 1024, 2048, 4096)
+        for dtype in _DTYPES
+    ],
+]
+
+_ALLOCATION_CONFIGS = [
+    *[
+        _cfg("auto2d_nv", dtype, H, M=M, allocation="auto")
+        for M in (1, 16, 128)
+        for H in (256, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("auto3d_nv", "float16", H, B=B, S=S, allocation="auto")
+        for B in (1, 4, 16)
+        for S in (16, 64)
+        for H in (256, 1024)
+    ],
+    *[
+        _cfg("auto_mx", "float16", H, M=M, block_size=32, scale_format="ue8m0", allocation="auto")
+        for M in (1, 16, 128)
+        for H in (256, 1024)
+    ],
+    *[
+        _cfg("auto_swizzled", "float16", H, M=M, swizzled=True, allocation="auto")
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    *[
+        _cfg("auto_matches_preallocated", "float16", H, M=M, allocation="compare")
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+]
+
+_RESIDUAL_CONFIGS = [
+    *[
+        _cfg("residual2d", dtype, H, M=M)
+        for M in (1, 4, 16, 128, 512)
+        for H in (256, 512, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("residual3d", dtype, H, B=B, S=S)
+        for B in (1, 4, 16)
+        for S in (16, 64, 128)
+        for H in (256, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("residual_mx", dtype, H, M=M, block_size=32, scale_format="ue8m0")
+        for M in (1, 16, 128)
+        for H in (256, 1024, 2048)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("residual_large_h", dtype, H, M=M)
+        for M in (1, 16, 128)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+    *[_cfg("residual_used_for_norm", "float16", H, M=M) for M in (16, 128) for H in (512, 1024)],
+    *[_cfg("residual_preallocated", "float16", H, M=M) for M in (16, 128) for H in (512, 1024)],
+    *[
+        _cfg("residual_swizzled", "float16", H, M=M, swizzled=True)
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    _cfg("residual_not_aliased", "float16", 512, M=16),
+]
+
+_BOTH_CONFIGS = [
+    *[
+        _cfg("both_nv", dtype, H, M=M, output_both_sf_layouts=True)
+        for M in (1, 16, 128, 256)
+        for H in (256, 512, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg(
+            "both_mx",
+            dtype,
+            H,
+            M=M,
+            block_size=32,
+            scale_format="ue8m0",
+            output_both_sf_layouts=True,
+        )
+        for M in (1, 16, 128, 256)
+        for H in (256, 512, 1024, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("both_consistency", "float16", H, M=M, output_both_sf_layouts=True)
+        for M in (1, 16, 128)
+        for H in (512, 1024, 4096)
+    ],
+    *[
+        _cfg("both3d", "float16", H, B=B, S=S, output_both_sf_layouts=True)
+        for B in (1, 4, 8)
+        for S in (16, 64, 128)
+        for H in (256, 1024)
+    ],
+    *[
+        _cfg(
+            "both_global",
+            "float16",
+            H,
+            M=M,
+            output_both_sf_layouts=True,
+            global_scale_mode="nonunit",
+        )
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    *[
+        _cfg("both_preallocated", "float16", H, M=M, output_both_sf_layouts=True)
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    *[
+        _cfg("both_large_h", dtype, H, M=M, output_both_sf_layouts=True)
+        for M in (1, 16, 128)
+        for H in (16384, 32768)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("both_residual", "float16", H, M=M, output_both_sf_layouts=True)
+        for M in (16, 128)
+        for H in (512, 1024)
+    ],
+    _cfg("both_ignores_swizzle", "float16", 1024, M=64, swizzled=True, output_both_sf_layouts=True),
+]
+
+_YOUT_CONFIGS = [
+    *[
+        _cfg("yout_reference", dtype, H, M=M, output_norm=True)
+        for M in (1, 64)
+        for H in (256, 4096)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("yout_quant_unchanged", dtype, H, M=M, output_norm=True, global_scale_mode="nonunit")
+        for M in (1, 64)
+        for H in (256, 2048)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("yout_both", "bfloat16", H, M=M, output_both_sf_layouts=True, output_norm=True)
+        for M in (1, 16, 128)
+        for H in (512, 2048)
+    ],
+    *[
+        _cfg("yout3d", "bfloat16", H, B=B, S=37, output_norm=True)
+        for B in (1, 4)
+        for H in (256, 2048)
+    ],
+    *[
+        _cfg(
+            "yout_not_global_scaled",
+            dtype,
+            2048,
+            M=M,
+            output_norm=True,
+            global_scale_mode="nonunit",
+        )
+        for M in (1, 64)
+        for dtype in _DTYPES
+    ],
+    *[
+        _cfg("yout_mx", dtype, 2048, M=M, block_size=32, scale_format="ue8m0", output_norm=True)
+        for M in (1, 64)
+        for dtype in _DTYPES
+    ],
+]
+
+_UPSTREAM_CONFIGS = [
+    *_NV2D_CONFIGS,
+    *_NV3D_CONFIGS,
+    *_LARGE_BATCH_CONFIGS,
+    *_MX_BASIC_CONFIGS,
+    *_CROSS_CONFIGS,
+    *_LARGE_H_CONFIGS,
+    *_SWIZZLED_CONFIGS,
+    *_ALLOCATION_CONFIGS,
+    *_RESIDUAL_CONFIGS,
+    *_BOTH_CONFIGS,
+    *_YOUT_CONFIGS,
+]
+
+_STRUCTURE_CONFIGS = [
+    _cfg("guard_subwarp_row_tail", "float16", 64, M=17),
+    _cfg("guard_nv_column_tail", "bfloat16", 80, M=129, swizzled=True),
+    _cfg("guard_mx_column_tail", "float16", 160, M=3, block_size=32, scale_format="ue8m0"),
+    *[
+        _cfg("guard_threshold", "bfloat16", H, M=3)
+        for H in (3072, 3088, 6144, 6160, 14336, 16384, 16400)
+    ],
+    *[
+        _cfg(f"guard_cluster{cluster}", "bfloat16", H, M=1)
+        for cluster, H in ((2, 32768), (4, 131072), (8, 262144), (16, 524288))
+    ],
+    _cfg("guard_pdl", "bfloat16", 4096, M=3, enable_pdl=True),
+    _cfg(
+        "guard_block32_e4m3",
+        "float16",
+        4096,
+        M=3,
+        block_size=32,
+        scale_format="e4m3",
+        global_scale_mode="nonunit",
+    ),
+    _cfg("guard_block16_requested_ue8", "float16", 4096, M=3, scale_format="ue8m0"),
+    _cfg("guard_zero_data", "bfloat16", 4096, M=3, data_mode="zero"),
+    _cfg("guard_zero_global", "float16", 4096, M=3, global_scale_mode="zero"),
+    _cfg("guard_both_column_tail", "bfloat16", 80, M=129, output_both_sf_layouts=True),
+    _cfg("guard_cluster16_both", "bfloat16", 524288, M=1, output_both_sf_layouts=True),
+    _cfg("guard_cluster16_yout", "bfloat16", 524288, M=1, output_norm=True),
+    _cfg(
+        "guard_pdl_both_yout",
+        "bfloat16",
+        4096,
+        M=3,
+        output_both_sf_layouts=True,
+        output_norm=True,
+        enable_pdl=True,
+    ),
+]
+
+CONFIGS = [*_UPSTREAM_CONFIGS, *_STRUCTURE_CONFIGS]
+
+assert len(_NV2D_CONFIGS) == 396
+assert len(_NV3D_CONFIGS) == 200
+assert len(_LARGE_BATCH_CONFIGS) == 2
+assert len(_MX_BASIC_CONFIGS) == 72
+assert len(_CROSS_CONFIGS) == 125
+assert len(_LARGE_H_CONFIGS) == 32
+assert len(_SWIZZLED_CONFIGS) == 64
+assert len(_ALLOCATION_CONFIGS) == 44
+assert len(_RESIDUAL_CONFIGS) == 137
+assert len(_BOTH_CONFIGS) == 116
+assert len(_YOUT_CONFIGS) == 34
+assert len(_UPSTREAM_CONFIGS) == 1222
+assert len(_STRUCTURE_CONFIGS) == 23
+assert len(CONFIGS) == 1245
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+
+BENCH_CONFIGS = [
+    _cfg("bench_nv", "bfloat16", 4096, M=32),
+    _cfg("bench_nv_large", "bfloat16", 8192, M=64),
+    _cfg("bench_nv_global", "bfloat16", 4096, M=32, global_scale_mode="one"),
+    _cfg("bench_nv_swizzled", "bfloat16", 4096, M=32, swizzled=True),
+    _cfg("bench_mx", "bfloat16", 4096, M=32, block_size=32, scale_format="ue8m0"),
+    _cfg("bench_nv_3d", "bfloat16", 128, B=32, S=32),
+    _cfg("bench_nv_both", "bfloat16", 4096, M=32, output_both_sf_layouts=True),
+    _cfg("bench_nv_both_large", "bfloat16", 8192, M=64, output_both_sf_layouts=True),
+    _cfg(
+        "bench_nv_both_global",
+        "bfloat16",
+        4096,
+        M=32,
+        output_both_sf_layouts=True,
+        global_scale_mode="one",
+    ),
+    _cfg(
+        "bench_mx_both",
+        "bfloat16",
+        4096,
+        M=32,
+        block_size=32,
+        scale_format="ue8m0",
+        output_both_sf_layouts=True,
+    ),
+]
+
+
+def _validate(config: dict[str, Any]) -> None:
+    if config["input_dtype"] not in _DTYPES:
+        raise ValueError(f"unsupported input_dtype={config['input_dtype']!r}")
+    if int(config["H"]) < 64 or int(config["H"]) % int(config["block_size"]):
+        raise ValueError("H must be >=64 and divisible by block_size")
+    if int(config["block_size"]) not in (16, 32):
+        raise ValueError("block_size must be 16 or 32")
+    if config["scale_format"] not in ("e4m3", "ue8m0"):
+        raise ValueError("scale_format must be e4m3 or ue8m0")
+
+
+def get_kernel(**config: Any):
+    """Return one source-faithful Add/RMSNorm/FP4 specialization."""
+    _validate(config)
+    input_dtype = str(config["input_dtype"])
+    H = int(config["H"])
+    block_size = int(config["block_size"])
+    scale_format = str(config["scale_format"])
+    swizzled = bool(config["swizzled"])
+    output_both_sf_layouts = bool(config["output_both_sf_layouts"])
+    output_norm = bool(config["output_norm"])
+    enable_pdl = bool(config["enable_pdl"])
+    source = _source_config(H)
+    cluster_n = int(source["cluster_n"])
+    tpr = int(source["tpr"])
+    threads = int(source["threads"])
+    rows = int(source["rows"])
+    warps_per_row = int(source["warps_per_row"])
+    vec_blocks = int(source["vec_blocks"])
+    cols = int(source["cols"])
+    tile_bytes = int(source["tile_bytes"])
+    smem_bytes = int(source["smem_bytes"])
+    total_values = 8 * vec_blocks
+    packed_pairs = 4 * vec_blocks
+    reduce_base = (4 if cluster_n == 1 else 2) * tile_bytes
+    reduce_count = rows * warps_per_row * cluster_n
+    mbar_offset = reduce_base + reduce_count * 4
+    expected_bytes = reduce_count * 4
+    total_partials_per_row = warps_per_row * cluster_n
+    full_columns = H == cluster_n * cols
+    num_scale_blocks = H // block_size
+    scale_blocks_per_thread = _ceil_div(num_scale_blocks, tpr)
+    use_e4m3_scale = block_size == 16 or scale_format == "e4m3"
+    row_lane_xors = tuple(lane_xor for lane_xor in (1, 2, 4, 8, 16) if lane_xor < min(tpr, 32))
+    full_lane_xors = (1, 2, 4, 8, 16)
+    scale_columns = H // block_size
+
+    @T.inline
+    def kernel_body(
+        x,
+        residual,
+        weight,
+        y,
+        scales,
+        scales_unswizzled,
+        y_norm,
+        global_scale,
+        runtime_M,
+        runtime_eps,
+    ):
+        # TIRX_TRANSCRIBE_START flashinfer_add_rmsnorm_fp4quant
+        T.attr({"tirx.required_block_size": 1})
+        tid = T.thread_id([threads])
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.wait()
+
+        if cluster_n > 1:
+            block_x_raw, block_y_raw = T.cta_id(
+                [T.cast(T.ceildiv(runtime_M, T.int32(rows)), "int32"), cluster_n]
+            )
+            _, cta_rank_raw = T.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
+            block_y: T.int32 = T.cast(block_y_raw, "int32")
+            cta_rank: T.int32 = T.cast(cta_rank_raw, "int32")
+        else:
+            block_x_raw = T.cta_id([T.cast(T.ceildiv(runtime_M, T.int32(rows)), "int32")])
+            block_y = T.int32(0)
+            cta_rank = T.int32(0)
+
+        fp4_max_rcp: T.float32 = _rcp_approx_ftz(T.float32(6.0))
+        block_x: T.int32 = T.cast(block_x_raw, "int32")
+        row_in_cta: T.int32 = tid // tpr
+        thread_in_row: T.int32 = tid % tpr
+        actual_row: T.int32 = block_x * rows + row_in_cta
+        row_valid: T.bool = actual_row < runtime_M
+        warp: T.int32 = tid // 32
+        lane: T.int32 = tid % 32
+        row_warp: T.int32 = warp // warps_per_row
+        warp_in_row: T.int32 = warp % warps_per_row
+
+        shared_raw = T.alloc_buffer((smem_bytes,), "uint8", scope="shared.dyn", align=1024)
+        T.attr({"tirx.dyn_smem_bytes": smem_bytes})
+
+        if cluster_n > 1:
+            if tid == 0:
+                T.ptx.mbarrier.init.shared.b64(shared_raw.ptr_to([mbar_offset]), T.uint32(1))
+            T.ptx.fence.mbarrier_init.release.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+            absolute_col: T.int32 = block_y * cols + local_col
+            col_valid: T.bool = absolute_col < H
+            source_bytes: T.uint32 = T.uint32(16)
+            if not full_columns:
+                source_bytes = T.cast(T.if_then_else(col_valid, 16, 0), "uint32")
+            if row_valid:
+                x_offset: T.int64 = T.cast(actual_row, "int64") * T.int64(H) + T.cast(
+                    absolute_col, "int64"
+                )
+                T.ptx["cp.async.ca.shared.global"](
+                    shared_raw.ptr_to([(row_in_cta * cols + local_col) * 2]),
+                    x.ptr_to([x_offset]),
+                    16,
+                    source_bytes,
+                )
+                T.ptx["cp.async.ca.shared.global"](
+                    shared_raw.ptr_to([tile_bytes + (row_in_cta * cols + local_col) * 2]),
+                    residual.ptr_to([x_offset]),
+                    16,
+                    source_bytes,
+                )
+            if cluster_n == 1:
+                T.ptx["cp.async.ca.shared.global"](
+                    shared_raw.ptr_to([2 * tile_bytes + (row_in_cta * cols + local_col) * 2]),
+                    weight.ptr_to([absolute_col]),
+                    16,
+                    source_bytes,
+                )
+        T.ptx.cp.async_.commit_group()
+        T.ptx.cp.async_.wait_group(0)
+
+        x_words = T.alloc_local((packed_pairs,), "uint32")
+        r_words = T.alloc_local((packed_pairs,), "uint32")
+        for vb in T.unroll(vec_blocks):
+            local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+            T.ptx.ld.shared.v4.b32(
+                x_words[vb * 4],
+                x_words[vb * 4 + 1],
+                x_words[vb * 4 + 2],
+                x_words[vb * 4 + 3],
+                shared_raw.ptr_to([(row_in_cta * cols + local_col) * 2]),
+            )
+            T.ptx.ld.shared.v4.b32(
+                r_words[vb * 4],
+                r_words[vb * 4 + 1],
+                r_words[vb * 4 + 2],
+                r_words[vb * 4 + 3],
+                shared_raw.ptr_to([tile_bytes + (row_in_cta * cols + local_col) * 2]),
+            )
+
+        x_f32 = T.alloc_local((total_values,), "float32")
+        r_f32 = T.alloc_local((total_values,), "float32")
+        for pair in T.unroll(packed_pairs):
+            x_low = T.alloc_local((1,), "uint16")
+            x_high = T.alloc_local((1,), "uint16")
+            T.ptx.mov.b32(x_low[0], x_high[0], x_words[pair])
+            x_f32[pair * 2] = _cvt_to_f32(x_low[0], input_dtype)
+            x_f32[pair * 2 + 1] = _cvt_to_f32(x_high[0], input_dtype)
+
+        for pair in T.unroll(packed_pairs):
+            r_low = T.alloc_local((1,), "uint16")
+            r_high = T.alloc_local((1,), "uint16")
+            T.ptx.mov.b32(r_low[0], r_high[0], r_words[pair])
+            r_f32[pair * 2] = _cvt_to_f32(r_low[0], input_dtype)
+            r_f32[pair * 2 + 1] = _cvt_to_f32(r_high[0], input_dtype)
+
+        h_f32 = T.alloc_local((total_values,), "float32")
+        h_sq = T.alloc_local((total_values,), "float32")
+        h_words = T.alloc_local((packed_pairs,), "uint32")
+        for pair in T.unroll(packed_pairs):
+            h_pair = T.alloc_local((1,), "uint64")
+            T.ptx.add.f32x2(
+                h_pair[0],
+                T.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                T.cuda.make_float2(r_f32[pair * 2], r_f32[pair * 2 + 1]),
+            )
+            T.ptx.mov.b64(h_f32[pair * 2], h_f32[pair * 2 + 1], h_pair[0])
+
+        for pair in T.unroll(packed_pairs):
+            h_pair = T.alloc_local((1,), "uint64")
+            sq_pair = T.alloc_local((1,), "uint64")
+            T.ptx.mov.b64(h_pair[0], h_f32[pair * 2], h_f32[pair * 2 + 1])
+            T.ptx.mul.f32x2(sq_pair[0], h_pair[0], h_pair[0])
+            T.ptx.mov.b64(h_sq[pair * 2], h_sq[pair * 2 + 1], sq_pair[0])
+
+        for pair in T.unroll(packed_pairs):
+            h_words[pair] = _cvt_pair_from_f32(h_f32[pair * 2 + 1], h_f32[pair * 2], input_dtype)
+
+        if cluster_n == 1:
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+                T.ptx.st.shared.v4.b32(
+                    shared_raw.ptr_to([3 * tile_bytes + (row_in_cta * cols + local_col) * 2]),
+                    h_words[vb * 4],
+                    h_words[vb * 4 + 1],
+                    h_words[vb * 4 + 2],
+                    h_words[vb * 4 + 3],
+                )
+
+        local_sum: T.float32 = T.float32(0.0)
+        for value in T.unroll(total_values):
+            local_sum = _add_f32(local_sum, h_sq[value])
+        local_sum = _butterfly_sum_f32(local_sum, row_lane_xors)
+        warp_sum: T.float32 = local_sum
+
+        if warps_per_row > 1 and cluster_n == 1:
+            if lane == 0:
+                reduce_index: T.int32 = row_warp + warp_in_row * rows
+                T.ptx.st.shared.b32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]),
+                    T.reinterpret("uint32", warp_sum),
+                )
+            T.ptx.bar.sync(T.uint32(0))
+            final_sum: T.float32 = T.float32(0.0)
+            if lane < warps_per_row:
+                reduce_word = T.alloc_local((1,), "uint32")
+                reduce_index: T.int32 = row_warp + lane * rows
+                T.ptx.ld.shared.b32(
+                    reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                )
+                final_sum = T.reinterpret("float32", reduce_word[0])
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq: T.float32 = final_sum
+        elif cluster_n > 1:
+            if warp == 0:
+                if T.cuda.elect_sync():
+                    T.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        shared_raw.ptr_to([mbar_offset]), T.uint32(expected_bytes)
+                    )
+            if lane < cluster_n:
+                reduce_index: T.int32 = (
+                    row_warp + warp_in_row * rows + cta_rank * rows * warps_per_row
+                )
+                peer_reduce: T.uint32 = _mapa_u32(
+                    shared_raw.ptr_to([reduce_base + reduce_index * 4]), lane
+                )
+                peer_mbar: T.uint32 = _mapa_u32(shared_raw.ptr_to([mbar_offset]), lane)
+                T.ptx.st_async.shared__cluster.mbarrier__complete_tx__bytes.f32(
+                    peer_reduce, warp_sum, peer_mbar
+                )
+            _cluster_mbarrier_wait(shared_raw.ptr_to([mbar_offset]))
+            final_sum = T.float32(0.0)
+            for iteration in T.unroll(_ceil_div(total_partials_per_row, 32)):
+                partial: T.int32 = lane + iteration * 32
+                if partial < total_partials_per_row:
+                    partial_warp: T.int32 = partial % warps_per_row
+                    partial_cta: T.int32 = partial // warps_per_row
+                    reduce_index: T.int32 = (
+                        row_warp + partial_warp * rows + partial_cta * rows * warps_per_row
+                    )
+                    reduce_word = T.alloc_local((1,), "uint32")
+                    T.ptx.ld.shared.b32(
+                        reduce_word[0], shared_raw.ptr_to([reduce_base + reduce_index * 4])
+                    )
+                    final_sum = _add_f32(final_sum, T.reinterpret("float32", reduce_word[0]))
+            final_sum = _butterfly_sum_f32(final_sum, full_lane_xors)
+            sum_sq = final_sum
+        else:
+            sum_sq = warp_sum
+
+        if H & (H - 1) == 0:
+            shifted: T.float32 = _fma_rn_f32(sum_sq, T.float32(1.0 / H), runtime_eps)
+        else:
+            mean_sq: T.float32 = _div_rn_f32(sum_sq, T.float32(H))
+            shifted = _add_f32(mean_sq, runtime_eps)
+        rstd: T.float32 = _rsqrt_approx_ftz(shifted)
+
+        global_scale_value: T.float32 = T.float32(0.0)
+        if use_e4m3_scale:
+            scale_bits = T.alloc_local((1,), "uint32")
+            T.ptx.ld.global_.b32(scale_bits[0], global_scale.ptr_to([0]))
+            global_scale_value = T.reinterpret("float32", scale_bits[0])
+
+        if cluster_n > 1:
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+        else:
+            T.ptx.bar.sync(T.uint32(0))
+
+        if row_valid:
+            for vb in T.unroll(vec_blocks):
+                local_col: T.int32 = (thread_in_row + vb * tpr) * 8
+                absolute_col: T.int32 = block_y * cols + local_col
+                col_valid: T.bool = absolute_col < H
+                if col_valid:
+                    residual_offset: T.int64 = T.cast(actual_row, "int64") * T.int64(H) + T.cast(
+                        absolute_col, "int64"
+                    )
+                    T.ptx.st.global_.v4.b32(
+                        residual.ptr_to([residual_offset]),
+                        h_words[vb * 4],
+                        h_words[vb * 4 + 1],
+                        h_words[vb * 4 + 2],
+                        h_words[vb * 4 + 3],
+                    )
+
+        if cluster_n > 1:
+            T.ptx.fence.acq_rel.cluster()
+            T.ptx.barrier.cluster.arrive.relaxed()
+            T.ptx.barrier.cluster.wait()
+
+        if row_valid:
+            if cluster_n > 1:
+                scale_iteration: T.int32 = T.int32(0)
+                while True:
+                    sf_index0: T.int32 = thread_in_row + scale_iteration * tpr
+                    _process_add_scale_block(
+                        shared_raw,
+                        residual,
+                        weight,
+                        y,
+                        scales,
+                        scales_unswizzled,
+                        y_norm,
+                        actual_row,
+                        row_in_cta,
+                        sf_index0,
+                        rstd,
+                        global_scale_value,
+                        fp4_max_rcp,
+                        H=H,
+                        block_size=block_size,
+                        scale_format=scale_format,
+                        swizzled=swizzled,
+                        output_both_sf_layouts=output_both_sf_layouts,
+                        output_norm=output_norm,
+                        input_dtype=input_dtype,
+                        cluster_n=cluster_n,
+                        cols=cols,
+                        tile_bytes=tile_bytes,
+                    )
+                    sf_index1: T.int32 = thread_in_row + (scale_iteration + 1) * tpr
+                    _process_add_scale_block(
+                        shared_raw,
+                        residual,
+                        weight,
+                        y,
+                        scales,
+                        scales_unswizzled,
+                        y_norm,
+                        actual_row,
+                        row_in_cta,
+                        sf_index1,
+                        rstd,
+                        global_scale_value,
+                        fp4_max_rcp,
+                        H=H,
+                        block_size=block_size,
+                        scale_format=scale_format,
+                        swizzled=swizzled,
+                        output_both_sf_layouts=output_both_sf_layouts,
+                        output_norm=output_norm,
+                        input_dtype=input_dtype,
+                        cluster_n=cluster_n,
+                        cols=cols,
+                        tile_bytes=tile_bytes,
+                    )
+                    scale_iteration = _add_s32(scale_iteration, T.int32(2))
+                    if scale_blocks_per_thread % 2 == 0:
+                        if scale_iteration == scale_blocks_per_thread:
+                            break
+                    else:
+                        if scale_iteration >= scale_blocks_per_thread:
+                            break
+            else:
+                static_limit = 1 if output_norm or block_size == 32 else 2
+                if scale_blocks_per_thread <= static_limit:
+                    for scale_iteration in T.unroll(scale_blocks_per_thread):
+                        sf_index: T.int32 = thread_in_row + scale_iteration * tpr
+                        _process_add_scale_block(
+                            shared_raw,
+                            residual,
+                            weight,
+                            y,
+                            scales,
+                            scales_unswizzled,
+                            y_norm,
+                            actual_row,
+                            row_in_cta,
+                            sf_index,
+                            rstd,
+                            global_scale_value,
+                            fp4_max_rcp,
+                            H=H,
+                            block_size=block_size,
+                            scale_format=scale_format,
+                            swizzled=swizzled,
+                            output_both_sf_layouts=output_both_sf_layouts,
+                            output_norm=output_norm,
+                            input_dtype=input_dtype,
+                            cluster_n=cluster_n,
+                            cols=cols,
+                            tile_bytes=tile_bytes,
+                        )
+                else:
+                    scale_iteration: T.int32 = T.int32(0)
+                    while True:
+                        sf_index: T.int32 = thread_in_row + scale_iteration * tpr
+                        _process_add_scale_block(
+                            shared_raw,
+                            residual,
+                            weight,
+                            y,
+                            scales,
+                            scales_unswizzled,
+                            y_norm,
+                            actual_row,
+                            row_in_cta,
+                            sf_index,
+                            rstd,
+                            global_scale_value,
+                            fp4_max_rcp,
+                            H=H,
+                            block_size=block_size,
+                            scale_format=scale_format,
+                            swizzled=swizzled,
+                            output_both_sf_layouts=output_both_sf_layouts,
+                            output_norm=output_norm,
+                            input_dtype=input_dtype,
+                            cluster_n=cluster_n,
+                            cols=cols,
+                            tile_bytes=tile_bytes,
+                        )
+                        scale_iteration = _add_s32(scale_iteration, T.int32(1))
+                        if scale_iteration == scale_blocks_per_thread:
+                            break
+
+        if enable_pdl:
+            T.ptx.griddepcontrol.launch_dependents()
+
+    @T.prim_func
+    def flashinfer_add_rmsnorm_fp4quant(
+        x_ptr: T.handle,
+        residual_ptr: T.handle,
+        weight_ptr: T.handle,
+        y_ptr: T.handle,
+        scale_ptr: T.handle,
+        scale_unswizzled_ptr: T.handle,
+        y_norm_ptr: T.handle,
+        global_scale_ptr: T.handle,
+        runtime_M: T.int32,
+        runtime_eps: T.float32,
+    ):
+        T.func_attr({"global_symbol": "flashinfer_add_rmsnorm_fp4quant"})
+        x = T.match_buffer(
+            x_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H),),
+            dtype=input_dtype,
+            scope="global",
+        )
+        residual = T.match_buffer(
+            residual_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H),),
+            dtype=input_dtype,
+            scope="global",
+        )
+        weight = T.match_buffer(weight_ptr, shape=(H,), dtype=input_dtype, scope="global")
+        y = T.match_buffer(
+            y_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H // 2),),
+            dtype="uint8",
+            scope="global",
+        )
+        if swizzled or output_both_sf_layouts:
+            scales = T.match_buffer(
+                scale_ptr,
+                shape=(
+                    T.cast(T.ceildiv(runtime_M, T.int32(128)), "int64")
+                    * T.int64(_ceil_div(scale_columns, 4) * 512),
+                ),
+                dtype="uint8",
+                scope="global",
+            )
+        else:
+            scales = T.match_buffer(
+                scale_ptr,
+                shape=(T.cast(runtime_M, "int64") * T.int64(scale_columns),),
+                dtype="uint8",
+                scope="global",
+            )
+        scales_unswizzled = T.match_buffer(
+            scale_unswizzled_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(scale_columns),),
+            dtype="uint8",
+            scope="global",
+        )
+        y_norm = T.match_buffer(
+            y_norm_ptr,
+            shape=(T.cast(runtime_M, "int64") * T.int64(H),),
+            dtype=input_dtype,
+            scope="global",
+        )
+        global_scale = T.match_buffer(global_scale_ptr, shape=(1,), dtype="float32", scope="global")
+        T.device_entry()
+        kernel_body(
+            x,
+            residual,
+            weight,
+            y,
+            scales,
+            scales_unswizzled,
+            y_norm,
+            global_scale,
+            runtime_M,
+            runtime_eps,
+        )
+
+    launch_params = ["blockIdx.x"]
+    if cluster_n > 1:
+        launch_params.extend(["blockIdx.y", "clusterCtaIdx.x", "clusterCtaIdx.y"])
+    launch_params.append("threadIdx.x")
+    if enable_pdl:
+        launch_params.append("tirx.use_programtic_dependent_launch")
+    launch_params.append("tirx.use_dyn_shared_memory")
+    return flashinfer_add_rmsnorm_fp4quant.with_attr("tirx.kernel_launch_params", launch_params)
+
+
+def prepare_data(**config: Any):
+    """Prepare deterministic inputs and caller-owned fixed-ABI outputs."""
+    config = dict(config)
+    data = _prepare_tensors(config)
+    output = _prepare_output(config)
+    return (
+        data["x_arg"],
+        data["residual_arg"],
+        data["weight"],
+        output["y_arg"],
+        output["scale_arg"],
+        output["scale_unswizzled_arg"],
+        output["y_norm_arg"],
+        data["global_scale"],
+    )
+
+
+_GUARD_ELEMENTS = 128
+_GUARD_BYTE = 0xA5
+
+
+def _torch_input_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def _logical_shape(config: dict[str, Any]) -> tuple[int, ...]:
+    H = int(config["H"])
+    if int(config["input_ndim"]) == 3:
+        return int(config["B"]), int(config["S"]), H
+    return int(config["M"]), H
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    dtype = _torch_input_dtype(str(config["input_dtype"]))
+    generator = torch.Generator(device="cuda").manual_seed(42)
+
+    x_backing = torch.empty(M * H + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    residual_backing = torch.empty(M * H + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    x = x_backing[: M * H].view(_logical_shape(config))
+    residual = residual_backing[: M * H].view(_logical_shape(config))
+    if str(config.get("data_mode", "random")) == "zero":
+        x.zero_()
+        residual.zero_()
+    elif H >= 65536:
+        columns = torch.arange(H, device="cuda")
+        x_pattern = torch.where(columns % 2 == 0, 0.75, -0.5).to(dtype)
+        residual_pattern = torch.where(columns % 3 == 0, -0.25, 0.5).to(dtype)
+        x.view(M, H).copy_(x_pattern.expand(M, H))
+        residual.view(M, H).copy_(residual_pattern.expand(M, H))
+    else:
+        x.normal_(generator=generator)
+        residual.normal_(generator=generator)
+    x_backing[M * H :].fill_(1.0)
+    residual_backing[M * H :].fill_(1.0)
+
+    weight_backing = torch.empty(H + _GUARD_ELEMENTS, dtype=dtype, device="cuda")
+    weight = weight_backing[:H]
+    weight.normal_(generator=generator)
+    weight_backing[H:].fill_(1.0)
+
+    mode = str(config.get("global_scale_mode", "none"))
+    if mode in ("none", "one"):
+        scale_value = 1.0
+    elif mode == "nonunit":
+        scale_value = 3.25
+    elif mode == "zero":
+        scale_value = 0.0
+    else:
+        raise ValueError(f"unsupported global_scale_mode={mode!r}")
+    global_scale = torch.tensor([scale_value], dtype=torch.float32, device="cuda")
+
+    return {
+        "x": x,
+        "x2d": x.view(M, H),
+        "x_arg": x_backing[: M * H],
+        "x_backing": x_backing,
+        "residual": residual,
+        "residual2d": residual.view(M, H),
+        "residual_arg": residual_backing[: M * H],
+        "residual_backing": residual_backing,
+        "weight": weight,
+        "weight_backing": weight_backing,
+        "global_scale": global_scale,
+    }
+
+
+def _scale_storage_size(config: dict[str, Any]) -> int:
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    if bool(config["swizzled"]) or bool(config["output_both_sf_layouts"]):
+        return _ceil_div(M, 128) * _ceil_div(columns, 4) * 512
+    return M * columns
+
+
+def _prepare_output(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    y_size = M * (H // 2)
+    scale_size = _scale_storage_size(config)
+    scale_unswizzled_size = M * columns
+    y_norm_size = M * H
+
+    y_backing = torch.full(
+        (y_size + _GUARD_ELEMENTS,), _GUARD_BYTE, dtype=torch.uint8, device="cuda"
+    )
+    scale_backing = torch.full(
+        (scale_size + _GUARD_ELEMENTS,), _GUARD_BYTE, dtype=torch.uint8, device="cuda"
+    )
+    scale_unswizzled_backing = torch.full(
+        (scale_unswizzled_size + _GUARD_ELEMENTS,), _GUARD_BYTE, dtype=torch.uint8, device="cuda"
+    )
+    input_dtype = _torch_input_dtype(str(config["input_dtype"]))
+    y_norm_backing = torch.empty(y_norm_size + _GUARD_ELEMENTS, dtype=input_dtype, device="cuda")
+    y_norm_backing.fill_(1.0)
+
+    y = y_backing[:y_size].view(M, H // 2)
+    if bool(config["swizzled"]) or bool(config["output_both_sf_layouts"]):
+        scale = scale_backing[:scale_size]
+    else:
+        scale = scale_backing[:scale_size].view(M, columns)
+    scale_unswizzled = scale_unswizzled_backing[:scale_unswizzled_size].view(M, columns)
+    y_norm = y_norm_backing[:y_norm_size].view(M, H)
+    return {
+        "y": y,
+        "scale": scale,
+        "scale_unswizzled": scale_unswizzled,
+        "y_norm": y_norm,
+        "y_arg": y_backing[:y_size],
+        "scale_arg": scale_backing[:scale_size],
+        "scale_unswizzled_arg": scale_unswizzled_backing[:scale_unswizzled_size],
+        "y_norm_arg": y_norm_backing[:y_norm_size],
+        "y_backing": y_backing,
+        "scale_backing": scale_backing,
+        "scale_unswizzled_backing": scale_unswizzled_backing,
+        "y_norm_backing": y_norm_backing,
+        "y_size": y_size,
+        "scale_size": scale_size,
+        "scale_unswizzled_size": scale_unswizzled_size,
+        "y_norm_size": y_norm_size,
+        "pointers": {
+            "y": y.data_ptr(),
+            "scale": scale.data_ptr(),
+            "scale_unswizzled": scale_unswizzled.data_ptr(),
+            "y_norm": y_norm.data_ptr(),
+        },
+        "strides": {
+            "y": y.stride(),
+            "scale": scale.stride(),
+            "scale_unswizzled": scale_unswizzled.stride(),
+            "y_norm": y_norm.stride(),
+        },
+    }
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]):
+    return executable(
+        data["x_arg"],
+        data["residual_arg"],
+        data["weight"],
+        output["y_arg"],
+        output["scale_arg"],
+        output["scale_unswizzled_arg"],
+        output["y_norm_arg"],
+        data["global_scale"],
+        int(config["M"]),
+        float(config["eps"]),
+    )
+
+
+@functools.cache
+def _compiled_test_specialization(
+    input_dtype: str,
+    H: int,
+    block_size: int,
+    scale_format: str,
+    swizzled: bool,
+    output_both_sf_layouts: bool,
+    enable_pdl: bool,
+    output_norm: bool,
+):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(
+        get_kernel(
+            input_dtype=input_dtype,
+            input_ndim=2,
+            M=1,
+            B=None,
+            S=None,
+            H=H,
+            block_size=block_size,
+            scale_format=scale_format,
+            swizzled=swizzled,
+            output_both_sf_layouts=output_both_sf_layouts,
+            output_norm=output_norm,
+            enable_pdl=enable_pdl,
+            eps=_DEFAULT_EPS,
+            global_scale_mode="none",
+            allocation="preallocated",
+            data_mode="random",
+        )
+    )
+
+
+@functools.cache
+def _flashinfer_compiled(
+    H: int,
+    block_size: int,
+    input_dtype: str,
+    scale_format: str,
+    swizzled: bool,
+    output_both_sf_layouts: bool,
+    enable_pdl: bool,
+    output_norm: bool,
+):
+    from flashinfer.cute_dsl.add_rmsnorm_fp4quant import _get_compiled_kernel
+
+    return _get_compiled_kernel(
+        H,
+        block_size,
+        input_dtype == "float16",
+        100,
+        scale_format,
+        swizzled,
+        output_both_sf_layouts,
+        enable_pdl,
+        output_norm,
+    )
+
+
+def _launch_flashinfer(data, output, config: dict[str, Any]):
+    kernel = _flashinfer_compiled(
+        int(config["H"]),
+        int(config["block_size"]),
+        str(config["input_dtype"]),
+        str(config["scale_format"]),
+        bool(config["swizzled"]),
+        bool(config["output_both_sf_layouts"]),
+        bool(config["enable_pdl"]),
+        bool(config["output_norm"]),
+    )
+    return kernel(
+        data["x2d"],
+        data["residual2d"],
+        data["weight"],
+        output["y"],
+        output["scale"],
+        output["scale_unswizzled"],
+        output["y_norm_arg"],
+        data["global_scale"],
+        int(config["M"]),
+        float(config["eps"]),
+    )
+
+
+def _snapshot_inputs(data):
+    return {
+        "x": data["x"].clone(),
+        "residual": data["residual"].clone(),
+        "weight": data["weight"].clone(),
+        "global_scale": data["global_scale"].clone(),
+    }
+
+
+def _assert_inputs_and_residual(data, snapshot, config: dict[str, Any], *, name: str):
+    import torch
+
+    if not torch.equal(data["x"], snapshot["x"]):
+        raise AssertionError(f"{name}: input tensor was modified")
+    if not torch.equal(data["weight"], snapshot["weight"]):
+        raise AssertionError(f"{name}: weight tensor was modified")
+    if not torch.equal(data["global_scale"], snapshot["global_scale"]):
+        raise AssertionError(f"{name}: global-scale tensor was modified")
+    expected_residual = (snapshot["x"].float() + snapshot["residual"].float()).to(
+        _torch_input_dtype(str(config["input_dtype"]))
+    )
+    if not torch.equal(data["residual"], expected_residual):
+        count = int((data["residual"] != expected_residual).sum().item())
+        raise AssertionError(f"{name}: {count} residual values differ from in-place add")
+
+    M, H = int(config["M"]), int(config["H"])
+    if not torch.equal(data["x_backing"][M * H :], torch.ones_like(data["x_backing"][M * H :])):
+        raise AssertionError(f"{name}: input guard was modified")
+    if not torch.equal(
+        data["residual_backing"][M * H :], torch.ones_like(data["residual_backing"][M * H :])
+    ):
+        raise AssertionError(f"{name}: residual guard was modified")
+    if not torch.equal(data["weight_backing"][H:], torch.ones_like(data["weight_backing"][H:])):
+        raise AssertionError(f"{name}: weight guard was modified")
+
+
+def _logical_scale_bytes(output, config: dict[str, Any]):
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    if not (bool(config["swizzled"]) or bool(config["output_both_sf_layouts"])):
+        return output["scale"].view(M, columns)
+    rows = torch.arange(M, device="cuda", dtype=torch.int64)[:, None]
+    cols = torch.arange(columns, device="cuda", dtype=torch.int64)[None, :]
+    offsets = (
+        (rows // 128) * (_ceil_div(columns, 4) * 512)
+        + (cols // 4) * 512
+        + (rows % 32) * 16
+        + ((rows % 128) // 32) * 4
+        + (cols % 4)
+    )
+    return output["scale"].view(-1)[offsets]
+
+
+def _valid_swizzled_offsets(config: dict[str, Any]):
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    columns = H // int(config["block_size"])
+    rows = torch.arange(M, device="cuda", dtype=torch.int64)[:, None]
+    cols = torch.arange(columns, device="cuda", dtype=torch.int64)[None, :]
+    return (
+        (rows // 128) * (_ceil_div(columns, 4) * 512)
+        + (cols // 4) * 512
+        + (rows % 32) * 16
+        + ((rows % 128) // 32) * 4
+        + (cols % 4)
+    ).reshape(-1)
+
+
+def _assert_output_integrity(output, config: dict[str, Any], *, name: str) -> None:
+    import torch
+
+    for field in ("y", "scale", "scale_unswizzled", "y_norm"):
+        if output[field].data_ptr() != output["pointers"][field]:
+            raise AssertionError(f"{name}: {field} pointer identity changed")
+        if output[field].stride() != output["strides"][field]:
+            raise AssertionError(f"{name}: {field} stride changed")
+    for field, size in (
+        ("y", output["y_size"]),
+        ("scale", output["scale_size"]),
+        ("scale_unswizzled", output["scale_unswizzled_size"]),
+    ):
+        if not torch.all(output[f"{field}_backing"][size:] == _GUARD_BYTE):
+            raise AssertionError(f"{name}: {field} trailing guard was modified")
+    if not torch.all(output["y_norm_backing"][output["y_norm_size"] :] == 1.0):
+        raise AssertionError(f"{name}: y_norm trailing guard was modified")
+
+    if bool(config["swizzled"]) or bool(config["output_both_sf_layouts"]):
+        valid = _valid_swizzled_offsets(config)
+        padding_mask = torch.ones(output["scale_size"], dtype=torch.bool, device="cuda")
+        padding_mask[valid] = False
+        if not torch.all(output["scale_arg"][padding_mask] == _GUARD_BYTE):
+            raise AssertionError(f"{name}: swizzled scale padding was modified")
+    if not bool(config["output_both_sf_layouts"]):
+        if not torch.all(output["scale_unswizzled_arg"] == _GUARD_BYTE):
+            raise AssertionError(f"{name}: disabled linear scale output was modified")
+    if not bool(config["output_norm"]):
+        if not torch.all(output["y_norm_arg"] == 1.0):
+            raise AssertionError(f"{name}: disabled y_norm output was modified")
+
+
+def _assert_raw_equal(actual, expected, config: dict[str, Any], *, name: str) -> None:
+    import torch
+
+    if not torch.equal(actual["y"], expected["y"]):
+        count = int((actual["y"] != expected["y"]).sum().item())
+        raise AssertionError(f"{name}: {count} packed FP4 bytes differ")
+    actual_scale = _logical_scale_bytes(actual, config)
+    expected_scale = _logical_scale_bytes(expected, config)
+    if not torch.equal(actual_scale, expected_scale):
+        count = int((actual_scale != expected_scale).sum().item())
+        raise AssertionError(f"{name}: {count} primary logical scale bytes differ")
+    if bool(config["output_both_sf_layouts"]):
+        if not torch.equal(actual["scale_unswizzled"], expected["scale_unswizzled"]):
+            count = int((actual["scale_unswizzled"] != expected["scale_unswizzled"]).sum().item())
+            raise AssertionError(f"{name}: {count} linear scale bytes differ")
+        if not torch.equal(actual_scale, actual["scale_unswizzled"]):
+            raise AssertionError(f"{name}: dual scale layouts disagree")
+    if bool(config["output_norm"]) and not torch.equal(actual["y_norm"], expected["y_norm"]):
+        count = int((actual["y_norm"] != expected["y_norm"]).sum().item())
+        raise AssertionError(f"{name}: {count} y_norm values differ")
+
+
+def _dequantize(output, data, config: dict[str, Any]):
+    import torch
+
+    M, H = int(config["M"]), int(config["H"])
+    packed = output["y"].view(M, H // 2)
+    nibbles = torch.stack((packed & 0x0F, packed >> 4), dim=-1).reshape(M, H).long()
+    table = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    fp4 = table[nibbles]
+    scale_bytes = _logical_scale_bytes(output, config)
+    if int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3":
+        scales = scale_bytes.view(torch.float8_e4m3fn).float()
+        scales = scales / data["global_scale"].float()
+    else:
+        scales = torch.pow(2.0, scale_bytes.int() - 127)
+    return (fp4.view(M, -1, int(config["block_size"])) * scales[..., None]).reshape(M, H)
+
+
+def _math_oracle(data, snapshot, config: dict[str, Any]):
+    h_fp32 = (
+        snapshot["x"].view(int(config["M"]), int(config["H"])).float()
+        + snapshot["residual"].view(int(config["M"]), int(config["H"])).float()
+    )
+    rstd = (h_fp32.square().mean(dim=-1, keepdim=True) + float(config["eps"])).rsqrt()
+    h_narrow = h_fp32.to(_torch_input_dtype(str(config["input_dtype"])))
+    weight = data["weight"].float()
+    if int(_source_config(int(config["H"]))["cluster_n"]) == 1:
+        return h_narrow.float() * rstd * weight
+    product = (h_narrow * data["weight"]).to(_torch_input_dtype(str(config["input_dtype"])))
+    return product.float() * rstd
+
+
+def _assert_math(output, data, snapshot, config: dict[str, Any]) -> None:
+    import torch
+
+    if (int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3") and float(
+        data["global_scale"].item()
+    ) == 0.0:
+        if torch.count_nonzero(output["y"] & 0x77) or torch.count_nonzero(
+            _logical_scale_bytes(output, config)
+        ):
+            raise AssertionError("zero global scale must produce signed-zero FP4 and scales")
+        return
+    oracle = _math_oracle(data, snapshot, config)
+    dequantized = _dequantize(output, data, config)
+    if not torch.isfinite(dequantized).all():
+        raise AssertionError("dequantized output contains non-finite values")
+    torch.testing.assert_close(
+        dequantized,
+        oracle,
+        rtol=0.5,
+        atol=2.0,
+        msg=lambda message: f"independent FP32 add/RMSNorm oracle: {message}",
+    )
+    if bool(config["output_norm"]):
+        torch.testing.assert_close(
+            output["y_norm"],
+            oracle.to(_torch_input_dtype(str(config["input_dtype"]))),
+            rtol=1e-2,
+            atol=1e-2,
+            msg=lambda message: f"optional y_norm oracle: {message}",
+        )
+
+
+def _check_public_allocation(reference, reference_data, config: dict[str, Any]) -> None:
+    import torch
+    from flashinfer.norm import add_rmsnorm_fp4quant
+
+    if str(config.get("allocation")) not in ("auto", "compare"):
+        return
+    public_data = _prepare_tensors(config)
+    global_scale = (
+        None if str(config.get("global_scale_mode")) == "none" else public_data["global_scale"]
+    )
+    result = add_rmsnorm_fp4quant(
+        public_data["x"],
+        public_data["residual"],
+        public_data["weight"],
+        global_scale=global_scale,
+        eps=float(config["eps"]),
+        block_size=int(config["block_size"]),
+        scale_format=str(config["scale_format"]),
+        is_sf_swizzled_layout=bool(config["swizzled"]),
+        output_both_sf_layouts=bool(config["output_both_sf_layouts"]),
+        enable_pdl=bool(config["enable_pdl"]),
+    )
+    public_y = result[0].view(torch.uint8).view_as(reference["y"])
+    if not torch.equal(public_y, reference["y"]):
+        raise AssertionError("public auto-allocated packed output differs")
+    public_output = dict(reference)
+    public_output["scale"] = result[1].view(torch.uint8)
+    if not torch.equal(
+        _logical_scale_bytes(public_output, config), _logical_scale_bytes(reference, config)
+    ):
+        raise AssertionError("public auto-allocated logical scales differ")
+    if not torch.equal(public_data["residual"], reference_data["residual"]):
+        raise AssertionError("public residual update differs from direct source kernel")
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one source-domain specialization."""
+    import torch
+
+    config = dict(config)
+    _validate(config)
+    tirx_data = _prepare_tensors(config)
+    source_data = _prepare_tensors(config)
+    tirx_snapshot = _snapshot_inputs(tirx_data)
+    source_snapshot = _snapshot_inputs(source_data)
+    tirx_output = _prepare_output(config)
+    source_output = _prepare_output(config)
+    executable = _compiled_test_specialization(
+        str(config["input_dtype"]),
+        int(config["H"]),
+        int(config["block_size"]),
+        str(config["scale_format"]),
+        bool(config["swizzled"]),
+        bool(config["output_both_sf_layouts"]),
+        bool(config["enable_pdl"]),
+        bool(config["output_norm"]),
+    )
+    if _launch_tirx(executable, tirx_data, tirx_output, config) is not None:
+        raise AssertionError("TIRx AddRMSNormFP4Quant ABI must return None")
+    if _launch_flashinfer(source_data, source_output, config) is not None:
+        raise AssertionError("FlashInfer AddRMSNormFP4Quant ABI must return None")
+    torch.cuda.synchronize()
+
+    _assert_raw_equal(tirx_output, source_output, config, name="FlashInfer raw-byte oracle")
+    if not torch.equal(tirx_data["residual"], source_data["residual"]):
+        count = int((tirx_data["residual"] != source_data["residual"]).sum().item())
+        raise AssertionError(f"FlashInfer residual oracle: {count} values differ")
+    _assert_inputs_and_residual(tirx_data, tirx_snapshot, config, name="TIRx")
+    _assert_inputs_and_residual(source_data, source_snapshot, config, name="FlashInfer")
+    _assert_math(tirx_output, tirx_data, tirx_snapshot, config)
+    _assert_output_integrity(tirx_output, config, name="TIRx output")
+    _assert_output_integrity(source_output, config, name="FlashInfer output")
+    _check_public_allocation(source_output, source_data, config)
+
+
+def prepare_bench(**config: Any):
+    """Compile the specialization before the bench suite assigns a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Build and prevalidate independent TIRx and CuTeDSL launch closures."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    tirx_data = _prepare_tensors(config)
+    tirx_output = _prepare_output(config)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        return _launch_tirx(executable, tirx_data, tirx_output, config)
+
+    if tirx_launch() is not None:
+        raise AssertionError("TIRx benchmark closure must return None")
+    torch.cuda.synchronize()
+
+    def build_flashinfer_reference():
+        source_data = _prepare_tensors(config)
+        source_output = _prepare_output(config)
+
+        def source_launch():
+            return _launch_flashinfer(source_data, source_output, config)
+
+        if source_launch() is not None:
+            raise AssertionError("FlashInfer benchmark closure must return None")
+        torch.cuda.synchronize()
+        _assert_raw_equal(tirx_output, source_output, config, name="benchmark raw-byte precheck")
+        if not torch.equal(tirx_data["residual"], source_data["residual"]):
+            raise AssertionError("benchmark residual precheck differs")
+        return source_launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cutedsl": build_flashinfer_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    """Benchmark one specialization against the CuTeDSL kernel reference."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer AddRMSNormFP4QuantKernel from FlashInfer f2e04400e330fb2debe0bf8730d9424a1d37927f to plain TIRx
- preserve the source launch, cluster reduction, residual update, packed E2M1 output, E4M3/UE8M0 scales, scale swizzling, dual-scale output, normalized output, and PDL paths
- add the full 1,245-case correctness matrix, ten active benchmark workloads, registry documentation, and promoted baselines

## TVM dependency

This port requires [spectrometerHBH/tvm@135a054f176a64a5fdc7637ebf52a0b210db3ea3](https://github.com/spectrometerHBH/tvm/commit/135a054f176a64a5fdc7637ebf52a0b210db3ea3) for required block-size lowering, exact E2M1x8 conversion and wide byte stores, cluster launch semantics, and the relaxed mbarrier wait used by the source kernel.

## Validation

- correctness: 1,245 passed, 0 failed, 0 skipped
- correctness reviewer: PASS; 105 distinct specializations have no tile primitive, FuncCall, or low-level IR violation
- strict registry and target bench-suite import checks passed
- license checker, license self-test, and staged pre-commit hooks passed
- baseline promotion preserves all 428 existing rows and adds only the ten rows for this kernel

## Performance

The only performance gate was the reference-enabled bench suite with the Proton timer, five rounds, and one-second cooldown. Final run 6 has ten status=ok rows and failure_count=0. Ratios are flashinfer_cutedsl / tirx and every required workload is strictly above 0.99.

| Workload | TIRx (us) | FlashInfer CuTeDSL (us) | Ratio |
| --- | ---: | ---: | ---: |
| NVFP4 H4096 | 5.6376 | 5.7757 | 1.0245 |
| NVFP4 H8192 | 5.9640 | 6.0530 | 1.0149 |
| NVFP4 global scale | 5.6352 | 5.7696 | 1.0238 |
| NVFP4 swizzled scale | 5.6895 | 5.8211 | 1.0231 |
| MXFP4 H4096 | 7.7207 | 7.8867 | 1.0215 |
| NVFP4 flattened 3-D H128 | 2.9511 | 2.9984 | 1.0160 |
| NVFP4 dual scale H4096 | 5.7419 | 5.8897 | 1.0257 |
| NVFP4 dual scale H8192 | 6.0994 | 6.1585 | 1.0097 |
| NVFP4 dual scale global | 5.6859 | 5.8198 | 1.0236 |
| MXFP4 dual scale | 7.6994 | 7.8751 | 1.0228 |