### PR TITLE
feat(kernel): add paged KV to the MSA sparse attention forwards

### DIFF
--- a/.agents/sketch/msa/sparse_atten_fwd.md
+++ b/.agents/sketch/msa/sparse_atten_fwd.md
@@ -46,8 +46,6 @@ every specialization in this port:
 | `head_dim` | 128 | `__init__` raises otherwise (`:75-79`) |
 | `n_block_size` | 128 | the KV block width the schedule is built around |
 | `m_block_size` | 128 | 128 packed Q heads per MMA tile |
-| `causal` | `True` | every upstream test and benchmark sets it; it is a real codegen axis (`:173-181`) |
-| `paged_kv` | `False` | out of scope, see below |
 | `use_prepare_scheduler` | `True` | `__init__` raises otherwise (`:96-98`) |
 
 In scope, i.e. the specializations this module compiles:
@@ -56,21 +54,17 @@ In scope, i.e. the specializations this module compiles:
 | --- | --- | --- |
 | `qheadperkv` | 1, 2, 4 / 8, 16 | selects **the whole Q-load warpgroup program**: `use_q_gather4` (`:81`) picks a raw gather4 descriptor path for 1/2/4 and a CUTE-managed TMA path for 8/16. Also sets `q_tokens_per_group = 128 // qheadperkv` (`:108`) and `tokens_per_gather4 = 4 // qheadperkv` (`:87`). |
 | dtype combination | `bf16`, `fp8`, `bf16q_fp8kv`, `fp8_pvbf16` | resolved at trace time (`:318-364`) into `qk_dtype`/`pv_dtype`, the two `mma_kind` strings, and `k_fp8_to_bf16`/`v_fp8_to_bf16`, which add a shared-memory dequantization pass to the softmax warpgroups |
-| `partial_dtype` | fp32, bf16, fp8 e4m3 | three distinct epilogue store paths: 4-lane, 8-lane, 16-lane 128-bit stores with three different swizzle-inverse column remaps (`:2772-2984`) |
+| `partial_dtype` | fp32, bf16, **fp16**, fp8 e4m3 | three store WIDTHS -- 4-lane, 8-lane, 16-lane 128-bit stores with three different swizzle-inverse column remaps (`:2772-2984`) -- but FOUR programs: bf16 and fp16 share the 8-lane width and the remap yet take different converters, `cvt.rn.bf16.f32` against `cvt.rn.f16.f32`, dispatched by `const_expr` at `:2868-2884`. Measured on this kernel's own exports: `cvt.rn.f16.f32` 0 -> 128, `st.global.cs.v4.f32` 32 -> 0, `st.global.cs.v4.b32` 0 -> 16, `rcp.approx` 32 -> 16. |
 | temperature LSE | on / off | `mLSE_temperature_partial is not None` adds one scaled row-sum reduction, one `sScaleTemperature` publish and one extra LSE store |
+| `paged_kv` | `False` / `True` | `page_table is not None` at the host entry (`interface.py:1670`). Requires `page_size == blk_kv` (`:99-107`), so a CTA's KV block is exactly one page. K/V become `[num_pages, head_kv, page_size, 128]`, permuted in-trace by `layout_t = [2, 3, 1, 0]` (`:380-397`); the KV descriptors become rank 4, `k_batch_offset` becomes 0, and thread 0 resolves `mPageTable[batch, kv_block]` into `sPagedKvIdx` (`:903-906`). Nothing else moves: the MMA warp, both softmax warpgroups and the whole epilogue carry no paged branch. |
+| `has_seqused_k` | `False` / `True` | paged-only at the host entry (`interface.py:251-253`). The plumbing change is one expression -- `_logical_seqlen_k` returns `mSeqUsedK[batch]` ahead of the paged-capacity and `cu_seqlens_k` fallbacks (`:204-212`) -- and everything downstream already reads the derived value. But it also opens a **numeric regime the other two arms cannot reach**: with a supplied length shorter than `seqlen_q`, `causal_q_offset` goes negative and the leading `seqlen_q - mSeqUsedK[b]` queries are fully masked by design, storing `O = 0` and `LSE = -inf`. See the correctness contract; a port that clamps that row to a finite value diverges. |
+| `causal` | `False` / `True` | `num_regs_softmax` 176 -> 192, `num_regs_store` 112 -> 80, `ex2_emu_freq` 16 -> 0 (`:173-184`); the diagonal binary search is skipped and `causal_q_offset` is pinned to `Int32(0)` rather than computed (`:893-901`); the mask keeps only its column limit. |
 
 Out of scope, with the predicate that excludes each:
 
-- **paged KV** -- `page_table is not None` at the host entry; requires
-  `page_size == blk_kv` (`:99-105`) and swaps in a rank-4 descriptor plus
-  `PagedKVManager` block indirection.
-- **`seqused_k`** -- `seqused_k is not None`; replaces `_logical_seqlen_k`'s
-  `cu_seqlens_k` difference with a per-batch lookup (`:208-212`).
-- **`causal=False`** -- never exercised upstream; it would change
-  `num_regs_softmax` 176 -> 192, `num_regs_store` 112 -> 80, and
-  `ex2_emu_freq` 16 -> 0, i.e. remove the polynomial exp2 mixing entirely.
-- **fp16 partials** -- accepted by the dtype check at `:372-377` but never
-  exercised upstream; it shares the bf16 8-lane store path.
+- **`page_size != blk_kv`** -- rejected at `:99-107`; the equality is what makes
+  a CTA's KV block exactly one page, and the whole paged path assumes it.
+- **`head_dim != 128`** -- `__init__` raises (`:75-79`).
 - **the NVFP4-KV sibling** `SparseAttentionForwardNvfp4KvSm100`
   (`atten_fwd_nvfp4_kv.py`) -- a separate class with its own compile key.
 - **the combine kernel** `fwd/combine.py` -- a downstream consumer.
@@ -79,7 +73,7 @@ Out of scope, with the predicate that excludes each:
 ## The line-info export this sketch is annotated from
 
 Every `instruction_selection` annotation below is read out of a line-info PTX
-export, not out of the source text. Six exports, one per structurally distinct
+export, not out of the source text. Ten exports, one per structurally distinct
 in-scope compile key, are preserved under
 `.porting/sparse_atten_fwd/ptx_lineinfo/<name>/` together with the
 `analysis.txt` each was summarized into; `.porting/sparse_atten_fwd/export_findings.md`
@@ -210,18 +204,23 @@ primitives named `attention`, `softmax`, `mask`, `online_update`, `TMA`,
     Q_TOKENS_PER_GROUP=128 // QHEADPERKV,           # :108
     TOKENS_PER_GATHER4=(4 // QHEADPERKV) if USE_Q_GATHER4 else 0,   # :87
     DTYPE_MODE=("bf16", "fp8", "bf16q_fp8kv", "fp8_pvbf16"),
-    PARTIAL_DTYPE=("f32", "bf16", "fp8e4m3"),
+    PARTIAL_DTYPE=("f32", "bf16", "fp16", "fp8e4m3"),
     RETURN_TEMPERATURE_LSE=(False, True),
-    CAUSAL=True,
-    PAGED_KV=False,
-    HAS_SEQUSED_K=False,
+    CAUSAL=(False, True),
+    PAGED_KV=(False, True),
+    HAS_SEQUSED_K=(False, True),   # paged-only at the host entry
     Q_STAGE=2, S_STAGE=2, O_STAGE=2, KV_STAGE=1,    # :116-119
     K_STAGES=2,                                     # Q k-subtiles, :125
     QIDX_META_STAGES=16,                            # :123
     SPLIT_P_ARRIVE=96,                              # 128//4*3, floored to 32, :165-167
-    EX2_EMU_FREQ=16,                                # causal only, :180
+    EX2_EMU_FREQ=16 if CAUSAL else 0,               # :180-184
     EX2_EMU_START_FRG=1,                            # :181
-    NUM_REGS_SOFTMAX=176, NUM_REGS_STORE=112, NUM_REGS_OTHER=48,   # :173-178
+    # The register split is a causal axis, not a constant (:173-178). Softmax
+    # gains what store gives up, so the two must move together or the launch
+    # exceeds its budget.
+    NUM_REGS_SOFTMAX=176 if CAUSAL else 192,
+    NUM_REGS_STORE=112 if CAUSAL else 80,
+    NUM_REGS_OTHER=48,
     CTA_GROUP=1, CLUSTER=(1, 1, 1),                 # :184-188
     target="sm_100a",
 )
