### PR TITLE
feat(kernel): port FlashInfer fused DIT LayerNorm

### DIFF
--- a/.agents/sketch/flashinfer/norm/fused_dit_layernorm.md
+++ b/.agents/sketch/flashinfer/norm/fused_dit_layernorm.md
@@ -1,0 +1,545 @@
+<!--
+Copyright (c) 2026 by FlashInfer team.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This execution sketch documents a TIRx port of FlashInfer's CUDA
+meta_fused_layernorm kernel. See LICENSE, NOTICE, and licenses/ for applicable
+terms.
+-->
+
+# FlashInfer fused DIT LayerNorm SM100: execution sketch
+
+This file is a non-executable execution sketch. It freezes the implementation
+shape of FlashInfer's CUDA `meta_fused_layernorm` for
+[`tirx_kernels/flashinfer/norm/fused_dit_layernorm.py`](../../../../tirx_kernels/flashinfer/norm/fused_dit_layernorm.py).
+The target may become executable only after independent source/PTX review; this
+file is permanently frozen after its first reviewer PASS.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+
+- `include/flashinfer/norm/fused_dit_layernorm.cuh`, SHA256
+  `f8d8af27f6715e282858547a3e8185a2cc71eaaad00d70923e9f02aad076e2f4`;
+- host dispatch in `csrc/norm.cu`, SHA256
+  `c4f86ef2046fdd13a5cd79f7ffc93c7522d228ffb53f3b2c8a77d29a3dc20e0f`;
+- public wrappers, tests, and benchmark copied under
+  `.porting/flashinfer_fused_dit_layernorm/source_export/source_artifacts/`.
+
+The writer-owned fresh export used the normal FlashInfer JIT path for
+`sm_100a`, `-O3 -DNDEBUG -lineinfo`, with no debug flags. Its PTX SHA256 is
+`549696308d8c16dad94ab13faed07e3e5708044e531b84ff7e739dcf3ac69607`;
+its compile-command SHA256 is
+`8562bd99cda718dad977d8b13a0f486ba130b26f498b723d53dcefca7c8591bc`.
+The export contains 54,062 `.loc` directives and all eighteen unique
+`meta_fused_layernorm` entries. The reviewer must independently export the
+same eighteen branches through the normal JIT path.
+
+## Frozen specialization and launch
+
+The complete family is the Cartesian product below. No runtime dispatch is
+allowed inside one generated member except the batch loop and residual-present
+branch.
+
+```text
+MODE = GRGB | RSS | GRSS
+OUTPUT = BF16 | NVFP4 | MXFP8
+USE_INPUT_SF_SCALE = false | true
+HIDDEN_SIZE = 3072 BF16 values
+BLOCK_SIZE = 384 threads = 12 warps
+GRID = (runtime_num_rows, 1, 1)
+DYNAMIC_SHARED = 0
+CLUSTER = none
+PDL = none
+```
+
+`blockIdx.x` is exactly the row within a batch. There is no row guard because
+the grid exactly covers `runtime_num_rows`. Every CTA executes a real runtime
+serial loop over `runtime_batch_size`; each of its 384 threads owns four
+adjacent BF16x2 pairs, or eight hidden values. Therefore `384*8=3072` and no
+column guard exists. Gate, scale, and shift always use the source WAN row
+stride `6*3072`, even when the public tensor is presented as a 2-D view.
+
+The mode traits are fixed:
+
+| mode | residual expression | LayerNorm epilogue |
+| --- | --- | --- |
+| GRGB | `input * (gate + gate_bias) + residual` | `centered * (rstd * gamma) + beta` |
+| RSS | `input + residual`, with residual optionally zero | normalized, then `(scale+scale_bias+1)` and `(shift+shift_bias)` |
+| GRSS | GRGB residual expression | RSS scale/shift epilogue |
+
+When enabled, input global scale multiplies the gate expression in GRGB/GRSS
+and the input directly in RSS before the residual FMA. The scale is loaded once
+per thread before all bias fragments and before the batch loop. The residual
+presence test is runtime-uniform and remains inside every batch iteration. A
+legal dummy pointer represents CUDA null only at the TIRx ABI boundary; it does
+not remove this branch.
+
+## Fixed device ABI
+
+All specializations have the same nineteen arguments. Unused pointers receive
+valid dummy allocations. Mode, output format, and input-scale presence are
+compile-time configuration, while batch, rows, epsilon, and residual presence
+remain runtime values.
+
+| position | argument | device dtype / role |
+| ---: | --- | --- |
+| 0 | `input_ptr` | read-only BF16 compact input |
+| 1 | `residual_ptr` | read-only BF16 compact residual or legal dummy |
+| 2 | `gate_ptr` | read-only BF16 stride-6 auxiliary or dummy |
+| 3 | `gate_bias_ptr` | read-only FP32 `[3072]` or dummy |
+| 4 | `gamma_ptr` | read-only FP32 `[3072]` or dummy |
+| 5 | `beta_ptr` | read-only FP32 `[3072]` or dummy |
+| 6 | `scale_ptr` | read-only BF16 stride-6 auxiliary or dummy |
+| 7 | `scale_bias_ptr` | read-only FP32 `[3072]` or dummy |
+| 8 | `shift_ptr` | read-only BF16 stride-6 auxiliary or dummy |
+| 9 | `shift_bias_ptr` | read-only FP32 `[3072]` or dummy |
+| 10 | `residual_output_ptr` | mutable BF16 compact residual output |
+| 11 | `norm_output_ptr` | mutable BF16, packed E2M1, or packed E4M3 output |
+| 12 | `sf_output_ptr` | mutable swizzled uint8 SF storage or dummy |
+| 13 | `output_sf_scale_ptr` | read-only FP32 NVFP4 global scale or dummy |
+| 14 | `input_sf_scale_ptr` | read-only FP32 input global scale or dummy |
+| 15 | `runtime_batch_size` | uniform int32 batch-loop extent |
+| 16 | `runtime_num_rows` | uniform int32 row extent and grid-x extent |
+| 17 | `runtime_epsilon` | uniform FP32 epsilon |
+| 18 | `runtime_has_residual` | uniform int32 CUDA-null semantic |
+
+Every FP32 bias buffer used by its specialization is non-null in the supported
+production and official-test domain. Although the public API types these biases
+as optional, the source device kernel unconditionally dereferences each used
+bias; this port does not invent a replacement algorithm for that upstream
+inconsistency.
+
+## Storage, ownership, and lifetime
+
+The kernel uses exactly 136 bytes of static shared storage in three separately
+aligned objects and no dynamic shared memory:
+
+1. `reduceStore`: 120 bytes, alignment 8, CUB
+   `BlockReduce<float2,384>::TempStorage`;
+2. `s_mean`: 8 bytes, alignment 8, one duplicated FP32 pair;
+3. `s_inv_std`: 8 bytes, alignment 8, one duplicated FP32 pair.
+
+Within `reduceStore`, lane zero of warp `w` writes its sum/sumsq pair to byte
+offset `16+8*w`, for `w=0..11`. Bytes 0..15 and 112..119 remain unused but are
+part of the source CUB ABI. After the first CTA barrier, thread zero keeps its
+live warp-zero result and serially loads the eleven pairs at byte offsets
+24,32,...,104. `s_mean` and `s_inv_std` are written only by thread zero, then
+published by the second CTA barrier and loaded by every thread.
+
+The optional input scale and every used gamma/beta/bias 32-byte fragment are
+register-resident across all runtime batch iterations. Input, residual, gate,
+scale, and shift packed fragments are reloaded inside each iteration. The
+unrounded FP32 residual fragment survives from its residual expression through
+sum/sumsq, centering, and epilogue. The BF16 residual fragment exists only for
+the early residual output store. The final BF16 fragment exists before all
+three output-format branches; both quantizers therefore consume BF16-rounded,
+not the preceding FP32, values.
+
+The mutable outputs are independent: the early BF16 residual store precedes
+the reduction; the norm payload and quant SF stores occur only after the
+epilogue. All input tensors, auxiliary backing allocations, FP32 parameters,
+and global scales are read-only for the complete launch.
+
+## Primitive vocabulary
+
+Structural notation does not move values or perform arithmetic:
+
+```text
+specialize(...)  launch(...)  reg_pair4(...)  shared_object(...)
+address(...)     wan_stride6_address(...)     sf_128x4_address(...)
+```
+
+All execution work stays in primitive TIRx/PTX operations:
+
+```text
+load_global_v4_b32  load_global_v4_b64  load_global_b32
+store_global_v4_b32 store_global_b32    store_global_b64 store_global_b8
+store_generic_v4_b32 store_generic_b32  store_generic_b64
+load_shared_b64     store_shared_v2_b32
+bf16x2_to_f32x2     f32x2_to_bf16x2_rn
+bf16_to_f32          max_f32_ftz
+neg_f32_ftz          compare_gt_u32      compare_eq_ftz_f32
+add_f32_ftz_rn      mul_f32_ftz         fma_f32_ftz_rn
+add_f32x2_ftz_rn    mul_f32x2_ftz_rn    fma_f32x2_ftz_rn
+abs_bf16x2          max_bf16x2          max_bf16
+shuffle_down_b32    shuffle_xor_b32
+cvt_e4m3x2_f32_rn_satfinite  cvt_f16x2_e4m3x2_rn  cvt_f32_f16
+cvt_ue8m0x2_f32_rp_satfinite cvt_bf16x2_ue8m0x2_rn
+cvt_e2m1x2_f32_rn_satfinite  mov_b32_bytes
+rcp_approx_ftz      rsqrt_approx_ftz
+and_b16 and_b32 or_b32 add_s32 sub_s32 shift_left_b32 shift_right_s32
+cvt_u16_u32 cvt_u64_u16 shift_left_b64 or_b64 branch
+reinterpret_b32 reinterpret_f32 low_byte low_half low_bf16_bits
+cta_barrier
+```
+
+There is no LayerNorm, block-reduce, quantize, tile-copy, tile-compute, or
+other compound primitive. There is no tile primitive and no external FuncCall
+escape. The exact CUB reduction and accurate-rsqrt expansion are written from
+the primitive vocabulary below.
+
+## Complete source-order execution sketch
+
+```text
+specialize(MODE, OUTPUT, USE_INPUT_SF_SCALE, HIDDEN_SIZE=3072)
+launch(grid=(runtime_num_rows,1,1), block=(384,1,1), static_shared=136)
+kernel(fixed nineteen-argument ABI):
+    tid = threadIdx.x                         # 0..383
+    lane = tid & 31                           # 0..31
+    warp = tid >> 5                           # 0..11
+    row = blockIdx.x                          # no row predicate
+    pair_base = tid * 4                       # BF16x2 units
+
+    shared reduceStore[120] align 8
+    shared s_mean[8] align 8
+    shared s_inv_std[8] align 8
+
+    if USE_INPUT_SF_SCALE:
+        input_sf = load_global_b32(input_sf_scale_ptr[0])
+        # selection: ld.global.b32; extent: one scalar/thread before batch loop
+    else:
+        input_sf = 1.0
+
+    if MODE == GRGB:
+        gamma[0:4] = load_global_v4_b64(gamma_ptr + 8*tid)
+        beta[0:4] = load_global_v4_b64(beta_ptr + 8*tid)
+        # selection: ld.global.v4.b64 per parameter; extent: 32 B/thread
+    if MODE in (GRGB,GRSS):
+        gate_bias[0:4] = load_global_v4_b64(gate_bias_ptr + 8*tid)
+        # selection: ld.global.v4.b64; extent: 32 B/thread
+    if MODE in (RSS,GRSS):
+        scale_bias[0:4] = load_global_v4_b64(scale_bias_ptr + 8*tid)
+        shift_bias[0:4] = load_global_v4_b64(shift_bias_ptr + 8*tid)
+        # selection: ld.global.v4.b64 per parameter; extent: 32 B/thread
+
+    for batch in serial_runtime_range(runtime_batch_size):
+        dense_pair = ((batch*runtime_num_rows + row)*1536 + pair_base)
+        auxiliary_pair = ((batch*runtime_num_rows + row)*9216 + pair_base)
+
+        input_bf16[0:4] = load_global_v4_b32(input_ptr + 2*dense_pair)
+        input[0:4] = bf16x2_to_f32x2(input_bf16[0:4])
+        # selection: ld.global.v4.b32, then eight scalar cvt.f32.bf16
+        # extent: one 16 B load and eight scalar widens/thread/iteration
+
+        if runtime_has_residual != 0:          # CTA-uniform branch
+            residual_bf16[0:4] = load_global_v4_b32(
+                residual_ptr + 2*dense_pair)
+            residual[0:4] = bf16x2_to_f32x2(residual_bf16[0:4])
+            # selection: ld.global.v4.b32 plus eight widens
+        else:
+            residual[0:4] = zero_f32x2
+            # extent: four zero register pairs, no residual global load
+
+        if MODE in (GRGB,GRSS):
+            gate_bf16[0:4] = load_global_v4_b32(
+                gate_ptr + 2*auxiliary_pair)
+            gate[0:4] = bf16x2_to_f32x2(gate_bf16[0:4])
+            # selection: ld.global.v4.b32 plus eight widens
+            if USE_INPUT_SF_SCALE:
+                gate[k] = add_f32x2_ftz_rn(gate[k],gate_bias[k])  # k=0..3
+                gate[k] = mul_f32x2_ftz_rn(gate[k],input_sf)      # k=0..3
+                input[k] = fma_f32x2_ftz_rn(input[k],gate[k],residual[k])
+                # selection: add.rn.ftz.f32x2 x4, mul... x4, fma... x4
+            else:
+                input[k] = fma_f32x2_ftz_rn(
+                    input[k],add_f32x2_ftz_rn(gate[k],gate_bias[k]),residual[k])
+                # selection: add.rn.ftz.f32x2 x4, fma.rn.ftz.f32x2 x4
+        else:                                  # RSS
+            if USE_INPUT_SF_SCALE:
+                input[k] = fma_f32x2_ftz_rn(input[k],input_sf,residual[k])
+                # selection: fma.rn.ftz.f32x2; extent: four pairs
+            else:
+                input[k] = add_f32x2_ftz_rn(input[k],residual[k])
+                # selection: add.rn.ftz.f32x2; extent: four pairs
+
+        residual_out_bf16[k] = f32x2_to_bf16x2_rn(input[k])      # k=0..3
+        store_global_v4_b32(residual_output_ptr + 2*dense_pair,
+                            residual_out_bf16[0:4])
+        # selection: cvt.rn.bf16x2.f32 x4, st.global.v4.b32 x1
+        # The reduction below still consumes unrounded input[0:4].
+
+        sum = 0.0
+        sum_sq = 0.0
+        for k in static_range(4):
+            sum = add_f32_ftz_rn(add_f32_ftz_rn(sum,input[k].x),input[k].y)
+            sum_sq = fma_f32_ftz_rn(
+                input[k].y,input[k].y,
+                fma_f32_ftz_rn(input[k].x,input[k].x,sum_sq))
+        # selection: ordered scalar add.rn.ftz.f32 x8 and
+        # fma.rn.ftz.f32 x8; extent: eight unrounded values/thread
+
+        pair = (sum,sum_sq)
+        for delta in (1,2,4,8,16):
+            peer_x, valid_x = shuffle_down_b32(pair.x,delta,mask=0xffffffff)
+            peer_y, valid_y = shuffle_down_b32(pair.y,delta,mask=0xffffffff)
+            if valid_x and valid_y:
+                pair = add_f32x2_ftz_rn(pair,(peer_x,peer_y))
+            # selection: paired shfl.sync.down.b32 and one
+            # add.rn.ftz.f32x2 for a valid source lane; extent: five stages
+
+        if lane == 0:
+            store_shared_v2_b32(reduceStore + 16 + 8*warp,pair)
+            # selection: st.shared.v2.b32; extent: one per warp, twelve total
+        cta_barrier()
+        # selection: bar.sync 0; extent: exactly one CTA barrier here
+
+        if tid == 0:
+            block_pair = pair                 # live warp-zero result
+            for byte_offset in (24,32,40,48,56,64,72,80,88,96,104):
+                partial = load_shared_b64(reduceStore + byte_offset)
+                block_pair = add_f32x2_ftz_rn(block_pair,partial)
+            # selection: ld.shared.b64 x11 and serial
+            # add.rn.ftz.f32x2 x11; only thread zero
+
+            mean = mul_f32_ftz(block_pair.x,0x1.555556p-12)  # 1/3072
+            mean_sq = mul_f32_ftz(block_pair.y,0x1.555556p-12)
+            neg_mean = neg_f32_ftz(mean)
+            variance = fma_f32_ftz_rn(neg_mean,mean,mean_sq)
+            variance = max_f32_ftz(variance,0.0)
+            variance_eps = add_f32_ftz_rn(variance,runtime_epsilon)
+            # selection: mul.ftz x2, neg.ftz.f32 x1, fma.rn.ftz,
+            # max.ftz,
+            # add.rn.ftz; extent: one scalar chain/CTA/iteration
+
+            bits = reinterpret_b32(variance_eps)
+            normal_test = compare_gt_u32(
+                add_s32(bits,-0x00800000),0x7effffff)
+            # selection: add.s32 x1 and setp.gt.u32 x1
+            if not normal_test:
+                normalized_bits = or_b32(and_b32(bits,0x00ffffff),0x3f000000)
+                exponent_adjust = sub_s32(normalized_bits,bits)
+                seed = rsqrt_approx_ftz(reinterpret_f32(normalized_bits))
+                seed_sq = mul_f32_ftz(seed,seed)
+                neg_seed_sq = neg_f32_ftz(seed_sq)
+                correction0 = fma_f32_ftz_rn(seed,seed,neg_seed_sq)
+                neg_normalized = neg_f32_ftz(reinterpret_f32(normalized_bits))
+                correction1 = fma_f32_ftz_rn(
+                    seed_sq,neg_normalized,1.0)
+                correction2 = fma_f32_ftz_rn(
+                    correction0,neg_normalized,correction1)
+                correction3 = fma_f32_ftz_rn(
+                    correction2,0.375,0.5)
+                correction4 = mul_f32_ftz(seed,correction2)
+                refined = fma_f32_ftz_rn(correction3,correction4,seed)
+                rstd_bits = add_s32(shift_right_s32(exponent_adjust,1),
+                                    reinterpret_b32(refined))
+                rstd = reinterpret_f32(rstd_bits)
+                # exact __frsqrt_rn normal-range PTX expansion, including
+                # neg.ftz.f32 x2 for seed_sq and normalized mantissa
+            else:
+                rstd = rsqrt_approx_ftz(variance_eps)
+                # exact __frsqrt_rn exceptional-range fallback
+
+            store_shared_v2_b32(s_mean,(mean,mean))
+            store_shared_v2_b32(s_inv_std,(rstd,rstd))
+            # selection: st.shared.v2.b32 x2; one thread
+
+        cta_barrier()
+        # selection: bar.sync 0; second and final barrier/iteration
+        mean2 = load_shared_b64(s_mean)
+        rstd2 = load_shared_b64(s_inv_std)
+        # selection: ld.shared.b64 x2; extent: every thread
+
+        for k in static_range(4):
+            input[k] = fma_f32x2_ftz_rn((-1.0,-1.0),mean2,input[k])
+        # selection: fma.rn.ftz.f32x2 x4
+
+        if MODE == GRGB:
+            for k in static_range(4):
+                scaled_inv = mul_f32x2_ftz_rn(rstd2,gamma[k])
+                input[k] = fma_f32x2_ftz_rn(input[k],scaled_inv,beta[k])
+            # selection: mul.rn.ftz.f32x2 x4, fma.rn.ftz.f32x2 x4
+        else:
+            input[k] = mul_f32x2_ftz_rn(input[k],rstd2)           # k=0..3
+            # selection: mul.rn.ftz.f32x2 x4
+
+        if MODE in (RSS,GRSS):
+            scale_bf16[0:4] = load_global_v4_b32(
+                scale_ptr + 2*auxiliary_pair)
+            scale[0:4] = bf16x2_to_f32x2(scale_bf16[0:4])
+            # selection: ld.global.v4.b32, then eight scalar widens
+            shift_bf16[0:4] = load_global_v4_b32(
+                shift_ptr + 2*auxiliary_pair)
+            shift[0:4] = bf16x2_to_f32x2(shift_bf16[0:4])
+            # selection: ld.global.v4.b32, then eight scalar widens
+            # source order is complete scale load/widen before shift load/widen
+            for k in static_range(4):
+                affine_scale = add_f32x2_ftz_rn(
+                    (1.0,1.0),add_f32x2_ftz_rn(scale[k],scale_bias[k]))
+                affine_shift = add_f32x2_ftz_rn(shift[k],shift_bias[k])
+                input[k] = fma_f32x2_ftz_rn(
+                    input[k],affine_scale,affine_shift)
+            # selection: add.rn.ftz.f32x2 x12, fma... x4
+
+        output_bf16[k] = f32x2_to_bf16x2_rn(input[k])            # k=0..3
+        # selection: cvt.rn.bf16x2.f32 x4 before format dispatch
+
+        if OUTPUT == BF16:
+            store_generic_v4_b32(norm_output_ptr + 2*dense_pair,output_bf16)
+            # selection: generic st.v4.b32; extent: 16 B/thread/iteration
+        elif OUTPUT == NVFP4:
+            execute the frozen NVFP4 tail below
+        else:                                      # MXFP8
+            execute the frozen MXFP8 tail below
+
+    # Fresh PTX retains a backward branch to advance batch and repeats all
+    # per-iteration loads, barriers, reduction, epilogue, and stores.
+```
+
+## Frozen NVFP4 tail
+
+The converter operates on the four final BF16x2 pairs. Two adjacent threads
+form one 16-value scale group. The optimized PTX emits a byte store from every
+thread, not only the source-level even-thread predicate: paired threads have
+the same reduced maximum and compute the same address, so they redundantly
+store the same byte. This instruction behavior is preserved.
+
+```text
+global_scale = load_global_b32(output_sf_scale_ptr[0])
+# selection: ld.global.b32; extent: one/thread/batch iteration
+
+max2 = abs_bf16x2(output_bf16[0])
+next2 = abs_bf16x2(output_bf16[1])
+local2 = max_bf16x2(max2,next2)
+next2 = abs_bf16x2(output_bf16[2])
+local2 = max_bf16x2(local2,next2)
+next2 = abs_bf16x2(output_bf16[3])
+local2 = max_bf16x2(local2,next2)
+peer2 = shuffle_xor_b32(local2,1,mask=0xffffffff)
+group2 = max_bf16x2(peer2,local2)
+vec_max_bf16 = max_bf16(group2.low,group2.high)
+vec_max = bf16_to_f32(vec_max_bf16)
+# selection: source-ordered abs.bf16x2 x4 and max.bf16x2 x4 total,
+# shfl.sync.bfly.b32 xor 1 x1, max.bf16 x1, cvt.f32.bf16 x1
+
+sf_value = mul_f32_ftz(global_scale,
+                       mul_f32_ftz(vec_max,rcp_approx_ftz(6.0)))
+sf_e4m3x2 = cvt_e4m3x2_f32_rn_satfinite(0.0,sf_value)
+sf_byte = low_byte(sf_e4m3x2)
+# selection: rcp.approx.ftz.f32; mul.ftz.f32 x2;
+# cvt.rn.satfinite.e4m3x2.f32 with zero high input
+
+k = tid // 2
+num_k_tiles = 48
+sf_offset = batch*ceil_div(runtime_num_rows,128)*(num_k_tiles*512) \
+          + (row//128)*(num_k_tiles*512) + (k//4)*512 \
+          + (row%32)*16 + ((row%128)//32)*4 + (k%4)
+store_global_b8(sf_output_ptr + sf_offset,sf_byte)
+# selection: st.global.b8; extent: one/thread/iteration, intentionally
+# redundant within each two-thread group
+
+is_zero = compare_eq_ftz_f32(vec_max,0.0)
+output_scale = 0.0
+if not is_zero:
+    sf_low_b16 = and_b16(sf_e4m3x2,0x00ff)
+    decoded_f16x2 = cvt_f16x2_e4m3x2_rn(sf_low_b16)
+    decoded_low_u16 = cvt_u16_u32(decoded_f16x2)
+    decoded_sf = cvt_f32_f16(decoded_low_u16)
+    output_scale = rcp_approx_ftz(
+        mul_f32_ftz(decoded_sf,rcp_approx_ftz(global_scale)))
+# selection after SF store: setp.eq.ftz.f32, zero mov, predicated branch;
+# nonzero path has and.b16 x1, cvt.rn.f16x2.e4m3x2 x1,
+# cvt.u16.u32 x1, cvt.f32.f16 x1, rcp.approx.ftz x2, mul.ftz x1
+
+q[k].x = mul_f32_ftz(bf16_to_f32(output_bf16[k].x),output_scale)
+q[k].y = mul_f32_ftz(bf16_to_f32(output_bf16[k].y),output_scale) # k=0..3
+byte[k] = cvt_e2m1x2_f32_rn_satfinite(q[k].y,q[k].x)             # k=0..3
+packed = mov_b32_bytes(byte[0],byte[1],byte[2],byte[3])
+store_generic_b32(norm_output_ptr +
+                  ((batch*runtime_num_rows+row)*384 + tid),packed)
+# selection: eight BF16 widens, mul.ftz x8,
+# cvt.rn.satfinite.e2m1x2.f32 x4, exact mov.b32 {b0,b1,b2,b3},
+# generic st.b32 x1
+```
+
+## Frozen MXFP8 tail
+
+Four adjacent threads form one 32-value scale group. As with NVFP4, optimized
+PTX emits one identical-address byte store per thread in the group.
+
+```text
+max2 = abs_bf16x2(output_bf16[0])
+next2 = abs_bf16x2(output_bf16[1])
+local2 = max_bf16x2(max2,next2)
+next2 = abs_bf16x2(output_bf16[2])
+local2 = max_bf16x2(local2,next2)
+next2 = abs_bf16x2(output_bf16[3])
+local2 = max_bf16x2(local2,next2)
+peer2 = shuffle_xor_b32(local2,1,0xffffffff)
+local2 = max_bf16x2(peer2,local2)
+peer4 = shuffle_xor_b32(local2,2,0xffffffff)
+group4 = max_bf16x2(peer4,local2)
+vec_max_bf16 = max_bf16(group4.low,group4.high)
+vec_max = bf16_to_f32(vec_max_bf16)
+# selection: source-ordered abs.bf16x2 x4 and max.bf16x2 x5 total,
+# shfl.sync.bfly.b32 xor 1 and xor 2, max.bf16, cvt.f32.bf16
+
+sf_value = mul_f32_ftz(vec_max,rcp_approx_ftz(448.0))
+sf_ue8m0x2 = cvt_ue8m0x2_f32_rp_satfinite(0.0,sf_value)
+sf_byte = low_byte(sf_ue8m0x2)
+is_zero = compare_eq_ftz_f32(vec_max,0.0)
+output_scale = 0.0
+if not is_zero:
+    sf_low_b16 = and_b16(sf_ue8m0x2,0x00ff)
+    decoded_bf16x2 = cvt_bf16x2_ue8m0x2_rn(sf_low_b16)
+    decoded_low_bits = low_bf16_bits(decoded_bf16x2)
+    decoded_sf = reinterpret_f32(shift_left_b32(decoded_low_bits,16))
+    output_scale = rcp_approx_ftz(decoded_sf)
+# selection: rcp.approx.ftz, mul.ftz,
+# cvt.rp.satfinite.ue8m0x2.f32 with zero high input,
+# then setp.eq.ftz.f32, zero mov, predicated branch; nonzero path has
+# and.b16 x1, cvt.rn.bf16x2.ue8m0x2 x1, shl.b32 16 x1, and
+# rcp.approx.ftz x1
+
+k = tid // 4
+num_k_tiles = 24
+sf_offset = batch*ceil_div(runtime_num_rows,128)*(num_k_tiles*512) \
+          + (row//128)*(num_k_tiles*512) + (k//4)*512 \
+          + (row%32)*16 + ((row%128)//32)*4 + (k%4)
+store_global_b8(sf_output_ptr + sf_offset,sf_byte)
+# selection: st.global.b8; extent: one/thread/iteration, intentionally
+# redundant within each four-thread group; PTX places this after the
+# zero-test and conditional UE8M0 decode/output-scale chain
+
+q[k].x = mul_f32_ftz(bf16_to_f32(output_bf16[k].x),output_scale)
+q[k].y = mul_f32_ftz(bf16_to_f32(output_bf16[k].y),output_scale) # k=0..3
+packed_pair[k] = cvt_e4m3x2_f32_rn_satfinite(q[k].y,q[k].x)       # k=0..3
+wide[k] = cvt_u64_u16(packed_pair[k])                             # k=0..3
+packed = or_b64(wide[0],shift_left_b64(wide[1],16))
+packed = or_b64(packed,shift_left_b64(wide[2],32))
+packed = or_b64(packed,shift_left_b64(wide[3],48))
+store_generic_b64(norm_output_ptr +
+                  ((batch*runtime_num_rows+row)*768 + 2*tid),packed)
+# selection: eight BF16 widens, mul.ftz x8,
+# cvt.rn.satfinite.e4m3x2.f32 x4, cvt.u64.u16 x4,
+# shl.b64 x3, or.b64 x3, generic st.b64 x1; little-endian pair order
+```
+
+## Output layouts and validation invariants
+
+BF16 norm output is compact `[B,R,3072]`. NVFP4 payload is compact packed
+E2M1, exposed as int32 `[B,R,384]`; MXFP8 payload is compact packed E4M3,
+exposed as int32 `[B,R,768]`.
+
+For a scale-group column `k`, both quant formats use the exact 128x4 layout
+above. NVFP4 has 48 K tiles and one logical SF for 16 hidden values; MXFP8 has
+24 K tiles and one logical SF for 32 values. The batch stride includes
+`ceil_div(R,128)` M tiles, so padding rows exist. Only source-addressed bytes
+may change; all padded SF bytes and external guards remain untouched.
+
+Correctness must cover all eighteen compile-time branches and the fixed
+43-config matrix. CUDA and TIRx residual BF16 bytes, packed quant bytes, and
+logical SF bytes must match exactly. BF16 norm values also compare to the FP32
+oracle at upstream `rtol=1.6e-2, atol=1e-5`; dequantized values use
+`rtol=0.5, atol=2.0`. Inputs, residual input, every auxiliary backing tensor,
+FP32 parameters, and both global scales remain unchanged. Destination-passing
+identity, 1-D/2-D bias views, 2-D/3-D auxiliary views, residual-none, one and
+odd row counts, source/TIRx output independence, SF padding, and guard bytes
+are part of the contract.
+
+Any implementation using a different reduction topology, computing statistics
+from BF16-rounded residuals, replacing accurate `__frsqrt_rn` with a lone
+approximate instruction, predicating away the PTX-observed redundant SF byte
+stores, moving bias loads into the batch loop, adding a row guard, PDL,
+clusters, tile primitives, or a FuncCall escape does not implement this sketch.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `flashinfer_layernorm`                  | `norm/layernorm.py`                                 | BF16 LayerNorm with FP32 affine parameters, independent int64 row strides, and optional PDL |
 | `flashinfer_fused_add_rmsnorm`          | `norm/fused_add_rmsnorm.py`                         | Shared fused residual-add RMSNorm / Gemma family with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
 | `flashinfer_fused_add_rmsnorm_quant`    | `norm/fused_add_rmsnorm_quant.py`                   | Fused residual add, RMSNorm, and FP8 quantization with compact, int64-strided, PDL, async-copy, and cluster-reduction paths |
