### PR TITLE
Revert local Top-K and RMSNorm fixes

### DIFF
--- a/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from tirx_kernels.flashinfer.utils.fp_quant import (
     absmax_8,
-    cvt_e2m1x8,
     hmax2,
     pack_u32x2_to_u64,
     sf_offset_128x4,
@@ -248,8 +247,12 @@ def _quantize_and_pack_16(values, output_scale):
     scaled = T.alloc_local((16,), "float32")
     for value in range(16):
         T.evaluate(T.ptx.mul.f32(scaled[value], values[value], output_scale))
-    low = cvt_e2m1x8([scaled[index] for index in range(8)])
-    high = cvt_e2m1x8([scaled[index] for index in range(8, 16)])
+    low = T.cuda.cvt_e2m1x8_f32(
+        scaled[0], scaled[1], scaled[2], scaled[3], scaled[4], scaled[5], scaled[6], scaled[7]
+    )
+    high = T.cuda.cvt_e2m1x8_f32(
+        scaled[8], scaled[9], scaled[10], scaled[11], scaled[12], scaled[13], scaled[14], scaled[15]
+    )
     return pack_u32x2_to_u64(low, high)
 
 
@@ -297,9 +300,7 @@ def _process_scale_block(
             scale_word = _cvt_f32_to_e4m3(scale_value)
             output_scale = _mul_f32(_e4m3_to_f32_rcp(scale_word), global_scale_value)
             scale_offset = _scale_offset(actual_row, sf_index, H, block_size, swizzled)
-            T.ptx.st.global_.b8(
-                T.address_of(scales[scale_offset]), T.cast(scale_word, "uint8")
-            )
+            T.ptx.st.global_.b8(T.address_of(scales[scale_offset]), scale_word)
             packed0 = _quantize_and_pack_16(values0, output_scale)
             y_offset = T.cast(actual_row, "int64") * (H // 2) + block_start // 2
             _store_global_u64(T.address_of(y[y_offset]), packed0)
@@ -324,9 +325,7 @@ def _process_scale_block(
                 scale_word = _cvt_f32_to_e4m3(scale_value)
                 output_scale = _mul_f32(_e4m3_to_f32_rcp(scale_word), global_scale_value)
             scale_offset = _scale_offset(actual_row, sf_index, H, block_size, swizzled)
-            T.ptx.st.global_.b8(
-                T.address_of(scales[scale_offset]), T.cast(scale_word, "uint8")
-            )
+            T.ptx.st.global_.b8(T.address_of(scales[scale_offset]), scale_word)
             packed0 = _quantize_and_pack_16(values0, output_scale)
             packed1 = _quantize_and_pack_16(values1, output_scale)
             y_offset = T.cast(actual_row, "int64") * (H // 2) + block_start // 2

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -514,6 +514,11 @@ def get_kernel(
         _threshold(hist, scal, tid, warp, lane, rank, phase, k_rem, True)
         bin_t = T.alloc_local((1,), "int32")
         bin_t[0] = T.cast(R.ld_shared_u32(scal, THR), "int32")
+        if nc > 1 and t < rounds - 1:
+            # Skipped on the final round: no further threshold() means no
+            # further peer read of this bank (:260-263).
+            T.evaluate(T.ptx.barrier.cluster.arrive())
+
         raw = T.alloc_local((1,), "int32")
         raw[0] = T.cast(R.ld_shared_u32(scal, NCACHED + (phase ^ 1)), "int32")
         n_sh = T.alloc_local((1,), "int32")
@@ -568,13 +573,6 @@ def get_kernel(
                 ring_base,
                 tid,
             )
-
-        if nc > 1 and t < rounds - 1:
-            # Publish only after every thread has consumed the previous
-            # ping-pong bank.  Arriving immediately after threshold selection
-            # lets the next round overwrite that bank while another warp is
-            # still reading its cached candidates.
-            T.evaluate(T.ptx.barrier.cluster.arrive())
 
     @T.macro
     def _emit(logits, out_idx, out_val, seq_lens_g, aux, ovf):

--- a/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
@@ -487,12 +487,6 @@ def get_kernel(
                     # One fenced arrival from thread 0 (:176), an acquire spin to the
                     # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                     # one (:133) and the phase bump is followed by another (:182).
-                    # Complete every CTA-local state update before thread 0
-                    # publishes the group arrival.  The following acquire
-                    # spin is the inter-CTA handoff; without this CTA
-                    # rendezvous, another warp could still be folding its
-                    # histogram when the consumer observes the arrival.
-                    bar_sync()
                     if tx == 0:
                         red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                     bar_target0: T.int32 = (barrier_phase + T.int32(1)) * T.int32(ctas_per_group)
@@ -551,7 +545,6 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
-                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target1: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -683,7 +676,6 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
-                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target2: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -728,7 +720,6 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
-                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target3: T.int32 = (barrier_phase + T.int32(1)) * T.int32(
@@ -892,7 +883,6 @@ def get_kernel(
                         # One fenced arrival from thread 0 (:176), an acquire spin to the
                         # absolute target (:179), then TWO CTA barriers: wait_ge ends with
                         # one (:133) and the phase bump is followed by another (:182).
-                        bar_sync()
                         if tx == 0:
                             red_release_gpu_add_s32(state, arrival_word, T.int32(1))
                         bar_target4: T.int32 = (barrier_phase + T.int32(1)) * T.int32(


### PR DESCRIPTION
This PR reverts the two canonical-kernel commits previously merged from the local fix branches:\n\n- 7b0ba162e9f1671c1d2fedff56c239ee1cfdfb8a — fix(norm): make RMSNorm FP4 quantization parse on pinned TVM\n- 72f3d67f3d7b319a769bb9e4cb5ca7f6d1cc046a — fix(topk): order multi-CTA state handoffs\n\nThe branch is based on the current main at f2210e411db5c9391e52889d886be795d24d266f and contains only the inverse changes for those two commits. Later main commits are preserved.\n\nValidation:\n- git diff --check origin/main...HEAD\n- Revert applies cleanly to the current main.