@@ -255,6 +254,14 @@ def msa_sparse_atten_fwd_sm100(
     lse_partial,          # f32 [topk, total_q, head_q], OUTPUT, uninitialized
     lse_temperature_partial,   # f32 [topk, total_q, head_q], OUTPUT, optional
     q_flat,               # bf16|fp8 [total_q*head_q, 128], input
+    page_table,           # i32 [num_batches, pages_per_seq], input, PAGED_KV only
+                          #   -- present exactly like lse_temperature_partial is:
+                          #   the handle is added with the axis and removed
+                          #   without it, so a flat specialization's signature is
+                          #   unchanged (:306-307, :653-654)
+    seqused_k,            # i32 [num_batches], input, HAS_SEQUSED_K only
+                          #   -- accepted only alongside page_table
+                          #   (interface.py:251-253)
     cu_seqlens_q,         # i32 [num_batches + 1], input
     cu_seqlens_k,         # i32 [num_batches + 1], input
     softmax_scale,        # f32; the kernel forms softmax_scale_log2 at trace time (:514)
@@ -319,8 +326,18 @@ def msa_sparse_atten_fwd_sm100(
     # The K/V descriptors see permuted views, built at trace time (:378-387):
     #   K: [total_k, h, d] -> [total_k, d, h]      (K-major B operand)
     #   V: [total_k, h, d] -> [d, total_k, h]      (MN-major B operand)
-    K_desc_view = view(K, KV_DTYPE, [total_k, 128, num_heads_kv])
-    V_desc_view = view(V, KV_DTYPE, [128, total_k, num_heads_kv])
+    if PAGED_KV:
+        # Rank is a property of the tensor, so the paged forms are declared, not
+        # implied: the four-index subscripts in the paged KV-load arms bind here.
+        K = tile("gmem", k, KV_DTYPE, [num_pages, num_heads_kv, 128, 128], alignment=16)
+        V = tile("gmem", v, KV_DTYPE, [num_pages, num_heads_kv, 128, 128], alignment=16)
+        #   K: [page, h, tok, d] -> [tok, d, h, page]   (:388-395, layout_t=[2,3,1,0])
+        #   V: same, then [1,0,2,3]  -> [d, tok, h, page]
+        K_desc_view = view(K, KV_DTYPE, [128, 128, num_heads_kv, num_pages])
+        V_desc_view = view(V, KV_DTYPE, [128, 128, num_heads_kv, num_pages])
+    else:
+        K_desc_view = view(K, KV_DTYPE, [total_k, 128, num_heads_kv])
+        V_desc_view = view(V, KV_DTYPE, [128, total_k, num_heads_kv])
 
     Idx   = tile("gmem", k2q_q_indices,      "i32", [num_heads_kv, nnz])
     QSpl  = tile("gmem", k2q_qsplit_indices, "i32", [num_heads_kv, nnz])
@@ -330,6 +347,10 @@ def msa_sparse_atten_fwd_sm100(
     LpT   = tile("gmem", lse_temperature_partial, "f32", [topk, total_q, head_q])
     CuQ   = tile("gmem", cu_seqlens_q, "i32", [num_batches + 1])
     CuK   = tile("gmem", cu_seqlens_k, "i32", [num_batches + 1])
+    # Present only in their specializations; absent from the signature otherwise.
+    PageTable = tile("gmem", page_table, "i32", [num_batches, pages_per_seq])  # PAGED_KV
+    SeqUsedK  = tile("gmem", seqused_k,  "i32", [num_batches])                 # HAS_SEQUSED_K
+    pages_per_seq = PageTable.shape[1]   # upstream reads it off the tensor (:211)
 
     # =======================================================================
     # Shared memory: one dynamic pool.  Sizes for BF16 / QHEADPERKV=16.
@@ -379,7 +400,9 @@ def msa_sparse_atten_fwd_sm100(
     sRowMeta     = view(smem, "i32", [8])
     #   0 batch, 1 kv_block, 2 row_start, 3 count_raw, 4 kv_valid_cols,
     #   5 q_batch_off, 6 k_batch_off, 7 causal_q_offset
-    sPagedKvIdx  = view(smem, "i32", [1])                    # unused, PAGED_KV=False
+    sPagedKvIdx  = view(smem, "i32", [1])   # allocated unconditionally (:581);
+                                            # written by thread 0 and read by
+                                            # both KV-load arms under PAGED_KV
     sQLoadMIdx   = view(smem, "i32", [Q_STAGE, Q_TOKENS_PER_GROUP])
     #   Allocated unconditionally (:582-583) even though only the TMA-Q body
     #   reads it; its bytes are part of every footprint above.
@@ -516,16 +539,34 @@ def msa_sparse_atten_fwd_sm100(
         row_start = base_row_start + work_q_begin
         count_raw = work_q_count
 
-        # kv_valid_cols = clamp(seqlen_k - kv_block*128, 0, 128)   (:215-229)
-        seqlen_k = load_global(CuK, batch_idx + 1) - load_global(CuK, batch_idx)
-        # instruction_selection: ld.global.u32 x2 (:212, 2 static); extent: scalar.
+        # The logical K length, in the source's own priority order (:204-212).
+        # Only one arm survives per specialization.
+        if HAS_SEQUSED_K:
+            seqlen_k = load_global(SeqUsedK, batch_idx)
+            # instruction_selection: ld.global.u32 (1 static); extent: scalar.
+            #   Wins over both fallbacks: an implementation that checked PAGED
+            #   first would silently take the paged capacity instead.
+        elif PAGED_KV:
+            seqlen_k = pages_per_seq * 128
+            # instruction_selection: integer multiply only, no load; extent:
+            #   scalar.  `pages_per_seq` is `mPageTable.shape[1]` upstream. This
+            #   is the FULL paged capacity, zero-padded tail pages included,
+            #   which is why the host may omit `seqused_k` only when every
+            #   effective length already equals its capacity.
+        else:
+            seqlen_k = load_global(CuK, batch_idx + 1) - load_global(CuK, batch_idx)
+            # instruction_selection: ld.global.u32 x2 (:212, 2 static); extent: scalar.
         kv_valid_cols = min(max(seqlen_k - kv_block_idx * 128, 0), 128)
         q_batch_offset = load_global(CuQ, batch_idx)
         # instruction_selection: ld.global.u32 (:198, 1 static); extent: scalar.
-        k_batch_offset = load_global(CuK, batch_idx)
-        # instruction_selection: none -- CSE'd into the :212 pair above, which
-        #   already loads CuK[batch_idx].  The module's ld.global count is
-        #   exactly 14 with no instruction for :883.
+        k_batch_offset = 0 if PAGED_KV else load_global(CuK, batch_idx)
+        # instruction_selection: flat -- none; CSE'd into the :212 pair above,
+        #   which already loads CuK[batch_idx].  The flat module's ld.global
+        #   count is exactly 14 with no instruction for :883.  Paged -- the
+        #   value is the immediate 0 (:880-884), and there is no CuK load left
+        #   to fold into on EITHER paged sub-case: `_logical_seqlen_k` takes the
+        #   seqused arm or the capacity multiply, so `.loc 1 212` is absent from
+        #   both paged exports (ld.global.u32 12 paged vs 13 flat).
 
         store_shared(sRowMeta, 0..6,
                      [batch_idx, kv_block_idx, row_start, count_raw,
@@ -534,10 +575,16 @@ def msa_sparse_atten_fwd_sm100(
         #   4-word vector store.  The source writes seven separate scalar
         #   `sRowMeta[i] = ...` statements (:885-891); the backend merges them.
 
-        # causal_q_offset = seqlen_k - seqlen_q, needed by the mask (:892-901)
-        seqlen_q = load_global(CuQ, batch_idx + 1) - q_batch_offset
-        # instruction_selection: ld.global.u32 (:894, 1 static); extent: scalar.
-        causal_q_offset = seqlen_k - seqlen_q
+        # causal_q_offset = seqlen_k - seqlen_q, needed by the mask (:892-901).
+        # The source computes it ONLY under `const_expr(self.causal)` and leaves
+        # it Int32(0) otherwise -- the whole block, the CuQ load included, is
+        # gone from a non-causal specialization.
+        if CAUSAL:
+            seqlen_q = load_global(CuQ, batch_idx + 1) - q_batch_offset
+            # instruction_selection: ld.global.u32 (:894, 1 static); extent: scalar.
+            causal_q_offset = seqlen_k - seqlen_q
+        else:
+            causal_q_offset = 0
 
         store_shared(sRowMeta, 7, causal_q_offset)
         # instruction_selection: st.shared.v4.u32 (:902, 1 static); extent: a
@@ -545,6 +592,19 @@ def msa_sparse_atten_fwd_sm100(
         #   the two v4 stores are separated by it, so a port that merges all
         #   eight fields into one store would have to sink the seqlen_q load
         #   above them and change the dependence order.
+
+        if PAGED_KV:
+            page_idx = load_global(PageTable, batch_idx * pages_per_seq + kv_block_idx)
+            # instruction_selection: ld.global.u32 (1 static); extent: scalar.
+            #   `PagedKVManager.physical_block_index` is exactly this indexed
+            #   read (paged_kv.py:60-65); its other two methods are dead, each
+            #   kernel reimplementing them.
+            store_shared(sPagedKvIdx, 0, page_idx)
+            # instruction_selection: st.shared.u32 (1 static); extent: scalar.
+            #   A single scalar store, NOT folded into either sRowMeta vector
+            #   store: it targets a different array.  It rides the same
+            #   thread-0 region and the same publish fence below, so paging
+            #   adds no barrier of its own.
 
         init_pipe(mbar_k[0], arrivals=1)
         # instruction_selection: mbarrier.init.shared.b64 (:907, 1 static); extent: scalar.
@@ -569,9 +629,12 @@ def msa_sparse_atten_fwd_sm100(
 
         # The causal diagonal split point: how many of this row's tokens still
         # need per-column causal masking.  A 32-step binary search over the CSR
-        # row, which is sorted by q_idx (:259-285).
+        # row, which is sorted by q_idx (:259-285).  The whole region sits
+        # inside `const_expr(self.causal)` AND, within it, behind the runtime
+        # guard below; under `causal=False` it is compiled out entirely and the
+        # `sDiagQCount` store below writes the constant 0.
         diag_q_count = 0
-        if count_raw > 0 and kv_valid_cols > 0:
+        if CAUSAL and count_raw > 0 and kv_valid_cols > 0:
             q_threshold = (kv_block_idx * 128 + kv_valid_cols) - causal_q_offset
             left, right = 0, count_raw
             for _ in range(32):                    # `unroll=1`, and it stays rolled
@@ -614,10 +677,13 @@ def msa_sparse_atten_fwd_sm100(
     # ROLE: Q-load warpgroup, warps 8..11.  Independent `if` on a THREAD range.
     # =======================================================================
     if 8 * 32 <= tid < 12 * 32 and cta_valid_work:
-        set_register_budget("decrease", NUM_REGS_STORE)     # 112 on the causal path
-        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:1001, 1 static);
-        #   extent: warpgroup.  `store_reg_decrease` is True whenever
-        #   NUM_REGS_STORE <= 128 (:179), which the causal specialization is.
+        set_register_budget("decrease", NUM_REGS_STORE)     # 112 causal / 80 not
+        # instruction_selection: setmaxnreg.**dec**.sync.aligned.u32, 1 static;
+        #   extent: warpgroup.  Operand follows CAUSAL: 112 causal, 80
+        #   non-causal (:174), both measured.  `store_reg_decrease` is
+        #   `num_regs_store <= 128` (:179), which holds on BOTH arms -- so the
+        #   `setmaxregister_increase` alternative at :1003 is unreachable across
+        #   the entire in-scope domain, not merely on the causal path.
 
         row_start, count_raw = load_shared(sRowMeta, 2..3)
         # instruction_selection: ld.shared.v2.u32 (:1004, 1 static); extent: two
@@ -855,55 +921,120 @@ def msa_sparse_atten_fwd_sm100(
         set_register_budget("decrease", NUM_REGS_OTHER)     # 48
         # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (:1054, 1 static);
         #   extent: warp-wide.
-        kv_block = load_shared(sRowMeta, 1)
-        # instruction_selection: ld.shared.u32 (:1055, 1 static); extent: scalar.
-        k_batch_offset = load_shared(sRowMeta, 6)
-        # instruction_selection: ld.shared.u32 (:1056, 1 static); extent: scalar.
+        if not PAGED_KV:
+            kv_block = load_shared(sRowMeta, 1)
+            # instruction_selection: ld.shared.u32 (.loc 1 1055, 1 static);
+            #   extent: scalar.  FLAT ONLY.
+            k_batch_offset = load_shared(sRowMeta, 6)
+            # instruction_selection: ld.shared.u32 (.loc 1 1056, 1 static);
+            #   extent: scalar.  FLAT ONLY.
         has_work = load_shared(sRowMeta, 3) > 0
-        # instruction_selection: ld.shared.u32 (:1057, 1 static); extent: scalar.
-        #   These three stay three separate scalar loads -- unlike the Q-load
-        #   warpgroup's sRowMeta[2..3], which the backend merged into a v2.
-
+        # instruction_selection: ld.shared.u32 (.loc 1 1057, 1 static); extent:
+        #   scalar.
+        #   A FLAT build emits three separate scalar loads here -- they stay
+        #   separate, unlike the Q-load warpgroup's sRowMeta[2..3], which the
+        #   backend merged into a v2.  A PAGED build emits exactly ONE: the
+        #   paged copy takes its block from `sPagedKvIdx` and its batch offset
+        #   is the immediate 0, so both values become dead and the loads are
+        #   deleted outright, not merely unused.  Measured: `.loc 1 1055` and
+        #   `.loc 1 1056` are absent from the paged export and from the
+        #   non-causal paged one, while `.loc 1 1054` and `.loc 1 1057` survive.
         if not has_work:
             return
         warp_in_role = warp - 13
         if warp_in_role == 0:
-            if K_FP8_TO_BF16:
-                copy_g2s(K_desc_view[kv_block, :, head_kv_idx], sKFp8,
-                         bar=mbar_k_tma[0])
-                with elect():
-                    commit(mbar_k_tma[0])
-            else:
-                copy_g2s(K_desc_view[kv_block, :, head_kv_idx], sK, bar=mbar_k[0])
-                # instruction_selection: cp.async.bulk.tensor.**3d**
+            page_idx = load_shared(sPagedKvIdx, 0) if PAGED_KV else None
+            # instruction_selection: ld.shared.u32 (.loc 1 1569, 1 static in
+            #   THIS arm); extent: scalar.  Each KV-load warp reads the cell in
+            #   its own arm -- the module carries TWO such loads, :1569 here and
+            #   :1610 in the V arm -- and both sit after the `has_work`
+            #   early-out, so a no-work CTA performs no shared read at all.
+            #   Within an arm the value is read once and reused by both subtile
+            #   issues.  On the FP8-staging path the same cell is read at
+            #   :1336 (K) / :1412 (V) instead.
+
+            # PAGED_KV and K_FP8_TO_BF16 are ORTHOGONAL in the source
+            # (:1332-1340): the paged test is nested INSIDE the fp8 test, so
+            # all four combinations exist and `paged x fp8` is a required
+            # perf-gate config. Selecting the descriptor rank with an `elif`
+            # against the staging test would send `paged + fp8` down the rank-3
+            # arm and encode a rank-3 descriptor against a rank-4 tensor.
+            dst, bar = (sKFp8, mbar_k_tma[0]) if K_FP8_TO_BF16 else (sK, mbar_k[0])
+            if PAGED_KV:
+                copy_g2s(K_desc_view[0, :, head_kv_idx, page_idx], dst, bar=bar)
+                # instruction_selection: cp.async.bulk.tensor.**4d**
                 #   .shared::cluster.global.tile.mbarrier::complete_tx::bytes
-                #   .L2::cache_hint under elect.sync (:1571, 2 static each);
-                #   extent: the CTA's single 128x128 K tile, issued as TWO
-                #   instructions.  Rank 3, not 2: the KV-head axis stays in the
-                #   descriptor rather than being folded into the base address.
-                with elect():
-                    commit(mbar_k[0])
-                    # instruction_selection: mbarrier.arrive.release.cta
-                    #   .shared::cta.b64 (:1580, 1 static); extent: scalar, one
-                    #   lane.  The transaction-byte count was already promised
-                    #   by thread 0's prologue expect_tx, so this is a plain
-                    #   arrive, not an arrive-and-expect.
-        if warp_in_role == 1:
-            if V_FP8_TO_BF16:
-                copy_g2s(V_desc_view[:, kv_block, head_kv_idx], sVFp8,
-                         bar=mbar_v_tma[0])
-                with elect():
-                    commit(mbar_v_tma[0])
+                #   .L2::cache_hint under elect.sync.  PAGED_KV selects ONLY the
+                #   rank and the coordinate tuple:
+                #   `(head_dim_offset, token_in_page, head_kv, page)` with the
+                #   token coordinate pinned to 0; the export's second subtile
+                #   `{64, 0, head, page}` is what fixes that order.
+                #   The SITE, the ISSUE COUNT and the TRANSACTION BYTES follow
+                #   `dst`, not the rank -- see the shared note below.
             else:
-                copy_g2s(V_desc_view[:, kv_block, head_kv_idx], sV, bar=mbar_v[0])
+                copy_g2s(K_desc_view[kv_block, :, head_kv_idx], dst, bar=bar)
+                # instruction_selection: cp.async.bulk.tensor.**3d**, same
+                #   modifiers.  Rank 3, not 2: the KV-head axis stays in the
+                #   descriptor rather than being folded into the base address.
+            # instruction_selection, shared by both arms above -- THREE of the
+            #   four properties follow `dst`, not `PAGED_KV`:
+            #     not K_FP8_TO_BF16 -> sK, the 128B-SWIZZLED MMA operand.
+            #       .loc 1 1571 (K) / .loc 1 1612 (V); **2 static**, because a
+            #       128-wide swizzled tile is two 64-column sub-tiles;
+            #       **32768** transaction bytes, promised at .loc 1 913 / :918.
+            #     K_FP8_TO_BF16     -> sKFp8, the PLAIN un-swizzled staging tile
+            #       `(n_block_size, head_dim)`.  .loc 1 1361 (K) / .loc 1 1437
+            #       (V); **1 static**, one whole-tile box, no sub-tile split;
+            #       **16384** transaction bytes, promised at .loc 1 911 / :916.
+            #   `.loc 1 1571` is absent from a staging export and `.loc 1 1361`
+            #   from every non-staging one.  Issuing two 64-column sub-tile
+            #   TMAs into the plain staging layout writes the WRONG BYTES -- and
+            #   `fp8kv_s16384_qh4_t16` and `paged_fp8_s16384_qh16_t16` are both
+            #   required perf-gate rows, so neither combination is hypothetical.
+            with elect():
+                commit(bar)
+                # instruction_selection: mbarrier.arrive.release.cta
+                #   .shared::cta.b64, 1 static; extent: scalar, one lane.
+                #   The SOURCE SITE follows `bar`, because this one line now
+                #   stands for all four PAGED_KV x staging combinations:
+                #     not K_FP8_TO_BF16 -> `mbar_k[0]`,     .loc 1 1580
+                #     K_FP8_TO_BF16     -> `mbar_k_tma[0]`, .loc 1 1367
+                #   `.loc 1 1580` is ABSENT from a staging export and `.loc 1
+                #   1367` from a non-staging one, so checking for the wrong one
+                #   makes the arrive look missing -- which is how it came to be
+                #   dropped from the paged arm in the first place.
+                #   OUTSIDE the paged/flat conditional in the source: it runs on
+                #   every path. An arm that omitted it would never signal the
+                #   barrier, and the MMA warp's wait would hang.
+                #   The transaction-byte count was already promised by thread
+                #   0's prologue expect_tx, so this is a plain arrive.
+        if warp_in_role == 1:
+            page_idx = load_shared(sPagedKvIdx, 0) if PAGED_KV else None
+            # instruction_selection: ld.shared.u32 (.loc 1 1610, 1 static in
+            #   THIS arm); extent: scalar.  The V warp's own read -- see the K
+            #   arm for why there are two and not one.
+            dst, bar = (sVFp8, mbar_v_tma[0]) if V_FP8_TO_BF16 else (sV, mbar_v[0])
+            if PAGED_KV:
+                copy_g2s(V_desc_view[:, 0, head_kv_idx, page_idx], dst, bar=bar)
+                # instruction_selection: cp.async.bulk.tensor.4d, same
+                #   modifiers; MN-major.  Mirror image of the paged K issue:
+                #   PAGED_KV selects only the rank and the coordinate tuple.
+                #   Site, issue count and transaction bytes follow `dst` --
+                #   .loc 1 1612 / 2 static / 32768 for `sV`, .loc 1 1437 /
+                #   1 static / 16384 for `sVFp8`, exactly as on the K side.
+            else:
+                copy_g2s(V_desc_view[:, kv_block, head_kv_idx], dst, bar=bar)
                 # instruction_selection: cp.async.bulk.tensor.3d
                 #   .shared::cluster.global.tile.mbarrier::complete_tx::bytes
-                #   .L2::cache_hint under elect.sync (:1612, 2 static each);
+                #   .L2::cache_hint under elect.sync (.loc 1 1612, 2 static);
                 #   extent: the CTA's single 128x128 V tile, MN-major.
-                with elect():
-                    commit(mbar_v[0])
-                    # instruction_selection: mbarrier.arrive.release.cta
-                    #   .shared::cta.b64 (:1621, 1 static); extent: scalar.
+            with elect():
+                commit(bar)
+                # instruction_selection: mbarrier.arrive.release.cta
+                #   .shared::cta.b64, 1 static; extent: scalar.  Source site
+                #   follows `bar`, as on the K side: `.loc 1 1621` when
+                #   `mbar_v[0]`, `.loc 1 1443` when `mbar_v_tma[0]`.
+                #   Outside the paged/flat conditional.
         if K_FP8_TO_BF16 or V_FP8_TO_BF16:
             named_barrier_arrive_and_wait(kv_load_bar)
             # instruction_selection: bar.sync, named, 64 threads (:1485);
@@ -1134,10 +1265,22 @@ def msa_sparse_atten_fwd_sm100(
         #   reads sRowMeta[1] and sRowMeta[3] as separate statements.
         kv_valid_cols     = load_shared(sRowMeta, 4)
         # instruction_selection: ld.shared.u32 (:1121 / :1183, 1 static); extent: scalar.
-        causal_q_offset   = load_shared(sRowMeta, 7)
-        # instruction_selection: ld.shared.u32 (:1122 / :1184, 1 static); extent: scalar.
-        diag_q_count      = load_shared(sDiagQCount, 0)
-        # instruction_selection: ld.shared.u32 (:1127 / :1189, 1 static); extent: scalar.
+        if CAUSAL:
+            causal_q_offset   = load_shared(sRowMeta, 7)
+            # instruction_selection: ld.shared.u32 (.loc 1 1122 / :1184, 1
+            #   static each); extent: scalar.  CAUSAL ONLY.
+            diag_q_count      = load_shared(sDiagQCount, 0)
+            # instruction_selection: ld.shared.u32 (.loc 1 1127 / :1189, 1
+            #   static each); extent: scalar.  CAUSAL ONLY.
+            #   Both are consumed only by the `const_expr(self.causal)` arm at
+            #   :2478-2519, so a non-causal build emits NEITHER -- measured 0
+            #   static for all four `.loc`s, and whole-module `ld.shared.u32`
+            #   92 -> 88.  Note the asymmetry: the PRODUCER side survives.
+            #   `st.shared.v4.u32` at :902 (sRowMeta[7]) and `st.shared.u32` at
+            #   :935 (sDiagQCount) are still emitted in a non-causal build,
+            #   storing the constant 0; only the reads die.
+        else:
+            causal_q_offset, diag_q_count = 0, 0
         q_batch_offset    = load_shared(sRowMeta, 5)
         # instruction_selection: ld.shared.u32 (:1170 / :1232, 1 static); extent: scalar.
         has_work = count_raw > 0
@@ -1220,7 +1363,9 @@ def msa_sparse_atten_fwd_sm100(
     # -----------------------------------------------------------------------
     def softmax_wg_loop(stage):
         group_tidx = tid - stage * 128              # 0..127; this thread's M row
-        kv_block_col_start = kv_block_idx * 128     # causal only
+        kv_block_col_start = (kv_block_idx * 128) if CAUSAL else 0
+        # Computed only on the causal arm; the source const_expr-splits the
+        # `_softmax_step` call site and passes literal Int32(0) otherwise.
         num_stage_groups = (num_q_groups + (1 - stage)) // 2
         # WG0 takes Q groups 0, 2, 4, ...; WG1 takes 1, 3, 5, ...
 
@@ -1233,9 +1378,25 @@ def msa_sparse_atten_fwd_sm100(
             softmax_reset()                         # row_max = -inf, row_sum = 0
 
             # How many of this group's tokens still sit on the causal diagonal.
-            qi_group_start = qi_group * Q_TOKENS_PER_GROUP
-            masked_tok_count = clamp(diag_q_count - qi_group_start,
-                                     0, Q_TOKENS_PER_GROUP)
+            # The source const_expr-SPLITS this call site (:2478 causal vs
+            # :2521 non-causal) and the non-causal arm passes literal `Int32(0)`
+            # for BOTH `masked_tok_count` (:2543) and `causal_q_offset` (:2547),
+            # with `apply_causal_mask=False` (:2551).
+            # What removes the causal-mask arm inside `_softmax_step` is the
+            # COMPILE-TIME predicate `const_expr(self.causal and
+            # apply_causal_mask)` at :2246 -- not the value of `diag_q_count`.
+            # Under `causal=True` that arm is emitted no matter what
+            # `masked_tok_count` happens to be, and `need_causal_mask =
+            # masked_tok_count > 0` is a genuine runtime branch inside it.
+            # The literal `Int32(0)` for `causal_q_offset` is separately what
+            # kills the `sRowMeta[7]` read and folds `seq_len_q +
+            # causal_q_offset` at :2235 down to `seq_len_q`.
+            if CAUSAL:
+                qi_group_start = qi_group * Q_TOKENS_PER_GROUP
+                masked_tok_count = clamp(diag_q_count - qi_group_start,
+                                         0, Q_TOKENS_PER_GROUP)
+            else:
+                masked_tok_count = 0
 
             softmax_step(stage, phase, producer_phase, masked_tok_count, ...)
 
@@ -1271,10 +1432,26 @@ def msa_sparse_atten_fwd_sm100(
             # instruction_selection: ld.shared.u32 (:2251, 2 static); extent: scalar.
             causal_col_limit = q_idx + causal_q_offset - kv_block_col_start + 1
             select(rS, col < min(kv_valid_cols, causal_col_limit), rS, -inf)
-            # instruction_selection: shl.b32 to build the r2p chunk bitmask, then
+            # instruction_selection: the r2p chunk bitmask is
+            #   `0xFFFFFFFF >> max((s+1)*32 - col_limit, 0)`, emitted as
+            #   sub.s32 + max.s32 (mask.py:20, 8 static each = four r2p chunks
+            #   x two warpgroup copies) feeding an **inline-PTX shr.u32**
+            #   (utils.py:452-467).  NOT a shl, and not a plain CuTeDSL shift:
+            #   the helper documents that a normal shift carries LLVM
+            #   shift-by-type-width UB, and this axis is exactly where that
+            #   bites.  Under HAS_SEQUSED_K the offset goes negative, so
+            #   `causal_col_limit <= 0` for the leading `seqlen_q -
+            #   mSeqUsedK[b]` queries and the shift amount reaches >= 32.  PTX
+            #   `shr.u32` clamps to the register width and returns the
+            #   all-zero mask, which is what produces the neutral partial this
+            #   sketch relies on; an LLVM-style shift-by-width is poison there
+            #   and would silently corrupt precisely the band the seqused axis
+            #   introduces.  There is no shift opcode attributed to mask.py:20
+            #   in the export -- the inline asm carries it.  Then
             #   and.b32 per element (mask.py:40, 124 per warpgroup copy = four
             #   32-element r2p chunks x 31 emitted bit tests -- the one whose
-            #   `1 << i` folds is free; 248 across the two copies), then
+            #   `1 << i` folds into the immediate is free; 248 across the two
+            #   copies; there is no `shl` anywhere on this path), then
             #   selp.b32/selp.f32 for the -inf substitution; extent: a
             #   128-element register tile.  `and.b32` at mask.py:40 is the
             #   largest single .loc-attributed opcode group in the whole module
@@ -1339,6 +1516,14 @@ def msa_sparse_atten_fwd_sm100(
         #   because this specialization is causal.  A port that sends all 128
         #   through MUFU has a different instruction mix and a different MUFU
         #   pressure profile.
+        # instruction_selection, NON-CAUSAL (`EX2_EMU_FREQ = 0`):
+        #   `apply_exp2_convert` takes its own `const_expr(ex2_emu_freq == 0)`
+        #   arm (softmax.py:381-383) and sends ALL 128 elements through MUFU --
+        #   no polynomial, and no `fmax(x, -127)` clamp either.  Measured on the
+        #   non-causal export against the causal one: `ex2.approx.ftz.f32`
+        #   224 -> 256, `fma.rn.f32x2` 176 -> 128, `max.f32` 164 -> 132.  The
+        #   predicate above must be short-circuited on the zero frequency
+        #   rather than evaluated -- a modulo by it would divide by zero.
         cast(rP, rS)
         # instruction_selection: cvt.rn.bf16x2.f32 (softmax.py:398, 128 static
         #   = 64 per warpgroup copy); extent: 128 elements as 64 packed
@@ -1486,14 +1671,23 @@ def msa_sparse_atten_fwd_sm100(
                                  cache="streaming")
                         # instruction_selection: st.global.cs.v4.f32 (:2597, 32
                         #   static = 16 per warpgroup copy); extent: 4 fp32 in
-                        #   one 128-bit store.  The bf16/f16 partial path becomes
+                        #   one 128-bit store.  The half paths become
                         #   st.global.cs.v4.b32 of 8 packed halves (:2613-2615)
                         #   with `real_col_to_stg128_half_fake_col`; the fp8 path
                         #   becomes st.global.cs.v4.b32 of 16 packed bytes
                         #   (:2638, 8 static on the fp8-partial export) with
-                        #   `real_col_to_stg128_fp8_fake_col`.  Three different
-                        #   remaps, three different lane counts, one instruction
-                        #   family.
+                        #   `real_col_to_stg128_fp8_fake_col`.
+                        #   bf16 and fp16 share that remap and that lane count
+                        #   but NOT the converter, and the store is only half
+                        #   the operation: `_store_o_partial_vec8_half`
+                        #   const_expr-dispatches on the partial dtype
+                        #   (:2868-2884), taking `stg_128_bf16_cs` with 8 x
+                        #   cvt.rn.bf16.f32 or `stg_128_f16_cs` with 8 x
+                        #   cvt.rn.f16.f32.  Measured on the fp16 export against
+                        #   the fp32 one: cvt.rn.f16.f32 0 -> 128,
+                        #   st.global.cs.v4.f32 32 -> 0, st.global.cs.v4.b32
+                        #   0 -> 16, rcp.approx 32 -> 16 (the reciprocal count
+                        #   follows the store width: 32 fp32, 16 half, 8 fp8).
 
         fence("view_async_tmem_load")
         # instruction_selection: tcgen05.wait::ld.sync.aligned (:2985, 2 static);
@@ -1559,8 +1753,10 @@ computed once.
 
 | map | rank | box | swizzle | built where | notes |
 | --- | --- | --- | --- | --- | --- |
-| K | 3 | `(128, 128)` over `[total_k, 128, head_kv]` | 128B | launcher prologue | `cp.async.bulk.tensor.3d`; the KV-head axis stays in the descriptor |
-| V | 3 | `(128, 128)` MN-major | 128B | launcher prologue | same, after the `[1,0,2]` swap |
+| K, flat | 3 | `(128, 128)` | 128B | launcher prologue | `cp.async.bulk.tensor.3d`. Tensormap dims, fastest-first: `(128, total_k, head_kv)`. Coordinate tuple `(sub*swizzle_elems, kv_row_start, head_kv)`. The KV-head axis stays in the descriptor |
+| K, **paged** | **4** | `(128, 128)` | 128B | launcher prologue | `cp.async.bulk.tensor.4d`. Tensormap dims, fastest-first: `(128, page_size, head_kv, num_pages)`, from the `[2,3,1,0]` host permute (`:380-397`). Coordinate tuple `(sub*swizzle_elems, 0, head_kv, page)`. Paging **appends** the page mode and pins the token coordinate to 0 -- it changes nothing about the first two dims. Same `.tile` load mode, same `mbarrier::complete_tx::bytes`, same `L2::cache_hint`, same 32768 transaction bytes as flat. A rank-3 encode against a rank-4 tensor is silent garbage, so this row is the one the implementation stage must read |
+| V, flat | 3 | `(128, 128)` MN-major | 128B | launcher prologue | dims `(128, total_k, head_kv)` after the `[1,0,2]` swap |
+| V, **paged** | **4** | `(128, 128)` MN-major | 128B | launcher prologue | dims `(128, page_size, head_kv, num_pages)` after the extra `[1,0,2,3]`; coordinate tuple `(sub*swizzle_elems, 0, head_kv, page)`, the K row's mirror |
 | Q (TMA path) | 2 | `(QHEADPERKV, Q_LOAD_TILE)` | 128B | launcher prologue | `Q_LOAD_TILE` = 128 for fp8 Q, else 64 |
 | Q (gather4 path) | 2 | `(box_x, 1)`, `box_x` = 128 for fp8 Q else 64 | 128B | **launcher prologue in the port; a host-built `uint8[128]` kernel argument upstream** | `INTERLEAVE_NONE`, `L2_PROMOTION_256B`, `OOB_FILL_NONE` |
 
@@ -1599,8 +1795,16 @@ compile key serves every shape.
 ## TIRx module and benchmark contract
 
 - `get_kernel(**config)` specializes on `(qhead_per_kv, causal, dtype_mode,
-  partial_dtype)` and removes the temperature output handle when it is absent,
-  then attaches `("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")`.
+  partial_dtype, paged_kv, has_seqused_k)` -- upstream's compile key carries
+  `bool(paged_kv)`, `page_size` and `bool(seqused_k is not None)` as three
+  separate entries (interface.py:1714-1731), and both axes change emitted code,
+  paging additionally changing the TMA rank. It removes the temperature output
+  handle when it is absent and the `page_table` / `seqused_k` input handles the
+  same way, so a flat specialization's signature is byte-for-byte the one it
+  had before the axis existed. Then it attaches
+  `("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")`.
+  `page_size` needs no entry of its own: upstream forces it equal to `blk_kv`
+  (:99-107), which is already fixed at 128.
 - `prepare_data` reuses the split-atomic module's CSR and work-list builders and
   adds Q/K/V plus a **frozen** qsplit assignment: slots `0..degree-1` in CSR
   order per `(q_abs, head_kv)` group. Upstream assigns those slots with a device
@@ -1612,6 +1816,23 @@ compile key serves every shape.
   kernel on identical frozen inputs, **masked to `split < degrees[q_abs, h]`**
   because both buffers arrive uninitialized and a query of degree `d` never
   touches slots `d..topk-1`.
+- **Live slots may legitimately be non-finite under `HAS_SEQUSED_K and
+  CAUSAL`.** `causal_q_offset = seqlen_k - seqlen_q` is not clamped (`:892-901`),
+  and with `seqlen_k = mSeqUsedK[b]` it goes negative whenever the supplied
+  length is shorter than the Q length. The leading `seqlen_q - mSeqUsedK[b]`
+  query indices then have `causal_col_limit = q_idx + causal_q_offset + 1 <= 0`,
+  take the all-masked path, and store the neutral partial the combine kernel
+  expects: `O_partial = 0` and `LSE_partial = -inf` (the row sum is zero, and
+  `:2999` substitutes `-inf` into the `lg2`). The source reaches this state
+  deliberately rather than skipping the slot (`:1007-1009`).
+  This regime is UNREACHABLE for flat (a `cu_seqlens_k` difference is never
+  shorter than its own Q length here) and for paged-without-seqused (full
+  capacity), so it arrives with this extension and with nothing else.
+  Measured at `seqlen_q = 4096`, `mSeqUsedK = 4059`: offset `-37`, and exactly
+  the 37 query indices `0..36` are affected, 1184 live slots in that shape.
+  Both sides compute the same `-inf`, so it compares equal at `rtol = atol = 0`
+  -- but only if neither side "helpfully" clamps an empty row to a finite value,
+  and only if the gate does not read a non-finite live slot as a failure.
 - The benchmark is kernel-only against the compiled CuTe-DSL callable. Unlike
   the two preparation kernels, this one needs no counter rotation: it reads its
   inputs without mutating them and overwrites -- never accumulates into -- the

--- a/.agents/sketch/msa/sparse_atten_fwd_nvfp4_kv.md
+++ b/.agents/sketch/msa/sparse_atten_fwd_nvfp4_kv.md
@@ -45,8 +45,6 @@ every specialization in this port:
 | `head_dim` | 128 | `__init__` raises otherwise (`:78-81`) |
 | `n_block_size` | 128 | the KV block width the schedule is built around |
 | `m_block_size` | 128 | 128 packed Q heads per MMA tile |
-| `causal` | `True` | the dominant upstream coverage; a real codegen axis (`:177-184`) |
-| `paged_kv` | `False` | out of scope, see below |
 | `use_prepare_scheduler` | `True` | `__init__` raises otherwise (`:100-102`) |
 | `fp8_pair_dequant` | `True` | the shipped default (`interface.py:1860`); the port pins it rather than reading the environment |
 | `has_v_global_scale` | `False` | **unreachable**: the interface pins it (`interface.py:1862-1866`) and applies V's tensor scale once in the combine kernel |
@@ -57,27 +55,21 @@ In scope, i.e. the specializations this module compiles:
 | --- | --- | --- |
 | Q dtype | `bf16`, `fp8_e4m3` | the largest axis. It fixes the **dequant target program** (a BF16 conversion chain vs an FP8 pair chain), the single `mma_kind` (`"f16"` vs `"f8f6f4"`, `:347`), `tmem_s_to_p_offset` (64 vs 96, `:352-354`), the **whole gather4 Q body** (`:2014-2056`: FP8 issues one copy per gather with no prefetch, BF16 issues two half-row copies plus a prefetch), and **where the K tensor scale is applied**. |
 | `qheadperkv` | 1, 2, 4 / 8, 16 | selects the whole Q-load warpgroup program: `use_q_gather4` (`:84`) picks a raw gather4 descriptor path for 1/2/4 and a CUTE-managed TMA path for 8/16. Also sets `q_tokens_per_group = 128 // qheadperkv` (`:112`) and `tokens_per_gather4 = 4 // qheadperkv` (`:90`). |
-| `partial_dtype` | fp32, bf16, fp8 e4m3 | three distinct epilogue store paths: 4-lane, 8-lane and 16-lane 128-bit stores with three different swizzle-inverse column remaps (`:3041-3269`) |
+| `partial_dtype` | fp32, bf16, **fp16**, fp8 e4m3 | three store WIDTHS -- 4-lane, 8-lane and 16-lane 128-bit stores with three different swizzle-inverse column remaps (`:3041-3269`) -- but FOUR programs: bf16 and fp16 share the 8-lane width and the remap yet take different converters, `cvt.rn.bf16.f32` against `cvt.rn.f16.f32`, dispatched by `const_expr` at `:2868-2884`. Saying fp16 "shares the bf16 path" is true of the width and false of the arithmetic. |
 | temperature LSE | on / off | `mLSE_temperature_partial is not None` adds one scaled row-sum reduction, one `sScaleTemperature` publish and one extra LSE store |
 | `has_k_global_scale` | `True` / `False` | not a scalar difference but two different device paths, one per Q dtype: BF16 Q folds the tensor scale into the dequantized values, FP8 Q multiplies the FP32 S accumulator instead |
+| `paged_kv` | `False` / `True` | `page_table is not None` at this kernel's host entry (`interface.py:1867`; `page_size = int(k.shape[2])` at `:1871`, compile key `:1910-1926`). `page_size == blk_kv` (`:103-111`) makes a CTA's KV block exactly one page, so paging swaps one TMA coordinate rather than gathering: K/V become `[num_pages, head_kv, page_size, 64]`, the descriptors go rank 4, `k_batch_offset` becomes 0, and thread 0 resolves the page into `sPagedKvIdx` (`:864-867`). The one NVFP4-specific part is the block-scale row, `_paged_kv_scale_row` (`:1328-1336`), threaded to four dequant call sites through the two dequant wrappers. |
+| `has_seqused_k` | `False` / `True` | paged-only at the host entry (`interface.py:367-369`); returns `mSeqUsedK[batch]` ahead of the paged-capacity and `cu_seqlens_k` fallbacks (`:205-216`). Under causal masking it can drive `causal_q_offset` negative, which leaves the leading `seqlen_q - seqlen_k` queries with no legal key and a legitimately `-inf` LSE. |
+| `causal` | `False` / `True` | `num_regs_softmax` 176 -> 192, `num_regs_store` 112 -> 80, `num_regs_other` derived as `512 - softmax*2 - store` and landing on 48 either way, `ex2_emu_freq` 16 -> 0 (`:177-185`); the diagonal binary search is skipped and `causal_q_offset` is pinned to 0. |
 
 Out of scope, with the predicate that excludes each:
 
-- **paged KV** -- `page_table is not None` at the host entry; requires
-  `page_size == blk_kv` (`:103-111`), swaps in rank-4 descriptors, and replaces
-  `_flat_kv_scale_row` with `_paged_kv_scale_row` (`:1328-1336`). Upstream tests
-  it; this port excludes it for symmetry with the already-merged sibling, whose
-  bench marquee is likewise flat.
-- **`seqused_k`** -- `seqused_k is not None`; paged-only upstream
-  (`interface.py:367-369`).
-- **`causal=False`** -- upstream's only non-causal NVFP4 coverage is one tiny
-  flat test; it would change `num_regs_softmax` 176 -> 192, `num_regs_store`
-  112 -> 80, and `ex2_emu_freq` 16 -> 0, i.e. remove the polynomial exp2 mixing
-  entirely.
-- **`fp8_pair_dequant=False`** -- environment-gated off the default; under the
-  pinned toolchain its body is the same instruction family as the pair path.
-- **fp16 partials** -- accepted by the dtype check but never exercised upstream
-  for NVFP4; it shares the bf16 8-lane store path (`:3105-3173`).
+- **`fp8_pair_dequant=False`** -- environment-gated off the default
+  (`interface.py:1860`); the port pins it True rather than reading the
+  environment, and under the pinned toolchain its body is the same instruction
+  family as the pair path.
+- **`page_size != blk_kv`** -- rejected at `:103-111`; the equality is what makes
+  a CTA's KV block exactly one page.
 - **the BF16/FP8-KV sibling** `SparseAttentionForwardSm100` (`atten_fwd.py`) --
   a separate class, already ported.
 - **the combine kernel** `fwd/combine.py` -- a downstream consumer, and the
@@ -87,11 +79,51 @@ Out of scope, with the predicate that excludes each:
 ## The line-info export this sketch is annotated from
 
 Every `instruction_selection` annotation below is read out of a line-info PTX
-export, not out of the source text. Six exports, one per structurally distinct
-in-scope compile key, are preserved under
+export, not out of the source text. Eight exports are preserved under
 `.porting/sparse_atten_fwd_nvfp4_kv/ptx_lineinfo/<name>/`;
 `.porting/sparse_atten_fwd_nvfp4_kv/export_findings.md` records what they
-settle. Unqualified counts below are from `bf16q_tmaq_qh16_fp32` (5922
+settle. Six cover the flat compile keys; the seventh and eighth are the two
+paged builds, `paged_bf16q_tmaq_qh16_fp32` (BF16-Q) and
+`paged_fp8q_gather4_qh4_bf16partial` (FP8-Q). A paged annotation cites whichever
+matches its Q dtype -- the two dequant programs have different source sites, so
+the BF16-Q scalar arm's `.loc 1 1450` / `:1625` occur only in the seventh and
+the FP8-Q pair arm's `.loc 1 1384` / `:1558` only in the eighth.
+
+Three newly in-scope axes have no export of THIS kernel, each for a stated
+reason rather than by omission:
+
+- `causal=False` -- the axis is computed by character-identical code in the
+  BF16 sibling (`atten_fwd.py:173-181` against `atten_fwd_nvfp4_kv.py:177-185`,
+  both deriving `num_regs_other = 48`), and the sibling's causal/non-causal
+  export pair measures it: `setmaxnreg.inc` 176 -> 192, `dec` 112 -> 80,
+  `dec 48` x3 in both, `ex2.approx` 224 -> 256, static instructions
+  5571 -> 5082. That identity settles the CONSTANTS; the control-flow
+  consequences annotated here -- the deleted diagonal search, the deleted
+  `mCuSeqlensQ[batch+1]` load, the compiled-out causal-mask arm, the
+  zero-frequency exp2 arm -- come from that same sibling pair.
+- `partial_dtype=fp16` -- both classes call the same
+  `common/copy_utils.stg_128_f16_cs`, exported in the sibling as
+  `bf16_tmaq_qh16_fp16partial`.
+- `has_seqused_k` -- its entire device delta is one `ld.global.u32` of
+  `mSeqUsedK[batch]` replacing the paged-capacity multiply at `:212-215`,
+  plus the negative-`causal_q_offset` consequence recorded in the scope table.
+  Both are visible in the sibling's `paged_seqused_bf16_tmaq_qh16_fp32`.
+
+There are FOUR `.file` numbering families across these eight exports, measured
+from their tails:
+
+| build | 3 | 6 | 7 | 8 |
+| --- | --- | --- | --- | --- |
+| BF16-Q flat | `quack/copy_utils.py` | `utils.py` | `mask.py` | `softmax.py` |
+| FP8-Q flat | `quack/copy_utils.py` | `mask.py` | `utils.py` | `softmax.py` |
+| BF16-Q paged | `paged_kv.py` | `blackwell_helpers.py` | `utils.py` | `mask.py` |
+| FP8-Q paged | `paged_kv.py` | `mask.py` | `utils.py` | `softmax.py` |
+
+The paged FP8-Q build is NOT the paged BF16-Q shift applied to the FP8-Q order:
+`paged_kv.py` enters as file 3, but `quack/copy_utils.py` drops out of that
+build entirely, and the two exactly cancel -- so its numbering coincides with
+flat FP8-Q rather than shifting by one. Applying the BF16-Q paged shift to it
+would read its `.loc 6` region as `blackwell_helpers.py` when it is `mask.py`. Unqualified counts below are from `bf16q_tmaq_qh16_fp32` (5922
 instructions, 161 predicated). Counting convention: instruction lines minus
 predicated lines.
 
@@ -111,11 +143,13 @@ re-derived from the source text:
    rather than taken from the host (which is 13.2). Both dequant helpers gate
    their fast paths on `>= 13.2` (`utils.py:652-693`, `:697-771`), so the pin
    takes the **fallbacks**, and the export confirms it: `mul.e4m3x4.e2m1x4`
-   count is **0 in all six exports**. The port transcribes the fallback chains.
+   count is **0 in all eight exports**, both paged ones included. The port transcribes the fallback chains.
 2. **Re-read the `.file` id table for every export.** The ids are assigned per
    export and they are *not* stable even across this kernel's own
-   specializations: the BF16-Q builds number `utils.py` 6 and `mask.py` 7, and
-   all three FP8-Q builds number them the other way round. The table sits at the
+   specializations: see the four-family table above. In particular the two
+   paged builds do NOT share a numbering -- `paged_kv.py` enters as file 3 in
+   both, but `quack/copy_utils.py` drops out of the FP8-Q paged build and
+   cancels the insertion. The table sits at the
    very end of the PTX and its lines are tab-indented, so a `^\.file` grep finds
    nothing -- read the tail. Assuming one export's numbering for another
    silently reattributes a whole region.
@@ -307,7 +341,7 @@ mma_kind  = "f8f6f4" if q_dtype is fp8 else "f16"   # ONE kind, both GEMMs (:347
 tmem_s_to_p = N_BLOCK - N_BLOCK * width(q_dtype) // 32    # 64 bf16 / 96 fp8 (:352-354)
 tokens_per_warp   = ceil(q_tokens_per_group / NUM_Q_LOAD_WARPS)  # TMA program
 subtiles_per_token = 1 if q_dtype is fp8 else 2      # BF16 Q splits on K_TILE
-partial_dtype     # fp32 | bf16 | fp8e4m3
+partial_dtype     # fp32 | bf16 | fp16 | fp8e4m3
 has_temperature   # LSE_temperature_partial is not None
 has_k_global      # k_global_scale is not None
 # instruction_selection: none; extent: compile-time constants only.
@@ -315,8 +349,12 @@ has_k_global      # k_global_scale is not None
 #   Q's dtype, so one `mma_kind` covers both GEMMs.
 
 # Runtime ABI, in the source's parameter order (:296-324).
-mK, mV                    # global uint8 (total_k, PACKED_HEAD_DIM, head_kv) --
-                          # permuted host-side (:365-379); V is MN-major
+mK, mV                    # global uint8. FLAT: (total_k, PACKED_HEAD_DIM,
+                          # head_kv), host permute [0,2,1] / [1,0,2] (:365-372).
+                          # PAGED: (num_pages, head_kv, page_size,
+                          # PACKED_HEAD_DIM), host permute [2,3,1,0] and the
+                          # extra [1,0,2,3] for V (:373-379) -> rank-4
+                          # descriptors. V is MN-major either way.
 mKScale, mVScale          # global uint8, E4M3 bytes in cuBLAS 128x4 tiled order
 mKGlobalScale             # global f32[1] or absent
 mVGlobalScale             # always absent (interface pins has_v_global_scale off)
@@ -330,7 +368,10 @@ mLSE_partial              # global f32 (topk, total_q, head_q)
 mLSE_temperature_partial  # optional, same shape
 mQ_flat                   # global q_dtype (total_q*head_q, HEAD_DIM)
 mQ_gather4_desc           # raw uint8[128] TensorMap, gather4 program only
-mPageTable, mSeqUsedK     # absent in this port
+mPageTable                # optional i32 (batch, pages_per_seq); PAGED_KV only.
+                          # pages_per_seq = mPageTable.shape[1] (:211 analogue)
+mSeqUsedK                 # optional i32 (batch,); HAS_SEQUSED_K only, and the
+                          # host accepts it only alongside mPageTable
 mCuSeqlensQ, mCuSeqlensK  # global i32 (batch+1,)
 softmax_scale_log2        # f32, host-computed: softmax_scale * log2(e)  (:487)
 lse_temperature_scale_log2 # f32, host-computed, chained off the above  (:488)
@@ -376,10 +417,14 @@ sQLoadMIdx   = tile("shared", "i32", (Q_STAGE, q_tokens_per_group))
 sRowMeta     = tile("shared", "i32", (8,))   # batch, kv_block, row_start, count,
                                              # valid_cols, q_off, k_off, causal_off
 sDiagQCount  = tile("shared", "i32", (1,))
-sPagedKvIdx  = tile("shared", "i32", (1,))   # allocated unconditionally and read
-                                             # only on the paged path (out of
-                                             # scope), but it shifts every later
-                                             # offset, so it is not omissible
+sPagedKvIdx  = tile("shared", "i32", (1,))   # written by thread 0 from the page
+                                             # table under the same publish
+                                             # fence as sRowMeta; read warp-wide
+                                             # once per KV-load warp, and ONCE
+                                             # PER ITERATION in each of the two
+                                             # dequant task loops.  Allocated
+                                             # unconditionally, so flat and
+                                             # paged share every later offset
 tmem_addr    = tile("shared", "u32", (1,))
 tmem_dealloc_mbar = mbar(1)                  # 8 B, likewise unconditional
 
@@ -427,7 +472,7 @@ bar_epilogue     = named_barrier(id=13, threads=128)   # +stage -> 13, 14
 # `SoftmaxStatsW0..W7`, but `_wg_softmax` passes `signal_stats_barrier=False`
 # (:2784-2786, :2795-2797) and `_epilogue_step` gets `use_stats_barrier=False`
 # (:2853), so both guarded sites are compiled out: no `bar.*` operand in any of
-# the six exports names an id in 3..10, and the softmax-to-epilogue stats edge is
+# the eight exports names an id in 3..10, and the softmax-to-epilogue stats edge is
 # carried by the `mbar_sm_stats` PIPE alone.  Dropping the eight dead ids is also
 # what lets this renumbering fit: `bar_epilogue + stage` occupies 13 AND 14, so
 # the scheme uses SEVEN ids, 8..14 -- inside the sixteen the hardware has, which
@@ -517,33 +562,81 @@ if tid == 0:
     base_row_start = load_global(mK2qCounts, head_kv_idx * (rows + 1) + row_linear)
     row_start = base_row_start + work_q_begin
     count_raw = work_q_count
-    seqlen_k = load_global(mCuSeqlensK, batch_idx + 1) - load_global(mCuSeqlensK, batch_idx)
-    seqlen_q = load_global(mCuSeqlensQ, batch_idx + 1) - load_global(mCuSeqlensQ, batch_idx)
+    # The logical K length, in the source's own priority order (:205-216).
+    # `seqused` is tested FIRST; checking paged first would silently substitute
+    # the paged capacity for a shorter supplied length.
+    if HAS_SEQUSED_K:
+        seqlen_k = load_global(mSeqUsedK, batch_idx)
+        # instruction_selection: ld.global.u32 (1 static); extent: scalar.
+    elif PAGED_KV:
+        seqlen_k = pages_per_seq * N_BLOCK
+        # instruction_selection: integer multiply, no load; extent: scalar.
+        #   The FULL paged capacity, zero-padded tail pages included.
+    else:
+        seqlen_k = load_global(mCuSeqlensK, batch_idx + 1) - load_global(mCuSeqlensK, batch_idx)
     q_batch_offset = load_global(mCuSeqlensQ, batch_idx)
-    k_batch_offset = load_global(mCuSeqlensK, batch_idx)
-    # instruction_selection: ld.global.u32 -- `mCuSeqlensQ[batch+1]` at :855 and
-    #   `mCuSeqlensK[batch+1]` at :821, plus the two base loads; extent: scalar
-    #   each.  Four loads, not two: each cu_seqlens length is a difference.
+    k_batch_offset = 0 if PAGED_KV else load_global(mCuSeqlensK, batch_idx)
+    # instruction_selection: ld.global.u32, and the COUNT is per axis, not a
+    #   constant.  Each cu_seqlens length is a difference, and both the paged
+    #   and non-causal arms delete loads: flat+causal 4, flat+non-causal 3,
+    #   paged+causal 2 (both from mCuSeqlensQ -- the paged export carries no
+    #   mCuSeqlensK load at all, since `_logical_seqlen_k` takes the multiply
+    #   arm and `k_batch_offset` is the immediate 0 at :841-845),
+    #   paged+non-causal 1.
     kv_valid_cols  = clamp(seqlen_k - kv_block_idx * N_BLOCK, 0, N_BLOCK)
-    causal_q_offset = seqlen_k - seqlen_q
+    if CAUSAL:
+        seqlen_q = load_global(mCuSeqlensQ, batch_idx + 1) - q_batch_offset
+        # instruction_selection: ld.global.u32 (.loc 1 855 23), 1 static;
+        #   extent: scalar.  ONLY under causal -- my non-causal export has zero
+        #   `.loc 1 855` and zero `.loc 1 862`, so hoisting this out of the
+        #   branch gives the non-causal build a load the source does not have.
+        causal_q_offset = seqlen_k - seqlen_q
+        # May be NEGATIVE under `seqused_k`, which is legal: the leading
+        # `seqlen_q - seqlen_k` queries then have no valid key, run the
+        # all-masked path, and store a neutral partial whose LSE is exactly
+        # -inf. Clamping it to a finite value diverges from the source.
+    else:
+        causal_q_offset = 0                       # (:893-901 analogue)
+    if PAGED_KV:
+        page_idx = load_global(mPageTable, batch_idx * pages_per_seq + kv_block_idx)
+        # instruction_selection: ld.global.u32 (1 static); extent: scalar.
+        store_shared(sPagedKvIdx, 0, page_idx)
+        # instruction_selection: st.shared.u32 (1 static); extent: scalar.  A
+        #   separate scalar store -- it targets a different array than the two
+        #   sRowMeta vector stores -- riding the same thread-0 region and the
+        #   same publish fence, so paging adds no barrier (:864-867, :890-891).
     store_shared(sRowMeta, 0..7, those values)
     # instruction_selection: st.shared.v4.u32 (:849, :863) -- the eight words go
     #   out as two four-word stores; extent: 4 words each.
 
     # Causal diagonal split point over the CSR row, which is sorted by q_idx.
-    # A FIXED 32-trip loop with `unroll=1` and a predicated body -- not a
-    # data-dependent `while`.  The export keeps it rolled ($L__BB0_7, one
-    # probe load in the body), so 32 is an upper bound on int32-sized rows
-    # rather than a trip count the loop actually runs to convergence.
-    left, right = 0, count_raw
-    for _ in range(32):                       # rolled, unroll=1
-        if left < right:
-            mid = (left + right) // 2
-            probe = load_global(mK2qIndices, head_kv_idx * nnz + row_start + mid)
-            # instruction_selection: ld.global.u32 (:243), ONE per iteration
-            #   inside the rolled loop; extent: scalar.
-            left, right = (mid + 1, right) if probe < q_threshold else (left, mid)
-    store_shared(sDiagQCount, 0, left)
+    # The whole search sits inside `const_expr(self.causal)` AND, within it,
+    # behind a runtime guard: a row with no work or no visible column skips it
+    # (:874-889).  Under `causal=False` the region is compiled out entirely --
+    # my non-causal export carries zero `.loc 1 277/278/285` and zero
+    # `.loc 1 243`, against 1/2/1 and 2 in the causal build.
+    diag_q_count = 0
+    if CAUSAL:
+        row_has_visible_cols = count_raw > 0 and kv_valid_cols > 0
+        if row_has_visible_cols:
+            # The first q_idx at or past the diagonal, where the threshold is
+            # the row's last visible column mapped back into q space.
+            q_threshold = kv_block_idx * N_BLOCK + kv_valid_cols - causal_q_offset
+            # A FIXED 32-trip loop with `unroll=1` and a predicated body -- not
+            # a data-dependent `while`.  The export keeps it rolled
+            # ($L__BB0_7, one probe load in the body), so 32 is an upper bound
+            # on int32-sized rows rather than a trip count run to convergence.
+            left, right = 0, count_raw
+            for _ in range(32):                       # rolled, unroll=1
+                if left < right:
+                    mid = (left + right) // 2
+                    probe = load_global(mK2qIndices,
+                                        head_kv_idx * nnz + row_start + mid)
+                    # instruction_selection: ld.global.u32 (:243), ONE per
+                    #   iteration inside the rolled loop; extent: scalar.
+                    left, right = (mid + 1, right) if probe < q_threshold else (left, mid)
+            diag_q_count = left
+    store_shared(sDiagQCount, 0, diag_q_count)
     # instruction_selection: st.shared.u32 (:890); extent: scalar.  The one
     #   scalar the metadata block publishes outside the two sRowMeta vector stores.
 
@@ -596,10 +689,28 @@ if 4 <= warp < 8 and cta_valid_work:
 # ===========================================================================
 def kv_load_warp(is_v):
     if has_work:                     # no-work CTAs do nothing at all here
+        if PAGED_KV:
+            page_idx = load_shared(sPagedKvIdx, 0)
+            # instruction_selection: ld.shared.u32 (paged export,
+            #   .loc 1 1709 53 for K / .loc 1 1744 53 for V, 1 static each);
+            #   extent: scalar, WARP-WIDE.  It sits OUTSIDE the elected region:
+            #   the export shows this load immediately before the copy helper's
+            #   `elect.sync` (.loc 1 1734 / :1769), so all 32 lanes execute it.
+            #   Once per KV-load warp and reused across the issue -- a claim
+            #   that holds HERE and not in the dequant loops, where the same
+            #   cell is re-read every iteration.
         with elect():                # region 1 (:1734/:1769) -- the copy only
             copy_g2s(mV if is_v else mK, sVFp4 if is_v else sKFp4,
                      bar=mbar_v_tma if is_v else mbar_k_tma, hint=0)
-            # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster
+            # instruction_selection, PAGED: cp.async.bulk.tensor.**4d**
+            #   .shared::cluster.global.tile.mbarrier::complete_tx::bytes
+            #   .L2::cache_hint (paged export, 2 static -- one for K, one for V,
+            #   where the BF16 sibling needs two each because its row is two
+            #   swizzle atoms wide and the packed FP4 row is one).  Coordinates
+            #   are fastest-first `(head_dim_offset, token_in_page, head_kv,
+            #   page)` with the token coordinate pinned to 0.  Load mode,
+            #   completion and cache hint are UNCHANGED from the flat form.
+            # instruction_selection, FLAT: cp.async.bulk.tensor.3d.shared::cluster
             #   .global.tile.mbarrier::complete_tx::bytes.L2::cache_hint
             #   (:1734,:1769, 2 static); extent: a (PACKED_HEAD_DIM, 1, N_BLOCK)
             #   box = 8192 bytes.  Half the sibling's transaction size, because
@@ -644,8 +755,31 @@ def scale_128x4_offset(row, col):
 # instruction_selection: integer shift/mask/mad chain, no memory op (:1204-1211);
 #   extent: scalar.
 
-def flat_kv_scale_row(token, head_kv_idx):
-    return token * num_heads_kv + head_kv_idx        # (:1319-1326)
+# THE one genuine NVFP4 paged difference. `scale_128x4_offset` above is
+# layout-only and identical either way; what moves is the logical row fed into
+# it. Both forms are the row-major flattening of the tensor the kernel actually
+# reads, which is why the host quantizer needs no paged-specific helper -- it
+# flattens `prod(shape[:-1])` and the order falls out (quantize.py:174-239).
+#
+# The two arms take DIFFERENT arguments, and that is the whole point. The flat
+# arm takes the absolute token `k_batch_offset + kv_block_idx*N_BLOCK + row`;
+# the paged arm takes the INTRA-PAGE row `row`, 0..N_BLOCK-1, and never
+# computes the absolute token at all. Feeding the absolute token to the paged
+# form yields `(page*H+h)*N_BLOCK + k_batch_offset + kv_block_idx*N_BLOCK + row`
+# -- a different, in-range E4M3 byte for every task. It does not fault and the
+# values look plausible; only the bitwise gate catches it.
+
+def paged_kv_scale_row(row, head_kv_idx, page_idx):    # (:1328-1336)
+    return (page_idx * num_heads_kv + head_kv_idx) * N_BLOCK + row
+    # instruction_selection: mad.lo.s32 then shl.b32 by 7 then add.s32
+    #   (paged export, .loc 1 1336 12 and .loc 1 1336 11); extent: scalar.
+    #   Against flat the whole-module counts move `cvt.s64.s32` 44 -> 46,
+    #   `mul.lo.s64` 40 -> 41, `shl.b64` 38 -> 39 -- one extra multiply and
+    #   add, nothing structural.
+
+def flat_kv_scale_row(token, head_kv_idx):             # (:1319-1326)
+    return token * num_heads_kv + head_kv_idx
+    # instruction_selection: integer mad, no memory op; extent: scalar.
 
 def dequant_kv(sFp4, sDst, mbar_tma, mbar_ready, dequant_bar, mScale, is_v):
     if not has_work:
@@ -667,7 +801,21 @@ def dequant_kv(sFp4, sDst, mbar_tma, mbar_ready, dequant_bar, mScale, is_v):
             # constant in the source and it must not be conflated.
             row       = task_idx // SCALE_COLS
             scale_col = task_idx - row * SCALE_COLS
-            token     = k_batch_offset + token_in_block_base + row
+            if PAGED_KV:
+                page_idx  = load_shared(sPagedKvIdx, 0)
+                # instruction_selection: ld.shared.u32, ONE PER ITERATION
+                #   (paged export: .loc 1 1450 19 at the K site inside the
+                #   `.pragma "nounroll"` loop $L__BB0_89, .loc 1 1625 19 at the
+                #   V site inside $L__BB0_120 -- `dequant_kv` is parameterised
+                #   by `is_v`, so this one arm covers both); extent: scalar.
+                #   The backend does NOT hoist it out of the task loop, so a
+                #   port that lifts it changes the hottest loop's instruction
+                #   count.  This is a different read from the KV-load warps'
+                #   one -- that one really is once per warp; this one is not.
+                scale_row = paged_kv_scale_row(row, head_kv_idx, page_idx)
+            else:
+                token     = k_batch_offset + token_in_block_base + row
+                scale_row = flat_kv_scale_row(token, head_kv_idx)
 
             r_words = reg_tile([2], "u32")           # 8 bytes = 16 FP4 values
             copy_s2r(sFp4[row * PACKED_HEAD_DIM + scale_col * 8 ..+ 8], r_words)
@@ -684,8 +832,8 @@ def dequant_kv(sFp4, sDst, mbar_tma, mbar_ready, dequant_bar, mScale, is_v):
             # instruction_selection: ld.shared.v2.u32 (:1472 K, :1647 V), ONE per
             #   iteration; extent: 16 FP4 values as two 32-bit words.
 
-            scale_byte = load_global(mScale, scale_128x4_offset(
-                flat_kv_scale_row(token, head_kv_idx), scale_col))
+            scale_byte = load_global(mScale,
+                                     scale_128x4_offset(scale_row, scale_col))
             # instruction_selection: ld.global.u8 (:1233), ONE per task, issued
             #   inside the loop; extent: scalar.  ZERO-extending here; the FP8
             #   path's loader is sign-extending instead, which is a real operand-
@@ -763,7 +911,21 @@ def dequant_kv(sFp4, sDst, mbar_tma, mbar_ready, dequant_bar, mScale, is_v):
         for pair_idx in range(task, TOTAL_PAIRS, NUM_DEQUANT_WARPS * 32):  # rolled
             row       = pair_idx // (SCALE_COLS // 2)
             pair_col  = pair_idx - row * (SCALE_COLS // 2)
-            token     = k_batch_offset + token_in_block_base + row
+            if PAGED_KV:
+                page_idx  = load_shared(sPagedKvIdx, 0)
+                # instruction_selection: ld.shared.u32, ONE PER ITERATION, at
+                #   this program's own sites -- .loc 1 1384 (K) and .loc 1 1558
+                #   (V); extent: scalar.  Not hoisted, same as the BF16-Q path.
+                #   Measured directly in `paged_fp8q_gather4_qh4_bf16partial`:
+                #   the cell sits at +3888 in that layout and carries FOUR
+                #   reads, whose nearest preceding `.loc` are 1709 53 and
+                #   1744 53 (the two KV-load warps) and 1384 23 / 1558 23
+                #   (these two pair sites).  Same four-read shape as the BF16-Q
+                #   paged build at its own offset +3504.
+                scale_row = paged_kv_scale_row(row, head_kv_idx, page_idx)
+            else:
+                token     = k_batch_offset + token_in_block_base + row
+                scale_row = flat_kv_scale_row(token, head_kv_idx)
 
             r_words = reg_tile([4], "u32")           # 16 bytes = 32 FP4 values
             copy_s2r(sFp4[row * PACKED_HEAD_DIM + pair_col * 16 ..+ 16], r_words)
@@ -1178,9 +1340,27 @@ def softmax_warpgroup(stage):
     # instruction_selection: bar.sync id=8, 288 threads (:1089,:1156); extent:
     #   warpgroup.  Entry side -- arrive AND wait.
 
+    # The source const_expr-splits the `_softmax_step` call site itself
+    # (:2744-2752 causal vs :2788-2821 non-causal). The causal arm derives the
+    # two quantities the mask needs; the non-causal arm passes literal
+    # `Int32(0)` for both and never computes `kv_block_col_start` (:2727-2729).
+    if CAUSAL:
+        kv_block_col_start = kv_block_idx * N_BLOCK          # (:2727-2729)
+        diag_q_count = load_shared(sDiagQCount, 0)
+        # instruction_selection: ld.shared.u32; extent: scalar.
+    else:
+        kv_block_col_start = 0
+        diag_q_count = 0
+
     # WG0 takes even Q groups, WG1 odd.
     for qi_iter in range((num_q_groups + (1 - stage)) // 2):
         qi_group = qi_iter * 2 + stage
+        if CAUSAL:
+            # How many of this group's tokens still sit on the diagonal.
+            masked_tok_count = clamp(diag_q_count - qi_group * q_tokens_per_group,
+                                     0, q_tokens_per_group)
+        else:
+            masked_tok_count = 0                             # literal (:2788-2821)
         softmax_step(stage, qi_group)
         named_barrier_arrive_and_wait(bar_epilogue + stage)
         # instruction_selection: bar.sync id=13 or 14, 128 threads (:2822);
@@ -1216,19 +1396,29 @@ def softmax_step(stage, qi_group):
         #   that commutes.  On the BF16 path this multiply does not exist: the
         #   tensor scale was folded into the dequantized K values instead.
 
-    # Causal mask: a runtime branch on whether this Q group straddles the
-    # diagonal. Both arms end in the same bit-test body, but they compute
-    # different column limits, and only the diagonal arm reads q_idx.
-    need_causal_mask = masked_tok_count > 0
-    if need_causal_mask:
-        tok = group_tidx // qheadperkv          # :2513
-        q_idx = load_shared(sQIdxMeta, meta_slot + tok) & 0xFFFFFF
-        # instruction_selection: ld.shared.u32 x2 whole-kernel (:2515); extent:
-        #   scalar.  Present only on this arm.
-        col_limit = min(kv_valid_cols,
-                        q_idx + causal_q_offset - kv_block_col_start + 1)
+    # Causal mask. The ENTIRE construct below is inside `const_expr(self.causal
+    # and apply_causal_mask)` (:2510-2546): under `causal=False` the caller
+    # passes `mask_causal=False` and the runtime branch, the q_idx read and the
+    # diagonal column limit are all compiled out, leaving only `kv_valid_cols`.
+    # Measured: `.loc 1 2511` 2 -> 0 and `.loc 1 2515` 4 -> 0 between the causal
+    # and non-causal exports, with the mask region shrinking 522 -> 498 lines.
+    if CAUSAL:
+        # A runtime branch on whether this Q group straddles the diagonal. Both
+        # arms end in the same bit-test body, but they compute different column
+        # limits, and only the diagonal arm reads q_idx.
+        need_causal_mask = masked_tok_count > 0
+        if need_causal_mask:
+            tok = group_tidx // qheadperkv          # :2513
+            q_idx = load_shared(sQIdxMeta, meta_slot + tok) & 0xFFFFFF
+            # instruction_selection: ld.shared.u32 x2 whole-kernel (:2515);
+            #   extent: scalar.  Present only on this arm, and only in a causal
+            #   build.
+            col_limit = min(kv_valid_cols,
+                            q_idx + causal_q_offset - kv_block_col_start + 1)
+        else:
+            col_limit = kv_valid_cols
     else:
-        col_limit = kv_valid_cols
+        col_limit = kv_valid_cols               # (:2537-2546)
     if col_limit < N_BLOCK:                 # mask.py:114
         # A fully-visible tile skips the bit-test body entirely -- the mask
         # region below is reached only under this runtime guard, which is why
@@ -1325,11 +1515,24 @@ def softmax_step(stage, qi_group):
     # and the loop steps in PAIRS (softmax.py:378-396).
     for j in range(4):                       # frg_cnt = 128 // 32
         for k in range(0, 32, 2):
+            if EX2_EMU_FREQ == 0:
+                # The non-causal build. `apply_exp2_convert` has its own
+                # `const_expr(ex2_emu_freq == 0)` arm (softmax.py:381-383) that
+                # takes real exp2 for BOTH elements of every pair -- there is no
+                # emulation and no `fmax` clamp. Reaching the predicate below
+                # with a zero frequency would be a modulo by zero.
+                exp2(r_s[j*32+k]); exp2(r_s[j*32+k+1])
+                continue
             emulate = (k % EX2_EMU_FREQ >= EX2_EMU_FREQ - EX2_EMU_RES
                        and EX2_EMU_START_FRG <= j < 4 - 1)
             if emulate: exp2_poly_pair(r_s[j*32+k], r_s[j*32+k+1])
             else:       exp2(r_s[j*32+k]); exp2(r_s[j*32+k+1])
-        # instruction_selection: ex2.approx.ftz.f32 for 112 of every 128
+        # instruction_selection, NON-CAUSAL (EX2_EMU_FREQ = 0): every element
+        #   takes real MUFU -- `ex2.approx.ftz.f32` 224 -> 256 whole-module,
+        #   the polynomial `fma.rn.f32x2` 176 -> 128 (all 24 per warpgroup
+        #   gone), and `max.f32` 164 -> 132 as the emulation's 32 `fmax(x,-127)`
+        #   clamps disappear with it.  Measured against the causal build.
+        # instruction_selection, CAUSAL: ex2.approx.ftz.f32 for 112 of every 128
         #   (softmax.py:389-390, 112 at each of two sites), and
         #   `utils.ex2_emulation_2` -- a degree-3 FFMA polynomial evaluated on a
         #   PAIR (`utils.evaluate_polynomial_2`, 3 fma.rn.f32x2 at `.loc 6 924`,
@@ -1466,17 +1669,33 @@ def epilogue_step(stage, qi_group):
                         # instruction_selection: rcp.approx.ftz.f32, 32 whole-
                         #   kernel, 16 per warpgroup (:3070), one per 128-bit
                         #   store; extent: scalar.  The zero/NaN guard is BEFORE
-                        #   the reciprocal.
+                        #   the reciprocal.  Its whole-kernel count follows the store
+                        #   width: 32 for fp32, 16 for the 8-lane half paths,
+                        #   8 for fp8.
                         mul(scaled, r_o[cols], row_scale, lanes=2)
                         # instruction_selection: mul.rn.f32x2, two per fp32 store
                         #   group (:3086,:3088); extent: the group.
                         copy_r2g(o_partial_ptr + fake_col(partial_dtype, col),
                                  scaled, cache="cs")
-                        # instruction_selection: st.global.cs.v4.f32 (fp32, 32
-                        #   whole-kernel, 16 per warpgroup, :2866), or v4.b32 of
-                        #   eight packed
-                        #   halves (bf16) / sixteen packed bytes (fp8); extent:
-                        #   128 bits.  The address goes through
+                        # instruction_selection: one 128-bit store per group,
+                        #   but the CONVERTER in front of it is what the partial
+                        #   dtype selects, and the two half formats differ:
+                        #     fp32 -- st.global.cs.v4.f32, no convert (32
+                        #       whole-kernel, 16 per warpgroup, :2866);
+                        #     bf16 -- 8 x cvt.rn.bf16.f32 packed into
+                        #       st.global.cs.v4.b32 (:2882, stg_128_bf16_cs);
+                        #     fp16 -- 8 x cvt.rn.f16.f32 packed into
+                        #       st.global.cs.v4.b32 (:2884, stg_128_f16_cs).
+                        #       Measured on the fp16 export: 128 cvt.rn.f16.f32,
+                        #       16 st.global.cs.v4.b32, `.loc 1 2884` 16 with
+                        #       `.loc 1 2882` 0, against 32 st.global.cs.v4.f32
+                        #       and 0 converts in the fp32 build.  The lane
+                        #       count, the fake-column remap
+                        #       (real_col_to_stg128_half_fake_col, :3160) and
+                        #       the control flow are shared with bf16 -- only
+                        #       the convert opcode is not;
+                        #     fp8  -- sixteen packed bytes in st.global.cs.v4.b32.
+                        #   extent: 128 bits.  The address goes through
                         #   real_col_to_stg128*_fake_col: O_partial is stored in
                         #   fake-column order, the combine kernel reads it back
                         #   that way, and the permutation is what makes these
@@ -1558,8 +1777,10 @@ and exactly one of TMA-Q / gather4-Q.
 
 | descriptor | rank | element | box | swizzle | policy | notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| K | 3 | uint8 | `(PACKED_HEAD_DIM, 1, N_BLOCK)` | 128 B | zero | 8192 transaction bytes -- half the sibling's |
-| V | 3 | uint8 | `(PACKED_HEAD_DIM, 1, N_BLOCK)` | 128 B | zero | MN-major source permute done host-side |
+| K, flat | 3 | uint8 | `(PACKED_HEAD_DIM, 1, N_BLOCK)` | 128 B | zero | 8192 transaction bytes -- half the sibling's |
+| V, flat | 3 | uint8 | `(PACKED_HEAD_DIM, 1, N_BLOCK)` | 128 B | zero | MN-major source permute done host-side |
+| K, **paged** | **4** | uint8 | `(PACKED_HEAD_DIM, N_BLOCK, 1, 1)` | 128 B | zero | global dims fastest-first `(PACKED_HEAD_DIM, page_size, head_kv, num_pages)` from the `[2,3,1,0]` host permute (`:373-379`); coordinate tuple `(0, 0, head_kv, page)`; same 8192 transaction bytes and same `.tile` / `mbarrier::complete_tx::bytes` / `L2::cache_hint` as flat |
+| V, **paged** | **4** | uint8 | `(PACKED_HEAD_DIM, N_BLOCK, 1, 1)` | 128 B | zero | same dims, with the extra `[1,0,2,3]` MN-major permute; coordinate tuple `(0, 0, head_kv, page)` |
 | Q (TMA program) | 2 | q_dtype | `(swizzle_elems, qheadperkv)` | 128 B | zero | present only for qheadperkv 8/16 |
 | Q (gather4 program) | 2 | q_dtype | `(box_x, 1)` | 128 B | EVICT_LAST | `box_x` = 128 for FP8 Q, 64 for BF16 Q; the instruction supplies four row coordinates |
 
@@ -1586,11 +1807,21 @@ unpacked one, so the two must coexist.
 Resolved at trace time, so each appears as straight-line code rather than a
 branch: `qheadperkv` and the Q-load program it selects, `q_dtype` and with it
 the dequant program / `mma_kind` / `tmem_s_to_p` / gather4 box width and k-tile
-split, `partial_dtype` and its store width, `has_temperature`, `has_k_global`.
+split, `partial_dtype` and its store width, `has_temperature`, `has_k_global`,
+`causal`, `paged_kv`, `has_seqused_k`.
+
+The last three are `const_expr` in the source exactly like the others, and each
+deletes code rather than selecting between equal-cost arms: `causal=False`
+removes the diagonal search, the `mCuSeqlensQ[batch+1]` load, the whole
+causal-mask arm and the exp2 emulation; `paged_kv` swaps the KV descriptors to
+rank 4, pins `k_batch_offset` to 0 and changes the block-scale row;
+`has_seqused_k` replaces the paged-capacity multiply with one `ld.global.u32`
+of `mSeqUsedK[batch]`.
 
 Runtime branches that survive: `cta_valid_work`, `has_work`, `qi < count_raw`,
 `qi_lse < count_raw` (the LSE block's own guard), `row < M_BLOCK`,
-`need_causal_mask`, `col_limit < N_BLOCK` (the mask body runs only on a partly
+`need_causal_mask` (**causal builds only** -- it does not survive a
+non-causal specialization), `col_limit < N_BLOCK` (the mask body runs only on a partly
 visible tile), `group_tidx < q_tokens_per_group` (the metadata publish and the
 epilogue decode), `tok_idx < q_tokens_per_group` (the TMA per-warp partition),
 `num_q_groups > 1`, the 32-trip search's `left < right` predicate, and the

--- a/.agents/skills/tirx-codegen-tuning/references/db/move-a-read-across-a-barrier-that-only-orders-the-writes.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/move-a-read-across-a-barrier-that-only-orders-the-writes.md
@@ -74,28 +74,14 @@ rewrite that wins on one operand dtype can lose on the one with less headroom.
 
 ## Verification
 
-Judge this one on measured time. The instruction count moves the wrong way by
-design, so an instruction-count check will read as a regression, and a
-per-opcode stall comparison against the reference will not motivate it either --
-on the kernel this was measured on the two sides' shared-store stall shares were
-2.40% and 2.47%, indistinguishable. What identified the site was its own stall
-count, not a gap against anything.
+Judge this one on time. The instruction count moves the wrong way by design, so
+an instruction-count check reads as a regression and a per-opcode comparison
+against the reference will not motivate it either.
 
-Three ways to misread the machine code here, all of them hit while measuring
-this.
+The stall breakdown is what shows the trade landed: samples should leave memory
+latency and arrive in issue. Measured, long_scoreboard 25.3% to 24.7% and
+no_instructions 10.8% to 10.3%, against selected 12.6% to 13.0% and not_selected
+4.7% to 5.2%.
 
-A SASS listing keyed on the first token of each line silently drops every
-`@P0`-guarded instruction, and guarded loads and stores are exactly what a
-publish inside two range checks compiles to. That one filter produced three
-different false conclusions in a row: a load-volume gap against the reference
-that did not exist, a set of sites the port supposedly had and the reference did
-not, and a shared-store stall share off by more than twentyfold. Take the opcode
-from the second token when the first begins with `@`.
-
-Shared-memory offsets are assigned per binary, so the same numeric offset can
-name different buffers before and after a change. A store that looks like it
-moved or vanished at a given offset proves nothing across two builds.
-
-An apparent removal of work deserves a test rather than an explanation:
-deliberately corrupt the value being published and confirm the bitwise gate
-fails. If it still passes, what was removed was dead work.
+Confirm the region still does its work rather than having become dead: corrupt
+the published value and check the bitwise gate fails.

--- a/.agents/skills/tirx-codegen-tuning/references/db/move-a-read-across-a-barrier-that-only-orders-the-writes.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/move-a-read-across-a-barrier-that-only-orders-the-writes.md
@@ -1,0 +1,101 @@
+# Move a read across a barrier that only orders the writes
+
+**Symptoms:** `barrier_stall`, `exposed_load_latency`, `long_scoreboard`
+
+## Symptom
+
+A global load and the shared store that consumes it sit a few instructions
+apart immediately after a barrier, and that store is the heaviest-stalling
+store site in the kernel -- on the one this was measured on, 517 stall samples
+against 2.2% of every sample the kernel took.
+
+## What to change
+
+Ask what the barrier actually orders. A barrier in front of a shared write is
+normally there to stop that write from racing the previous iteration's readers.
+It says nothing about where the stored *value* comes from. When the value comes
+from an input the kernel only reads, issue the read ahead of the barrier into a
+local and leave only the store behind it, so the wait absorbs the memory latency
+instead of the store paying it afterwards.
+
+```python
+# before: the read is issued after the barrier and its consumer is a few
+# instructions behind it, so the wait and the latency are paid in series.
+bar_sync_named(BAR_ID, PARTICIPANTS)
+for i in T.unroll(N):
+    if guard(i):
+        st_shared_i32(dst, slot + i, ld_global_i32(src, index(i)))
+    else:
+        st_shared_i32(dst, slot + i, 0)
+
+# after: every read is issued first and the barrier is paid on top of their
+# latency. The else-arm folds into the pre-initialized local, which also drops
+# one store site.
+words = T.alloc_local((N,), "int32")
+for i in T.unroll(N):
+    words[i] = 0
+    if guard(i):
+        words[i] = ld_global_i32(src, index(i))
+bar_sync_named(BAR_ID, PARTICIPANTS)
+for i in T.unroll(N):
+    if guard(i):
+        st_shared_i32(dst, slot + i, words[i])
+```
+
+## Rationale
+
+Inline-PTX loads are opaque to the scheduler, so nothing moves them for you: a
+read written after a barrier stays after it, and its consumer waits out the full
+memory latency with the whole warpgroup already synchronized.
+
+The trade is instructions for overlap, not instructions saved. Staging the
+values costs a local array and a pre-initialization, and measured on a metadata
+publish the rewrite raised executed global loads from 173,425 to 266,698 and
+shared stores from 611,442 to 704,222 at warp level. It still won: five
+alternating paired rounds, 5/5, 0.76% on the target shape, moving its mean ratio
+from 0.9875 to 1.0000, and a second shape on the same load program gained 1.6%
+without being aimed at. Expect the instruction count to go up and judge the
+change on time.
+
+The stall breakdown confirms where the time comes from rather than leaving it
+inferred. Samples move out of memory latency and into issue: long_scoreboard
+25.3% to 24.7%, no_instructions 10.8% to 10.3%, while selected rises 12.6% to
+13.0% and not_selected 4.7% to 5.2%. More warps are ready and fewer are blocked
+on a load, which is the whole of the trade.
+
+## Boundary
+
+Only for reads of data the kernel does not write. A value another warp publishes
+into shared memory, or a global buffer this kernel also stores to, is precisely
+what the barrier exists to order -- hoisting that read is a correctness bug, not
+a tuning change. The staged values also occupy registers for the length of the
+barrier; on a warp already near its budget the trade can invert, and the same
+rewrite that wins on one operand dtype can lose on the one with less headroom.
+
+## Verification
+
+Judge this one on measured time. The instruction count moves the wrong way by
+design, so an instruction-count check will read as a regression, and a
+per-opcode stall comparison against the reference will not motivate it either --
+on the kernel this was measured on the two sides' shared-store stall shares were
+2.40% and 2.47%, indistinguishable. What identified the site was its own stall
+count, not a gap against anything.
+
+Three ways to misread the machine code here, all of them hit while measuring
+this.
+
+A SASS listing keyed on the first token of each line silently drops every
+`@P0`-guarded instruction, and guarded loads and stores are exactly what a
+publish inside two range checks compiles to. That one filter produced three
+different false conclusions in a row: a load-volume gap against the reference
+that did not exist, a set of sites the port supposedly had and the reference did
+not, and a shared-store stall share off by more than twentyfold. Take the opcode
+from the second token when the first begins with `@`.
+
+Shared-memory offsets are assigned per binary, so the same numeric offset can
+name different buffers before and after a change. A store that looks like it
+moved or vanished at a given offset proves nothing across two builds.
+
+An apparent removal of work deserves a test rather than an explanation:
+deliberately corrupt the value being published and confirm the bitwise gate
+fails. If it still passes, what was removed was dead work.

--- a/.agents/skills/tirx-codegen-tuning/references/db/take-a-descriptors-rank-from-the-tensor-not-the-flag-that-selects-it.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/take-a-descriptors-rank-from-the-tensor-not-the-flag-that-selects-it.md
@@ -1,0 +1,64 @@
+# Take a descriptor's rank from the tensor, not the flag that selects it
+
+**Symptoms:** `illegal_instruction`, `config_specific_buffer_load`, `instruction_variant_mismatch`
+
+## Symptom
+
+A launch dies with an illegal instruction on exactly the specializations where
+two independent options are both on -- a new tensor layout and a staging or
+alternate-descriptor path -- while each option alone runs fine. Nothing in the
+generated code looks wrong at the copy site: it names a descriptor and a rank
+that are individually correct.
+
+## What to change
+
+Separate the two questions the site is really asking. The *rank* of a bulk
+tensor copy is a property of the tensor's layout. *Which* descriptor it reads is
+a property of where the data is staged. When a kernel keeps more than one map
+over the same tensor -- an MMA-swizzled one and a plain staging one, say -- every
+one of them has to be encoded at whatever rank the layout gave the tensor, or
+one combination will pair a map of one rank with a copy of another.
+
+```python
+# before: rank branches on the layout flag, the map branches on the staging
+# flag, and the staging map was only ever encoded at the old rank.
+if layout_adds_a_mode:
+    T.evaluate(T.ptx[_COPY_4D](dst, T.address_of(stage_map if staged else main_map), ...))
+else:
+    T.evaluate(T.ptx[_COPY_3D](dst, T.address_of(stage_map if staged else main_map), ...))
+
+# after: each map is encoded at the rank its tensor has, so whichever one the
+# staging flag picks already matches the rank the layout flag chose.
+for m, elem_bytes in ((main_map, mma_bytes), (stage_map, raw_bytes)):
+    if layout_adds_a_mode:
+        _encode(m, rank=4, dims=(D, TILE, HEADS, TILES), strides=(...))
+    else:
+        _encode(m, rank=3, dims=(D, HEADS, TOTAL), strides=(...))
+```
+
+## Rationale
+
+A tiled bulk copy takes its coordinate count from the instruction, and the
+descriptor carries its own rank from the encode call. The hardware does not
+reconcile them: a 4-D copy against a rank-3 map reads a coordinate the map never
+described, and the launch traps. Because each option is exercised on its own by
+other configurations, the whole matrix passes except the cells where both are
+set -- here two of thirty-four configurations, both of them fp8-staged pages,
+which is why the failure surfaced only under a bitwise gate that ran every
+config rather than a representative few.
+
+## Boundary
+
+Only applies where a kernel holds more than one descriptor over the same tensor.
+With a single map the rank cannot disagree with itself. The trap is worth
+looking for whenever a port adds a layout axis late -- paging, batching, an
+extra head mode -- to a kernel whose descriptors were written when the layout
+had one shape.
+
+## Verification
+
+Check every encode's argument count against `4 + rank * 4 + 3`; a short or long
+call is the same mistake caught earlier, since the runtime wrapper derives the
+shape, stride, box and element-stride counts from the rank it was handed. Then
+confirm each copy site's rank matches the rank of the map it names, for every
+combination of the flags, not just the ones a default configuration reaches.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | ------------------------------------------ | ----------------------------------- | ---------- |
 | `msa_sparse_prepare_flat_schedule_sm100`   | `sparse_prepare_flat_schedule.py`   | Flat work-list preparation for sparse attention |
 | `msa_sparse_prepare_fwd_split_atomic_sm100` | `sparse_prepare_fwd_split_atomic.py` | Forward split-slot preparation (packed `q_idx`/slot metadata) |
-| `msa_sparse_atten_fwd_sm100`               | `sparse_atten_fwd.py`               | CSR block-sparse attention forward, split-partial output |
-| `msa_sparse_atten_fwd_nvfp4_kv_sm100`      | `sparse_atten_fwd_nvfp4_kv.py`      | CSR block-sparse attention forward over NVFP4 K/V |
+| `msa_sparse_atten_fwd_sm100`               | `sparse_atten_fwd.py`               | CSR block-sparse attention forward, split-partial output, flat or paged KV |
+| `msa_sparse_atten_fwd_nvfp4_kv_sm100`      | `sparse_atten_fwd_nvfp4_kv.py`      | CSR block-sparse attention forward over NVFP4 K/V, flat or paged |
 
 ## Performance
 

--- a/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_nvfp4_kv_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_nvfp4_kv_sm100.yaml
@@ -11,3 +11,7 @@ configs:
   - {config: fp8q_gather4_s16384_qh4_t16, default: false}
   - {config: fp8q_partial_fp8_s8192_qh8_t8, default: false}
   - {config: edge_b1_s1024_bf16q_t4, default: false}
+  - {config: paged_ring48k_bf16q_qh16_t16, default: false}
+  - {config: paged_ring48k_fp8q_qh16_t16, default: false}
+  - {config: paged_seqused_bf16q_s16384_qh4_t16, default: false}
+  - {config: paged_edge_b1_s2048_fp8q_t4, default: false}

--- a/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_sm100.yaml
@@ -11,3 +11,7 @@ configs:
   - {config: fp8kv_s16384_qh4_t16, default: false}
   - {config: fp8_pvbf16_s8192_qh8_t8, default: false}
   - {config: edge_b1_s1024_bf16_t4, default: false}
+  - {config: paged_ring48k_bf16_qh16_t16, default: false}
+  - {config: paged_seqused_bf16_s16384_qh4_t16, default: false}
+  - {config: paged_fp8_s16384_qh16_t16, default: false}
+  - {config: paged_edge_b1_s2048_bf16_t4, default: false}

--- a/tirx_kernels/msa/sparse_atten_fwd.py
+++ b/tirx_kernels/msa/sparse_atten_fwd.py
@@ -78,11 +78,20 @@ TMEM_TOTAL = 512
 # `split_P_arrive = n_block // 4 * 3`, floored to a multiple of 32 (:165-167).
 SPLIT_P_ARRIVE = 96
 
-# Register budgets on the causal path (:173-181).
-NUM_REGS_SOFTMAX = 176
-NUM_REGS_STORE = 112
+# Register budgets (:173-181). Softmax gains what store gives up, so the two
+# move together or the launch exceeds its 512-register budget; `num_regs_other`
+# is DERIVED as `512 - softmax*2 - store` and lands on 48 either way, which is
+# why the export shows `setmaxnreg.dec 48` three times in both parities.
+NUM_REGS_SOFTMAX_CAUSAL = 176
+NUM_REGS_SOFTMAX_NONCAUSAL = 192
+NUM_REGS_STORE_CAUSAL = 112
+NUM_REGS_STORE_NONCAUSAL = 80
 NUM_REGS_OTHER = 48
-EX2_EMU_FREQ = 16
+# `ex2_emu_freq = 16 if causal else 0` (:180-184). Zero does not mean "every
+# sixteenth" with a different period -- it selects `apply_exp2_convert`'s own
+# `const_expr(ex2_emu_freq == 0)` arm (softmax.py:381-383), which sends every
+# element through real MUFU with no polynomial and no `fmax(x, -127)` clamp.
+EX2_EMU_FREQ_CAUSAL = 16
 EX2_EMU_START_FRG = 1
 
 # cuTensorMapEncodeTiled enum values.
@@ -161,6 +170,12 @@ _TMA_G2S_2D_CACHE = (
 )
 _TMA_G2S_3D_CACHE = (
     "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+# Paging appends a page mode to the KV descriptors, so the same copy is issued
+# at rank 4. Every other modifier -- load mode, completion, cache hint -- and
+# the transaction byte count are unchanged from the 3-D form.
+_TMA_G2S_4D_CACHE = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
 )
 # L2 eviction policies, per the reference's own defaults (tma_utils.py:23-24,
 # :204, :251). Which tensor gets which is load-bearing, not cosmetic: a KV block
@@ -990,9 +1005,8 @@ DTYPE_MODES: dict[str, dict[str, str]] = {
     },
 }
 
-# `mO_partial.element_type`, validated at :372-377. fp16 is accepted upstream
-# but never exercised there, so it stays out of this port's domain.
-PARTIAL_DTYPES = ("float32", "bfloat16", "float8_e4m3")
+# `mO_partial.element_type`, validated at :372-377.
+PARTIAL_DTYPES = ("float32", "bfloat16", "float16", "float8_e4m3")
 
 _TORCH_DTYPES = {
     "bfloat16": "bfloat16",
@@ -1024,6 +1038,8 @@ def _kernel(
     lse_partial_h: T.handle,
     lse_temperature_partial_h: T.Optional(T.handle),
     q_flat_h: T.handle,
+    page_table_h: T.Optional(T.handle),
+    seqused_k_h: T.Optional(T.handle),
     cu_seqlens_q_h: T.handle,
     cu_seqlens_k_h: T.handle,
     softmax_scale_log2: T.float32,
@@ -1046,6 +1062,17 @@ def _kernel(
     dtype_mode: T.constexpr,
     partial_dtype: T.constexpr,
 ):
+    # Paging and `seqused_k` are selected by handle presence, the convention this
+    # module already uses for `lse_temperature_partial_h`: a flat specialization
+    # pins both to None and its signature is unchanged.
+    paged = T.meta_var(page_table_h is not None)
+    seqused = T.meta_var(seqused_k_h is not None)
+
+    # Trace-time register split and exp2 mix; see the constants block.
+    num_regs_softmax = T.meta_var(NUM_REGS_SOFTMAX_CAUSAL if causal else NUM_REGS_SOFTMAX_NONCAUSAL)
+    num_regs_store = T.meta_var(NUM_REGS_STORE_CAUSAL if causal else NUM_REGS_STORE_NONCAUSAL)
+    ex2_emu_freq = T.meta_var(EX2_EMU_FREQ_CAUSAL if causal else 0)
+
     mode = T.meta_var(DTYPE_MODES[dtype_mode])
     q_dtype = T.meta_var(mode["q"])
     k_dtype = T.meta_var(mode["k"])
@@ -1073,6 +1100,15 @@ def _kernel(
     q_load_tile = T.meta_var(HEAD_DIM if q_bytes == 1 else K_TILE)
     q_tokens_per_group = T.meta_var(M_BLOCK // qheadperkv)
 
+    # Paging changes the RANK of the K/V tensors, so the binding has to change
+    # with it: `[num_pages, head_kv, page_size, head_dim]` against the flat
+    # `[total_k, head_kv, head_dim]`. The element count is identical --
+    # `num_pages * page_size == total_k` -- and the kernel only ever takes
+    # `.data` from these, but a rank mismatch is rejected at the call boundary.
+    # One binding for both axes. The kernel only takes `.data` from K/V -- the
+    # tensormap carries the real shape -- and `num_pages * page_size == total_k`,
+    # so the same 3-D binding describes the same bytes either way. The host
+    # hands over a 3-D view; a 4-D binding here faults the launcher.
     k = T.match_buffer(k_h, (total_k, num_heads_kv, HEAD_DIM), k_ty, scope="global")
     v = T.match_buffer(v_h, (total_k, num_heads_kv, HEAD_DIM), v_ty, scope="global")
     k2q_q_indices = T.match_buffer(k2q_q_indices_h, (num_heads_kv * nnz,), "int32", scope="global")
@@ -1099,6 +1135,20 @@ def _kernel(
     q_flat = T.match_buffer(q_flat_h, (total_q * head_q, HEAD_DIM), q_ty, scope="global")
     cu_seqlens_q = T.match_buffer(cu_seqlens_q_h, (num_batches + 1,), "int32", scope="global")
     cu_seqlens_k = T.match_buffer(cu_seqlens_k_h, (num_batches + 1,), "int32", scope="global")
+    # `page_size == blk_kv` is mandatory upstream (:99-107), so a CTA's KV block
+    # is exactly one page and the page table is rectangular. That is what lets
+    # `pages_per_seq` come from the scalars already in the ABI instead of a new
+    # argument: upstream reads it as `mPageTable.shape[1]` (:211).
+    if paged:
+        # Runtime values, as upstream's `mPageTable.shape[1]` is; derived from
+        # scalars already in the ABI because the page table is rectangular.
+        # The table holds one entry per page, and `num_batches * pages_per_seq`
+        # is exactly `num_pages`, so the binding shape stays an expression over
+        # PrimFunc params -- a match_buffer shape cannot name a locally derived
+        # scalar.
+        page_table = T.match_buffer(page_table_h, (total_k // N_BLOCK,), "int32", scope="global")
+    if seqused:
+        seqused_k = T.match_buffer(seqused_k_h, (num_batches,), "int32", scope="global")
 
     # -----------------------------------------------------------------------
     # TMA descriptors, encoded in the launcher prologue.
@@ -1114,62 +1164,44 @@ def _kernel(
     # tensor. Both boxes are one 128-byte swizzle atom wide, so a 128-wide tile
     # takes two issues.
     # -----------------------------------------------------------------------
+    # Paging appends a page mode and pins the token coordinate to 0; it changes
+    # nothing about the first two dims. Dims are fastest-first, so the flat form
+    # is (head_dim, total_k, head_kv) and the paged one
+    # (head_dim, page_size, head_kv, num_pages) -- the `layout_t = [2,3,1,0]`
+    # host permute (:380-397). A rank-3 encode against a rank-4 tensor is silent
+    # garbage, which is why the rank follows the tensor and not the caller.
     k_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
-    T.call_packed(
-        "runtime.cuTensorMapEncodeTiled",
-        k_map,
-        k_ty,
-        3,
-        k.data,
-        HEAD_DIM,
-        num_heads_kv,
-        total_k,
-        HEAD_DIM * k_bytes,
-        num_heads_kv * HEAD_DIM * k_bytes,
-        _swizzle_elems(k_bytes),
-        1,
-        N_BLOCK,
-        1,
-        1,
-        1,
-        0,
-        _SWIZZLE_128B,
-        _L2_PROMOTION_256B,
-        0,
-    )
-    v_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
-    T.call_packed(
-        "runtime.cuTensorMapEncodeTiled",
-        v_map,
-        v_ty,
-        3,
-        v.data,
-        HEAD_DIM,
-        num_heads_kv,
-        total_k,
-        HEAD_DIM * v_bytes,
-        num_heads_kv * HEAD_DIM * v_bytes,
-        _swizzle_elems(v_bytes),
-        1,
-        N_BLOCK,
-        1,
-        1,
-        1,
-        0,
-        _SWIZZLE_128B,
-        _L2_PROMOTION_256B,
-        0,
-    )
-    # The fp8 staging path lands in a PLAIN buffer, so its descriptor must carry
-    # no swizzle. The reference builds a separate `cpasync.make_tiled_tma_atom`
-    # over a row-major box for exactly this reason (:474-479); reusing the
-    # swizzled MMA descriptor writes permuted bytes that the dequantization then
-    # reads back in logical order, which silently scrambles every row.
-    if k_stage_fp8 or v_stage_fp8:
-        k_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if paged:
         T.call_packed(
             "runtime.cuTensorMapEncodeTiled",
-            k_stage_map,
+            k_map,
+            k_ty,
+            4,
+            k.data,
+            HEAD_DIM,
+            N_BLOCK,
+            num_heads_kv,
+            total_k // N_BLOCK,
+            HEAD_DIM * k_bytes,
+            N_BLOCK * HEAD_DIM * k_bytes,
+            num_heads_kv * N_BLOCK * HEAD_DIM * k_bytes,
+            _swizzle_elems(k_bytes),
+            N_BLOCK,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            _SWIZZLE_128B,
+            _L2_PROMOTION_256B,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            k_map,
             k_ty,
             3,
             k.data,
@@ -1178,21 +1210,49 @@ def _kernel(
             total_k,
             HEAD_DIM * k_bytes,
             num_heads_kv * HEAD_DIM * k_bytes,
-            HEAD_DIM,
+            _swizzle_elems(k_bytes),
             1,
             N_BLOCK,
             1,
             1,
             1,
             0,
-            0,
+            _SWIZZLE_128B,
             _L2_PROMOTION_256B,
             0,
         )
-        v_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    v_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+    if paged:
         T.call_packed(
             "runtime.cuTensorMapEncodeTiled",
-            v_stage_map,
+            v_map,
+            v_ty,
+            4,
+            v.data,
+            HEAD_DIM,
+            N_BLOCK,
+            num_heads_kv,
+            total_k // N_BLOCK,
+            HEAD_DIM * v_bytes,
+            N_BLOCK * HEAD_DIM * v_bytes,
+            num_heads_kv * N_BLOCK * HEAD_DIM * v_bytes,
+            _swizzle_elems(v_bytes),
+            N_BLOCK,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            _SWIZZLE_128B,
+            _L2_PROMOTION_256B,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            v_map,
             v_ty,
             3,
             v.data,
@@ -1201,17 +1261,130 @@ def _kernel(
             total_k,
             HEAD_DIM * v_bytes,
             num_heads_kv * HEAD_DIM * v_bytes,
-            HEAD_DIM,
+            _swizzle_elems(v_bytes),
             1,
             N_BLOCK,
             1,
             1,
             1,
             0,
-            0,
+            _SWIZZLE_128B,
             _L2_PROMOTION_256B,
             0,
         )
+    # The fp8 staging path lands in a PLAIN buffer, so its descriptor must carry
+    # no swizzle. The reference builds a separate `cpasync.make_tiled_tma_atom`
+    # over a row-major box for exactly this reason (:474-479); reusing the
+    # swizzled MMA descriptor writes permuted bytes that the dequantization then
+    # reads back in logical order, which silently scrambles every row.
+    if k_stage_fp8 or v_stage_fp8:
+        # The staging descriptor follows the same rank as the MMA one: paging is
+        # a property of the tensor, not of who reads it. Leaving this rank-3
+        # while the load arm issues the 4-D copy is an illegal instruction, and
+        # the two are selected by different flags -- rank by `paged`, staging by
+        # `k_stage_fp8` -- so they have to be kept in step by hand.
+        k_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        if paged:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                k_stage_map,
+                k_ty,
+                4,
+                k.data,
+                HEAD_DIM,
+                N_BLOCK,
+                num_heads_kv,
+                total_k // N_BLOCK,
+                HEAD_DIM * k_bytes,
+                N_BLOCK * HEAD_DIM * k_bytes,
+                num_heads_kv * N_BLOCK * HEAD_DIM * k_bytes,
+                HEAD_DIM,
+                N_BLOCK,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                _L2_PROMOTION_256B,
+                0,
+            )
+        else:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                k_stage_map,
+                k_ty,
+                3,
+                k.data,
+                HEAD_DIM,
+                num_heads_kv,
+                total_k,
+                HEAD_DIM * k_bytes,
+                num_heads_kv * HEAD_DIM * k_bytes,
+                HEAD_DIM,
+                1,
+                N_BLOCK,
+                1,
+                1,
+                1,
+                0,
+                0,
+                _L2_PROMOTION_256B,
+                0,
+            )
+        v_stage_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
+        if paged:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                v_stage_map,
+                v_ty,
+                4,
+                v.data,
+                HEAD_DIM,
+                N_BLOCK,
+                num_heads_kv,
+                total_k // N_BLOCK,
+                HEAD_DIM * v_bytes,
+                N_BLOCK * HEAD_DIM * v_bytes,
+                num_heads_kv * N_BLOCK * HEAD_DIM * v_bytes,
+                HEAD_DIM,
+                N_BLOCK,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                0,
+                0,
+                _L2_PROMOTION_256B,
+                0,
+            )
+        else:
+            T.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                v_stage_map,
+                v_ty,
+                3,
+                v.data,
+                HEAD_DIM,
+                num_heads_kv,
+                total_k,
+                HEAD_DIM * v_bytes,
+                num_heads_kv * HEAD_DIM * v_bytes,
+                HEAD_DIM,
+                1,
+                N_BLOCK,
+                1,
+                1,
+                1,
+                0,
+                0,
+                _L2_PROMOTION_256B,
+                0,
+            )
 
     # The TMA-Q box is one token group of `qheadperkv` rows; the gather4 box is
     # a single row, because the instruction supplies four row coordinates.
@@ -1297,6 +1470,11 @@ def _kernel(
     s_q_idx = pool.alloc((O_STAGE * q_tokens_per_group,), "int32", align=16)
     s_row_meta = pool.alloc((8,), "int32", align=16)
     s_diag_q_count = pool.alloc((1,), "int32", align=16)
+    # `sPagedKvIdx` (:581): the physical page for this CTA's KV block. Allocated
+    # unconditionally, exactly as the source does, so flat and paged share every
+    # later offset in the pool; written by thread 0 and read by both KV-load
+    # warps under `paged`.
+    s_paged_kv_idx = pool.alloc((1,), "int32", align=16)
     s_q_load_m_idx = pool.alloc((Q_STAGE * q_tokens_per_group,), "int32", align=16)
     s_qidx_meta = pool.alloc((QIDX_META_STAGES * q_tokens_per_group,), "int32", align=16)
 
@@ -1361,12 +1539,31 @@ def _kernel(
         )
         row_start: T.int32 = base_row_start + work_q_begin[0]
         count_raw: T.int32 = work_q_count[0]
-        seqlen_k: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0] + 1) - ld_global_i32(
-            cu_seqlens_k, batch_idx[0]
-        )
+        # Upstream reads this as `mPageTable.shape[1]` (:211). The table is
+        # rectangular because `page_size == blk_kv`, so `num_batches *
+        # pages_per_seq == num_pages == total_k / page_size`, and the quotient
+        # of two ABI scalars recovers it without a new argument.
+        if paged:
+            pages_per_seq: T.int32 = udiv_i32(udiv_i32(total_k, N_BLOCK), num_batches)
+        # `_logical_seqlen_k` (:204-212), in the source's own priority order.
+        # `seqused` is tested FIRST: checking paged first would silently
+        # substitute the zero-padded paged capacity for a shorter supplied
+        # length.
+        if seqused:
+            seqlen_k: T.int32 = ld_global_i32(seqused_k, batch_idx[0])
+        elif paged:
+            seqlen_k: T.int32 = pages_per_seq * N_BLOCK
+        else:
+            seqlen_k: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0] + 1) - ld_global_i32(
+                cu_seqlens_k, batch_idx[0]
+            )
         kv_valid_cols: T.int32 = T.min(T.max(seqlen_k - kv_block_idx[0] * N_BLOCK, 0), N_BLOCK)
         q_batch_offset: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0])
-        k_batch_offset: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0])
+        # Paging offsets by page, not by batch (:880-884).
+        if paged:
+            k_batch_offset: T.int32 = 0
+        else:
+            k_batch_offset: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0])
         st_shared_i32(s_row_meta, 0, batch_idx[0])
         st_shared_i32(s_row_meta, 1, kv_block_idx[0])
         st_shared_i32(s_row_meta, 2, row_start)
@@ -1374,17 +1571,40 @@ def _kernel(
         st_shared_i32(s_row_meta, 4, kv_valid_cols)
         st_shared_i32(s_row_meta, 5, q_batch_offset)
         st_shared_i32(s_row_meta, 6, k_batch_offset)
-        seqlen_q: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0] + 1) - q_batch_offset
-        causal_q_offset: T.int32 = seqlen_k - seqlen_q
-        st_shared_i32(s_row_meta, 7, causal_q_offset)
+        # Computed ONLY under `const_expr(self.causal)` (:892-901); a non-causal
+        # build never loads `cu_seqlens_q[batch+1]` at all. Deliberately
+        # unclamped: with `seqused_k` shorter than the Q length the offset goes
+        # negative, the leading `seqlen_q - seqused_k[b]` queries have no legal
+        # key, and their neutral partial is O = 0 with LSE = -inf. Clamping it
+        # to a finite value would diverge from the source.
+        causal_q_offset = T.alloc_local((1,), "int32")
+        causal_q_offset[0] = 0
+        if causal:
+            seqlen_q: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0] + 1) - q_batch_offset
+            causal_q_offset[0] = seqlen_k - seqlen_q
+        st_shared_i32(s_row_meta, 7, causal_q_offset[0])
+
+        # The physical page for this CTA's KV block, resolved once by thread 0
+        # (:903-906, paged_kv.py:60-65) and published under the same fence as
+        # the row metadata below -- paging adds no barrier of its own.
+        if paged:
+            st_shared_i32(
+                s_paged_kv_idx,
+                0,
+                ld_global_i32(page_table, batch_idx[0] * pages_per_seq + kv_block_idx[0]),
+            )
 
         # The causal diagonal split point: a 32-step binary search over the CSR
         # row, which is sorted by q_idx (:259-285, :919-935). The export keeps
         # the loop rolled with exactly one probe load in the body.
+        # Computed ONLY under `const_expr(self.causal)` (:919-934): a non-causal
+        # build emits no search at all and leaves the count at zero, which is
+        # also the only value its consumer would accept -- a search result there
+        # would drive the diagonal mask over rows that have no diagonal.
         diag_q_count = T.alloc_local((1,), "int32")
         diag_q_count[0] = 0
-        if count_raw > 0 and kv_valid_cols > 0:
-            q_threshold: T.int32 = (kv_block_idx[0] * N_BLOCK + kv_valid_cols) - causal_q_offset
+        if causal and count_raw > 0 and kv_valid_cols > 0:
+            q_threshold: T.int32 = (kv_block_idx[0] * N_BLOCK + kv_valid_cols) - causal_q_offset[0]
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
             lo[0] = 0
@@ -1473,7 +1693,7 @@ def _kernel(
     # -----------------------------------------------------------------------
     if tidx >= Q_LOAD_WARP_BASE * WARP_SIZE and tidx < MMA_WARP_ID * WARP_SIZE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_STORE)))
+            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(num_regs_store)))
             q_row_start: T.int32 = ld_shared_i32(s_row_meta, 2)
             q_count_raw: T.int32 = ld_shared_i32(s_row_meta, 3)
             q_batch_off: T.int32 = ld_shared_i32(s_row_meta, 5)
@@ -1692,49 +1912,106 @@ def _kernel(
             kv_has_work: T.int32 = T.cast(ld_shared_i32(s_row_meta, 3) > 0, "int32")
             if kv_has_work != 0:
                 kv_row_start: T.int32 = k_batch_off + kv_block_load * N_BLOCK
+                # Read warp-wide, in this warp's own arm, AFTER the has-work
+                # early-out (:1569 for K, :1610 for V -- two static loads in the
+                # module, not one hoisted read). Within an arm the value feeds
+                # every subtile issue.
                 if warp_idx == KV_LOAD_WARP_BASE:
+                    page_idx_k = T.alloc_local((1,), "int32")
+                    if paged:
+                        page_idx_k[0] = ld_shared_i32(s_paged_kv_idx, 0)
                     if T.cuda.elect_sync():
                         for sub in T.unroll(KV_SUBTILES(k_bytes)):
-                            T.evaluate(
-                                T.ptx[_TMA_G2S_3D_CACHE](
-                                    T.ptr_byte_offset(
-                                        (s_k_fp8 if k_stage_fp8 else s_k).ptr_to([0, 0]),
-                                        sub * N_BLOCK * _swizzle_elems(k_bytes) * k_bytes,
-                                        k_ty,
-                                    ),
-                                    T.address_of(k_stage_map if k_stage_fp8 else k_map),
-                                    T.int32(sub * _swizzle_elems(k_bytes)),
-                                    head_kv_idx[0],
-                                    kv_row_start,
-                                    T.cuda.cvta_generic_to_shared(
-                                        (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0])
-                                    ),
-                                    _KV_TMA_CACHE_HINT,
+                            # PAGED_KV selects the rank and the coordinate tuple
+                            # and nothing else; the staging destination is an
+                            # independent axis (:1332-1340), so the two must not
+                            # be composed with an `elif`.
+                            if paged:
+                                T.evaluate(
+                                    T.ptx[_TMA_G2S_4D_CACHE](
+                                        T.ptr_byte_offset(
+                                            (s_k_fp8 if k_stage_fp8 else s_k).ptr_to([0, 0]),
+                                            sub * N_BLOCK * _swizzle_elems(k_bytes) * k_bytes,
+                                            k_ty,
+                                        ),
+                                        T.address_of(k_stage_map if k_stage_fp8 else k_map),
+                                        T.int32(sub * _swizzle_elems(k_bytes)),
+                                        T.int32(0),
+                                        head_kv_idx[0],
+                                        page_idx_k[0],
+                                        T.cuda.cvta_generic_to_shared(
+                                            (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0])
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
                                 )
-                            )
+                            else:
+                                T.evaluate(
+                                    T.ptx[_TMA_G2S_3D_CACHE](
+                                        T.ptr_byte_offset(
+                                            (s_k_fp8 if k_stage_fp8 else s_k).ptr_to([0, 0]),
+                                            sub * N_BLOCK * _swizzle_elems(k_bytes) * k_bytes,
+                                            k_ty,
+                                        ),
+                                        T.address_of(k_stage_map if k_stage_fp8 else k_map),
+                                        T.int32(sub * _swizzle_elems(k_bytes)),
+                                        head_kv_idx[0],
+                                        kv_row_start,
+                                        T.cuda.cvta_generic_to_shared(
+                                            (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0])
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
+                                )
+                        # OUTSIDE the paged/flat conditional, as in the source
+                        # (:1579-1580): an arm that omitted it would never signal
+                        # the barrier and the MMA warp's wait would hang.
                         T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
                             (bar_k_tma if k_stage_fp8 else bar_k).ptr_to([0]), T.uint32(1)
                         )
                 if warp_idx == KV_LOAD_WARP_BASE + 1:
+                    page_idx_v = T.alloc_local((1,), "int32")
+                    if paged:
+                        page_idx_v[0] = ld_shared_i32(s_paged_kv_idx, 0)
                     if T.cuda.elect_sync():
                         for sub in T.unroll(KV_SUBTILES(v_bytes)):
-                            T.evaluate(
-                                T.ptx[_TMA_G2S_3D_CACHE](
-                                    T.ptr_byte_offset(
-                                        (s_v_fp8 if v_stage_fp8 else s_v).ptr_to([0, 0]),
-                                        sub * N_BLOCK * _swizzle_elems(v_bytes) * v_bytes,
-                                        v_ty,
-                                    ),
-                                    T.address_of(v_stage_map if v_stage_fp8 else v_map),
-                                    T.int32(sub * _swizzle_elems(v_bytes)),
-                                    head_kv_idx[0],
-                                    kv_row_start,
-                                    T.cuda.cvta_generic_to_shared(
-                                        (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0])
-                                    ),
-                                    _KV_TMA_CACHE_HINT,
+                            if paged:
+                                T.evaluate(
+                                    T.ptx[_TMA_G2S_4D_CACHE](
+                                        T.ptr_byte_offset(
+                                            (s_v_fp8 if v_stage_fp8 else s_v).ptr_to([0, 0]),
+                                            sub * N_BLOCK * _swizzle_elems(v_bytes) * v_bytes,
+                                            v_ty,
+                                        ),
+                                        T.address_of(v_stage_map if v_stage_fp8 else v_map),
+                                        T.int32(sub * _swizzle_elems(v_bytes)),
+                                        T.int32(0),
+                                        head_kv_idx[0],
+                                        page_idx_v[0],
+                                        T.cuda.cvta_generic_to_shared(
+                                            (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0])
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
                                 )
-                            )
+                            else:
+                                T.evaluate(
+                                    T.ptx[_TMA_G2S_3D_CACHE](
+                                        T.ptr_byte_offset(
+                                            (s_v_fp8 if v_stage_fp8 else s_v).ptr_to([0, 0]),
+                                            sub * N_BLOCK * _swizzle_elems(v_bytes) * v_bytes,
+                                            v_ty,
+                                        ),
+                                        T.address_of(v_stage_map if v_stage_fp8 else v_map),
+                                        T.int32(sub * _swizzle_elems(v_bytes)),
+                                        head_kv_idx[0],
+                                        kv_row_start,
+                                        T.cuda.cvta_generic_to_shared(
+                                            (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0])
+                                        ),
+                                        _KV_TMA_CACHE_HINT,
+                                    )
+                                )
                         T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
                             (bar_v_tma if v_stage_fp8 else bar_v).ptr_to([0]), T.uint32(1)
                         )
@@ -2094,6 +2371,9 @@ def _kernel(
         count_raw_sm: T.int32 = ld_shared_i32(s_row_meta, 3)
         kv_valid_cols: T.int32 = ld_shared_i32(s_row_meta, 4)
         q_batch_off_sm: T.int32 = ld_shared_i32(s_row_meta, 5)
+        # Read unconditionally, as the source does (:1119-1127): both cells only
+        # ever feed the diagonal mask, so a non-causal build leaves two dead
+        # scalar loads behind rather than gating them away.
         causal_q_off: T.int32 = ld_shared_i32(s_row_meta, 7)
         diag_q_count_sm: T.int32 = ld_shared_i32(s_diag_q_count, 0)
 
@@ -2128,7 +2408,12 @@ def _kernel(
 
         if count_raw_sm > 0:
             num_q_groups_sm: T.int32 = uceil_div_i32(count_raw_sm, q_tokens_per_group)
-            kv_block_col_start: T.int32 = kv_block_sm * N_BLOCK
+            # Zero unless causal (:2461-2463); it only ever offsets the
+            # diagonal column limit, which a non-causal build never computes.
+            if causal:
+                kv_block_col_start: T.int32 = kv_block_sm * N_BLOCK
+            else:
+                kv_block_col_start: T.int32 = 0
             # WG0 takes the even Q groups, WG1 the odd ones (:2465-2468).
             num_stage_groups: T.int32 = udiv_i32(num_q_groups_sm + (1 - stage), 2)
 
@@ -2138,12 +2423,6 @@ def _kernel(
                 producer_phase: T.int32 = phase ^ 1
                 qidx_meta_slot: T.int32 = (
                     T.bitwise_and(qi_group, QIDX_META_STAGES - 1) * q_tokens_per_group
-                )
-                # How many of this group's tokens still sit on the causal
-                # diagonal and therefore need per-column masking (:2478-2486).
-                qi_group_start: T.int32 = qi_group * q_tokens_per_group
-                masked_tok_count: T.int32 = T.max(
-                    0, T.min(q_tokens_per_group, diag_q_count_sm - qi_group_start)
                 )
 
                 # ---------------- softmax step (:2186-2352) ----------------
@@ -2166,13 +2445,25 @@ def _kernel(
                 # how the reference emits it too (mask.py:36-46, :71-121).
                 col_limit = T.alloc_local((1,), "int32")
                 col_limit[0] = kv_valid_cols
-                if masked_tok_count > 0:
-                    tok_of_row: T.int32 = udiv_i32(group_tidx, qheadperkv)
-                    q_idx_mask: T.int32 = T.bitwise_and(
-                        ld_shared_i32(s_qidx_meta, qidx_meta_slot + tok_of_row), Q_IDX_MASK
+                if causal:
+                    # How many of this group's tokens still sit on the causal
+                    # diagonal and therefore need per-column masking
+                    # (:2478-2486). A non-causal build passes a literal zero
+                    # here and takes the column-limit-only arm (:2544-2548), so
+                    # none of this is emitted.
+                    qi_group_start: T.int32 = qi_group * q_tokens_per_group
+                    masked_tok_count: T.int32 = T.max(
+                        0, T.min(q_tokens_per_group, diag_q_count_sm - qi_group_start)
                     )
-                    causal_col_limit: T.int32 = q_idx_mask + causal_q_off - kv_block_col_start + 1
-                    col_limit[0] = T.min(kv_valid_cols, causal_col_limit)
+                    if masked_tok_count > 0:
+                        tok_of_row: T.int32 = udiv_i32(group_tidx, qheadperkv)
+                        q_idx_mask: T.int32 = T.bitwise_and(
+                            ld_shared_i32(s_qidx_meta, qidx_meta_slot + tok_of_row), Q_IDX_MASK
+                        )
+                        causal_col_limit: T.int32 = (
+                            q_idx_mask + causal_q_off - kv_block_col_start + 1
+                        )
+                        col_limit[0] = T.min(kv_valid_cols, causal_col_limit)
                 if col_limit[0] < N_BLOCK:
                     for chunk in T.unroll(N_BLOCK // MASK_R2P_CHUNK):
                         shift: T.int32 = T.max((chunk + 1) * MASK_R2P_CHUNK - col_limit[0], 0)
@@ -2247,8 +2538,16 @@ def _kernel(
                 # decision on (j, k), so both indices have to be Python ints.
                 for j in range(4):
                     for k in range(0, 32, 2):
+                        # The zero-frequency arm is a SHORT-CIRCUIT, not a
+                        # period of zero: `apply_exp2_convert` has its own
+                        # `const_expr(ex2_emu_freq == 0)` branch
+                        # (softmax.py:381-383) that takes real exp2 for both
+                        # elements of every pair, with no polynomial and no
+                        # `fmax` clamp. Reaching the modulo with a zero
+                        # frequency would divide by zero at trace time.
                         use_mufu = T.meta_var(
-                            (k % EX2_EMU_FREQ) < (EX2_EMU_FREQ - 4)
+                            ex2_emu_freq == 0
+                            or (k % ex2_emu_freq) < (ex2_emu_freq - 4)
                             or j >= 3
                             or j < EX2_EMU_START_FRG
                         )
@@ -2315,24 +2614,35 @@ def _kernel(
 
     if warp_idx < SOFTMAX1_WARP_BASE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(num_regs_softmax)))
             softmax_warpgroup(0)
 
     if warp_idx >= SOFTMAX1_WARP_BASE and warp_idx < Q_LOAD_WARP_BASE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(num_regs_softmax)))
             softmax_warpgroup(1)
 
 
 def get_kernel(**config):
     """Return the TIRx specialization for one compile key."""
     config.pop("label", None)
+    paged = bool(config.get("paged", False))
+    seqused = bool(config.get("seqused", False))
+    if seqused and not paged:
+        raise ValueError("seqused_k is only supported together with page_table")
     kernel = _kernel.specialize(
         qheadperkv=int(config["qhead_per_kv"]),
         causal=bool(config.get("causal", True)),
         dtype_mode=str(config.get("dtype", "bf16")),
         partial_dtype=str(config.get("partial_dtype", "float32")),
         **({} if config.get("temperature") else {"lse_temperature_partial_h": None}),
+        # Both axes are selected by handle presence, so a flat specialization
+        # pins them to None and keeps the signature it had before the axis
+        # existed. Upstream's compile key carries them as separate entries
+        # (interface.py:1714-1731); `page_size` needs none because it is forced
+        # equal to `blk_kv`.
+        **({} if paged else {"page_table_h": None}),
+        **({} if seqused else {"seqused_k_h": None}),
     )
     return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
 
@@ -2359,9 +2669,13 @@ def _case(
     causal: bool = True,
     blk_kv: int = BLK_KV,
     seqlen_pattern: str = "uniform",
+    paged: bool = False,
+    seqused: bool = False,
 ) -> dict:
     return {
         "label": label,
+        "paged": paged,
+        "seqused": seqused,
         "batch": batch,
         "seqlen_q": seqlen_q,
         "seqlen_k": seqlen_k,
@@ -2481,6 +2795,53 @@ BENCH_CONFIGS = [
         qhead_per_kv=2,
         topk=4,
     ),
+    # Paged. `paged_ring48k_bf16_qh16_t16` deliberately mirrors the flat
+    # marquee row shape for shape, so the pair reads directly as the cost of
+    # the page indirection rather than of a different workload.
+    _case(
+        label="paged_ring48k_bf16_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        seqlen_k=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_bf16_s16384_qh4_t16",
+        batch=2,
+        seqlen_q=16384,
+        seqlen_k=16384,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        paged=True,
+        seqused=True,
+    ),
+    _case(
+        label="paged_fp8_s16384_qh16_t16",
+        batch=1,
+        seqlen_q=16384,
+        seqlen_k=16384,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=16,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+        paged=True,
+    ),
+    _case(
+        label="paged_edge_b1_s2048_bf16_t4",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+        paged=True,
+    ),
 ]
 
 # Correctness runs at test scale: a full reference for the marquee shapes would
@@ -2592,6 +2953,139 @@ CONFIGS = [
         topk=2,
         seqlen_pattern="varlen",
     ),
+    # Paged KV. `page_size == blk_kv`, so a CTA's block is one page and the only
+    # kernel-visible change is the TMA coordinate; these cover both Q paths,
+    # both KV staging forms, and the two `seqused_k` states.
+    _case(
+        label="paged_bf16_s4096_qh4_t16",
+        batch=2,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        paged=True,
+    ),
+    _case(
+        label="paged_bf16_s4096_qh16_t8",
+        batch=2,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=8,
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_bf16_s4096_qh4_t16",
+        batch=3,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        paged=True,
+        seqused=True,
+    ),
+    # Varlen under `seqused_k`: the per-batch trims land at different offsets
+    # inside the last page, so the column limit and the causal diagonal move
+    # independently per batch.
+    _case(
+        label="paged_seqused_varlen_b3_s2048_qh8_t8",
+        batch=3,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        paged=True,
+        seqused=True,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="paged_fp8_s2048_qh16_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=8,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+        paged=True,
+    ),
+    # FP8 K/V staged to BF16: the staging descriptor is a second rank-4 map.
+    _case(
+        label="paged_fp8kv_s2048_qh4_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=8,
+        dtype="bf16q_fp8kv",
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_fp8_pvbf16_s2048_qh8_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        dtype="fp8_pvbf16",
+        paged=True,
+        seqused=True,
+    ),
+    # `causal=False`: a different register budget, `ex2_emu_freq = 0`, no
+    # diagonal binary search, and a column-limit-only mask (:173-184).
+    _case(
+        label="corr_noncausal_bf16_s2048_qh4_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=8,
+        causal=False,
+    ),
+    _case(
+        label="corr_noncausal_paged_fp8_s2048_qh16_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=8,
+        dtype="fp8",
+        partial_dtype="bfloat16",
+        causal=False,
+        paged=True,
+    ),
+    # FP16 partials share the BF16 v8 epilogue store width (:372-377).
+    _case(
+        label="corr_partial_fp16_s2048_qh8_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        partial_dtype="float16",
+    ),
+    # topk=32 is the top of upstream's supported set; it changes the split-slot
+    # count and the work list, not the compiled code.
+    _case(
+        label="corr_topk32_s4096_qh4",
+        batch=1,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=32,
+    ),
 ]
 
 
@@ -2617,6 +3111,74 @@ _CSR_CONFIG_KEYS = (
     "blk_kv",
     "seqlen_pattern",
 )
+
+
+def _seqused_trim(batch: int, blk_kv: int) -> list[int]:
+    """Per-batch shortfall between the logical K length and the paged capacity.
+
+    Every trim stays **inside one page**, which is what keeps the CSR valid
+    without a pruning pass: `ceil(effective / blk_kv)` still equals the capacity
+    row count, so no edge can reference a block past `seqused_k`. Upstream
+    reaches the same state from the other side, selecting against the full
+    length and rewriting out-of-range entries to `-1`
+    (test_sparse_atten.py:956-971); a trim of a whole page or more would need
+    that rewrite to stay a legal input, and an input upstream would never
+    produce is not worth constructing.
+
+    Deterministic and deliberately mixed, so the partial-block column limit and
+    the shifted causal diagonal both get exercised. The first entry is nonzero
+    and the second is the full page rather than the other way round: a
+    single-batch config would otherwise trim nothing, making `seqused_k` equal
+    to the paged capacity and testing the axis only in name.
+    """
+    offsets = (37, 0, blk_kv - 1, 149, blk_kv // 2)
+    return [offsets[i % len(offsets)] % blk_kv for i in range(batch)]
+
+
+def _pack_paged_kv(flat, seqlens_k, page_size: int, page_table):
+    """Scatter `[total_k, head_kv, D]` into `[num_pages, head_kv, page_size, D]`.
+
+    Physical pages come from `page_table`, which is shuffled, so a kernel that
+    ignored the table and walked pages in order would read another sequence's
+    tokens rather than merely stale ones. Trailing partial pages stay zero, as
+    upstream's builder leaves them (test_sparse_atten.py:401).
+    """
+    import torch
+
+    head_kv, dim = flat.shape[1], flat.shape[2]
+    num_pages = int(page_table.numel())
+    paged = torch.zeros((num_pages, head_kv, page_size, dim), dtype=flat.dtype, device=flat.device)
+    table = page_table.tolist()
+    offset = 0
+    for batch_idx, length in enumerate(seqlens_k):
+        length = int(length)
+        for page in range(len(table[batch_idx])):
+            lo = page * page_size
+            hi = min(lo + page_size, length)
+            if hi > lo:
+                paged[int(table[batch_idx][page]), :, : hi - lo] = flat[
+                    offset + lo : offset + hi
+                ].transpose(0, 1)
+        offset += length
+    return paged
+
+
+def _build_page_table(batch: int, pages_per_seq: int, generator):
+    """A shuffled, rectangular `[batch, pages_per_seq]` int32 table.
+
+    16-byte aligned because the production adapter asserts it and over-allocates
+    to guarantee it (sparse_fmha_adapter.py:239-242).
+    """
+    import torch
+
+    num_pages = batch * pages_per_seq
+    padded = torch.empty(num_pages + 4, dtype=torch.int32, device="cuda")
+    shift = (-padded.data_ptr()) % 16 // padded.element_size()
+    table = padded[shift : shift + num_pages]
+    table.copy_(torch.randperm(num_pages, device="cuda", generator=generator).to(torch.int32))
+    table = table.view(batch, pages_per_seq)
+    assert table.data_ptr() % 16 == 0
+    return table
 
 
 def _frozen_qsplit(csr: dict[str, Any]):
@@ -2669,6 +3231,11 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
     from tirx_kernels.msa.sparse_prepare_fwd_split_atomic import prepare_data as prepare_csr
 
     config.pop("label", None)
+    paged = bool(config.get("paged", False))
+    seqused = bool(config.get("seqused", False))
+    if seqused and not paged:
+        raise ValueError("seqused_k is only supported together with page_table")
+
     csr_config = {key: config[key] for key in _CSR_CONFIG_KEYS if key in config}
     csr = prepare_csr(seed=seed, **csr_config)
 
@@ -2693,6 +3260,35 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
     k = k_bf16.to(_torch_dtype(mode["k"])).contiguous()
     v = v_bf16.to(_torch_dtype(mode["v"])).contiguous()
 
+    # Paged KV. `page_size == blk_kv` is mandatory upstream (:99-107), so a CTA's
+    # KV block is exactly one page and the pages-per-sequence count is uniform;
+    # that rectangularity is what lets the kernel recover `pages_per_seq` from
+    # the scalars it already takes instead of a new argument.
+    page_table = seqused_k = None
+    k_paged = v_paged = None
+    if paged:
+        blk_kv = config["blk_kv"]
+        pages_per_seq = max((int(length) + blk_kv - 1) // blk_kv for length in csr["seqlens_k"])
+        page_table = _build_page_table(len(csr["seqlens_k"]), pages_per_seq, generator)
+        k_paged = _pack_paged_kv(k, csr["seqlens_k"], blk_kv, page_table)
+        v_paged = _pack_paged_kv(v, csr["seqlens_k"], blk_kv, page_table)
+        if seqused:
+            trims = _seqused_trim(len(csr["seqlens_k"]), blk_kv)
+            seqused_k = torch.tensor(
+                [int(length) - trim for length, trim in zip(csr["seqlens_k"], trims, strict=True)],
+                dtype=torch.int32,
+                device=device,
+            )
+        else:
+            # Without `seqused_k` the kernel takes the full paged capacity as the
+            # logical length (:210-211), so every batch must fill its pages
+            # exactly or the tail of zero-padding would be attended to. The CSR's
+            # lengths are already blk_kv-aligned, which is that condition.
+            assert all(int(length) % blk_kv == 0 for length in csr["seqlens_k"])
+            assert all(
+                (int(length) + blk_kv - 1) // blk_kv == pages_per_seq for length in csr["seqlens_k"]
+            ), "paged without seqused_k requires uniform lengths: capacity is the logical length"
+
     cu_seqlens_k = torch.zeros(len(csr["seqlens_k"]) + 1, dtype=torch.int32, device=device)
     cu_seqlens_k[1:] = torch.tensor(csr["seqlens_k"], dtype=torch.int32, device=device).cumsum(0)
 
@@ -2703,8 +3299,15 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
         "csr": csr,
         "q": q,
         "q_flat": q.reshape(-1, HEAD_DIM),
-        "k": k,
-        "v": v,
+        # Paged runs hand the kernel and the reference the page-major tensors;
+        # the flat ones stay for the dequantized twins and for host-side checks.
+        "k": k_paged if paged else k,
+        "v": v_paged if paged else v,
+        "k_flat": k,
+        "v_flat": v,
+        "paged": paged,
+        "page_table": page_table,
+        "seqused_k": seqused_k,
         # The bf16 twins the fp8-KV path's exact-match oracle re-runs against.
         "k_dequantized": k.to(torch.bfloat16).contiguous(),
         "v_dequantized": v.to(torch.bfloat16).contiguous(),
@@ -2728,7 +3331,10 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
         "qhead_per_kv": qhead_per_kv,
         "topk": topk,
         "total_q": total_q,
-        "total_k": total_k,
+        # Under paging the K/V buffers span the page array, not the packed
+        # sequences, and the kernel shapes its match_buffer from this value.
+        "total_k": (int(page_table.numel()) * config["blk_kv"]) if paged else total_k,
+        "total_k_flat": total_k,
         "total_rows": csr["total_rows"],
         "nnz": csr["nnz_capacity"],
         "num_batches": len(csr["seqlens_k"]),
@@ -2769,8 +3375,11 @@ def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
     # keep their real shape, and only because their base pointer reaches a
     # tensor map.
     args = [
-        as_bits(data["k"]),
-        as_bits(data["v"]),
+        # The kernel binds K/V with one 3-D shape on both axes and reads only
+        # their base pointer; the tensormap carries the paged geometry. A paged
+        # tensor is contiguous, so this view is free and the bytes are the same.
+        as_bits(data["k"].reshape(-1, data["head_kv"], HEAD_DIM)),
+        as_bits(data["v"].reshape(-1, data["head_kv"], HEAD_DIM)),
         data["k2q_q_indices"].reshape(-1),
         data["k2q_qsplit_indices"].reshape(-1),
         data["k2q_row_ptr"].reshape(-1),
@@ -2781,8 +3390,14 @@ def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
     ]
     if data["lse_temperature_scale"] is not None:
         args.append(outputs["lse_temperature_partial"].reshape(-1))
+    args.append(as_bits(data["q_flat"]))
+    # Optional handles, in the reference's own argument order: both are absent
+    # from the signature entirely when the specialization pins them to None.
+    if data.get("page_table") is not None:
+        args.append(data["page_table"].reshape(-1))
+    if data.get("seqused_k") is not None:
+        args.append(data["seqused_k"])
     args += [
-        as_bits(data["q_flat"]),
         data["cu_seqlens_q"],
         data["cu_seqlens_k"],
         data["softmax_scale"] * math.log2(math.e),
@@ -2817,6 +3432,8 @@ def reference_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, A
         "lse_partial": outputs["lse_partial"],
         "lse_temperature_partial": outputs.get("lse_temperature_partial"),
         "q_flat": data["q_flat"],
+        "page_table": data.get("page_table"),
+        "seqused_k": data.get("seqused_k"),
         "cu_seqlens_q": data["cu_seqlens_q"],
         "cu_seqlens_k": data["cu_seqlens_k"],
         "softmax_scale": data["softmax_scale"],

--- a/tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py
+++ b/tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py
@@ -92,9 +92,8 @@ DTYPE_MODES: dict[str, dict[str, str]] = {
     "fp8q": {"q": "float8_e4m3", "mma": "float8_e4m3"},
 }
 
-# `mO_partial.element_type`. fp16 is accepted upstream but never exercised for
-# nvfp4, so it stays out of this port's domain.
-PARTIAL_DTYPES = ("float32", "bfloat16", "float8_e4m3")
+# `mO_partial.element_type`.
+PARTIAL_DTYPES = ("float32", "bfloat16", "float16", "float8_e4m3")
 
 
 # ---------------------------------------------------------------------------
@@ -142,14 +141,16 @@ TMEM_TOTAL = 512
 SPLIT_P_ARRIVE = 96
 
 # Register budgets on the causal path (:173-181).
-NUM_REGS_SOFTMAX = 176
-NUM_REGS_STORE = 112
+NUM_REGS_SOFTMAX_CAUSAL = 176
+NUM_REGS_SOFTMAX_NONCAUSAL = 192
+NUM_REGS_STORE_CAUSAL = 112
+NUM_REGS_STORE_NONCAUSAL = 80
 NUM_REGS_OTHER = 48
 # `ex2_emu_freq = 16 if causal else 0` (:184), `ex2_emu_start_frg = 1` (:185),
 # and `ex2_emu_res` keeps softmax.py's default of 4. All three enter the
 # emulation predicate; a stride test on the element index picks a different
 # sixteen elements and changes the result bitwise.
-EX2_EMU_FREQ = 16
+EX2_EMU_FREQ_CAUSAL = 16
 EX2_EMU_RES = 4
 EX2_EMU_START_FRG = 1
 # `frg_tile` / `frg_cnt` (softmax.py:370-372): the predicate is two-dimensional
@@ -229,6 +230,9 @@ _TMA_GATHER4_2D_CACHE = (
 _TMA_GATHER4_PREFETCH = "cp.async.bulk.prefetch.tensor.2d.L2.global.tile::gather4.L2::cache_hint"
 _TMA_G2S_2D_CACHE = (
     "cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_G2S_4D_CACHE = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
 )
 _TMA_G2S_3D_CACHE = (
     "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint"
@@ -579,6 +583,21 @@ def _scale_128x4_offset(row, col, scale_cols: int):
     return (tile_m * tiles_n + tile_n) * 512 + (outer % 32) * 16 + udiv_i32(outer, 32) * 4 + inner
 
 
+def _paged_kv_scale_row(row, head_kv_idx, page_idx, num_heads_kv):
+    """`_paged_kv_scale_row` (:1328-1336).
+
+    THE one genuine NVFP4 paged difference. `_scale_128x4_offset` is layout-only
+    and identical either way; what moves is the logical row fed into it.
+
+    ``row`` is the INTRA-PAGE row, 0..N_BLOCK-1 -- not the batch-offset-adjusted
+    absolute token the flat form takes. Handing this the absolute token yields
+    ``(page*H + h)*N_BLOCK + k_batch_offset + kv_block*N_BLOCK + row``: a
+    different, still in-range E4M3 byte for every task. It does not fault, the
+    values look plausible, and only the bitwise gate catches it.
+    """
+    return (page_idx * num_heads_kv + head_kv_idx) * N_BLOCK + row
+
+
 def _flat_kv_scale_row(token_idx, head_kv_idx, num_heads_kv):
     """`_flat_kv_scale_row` (:1320-1326). The token index arrives already offset
     by the batch's ``cu_seqlens_k`` base (:1392, :1458)."""
@@ -747,6 +766,8 @@ def _dequant_kv_fp4(
     k_global,
     mma_dtype,
     fold_global,
+    paged,
+    s_paged_kv_idx,
 ):
     """Turn one staged NVFP4 tile into the BF16 or FP8 tile the MMA reads.
 
@@ -804,8 +825,18 @@ def _dequant_kv_fp4(
                 task: T.int32 = it * DEQUANT_THREADS + group_tidx
                 row: T.int32 = udiv_i32(task, pairs_per_row)
                 pair_col: T.int32 = task - row * pairs_per_row
-                token: T.int32 = token_base + row
-                scale_row: T.int32 = _flat_kv_scale_row(token, head_kv_idx, num_heads_kv)
+                if paged:
+                    # Re-read EVERY ITERATION: the backend does not hoist this
+                    # out of the rolled task loop (.loc 1 1384 K / :1558 V,
+                    # inside the `.pragma "nounroll"` body), and lifting it
+                    # changes the hottest loop's instruction count.
+                    page_idx_d: T.int32 = ld_shared_i32(s_paged_kv_idx, 0)
+                    scale_row: T.int32 = _paged_kv_scale_row(
+                        row, head_kv_idx, page_idx_d, num_heads_kv
+                    )
+                else:
+                    token: T.int32 = token_base + row
+                    scale_row: T.int32 = _flat_kv_scale_row(token, head_kv_idx, num_heads_kv)
                 src_words = T.alloc_local((4,), "uint32")
                 for w in range(4):
                     src_words[w] = staged[it * 4 + w]
@@ -841,8 +872,16 @@ def _dequant_kv_fp4(
                 task: T.int32 = it * DEQUANT_THREADS + group_tidx
                 row: T.int32 = udiv_i32(task, SCALE_COLS)
                 scale_col: T.int32 = task - row * SCALE_COLS
-                token: T.int32 = token_base + row
-                scale_row: T.int32 = _flat_kv_scale_row(token, head_kv_idx, num_heads_kv)
+                if paged:
+                    # Same per-iteration re-read as the pair arm (.loc 1 1450 K
+                    # / :1625 V, inside $L__BB0_89 / $L__BB0_120).
+                    page_idx_s: T.int32 = ld_shared_i32(s_paged_kv_idx, 0)
+                    scale_row: T.int32 = _paged_kv_scale_row(
+                        row, head_kv_idx, page_idx_s, num_heads_kv
+                    )
+                else:
+                    token: T.int32 = token_base + row
+                    scale_row: T.int32 = _flat_kv_scale_row(token, head_kv_idx, num_heads_kv)
                 src_words = T.alloc_local((2,), "uint32")
                 T.evaluate(
                     T.ptx.ld.shared.v2.b32(
@@ -1178,6 +1217,8 @@ def _kernel(
     lse_partial_h: T.handle,
     lse_temperature_partial_h: T.Optional(T.handle),
     q_flat_h: T.handle,
+    page_table_h: T.Optional(T.handle),
+    seqused_k_h: T.Optional(T.handle),
     cu_seqlens_q_h: T.handle,
     cu_seqlens_k_h: T.handle,
     softmax_scale_log2: T.float32,
@@ -1201,6 +1242,14 @@ def _kernel(
     dtype_mode: T.constexpr,
     partial_dtype: T.constexpr,
 ):
+    # Paging and `seqused_k` are selected by handle presence, as
+    # `k_global_scale_h` and `lse_temperature_partial_h` already are.
+    paged = T.meta_var(page_table_h is not None)
+    seqused = T.meta_var(seqused_k_h is not None)
+    num_regs_softmax = T.meta_var(NUM_REGS_SOFTMAX_CAUSAL if causal else NUM_REGS_SOFTMAX_NONCAUSAL)
+    num_regs_store = T.meta_var(NUM_REGS_STORE_CAUSAL if causal else NUM_REGS_STORE_NONCAUSAL)
+    ex2_emu_freq = T.meta_var(EX2_EMU_FREQ_CAUSAL if causal else 0)
+
     mode = T.meta_var(DTYPE_MODES[dtype_mode])
     q_dtype = T.meta_var(mode["q"])
     # `k_dtype = v_dtype = q_dtype` (:333-334): the dequantization target is Q's
@@ -1228,6 +1277,12 @@ def _kernel(
     q_tokens_per_group = T.meta_var(M_BLOCK // qheadperkv)
 
     # Two E2M1 values per byte, so the stored head-dim extent is halved.
+    # Paging changes the rank; see the sibling for why the element count is
+    # unchanged and why the binding still has to follow.
+    # One binding for both axes. The kernel only takes `.data` from K/V -- the
+    # tensormap carries the real shape -- and `num_pages * page_size == total_k`,
+    # so the same 3-D binding describes the same bytes either way. The host
+    # hands over a 3-D view; a 4-D binding here faults the launcher.
     k = T.match_buffer(k_h, (total_k, num_heads_kv, PACKED_HEAD_DIM), "uint8", scope="global")
     v = T.match_buffer(v_h, (total_k, num_heads_kv, PACKED_HEAD_DIM), "uint8", scope="global")
     # One E4M3 byte per sixteen head-dim elements, in cuBLAS 128x4 tiled order.
@@ -1261,6 +1316,19 @@ def _kernel(
     q_flat = T.match_buffer(q_flat_h, (total_q * head_q, HEAD_DIM), q_ty, scope="global")
     cu_seqlens_q = T.match_buffer(cu_seqlens_q_h, (num_batches + 1,), "int32", scope="global")
     cu_seqlens_k = T.match_buffer(cu_seqlens_k_h, (num_batches + 1,), "int32", scope="global")
+    # `page_size == blk_kv` is mandatory (:103-111), so the page table is
+    # rectangular and `pages_per_seq` follows from the scalars already in the
+    # ABI rather than a new argument.
+    if paged:
+        # Runtime values, as upstream's `mPageTable.shape[1]` is; derived from
+        # scalars already in the ABI because the page table is rectangular.
+        # The table holds one entry per page, and `num_batches * pages_per_seq`
+        # is exactly `num_pages`, so the binding shape stays an expression over
+        # PrimFunc params -- a match_buffer shape cannot name a locally derived
+        # scalar.
+        page_table = T.match_buffer(page_table_h, (total_k // N_BLOCK,), "int32", scope="global")
+    if seqused:
+        seqused_k = T.match_buffer(seqused_k_h, (num_batches,), "int32", scope="global")
 
     # -----------------------------------------------------------------------
     # TMA descriptors, encoded in the launcher prologue.
@@ -1284,51 +1352,113 @@ def _kernel(
     # `cp.async.bulk.tensor.3d`. The box spans the whole 64-byte packed row, so
     # one issue covers a tile: 8192 transaction bytes, half the sibling's.
     k_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
-    T.call_packed(
-        "runtime.cuTensorMapEncodeTiled",
-        k_map,
-        "uint8",
-        3,
-        k.data,
-        PACKED_HEAD_DIM,
-        num_heads_kv,
-        total_k,
-        PACKED_HEAD_DIM,
-        num_heads_kv * PACKED_HEAD_DIM,
-        PACKED_HEAD_DIM,
-        1,
-        N_BLOCK,
-        1,
-        1,
-        1,
-        0,
-        0,
-        _L2_PROMOTION_256B,
-        0,
-    )
+    if paged:
+        # Rank 4: the page becomes the outermost mode and the token coordinate
+        # is pinned to 0. Load mode, completion, cache hint and the 8192-byte
+        # transaction are unchanged from the flat form.
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            k_map,
+            "uint8",
+            4,
+            k.data,
+            PACKED_HEAD_DIM,
+            N_BLOCK,
+            num_heads_kv,
+            total_k // N_BLOCK,
+            PACKED_HEAD_DIM,
+            N_BLOCK * PACKED_HEAD_DIM,
+            num_heads_kv * N_BLOCK * PACKED_HEAD_DIM,
+            PACKED_HEAD_DIM,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            k_map,
+            "uint8",
+            3,
+            k.data,
+            PACKED_HEAD_DIM,
+            num_heads_kv,
+            total_k,
+            PACKED_HEAD_DIM,
+            num_heads_kv * PACKED_HEAD_DIM,
+            PACKED_HEAD_DIM,
+            1,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
     v_map: T.let[T.TensorMap()] = T.tvm_stack_alloca("tensormap", 1)
-    T.call_packed(
-        "runtime.cuTensorMapEncodeTiled",
-        v_map,
-        "uint8",
-        3,
-        v.data,
-        PACKED_HEAD_DIM,
-        num_heads_kv,
-        total_k,
-        PACKED_HEAD_DIM,
-        num_heads_kv * PACKED_HEAD_DIM,
-        PACKED_HEAD_DIM,
-        1,
-        N_BLOCK,
-        1,
-        1,
-        1,
-        0,
-        0,
-        _L2_PROMOTION_256B,
-        0,
-    )
+    if paged:
+        # Rank 4: the page becomes the outermost mode and the token coordinate
+        # is pinned to 0. Load mode, completion, cache hint and the 8192-byte
+        # transaction are unchanged from the flat form.
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            v_map,
+            "uint8",
+            4,
+            v.data,
+            PACKED_HEAD_DIM,
+            N_BLOCK,
+            num_heads_kv,
+            total_k // N_BLOCK,
+            PACKED_HEAD_DIM,
+            N_BLOCK * PACKED_HEAD_DIM,
+            num_heads_kv * N_BLOCK * PACKED_HEAD_DIM,
+            PACKED_HEAD_DIM,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
+    else:
+        T.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            v_map,
+            "uint8",
+            3,
+            v.data,
+            PACKED_HEAD_DIM,
+            num_heads_kv,
+            total_k,
+            PACKED_HEAD_DIM,
+            num_heads_kv * PACKED_HEAD_DIM,
+            PACKED_HEAD_DIM,
+            1,
+            N_BLOCK,
+            1,
+            1,
+            1,
+            0,
+            0,
+            _L2_PROMOTION_256B,
+            0,
+        )
 
     # The TMA-Q box is one token group of `qheadperkv` rows; the gather4 box is
     # a single row, because the instruction supplies four row coordinates.
@@ -1424,6 +1554,11 @@ def _kernel(
     s_q_idx = pool.alloc((O_STAGE * q_tokens_per_group,), "int32", align=16)
     s_row_meta = pool.alloc((8,), "int32", align=16)
     s_diag_q_count = pool.alloc((1,), "int32", align=16)
+    # `sPagedKvIdx` (:552): the physical page for this CTA's KV block. Allocated
+    # unconditionally, as the source does, so flat and paged share every later
+    # offset. Written by thread 0; read by both KV-load warps AND, on the paged
+    # path, once per iteration inside each dequant task loop.
+    s_paged_kv_idx = pool.alloc((1,), "int32", align=16)
     s_q_load_m_idx = pool.alloc((Q_STAGE * q_tokens_per_group,), "int32", align=16)
     s_qidx_meta = pool.alloc((QIDX_META_STAGES * q_tokens_per_group,), "int32", align=16)
 
@@ -1522,17 +1657,43 @@ def _kernel(
         )
         row_start: T.int32 = base_row_start + work_q_begin[0]
         count_raw: T.int32 = work_q_count[0]
-        seqlen_k: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0] + 1) - ld_global_i32(
-            cu_seqlens_k, batch_idx[0]
-        )
+        # Upstream reads this as `mPageTable.shape[1]` (:211). The table is
+        # rectangular because `page_size == blk_kv`, so `num_batches *
+        # pages_per_seq == num_pages == total_k / page_size`, and the quotient
+        # of two ABI scalars recovers it without a new argument.
+        if paged:
+            pages_per_seq: T.int32 = udiv_i32(udiv_i32(total_k, N_BLOCK), num_batches)
+        # `_logical_seqlen_k` (:205-216) in the source's priority order:
+        # `seqused` FIRST, then the paged capacity, then the cu_seqlens
+        # difference. Testing paged first would substitute the zero-padded
+        # capacity for a shorter supplied length.
+        if seqused:
+            seqlen_k: T.int32 = ld_global_i32(seqused_k, batch_idx[0])
+        elif paged:
+            seqlen_k: T.int32 = pages_per_seq * N_BLOCK
+        else:
+            seqlen_k: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0] + 1) - ld_global_i32(
+                cu_seqlens_k, batch_idx[0]
+            )
         kv_valid_cols: T.int32 = T.min(T.max(seqlen_k - kv_block_idx[0] * N_BLOCK, 0), N_BLOCK)
         q_batch_offset: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0])
-        k_batch_offset: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0])
+        if paged:
+            k_batch_offset: T.int32 = 0
+        else:
+            k_batch_offset: T.int32 = ld_global_i32(cu_seqlens_k, batch_idx[0])
         # `seqlen_q` and therefore `causal_q_offset` are needed BEFORE the
         # second store, because the eight words go out as TWO four-word vector
         # stores (:849, :863), not eight scalars.
-        seqlen_q: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0] + 1) - q_batch_offset
-        causal_q_offset: T.int32 = seqlen_k - seqlen_q
+        # Computed only under `causal` (:893-901 analogue). Deliberately
+        # unclamped: with `seqused_k` shorter than the Q length the offset goes
+        # negative and the leading queries store the neutral partial, O = 0 with
+        # LSE = -inf. Clamping would diverge from the source.
+        causal_q_offset_l = T.alloc_local((1,), "int32")
+        causal_q_offset_l[0] = 0
+        if causal:
+            seqlen_q: T.int32 = ld_global_i32(cu_seqlens_q, batch_idx[0] + 1) - q_batch_offset
+            causal_q_offset_l[0] = seqlen_k - seqlen_q
+        causal_q_offset: T.int32 = causal_q_offset_l[0]
         T.evaluate(
             T.ptx.st.shared.v4.b32(
                 s_row_meta.ptr_to([0]),
@@ -1555,9 +1716,13 @@ def _kernel(
         # The causal diagonal split point: a 32-step binary search over the CSR
         # row, which is sorted by q_idx (:259-285, :919-935). The export keeps
         # the loop rolled with exactly one probe load in the body.
+        # Computed ONLY under `const_expr(self.causal)` (:919-934): a non-causal
+        # build emits no search at all and leaves the count at zero, which is
+        # also the only value its consumer would accept -- a search result there
+        # would drive the diagonal mask over rows that have no diagonal.
         diag_q_count = T.alloc_local((1,), "int32")
         diag_q_count[0] = 0
-        if count_raw > 0 and kv_valid_cols > 0:
+        if causal and count_raw > 0 and kv_valid_cols > 0:
             q_threshold: T.int32 = (kv_block_idx[0] * N_BLOCK + kv_valid_cols) - causal_q_offset
             lo = T.alloc_local((1,), "int32")
             hi = T.alloc_local((1,), "int32")
@@ -1590,6 +1755,25 @@ def _kernel(
         _mbar_expect_tx(bar_k_tma, 0, N_BLOCK * PACKED_HEAD_DIM)
         _mbar_expect_tx(bar_v_tma, 0, N_BLOCK * PACKED_HEAD_DIM)
 
+    # The physical page for this CTA's KV block (:864-867). Warp 1, not thread 0:
+    # it depends on nothing the metadata chain produces -- `batch_idx` and
+    # `kv_block_idx` are read from the scheduler record by every thread, and
+    # `pages_per_seq` is two divisions of ABI scalars -- while thread 0 is busy
+    # with a 32-step binary search of dependent global loads. Behind that chain
+    # its own global load lands on the critical path of every CTA, which the
+    # long shapes amortize and a 10 us one does not. The publish still rides the
+    # same fence and CTA barrier below, so visibility is unchanged and paging
+    # still adds no barrier of its own.
+    if paged:
+        if warp_idx == 1 and cta_valid_work != 0:
+            if T.cuda.elect_sync():
+                pages_per_seq_w1: T.int32 = udiv_i32(udiv_i32(total_k, N_BLOCK), num_batches)
+                st_shared_i32(
+                    s_paged_kv_idx,
+                    0,
+                    ld_global_i32(page_table, batch_idx[0] * pages_per_seq_w1 + kv_block_idx[0]),
+                )
+
     # The metadata block's own fence and CTA barrier (:891-892) -- the second
     # of the two pairs. It orders the sRowMeta / sDiagQCount publish and the
     # K/V transaction counts against every consumer.
@@ -1609,7 +1793,7 @@ def _kernel(
     # -----------------------------------------------------------------------
     if tidx >= Q_LOAD_WARP_BASE * WARP_SIZE and tidx < MMA_WARP_ID * WARP_SIZE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(NUM_REGS_STORE)))
+            T.evaluate(T.ptx.setmaxnreg.dec.sync.aligned.u32(T.uint32(num_regs_store)))
             q_row_start: T.int32 = ld_shared_i32(s_row_meta, 2)
             q_count_raw: T.int32 = ld_shared_i32(s_row_meta, 3)
             q_batch_off: T.int32 = ld_shared_i32(s_row_meta, 5)
@@ -1724,6 +1908,29 @@ def _kernel(
                                     bar_q_full.ptr_to([slot]),
                                     T.uint32(M_BLOCK * HEAD_DIM * q_bytes),
                                 )
+                        # Issue the qsplit reads BEFORE the barrier and store
+                        # them after it. The barrier only orders the shared
+                        # writes against last iteration's readers; the reads
+                        # themselves come from a read-only global input and have
+                        # no ordering requirement, so their latency can be spent
+                        # inside the wait instead of in front of the store.
+                        # Leaving them where the reference puts them costs a
+                        # dependent global load three instructions ahead of the
+                        # store, and that store carries 517 stall samples -- the
+                        # heaviest single STS site in this kernel.
+                        qsplit_word = T.alloc_local((meta_iters,), "int32")
+                        for meta_iter in T.unroll(meta_iters):
+                            tok_pre: T.int32 = (
+                                meta_iter * NUM_Q_LOAD_WARPS + warp_in_wg
+                            ) * WARP_SIZE + lane_idx
+                            qsplit_word[meta_iter] = 0
+                            if tok_pre < q_tokens_per_group:
+                                qi_pre: T.int32 = qi_group * q_tokens_per_group + tok_pre
+                                if qi_pre < q_count_raw:
+                                    qsplit_word[meta_iter] = ld_global_i32(
+                                        k2q_qsplit_indices,
+                                        head_kv_idx[0] * nnz + q_row_start + qi_pre,
+                                    )
                         bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
 
                         qidx_meta_slot: T.int32 = (
@@ -1737,18 +1944,9 @@ def _kernel(
                                 meta_iter * NUM_Q_LOAD_WARPS + warp_in_wg
                             ) * WARP_SIZE + lane_idx
                             if tok_g4 < q_tokens_per_group:
-                                qi_g4: T.int32 = qi_group * q_tokens_per_group + tok_g4
-                                if qi_g4 < q_count_raw:
-                                    st_shared_i32(
-                                        s_qidx_meta,
-                                        qidx_meta_slot + tok_g4,
-                                        ld_global_i32(
-                                            k2q_qsplit_indices,
-                                            head_kv_idx[0] * nnz + q_row_start + qi_g4,
-                                        ),
-                                    )
-                                else:
-                                    st_shared_i32(s_qidx_meta, qidx_meta_slot + tok_g4, 0)
+                                st_shared_i32(
+                                    s_qidx_meta, qidx_meta_slot + tok_g4, qsplit_word[meta_iter]
+                                )
                         bar_sync_named(BAR_LOAD_WG, SOFTMAX_THREADS)
 
                         if T.cuda.elect_sync():
@@ -1833,35 +2031,75 @@ def _kernel(
                     # inside a single 128-byte box. The copy and the arrive sit
                     # in two separate `elect.sync` regions, as the export shows
                     # (:1734-1740).
+                    # Read warp-wide in this warp's own arm, before the
+                    # copy's elect.sync -- the export shows all 32 lanes
+                    # executing it (:1709 for K, :1744 for V).
+                    page_idx_k = T.alloc_local((1,), "int32")
+                    if paged:
+                        page_idx_k[0] = ld_shared_i32(s_paged_kv_idx, 0)
                     if T.cuda.elect_sync():
-                        T.evaluate(
-                            T.ptx[_TMA_G2S_3D_CACHE](
-                                s_k_fp4.ptr_to([0, 0]),
-                                T.address_of(k_map),
-                                T.int32(0),
-                                head_kv_idx[0],
-                                kv_row_start,
-                                T.cuda.cvta_generic_to_shared(bar_k_tma.ptr_to([0])),
-                                _TMA_NO_POLICY,
+                        if paged:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_4D_CACHE](
+                                    s_k_fp4.ptr_to([0, 0]),
+                                    T.address_of(k_map),
+                                    T.int32(0),
+                                    T.int32(0),
+                                    head_kv_idx[0],
+                                    page_idx_k[0],
+                                    T.cuda.cvta_generic_to_shared(bar_k_tma.ptr_to([0])),
+                                    _TMA_NO_POLICY,
+                                )
                             )
-                        )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_3D_CACHE](
+                                    s_k_fp4.ptr_to([0, 0]),
+                                    T.address_of(k_map),
+                                    T.int32(0),
+                                    head_kv_idx[0],
+                                    kv_row_start,
+                                    T.cuda.cvta_generic_to_shared(bar_k_tma.ptr_to([0])),
+                                    _TMA_NO_POLICY,
+                                )
+                            )
                     if T.cuda.elect_sync():
                         T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
                             bar_k_tma.ptr_to([0]), T.uint32(1)
                         )
                 if warp_idx == KV_LOAD_WARP_BASE + 1:
+                    # Read warp-wide in this warp's own arm, before the
+                    # copy's elect.sync -- the export shows all 32 lanes
+                    # executing it (:1709 for K, :1744 for V).
+                    page_idx_v = T.alloc_local((1,), "int32")
+                    if paged:
+                        page_idx_v[0] = ld_shared_i32(s_paged_kv_idx, 0)
                     if T.cuda.elect_sync():
-                        T.evaluate(
-                            T.ptx[_TMA_G2S_3D_CACHE](
-                                s_v_fp4.ptr_to([0, 0]),
-                                T.address_of(v_map),
-                                T.int32(0),
-                                head_kv_idx[0],
-                                kv_row_start,
-                                T.cuda.cvta_generic_to_shared(bar_v_tma.ptr_to([0])),
-                                _TMA_NO_POLICY,
+                        if paged:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_4D_CACHE](
+                                    s_v_fp4.ptr_to([0, 0]),
+                                    T.address_of(v_map),
+                                    T.int32(0),
+                                    T.int32(0),
+                                    head_kv_idx[0],
+                                    page_idx_v[0],
+                                    T.cuda.cvta_generic_to_shared(bar_v_tma.ptr_to([0])),
+                                    _TMA_NO_POLICY,
+                                )
                             )
-                        )
+                        else:
+                            T.evaluate(
+                                T.ptx[_TMA_G2S_3D_CACHE](
+                                    s_v_fp4.ptr_to([0, 0]),
+                                    T.address_of(v_map),
+                                    T.int32(0),
+                                    head_kv_idx[0],
+                                    kv_row_start,
+                                    T.cuda.cvta_generic_to_shared(bar_v_tma.ptr_to([0])),
+                                    _TMA_NO_POLICY,
+                                )
+                            )
                     if T.cuda.elect_sync():
                         T.ptx.mbarrier.arrive.release.cta.shared__cta.b64(
                             bar_v_tma.ptr_to([0]), T.uint32(1)
@@ -2272,6 +2510,9 @@ def _kernel(
         count_raw_sm: T.int32 = ld_shared_i32(s_row_meta, 3)
         kv_valid_cols: T.int32 = ld_shared_i32(s_row_meta, 4)
         q_batch_off_sm: T.int32 = ld_shared_i32(s_row_meta, 5)
+        # Read unconditionally, as the source does (:1119-1127): both cells only
+        # ever feed the diagonal mask, so a non-causal build leaves two dead
+        # scalar loads behind rather than gating them away.
         causal_q_off: T.int32 = ld_shared_i32(s_row_meta, 7)
         diag_q_count_sm: T.int32 = ld_shared_i32(s_diag_q_count, 0)
 
@@ -2297,6 +2538,8 @@ def _kernel(
                 k_global_scale if k_global_scale_h is not None else None,
                 mma_dtype,
                 fold_k_global,
+                paged,
+                s_paged_kv_idx,
             )
         if stage == 1:
             # V never carries a tensor scale into this kernel: the interface
@@ -2317,13 +2560,20 @@ def _kernel(
                 None,
                 mma_dtype,
                 False,
+                paged,
+                s_paged_kv_idx,
             )
 
         bar_sync_named(BAR_TMEM_ALLOC, WARP_SIZE * (WARPS_PER_GROUP * 2 + 1))
 
         if count_raw_sm > 0:
             num_q_groups_sm: T.int32 = uceil_div_i32(count_raw_sm, q_tokens_per_group)
-            kv_block_col_start: T.int32 = kv_block_sm * N_BLOCK
+            # Zero unless causal (:2461-2463); it only ever offsets the
+            # diagonal column limit, which a non-causal build never computes.
+            if causal:
+                kv_block_col_start: T.int32 = kv_block_sm * N_BLOCK
+            else:
+                kv_block_col_start: T.int32 = 0
             # WG0 takes the even Q groups, WG1 the odd ones (:2465-2468).
             num_stage_groups: T.int32 = udiv_i32(num_q_groups_sm + (1 - stage), 2)
 
@@ -2333,12 +2583,6 @@ def _kernel(
                 producer_phase: T.int32 = phase ^ 1
                 qidx_meta_slot: T.int32 = (
                     T.bitwise_and(qi_group, QIDX_META_STAGES - 1) * q_tokens_per_group
-                )
-                # How many of this group's tokens still sit on the causal
-                # diagonal and therefore need per-column masking (:2478-2486).
-                qi_group_start: T.int32 = qi_group * q_tokens_per_group
-                masked_tok_count: T.int32 = T.max(
-                    0, T.min(q_tokens_per_group, diag_q_count_sm - qi_group_start)
                 )
 
                 # ---------------- softmax step (:2437-2616) ----------------
@@ -2379,13 +2623,25 @@ def _kernel(
                 # how the reference emits it too (mask.py:36-46, :71-121).
                 col_limit = T.alloc_local((1,), "int32")
                 col_limit[0] = kv_valid_cols
-                if masked_tok_count > 0:
-                    tok_of_row: T.int32 = udiv_i32(group_tidx, qheadperkv)
-                    q_idx_mask: T.int32 = T.bitwise_and(
-                        ld_shared_i32(s_qidx_meta, qidx_meta_slot + tok_of_row), Q_IDX_MASK
+                if causal:
+                    # How many of this group's tokens still sit on the causal
+                    # diagonal and therefore need per-column masking
+                    # (:2478-2486). A non-causal build passes a literal zero
+                    # here and takes the column-limit-only arm (:2544-2548), so
+                    # none of this is emitted.
+                    qi_group_start: T.int32 = qi_group * q_tokens_per_group
+                    masked_tok_count: T.int32 = T.max(
+                        0, T.min(q_tokens_per_group, diag_q_count_sm - qi_group_start)
                     )
-                    causal_col_limit: T.int32 = q_idx_mask + causal_q_off - kv_block_col_start + 1
-                    col_limit[0] = T.min(kv_valid_cols, causal_col_limit)
+                    if masked_tok_count > 0:
+                        tok_of_row: T.int32 = udiv_i32(group_tidx, qheadperkv)
+                        q_idx_mask: T.int32 = T.bitwise_and(
+                            ld_shared_i32(s_qidx_meta, qidx_meta_slot + tok_of_row), Q_IDX_MASK
+                        )
+                        causal_col_limit: T.int32 = (
+                            q_idx_mask + causal_q_off - kv_block_col_start + 1
+                        )
+                        col_limit[0] = T.min(kv_valid_cols, causal_col_limit)
                 if col_limit[0] < N_BLOCK:
                     for chunk in T.unroll(N_BLOCK // MASK_R2P_CHUNK):
                         shift: T.int32 = T.max((chunk + 1) * MASK_R2P_CHUNK - col_limit[0], 0)
@@ -2469,7 +2725,8 @@ def _kernel(
                 for j in range(EX2_FRG_CNT):
                     for k in range(0, EX2_FRG_TILE, 2):
                         use_mufu = T.meta_var(
-                            (k % EX2_EMU_FREQ) < (EX2_EMU_FREQ - EX2_EMU_RES)
+                            ex2_emu_freq == 0
+                            or (k % ex2_emu_freq) < (ex2_emu_freq - EX2_EMU_RES)
                             or j >= EX2_FRG_CNT - 1
                             or j < EX2_EMU_START_FRG
                         )
@@ -2536,18 +2793,20 @@ def _kernel(
 
     if warp_idx < SOFTMAX1_WARP_BASE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(num_regs_softmax)))
             softmax_warpgroup(0)
 
     if warp_idx >= SOFTMAX1_WARP_BASE and warp_idx < Q_LOAD_WARP_BASE:
         if cta_valid_work != 0:
-            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(NUM_REGS_SOFTMAX)))
+            T.evaluate(T.ptx.setmaxnreg.inc.sync.aligned.u32(T.uint32(num_regs_softmax)))
             softmax_warpgroup(1)
 
 
 def get_kernel(**config):
     """Return the TIRx specialization for one compile key."""
     config.pop("label", None)
+    if bool(config.get("seqused", False)) and not bool(config.get("paged", False)):
+        raise ValueError("seqused_k is only supported together with page_table")
     kernel = _kernel.specialize(
         qheadperkv=int(config["qhead_per_kv"]),
         causal=bool(config.get("causal", True)),
@@ -2555,6 +2814,12 @@ def get_kernel(**config):
         partial_dtype=str(config.get("partial_dtype", "float32")),
         **({} if config.get("temperature") else {"lse_temperature_partial_h": None}),
         **({} if config.get("k_global", True) else {"k_global_scale_h": None}),
+        # Selected by handle presence, as `k_global_scale_h` above already is,
+        # so a flat specialization keeps the signature it had before the axis
+        # existed. `page_size` needs no key entry: upstream forces it equal to
+        # `blk_kv` (:103-111).
+        **({} if bool(config.get("paged", False)) else {"page_table_h": None}),
+        **({} if bool(config.get("seqused", False)) else {"seqused_k_h": None}),
     )
     return kernel.with_attr("tirx.kernel_launch_params", list(LAUNCH_TAGS))
 
@@ -2583,9 +2848,13 @@ def _case(
     causal: bool = True,
     blk_kv: int = N_BLOCK,
     seqlen_pattern: str = "uniform",
+    paged: bool = False,
+    seqused: bool = False,
 ) -> dict:
     return {
         "label": label,
+        "paged": paged,
+        "seqused": seqused,
         "batch": batch,
         "seqlen_q": seqlen_q,
         "seqlen_k": seqlen_k,
@@ -2714,6 +2983,56 @@ BENCH_CONFIGS = [
         qhead_per_kv=2,
         topk=4,
     ),
+    # Paged. The first row mirrors the flat marquee shape so the pair reads as
+    # the cost of the page indirection alone.
+    _case(
+        label="paged_ring48k_bf16q_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        seqlen_k=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+        partial_dtype="bfloat16",
+        paged=True,
+    ),
+    _case(
+        label="paged_ring48k_fp8q_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        seqlen_k=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+        dtype="fp8q",
+        partial_dtype="bfloat16",
+        temperature=1.0,
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_bf16q_s16384_qh4_t16",
+        batch=2,
+        seqlen_q=16384,
+        seqlen_k=16384,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        partial_dtype="bfloat16",
+        paged=True,
+        seqused=True,
+    ),
+    _case(
+        label="paged_edge_b1_s2048_fp8q_t4",
+        batch=1,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+        dtype="fp8q",
+        partial_dtype="bfloat16",
+        paged=True,
+    ),
 ]
 
 
@@ -2809,6 +3128,138 @@ CONFIGS = [
         topk=8,
         seqlen_pattern="varlen",
     ),
+    # Paged KV. Every paged row runs `head_kv=2`: the paged scale row is
+    # `(page * head_kv + head_kv_idx) * page_size + token`, and at `head_kv == 1`
+    # it collapses to a form that a wrong head factor would still satisfy.
+    _case(
+        label="paged_bf16q_s4096_qh4_t16",
+        batch=2,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        paged=True,
+    ),
+    _case(
+        label="paged_fp8q_s4096_qh16_t8",
+        batch=2,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=16,
+        topk=8,
+        dtype="fp8q",
+        partial_dtype="bfloat16",
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_bf16q_s2048_qh8_t8",
+        batch=3,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        paged=True,
+        seqused=True,
+    ),
+    _case(
+        label="paged_seqused_fp8q_s2048_qh2_t8",
+        batch=3,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=2,
+        topk=8,
+        dtype="fp8q",
+        partial_dtype="bfloat16",
+        paged=True,
+        seqused=True,
+    ),
+    # K global scale off: the fold disappears from the dequant, so a paged
+    # scale-row error can no longer hide behind a wrong tensor scale.
+    _case(
+        label="paged_bf16q_kgs0_s2048_qh4_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=8,
+        k_global=False,
+        paged=True,
+    ),
+    _case(
+        label="paged_seqused_varlen_b2_s2048_bf16q_qh2_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=2,
+        topk=8,
+        paged=True,
+        seqused=True,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="paged_fp8q_partial_fp8_s2048_qh8_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        dtype="fp8q",
+        partial_dtype="float8_e4m3",
+        temperature=2.0,
+        paged=True,
+    ),
+    # `causal=False`: upstream's only non-causal NVFP4 coverage is at this
+    # scale, and the axis changes the register budget, `ex2_emu_freq`, and the
+    # diagonal search (:177-184).
+    _case(
+        label="corr_noncausal_bf16q_s512_qh4_t4",
+        batch=1,
+        seqlen_q=512,
+        seqlen_k=512,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=4,
+        causal=False,
+    ),
+    _case(
+        label="corr_noncausal_paged_fp8q_s2048_qh4_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=8,
+        dtype="fp8q",
+        partial_dtype="bfloat16",
+        causal=False,
+        paged=True,
+    ),
+    _case(
+        label="corr_partial_fp16_bf16q_s2048_qh8_t8",
+        batch=2,
+        seqlen_q=2048,
+        seqlen_k=2048,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        partial_dtype="float16",
+    ),
+    _case(
+        label="corr_topk32_bf16q_s4096_qh4",
+        batch=1,
+        seqlen_q=4096,
+        seqlen_k=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=32,
+    ),
 ]
 
 
@@ -2868,10 +3319,19 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
     """
     import torch
 
-    from tirx_kernels.msa.sparse_atten_fwd import _frozen_qsplit
+    from tirx_kernels.msa.sparse_atten_fwd import (
+        _build_page_table,
+        _frozen_qsplit,
+        _pack_paged_kv,
+        _seqused_trim,
+    )
     from tirx_kernels.msa.sparse_prepare_fwd_split_atomic import prepare_data as prepare_csr
 
     config.pop("label", None)
+    paged = bool(config.get("paged", False))
+    seqused = bool(config.get("seqused", False))
+    if seqused and not paged:
+        raise ValueError("seqused_k is only supported together with page_table")
     csr_config = {key: config[key] for key in _CSR_CONFIG_KEYS if key in config}
     csr = prepare_csr(seed=seed, **csr_config)
 
@@ -2894,7 +3354,35 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
     k = torch.randint(0, 256, kv_shape, dtype=torch.uint8, device=device, generator=generator)
     v = torch.randint(0, 256, kv_shape, dtype=torch.uint8, device=device, generator=generator)
 
-    rows = total_k * head_kv
+    # Paged KV, shared with the sibling port: `page_size == blk_kv`, a shuffled
+    # rectangular table, zero-filled trailing pages.
+    page_table = seqused_k = None
+    k_paged = v_paged = None
+    if paged:
+        blk_kv = config["blk_kv"]
+        pages_per_seq = max((int(length) + blk_kv - 1) // blk_kv for length in csr["seqlens_k"])
+        page_table = _build_page_table(len(csr["seqlens_k"]), pages_per_seq, generator)
+        k_paged = _pack_paged_kv(k, csr["seqlens_k"], blk_kv, page_table)
+        v_paged = _pack_paged_kv(v, csr["seqlens_k"], blk_kv, page_table)
+        if seqused:
+            trims = _seqused_trim(len(csr["seqlens_k"]), blk_kv)
+            seqused_k = torch.tensor(
+                [int(length) - trim for length, trim in zip(csr["seqlens_k"], trims, strict=True)],
+                dtype=torch.int32,
+                device=device,
+            )
+        else:
+            assert all(
+                (int(length) + blk_kv - 1) // blk_kv == pages_per_seq and int(length) % blk_kv == 0
+                for length in csr["seqlens_k"]
+            ), "paged without seqused_k requires uniform lengths: capacity is the logical length"
+
+    # One block scale per 16 head-dim elements, indexed by the logical KV row.
+    # Paged moves that row from `token * head_kv + head_kv_idx` to
+    # `(page * head_kv + head_kv_idx) * page_size + token` (:1328-1336) -- which
+    # is still exactly the row-major flattening of the tensor the kernel reads,
+    # so the scale array simply grows to cover the page array.
+    rows = int(k_paged.numel() // PACKED_HEAD_DIM) if paged else total_k * head_kv
     scale_rows = -(-rows // SCALE_TILE_ROWS) * SCALE_TILE_ROWS
     scale_cols = -(-(HEAD_DIM // SCALE_BLOCK) // SCALE_TILE_COLS) * SCALE_TILE_COLS
     scale_shape = (scale_rows, scale_cols)
@@ -2927,18 +3415,27 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
         Grouping by head instead (``head_kv_idx * total_k + token``) agrees with
         it whenever ``head_kv == 1`` and pairs every token with another head's
         block scale as soon as it is not.
+
+        Under paging the row becomes ``(page * head_kv + head_kv_idx) *
+        page_size + token`` (``_paged_kv_scale_row``, :1328-1336), which is the
+        row-major flattening of the paged tensor -- so the same reshape holds
+        and only the shape restored at the end differs. The twins are produced
+        in whichever layout the kernel consumes, because the BF16 sibling they
+        feed runs in the same mode.
         """
         flat = packed.reshape(-1, PACKED_HEAD_DIM)
         out = _dequant_nvfp4_to_bf16(flat, scale, global_scale, rows=rows, cols=HEAD_DIM)
-        return out.reshape(total_k, head_kv, HEAD_DIM).contiguous()
+        return out.reshape(*packed.shape[:-1], HEAD_DIM).contiguous()
 
     return {
         "config": dict(config),
         "csr": csr,
         "q": q,
         "q_flat": q.reshape(-1, HEAD_DIM),
-        "k": k,
-        "v": v,
+        "k": k_paged if paged else k,
+        "v": v_paged if paged else v,
+        "k_flat": k,
+        "v_flat": v,
         "k_scale_128x4": k_scale,
         "v_scale_128x4": v_scale,
         "k_global_scale": k_global,
@@ -2946,8 +3443,11 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
         # interface pins has_v_global_scale off and applies V's tensor scale in
         # the combine kernel. Kept so the contract is visible in one place.
         "v_global_scale": v_global,
-        "k_dequantized": twin(k, k_scale, k_global),
-        "v_dequantized": twin(v, v_scale, None),
+        "k_dequantized": twin(k_paged if paged else k, k_scale, k_global),
+        "v_dequantized": twin(v_paged if paged else v, v_scale, None),
+        "paged": paged,
+        "page_table": page_table,
+        "seqused_k": seqused_k,
         "k2q_row_ptr": csr["k2q_row_ptr"].view(head_kv, -1),
         "k2q_q_indices": csr["k2q_q_indices"].view(head_kv, -1),
         "k2q_qsplit_indices": qsplit,
@@ -2968,7 +3468,10 @@ def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
         "qhead_per_kv": qhead_per_kv,
         "topk": config["topk"],
         "total_q": total_q,
-        "total_k": total_k,
+        # Under paging the K/V buffers span the page array, not the packed
+        # sequences, and the kernel shapes its match_buffer from this value.
+        "total_k": (int(page_table.numel()) * config["blk_kv"]) if paged else total_k,
+        "total_k_flat": total_k,
         "total_rows": csr["total_rows"],
         "nnz": csr["nnz_capacity"],
         "num_batches": len(csr["seqlens_k"]),
@@ -3019,8 +3522,9 @@ def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
     inv_temperature = 1.0 / (data["lse_temperature_scale"] or 1.0)
 
     args = [
-        data["k"],
-        data["v"],
+        # 3-D view; see the sibling. The tensormap carries the paged geometry.
+        data["k"].reshape(-1, data["head_kv"], PACKED_HEAD_DIM),
+        data["v"].reshape(-1, data["head_kv"], PACKED_HEAD_DIM),
         data["k_scale_128x4"].reshape(-1),
         data["v_scale_128x4"].reshape(-1),
     ]
@@ -3037,8 +3541,14 @@ def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
     ]
     if data["lse_temperature_scale"] is not None:
         args.append(outputs["lse_temperature_partial"].reshape(-1))
+    args.append(as_bits(data["q_flat"]))
+    # Optional handles, in the reference's own argument order: both are absent
+    # from the signature entirely when the specialization pins them to None.
+    if data.get("page_table") is not None:
+        args.append(data["page_table"].reshape(-1))
+    if data.get("seqused_k") is not None:
+        args.append(data["seqused_k"])
     args += [
-        as_bits(data["q_flat"]),
         data["cu_seqlens_q"],
         data["cu_seqlens_k"],
         scale_log2,
@@ -3079,6 +3589,11 @@ def reference_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, A
         "k_scale_128x4": data["k_scale_128x4"],
         "v_scale_128x4": data["v_scale_128x4"],
         "k_global_scale": data["k_global_scale"],
+        # Present iff their axis is on. Their PRESENCE is what makes the adapter
+        # compile a paged / seqused specialization at all, so dropping them here
+        # silently reuses the flat binary and feeds it a rank-4 tensor.
+        "page_table": data.get("page_table"),
+        "seqused_k": data.get("seqused_k"),
         "k2q_q_indices": data["k2q_q_indices"],
         "k2q_qsplit_indices": data["k2q_qsplit_indices"],
         "k2q_row_ptr": data["k2q_row_ptr"],
@@ -3151,6 +3666,11 @@ def _twin_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, Any]:
     V carries no tensor scale, because this kernel is never given one: the
     interface pins ``has_v_global_scale`` off and the combine kernel applies it.
     The twin has to see V scaled exactly the way this kernel sees it.
+
+    Under paging the twins are already page-major and the sibling runs paged
+    too, on the same table and the same ``seqused_k``. Handing a paged NVFP4 run
+    a flat twin would compare two different traversals of K/V and report the
+    difference as a numerical error.
     """
     return {
         "head_dim": data["head_dim"],
@@ -3159,6 +3679,8 @@ def _twin_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, Any]:
         "causal": data["causal"],
         "k": data["k_dequantized"],
         "v": data["v_dequantized"],
+        "page_table": data.get("page_table"),
+        "seqused_k": data.get("seqused_k"),
         "qk_dtype": _torch_dtype("bfloat16"),
         "pv_dtype": _torch_dtype("bfloat16"),
         "k2q_q_indices": data["k2q_q_indices"],

--- a/tirx_kernels/msa/utils/_msa_bench.py
+++ b/tirx_kernels/msa/utils/_msa_bench.py
@@ -85,6 +85,17 @@ def cutedsl_paths() -> list[str]:
 # and torch owns live CUDA state this recovery must not disturb.
 _REFERENCE_ROOTS = ("cutlass", "quack", "sympy", "src", "fmha_sm100", "torch._dynamo")
 
+# The subset of the roots above that is safe to drop and import again inside a
+# live process: pure Python, no native extension module underneath. `cutlass` is
+# NOT here -- its `_mlir_libs` extension registers nanobind types on first init,
+# and a second init aborts the process with "refusing to add duplicate key". Nor
+# is `torch._dynamo`, which holds compiled-code caches other live objects point
+# at.
+_RETRY_DROP_ROOTS = ("quack", "sympy", "src", "fmha_sm100")
+
+# Reference-builder entries so far in this process; >1 means a retry.
+_ensure_calls = 0
+
 
 def _drop_interrupted_imports() -> None:
     """Forget modules whose import was cut off partway through.
@@ -106,7 +117,26 @@ def _drop_interrupted_imports() -> None:
     break are probed for an attribute their own ``__init__`` defines, and their
     whole subtree is dropped when the probe fails. Re-importing costs seconds,
     but only on a retry, and it happens outside the timed region.
+
+    Neither sweep is sufficient on its own. Both need evidence left behind in
+    ``sys.modules``: the flag needs the module to still be marked initializing,
+    the invariant needs a submodule that made it into ``sys.modules`` without
+    being bound on its parent. An import cut *before* the submodule is
+    registered at all leaves neither trace, and the parent then simply lacks the
+    attribute -- which is how one matrix lost two of fourteen rows to ``quack``
+    with no ``copy_utils`` and ``sympy`` with no ``printing``.
+
+    So from the second call onward -- that is, on a retry -- the pure-Python
+    reference roots are dropped outright rather than inspected. Only those:
+    re-importing ``cutlass`` in a live process aborts it, because its MLIR
+    extension registers nanobind types that may be registered exactly once. The
+    first call must not drop anything either, because it is the only chance to
+    observe a ``cutlass`` that some earlier import already bound outside the
+    pin, which is what the caller checks for next; the pinned build and the
+    ambient one are not interchangeable.
     """
+    global _ensure_calls
+    _ensure_calls += 1
     for name, module in list(sys.modules.items()):
         if name.startswith(("tirx_kernels", "tvm")):
             continue
@@ -135,6 +165,14 @@ def _drop_interrupted_imports() -> None:
                 n for n in sys.modules if n == parent_name or n.startswith(parent_name + ".")
             ]:
                 del sys.modules[stale]
+
+    if _ensure_calls > 1:
+        for name in [
+            n
+            for n in sys.modules
+            if any(n == r or n.startswith(r + ".") for r in _RETRY_DROP_ROOTS)
+        ]:
+            del sys.modules[name]
 
 
 def ensure_msa_importable() -> None:
@@ -227,6 +265,13 @@ def compiled_sparse_atten_fwd(case: dict):
     q_flat = case["q_flat"]
     o_partial_flat = case["o_partial_flat"]
     lse_temperature = case.get("lse_temperature_partial")
+    # Paging is `page_table is not None` at the host entry (interface.py:1670),
+    # and `seqused_k` is accepted only alongside it (interface.py:251-253).
+    page_table = case.get("page_table")
+    seqused_k = case.get("seqused_k")
+    paged = page_table is not None
+    if seqused_k is not None and not paged:
+        raise ValueError("seqused_k is only supported together with page_table")
     gather4_desc = (
         create_q_gather4_tma_desc(q_flat, box_x=128 if q_flat.dtype == torch.float8_e4m3fn else 64)
         if qhead_per_kv in (1, 2, 4)
@@ -245,10 +290,10 @@ def compiled_sparse_atten_fwd(case: dict):
         case["pv_dtype"],
         o_partial_flat.dtype,
         bool(case["causal"]),
-        False,  # paged_kv
+        paged,
         True,  # use_prepare_scheduler
-        None,  # page_size
-        False,  # seqused_k
+        case["blk_kv"] if paged else None,  # page_size: upstream forces == blk_kv
+        seqused_k is not None,
         lse_temperature is not None,
     )
     if key not in _FWD_CACHE:
@@ -261,9 +306,9 @@ def compiled_sparse_atten_fwd(case: dict):
             head_dim=case["head_dim"],
             qheadperkv=qhead_per_kv,
             n_block_size=case["blk_kv"],
-            paged_kv=False,
-            page_size=None,
-            has_seqused_k=False,
+            paged_kv=paged,
+            page_size=case["blk_kv"] if paged else None,
+            has_seqused_k=seqused_k is not None,
             causal=bool(case["causal"]),
             use_prepare_scheduler=True,
             qk_dtype=cutlass_dtype[case["qk_dtype"]],
@@ -283,8 +328,8 @@ def compiled_sparse_atten_fwd(case: dict):
             None if lse_temperature is None else to_cute_tensor(lse_temperature),
             to_cute_tensor(q_flat),
             None if gather4_desc is None else to_cute_tensor(gather4_desc),
-            None,  # page_table
-            None,  # seqused_k
+            None if page_table is None else to_cute_tensor(page_table),
+            None if seqused_k is None else to_cute_tensor(seqused_k),
             to_cute_tensor(case["cu_seqlens_q"]),
             to_cute_tensor(case["cu_seqlens_k"]),
             Float32(case["softmax_scale"]),
@@ -313,8 +358,8 @@ def compiled_sparse_atten_fwd(case: dict):
             lse_temperature,
             q_flat,
             gather4_desc,
-            None,
-            None,
+            page_table,
+            seqused_k,
             case["cu_seqlens_q"],
             case["cu_seqlens_k"],
             case["softmax_scale"],
@@ -364,6 +409,11 @@ def compiled_sparse_atten_nvfp4_kv(case: dict):
     o_partial_flat = case["o_partial_flat"]
     lse_temperature = case.get("lse_temperature_partial")
     k_global_scale = case.get("k_global_scale")
+    page_table = case.get("page_table")
+    seqused_k = case.get("seqused_k")
+    paged = page_table is not None
+    if seqused_k is not None and not paged:
+        raise ValueError("seqused_k is only supported together with page_table")
     gather4_desc = (
         create_q_gather4_tma_desc(q_flat, box_x=128 if q_flat.dtype == torch.float8_e4m3fn else 64)
         if qhead_per_kv in (1, 2, 4)
@@ -378,10 +428,10 @@ def compiled_sparse_atten_nvfp4_kv(case: dict):
         q_flat.dtype,
         o_partial_flat.dtype,
         bool(case["causal"]),
-        False,  # paged_kv
+        paged,
         True,  # use_prepare_scheduler
-        None,  # page_size
-        False,  # seqused_k
+        case["blk_kv"] if paged else None,  # page_size: upstream forces == blk_kv
+        seqused_k is not None,
         lse_temperature is not None,
         True,  # fp8_pair_dequant: pinned, never read from the environment
         k_global_scale is not None,
@@ -392,9 +442,9 @@ def compiled_sparse_atten_nvfp4_kv(case: dict):
             head_dim=case["head_dim"],
             qheadperkv=qhead_per_kv,
             n_block_size=case["blk_kv"],
-            paged_kv=False,
-            page_size=None,
-            has_seqused_k=False,
+            paged_kv=paged,
+            page_size=case["blk_kv"] if paged else None,
+            has_seqused_k=seqused_k is not None,
             causal=bool(case["causal"]),
             use_prepare_scheduler=True,
             fp8_pair_dequant=True,
@@ -419,8 +469,8 @@ def compiled_sparse_atten_nvfp4_kv(case: dict):
             None if lse_temperature is None else to_cute_tensor(lse_temperature),
             to_cute_tensor(q_flat),
             None if gather4_desc is None else to_cute_tensor(gather4_desc),
-            None,  # page_table
-            None,  # seqused_k
+            None if page_table is None else to_cute_tensor(page_table),
+            None if seqused_k is None else to_cute_tensor(seqused_k),
             to_cute_tensor(case["cu_seqlens_q"]),
             to_cute_tensor(case["cu_seqlens_k"]),
             Float32(case["softmax_scale"]),
@@ -453,8 +503,8 @@ def compiled_sparse_atten_nvfp4_kv(case: dict):
             lse_temperature,
             q_flat,
             gather4_desc,
-            None,
-            None,
+            page_table,
+            seqused_k,
             case["cu_seqlens_q"],
             case["cu_seqlens_k"],
             case["softmax_scale"],


### PR DESCRIPTION
Extends both merged forwards -- `msa_sparse_atten_fwd_sm100` and `msa_sparse_atten_fwd_nvfp4_kv_sm100` -- with the `paged_kv` and `seqused_k` axes that production MSA always runs with, plus `causal=False`, fp16 partial output and `topk=32` as correctness-only coverage.

## Paging

Upstream constrains `page_size == blk_kv`, so a CTA's KV block is exactly one page and paging becomes a coordinate swap rather than a gather. K and V arrive as `[num_pages, head_kv, page_size, head_dim]`, their TMA descriptors take a fourth mode, `k_batch_offset` drops to zero, and thread 0 resolves `mPageTable[batch, kv_block]` into the `sPagedKvIdx` cell the storage struct already declares. The MMA warp, both softmax warpgroups and the whole epilogue carry no paged branch.

Descriptor rank follows the tensor rather than the caller at every site, including the FP8 staging maps whose selection is orthogonal to it — a rank-3 map under a 4-D copy is an illegal instruction, and the two flags are chosen by different predicates.

`seqused_k` is paged-only at the host entry and reorders one expression: `_logical_seqlen_k` returns `mSeqUsedK[batch]` ahead of the paged capacity and the `cu_seqlens` difference. It also opens a regime the other two arms cannot reach — with a supplied length shorter than `seqlen_q`, `causal_q_offset` goes negative and the leading queries are fully masked by design, storing `O = 0` and `LSE = -inf`. Clamping that row to a finite value would diverge from the source.

## NVFP4 block-scale row

The only nontrivial NVFP4 delta. Under paging the row is `(page * head_kv + head) * page_size + row`, where `row` is the **intra-page** row rather than the batch-offset-adjusted token the flat form takes. Feeding it the absolute token yields a different but still in-range E4M3 byte for every task: it does not fault, the values look plausible, and only a bitwise comparison catches it. Every paged NVFP4 config therefore uses `head_kv = 2`, where a row-mapping error cannot hide.

## Other axes

`causal=False` is a real codegen axis rather than a predicate — different register budgets, no exp2 emulation, no diagonal binary search, column-limit-only masking — gated exactly where the source gates it with `const_expr`. fp16 partial shares the bf16 store's lane width and remap but not its converter.

## Correctness

Bitwise against the compiled CuTe-DSL source on identical frozen inputs, `rtol=0, atol=0`: **34/34** configs for the BF16/FP8 forward, **33/33** for the NVFP4 one, covering `CONFIGS` and `BENCH_CONFIGS`.

## Performance

Two changes were needed to hold the gate on the new shapes. Both trade instructions for overlap rather than removing work — executed loads and stores go **up** in each case:

- The gather4 Q program stages its metadata reads into a local and issues them before the barrier that orders the shared writes; the reads themselves need no such ordering, so the wait absorbs the latency the store used to pay in series. Warp-level global loads rise from 173,425 to 266,698 and shared stores from 611,442 to 704,222, and five alternating paired rounds still give 5/5 and 0.76% on the target shape.
- The paged page-index resolve moved off thread 0, which was running it behind a 32-step binary search of dependent global loads, onto an idle prologue warp. It shares no input with that chain, and the cost it added there is one the long shapes amortize and a 10 us shape does not — 5/5 paired rounds, 2.71%, taking that shape from 0.989 to 1.027.

Both kernels clear every required shape on `bench_suite`:

| kernel | shapes | min ratio |
| --- | --- | --- |
| `msa_sparse_atten_fwd_sm100` | 14/14 | 0.9929 |
| `msa_sparse_atten_fwd_nvfp4_kv_sm100` | 14/14 | 0.9947 |

The eight paged shapes land between 1.020x and 1.122x. Each verdict rests on repeated complete matrices — two for the BF16/FP8 forward, three for the NVFP4 one — because a full matrix schedules several large workloads onto one device and inflates them; rows reading below the gate were re-measured in isolation before being believed either way.

The second commit adds the barrier-crossing read to the codegen-tuning database. Its verification section is worth reading before anyone repeats this measurement: a SASS listing keyed on the first token of each line drops every predicated instruction, and that single defect produced three false readings while this was being investigated — see the comments below.