+| `flashinfer_fused_dit_layernorm`        | `norm/fused_dit_layernorm.py`                       | WAN DIT fused gate/residual LayerNorm with gamma/beta or scale/shift epilogues and BF16, NVFP4, or MXFP8 output |
 | `flashinfer_qk_rmsnorm`                 | `norm/qk_rmsnorm.py`                                | Shared 3-D QK RMSNorm / Gemma RMSNorm family with arbitrary int64 batch/head strides, PDL, and sync/async copy paths |
 | `selective_state_update_stp_simple`     | `mamba/selective_state_update_stp_simple.py`        | Single-token, `algorithm="simple"` |
 | `selective_state_update_stp_vertical`   | `mamba/selective_state_update_stp_vertical.py`      | Single-token, `algorithm="vertical"` |

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -10,7 +10,7 @@ tree, so a kernel's configs sit at `config/<bucket>/<kernel>.yaml`. With no
 `--workloads`, the flagged configs across all files are assembled into
 `.bench-suite/workloads.generated.yaml` and that is what runs. The generated
 file is the inspectable source of truth for the current representative sweep.
-Every kernel has at most three default small/medium/large representatives; the current tree assembles 182
+Every kernel has at most three default small/medium/large representatives; the current tree assembles 185
 workloads. Widening or narrowing the sweep is a YAML `default`
 flag flip, not a scheduler rule or a second selection file. Multi-GPU configs
 are deliberately absent from the default measured sweep but remain available

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -3,12 +3,12 @@
   "label": "post-refactor",
   "git": {
     "tir": "135a054f",
-    "tirx-kernels": "359c47fd",
+    "tirx-kernels": "f2210e41-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "95c1d639f26f6c93c475c43a8a2d743a12029361"
+    "tirx-kernels:tirx_kernels": "540c7f7e9904ebd86834d18b458e34eea1f3e8c3"
   },
   "baselines": {
     "torch": {
@@ -2348,6 +2348,216 @@
       "impls": {
         "tirx": 3.8162779479448434,
         "flashinfer_cutedsl": 3.898806482512027
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grgb_bf16_b1_r1920",
+      "label": "grgb_bf16_b1_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 16.554921760341088,
+        "flashinfer_cuda": 16.926425777612465
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grgb_bf16_b1_r768",
+      "label": "grgb_bf16_b1_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.48553728484952,
+        "flashinfer_cuda": 8.684978720650145
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grgb_bf16_b2_r1920",
+      "label": "grgb_bf16_b2_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 28.90225468781187,
+        "flashinfer_cuda": 29.403238043442887
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grgb_bf16_b2_r768",
+      "label": "grgb_bf16_b2_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 13.510463037885032,
+        "flashinfer_cuda": 13.948722863275776
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grgb_bf16_b4_r1920",
+      "label": "grgb_bf16_b4_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 52.180766932723905,
+        "flashinfer_cuda": 53.37378188564974
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grss_bf16_b1_r1920",
+      "label": "grss_bf16_b1_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 23.081869985737896,
+        "flashinfer_cuda": 23.093724749260456
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grss_bf16_b1_r768",
+      "label": "grss_bf16_b1_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 10.959134800138894,
+        "flashinfer_cuda": 11.070855048127719
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grss_bf16_b2_r1920",
+      "label": "grss_bf16_b2_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 40.82137864634635,
+        "flashinfer_cuda": 40.96453618088016
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grss_bf16_b2_r768",
+      "label": "grss_bf16_b2_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 18.593254022557513,
+        "flashinfer_cuda": 18.69461194098422
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "grss_bf16_b4_r1920",
+      "label": "grss_bf16_b4_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 73.00627573783414,
+        "flashinfer_cuda": 73.5403711990731
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "rss_bf16_b1_r1920",
+      "label": "rss_bf16_b1_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 17.416447890523088,
+        "flashinfer_cuda": 17.585854350378437
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "rss_bf16_b1_r768",
+      "label": "rss_bf16_b1_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 8.537359069073187,
+        "flashinfer_cuda": 8.684042477341125
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "rss_bf16_b2_r1920",
+      "label": "rss_bf16_b2_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 31.54825560820634,
+        "flashinfer_cuda": 31.731525016773265
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "rss_bf16_b2_r768",
+      "label": "rss_bf16_b2_r768",
+      "status": "ok",
+      "impls": {
+        "tirx": 14.448186534199149,
+        "flashinfer_cuda": 14.67498084331852
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      }
+    },
+    {
+      "kernel": "flashinfer_fused_dit_layernorm",
+      "config": "rss_bf16_b4_r1920",
+      "label": "rss_bf16_b4_r1920",
+      "status": "ok",
+      "impls": {
+        "tirx": 57.34849170808811,
+        "flashinfer_cuda": 57.70744821067791
       },
       "aggregated": {
         "rounds": 5,

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -2,8 +2,8 @@
 
 - Timestamp: `14`
 - Label:     `post-refactor`
-- Git:       `{'tir': '135a054f', 'tirx-kernels': '359c47fd', 'tirx-bench-ci': None}`
-- Workloads: 438 ok, 0 failed
+- Git:       `{'tir': '135a054f', 'tirx-kernels': 'f2210e41-dirty', 'tirx-bench-ci': None}`
+- Workloads: 453 ok, 0 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -273,6 +273,26 @@ Grouped workloads show one row per config and one timing column per implementati
 | `bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1` | tirx | 3.3662 | flashinfer_cutedsl | 3.4006 | 1.010 | — |
 | `bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1` | tirx | 3.7142 | flashinfer_cutedsl | 3.7284 | 1.004 | — |
 | `bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1` | tirx | 3.8163 | flashinfer_cutedsl | 3.8988 | 1.022 | — |
+
+## flashinfer_fused_dit_layernorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `grgb_bf16_b1_r1920` | tirx | 16.5549 | flashinfer_cuda | 16.9264 | 1.022 | — |
+| `grgb_bf16_b1_r768` | tirx | 8.4855 | flashinfer_cuda | 8.6850 | 1.024 | — |
+| `grgb_bf16_b2_r1920` | tirx | 28.9023 | flashinfer_cuda | 29.4032 | 1.017 | — |
+| `grgb_bf16_b2_r768` | tirx | 13.5105 | flashinfer_cuda | 13.9487 | 1.032 | — |
+| `grgb_bf16_b4_r1920` | tirx | 52.1808 | flashinfer_cuda | 53.3738 | 1.023 | — |
+| `grss_bf16_b1_r1920` | tirx | 23.0819 | flashinfer_cuda | 23.0937 | 1.001 | — |
+| `grss_bf16_b1_r768` | tirx | 10.9591 | flashinfer_cuda | 11.0709 | 1.010 | — |
+| `grss_bf16_b2_r1920` | tirx | 40.8214 | flashinfer_cuda | 40.9645 | 1.004 | — |
+| `grss_bf16_b2_r768` | tirx | 18.5933 | flashinfer_cuda | 18.6946 | 1.005 | — |
+| `grss_bf16_b4_r1920` | tirx | 73.0063 | flashinfer_cuda | 73.5404 | 1.007 | — |
+| `rss_bf16_b1_r1920` | tirx | 17.4164 | flashinfer_cuda | 17.5859 | 1.010 | — |
+| `rss_bf16_b1_r768` | tirx | 8.5374 | flashinfer_cuda | 8.6840 | 1.017 | — |
+| `rss_bf16_b2_r1920` | tirx | 31.5483 | flashinfer_cuda | 31.7315 | 1.006 | — |
+| `rss_bf16_b2_r768` | tirx | 14.4482 | flashinfer_cuda | 14.6750 | 1.016 | — |
+| `rss_bf16_b4_r1920` | tirx | 57.3485 | flashinfer_cuda | 57.7074 | 1.006 | — |
 
 ## flashinfer_layernorm
 

--- a/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_fused_dit_layernorm.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/norm/flashinfer_fused_dit_layernorm.yaml
@@ -1,0 +1,27 @@
+kernel: flashinfer_fused_dit_layernorm
+selection_rationale: The defaults cover the shortest official single-batch RSS launch, the larger single-batch GRGB affine path, and the largest official batched GRSS runtime loop.
+configs:
+  - {config: grgb_bf16_b1_r1920, default: true, selection_role: medium}
+  - {config: grgb_bf16_b1_r768, default: false}
+  - {config: grgb_bf16_b2_r1920, default: false}
+  - {config: grgb_bf16_b2_r768, default: false}
+  - {config: grgb_bf16_b4_r1920, default: false}
+  - {config: rss_bf16_b1_r1920, default: false}
+  - {config: rss_bf16_b1_r768, default: true, selection_role: small}
+  - {config: rss_bf16_b2_r1920, default: false}
+  - {config: rss_bf16_b2_r768, default: false}
+  - {config: rss_bf16_b4_r1920, default: false}
+  - {config: grss_bf16_b1_r1920, default: false}
+  - {config: grss_bf16_b1_r768, default: false}
+  - {config: grss_bf16_b2_r1920, default: false}
+  - {config: grss_bf16_b2_r768, default: false}
+  - {config: grss_bf16_b4_r1920, default: true, selection_role: large}
+  - {config: grgb_nvfp4_b1_r768, default: false}
+  - {config: grgb_mxfp8_b1_r768, default: false}
+  - {config: rss_nvfp4_b1_r768, default: false}
+  - {config: rss_mxfp8_b1_r768, default: false}
+  - {config: grss_nvfp4_b1_r768, default: false}
+  - {config: grss_mxfp8_b1_r768, default: false}
+  - {config: grgb_bf16_b1_r768_inputsf0p75, default: false}
+  - {config: rss_bf16_b1_r768_inputsf0p75, default: false}
+  - {config: grss_bf16_b1_r768_inputsf0p75, default: false}

--- a/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
@@ -1,0 +1,1793 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400e330fb2debe0bf8730d9424a1d37927f), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer fused DIT LayerNorm port.
+
+The primary source is ``meta_fused_layernorm`` in
+``include/flashinfer/norm/fused_dit_layernorm.cuh``.  The source dispatch and
+public interfaces are in ``csrc/norm.cu``, ``csrc/flashinfer_norm_binding.cu``,
+``flashinfer/norm/__init__.py``, and ``flashinfer/diffusion_ops/__init__.py``.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+from tirx_kernels.runner import bench
+from tvm.script import tirx as T
+
+KERNEL_META = {
+    "name": "flashinfer_fused_dit_layernorm",
+    "category": "flashinfer",
+    "compute_capability": 10,
+}
+
+_HIDDEN_SIZE = 3072
+_BLOCK_SIZE = 384
+_DEFAULT_EPSILON = 1e-6
+_MODES = ("grgb", "rss", "grss")
+_OUTPUT_FORMATS = ("bf16", "nvfp4", "mxfp8")
+_FULL_MASK = 0xFFFFFFFF
+_AUXILIARY_STRIDE = 6 * _HIDDEN_SIZE
+_SF_SENTINEL = 0xA5
+_GUARD_ELEMENTS = 64
+_BF16_GUARD = 7.25
+
+
+def _load_global_bf16x8(buffer, index):
+    words = T.alloc_local((4,), "uint32")
+    values = T.alloc_local((8,), "float32")
+    bits = T.alloc_local((8,), "uint16")
+    T.evaluate(
+        T.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    for pair in range(4):
+        T.evaluate(T.ptx.mov.b32(bits[pair * 2], bits[pair * 2 + 1], words[pair]))
+        T.evaluate(T.ptx.cvt.f32.bf16(values[pair * 2], bits[pair * 2]))
+        T.evaluate(T.ptx.cvt.f32.bf16(values[pair * 2 + 1], bits[pair * 2 + 1]))
+    return values
+
+
+def _load_global_f32x8(buffer, index):
+    words = T.alloc_local((4,), "uint64")
+    values = T.alloc_local((8,), "float32")
+    T.evaluate(
+        T.ptx.ld.global_.v4.b64(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+    )
+    for pair in range(4):
+        T.evaluate(T.ptx.mov.b64(values[pair * 2], values[pair * 2 + 1], words[pair]))
+    return values
+
+
+def _load_global_f32(buffer, index):
+    value = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.ld.global_.b32(value[0], buffer.ptr_to([index])))
+    return value[0]
+
+
+def _pack_f32x2(low, high):
+    packed = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.mov.b64(packed[0], low, high))
+    return packed[0]
+
+
+def _unpack_f32x2(packed):
+    values = T.alloc_local((2,), "float32")
+    T.evaluate(T.ptx.mov.b64(values[0], values[1], packed))
+    return values
+
+
+def _f32x2_binary(chain: str, lhs_low, lhs_high, rhs_low, rhs_high):
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx[chain](out[0], _pack_f32x2(lhs_low, lhs_high), _pack_f32x2(rhs_low, rhs_high)))
+    return _unpack_f32x2(out[0])
+
+
+def _f32x2_fma(lhs_low, lhs_high, rhs_low, rhs_high, acc_low, acc_high):
+    out = T.alloc_local((1,), "uint64")
+    T.evaluate(
+        T.ptx.fma.rn.ftz.f32x2(
+            out[0],
+            _pack_f32x2(lhs_low, lhs_high),
+            _pack_f32x2(rhs_low, rhs_high),
+            _pack_f32x2(acc_low, acc_high),
+        )
+    )
+    return _unpack_f32x2(out[0])
+
+
+def _add_f32(lhs, rhs):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.add.rn.ftz.f32(out[0], lhs, rhs))
+    return out[0]
+
+
+def _mul_f32(lhs, rhs):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.mul.ftz.f32(out[0], lhs, rhs))
+    return out[0]
+
+
+def _fma_f32(lhs, rhs, acc):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.fma.rn.ftz.f32(out[0], lhs, rhs, acc))
+    return out[0]
+
+
+def _neg_f32(value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.neg.ftz.f32(out[0], value))
+    return out[0]
+
+
+def _max_f32(lhs, rhs):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.max.ftz.f32(out[0], lhs, rhs))
+    return out[0]
+
+
+def _rcp_f32(value):
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.rcp.approx.ftz.f32(out[0], value))
+    return out[0]
+
+
+@T.inline
+def _rsqrt_accurate(value, result):
+    """Transcribe the SM100 ``__frsqrt_rn`` expansion from fresh source PTX."""
+    bits: T.int32 = T.reinterpret("int32", value)
+    adjusted = T.alloc_local((1,), "int32")
+    T.evaluate(T.ptx.add.s32(adjusted[0], bits, T.int32(-0x00800000)))
+    if T.reinterpret("uint32", adjusted[0]) <= T.uint32(0x7EFFFFFF):
+        mantissa = T.alloc_local((1,), "uint32")
+        normalized_bits = T.alloc_local((1,), "uint32")
+        exponent_adjust = T.alloc_local((1,), "int32")
+        T.evaluate(T.ptx.and_.b32(mantissa[0], T.reinterpret("uint32", bits), 0x00FFFFFF))
+        T.evaluate(T.ptx.or_.b32(normalized_bits[0], mantissa[0], T.uint32(0x3F000000)))
+        T.evaluate(
+            T.ptx.sub.s32(exponent_adjust[0], T.reinterpret("int32", normalized_bits[0]), bits)
+        )
+        normalized: T.float32 = T.reinterpret("float32", normalized_bits[0])
+        seed = T.alloc_local((1,), "float32")
+        T.evaluate(T.ptx.rsqrt.approx.ftz.f32(seed[0], normalized))
+        seed_sq: T.float32 = _mul_f32(seed[0], seed[0])
+        correction0: T.float32 = _fma_f32(seed[0], seed[0], _neg_f32(seed_sq))
+        neg_normalized: T.float32 = _neg_f32(normalized)
+        correction1: T.float32 = _fma_f32(seed_sq, neg_normalized, T.float32(1.0))
+        correction2: T.float32 = _fma_f32(correction0, neg_normalized, correction1)
+        correction3: T.float32 = _fma_f32(correction2, T.float32(0.375), T.float32(0.5))
+        correction4: T.float32 = _mul_f32(seed[0], correction2)
+        refined: T.float32 = _fma_f32(correction3, correction4, seed[0])
+        half_adjust = T.alloc_local((1,), "int32")
+        result_bits = T.alloc_local((1,), "int32")
+        T.evaluate(T.ptx.shr.s32(half_adjust[0], exponent_adjust[0], T.uint32(1)))
+        T.evaluate(T.ptx.add.s32(result_bits[0], half_adjust[0], T.reinterpret("int32", refined)))
+        result[0] = T.reinterpret("float32", T.reinterpret("uint32", result_bits[0]))
+    else:
+        T.evaluate(T.ptx.rsqrt.approx.ftz.f32(result[0], value))
+
+
+def _pack_bf16x8(values):
+    words = T.alloc_local((4,), "uint32")
+    for pair in range(4):
+        T.evaluate(T.ptx.cvt.rn.bf16x2.f32(words[pair], values[pair * 2 + 1], values[pair * 2]))
+    return words
+
+
+def _store_global_v4_b32(buffer, index, words):
+    T.evaluate(
+        T.ptx.st.global_.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3])
+    )
+
+
+def _store_generic_v4_b32(buffer, index, words):
+    T.evaluate(T.ptx.st.v4.b32(buffer.ptr_to([index]), words[0], words[1], words[2], words[3]))
+
+
+def _abs_bf16x2(value):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.abs.bf16x2(out[0], value))
+    return out[0]
+
+
+def _max_bf16x2(lhs, rhs):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(T.ptx.max.bf16x2(out[0], lhs, rhs))
+    return out[0]
+
+
+def _shfl_xor_u32(value, lane_xor: int):
+    out = T.alloc_local((1,), "uint32")
+    T.evaluate(
+        T.ptx.shfl_sync.bfly.b32(
+            out[0], value, T.uint32(lane_xor), T.uint32(31), T.uint32(_FULL_MASK)
+        )
+    )
+    return out[0]
+
+
+def _bf16x2_horizontal_max_to_f32(value):
+    bits = T.alloc_local((2,), "uint16")
+    maximum = T.alloc_local((1,), "uint16")
+    out = T.alloc_local((1,), "float32")
+    T.evaluate(T.ptx.mov.b32(bits[0], bits[1], value))
+    T.evaluate(T.ptx.max.bf16(maximum[0], bits[0], bits[1]))
+    T.evaluate(T.ptx.cvt.f32.bf16(out[0], maximum[0]))
+    return out[0]
+
+
+def _quant_group_max(words, output_format: str):
+    maximum: T.uint32 = _abs_bf16x2(words[0])
+    next_value: T.uint32 = _abs_bf16x2(words[1])
+    maximum = _max_bf16x2(maximum, next_value)
+    next_value = _abs_bf16x2(words[2])
+    maximum = _max_bf16x2(maximum, next_value)
+    next_value = _abs_bf16x2(words[3])
+    maximum = _max_bf16x2(maximum, next_value)
+    peer: T.uint32 = _shfl_xor_u32(maximum, 1)
+    maximum = _max_bf16x2(peer, maximum)
+    if output_format == "mxfp8":
+        peer = _shfl_xor_u32(maximum, 2)
+        maximum = _max_bf16x2(peer, maximum)
+    return _bf16x2_horizontal_max_to_f32(maximum)
+
+
+def _widen_and_scale_bf16x8(words, scale):
+    bits = T.alloc_local((8,), "uint16")
+    widened = T.alloc_local((8,), "float32")
+    values = T.alloc_local((8,), "float32")
+    for pair in range(4):
+        T.evaluate(T.ptx.mov.b32(bits[pair * 2], bits[pair * 2 + 1], words[pair]))
+        T.evaluate(T.ptx.cvt.f32.bf16(widened[pair * 2], bits[pair * 2]))
+        T.evaluate(T.ptx.cvt.f32.bf16(widened[pair * 2 + 1], bits[pair * 2 + 1]))
+        T.evaluate(T.ptx.mul.ftz.f32(values[pair * 2], widened[pair * 2], scale))
+        T.evaluate(T.ptx.mul.ftz.f32(values[pair * 2 + 1], widened[pair * 2 + 1], scale))
+    return values
+
+
+def _sf_offset(batch, row, col, runtime_num_rows, num_k_tiles: int):
+    return (
+        T.cast(batch, "int64")
+        * T.ceildiv(T.cast(runtime_num_rows, "int64"), T.int64(128))
+        * T.int64(num_k_tiles * 512)
+        + T.truncdiv(T.cast(row, "int64"), T.int64(128)) * T.int64(num_k_tiles * 512)
+        + T.truncdiv(T.cast(col, "int64"), T.int64(4)) * T.int64(512)
+        + T.truncmod(T.cast(row, "int64"), T.int64(32)) * T.int64(16)
+        + T.truncdiv(T.truncmod(T.cast(row, "int64"), T.int64(128)), T.int64(32)) * T.int64(4)
+        + T.truncmod(T.cast(col, "int64"), T.int64(4))
+    )
+
+
+@T.inline
+def _store_nvfp4(
+    output_words, norm_output, sf_output, output_sf_scale, batch, row, tid, runtime_num_rows
+):
+    global_scale: T.float32 = _load_global_f32(output_sf_scale, T.int64(0))
+    vec_max: T.float32 = _quant_group_max(output_words, "nvfp4")
+    sf_value: T.float32 = _mul_f32(global_scale, _mul_f32(vec_max, _rcp_f32(T.float32(6.0))))
+    sf_pair = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.cvt.rn.satfinite.e4m3x2.f32(sf_pair[0], T.float32(0.0), sf_value))
+    sf_col: T.int32 = tid // 2
+    sf_offset: T.int64 = _sf_offset(batch, row, sf_col, runtime_num_rows, 48)
+    T.evaluate(T.ptx.st.global_.b8(sf_output.ptr_to([sf_offset]), T.cast(sf_pair[0], "uint8")))
+
+    output_scale = T.alloc_local((1,), "float32")
+    output_scale[0] = T.float32(0.0)
+    if vec_max == T.float32(0.0):
+        T.evaluate(T.uint32(0))
+    else:
+        sf_low = T.alloc_local((1,), "uint16")
+        decoded_pair = T.alloc_local((1,), "uint32")
+        decoded_low = T.alloc_local((1,), "uint16")
+        decoded = T.alloc_local((1,), "float32")
+        T.evaluate(T.ptx.and_.b16(sf_low[0], sf_pair[0], T.uint16(0x00FF)))
+        T.evaluate(T.ptx.cvt.rn.f16x2.e4m3x2(decoded_pair[0], sf_low[0]))
+        T.evaluate(T.ptx.cvt.u16.u32(decoded_low[0], decoded_pair[0]))
+        T.evaluate(T.ptx.cvt.f32.f16(decoded[0], decoded_low[0]))
+        decoded_over_global: T.float32 = _mul_f32(decoded[0], _rcp_f32(global_scale))
+        T.evaluate(T.ptx.rcp.approx.ftz.f32(output_scale[0], decoded_over_global))
+
+    scaled = _widen_and_scale_bf16x8(output_words, output_scale[0])
+    packed: T.uint32 = T.cuda.cvt_e2m1x8_f32(
+        scaled[0], scaled[1], scaled[2], scaled[3], scaled[4], scaled[5], scaled[6], scaled[7]
+    )
+    global_row: T.int64 = T.cast(batch, "int64") * T.cast(runtime_num_rows, "int64") + T.cast(
+        row, "int64"
+    )
+    T.evaluate(T.ptx.st.b32(norm_output.ptr_to([global_row * T.int64(384) + tid]), packed))
+
+
+@T.inline
+def _store_mxfp8(output_words, norm_output, sf_output, batch, row, tid, runtime_num_rows):
+    vec_max: T.float32 = _quant_group_max(output_words, "mxfp8")
+    sf_value: T.float32 = _mul_f32(vec_max, _rcp_f32(T.float32(448.0)))
+    sf_pair = T.alloc_local((1,), "uint16")
+    T.evaluate(T.ptx.cvt.rp.satfinite.ue8m0x2.f32(sf_pair[0], T.float32(0.0), sf_value))
+
+    output_scale = T.alloc_local((1,), "float32")
+    output_scale[0] = T.float32(0.0)
+    if vec_max == T.float32(0.0):
+        T.evaluate(T.uint32(0))
+    else:
+        sf_low = T.alloc_local((1,), "uint16")
+        decoded_pair = T.alloc_local((1,), "uint32")
+        decoded_bits = T.alloc_local((1,), "uint32")
+        T.evaluate(T.ptx.and_.b16(sf_low[0], sf_pair[0], T.uint16(0x00FF)))
+        T.evaluate(T.ptx.cvt.rn.bf16x2.ue8m0x2(decoded_pair[0], sf_low[0]))
+        T.evaluate(T.ptx.shl.b32(decoded_bits[0], decoded_pair[0], T.uint32(16)))
+        T.evaluate(
+            T.ptx.rcp.approx.ftz.f32(output_scale[0], T.reinterpret("float32", decoded_bits[0]))
+        )
+
+    sf_col: T.int32 = tid // 4
+    sf_offset: T.int64 = _sf_offset(batch, row, sf_col, runtime_num_rows, 24)
+    T.evaluate(T.ptx.st.global_.b8(sf_output.ptr_to([sf_offset]), T.cast(sf_pair[0], "uint8")))
+
+    scaled = _widen_and_scale_bf16x8(output_words, output_scale[0])
+    pairs = T.alloc_local((4,), "uint16")
+    wide = T.alloc_local((4,), "uint64")
+    for pair in range(4):
+        T.evaluate(
+            T.ptx.cvt.rn.satfinite.e4m3x2.f32(pairs[pair], scaled[pair * 2 + 1], scaled[pair * 2])
+        )
+        T.evaluate(T.ptx.cvt.u64.u16(wide[pair], pairs[pair]))
+    shifted = T.alloc_local((3,), "uint64")
+    packed = T.alloc_local((1,), "uint64")
+    T.evaluate(T.ptx.shl.b64(shifted[0], wide[1], T.uint32(16)))
+    T.evaluate(T.ptx.or_.b64(packed[0], wide[0], shifted[0]))
+    T.evaluate(T.ptx.shl.b64(shifted[1], wide[2], T.uint32(32)))
+    T.evaluate(T.ptx.or_.b64(packed[0], packed[0], shifted[1]))
+    T.evaluate(T.ptx.shl.b64(shifted[2], wide[3], T.uint32(48)))
+    T.evaluate(T.ptx.or_.b64(packed[0], packed[0], shifted[2]))
+    global_row: T.int64 = T.cast(batch, "int64") * T.cast(runtime_num_rows, "int64") + T.cast(
+        row, "int64"
+    )
+    T.evaluate(
+        T.ptx.st.b64(
+            norm_output.ptr_to([global_row * T.int64(768) + T.cast(tid * 2, "int64")]), packed[0]
+        )
+    )
+
+
+def _cfg(
+    mode: str,
+    batch_size: int,
+    num_rows: int,
+    output_format: str = "bf16",
+    *,
+    use_input_sf_scale: bool = False,
+    input_sf_scale: float = 1.0,
+    has_residual: bool = True,
+    destination_passing: bool = False,
+    auxiliary_ndim: int = 3,
+    bias_ndim: int = 2,
+    suffix: str = "",
+) -> dict[str, Any]:
+    label = f"{mode}_{output_format}_b{batch_size}_r{num_rows}"
+    if use_input_sf_scale:
+        label += f"_inputsf{str(input_sf_scale).replace('.', 'p')}"
+    if not has_residual:
+        label += "_noresidual"
+    if destination_passing:
+        label += "_destination"
+    if auxiliary_ndim == 2:
+        label += "_aux2d"
+    if bias_ndim == 1:
+        label += "_bias1d"
+    if suffix:
+        label += f"_{suffix}"
+    return {
+        "label": label,
+        "mode": mode,
+        "batch_size": batch_size,
+        "num_rows": num_rows,
+        "output_format": output_format,
+        "use_input_sf_scale": use_input_sf_scale,
+        "input_sf_scale": input_sf_scale,
+        "has_residual": has_residual,
+        "destination_passing": destination_passing,
+        "auxiliary_ndim": auxiliary_ndim,
+        "bias_ndim": bias_ndim,
+        "epsilon": _DEFAULT_EPSILON,
+    }
+
+
+_OFFICIAL_SHAPES = ((1, 1920), (1, 768), (2, 1920), (2, 768), (4, 1920))
+
+_OFFICIAL_BF16_CONFIGS = [
+    _cfg(mode, batch_size, num_rows) for mode in _MODES for batch_size, num_rows in _OFFICIAL_SHAPES
+]
+
+_OFFICIAL_QUANT_CONFIGS = [
+    _cfg(mode, batch_size, num_rows, output_format)
+    for mode in ("grgb", "rss")
+    for output_format in ("nvfp4", "mxfp8")
+    for batch_size, num_rows in ((1, 768), (2, 1920))
+]
+
+_DESTINATION_CONFIGS = [
+    _cfg("grgb", 1, 768, destination_passing=True),
+    _cfg("rss", 1, 768, destination_passing=True),
+]
+
+_BOUNDARY_CONFIGS = [
+    _cfg("rss", 1, 768, has_residual=False),
+    _cfg("grgb", 1, 769, suffix="odd_rows"),
+    _cfg("grgb", 1, 1, suffix="single_row"),
+    _cfg("grss", 1, 768, auxiliary_ndim=2),
+    _cfg("rss", 1, 768, bias_ndim=1),
+]
+
+_GRSS_QUANT_CONFIGS = [_cfg("grss", 1, 768, output_format) for output_format in ("nvfp4", "mxfp8")]
+
+_INPUT_SCALE_CONFIGS = [
+    _cfg(mode, 1, 768, output_format, use_input_sf_scale=True, input_sf_scale=0.75)
+    for mode in _MODES
+    for output_format in _OUTPUT_FORMATS
+]
+
+_SF_PADDING_CONFIGS = [
+    _cfg("rss", 1, 129, output_format, suffix="sf_padding_guard")
+    for output_format in ("nvfp4", "mxfp8")
+]
+
+CONFIGS = [
+    *_OFFICIAL_BF16_CONFIGS,
+    *_OFFICIAL_QUANT_CONFIGS,
+    *_DESTINATION_CONFIGS,
+    *_BOUNDARY_CONFIGS,
+    *_GRSS_QUANT_CONFIGS,
+    *_INPUT_SCALE_CONFIGS,
+    *_SF_PADDING_CONFIGS,
+]
+
+BENCH_CONFIGS = [
+    *[dict(config) for config in _OFFICIAL_BF16_CONFIGS],
+    *[_cfg(mode, 1, 768, output_format) for mode in _MODES for output_format in ("nvfp4", "mxfp8")],
+    *[_cfg(mode, 1, 768, use_input_sf_scale=True, input_sf_scale=0.75) for mode in _MODES],
+]
+
+assert len(CONFIGS) == 43
+assert len(BENCH_CONFIGS) == 24
+assert len({config["label"] for config in CONFIGS}) == len(CONFIGS)
+assert len({config["label"] for config in BENCH_CONFIGS}) == len(BENCH_CONFIGS)
+
+
+def _validate(
+    mode: str,
+    batch_size: int,
+    num_rows: int,
+    output_format: str,
+    use_input_sf_scale: bool,
+    input_sf_scale: float,
+    has_residual: bool,
+    destination_passing: bool,
+    auxiliary_ndim: int,
+    bias_ndim: int,
+    epsilon: float,
+) -> None:
+    del destination_passing
+    if mode not in _MODES:
+        raise ValueError(f"unsupported mode: {mode}")
+    if output_format not in _OUTPUT_FORMATS:
+        raise ValueError(f"unsupported output format: {output_format}")
+    if batch_size <= 0 or num_rows <= 0:
+        raise ValueError(
+            f"batch_size and num_rows must be positive, got {batch_size} and {num_rows}"
+        )
+    if mode != "rss" and not has_residual:
+        raise ValueError(f"mode {mode} requires a residual input")
+    if auxiliary_ndim not in (2, 3):
+        raise ValueError(f"auxiliary_ndim must be 2 or 3, got {auxiliary_ndim}")
+    if bias_ndim not in (1, 2):
+        raise ValueError(f"bias_ndim must be 1 or 2, got {bias_ndim}")
+    if epsilon <= 0:
+        raise ValueError(f"epsilon must be positive, got {epsilon}")
+    if use_input_sf_scale and input_sf_scale <= 0:
+        raise ValueError(f"input_sf_scale must be positive, got {input_sf_scale}")
+
+
+def get_kernel(
+    mode: str,
+    batch_size: int,
+    num_rows: int,
+    output_format: str,
+    use_input_sf_scale: bool,
+    input_sf_scale: float,
+    has_residual: bool,
+    destination_passing: bool,
+    auxiliary_ndim: int,
+    bias_ndim: int,
+    epsilon: float = _DEFAULT_EPSILON,
+):
+    """Return one of the eighteen compile-time source specializations."""
+    _validate(
+        mode,
+        batch_size,
+        num_rows,
+        output_format,
+        use_input_sf_scale,
+        input_sf_scale,
+        has_residual,
+        destination_passing,
+        auxiliary_ndim,
+        bias_ndim,
+        epsilon,
+    )
+
+    norm_dtype = "bfloat16" if output_format == "bf16" else "int32"
+    norm_values_per_row = _HIDDEN_SIZE if output_format == "bf16" else _HIDDEN_SIZE // 8
+    if output_format == "mxfp8":
+        norm_values_per_row = _HIDDEN_SIZE // 4
+    sf_k_tiles = 1
+    if output_format == "nvfp4":
+        sf_k_tiles = (_HIDDEN_SIZE + 63) // 64
+    elif output_format == "mxfp8":
+        sf_k_tiles = (_HIDDEN_SIZE + 127) // 128
+
+    @T.prim_func
+    def flashinfer_fused_dit_layernorm(
+        input_ptr: T.handle,
+        residual_ptr: T.handle,
+        gate_ptr: T.handle,
+        gate_bias_ptr: T.handle,
+        gamma_ptr: T.handle,
+        beta_ptr: T.handle,
+        scale_ptr: T.handle,
+        scale_bias_ptr: T.handle,
+        shift_ptr: T.handle,
+        shift_bias_ptr: T.handle,
+        residual_output_ptr: T.handle,
+        norm_output_ptr: T.handle,
+        sf_output_ptr: T.handle,
+        output_sf_scale_ptr: T.handle,
+        input_sf_scale_ptr: T.handle,
+        runtime_batch_size: T.int32,
+        runtime_num_rows: T.int32,
+        runtime_epsilon: T.float32,
+        runtime_has_residual: T.int32,
+    ):
+        T.func_attr({"tir.is_entry_func": True})
+        input_buffer = T.match_buffer(
+            input_ptr,
+            shape=(
+                T.cast(runtime_batch_size, "int64")
+                * T.cast(runtime_num_rows, "int64")
+                * T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        residual_buffer = T.match_buffer(
+            residual_ptr,
+            shape=(
+                T.cast(runtime_batch_size, "int64")
+                * T.cast(runtime_num_rows, "int64")
+                * T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        gate_buffer = T.match_buffer(
+            gate_ptr,
+            shape=(
+                (
+                    T.cast(runtime_batch_size, "int64") * T.cast(runtime_num_rows, "int64")
+                    - T.int64(1)
+                )
+                * T.int64(_AUXILIARY_STRIDE)
+                + T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        gate_bias_buffer = T.match_buffer(
+            gate_bias_ptr, shape=(_HIDDEN_SIZE,), dtype="float32", scope="global"
+        )
+        gamma_buffer = T.match_buffer(
+            gamma_ptr, shape=(_HIDDEN_SIZE,), dtype="float32", scope="global"
+        )
+        beta_buffer = T.match_buffer(
+            beta_ptr, shape=(_HIDDEN_SIZE,), dtype="float32", scope="global"
+        )
+        scale_buffer = T.match_buffer(
+            scale_ptr,
+            shape=(
+                (
+                    T.cast(runtime_batch_size, "int64") * T.cast(runtime_num_rows, "int64")
+                    - T.int64(1)
+                )
+                * T.int64(_AUXILIARY_STRIDE)
+                + T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        scale_bias_buffer = T.match_buffer(
+            scale_bias_ptr, shape=(_HIDDEN_SIZE,), dtype="float32", scope="global"
+        )
+        shift_buffer = T.match_buffer(
+            shift_ptr,
+            shape=(
+                (
+                    T.cast(runtime_batch_size, "int64") * T.cast(runtime_num_rows, "int64")
+                    - T.int64(1)
+                )
+                * T.int64(_AUXILIARY_STRIDE)
+                + T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        shift_bias_buffer = T.match_buffer(
+            shift_bias_ptr, shape=(_HIDDEN_SIZE,), dtype="float32", scope="global"
+        )
+        residual_output_buffer = T.match_buffer(
+            residual_output_ptr,
+            shape=(
+                T.cast(runtime_batch_size, "int64")
+                * T.cast(runtime_num_rows, "int64")
+                * T.int64(_HIDDEN_SIZE),
+            ),
+            dtype="bfloat16",
+            scope="global",
+        )
+        norm_output_buffer = T.match_buffer(
+            norm_output_ptr,
+            shape=(
+                T.cast(runtime_batch_size, "int64")
+                * T.cast(runtime_num_rows, "int64")
+                * T.int64(norm_values_per_row),
+            ),
+            dtype=norm_dtype,
+            scope="global",
+        )
+        sf_output_buffer = T.match_buffer(
+            sf_output_ptr,
+            shape=(
+                T.cast(runtime_batch_size, "int64")
+                * T.ceildiv(T.cast(runtime_num_rows, "int64"), T.int64(128))
+                * T.int64(sf_k_tiles * 32 * 4 * 4),
+            ),
+            dtype="uint8",
+            scope="global",
+        )
+        output_sf_scale_buffer = T.match_buffer(
+            output_sf_scale_ptr, shape=(1,), dtype="float32", scope="global"
+        )
+        input_sf_scale_buffer = T.match_buffer(
+            input_sf_scale_ptr, shape=(1,), dtype="float32", scope="global"
+        )
+        T.device_entry()
+        # TIRX_TRANSCRIBE_START flashinfer_fused_dit_layernorm
+        row = T.cta_id([runtime_num_rows])
+        tid = T.thread_id([_BLOCK_SIZE])
+        lane: T.int32 = tid % 32
+        warp: T.int32 = tid // 32
+
+        reduce_store = T.alloc_buffer((120,), "uint8", scope="shared", align=8)
+        shared_mean = T.alloc_buffer((8,), "uint8", scope="shared", align=8)
+        shared_inv_std = T.alloc_buffer((8,), "uint8", scope="shared", align=8)
+
+        if use_input_sf_scale:
+            input_scale: T.float32 = _load_global_f32(input_sf_scale_buffer, T.int64(0))
+        else:
+            input_scale: T.float32 = T.float32(1.0)
+
+        if mode == "grgb":
+            gamma_values = _load_global_f32x8(gamma_buffer, T.cast(tid * 8, "int64"))
+            beta_values = _load_global_f32x8(beta_buffer, T.cast(tid * 8, "int64"))
+        if mode in ("grgb", "grss"):
+            gate_bias_values = _load_global_f32x8(gate_bias_buffer, T.cast(tid * 8, "int64"))
+        if mode in ("rss", "grss"):
+            scale_bias_values = _load_global_f32x8(scale_bias_buffer, T.cast(tid * 8, "int64"))
+            shift_bias_values = _load_global_f32x8(shift_bias_buffer, T.cast(tid * 8, "int64"))
+
+        for batch_id in T.serial(runtime_batch_size, unroll=False):
+            global_row: T.int64 = T.cast(batch_id, "int64") * T.cast(
+                runtime_num_rows, "int64"
+            ) + T.cast(row, "int64")
+            dense_index: T.int64 = global_row * T.int64(_HIDDEN_SIZE) + T.cast(tid * 8, "int64")
+            auxiliary_index: T.int64 = global_row * T.int64(_AUXILIARY_STRIDE) + T.cast(
+                tid * 8, "int64"
+            )
+
+            input_values = _load_global_bf16x8(input_buffer, dense_index)
+            residual_values = T.alloc_local((8,), "float32")
+            if runtime_has_residual != 0:
+                loaded_residual = _load_global_bf16x8(residual_buffer, dense_index)
+                for value in T.unroll(8):
+                    residual_values[value] = loaded_residual[value]
+            else:
+                for value in T.unroll(8):
+                    residual_values[value] = T.float32(0.0)
+
+            if mode in ("grgb", "grss"):
+                gate_values = _load_global_bf16x8(gate_buffer, auxiliary_index)
+                if use_input_sf_scale:
+                    biased_gate_values = T.alloc_local((8,), "float32")
+                    for pair in T.unroll(4):
+                        biased_gate = _f32x2_binary(
+                            "add.rn.ftz.f32x2",
+                            gate_values[pair * 2],
+                            gate_values[pair * 2 + 1],
+                            gate_bias_values[pair * 2],
+                            gate_bias_values[pair * 2 + 1],
+                        )
+                        biased_gate_values[pair * 2] = biased_gate[0]
+                        biased_gate_values[pair * 2 + 1] = biased_gate[1]
+                    scaled_gate_values = T.alloc_local((8,), "float32")
+                    for pair in T.unroll(4):
+                        scaled_gate = _f32x2_binary(
+                            "mul.rn.ftz.f32x2",
+                            biased_gate_values[pair * 2],
+                            biased_gate_values[pair * 2 + 1],
+                            input_scale,
+                            input_scale,
+                        )
+                        scaled_gate_values[pair * 2] = scaled_gate[0]
+                        scaled_gate_values[pair * 2 + 1] = scaled_gate[1]
+                    for pair in T.unroll(4):
+                        updated = _f32x2_fma(
+                            input_values[pair * 2],
+                            input_values[pair * 2 + 1],
+                            scaled_gate_values[pair * 2],
+                            scaled_gate_values[pair * 2 + 1],
+                            residual_values[pair * 2],
+                            residual_values[pair * 2 + 1],
+                        )
+                        input_values[pair * 2] = updated[0]
+                        input_values[pair * 2 + 1] = updated[1]
+                else:
+                    for pair in T.unroll(4):
+                        biased_gate = _f32x2_binary(
+                            "add.rn.ftz.f32x2",
+                            gate_values[pair * 2],
+                            gate_values[pair * 2 + 1],
+                            gate_bias_values[pair * 2],
+                            gate_bias_values[pair * 2 + 1],
+                        )
+                        updated = _f32x2_fma(
+                            input_values[pair * 2],
+                            input_values[pair * 2 + 1],
+                            biased_gate[0],
+                            biased_gate[1],
+                            residual_values[pair * 2],
+                            residual_values[pair * 2 + 1],
+                        )
+                        input_values[pair * 2] = updated[0]
+                        input_values[pair * 2 + 1] = updated[1]
+            else:
+                if use_input_sf_scale:
+                    for pair in T.unroll(4):
+                        updated = _f32x2_fma(
+                            input_values[pair * 2],
+                            input_values[pair * 2 + 1],
+                            input_scale,
+                            input_scale,
+                            residual_values[pair * 2],
+                            residual_values[pair * 2 + 1],
+                        )
+                        input_values[pair * 2] = updated[0]
+                        input_values[pair * 2 + 1] = updated[1]
+                else:
+                    for pair in T.unroll(4):
+                        updated = _f32x2_binary(
+                            "add.rn.ftz.f32x2",
+                            input_values[pair * 2],
+                            input_values[pair * 2 + 1],
+                            residual_values[pair * 2],
+                            residual_values[pair * 2 + 1],
+                        )
+                        input_values[pair * 2] = updated[0]
+                        input_values[pair * 2 + 1] = updated[1]
+
+            residual_words = _pack_bf16x8(input_values)
+            _store_global_v4_b32(residual_output_buffer, dense_index, residual_words)
+
+            thread_sum: T.float32 = T.float32(0.0)
+            thread_sum_sq: T.float32 = T.float32(0.0)
+            for pair in T.unroll(4):
+                thread_sum = _add_f32(
+                    _add_f32(thread_sum, input_values[pair * 2]), input_values[pair * 2 + 1]
+                )
+                thread_sum_sq = _fma_f32(
+                    input_values[pair * 2 + 1],
+                    input_values[pair * 2 + 1],
+                    _fma_f32(input_values[pair * 2], input_values[pair * 2], thread_sum_sq),
+                )
+
+            for stage in T.unroll(5):
+                delta: T.int32 = 1 << stage
+                peer_sum_word = T.alloc_local((1,), "uint32")
+                peer_sq_word = T.alloc_local((1,), "uint32")
+                T.evaluate(
+                    T.ptx.shfl_sync.down.b32(
+                        peer_sum_word[0],
+                        T.reinterpret("uint32", thread_sum),
+                        T.cast(delta, "uint32"),
+                        T.uint32(31),
+                        T.uint32(_FULL_MASK),
+                    )
+                )
+                T.evaluate(
+                    T.ptx.shfl_sync.down.b32(
+                        peer_sq_word[0],
+                        T.reinterpret("uint32", thread_sum_sq),
+                        T.cast(delta, "uint32"),
+                        T.uint32(31),
+                        T.uint32(_FULL_MASK),
+                    )
+                )
+                if lane <= 31 - delta:
+                    reduced = _f32x2_binary(
+                        "add.rn.ftz.f32x2",
+                        thread_sum,
+                        thread_sum_sq,
+                        T.reinterpret("float32", peer_sum_word[0]),
+                        T.reinterpret("float32", peer_sq_word[0]),
+                    )
+                    thread_sum = reduced[0]
+                    thread_sum_sq = reduced[1]
+
+            if lane == 0:
+                T.evaluate(
+                    T.ptx.st.shared.v2.b32(
+                        reduce_store.ptr_to([16 + warp * 8]),
+                        T.reinterpret("uint32", thread_sum),
+                        T.reinterpret("uint32", thread_sum_sq),
+                    )
+                )
+            T.ptx.bar.sync(T.uint32(0))
+
+            if tid == 0:
+                for partial_index in T.unroll(11):
+                    partial_word = T.alloc_local((1,), "uint64")
+                    T.evaluate(
+                        T.ptx.ld.shared.b64(
+                            partial_word[0], reduce_store.ptr_to([24 + partial_index * 8])
+                        )
+                    )
+                    partial = _unpack_f32x2(partial_word[0])
+                    reduced = _f32x2_binary(
+                        "add.rn.ftz.f32x2", thread_sum, thread_sum_sq, partial[0], partial[1]
+                    )
+                    thread_sum = reduced[0]
+                    thread_sum_sq = reduced[1]
+
+                mean: T.float32 = _mul_f32(thread_sum, T.float32(1.0 / _HIDDEN_SIZE))
+                mean_sq: T.float32 = _mul_f32(thread_sum_sq, T.float32(1.0 / _HIDDEN_SIZE))
+                variance: T.float32 = _fma_f32(_neg_f32(mean), mean, mean_sq)
+                variance = _max_f32(variance, T.float32(0.0))
+                inv_std = T.alloc_local((1,), "float32")
+                _rsqrt_accurate(_add_f32(variance, runtime_epsilon), inv_std)
+                T.evaluate(
+                    T.ptx.st.shared.v2.b32(
+                        shared_mean.ptr_to([0]),
+                        T.reinterpret("uint32", mean),
+                        T.reinterpret("uint32", mean),
+                    )
+                )
+                T.evaluate(
+                    T.ptx.st.shared.v2.b32(
+                        shared_inv_std.ptr_to([0]),
+                        T.reinterpret("uint32", inv_std[0]),
+                        T.reinterpret("uint32", inv_std[0]),
+                    )
+                )
+            T.ptx.bar.sync(T.uint32(0))
+
+            mean_word = T.alloc_local((1,), "uint64")
+            inv_std_word = T.alloc_local((1,), "uint64")
+            T.evaluate(T.ptx.ld.shared.b64(mean_word[0], shared_mean.ptr_to([0])))
+            T.evaluate(T.ptx.ld.shared.b64(inv_std_word[0], shared_inv_std.ptr_to([0])))
+            mean_pair = _unpack_f32x2(mean_word[0])
+            inv_std_pair = _unpack_f32x2(inv_std_word[0])
+
+            for pair in T.unroll(4):
+                centered = _f32x2_fma(
+                    T.float32(-1.0),
+                    T.float32(-1.0),
+                    mean_pair[0],
+                    mean_pair[1],
+                    input_values[pair * 2],
+                    input_values[pair * 2 + 1],
+                )
+                input_values[pair * 2] = centered[0]
+                input_values[pair * 2 + 1] = centered[1]
+
+            if mode == "grgb":
+                for pair in T.unroll(4):
+                    scaled_inv = _f32x2_binary(
+                        "mul.rn.ftz.f32x2",
+                        inv_std_pair[0],
+                        inv_std_pair[1],
+                        gamma_values[pair * 2],
+                        gamma_values[pair * 2 + 1],
+                    )
+                    normalized = _f32x2_fma(
+                        input_values[pair * 2],
+                        input_values[pair * 2 + 1],
+                        scaled_inv[0],
+                        scaled_inv[1],
+                        beta_values[pair * 2],
+                        beta_values[pair * 2 + 1],
+                    )
+                    input_values[pair * 2] = normalized[0]
+                    input_values[pair * 2 + 1] = normalized[1]
+            else:
+                for pair in T.unroll(4):
+                    normalized = _f32x2_binary(
+                        "mul.rn.ftz.f32x2",
+                        input_values[pair * 2],
+                        input_values[pair * 2 + 1],
+                        inv_std_pair[0],
+                        inv_std_pair[1],
+                    )
+                    input_values[pair * 2] = normalized[0]
+                    input_values[pair * 2 + 1] = normalized[1]
+
+            if mode in ("rss", "grss"):
+                scale_values = _load_global_bf16x8(scale_buffer, auxiliary_index)
+                shift_values = _load_global_bf16x8(shift_buffer, auxiliary_index)
+                for pair in T.unroll(4):
+                    biased_scale = _f32x2_binary(
+                        "add.rn.ftz.f32x2",
+                        scale_values[pair * 2],
+                        scale_values[pair * 2 + 1],
+                        scale_bias_values[pair * 2],
+                        scale_bias_values[pair * 2 + 1],
+                    )
+                    affine_scale = _f32x2_binary(
+                        "add.rn.ftz.f32x2",
+                        T.float32(1.0),
+                        T.float32(1.0),
+                        biased_scale[0],
+                        biased_scale[1],
+                    )
+                    affine_shift = _f32x2_binary(
+                        "add.rn.ftz.f32x2",
+                        shift_values[pair * 2],
+                        shift_values[pair * 2 + 1],
+                        shift_bias_values[pair * 2],
+                        shift_bias_values[pair * 2 + 1],
+                    )
+                    output_pair = _f32x2_fma(
+                        input_values[pair * 2],
+                        input_values[pair * 2 + 1],
+                        affine_scale[0],
+                        affine_scale[1],
+                        affine_shift[0],
+                        affine_shift[1],
+                    )
+                    input_values[pair * 2] = output_pair[0]
+                    input_values[pair * 2 + 1] = output_pair[1]
+
+            output_words = _pack_bf16x8(input_values)
+            if output_format == "bf16":
+                _store_generic_v4_b32(norm_output_buffer, dense_index, output_words)
+            elif output_format == "nvfp4":
+                _store_nvfp4(
+                    output_words,
+                    norm_output_buffer,
+                    sf_output_buffer,
+                    output_sf_scale_buffer,
+                    batch_id,
+                    row,
+                    tid,
+                    runtime_num_rows,
+                )
+            else:
+                _store_mxfp8(
+                    output_words,
+                    norm_output_buffer,
+                    sf_output_buffer,
+                    batch_id,
+                    row,
+                    tid,
+                    runtime_num_rows,
+                )
+
+    return flashinfer_fused_dit_layernorm.with_attr(
+        "tirx.kernel_launch_params", ["blockIdx.x", "threadIdx.x"]
+    )
+
+
+def prepare_data(**config: Any) -> tuple[Any, ...]:
+    """Prepare the complete fixed-ABI argument tuple for one TIRx launch."""
+    config = dict(config)
+    _validate_config(config)
+    data = _prepare_tensors(config)
+    output = _prepare_output(config)
+    return tuple(_tirx_args(data, output, config))
+
+
+def run_test(**config: Any) -> None:
+    """Compile, launch, and validate one source-domain specialization."""
+    import torch
+
+    config = dict(config)
+    _validate_config(config)
+    data = _prepare_tensors(config)
+    snapshot = _snapshot_inputs(data)
+    tirx_output = _prepare_output(config)
+    source_output = _prepare_output(config)
+    executable = _compiled_specialization(
+        str(config["mode"]), str(config["output_format"]), bool(config["use_input_sf_scale"])
+    )
+
+    if _launch_tirx(executable, data, tirx_output, config) is not None:
+        raise AssertionError("TIRx fused DIT LayerNorm ABI must return None")
+    source_module = _flashinfer_module()
+    if _launch_flashinfer(source_module, data, source_output, config) is not None:
+        raise AssertionError("FlashInfer fused DIT LayerNorm ABI must return None")
+    torch.cuda.synchronize()
+
+    _assert_outputs_match(tirx_output, source_output, config, name="FlashInfer CUDA oracle")
+    _assert_math(tirx_output, data, config)
+    _assert_output_integrity(tirx_output, config, name="TIRx output")
+    _assert_output_integrity(source_output, config, name="FlashInfer output")
+    _check_public_wrappers(source_module, data, source_output, config)
+    _assert_inputs_unchanged(data, snapshot)
+
+
+def prepare_bench(**config: Any):
+    """Compile the selected specialization before GPU assignment."""
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    config = dict(config)
+    _validate_config(config)
+    state = {
+        "config": config,
+        "executable": _compiled_specialization(
+            str(config["mode"]), str(config["output_format"]), bool(config["use_input_sf_scale"])
+        ),
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs: Any
+):
+    """Construct and prevalidate two direct single-kernel launch closures."""
+    import torch
+
+    config = dict(prepared["config"])
+    config.update(kwargs)
+    _validate_config(config)
+    data = _prepare_tensors(config)
+    snapshot = _snapshot_inputs(data)
+    tirx_output = _prepare_output(config)
+    source_output = _prepare_output(config)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        return _launch_tirx(executable, data, tirx_output, config)
+
+    if tirx_launch() is not None:
+        raise AssertionError("TIRx benchmark closure must return None")
+    torch.cuda.synchronize()
+
+    source_module = _flashinfer_module()
+
+    def flashinfer_launch():
+        return _launch_flashinfer(source_module, data, source_output, config)
+
+    if flashinfer_launch() is not None:
+        raise AssertionError("FlashInfer benchmark closure must return None")
+    torch.cuda.synchronize()
+    _assert_outputs_match(tirx_output, source_output, config, name="benchmark precheck")
+    _check_public_wrappers(source_module, data, source_output, config)
+    _assert_inputs_unchanged(data, snapshot)
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"flashinfer_cuda": lambda: flashinfer_launch},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(
+    *,
+    warmup: float | None = None,
+    repeat: float | None = None,
+    timer: str | None = None,
+    rounds: int = 1,
+    cooldown_s: float = 1.0,
+    **config: Any,
+) -> dict[str, Any]:
+    """Benchmark the TIRx kernel against one direct FlashInfer CUDA launch."""
+    prepared = prepare_bench(**config)
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def _validate_config(config: dict[str, Any]) -> None:
+    _validate(
+        str(config["mode"]),
+        int(config["batch_size"]),
+        int(config["num_rows"]),
+        str(config["output_format"]),
+        bool(config["use_input_sf_scale"]),
+        float(config["input_sf_scale"]),
+        bool(config["has_residual"]),
+        bool(config["destination_passing"]),
+        int(config["auxiliary_ndim"]),
+        int(config["bias_ndim"]),
+        float(config.get("epsilon", _DEFAULT_EPSILON)),
+    )
+
+
+def _mode_id(mode: str) -> int:
+    return {"grgb": 0, "rss": 1, "grss": 2}[mode]
+
+
+def _output_id(output_format: str) -> int:
+    return {"bf16": 0, "nvfp4": 1, "mxfp8": 2}[output_format]
+
+
+def _auxiliary_positions(mode: str) -> dict[str, int]:
+    if mode == "grgb":
+        return {"gate": 2}
+    if mode == "rss":
+        return {"scale": 4, "shift": 3}
+    return {"gate": 5, "scale": 1, "shift": 0}
+
+
+def _auxiliary_view(backing, position: int, config: dict[str, Any]):
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    offset = position * _HIDDEN_SIZE
+    if int(config["auxiliary_ndim"]) == 2:
+        return torch.as_strided(
+            backing,
+            size=(batch_size * num_rows, _HIDDEN_SIZE),
+            stride=(_AUXILIARY_STRIDE, 1),
+            storage_offset=offset,
+        )
+    return torch.as_strided(
+        backing,
+        size=(batch_size, num_rows, _HIDDEN_SIZE),
+        stride=(num_rows * _AUXILIARY_STRIDE, _AUXILIARY_STRIDE, 1),
+        storage_offset=offset,
+    )
+
+
+def _auxiliary_arg(backing, position: int, config: dict[str, Any]):
+    rows = int(config["batch_size"]) * int(config["num_rows"])
+    offset = position * _HIDDEN_SIZE
+    size = (rows - 1) * _AUXILIARY_STRIDE + _HIDDEN_SIZE
+    return backing[offset : offset + size]
+
+
+def _bias_view(table, position: int, config: dict[str, Any]):
+    if int(config["bias_ndim"]) == 1:
+        return table[0, position]
+    return table[:, position]
+
+
+def _prepare_tensors(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    dense_size = batch_size * num_rows * _HIDDEN_SIZE
+    auxiliary_size = batch_size * num_rows * 6 * _HIDDEN_SIZE
+    generator = torch.Generator(device="cuda").manual_seed(42)
+
+    input_backing = torch.empty(dense_size + _GUARD_ELEMENTS, dtype=torch.bfloat16, device="cuda")
+    residual_backing = torch.empty_like(input_backing)
+    input_backing.fill_(_BF16_GUARD)
+    residual_backing.fill_(_BF16_GUARD)
+    input_tensor = input_backing[:dense_size].view(batch_size, num_rows, _HIDDEN_SIZE)
+    residual = residual_backing[:dense_size].view(batch_size, num_rows, _HIDDEN_SIZE)
+    input_tensor.normal_(generator=generator)
+    residual.normal_(generator=generator)
+
+    auxiliary_backing = torch.empty(
+        auxiliary_size + _GUARD_ELEMENTS, dtype=torch.bfloat16, device="cuda"
+    )
+    auxiliary_backing.fill_(_BF16_GUARD)
+    auxiliary_backing[:auxiliary_size].normal_(generator=generator)
+    bias_backing = torch.empty(
+        6 * _HIDDEN_SIZE + _GUARD_ELEMENTS, dtype=torch.float32, device="cuda"
+    )
+    bias_backing.fill_(_BF16_GUARD)
+    bias_backing[: 6 * _HIDDEN_SIZE].normal_(generator=generator)
+    bias_table = bias_backing[: 6 * _HIDDEN_SIZE].view(1, 6, _HIDDEN_SIZE)
+
+    gamma_backing = torch.empty(_HIDDEN_SIZE + _GUARD_ELEMENTS, dtype=torch.float32, device="cuda")
+    beta_backing = torch.empty_like(gamma_backing)
+    gamma_backing.fill_(_BF16_GUARD)
+    beta_backing.fill_(_BF16_GUARD)
+    gamma = gamma_backing[:_HIDDEN_SIZE]
+    beta = beta_backing[:_HIDDEN_SIZE]
+    gamma.normal_(generator=generator)
+    beta.normal_(generator=generator)
+
+    data: dict[str, Any] = {
+        "input": input_tensor,
+        "input_arg": input_backing[:dense_size],
+        "input_backing": input_backing,
+        "residual": residual,
+        "residual_arg": residual_backing[:dense_size],
+        "residual_backing": residual_backing,
+        "auxiliary_backing": auxiliary_backing,
+        "auxiliary_size": auxiliary_size,
+        "bias_backing": bias_backing,
+        "gamma": gamma,
+        "gamma_backing": gamma_backing,
+        "beta": beta,
+        "beta_backing": beta_backing,
+        "source_empty_bf16": torch.empty(0, dtype=torch.bfloat16, device="cuda"),
+        "source_empty_f32": torch.empty(0, dtype=torch.float32, device="cuda"),
+        "input_sf_scale": torch.tensor(
+            [float(config["input_sf_scale"])], dtype=torch.float32, device="cuda"
+        ),
+    }
+    for name, position in _auxiliary_positions(str(config["mode"])).items():
+        data[name] = _auxiliary_view(auxiliary_backing, position, config)
+        data[f"{name}_arg"] = _auxiliary_arg(auxiliary_backing, position, config)
+        data[f"{name}_bias"] = _bias_view(bias_table, position, config)
+        data[f"{name}_bias_arg"] = bias_backing[
+            position * _HIDDEN_SIZE : (position + 1) * _HIDDEN_SIZE
+        ]
+
+    # All pointer slots in the fixed TIRx ABI receive valid, sufficiently large
+    # storage even when their compile-time mode does not dereference them.
+    default_aux = _auxiliary_arg(auxiliary_backing, 0, config)
+    default_bias = bias_backing[:_HIDDEN_SIZE]
+    for name in ("gate", "scale", "shift"):
+        data.setdefault(f"{name}_arg", default_aux)
+        data.setdefault(name, _auxiliary_view(auxiliary_backing, 0, config))
+        data.setdefault(f"{name}_bias_arg", default_bias)
+        data.setdefault(f"{name}_bias", _bias_view(bias_table, 0, config))
+
+    if str(config["output_format"]) == "nvfp4":
+        _, oracle_norm = _math_oracle(data, config)
+        maximum = max(float(oracle_norm.abs().max().item()), 1e-12)
+        output_scale = (448.0 * 6.0) / maximum
+    else:
+        output_scale = 0.0
+    data["output_sf_scale"] = torch.tensor([output_scale], dtype=torch.float32, device="cuda")
+    return data
+
+
+def _output_layout(config: dict[str, Any]):
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    output_format = str(config["output_format"])
+    if output_format == "bf16":
+        norm_shape = (batch_size, num_rows, _HIDDEN_SIZE)
+        norm_dtype = torch.bfloat16
+        norm_bytes = batch_size * num_rows * _HIDDEN_SIZE * 2
+        num_k_tiles = 1
+    elif output_format == "nvfp4":
+        norm_shape = (batch_size, num_rows, _HIDDEN_SIZE // 8)
+        norm_dtype = torch.int32
+        norm_bytes = batch_size * num_rows * (_HIDDEN_SIZE // 2)
+        num_k_tiles = 48
+    else:
+        norm_shape = (batch_size, num_rows, _HIDDEN_SIZE // 4)
+        norm_dtype = torch.int32
+        norm_bytes = batch_size * num_rows * _HIDDEN_SIZE
+        num_k_tiles = 24
+    sf_shape = (batch_size, _ceil_div(num_rows, 128), num_k_tiles, 32, 4, 4)
+    sf_size = batch_size * _ceil_div(num_rows, 128) * num_k_tiles * 512
+    return norm_shape, norm_dtype, norm_bytes, sf_shape, sf_size
+
+
+def _prepare_output(config: dict[str, Any]) -> dict[str, Any]:
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    residual_size = batch_size * num_rows * _HIDDEN_SIZE
+    norm_shape, norm_dtype, norm_bytes, sf_shape, sf_size = _output_layout(config)
+
+    residual_backing = torch.empty(
+        residual_size + _GUARD_ELEMENTS, dtype=torch.bfloat16, device="cuda"
+    )
+    residual_backing.fill_(_BF16_GUARD)
+    residual = residual_backing[:residual_size].view(batch_size, num_rows, _HIDDEN_SIZE)
+
+    if norm_dtype == torch.bfloat16:
+        norm_elements = norm_bytes // 2
+        norm_backing = torch.empty(
+            norm_elements + _GUARD_ELEMENTS, dtype=torch.bfloat16, device="cuda"
+        )
+        norm_backing.fill_(_BF16_GUARD)
+        norm_arg = norm_backing[:norm_elements]
+        norm = norm_arg.view(norm_shape)
+        norm_guard_size = norm_elements
+    else:
+        norm_backing = torch.full(
+            (norm_bytes + _GUARD_ELEMENTS,), _SF_SENTINEL, dtype=torch.uint8, device="cuda"
+        )
+        norm_arg = norm_backing[:norm_bytes].view(torch.int32)
+        norm = norm_arg.view(norm_shape)
+        norm_guard_size = norm_bytes
+
+    sf_backing = torch.full(
+        (sf_size + _GUARD_ELEMENTS,), _SF_SENTINEL, dtype=torch.uint8, device="cuda"
+    )
+    sf_arg = sf_backing[:sf_size]
+    sf = sf_arg.view(sf_shape)
+    return {
+        "residual": residual,
+        "residual_arg": residual_backing[:residual_size],
+        "residual_backing": residual_backing,
+        "residual_size": residual_size,
+        "norm": norm,
+        "norm_arg": norm_arg,
+        "norm_backing": norm_backing,
+        "norm_guard_size": norm_guard_size,
+        "sf": sf,
+        "sf_arg": sf_arg,
+        "sf_backing": sf_backing,
+        "sf_size": sf_size,
+        "pointers": (residual.data_ptr(), norm.data_ptr(), sf.data_ptr()),
+        "shapes": (tuple(residual.shape), tuple(norm.shape), tuple(sf.shape)),
+        "strides": (residual.stride(), norm.stride(), sf.stride()),
+    }
+
+
+def _tirx_args(data, output, config: dict[str, Any]) -> list[Any]:
+    return [
+        data["input_arg"],
+        data["residual_arg"] if bool(config["has_residual"]) else data["input_arg"],
+        data["gate_arg"],
+        data["gate_bias_arg"],
+        data["gamma"] if str(config["mode"]) == "grgb" else data["gate_bias_arg"],
+        data["beta"] if str(config["mode"]) == "grgb" else data["gate_bias_arg"],
+        data["scale_arg"],
+        data["scale_bias_arg"],
+        data["shift_arg"],
+        data["shift_bias_arg"],
+        output["residual_arg"],
+        output["norm_arg"],
+        output["sf_arg"],
+        data["output_sf_scale"],
+        data["input_sf_scale"],
+        int(config["batch_size"]),
+        int(config["num_rows"]),
+        float(config.get("epsilon", _DEFAULT_EPSILON)),
+        int(bool(config["has_residual"])),
+    ]
+
+
+def _launch_tirx(executable, data, output, config: dict[str, Any]):
+    return executable(*_tirx_args(data, output, config))
+
+
+@functools.cache
+def _compiled_specialization(mode: str, output_format: str, use_input_sf_scale: bool):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(
+        get_kernel(
+            mode=mode,
+            batch_size=1,
+            num_rows=1,
+            output_format=output_format,
+            use_input_sf_scale=use_input_sf_scale,
+            input_sf_scale=1.0,
+            has_residual=True,
+            destination_passing=False,
+            auxiliary_ndim=3,
+            bias_ndim=2,
+            epsilon=_DEFAULT_EPSILON,
+        )
+    )
+
+
+def _flashinfer_module():
+    import flashinfer.norm as flashinfer_norm
+
+    return flashinfer_norm.get_norm_module()
+
+
+def _launch_flashinfer(module, data, output, config: dict[str, Any]):
+    mode = str(config["mode"])
+    empty_bf16 = data["source_empty_bf16"]
+    empty_f32 = data["source_empty_f32"]
+    return module.fused_dit_layernorm(
+        data["input"],
+        data["residual"] if bool(config["has_residual"]) else empty_bf16,
+        data["gate"] if mode in ("grgb", "grss") else empty_bf16,
+        data["gate_bias"] if mode in ("grgb", "grss") else empty_f32,
+        data["gamma"] if mode == "grgb" else empty_f32,
+        data["beta"] if mode == "grgb" else empty_f32,
+        data["scale"] if mode in ("rss", "grss") else empty_bf16,
+        data["scale_bias"] if mode in ("rss", "grss") else empty_f32,
+        data["shift"] if mode in ("rss", "grss") else empty_bf16,
+        data["shift_bias"] if mode in ("rss", "grss") else empty_f32,
+        output["residual"],
+        output["norm"],
+        output["sf"],
+        data["output_sf_scale"],
+        data["input_sf_scale"] if bool(config["use_input_sf_scale"]) else empty_f32,
+        float(config.get("epsilon", _DEFAULT_EPSILON)),
+        _mode_id(mode),
+        _output_id(str(config["output_format"])),
+    )
+
+
+def _snapshot_inputs(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: data[name].clone()
+        for name in (
+            "input_backing",
+            "residual_backing",
+            "auxiliary_backing",
+            "bias_backing",
+            "gamma_backing",
+            "beta_backing",
+            "output_sf_scale",
+            "input_sf_scale",
+        )
+    }
+
+
+def _assert_inputs_unchanged(data: dict[str, Any], snapshot: dict[str, Any]) -> None:
+    import torch
+
+    for name, expected in snapshot.items():
+        if not torch.equal(data[name], expected):
+            count = int((data[name] != expected).sum().item())
+            raise AssertionError(f"{name} was modified at {count} element(s)")
+
+
+def _as_auxiliary_3d(value, config: dict[str, Any]):
+    return value.reshape(int(config["batch_size"]), int(config["num_rows"]), _HIDDEN_SIZE)
+
+
+def _math_oracle(data: dict[str, Any], config: dict[str, Any]):
+    import torch
+
+    mode = str(config["mode"])
+    value = data["input"].float()
+    residual = data["residual"].float() if bool(config["has_residual"]) else torch.zeros_like(value)
+    input_scale = float(config["input_sf_scale"]) if bool(config["use_input_sf_scale"]) else 1.0
+    if mode in ("grgb", "grss"):
+        gate = _as_auxiliary_3d(data["gate"], config).float()
+        gate = gate + data["gate_bias"].reshape(-1, _HIDDEN_SIZE)[0].float()
+        residual_fp32 = residual + value * (gate * input_scale)
+    else:
+        residual_fp32 = residual + value * input_scale
+
+    mean = residual_fp32.mean(dim=-1, keepdim=True)
+    mean_sq = residual_fp32.square().mean(dim=-1, keepdim=True)
+    variance = torch.clamp_min(mean_sq - mean.square(), 0.0)
+    normalized = (residual_fp32 - mean) * (variance + float(config["epsilon"])).rsqrt()
+    if mode == "grgb":
+        normalized = normalized * data["gamma"].float() + data["beta"].float()
+    else:
+        scale = _as_auxiliary_3d(data["scale"], config).float()
+        shift = _as_auxiliary_3d(data["shift"], config).float()
+        scale = scale + data["scale_bias"].reshape(-1, _HIDDEN_SIZE)[0].float()
+        shift = shift + data["shift_bias"].reshape(-1, _HIDDEN_SIZE)[0].float()
+        normalized = normalized * (1.0 + scale) + shift
+    return residual_fp32.to(torch.bfloat16), normalized.to(torch.bfloat16)
+
+
+def _logical_sf_bytes(sf, config: dict[str, Any]):
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    output_format = str(config["output_format"])
+    columns = _HIDDEN_SIZE // (16 if output_format == "nvfp4" else 32)
+    num_k_tiles = 48 if output_format == "nvfp4" else 24
+    batches = torch.arange(batch_size, device="cuda", dtype=torch.int64)[:, None, None]
+    rows = torch.arange(num_rows, device="cuda", dtype=torch.int64)[None, :, None]
+    cols = torch.arange(columns, device="cuda", dtype=torch.int64)[None, None, :]
+    offsets = (
+        batches * (_ceil_div(num_rows, 128) * num_k_tiles * 512)
+        + (rows // 128) * (num_k_tiles * 512)
+        + (cols // 4) * 512
+        + (rows % 32) * 16
+        + ((rows % 128) // 32) * 4
+        + (cols % 4)
+    )
+    return sf.reshape(-1)[offsets]
+
+
+def _dequantize(output: dict[str, Any], data: dict[str, Any], config: dict[str, Any]):
+    import torch
+
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    output_format = str(config["output_format"])
+    payload = output["norm"].view(torch.uint8)
+    scale_bytes = _logical_sf_bytes(output["sf"], config)
+    if output_format == "nvfp4":
+        payload = payload.view(batch_size, num_rows, _HIDDEN_SIZE // 2)
+        nibbles = torch.stack((payload & 0x0F, payload >> 4), dim=-1)
+        nibbles = nibbles.reshape(batch_size, num_rows, _HIDDEN_SIZE).long()
+        table = torch.tensor(
+            [
+                0.0,
+                0.5,
+                1.0,
+                1.5,
+                2.0,
+                3.0,
+                4.0,
+                6.0,
+                -0.0,
+                -0.5,
+                -1.0,
+                -1.5,
+                -2.0,
+                -3.0,
+                -4.0,
+                -6.0,
+            ],
+            dtype=torch.float32,
+            device="cuda",
+        )
+        values = table[nibbles].view(batch_size, num_rows, _HIDDEN_SIZE // 16, 16)
+        scales = scale_bytes.contiguous().view(torch.float8_e4m3fn).float()
+        scales = scales / data["output_sf_scale"].float()
+        return (values * scales[..., None]).reshape(batch_size, num_rows, _HIDDEN_SIZE)
+
+    values = payload.contiguous().view(torch.float8_e4m3fn).float()
+    values = values.view(batch_size, num_rows, _HIDDEN_SIZE // 32, 32)
+    exponent = scale_bytes.int() - 127
+    scales = torch.where(
+        scale_bytes == 0,
+        torch.zeros_like(scale_bytes, dtype=torch.float32),
+        torch.pow(torch.tensor(2.0, device="cuda"), exponent),
+    )
+    return (values * scales[..., None]).reshape(batch_size, num_rows, _HIDDEN_SIZE)
+
+
+def _assert_outputs_match(
+    actual: dict[str, Any], expected: dict[str, Any], config: dict[str, Any], *, name: str
+) -> None:
+    import torch
+
+    if not torch.equal(actual["residual"], expected["residual"]):
+        count = int((actual["residual"] != expected["residual"]).sum().item())
+        raise AssertionError(f"{name}: {count} residual BF16 values differ")
+    if str(config["output_format"]) == "bf16":
+        if not torch.allclose(actual["norm"], expected["norm"], rtol=1.6e-2, atol=1e-5):
+            difference = (actual["norm"].float() - expected["norm"].float()).abs()
+            count = int(
+                (~torch.isclose(actual["norm"], expected["norm"], rtol=1.6e-2, atol=1e-5))
+                .sum()
+                .item()
+            )
+            raise AssertionError(
+                f"{name} BF16 norm: {count} values differ; "
+                f"maximum absolute difference is {float(difference.max().item())}"
+            )
+        return
+    actual_payload = actual["norm"].view(torch.uint8)
+    expected_payload = expected["norm"].view(torch.uint8)
+    if not torch.equal(actual_payload, expected_payload):
+        count = int((actual_payload != expected_payload).sum().item())
+        raise AssertionError(f"{name}: {count} packed quantization bytes differ")
+    actual_sf = _logical_sf_bytes(actual["sf"], config)
+    expected_sf = _logical_sf_bytes(expected["sf"], config)
+    if not torch.equal(actual_sf, expected_sf):
+        count = int((actual_sf != expected_sf).sum().item())
+        raise AssertionError(f"{name}: {count} logical scale-factor bytes differ")
+
+
+def _assert_math(output, data, config: dict[str, Any]) -> None:
+    import torch
+
+    oracle_residual, oracle_norm = _math_oracle(data, config)
+    torch.testing.assert_close(
+        output["residual"],
+        oracle_residual,
+        rtol=1.6e-2,
+        atol=1e-5,
+        msg=lambda message: f"independent FP32 residual oracle: {message}",
+    )
+    if str(config["output_format"]) == "bf16":
+        torch.testing.assert_close(
+            output["norm"],
+            oracle_norm,
+            rtol=1.6e-2,
+            atol=1e-5,
+            msg=lambda message: f"independent FP32 LayerNorm oracle: {message}",
+        )
+    else:
+        dequantized = _dequantize(output, data, config)
+        if not torch.isfinite(dequantized).all():
+            raise AssertionError("dequantized norm output contains non-finite values")
+        torch.testing.assert_close(
+            dequantized,
+            oracle_norm.float(),
+            rtol=0.5,
+            atol=2.0,
+            msg=lambda message: f"independent quantized LayerNorm oracle: {message}",
+        )
+
+
+def _assert_output_integrity(output, config: dict[str, Any], *, name: str) -> None:
+    import torch
+
+    actual_pointers = (
+        output["residual"].data_ptr(),
+        output["norm"].data_ptr(),
+        output["sf"].data_ptr(),
+    )
+    actual_shapes = (
+        tuple(output["residual"].shape),
+        tuple(output["norm"].shape),
+        tuple(output["sf"].shape),
+    )
+    actual_strides = (output["residual"].stride(), output["norm"].stride(), output["sf"].stride())
+    if actual_pointers != output["pointers"]:
+        raise AssertionError(f"{name}: an output data pointer changed")
+    if actual_shapes != output["shapes"] or actual_strides != output["strides"]:
+        raise AssertionError(f"{name}: an output shape or stride changed")
+    if not torch.all(output["residual_backing"][output["residual_size"] :] == _BF16_GUARD):
+        raise AssertionError(f"{name}: residual trailing guard was modified")
+    norm_tail = output["norm_backing"][output["norm_guard_size"] :]
+    norm_sentinel = _BF16_GUARD if norm_tail.dtype == torch.bfloat16 else _SF_SENTINEL
+    if not torch.all(norm_tail == norm_sentinel):
+        raise AssertionError(f"{name}: norm trailing guard was modified")
+    if not torch.all(output["sf_backing"][output["sf_size"] :] == _SF_SENTINEL):
+        raise AssertionError(f"{name}: scale-factor trailing guard was modified")
+
+    output_format = str(config["output_format"])
+    if output_format == "bf16":
+        if not torch.all(output["sf_arg"] == _SF_SENTINEL):
+            raise AssertionError(f"{name}: disabled scale-factor output was modified")
+        return
+    valid = _logical_sf_offsets(config)
+    padding = torch.ones(output["sf_size"], dtype=torch.bool, device="cuda")
+    padding[valid] = False
+    if not torch.all(output["sf_arg"][padding] == _SF_SENTINEL):
+        raise AssertionError(f"{name}: swizzled scale-factor padding was modified")
+
+
+def _logical_sf_offsets(config: dict[str, Any]):
+    import torch
+
+    output_format = str(config["output_format"])
+    columns = _HIDDEN_SIZE // (16 if output_format == "nvfp4" else 32)
+    num_k_tiles = 48 if output_format == "nvfp4" else 24
+    batch_size = int(config["batch_size"])
+    num_rows = int(config["num_rows"])
+    batches = torch.arange(batch_size, device="cuda", dtype=torch.int64)[:, None, None]
+    rows = torch.arange(num_rows, device="cuda", dtype=torch.int64)[None, :, None]
+    cols = torch.arange(columns, device="cuda", dtype=torch.int64)[None, None, :]
+    return (
+        batches * (_ceil_div(num_rows, 128) * num_k_tiles * 512)
+        + (rows // 128) * (num_k_tiles * 512)
+        + (cols // 4) * 512
+        + (rows % 32) * 16
+        + ((rows % 128) // 32) * 4
+        + (cols % 4)
+    ).reshape(-1)
+
+
+def _public_call(api, data, output, config: dict[str, Any]):
+    mode = str(config["mode"])
+    common = {
+        "epsilon": float(config["epsilon"]),
+        "use_nvfp4": str(config["output_format"]) == "nvfp4",
+        "use_mxfp8": str(config["output_format"]) == "mxfp8",
+        "global_scaling_factor": (
+            data["output_sf_scale"] if str(config["output_format"]) == "nvfp4" else None
+        ),
+        "input_global_scaling_factor": (
+            data["input_sf_scale"] if bool(config["use_input_sf_scale"]) else None
+        ),
+    }
+    if output is not None:
+        common.update(
+            residual_out=output["residual"],
+            norm_out=output["norm"],
+            sf_out=(output["sf"] if str(config["output_format"]) != "bf16" else None),
+        )
+    if mode == "grgb":
+        return api(
+            data["input"],
+            data["residual"],
+            data["gate"],
+            data["gamma"],
+            data["beta"],
+            gate_bias=data["gate_bias"],
+            **common,
+        )
+    if mode == "rss":
+        return api(
+            data["input"],
+            data["scale"],
+            data["shift"],
+            residual=(data["residual"] if bool(config["has_residual"]) else None),
+            scale_bias=data["scale_bias"],
+            shift_bias=data["shift_bias"],
+            **common,
+        )
+    return api(
+        data["input"],
+        data["residual"],
+        data["gate"],
+        data["scale"],
+        data["shift"],
+        gate_bias=data["gate_bias"],
+        scale_bias=data["scale_bias"],
+        shift_bias=data["shift_bias"],
+        **common,
+    )
+
+
+def _check_public_wrappers(module, data, source_output, config: dict[str, Any]) -> None:
+    import flashinfer.norm as flashinfer_norm
+
+    mode = str(config["mode"])
+    api = {
+        "grgb": flashinfer_norm.fused_dit_gate_residual_layernorm_gamma_beta,
+        "rss": flashinfer_norm.fused_dit_residual_layernorm_scale_shift,
+        "grss": flashinfer_norm.fused_dit_gate_residual_layernorm_scale_shift,
+    }[mode]
+    captures: list[tuple[Any, ...]] = []
+
+    class _TrackedNormModule:
+        def __getattr__(self, name):
+            return getattr(module, name)
+
+        def fused_dit_layernorm(self, *args, **kwargs):
+            captures.append(args)
+            return module.fused_dit_layernorm(*args, **kwargs)
+
+    original_get_norm_module = flashinfer_norm.get_norm_module
+    flashinfer_norm.get_norm_module = lambda: _TrackedNormModule()
+    try:
+        auto_return = _public_call(api, data, None, config)
+        destination = _prepare_output(config)
+        destination_return = _public_call(api, data, destination, config)
+    finally:
+        flashinfer_norm.get_norm_module = original_get_norm_module
+
+    if len(captures) != 2:
+        raise AssertionError(f"public {mode} wrapper dispatched {len(captures)} low-level calls")
+    for index, returned in enumerate((auto_return, destination_return)):
+        if returned[0] is not captures[index][10] or returned[1] is not captures[index][11]:
+            raise AssertionError(f"public {mode} wrapper did not return its dispatched outputs")
+    if destination_return[0] is not destination["residual"]:
+        raise AssertionError(f"public {mode} residual destination identity changed")
+    if destination_return[1] is not destination["norm"]:
+        raise AssertionError(f"public {mode} norm destination identity changed")
+
+    auto_output = {"residual": auto_return[0], "norm": auto_return[1], "sf": captures[0][12]}
+    _assert_outputs_match(auto_output, source_output, config, name=f"public {mode} auto")
+    _assert_outputs_match(destination, source_output, config, name=f"public {mode} destination")
+    _assert_output_integrity(destination, config, name=f"public {mode} destination")
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port FlashInfer fused DIT LayerNorm from commit `f2e04400e330fb2debe0bf8730d9424a1d37927f`
- cover all 18 compile-time paths across GRGB, RSS, and GRSS modes; BF16, NVFP4, and MXFP8 outputs; and optional input scaling
- preserve the source launch shape, CUB-style float2 reduction, affine ordering, quantization packing, and swizzled scale-factor layout
- add 43 correctness configurations, 24 benchmark configurations, a source/PTX mapping sketch, curated bench-suite workloads, and 15 promoted baseline rows

## Validation

- `python -m tirx_kernels.test --kernel flashinfer_fused_dit_layernorm`: 43 passed, 0 failed, 0 skipped
- required 15-shape reference-enabled bench-suite matrix: 15/15 `status=ok`; minimum `flashinfer_cuda / tirx` ratio 1.000513596
- strict registry and all15 workload import checks passed
- license checker and self-test passed
- `pre-commit run --from-ref upstream/main --to-ref HEAD` passed

## Benchmark protocol

The performance matrix used five bench-suite rounds with one-second cooldowns and the direct low-level FlashInfer CUDA binding as `flashinfer_cuda`. Setup, allocation, JIT, dispatch checks, and output validation remain outside both timed launch closures.