### PR TITLE
feat(infra): bench-suite --with-references switch, occupancy deadlock fix, refreshed baseline

### DIFF
--- a/tests/test_bench_suite_run.py
+++ b/tests/test_bench_suite_run.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+from __future__ import annotations
+
+from tirx_kernels.bench_suite import run as bench_run
+
+_OUR_CHILD_PID = 4001
+_FOREIGN_PID = 9001
+
+
+def _pool_with_fake_smi(monkeypatch, apps_rows: list[str]) -> bench_run.GpuPool:
+    def fake_smi(args: list[str]) -> list[str]:
+        query = args[0]
+        if query == "--query-gpu=index,utilization.gpu":
+            return ["0, 0", "1, 0"]
+        if query == "--query-gpu=index,memory.used,memory.total":
+            return ["0, 7000, 180000", "1, 400, 180000"]
+        if query == "--query-gpu=index,memory.total":
+            return ["0, 180000", "1, 180000"]
+        if query == "--query-gpu=index,uuid":
+            return ["0, GPU-aaa", "1, GPU-bbb"]
+        if query == "--query-compute-apps=pid,gpu_uuid,used_memory":
+            return apps_rows
+        raise AssertionError(f"unexpected nvidia-smi query: {args!r}")
+
+    monkeypatch.setattr(bench_run.GpuPool, "_nvidia_smi", staticmethod(fake_smi))
+    monkeypatch.setattr(bench_run, "_our_pids", lambda: {_OUR_CHILD_PID})
+    return bench_run.GpuPool(allowed={"0", "1"})
+
+
+def test_parked_own_child_does_not_occupy_its_affinity_card(monkeypatch):
+    """An interference-parked bench child's residual context must not mark the
+    card externally occupied, or the child starves waiting to reacquire it."""
+    pool = _pool_with_fake_smi(monkeypatch, [f"{_OUR_CHILD_PID}, GPU-aaa, 7000"])
+    assert pool._occupied_indices() == set()
+    assert pool.try_acquire_exact(("0",)) is None  # occupancy not refreshed yet
+    pool.refresh_external_occupancy()
+    assert pool.try_acquire_exact(("0",)) == ("0",)
+
+
+def test_foreign_resident_memory_occupies_card(monkeypatch):
+    pool = _pool_with_fake_smi(monkeypatch, [f"{_FOREIGN_PID}, GPU-aaa, 53000"])
+    assert pool._occupied_indices() == {"0"}
+    pool.refresh_external_occupancy()
+    assert pool.try_acquire_exact(("0",)) is None
+    assert pool.try_acquire_exact(("1",)) == ("1",)
+
+
+def test_small_foreign_residual_is_forgiven_by_idle_floor(monkeypatch):
+    pool = _pool_with_fake_smi(monkeypatch, [f"{_FOREIGN_PID}, GPU-aaa, 300"])
+    assert pool._occupied_indices() == set()
+
+
+def test_mixed_own_and_foreign_memory_counts_only_foreign(monkeypatch):
+    pool = _pool_with_fake_smi(
+        monkeypatch,
+        [
+            f"{_OUR_CHILD_PID}, GPU-aaa, 4000",
+            f"{_FOREIGN_PID}, GPU-aaa, 2000",
+            f"{_OUR_CHILD_PID}, GPU-bbb, 6000",
+        ],
+    )
+    assert pool._occupied_indices() == {"0"}

--- a/tests/test_runner_interrupts.py
+++ b/tests/test_runner_interrupts.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+from __future__ import annotations
+
+import os
+import signal
+
+import pytest
+
+from tirx_kernels import runner
+
+
+class _Interrupted(BaseException):
+    pass
+
+
+@pytest.fixture
+def bench_child_handler():
+    """Install the bench child's SIGUSR1 handler shape for the test's duration."""
+
+    def handler(_signum, _frame):
+        if runner.gpu_interrupt_should_defer():
+            return
+        raise _Interrupted()
+
+    previous = signal.signal(signal.SIGUSR1, handler)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGUSR1, previous)
+
+
+def test_interrupt_outside_critical_section_raises_immediately(bench_child_handler):
+    with pytest.raises(_Interrupted):
+        os.kill(os.getpid(), signal.SIGUSR1)
+
+
+def test_interrupt_inside_critical_section_is_redelivered_at_exit(bench_child_handler):
+    """A signal landing mid-region must not unwind the region (an import or JIT
+    would be left half-executed); it is redelivered once the region exits."""
+    survived = []
+    with pytest.raises(_Interrupted):
+        with runner.defer_gpu_interrupts():
+            os.kill(os.getpid(), signal.SIGUSR1)
+            survived.append("region completed")
+    assert survived == ["region completed"]
+
+
+def test_nested_critical_sections_defer_until_outermost_exit(bench_child_handler):
+    survived = []
+    with pytest.raises(_Interrupted):
+        with runner.defer_gpu_interrupts():
+            with runner.defer_gpu_interrupts():
+                os.kill(os.getpid(), signal.SIGUSR1)
+            survived.append("inner exited, still deferred")
+    assert survived == ["inner exited, still deferred"]
+
+
+def test_quiet_critical_section_does_not_redeliver(bench_child_handler):
+    with runner.defer_gpu_interrupts():
+        pass
+    # No signal arrived inside the region: exiting must not synthesize one,
+    # and a later signal still raises immediately.
+    with pytest.raises(_Interrupted):
+        os.kill(os.getpid(), signal.SIGUSR1)

--- a/tirx_kernels/bench/__main__.py
+++ b/tirx_kernels/bench/__main__.py
@@ -116,6 +116,7 @@ def _prepared_child_main(args, *, child_started: float) -> int:
                 close_prepared_kernel_bench,
                 cuda_is_initialized,
                 current_process_cuda_memory_bytes,
+                gpu_interrupt_should_defer,
                 prepare_kernel_bench,
                 run_prepared_kernel_bench,
             )
@@ -176,6 +177,12 @@ def _prepared_child_main(args, *, child_started: float) -> int:
             pass
 
         def interrupt_gpu_attempt(_signum, _frame):
+            # Inside an uninterruptible region (a reference builder's import or
+            # JIT), record the interrupt and let the region finish; it is
+            # redelivered at the region's exit. Raising mid-import leaves
+            # partially initialized modules that poison retry-in-place.
+            if gpu_interrupt_should_defer():
+                return
             raise _GpuAttemptInterrupted()
 
         gpu_attempt = 1

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -2,9 +2,12 @@
 
 The bench suite measures registered kernels against one pinned before-run
 baseline. Its acceptance verdict is direct before/after wall time from
-`ratio_diff.py`. The suite runs only the TIRx implementation; external
-references are explicit diagnostics through `python -m tirx_kernels.bench
---with-references` and never replace the direct verdict.
+`ratio_diff.py`. By default the suite runs only the TIRx implementation;
+passing `--with-references` also runs every declared external reference
+(baseline) implementation, which enables the reference-ratio regression
+report against `baseline.json`. References remain diagnostics — they never
+replace the direct verdict. The same flag exists on
+`python -m tirx_kernels.bench` for single-workload diagnostics.
 
 ## Workloads
 
@@ -124,7 +127,9 @@ gate remains strict `after/before < 1.01`.
 - Terminal workload failures are collected without cancelling unrelated work;
   the complete sweep exits nonzero after reporting every failure.
 - External references are excluded from the suite's direct before/after
-  acceptance denominator.
+  acceptance denominator. They run only under `--with-references`; a
+  missing or failing enabled reference (`BASELINE_ERROR`) fails its
+  workload.
 
 Useful options:
 
@@ -139,6 +144,7 @@ Useful options:
 | `--out-dir PATH` | Artifact root |
 | `--check-imports` | Resolve selected imports and exit |
 | `--no-report` | Skip report generation |
+| `--with-references` | Also run external references and the ratio report (not with `--ab-before`) |
 
 ## Artifacts
 

--- a/tirx_kernels/bench_suite/baseline.json
+++ b/tirx_kernels/bench_suite/baseline.json
@@ -1,14 +1,15 @@
 {
-  "timestamp": "14",
-  "label": "post-refactor",
+  "timestamp": "4",
+  "label": "f727de3d-dirty",
+  "references_enabled": true,
   "git": {
-    "tir": "135a054f",
-    "tirx-kernels": "f2210e41-dirty",
+    "tir": "73e38d3f",
+    "tirx-kernels": "f727de3d-dirty",
     "tirx-bench-ci": null
   },
   "kernel_tree": {
     "tir:python/tvm/tirx": "4cbcd19685bc44fc81a64ae7708807a6f9bada7b",
-    "tirx-kernels:tirx_kernels": "540c7f7e9904ebd86834d18b458e34eea1f3e8c3"
+    "tirx-kernels:tirx_kernels": "a85ac53c60a693d538ed368405c8d8f3b41c9c9f"
   },
   "baselines": {
     "torch": {
@@ -30,11 +31,11 @@
     "flashinfer": {
       "importable": true,
       "source_dir": "/home/bohanhou/flashinfer",
-      "git_dir": "/home/bohanhou/flashinfer",
-      "git_sha": "f2e04400",
       "version": "0.6.18",
       "dist": "flashinfer-python",
-      "editable": true
+      "editable": true,
+      "git_dir": "/home/bohanhou/flashinfer",
+      "git_sha": "f2e04400"
     },
     "flash_kda": {
       "importable": true,
@@ -65,6 +66,775 @@
       "version": "4.6.0.dev0"
     }
   },
+  "selection": {
+    "mode": "default",
+    "keys": [
+      [
+        "fp16_bf16_gemm",
+        "fp16_1024x1024x1024"
+      ],
+      [
+        "fp16_bf16_gemm",
+        "fp16_16384x16384x16384"
+      ],
+      [
+        "fp16_bf16_gemm",
+        "bf16_4096x4096x4096"
+      ],
+      [
+        "nvfp4_gemm",
+        "1024x1024x1024"
+      ],
+      [
+        "nvfp4_gemm",
+        "4096x4096x4096"
+      ],
+      [
+        "nvfp4_gemm",
+        "16384x16384x16384"
+      ],
+      [
+        "rmsnorm",
+        "hs128_bs32"
+      ],
+      [
+        "rmsnorm",
+        "hs4096_bs128"
+      ],
+      [
+        "rmsnorm",
+        "hs8192_bs4113"
+      ],
+      [
+        "deepgemm_sm100_fp4_mqa_logits",
+        "s2048_skv4096_h64_d128_f32_dense_cp"
+      ],
+      [
+        "deepgemm_sm100_fp4_mqa_logits",
+        "s4096_skv8192_h64_d128_bf16_compressed_nocp"
+      ],
+      [
+        "deepgemm_sm100_fp4_paged_mqa_logits",
+        "b1_n1_mp1_ps32_h64_d128_f32_fixed"
+      ],
+      [
+        "deepgemm_sm100_fp4_paged_mqa_logits",
+        "b16_n1_mp128_ps64_h64_d128_bf16_fixed"
+      ],
+      [
+        "deepgemm_sm100_fp8_bmm",
+        "bhr_hdr_bhd_b4096_h8_r4096_d1024"
+      ],
+      [
+        "deepgemm_sm100_fp8_bmm",
+        "bhd_hdr_bhr_b8192_h8_r4096_d1024"
+      ],
+      [
+        "deepgemm_sm100_fp8_bmm",
+        "bhd_bhr_hdr_b4096_h8_r4096_d1024"
+      ],
+      [
+        "deepgemm_sm100_fp8_gemm_1d1d",
+        "m4096_n576_k7168"
+      ],
+      [
+        "deepgemm_sm100_fp8_gemm_1d1d",
+        "m4096_n7168_k16384"
+      ],
+      [
+        "deepgemm_sm100_fp8_gemm_1d1d",
+        "m4096_n4096_k7168_bfp4"
+      ],
+      [
+        "deepgemm_sm100_fp8_mqa_logits",
+        "s2048_skv4096_h64_d128_f32_dense_cp"
+      ],
+      [
+        "deepgemm_sm100_fp8_mqa_logits",
+        "s4096_skv8192_h64_d128_bf16_compressed_nocp"
+      ],
+      [
+        "deepgemm_sm100_fp8_paged_mqa_logits",
+        "b1_n1_mp1_ps64_h64_d128_f32_fixed"
+      ],
+      [
+        "deepgemm_sm100_fp8_paged_mqa_logits",
+        "b16_n1_mp128_ps64_h64_d128_bf16_fixed"
+      ],
+      [
+        "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
+        "g8_m4096_n7168_k4096_gran32_al160"
+      ],
+      [
+        "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
+        "g16_m7168_n2048_k2048_gran128_al128"
+      ],
+      [
+        "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
+        "g4_m4096_n7168_k8192_gran128_al128_psum"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
+        "g4_m8192_n6144_k7168"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
+        "g8_m4096_n4096_k2048_bfp4"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
+        "g8_m4096_n7168_k3072_psum_zp"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_masked",
+        "g32_m192_n6144_k7168"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_masked",
+        "g6_m1024_n4096_k2048"
+      ],
+      [
+        "deepgemm_sm100_m_grouped_fp8_gemm_masked",
+        "g32_m192_n4096_k4096_bfp4"
+      ],
+      [
+        "deepgemm_sm100_tf32_hc_prenorm_gemm",
+        "m128_n24_k16384_s64"
+      ],
+      [
+        "deepgemm_sm100_tf32_hc_prenorm_gemm",
+        "m8192_n24_k28672_s1"
+      ],
+      [
+        "deepgemm_sm100_tf32_hc_prenorm_gemm",
+        "m4096_n24_k7168_s1"
+      ],
+      [
+        "sm100_fp8_fp4_mega_moe",
+        "t64_m64_h7168_i3072_e384_k6_g1"
+      ],
+      [
+        "sm100_fp8_fp4_mega_moe",
+        "t8192_m8192_h7168_i3072_e384_k6_g1"
+      ],
+      [
+        "sm100_fp8_fp4_mega_moe",
+        "t8192_m8192_h7168_i3072_e384_k6_g1_s1"
+      ],
+      [
+        "flash_attention4",
+        "s1024_h32kv4"
+      ],
+      [
+        "flash_attention4",
+        "s4096_h32kv4_causal"
+      ],
+      [
+        "flash_attention4",
+        "s8192_h32kv32"
+      ],
+      [
+        "flash_attention_backward_sm100",
+        "b1_s2048_h16_causal"
+      ],
+      [
+        "flash_attention_backward_sm100",
+        "b1_s8192_h16_noncausal"
+      ],
+      [
+        "flash_attention_backward_sm100",
+        "b4_s8192_h16_noncausal"
+      ],
+      [
+        "act_and_mul",
+        "silu_fp16_d4096_t1"
+      ],
+      [
+        "act_and_mul",
+        "silu_bf16_d16384_t32768"
+      ],
+      [
+        "act_and_mul",
+        "gelu_tanh_fp16_d11008_t8192"
+      ],
+      [
+        "silu_and_mul_nvfp4_experts_quantize",
+        "fp16_b128_m2048_k2048"
+      ],
+      [
+        "silu_and_mul_nvfp4_experts_quantize",
+        "bf16_b8_m512_k2048"
+      ],
+      [
+        "silu_and_mul_nvfp4_experts_quantize",
+        "fp16_b8_m16_k2048"
+      ],
+      [
+        "gdn_decode_bf16_ilp4",
+        "t1_b1_h2_hv4_tv16"
+      ],
+      [
+        "gdn_decode_bf16_ilp4",
+        "t4_b8_h4_hv8_tv16"
+      ],
+      [
+        "gdn_decode_bf16_ilp4",
+        "t8_b4_h8_hv16_tv16"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_mtp",
+        "t2_b4_h16_hv32_tv32"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_mtp",
+        "t4_b64_h8_hv16_tv128"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_mtp",
+        "t8_b512_h16_hv32_tv128"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_t1",
+        "b16_h16_hv32_tv64"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_t1",
+        "b128_h8_hv16_tv128"
+      ],
+      [
+        "gdn_decode_bf16_wide_vec_t1",
+        "b512_h4_hv8_tv128"
+      ],
+      [
+        "gdn_decode_fp32_mtp_warp",
+        "t2_b4_h16_hv64_tv16_ilp2_sv0"
+      ],
+      [
+        "gdn_decode_fp32_mtp_warp",
+        "t8_b256_h16_hv64_tv64_ilp4_sv1"
+      ],
+      [
+        "gdn_decode_fp32_mtp_warp",
+        "t4_b64_h8_hv32_tv64_ilp4_sv1"
+      ],
+      [
+        "gdn_cp_prefill_sm100",
+        "fp16_q1_k1_v1_s2048_none_i32"
+      ],
+      [
+        "gdn_cp_prefill_sm100",
+        "fp16_q16_k16_v16_s4096+4096_init_f16_i64"
+      ],
+      [
+        "gdn_cp_prefill_sm100",
+        "fp16_q16_k16_v64_s192+64_initfinal_f16_i64"
+      ],
+      [
+        "gdn_prefill_sm100",
+        "hq8_hv32_s1024x8"
+      ],
+      [
+        "gdn_prefill_sm100",
+        "hq16_hv64_s1x8192"
+      ],
+      [
+        "gdn_prefill_sm100",
+        "hq32_hv32_s8192x16"
+      ],
+      [
+        "tinygemm2_sm100",
+        "b1_o128_k720"
+      ],
+      [
+        "tinygemm2_sm100",
+        "b16_o2880_k2880"
+      ],
+      [
+        "tinygemm2_sm100",
+        "b64_o4096_k3072"
+      ],
+      [
+        "flashkda_bf16_fused_m128",
+        "h96_fixed8192"
+      ],
+      [
+        "flashkda_bf16_fused_m128",
+        "h96_uniform"
+      ],
+      [
+        "flashkda_bf16_fused_m128",
+        "h64_mixed"
+      ],
+      [
+        "flashkda_decode_t1_precomputed",
+        "hv16h16_b1_s16"
+      ],
+      [
+        "flashkda_decode_t1_precomputed",
+        "hv16h16_b128_s8"
+      ],
+      [
+        "flashkda_decode_t1_precomputed",
+        "hv32h16_b32_s8"
+      ],
+      [
+        "flashkda_decode_t2_precomputed",
+        "hv32h16_b128_t2"
+      ],
+      [
+        "flashkda_decode_t2_precomputed",
+        "hv16h16_b64_t2"
+      ],
+      [
+        "flashkda_decode_t2_precomputed",
+        "hv12h12_b8_t2"
+      ],
+      [
+        "flashkda_decode_t3_lower_bound",
+        "hv16h16_b1_t3"
+      ],
+      [
+        "flashkda_decode_t3_lower_bound",
+        "hv16h16_b4_t3"
+      ],
+      [
+        "flashkda_decode_t3_lower_bound",
+        "hv16h16_b16_t3"
+      ],
+      [
+        "flashkda_decode_t4_precomputed",
+        "hv32h16_b128_t4"
+      ],
+      [
+        "flashkda_decode_t4_precomputed",
+        "hv16h16_b64_t4"
+      ],
+      [
+        "flashkda_decode_t4_precomputed",
+        "hv12h12_b8_t4"
+      ],
+      [
+        "flashkda_decode_t5_gram",
+        "hv32h16_b128_s1"
+      ],
+      [
+        "flashkda_decode_t5_gram",
+        "hv32h16_b1_s8"
+      ],
+      [
+        "flashkda_decode_t5_gram",
+        "hv32h16_b3_s4"
+      ],
+      [
+        "flashkda_decode_t6_gram",
+        "hv32h16_b128_s1"
+      ],
+      [
+        "flashkda_decode_t6_gram",
+        "hv32h16_b1_s8"
+      ],
+      [
+        "flashkda_decode_t6_gram",
+        "hv32h16_b3_s4"
+      ],
+      [
+        "recurrent_kda_decode_grouped",
+        "dec_hv16_b1"
+      ],
+      [
+        "recurrent_kda_decode_grouped",
+        "ver_t8_hv16_b128"
+      ],
+      [
+        "recurrent_kda_decode_grouped",
+        "ver_t8_hv12_b16"
+      ],
+      [
+        "recurrent_kda_decode_one_warp",
+        "hv16_b8_tr8_lb"
+      ],
+      [
+        "recurrent_kda_decode_one_warp",
+        "hv16_b128_tr16_lb"
+      ],
+      [
+        "recurrent_kda_decode_one_warp",
+        "hv12_b64_tr16_lb"
+      ],
+      [
+        "selective_state_update_mtp_horizontal",
+        "b1_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_horizontal",
+        "b512_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_horizontal",
+        "b2048_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_simple",
+        "b1_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_simple",
+        "b512_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_simple",
+        "b2048_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_vertical",
+        "b1_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_vertical",
+        "b512_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_mtp_vertical",
+        "b2048_h64_d64_s128_t6_r8_statebf16_official"
+      ],
+      [
+        "selective_state_update_stp_horizontal",
+        "b64_h64_d64_s128_r8_base"
+      ],
+      [
+        "selective_state_update_stp_horizontal",
+        "b64_h64_d128_s128_r8"
+      ],
+      [
+        "selective_state_update_stp_horizontal",
+        "b64_h64_d64_s256_r8"
+      ],
+      [
+        "selective_state_update_stp_simple",
+        "b64_h64_d64_s128_r8_base"
+      ],
+      [
+        "selective_state_update_stp_simple",
+        "b64_h64_d128_s128_r8"
+      ],
+      [
+        "selective_state_update_stp_simple",
+        "b64_h64_d64_s256_r8"
+      ],
+      [
+        "selective_state_update_stp_vertical",
+        "b64_h64_d64_s128_r8_base"
+      ],
+      [
+        "selective_state_update_stp_vertical",
+        "b64_h64_d128_s128_r8"
+      ],
+      [
+        "selective_state_update_stp_vertical",
+        "b64_h64_d64_s256_r8"
+      ],
+      [
+        "flashinfer_add_rmsnorm_fp4quant",
+        "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_add_rmsnorm_fp4quant",
+        "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_add_rmsnorm_fp4quant",
+        "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_fused_add_rmsnorm_quant",
+        "bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1"
+      ],
+      [
+        "flashinfer_fused_add_rmsnorm_quant",
+        "bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1"
+      ],
+      [
+        "flashinfer_fused_add_rmsnorm_quant",
+        "bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1"
+      ],
+      [
+        "flashinfer_fused_dit_layernorm",
+        "grgb_bf16_b1_r1920"
+      ],
+      [
+        "flashinfer_fused_dit_layernorm",
+        "rss_bf16_b1_r768"
+      ],
+      [
+        "flashinfer_fused_dit_layernorm",
+        "grss_bf16_b4_r1920"
+      ],
+      [
+        "flashinfer_layernorm",
+        "bf16_m1_h128_xc_yc_pdl0_eps1e6"
+      ],
+      [
+        "flashinfer_layernorm",
+        "bf16_m128_h1024_xc_yc_pdl0_eps1e6"
+      ],
+      [
+        "flashinfer_layernorm",
+        "bf16_m128_h16384_xc_yc_pdl0_eps1e6"
+      ],
+      [
+        "flashinfer_qk_rmsnorm",
+        "rms_bf16_b32_n32_h128_xc_yc_pdl0"
+      ],
+      [
+        "flashinfer_qk_rmsnorm",
+        "rms_f16_b16_n64_h128_xc_yc_pdl0"
+      ],
+      [
+        "flashinfer_qk_rmsnorm",
+        "gemma_bf16_b32_n32_h128_xc_yc_pdl0"
+      ],
+      [
+        "flashinfer_rmsnorm",
+        "rms_bf16_m32_h4096_xc_yc_pdl0"
+      ],
+      [
+        "flashinfer_rmsnorm",
+        "rms_bf16_m32_h4096_xc_yc_pdl1"
+      ],
+      [
+        "flashinfer_rmsnorm",
+        "gemma_bf16_m64_h8192_xc_yc_pdl0"
+      ],
+      [
+        "flashinfer_rmsnorm_fp4quant",
+        "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_rmsnorm_fp4quant",
+        "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_rmsnorm_fp4quant",
+        "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random"
+      ],
+      [
+        "flashinfer_rmsnorm_quant",
+        "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1"
+      ],
+      [
+        "flashinfer_rmsnorm_quant",
+        "bf16_e4m3_m64_h8192_xc_yc_pdl0_s1"
+      ],
+      [
+        "flashinfer_rmsnorm_quant",
+        "bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync"
+      ],
+      [
+        "mxfp4_quantize",
+        "fp16_linear_m4096_k4096"
+      ],
+      [
+        "mxfp4_quantize",
+        "fp16_128x4_m16384_k7168"
+      ],
+      [
+        "mxfp4_quantize",
+        "fp16_128x4_m128_k1024"
+      ],
+      [
+        "mxfp8_quantize",
+        "fp16_linear_m4096_k4096"
+      ],
+      [
+        "mxfp8_quantize",
+        "fp16_128x4_m16384_k7168"
+      ],
+      [
+        "mxfp8_quantize",
+        "fp16_128x4_m128_k1024"
+      ],
+      [
+        "nvfp4_quantize",
+        "fp16_linear_m4096_k4096"
+      ],
+      [
+        "nvfp4_quantize",
+        "fp16_128x4_m16384_k7168"
+      ],
+      [
+        "nvfp4_quantize",
+        "fp16_128x4_m128_k1024"
+      ],
+      [
+        "nvfp4_quantize_per_token",
+        "fp16_linear_m4096_k4096"
+      ],
+      [
+        "nvfp4_quantize_per_token",
+        "fp16_128x4_m16384_k7168"
+      ],
+      [
+        "nvfp4_quantize_per_token",
+        "fp16_128x4_m128_k1024"
+      ],
+      [
+        "fast_topk_clusters",
+        "f32_plain_b64_l16384_k256"
+      ],
+      [
+        "fast_topk_clusters",
+        "f32_plain_b16_l4096_k256"
+      ],
+      [
+        "fast_topk_clusters",
+        "f32_plain_b64_l65536_k1024"
+      ],
+      [
+        "filtered_topk",
+        "f32_plain_r4_l8192_k256"
+      ],
+      [
+        "filtered_topk",
+        "f32_plain_det_r2_l524288_k256_endbit"
+      ],
+      [
+        "filtered_topk",
+        "f32_plain_r64_l8192_k256"
+      ],
+      [
+        "radix_topk_multi_cta",
+        "f32_basic_r4_l57596_k256_vec4"
+      ],
+      [
+        "radix_topk_multi_cta",
+        "f32_basic_r4_l115188_k256_ctas3"
+      ],
+      [
+        "radix_topk_multi_cta",
+        "f32_basic_r2_l524288_k256_large"
+      ],
+      [
+        "radix_topk_single_cta",
+        "f32_basic_r8_l8192_k256"
+      ],
+      [
+        "radix_topk_single_cta",
+        "f32_basic_r64_l32768_k512"
+      ],
+      [
+        "radix_topk_single_cta",
+        "f32_basic_r256_l57592_k1024_maxchunk"
+      ],
+      [
+        "stable_sort_topk_by_value",
+        "f32_r4_k128"
+      ],
+      [
+        "stable_sort_topk_by_value",
+        "f32_r64_k256"
+      ],
+      [
+        "stable_sort_topk_by_value",
+        "f32_r64_k2048"
+      ],
+      [
+        "sparse_flashmla_decode_head64",
+        "deepseek_v4_v32_b128_sq2_sk32768_topk2048_p64"
+      ],
+      [
+        "sparse_flashmla_decode_head64",
+        "model1_b2_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64"
+      ],
+      [
+        "sparse_flashmla_decode_head64",
+        "v32_b148_sq2_sk32768_topk16384_p64"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_phase1",
+        "bench_regular_dqk512_hq128_s4096_kv8192_topk2048"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_phase1",
+        "bench_regular_dqk512_hq128_s4096_kv65536_topk2048"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_phase1",
+        "bench_regular_dqk576_hq128_s4096_kv32768_topk2048"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_small_topk_phase1",
+        "bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_small_topk_phase1",
+        "bench_smalltopk_dqk512_hq128_s4096_kv32768_topk1280"
+      ],
+      [
+        "sparse_flashmla_prefill_head128_small_topk_phase1",
+        "bench_smalltopk_dqk512_hq128_s4096_kv65536_topk1280"
+      ],
+      [
+        "sparse_flashmla_prefill_head64_phase1",
+        "bench_dqk512_hq64_s4096_kv8192_topk512"
+      ],
+      [
+        "sparse_flashmla_prefill_head64_phase1",
+        "bench_dqk512_hq64_s4096_kv65536_topk512"
+      ],
+      [
+        "sparse_flashmla_prefill_head64_phase1",
+        "bench_dqk576_hq64_s4096_kv32768_topk512"
+      ],
+      [
+        "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+        "ring48k_bf16q_qh16_t16"
+      ],
+      [
+        "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+        "varlen_b3_s8192_bf16q_qh4_t16"
+      ],
+      [
+        "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+        "ring48k_fp8q_qh16_t16"
+      ],
+      [
+        "msa_sparse_atten_fwd_sm100",
+        "ring48k_bf16_qh16_t16"
+      ],
+      [
+        "msa_sparse_atten_fwd_sm100",
+        "varlen_b3_s8192_qh4_t16"
+      ],
+      [
+        "msa_sparse_atten_fwd_sm100",
+        "ring48k_fp8_qh16_t16"
+      ],
+      [
+        "msa_sparse_prepare_flat_schedule_sm100",
+        "prefill_b1_k8192_h2"
+      ],
+      [
+        "msa_sparse_prepare_flat_schedule_sm100",
+        "decode_b64_k16384_h4_varlen"
+      ],
+      [
+        "msa_sparse_prepare_flat_schedule_sm100",
+        "decode_b128_k65536_h4"
+      ],
+      [
+        "msa_sparse_prepare_fwd_split_atomic_sm100",
+        "prefill_b1_k8192_h2"
+      ],
+      [
+        "msa_sparse_prepare_fwd_split_atomic_sm100",
+        "prefill_b1_k131072_h1"
+      ],
+      [
+        "msa_sparse_prepare_fwd_split_atomic_sm100",
+        "decode_b128_k65536_h4"
+      ]
+    ]
+  },
   "probe": {
     "enabled": true,
     "usable": [
@@ -79,6385 +849,11468 @@
     ],
     "failed": {}
   },
-  "results": [
-    {
-      "kernel": "act_and_mul",
-      "config": "gelu_fp16_d11008_t8192",
-      "label": "gelu_fp16_d11008_t8192",
-      "status": "ok",
-      "impls": {
-        "tirx": 154.21559296200397,
-        "flashinfer": 253.85058737524508
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+  "pipeline": {
+    "execution_mode": "pipeline",
+    "process_model": "one_shot_child_per_workload",
+    "max_prepare_processes": 16,
+    "ready_backlog": 16,
+    "measurement_protocol": {
+      "rounds": 5,
+      "cooldown_s": 0.0,
+      "default_rounds": 5,
+      "default_cooldown_s": 0.0,
+      "is_default": true
     },
+    "interference_retry_count": 19,
+    "interference_retries": [
+      {
+        "kernel": "gdn_decode_bf16_wide_vec_t1",
+        "config": "b16_h16_hv32_tv64",
+        "attempt": 1,
+        "intruder_pids": [
+          1909790
+        ],
+        "detail": "intruders [1909790]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 824180736
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "gdn_prefill_sm100",
+        "config": "hq8_hv32_s1024x8",
+        "attempt": 1,
+        "intruder_pids": [
+          1909790
+        ],
+        "detail": "intruders [1909790]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1044381696
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "gdn_decode_fp32_mtp_warp",
+        "config": "t4_b64_h8_hv32_tv64_ilp4_sv1",
+        "attempt": 1,
+        "intruder_pids": [
+          1912391
+        ],
+        "detail": "intruders [1912391]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 2522873856
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashkda_decode_t2_precomputed",
+        "config": "hv16h16_b64_t2",
+        "attempt": 1,
+        "intruder_pids": [
+          1914642
+        ],
+        "detail": "intruders [1914642]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1247805440
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "gdn_prefill_sm100",
+        "config": "hq8_hv32_s1024x8",
+        "attempt": 2,
+        "intruder_pids": [
+          1917479
+        ],
+        "detail": "intruders [1917479]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1044381696
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "recurrent_kda_decode_one_warp",
+        "config": "hv16_b8_tr8_lb",
+        "attempt": 1,
+        "intruder_pids": [
+          1923904
+        ],
+        "detail": "intruders [1923904]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1835008000
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "gdn_decode_fp32_mtp_warp",
+        "config": "t4_b64_h8_hv32_tv64_ilp4_sv1",
+        "attempt": 2,
+        "intruder_pids": [
+          1926037
+        ],
+        "detail": "intruders [1926037]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 2522873856
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashkda_decode_t2_precomputed",
+        "config": "hv16h16_b64_t2",
+        "attempt": 2,
+        "intruder_pids": [
+          1928293
+        ],
+        "detail": "intruders [1928293]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1262485504
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "selective_state_update_stp_vertical",
+        "config": "b64_h64_d64_s128_r8_base",
+        "attempt": 1,
+        "intruder_pids": [
+          1930773
+        ],
+        "detail": "intruders [1930773]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 985661440
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashinfer_add_rmsnorm_fp4quant",
+        "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+        "attempt": 1,
+        "intruder_pids": [
+          1930773
+        ],
+        "detail": "intruders [1930773]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 757071872
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashinfer_rmsnorm_quant",
+        "config": "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1",
+        "attempt": 1,
+        "intruder_pids": [
+          1936778
+        ],
+        "detail": "intruders [1936778]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 757071872
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "gdn_decode_fp32_mtp_warp",
+        "config": "t4_b64_h8_hv32_tv64_ilp4_sv1",
+        "attempt": 3,
+        "intruder_pids": [
+          1946889
+        ],
+        "detail": "intruders [1946889]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 2522873856
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashinfer_add_rmsnorm_fp4quant",
+        "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
+        "attempt": 2,
+        "intruder_pids": [
+          1949612
+        ],
+        "detail": "intruders [1949612]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1031798784
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "sparse_flashmla_prefill_head128_small_topk_phase1",
+        "config": "bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280",
+        "attempt": 1,
+        "intruder_pids": [
+          1952535
+        ],
+        "detail": "intruders [1952535]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 2153775104
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "selective_state_update_stp_vertical",
+        "config": "b64_h64_d64_s128_r8_base",
+        "attempt": 2,
+        "intruder_pids": [
+          1952535
+        ],
+        "detail": "intruders [1952535]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1258291200
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "flashinfer_rmsnorm_quant",
+        "config": "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1",
+        "attempt": 2,
+        "intruder_pids": [
+          1955086
+        ],
+        "detail": "intruders [1955086]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1040187392
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "msa_sparse_prepare_flat_schedule_sm100",
+        "config": "decode_b64_k16384_h4_varlen",
+        "attempt": 1,
+        "intruder_pids": [
+          1955086
+        ],
+        "detail": "intruders [1955086]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 759169024
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "selective_state_update_stp_vertical",
+        "config": "b64_h64_d64_s128_r8_base",
+        "attempt": 3,
+        "intruder_pids": [
+          1957441
+        ],
+        "detail": "intruders [1957441]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 1270874112
+        },
+        "retry_in_place": true
+      },
+      {
+        "kernel": "msa_sparse_prepare_flat_schedule_sm100",
+        "config": "decode_b64_k16384_h4_varlen",
+        "attempt": 2,
+        "intruder_pids": [
+          1961084
+        ],
+        "detail": "intruders [1961084]",
+        "resident_context_bytes_after_cleanup": {
+          "2": 759169024
+        },
+        "retry_in_place": true
+      }
+    ],
+    "failure_count": 9
+  },
+  "results": [
     {
       "kernel": "act_and_mul",
       "config": "gelu_tanh_fp16_d11008_t8192",
       "label": "gelu_tanh_fp16_d11008_t8192",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1902378,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 97.42118769782867,
-        "flashinfer": 109.36135321594384
+        "tirx": 97.63743398242445,
+        "flashinfer": 109.45219926455982
+      },
+      "round_samples": {
+        "tirx": [
+          97.64464000000001,
+          97.63328374655647,
+          97.63587168758717,
+          97.63257420249653,
+          97.64080027548209
+        ],
+        "flashinfer": [
+          109.46785780525502,
+          109.45229041916167,
+          109.45433483483484,
+          109.44168665667166,
+          109.44482660687594
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:08+00:00"
     },
     {
       "kernel": "act_and_mul",
       "config": "silu_bf16_d16384_t32768",
       "label": "silu_bf16_d16384_t32768",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1902003,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:39+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 615.7809928990774,
-        "flashinfer": 686.5465733196628
+        "tirx": 617.3432290241497,
+        "flashinfer": 1296.4385642664354
+      },
+      "round_samples": {
+        "tirx": [
+          454.1270517241379,
+          1044.6352336956522,
+          531.7856405228758,
+          523.6362191780822,
+          532.532
+        ],
+        "flashinfer": [
+          626.3031025641026,
+          1431.8600705882354,
+          2976.480546511628,
+          631.4951076923077,
+          816.0539939759036
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "act_and_mul",
-      "config": "silu_bf16_d4096_t8192",
-      "label": "silu_bf16_d4096_t8192",
-      "status": "ok",
-      "impls": {
-        "tirx": 33.24992735555463,
-        "flashinfer": 36.56187782538135
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "act_and_mul",
-      "config": "silu_fp16_d11008_t8192",
-      "label": "silu_fp16_d11008_t8192",
       "status": "ok",
-      "impls": {
-        "tirx": 97.68456794752666,
-        "flashinfer": 107.90169916536786
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "act_and_mul",
-      "config": "silu_fp16_d16384_t32768",
-      "label": "silu_fp16_d16384_t32768",
-      "status": "ok",
-      "impls": {
-        "tirx": 453.6279346517723,
-        "flashinfer": 470.2371823143351
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:09+00:00"
     },
     {
       "kernel": "act_and_mul",
       "config": "silu_fp16_d4096_t1",
       "label": "silu_fp16_d4096_t1",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1900549,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:33+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 2.568705236460192,
-        "flashinfer": 2.779491872595371
+        "tirx": 2.0772162764524036,
+        "flashinfer": 2.287944930015225
+      },
+      "round_samples": {
+        "tirx": [
+          2.0566969696969695,
+          2.079383295711061,
+          2.0850703430308295,
+          2.0816938864628822,
+          2.0832368873602753
+        ],
+        "flashinfer": [
+          2.287178318584071,
+          2.287588571428571,
+          2.291997842968076,
+          2.286429376083189,
+          2.2865305410122163
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "act_and_mul",
-      "config": "silu_fp16_d4096_t8192",
-      "label": "silu_fp16_d4096_t8192",
-      "status": "ok",
-      "impls": {
-        "tirx": 41.34725516565814,
-        "flashinfer": 46.525913769875416
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "allgather_gemm",
-      "config": "tp1_m8192_n106496_k16384_fp16_dynamic",
-      "label": "tp1_m8192_n106496_k16384_fp16_dynamic",
       "status": "ok",
-      "impls": {
-        "tirx": 21469.373800000005,
-        "cublas_nccl_cudagraph": 21463.20410000002,
-        "cublasmp_split_p2p": 21790.504399999998
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "allgather_gemm",
-      "config": "tp1_m8192_n24576_k4096_fp16_dynamic",
-      "label": "tp1_m8192_n24576_k4096_fp16_dynamic",
-      "status": "ok",
-      "impls": {
-        "tirx": 1066.3878999999993,
-        "cublas_nccl_cudagraph": 1034.9734000000003,
-        "cublasmp_split_p2p": 1079.9174999999964
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "allgather_gemm",
-      "config": "tp1_m8192_n51200_k5120_fp16_dynamic",
-      "label": "tp1_m8192_n51200_k5120_fp16_dynamic",
-      "status": "ok",
-      "impls": {
-        "tirx": 2876.293799999996,
-        "cublas_nccl_cudagraph": 2717.1455000000046,
-        "cublasmp_split_p2p": 2772.5312000000026
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "allgather_gemm",
-      "config": "tp1_m8192_n57344_k8192_fp16_dynamic",
-      "label": "tp1_m8192_n57344_k8192_fp16_dynamic",
-      "status": "ok",
-      "impls": {
-        "tirx": 6103.611899999998,
-        "cublas_nccl_cudagraph": 5984.332800000004,
-        "cublasmp_split_p2p": 6148.8382999999985
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepep_combine",
-      "config": "t4096_h7168_e256_k6",
-      "label": "t4096_h7168_e256_k6",
-      "status": "ok",
-      "impls": {
-        "tirx": 1098.7104999999974,
-        "deepep": 989.9300000000003
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepep_dispatch",
-      "config": "t4096_h7168_e256_k6",
-      "label": "t4096_h7168_e256_k6",
-      "status": "ok",
-      "impls": {
-        "tirx": 638.0496999999966,
-        "deepep": 616.1591999999997
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:59+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp4_mqa_logits",
       "config": "s2048_skv4096_h64_d128_f32_dense_cp",
       "label": "s2048_skv4096_h64_d128_f32_dense_cp",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889097,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 61.45464468217403,
-        "deepgemm": 63.93261206104777
+        "tirx": 37.55762301719374,
+        "deepgemm": 39.73038805373352
       },
+      "round_samples": {
+        "tirx": [
+          37.59140627580512,
+          37.54291612903226,
+          37.5465584725537,
+          37.54239030206677,
+          37.56484390651085
+        ],
+        "deepgemm": [
+          39.7373319112628,
+          39.715959049959054,
+          39.71612736236647,
+          39.747197847682116,
+          39.73532409739715
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": NaN,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:17+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp4_mqa_logits",
       "config": "s4096_skv8192_h64_d128_bf16_compressed_nocp",
       "label": "s4096_skv8192_h64_d128_bf16_compressed_nocp",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889098,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 184.36778627622917,
-        "deepgemm": 182.33902498221195
+        "tirx": 183.71977900466553,
+        "deepgemm": 187.32858892979374
       },
+      "round_samples": {
+        "tirx": [
+          182.97006553398057,
+          183.084304964539,
+          183.37236511627907,
+          184.37864418604653,
+          184.79351522248243
+        ],
+        "deepgemm": [
+          183.02262588235294,
+          182.9563511627907,
+          183.04556744186047,
+          202.9021308411215,
+          184.71626932084308
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": NaN,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:15+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp4_paged_mqa_logits",
       "config": "b16_n1_mp128_ps64_h64_d128_bf16_fixed",
       "label": "b16_n1_mp128_ps64_h64_d128_bf16_fixed",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889100,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 6.206333778355093,
-        "deepgemm": 6.5249555606924625
+        "tirx": 6.349493327457619,
+        "deepgemm": 6.54760803737796
       },
+      "round_samples": {
+        "tirx": [
+          6.344751196172249,
+          6.3591702127659575,
+          6.3485,
+          6.347217557251908,
+          6.347827671097981
+        ],
+        "deepgemm": [
+          6.547499029126214,
+          6.550167772511848,
+          6.544283490566038,
+          6.553458471760797,
+          6.542631422924901
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": NaN,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:15+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp4_paged_mqa_logits",
       "config": "b1_n1_mp1_ps32_h64_d128_f32_fixed",
       "label": "b1_n1_mp1_ps32_h64_d128_f32_fixed",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889099,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 6.2833463489701495,
-        "deepgemm": 7.28350358545801
+        "tirx": 4.031323254704748,
+        "deepgemm": 4.752044431611613
       },
+      "round_samples": {
+        "tirx": [
+          4.036222602739726,
+          4.031148957298908,
+          4.02744256915143,
+          4.0333266635644485,
+          4.028475480769231
+        ],
+        "deepgemm": [
+          4.745168341708543,
+          4.7595297321833865,
+          4.7526473779385165,
+          4.743866819221968,
+          4.759009887005649
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": NaN,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:06+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_bmm",
       "config": "bhd_bhr_hdr_b4096_h8_r4096_d1024",
       "label": "bhd_bhr_hdr_b4096_h8_r4096_d1024",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889103,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 176.1993716388436,
-        "deepgemm": 188.5497889700692
+        "tirx": 136.55380013669523,
+        "deepgemm": 139.15674126148534
       },
+      "round_samples": {
+        "tirx": [
+          136.79567068965517,
+          136.48590256410256,
+          136.31369939879758,
+          135.57059229208926,
+          137.6031357388316
+        ],
+        "deepgemm": [
+          139.47186836518046,
+          139.78066233766233,
+          138.710092920354,
+          138.56556194690265,
+          139.2555207373272
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "batch": 8,
+      "M": 1024,
+      "N": 4096,
+      "K": 4096,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:05+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_bmm",
       "config": "bhd_hdr_bhr_b8192_h8_r4096_d1024",
       "label": "bhd_hdr_bhr_b8192_h8_r4096_d1024",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889102,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 227.18522116670954,
-        "deepgemm": 253.69223907643146
+        "tirx": 222.80378437520653,
+        "deepgemm": 244.70852671140503
       },
+      "round_samples": {
+        "tirx": [
+          229.47864194373403,
+          221.52698417721518,
+          218.71379245283018,
+          222.89538461538461,
+          221.40411868686869
+        ],
+        "deepgemm": [
+          250.76900619195047,
+          242.92275179856117,
+          245.34711475409838,
+          237.895973880597,
+          246.60778693181817
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "batch": 8,
+      "M": 8192,
+      "N": 4096,
+      "K": 1024,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:05+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_bmm",
       "config": "bhr_hdr_bhd_b4096_h8_r4096_d1024",
       "label": "bhr_hdr_bhd_b4096_h8_r4096_d1024",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889101,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 138.14723451223688,
-        "deepgemm": 139.66368508188418
+        "tirx": 99.4254782068507,
+        "deepgemm": 99.32947843383405
       },
+      "round_samples": {
+        "tirx": [
+          99.83453288590604,
+          99.58936873156343,
+          100.05708771929825,
+          99.93698663101604,
+          97.70941506646972
+        ],
+        "deepgemm": [
+          97.18142381786339,
+          97.6370823117338,
+          100.17835695187166,
+          101.07370405405405,
+          100.57682503364737
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "batch": 8,
+      "M": 4096,
+      "N": 1024,
+      "K": 4096,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_bmm",
-      "config": "bhr_hdr_bhd_b8192_h8_r4096_d1024",
-      "label": "bhr_hdr_bhd_b8192_h8_r4096_d1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 197.2878959786697,
-        "deepgemm": 196.80998396343466
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n2112_k7168",
-      "label": "m4096_n2112_k7168",
       "status": "ok",
-      "impls": {
-        "tirx": 49.7281957682746,
-        "deepgemm": 49.791286837037326
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n24576_k1536",
-      "label": "m4096_n24576_k1536",
-      "status": "ok",
-      "impls": {
-        "tirx": 148.66030919061487,
-        "deepgemm": 148.33396458918847
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n24576_k1536_bfp4",
-      "label": "m4096_n24576_k1536_bfp4",
-      "status": "ok",
-      "impls": {
-        "tirx": 150.70220151124659,
-        "deepgemm": 149.78952810423777
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n32768_k512",
-      "label": "m4096_n32768_k512",
-      "status": "ok",
-      "impls": {
-        "tirx": 70.64113958869157,
-        "deepgemm": 72.28006960593413
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n4096_k7168",
-      "label": "m4096_n4096_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 123.26331147354847,
-        "deepgemm": 124.53633648642466
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:07+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
       "config": "m4096_n4096_k7168_bfp4",
       "label": "m4096_n4096_k7168_bfp4",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891528,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 81.03935910928554,
-        "deepgemm": 77.07477490746756
+        "tirx": 130.63601104816394,
+        "deepgemm": 91.02643738342492
       },
+      "round_samples": {
+        "tirx": [
+          82.27136855036855,
+          102.66865018094089,
+          147.44571804062127,
+          217.42890839694655,
+          103.36541007194245
+        ],
+        "deepgemm": [
+          81.99228588957055,
+          83.56521186440678,
+          110.62142857142857,
+          79.02571038251367,
+          99.92755020920502
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 4096,
+      "N": 4096,
+      "K": 7168,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:23+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
       "config": "m4096_n576_k7168",
       "label": "m4096_n576_k7168",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891465,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 18.602558852101627,
-        "deepgemm": 18.911991382329266
+        "tirx": 18.802547669202493,
+        "deepgemm": 19.098670977084268
       },
+      "round_samples": {
+        "tirx": [
+          18.79554398003743,
+          18.800221090473336,
+          18.799277577937648,
+          18.808471559633027,
+          18.809224137931032
+        ],
+        "deepgemm": [
+          19.097678615574786,
+          19.090043056397818,
+          19.099442563482466,
+          19.101609166136218,
+          19.10458148383006
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 4096,
+      "N": 576,
+      "K": 7168,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:19+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
       "config": "m4096_n7168_k16384",
       "label": "m4096_n7168_k16384",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891525,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 325.3168933751257,
-        "deepgemm": 323.98070042700107
+        "tirx": 336.4438385746054,
+        "deepgemm": 325.5337203707142
       },
+      "round_samples": {
+        "tirx": [
+          326.35452797202794,
+          338.8586955017301,
+          340.40742756183744,
+          335.23661475409835,
+          341.36192708333334
+        ],
+        "deepgemm": [
+          352.31957093425603,
+          317.40781660899654,
+          310.79169483568074,
+          304.0815507246377,
+          343.06796875000003
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 4096,
+      "N": 7168,
+      "K": 16384,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n7168_k16384_bfp4",
-      "label": "m4096_n7168_k16384_bfp4",
-      "status": "ok",
-      "impls": {
-        "tirx": 300.58447696399924,
-        "deepgemm": 297.4390636641321
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_fp8_gemm_1d1d",
-      "config": "m4096_n7168_k2048",
-      "label": "m4096_n7168_k2048",
       "status": "ok",
-      "impls": {
-        "tirx": 42.29515534583919,
-        "deepgemm": 42.3046325742683
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:23+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_mqa_logits",
       "config": "s2048_skv4096_h64_d128_f32_dense_cp",
       "label": "s2048_skv4096_h64_d128_f32_dense_cp",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891682,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 66.47137233296822,
-        "deepgemm": 68.12293986968241
+        "tirx": 47.24852850563785,
+        "deepgemm": 54.283086575991106
       },
+      "round_samples": {
+        "tirx": [
+          39.5728458813109,
+          42.60991871295512,
+          41.75313914174252,
+          40.5060822147651,
+          71.80065657741561
+        ],
+        "deepgemm": [
+          42.70617191719172,
+          53.55606155143339,
+          73.02841489361703,
+          48.5027157622739,
+          53.622068755439514
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": 1.176528334867477e-06,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:31+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_mqa_logits",
       "config": "s4096_skv8192_h64_d128_bf16_compressed_nocp",
       "label": "s4096_skv8192_h64_d128_bf16_compressed_nocp",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891823,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:56+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 181.8031915641307,
-        "deepgemm": 191.90377014895915
+        "tirx": 176.45205211291838,
+        "deepgemm": 186.87053820608045
       },
+      "round_samples": {
+        "tirx": [
+          177.91875235849056,
+          177.37501327433628,
+          177.68441906873613,
+          175.50706250000002,
+          173.77501336302893
+        ],
+        "deepgemm": [
+          181.3125396825397,
+          187.01289189189188,
+          190.23315130023641,
+          187.28529838709676,
+          188.50880976863755
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "max_diff": 2.57000874337443e-06,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:30+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_paged_mqa_logits",
       "config": "b16_n1_mp128_ps64_h64_d128_bf16_fixed",
       "label": "b16_n1_mp128_ps64_h64_d128_bf16_fixed",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891846,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:56+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 6.719288852872766,
-        "deepgemm": 6.94497400658989,
-        "sglang_cutedsl": 7.001058959468446
+        "tirx": 6.75303814158526,
+        "deepgemm": 6.878073569350544,
+        "sglang_cutedsl": 6.900553722147331
       },
+      "round_samples": {
+        "tirx": [
+          6.743035285815102,
+          6.758712906504066,
+          6.753158150851582,
+          6.758557320099255,
+          6.751727044656297
+        ],
+        "deepgemm": [
+          6.88056911764706,
+          6.877339285714286,
+          6.881270415647921,
+          6.873669310857709,
+          6.877519716885743
+        ],
+        "sglang_cutedsl": [
+          6.894257226849583,
+          6.900956834532375,
+          6.908352399418322,
+          6.8915678952473325,
+          6.907634254689043
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm",
+          "sglang_cutedsl"
+        ]
+      },
+      "max_diff": 0.0,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:32+00:00"
     },
     {
       "kernel": "deepgemm_sm100_fp8_paged_mqa_logits",
       "config": "b1_n1_mp1_ps64_h64_d128_f32_fixed",
       "label": "b1_n1_mp1_ps64_h64_d128_f32_fixed",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1891825,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:56+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 4.583967775869005,
-        "deepgemm": 5.315562220607044,
-        "sglang_cutedsl": 4.774711634128452
+        "tirx": 4.2384241611382425,
+        "deepgemm": 5.016066182732011,
+        "sglang_cutedsl": 4.735586685980171
       },
+      "round_samples": {
+        "tirx": [
+          4.241283864541832,
+          4.2277160077145615,
+          4.243603010348072,
+          4.239660914179104,
+          4.2398570089076415
+        ],
+        "deepgemm": [
+          5.011852467270896,
+          5.010451904761905,
+          5.022515749882463,
+          5.013950114416476,
+          5.021560677328316
+        ],
+        "sglang_cutedsl": [
+          4.740296805896806,
+          4.735064531104921,
+          4.716321658986176,
+          4.740370944309927,
+          4.745879489603024
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm",
+          "sglang_cutedsl"
+        ]
+      },
+      "max_diff": 0.0,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:31+00:00"
     },
     {
       "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
       "config": "g16_m7168_n2048_k2048_gran128_al128",
       "label": "g16_m7168_n2048_k2048_gran128_al128",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1894254,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:07+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 579.1164360647122,
-        "deepgemm": 581.884309417214
+        "tirx": 912.2860884353435,
+        "deepgemm": 918.9561795478958
       },
+      "round_samples": {
+        "tirx": [
+          717.75203125,
+          592.6552322580645,
+          755.8930204081634,
+          1029.8954895104894,
+          1465.2346687499999
+        ],
+        "deepgemm": [
+          610.9346666666667,
+          1133.3549689440995,
+          713.9933874999999,
+          720.9652871287129,
+          1415.5325875
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 7168,
+      "N": 2048,
+      "K": 35968,
+      "num_groups": 16,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
-      "config": "g4_m4096_n7168_k8192_gran128_al128",
-      "label": "g4_m4096_n7168_k8192_gran128_al128",
-      "status": "ok",
-      "impls": {
-        "tirx": 1013.3178369565218,
-        "deepgemm": 1009.7448536630037
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:43+00:00"
     },
     {
       "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
       "config": "g4_m4096_n7168_k8192_gran128_al128_psum",
       "label": "g4_m4096_n7168_k8192_gran128_al128_psum",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1894255,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:07+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 859.9105582608696,
-        "deepgemm": 876.6516703432494
+        "tirx": 857.4815699116326,
+        "deepgemm": 860.4166023634336
       },
+      "round_samples": {
+        "tirx": [
+          848.022358974359,
+          862.0541794871795,
+          854.8056016949153,
+          854.3537777777777,
+          868.1719316239315
+        ],
+        "deepgemm": [
+          868.0044957264957,
+          862.8666581196582,
+          875.3036068376069,
+          854.0700598290598,
+          841.8381913043478
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 4096,
+      "N": 7168,
+      "K": 34816,
+      "num_groups": 4,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
-      "config": "g4_m4096_n7168_k8192_gran32_al32",
-      "label": "g4_m4096_n7168_k8192_gran32_al32",
-      "status": "ok",
-      "impls": {
-        "tirx": 834.9966423415977,
-        "deepgemm": 868.6466070175438
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
-      "config": "g8_m4096_n7168_k4096_gran128_al128",
-      "label": "g8_m4096_n7168_k4096_gran128_al128",
       "status": "ok",
-      "impls": {
-        "tirx": 876.7164593629343,
-        "deepgemm": 872.7993783783784
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:40+00:00"
     },
     {
       "kernel": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
       "config": "g8_m4096_n7168_k4096_gran32_al160",
       "label": "g8_m4096_n7168_k4096_gran32_al160",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1893871,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:05+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 1126.3836740021864,
-        "deepgemm": 1181.24704316168
+        "tirx": 907.9103916799152,
+        "deepgemm": 930.4702721038716
       },
+      "round_samples": {
+        "tirx": [
+          909.9639729729729,
+          902.6226036036036,
+          918.8126576576576,
+          903.2952647058823,
+          904.8574594594595
+        ],
+        "deepgemm": [
+          933.7822685185185,
+          944.3490467289719,
+          934.1179722222223,
+          916.3516063829787,
+          923.7504666666667
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 4096,
+      "N": 7168,
+      "K": 31680,
+      "num_groups": 8,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g4_m8192_n4096_k2048",
-      "label": "g4_m8192_n4096_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 205.59350388732267,
-        "deepgemm": 207.51084512417128
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g4_m8192_n4096_k4096",
-      "label": "g4_m8192_n4096_k4096",
       "status": "ok",
-      "impls": {
-        "tirx": 363.90745384471,
-        "deepgemm": 367.8613641505665
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g4_m8192_n4096_k4096_psum",
-      "label": "g4_m8192_n4096_k4096_psum",
-      "status": "ok",
-      "impls": {
-        "tirx": 452.7249384112309,
-        "deepgemm": 452.475559274141
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:39+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
       "config": "g4_m8192_n6144_k7168",
       "label": "g4_m8192_n6144_k7168",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1894429,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:07+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 1001.1146587070707,
-        "deepgemm": 983.4412932525253
+        "tirx": 1000.2048575821176,
+        "deepgemm": 1029.7921486565504
       },
+      "round_samples": {
+        "tirx": [
+          987.0650714285715,
+          1002.6024693877551,
+          966.4163536585367,
+          1033.1875567010309,
+          1011.7528367346939
+        ],
+        "deepgemm": [
+          1035.4951958762886,
+          1021.9548061224491,
+          1039.065836734694,
+          1035.982081632653,
+          1016.4628229166668
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 33376,
+      "N": 6144,
+      "K": 7168,
+      "num_groups": 4,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g4_m8192_n6144_k7168_bfp4",
-      "label": "g4_m8192_n6144_k7168_bfp4",
-      "status": "ok",
-      "impls": {
-        "tirx": 977.0830166571483,
-        "deepgemm": 963.9918739577384
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g4_m8192_n7168_k3072",
-      "label": "g4_m8192_n7168_k3072",
       "status": "ok",
-      "impls": {
-        "tirx": 580.0537427130898,
-        "deepgemm": 582.0827163881632
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g8_m4096_n4096_k2048",
-      "label": "g8_m4096_n4096_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 194.3954499899903,
-        "deepgemm": 197.05758868427142
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:43+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
       "config": "g8_m4096_n4096_k2048_bfp4",
       "label": "g8_m4096_n4096_k2048_bfp4",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1894654,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 232.19814774058835,
-        "deepgemm": 234.17587798451945
+        "tirx": 186.0463375504735,
+        "deepgemm": 187.48249193479788
       },
+      "round_samples": {
+        "tirx": [
+          181.01369498910674,
+          185.3390982532751,
+          187.05743192488265,
+          188.9840240700219,
+          187.8374385150812
+        ],
+        "deepgemm": [
+          190.23918818380744,
+          186.76088351648352,
+          187.20840189125295,
+          185.45853553299494,
+          187.74545054945054
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 32032,
+      "N": 4096,
+      "K": 2048,
+      "num_groups": 8,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g8_m4096_n4096_k4096",
-      "label": "g8_m4096_n4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 361.93802752381407,
-        "deepgemm": 369.1488824004789
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g8_m4096_n6144_k7168",
-      "label": "g8_m4096_n6144_k7168",
       "status": "ok",
-      "impls": {
-        "tirx": 1109.6160250783698,
-        "deepgemm": 1105.3469540229885
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
-      "config": "g8_m4096_n7168_k3072",
-      "label": "g8_m4096_n7168_k3072",
-      "status": "ok",
-      "impls": {
-        "tirx": 594.7954234821875,
-        "deepgemm": 594.0340166666666
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:43+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
       "config": "g8_m4096_n7168_k3072_psum_zp",
       "label": "g8_m4096_n7168_k3072_psum_zp",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1894744,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 601.4369273086488,
-        "deepgemm": 603.6703185560917
+        "tirx": 511.4467019243691,
+        "deepgemm": 507.7964265380999
       },
+      "round_samples": {
+        "tirx": [
+          525.0819135135135,
+          511.0574438502674,
+          509.2139533333333,
+          497.4098440860215,
+          514.4703548387097
+        ],
+        "deepgemm": [
+          528.4446914893617,
+          496.5719574468085,
+          517.4433606557377,
+          508.7886830985916,
+          487.73344000000003
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "M": 34944,
+      "N": 7168,
+      "K": 3072,
+      "num_groups": 8,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
-      "config": "g32_m192_n4096_k2048",
-      "label": "g32_m192_n4096_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 72.78612727200836,
-        "deepgemm": 72.90357352555503
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:42+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
       "config": "g32_m192_n4096_k4096_bfp4",
       "label": "g32_m192_n4096_k4096_bfp4",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1896725,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:15+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 114.2317705082807,
-        "deepgemm": 113.95818026502913
+        "tirx": 115.26012220375627,
+        "deepgemm": 114.53728595588946
       },
+      "round_samples": {
+        "tirx": [
+          115.92273070607553,
+          114.97660090361445,
+          114.26822138554218,
+          116.35967678300456,
+          114.77338124054464
+        ],
+        "deepgemm": [
+          114.74876758409785,
+          114.34931803278688,
+          115.05157703927492,
+          116.11428462709284,
+          112.42248249619483
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "N": 4096,
+      "K": 4096,
+      "num_groups": 32,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:51+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
       "config": "g32_m192_n6144_k7168",
       "label": "g32_m192_n6144_k7168",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1895275,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:10+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 336.2359602574295,
-        "deepgemm": 329.70362983309786
+        "tirx": 338.7764615163124,
+        "deepgemm": 326.73441012654877
       },
+      "round_samples": {
+        "tirx": [
+          343.0942205882353,
+          334.62699642857143,
+          341.9773514492754,
+          331.7185576208179,
+          342.4651814946619
+        ],
+        "deepgemm": [
+          328.06356785714286,
+          329.6704285714286,
+          333.1227026022305,
+          328.916905,
+          313.89844660194177
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "N": 6144,
+      "K": 7168,
+      "num_groups": 32,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:48+00:00"
     },
     {
       "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
       "config": "g6_m1024_n4096_k2048",
       "label": "g6_m1024_n4096_k2048",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1896510,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:15+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 60.67401438204579,
-        "deepgemm": 60.570650448061905
+        "tirx": 39.168735489306016,
+        "deepgemm": 39.288192012825164
       },
+      "round_samples": {
+        "tirx": [
+          39.11285106382979,
+          39.25430485762144,
+          38.998009900990105,
+          39.19719074675325,
+          39.281320877335496
+        ],
+        "deepgemm": [
+          39.266407345575956,
+          39.29485535117057,
+          39.30189745693191,
+          39.30699351175994,
+          39.27080639868745
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "N": 4096,
+      "K": 2048,
+      "num_groups": 6,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
-      "config": "g6_m1024_n6144_k7168",
-      "label": "g6_m1024_n6144_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 200.74671802647958,
-        "deepgemm": 200.66859627965496
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:49+00:00"
     },
     {
       "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
       "config": "m128_n24_k16384_s64",
       "label": "m128_n24_k16384_s64",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1897055,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:17+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 5.3072744196172295,
-        "deepgemm": 5.219627647509479
+        "tirx": 5.24008745536396,
+        "deepgemm": 5.234267769684902
       },
+      "round_samples": {
+        "tirx": [
+          5.24235294117647,
+          5.24252688172043,
+          5.233721402214022,
+          5.235084636614536,
+          5.24675141509434
+        ],
+        "deepgemm": [
+          5.235690265486726,
+          5.233770452358037,
+          5.233718120805369,
+          5.231839210155148,
+          5.23632079961923
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "tirx_diff": 1.3211653993039363e-14,
+      "max_diff": 1.3211653993039363e-14,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
-      "config": "m137_n24_k7680_s16",
-      "label": "m137_n24_k7680_s16",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.306106116557874,
-        "deepgemm": 5.353494026385838
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
-      "config": "m13_n24_k7168_s1",
-      "label": "m13_n24_k7168_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 33.81148851944813,
-        "deepgemm": 33.47627753086087
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
-      "config": "m4096_n24_k28672_s16",
-      "label": "m4096_n24_k28672_s16",
-      "status": "ok",
-      "impls": {
-        "tirx": 57.89212258633691,
-        "deepgemm": 62.83643881062984
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:53+00:00"
     },
     {
       "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
       "config": "m4096_n24_k7168_s1",
       "label": "m4096_n24_k7168_s1",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1897541,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:19+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 36.01250838489896,
-        "deepgemm": 35.702096565921764
+        "tirx": 23.164969273576812,
+        "deepgemm": 23.82787117626287
       },
+      "round_samples": {
+        "tirx": [
+          23.204419047619048,
+          23.148640894568693,
+          23.142955613577023,
+          23.165763447828905,
+          23.163067364290384
+        ],
+        "deepgemm": [
+          23.828887801696023,
+          23.808794176042355,
+          23.835219787516603,
+          23.83694399460189,
+          23.829510121457492
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "tirx_diff": 1.7066348334537906e-11,
+      "max_diff": 1.7066348334537906e-11,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
-      "config": "m64_n24_k28672_s112",
-      "label": "m64_n24_k28672_s112",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.203853985026591,
-        "deepgemm": 7.295910957234064
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
-      "config": "m8192_n24_k16384_s1",
-      "label": "m8192_n24_k16384_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 50.53418241654101,
-        "deepgemm": 60.57727465307614
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:53+00:00"
     },
     {
       "kernel": "deepgemm_sm100_tf32_hc_prenorm_gemm",
       "config": "m8192_n24_k28672_s1",
       "label": "m8192_n24_k28672_s1",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1897240,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:17+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 83.96102247146229,
-        "deepgemm": 91.63302354900253
+        "tirx": 84.43010676547125,
+        "deepgemm": 92.62799183177556
       },
+      "round_samples": {
+        "tirx": [
+          84.46121,
+          84.44546749999999,
+          84.41870906801007,
+          84.38250695322377,
+          84.44264030612244
+        ],
+        "deepgemm": [
+          92.63074427994617,
+          92.62557951482479,
+          92.67550542005421,
+          92.60565484311051,
+          92.60247510094213
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "deepgemm"
+        ]
+      },
+      "tirx_diff": 6.806708530149308e-10,
+      "max_diff": 6.806708530149308e-10,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_plain_b16_l16384_k256",
-      "label": "bf16_plain_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.315430039853691,
-        "flashinfer": 10.636390047572817
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_plain_b64_l16384_k1024_tie_heavy",
-      "label": "bf16_plain_b64_l16384_k1024_tie_heavy",
       "status": "ok",
-      "impls": {
-        "tirx": 11.808709440817704,
-        "flashinfer": 12.889005253321622
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_plain_b64_l65536_k1024",
-      "label": "bf16_plain_b64_l65536_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.98384416324642,
-        "flashinfer": 17.379626806477507
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_pt_b16_l16384_k256",
-      "label": "bf16_pt_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.135281795175032,
-        "flashinfer": 11.315999284079126
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_rag_b16_l16384_k256",
-      "label": "bf16_rag_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.148079509086005,
-        "flashinfer": 10.141660470624371
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "bf16_rag_b300_l16384_k256",
-      "label": "bf16_rag_b300_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 17.736769374056607,
-        "flashinfer": 18.811297763426722
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_plain_b16_l16384_k256",
-      "label": "f16_plain_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.330373941198276,
-        "flashinfer": 10.367677404945761
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_plain_b16_l4096_k256",
-      "label": "f16_plain_b16_l4096_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.7626278062022385,
-        "flashinfer": 5.720782937867246
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_plain_b64_l16384_k1024_tie_heavy",
-      "label": "f16_plain_b64_l16384_k1024_tie_heavy",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.310705824602685,
-        "flashinfer": 10.834010305937683
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_plain_b64_l65536_k2048_i64",
-      "label": "f16_plain_b64_l65536_k2048_i64",
-      "status": "ok",
-      "impls": {
-        "tirx": 17.86619196443973,
-        "flashinfer": 18.91182523135481
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_pt_b16_l16384_k256",
-      "label": "f16_pt_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.990122267768026,
-        "flashinfer": 10.891726528891365
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f16_rag_b16_l16384_k256",
-      "label": "f16_rag_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.095775680713702,
-        "flashinfer": 9.904250605408697
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k2048_all_equal",
-      "label": "f32_plain_b16_l16384_k2048_all_equal",
-      "status": "ok",
-      "impls": {
-        "tirx": 17.02906334374407,
-        "flashinfer": 18.84488740855133
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k256",
-      "label": "f32_plain_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 13.466725761891453,
-        "flashinfer": 14.399956962439427
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k256_all_equal",
-      "label": "f32_plain_b16_l16384_k256_all_equal",
-      "status": "ok",
-      "impls": {
-        "tirx": 16.623915558773916,
-        "flashinfer": 18.154122963852434
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k256_i64",
-      "label": "f32_plain_b16_l16384_k256_i64",
-      "status": "ok",
-      "impls": {
-        "tirx": 13.420686040314143,
-        "flashinfer": 14.482802491022296
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k256_neg",
-      "label": "f32_plain_b16_l16384_k256_neg",
-      "status": "ok",
-      "impls": {
-        "tirx": 13.569874037143865,
-        "flashinfer": 15.402587414600815
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b16_l16384_k256_tie_heavy",
-      "label": "f32_plain_b16_l16384_k256_tie_heavy",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.36879530372728,
-        "flashinfer": 16.350402340406173
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:53+00:00"
     },
     {
       "kernel": "fast_topk_clusters",
       "config": "f32_plain_b16_l4096_k256",
       "label": "f32_plain_b16_l4096_k256",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1942573,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 6.705360241543075,
-        "flashinfer": 7.298516449760636
+        "tirx": 6.645068525505932,
+        "flashinfer": 7.256757625632625
+      },
+      "round_samples": {
+        "tirx": [
+          6.650747572815534,
+          6.645455844818785,
+          6.643396100278551,
+          6.641262407862408,
+          6.644480701754386
+        ],
+        "flashinfer": [
+          7.255513052208835,
+          7.256732922444787,
+          7.255776441102757,
+          7.258591093117409,
+          7.25717461928934
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b200_l16384_k256",
-      "label": "f32_plain_b200_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 24.860179582464507,
-        "flashinfer": 25.405898567657005
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b200_l65536_k1024",
-      "label": "f32_plain_b200_l65536_k1024",
       "status": "ok",
-      "impls": {
-        "tirx": 45.58549359469851,
-        "flashinfer": 46.1854230209686
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b300_l16384_k256",
-      "label": "f32_plain_b300_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 20.97409959806401,
-        "flashinfer": 22.08633863271252
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b64_l16384_k1024",
-      "label": "f32_plain_b64_l16384_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 14.871124585168214,
-        "flashinfer": 15.65283767985314
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b64_l16384_k2048",
-      "label": "f32_plain_b64_l16384_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.051104769999581,
-        "flashinfer": 15.801412140170715
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:13+00:00"
     },
     {
       "kernel": "fast_topk_clusters",
       "config": "f32_plain_b64_l16384_k256",
       "label": "f32_plain_b64_l16384_k256",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1942222,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:46+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 13.65114702208196,
-        "flashinfer": 14.268870524209298
+        "tirx": 13.725624022481814,
+        "flashinfer": 14.212751199919925
+      },
+      "round_samples": {
+        "tirx": [
+          13.729119266055045,
+          13.718956324446966,
+          13.72778770301624,
+          13.725323841429368,
+          13.726932977461448
+        ],
+        "flashinfer": [
+          14.20706644332775,
+          14.211878077373974,
+          14.206822429906541,
+          14.23234409221902,
+          14.205644956772336
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:13+00:00"
     },
     {
       "kernel": "fast_topk_clusters",
       "config": "f32_plain_b64_l65536_k1024",
       "label": "f32_plain_b64_l65536_k1024",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1942585,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:48+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 20.9927620851139,
-        "flashinfer": 21.414696338019116
+        "tirx": 20.83703467124705,
+        "flashinfer": 21.35372554920179
+      },
+      "round_samples": {
+        "tirx": [
+          20.85395238095238,
+          20.831649966147598,
+          20.823079872204474,
+          20.835548408488066,
+          20.840942728442727
+        ],
+        "flashinfer": [
+          21.34850989761092,
+          21.351831241283122,
+          21.34878724788549,
+          21.353050616482804,
+          21.366448742746613
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_plain_b8_l4096_k4096",
-      "label": "f32_plain_b8_l4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.672630117828723,
-        "flashinfer": 2.711304928986408
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_pt_b16_l16384_k256",
-      "label": "f32_pt_b16_l16384_k256",
       "status": "ok",
-      "impls": {
-        "tirx": 14.176903112475797,
-        "flashinfer": 15.382819182524589
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_pt_b16_l16384_k256_rowvar",
-      "label": "f32_pt_b16_l16384_k256_rowvar",
-      "status": "ok",
-      "impls": {
-        "tirx": 12.433105173142899,
-        "flashinfer": 12.903365349462904
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_pt_b200_l16384_k256",
-      "label": "f32_pt_b200_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 26.733519204956824,
-        "flashinfer": 26.79326579260196
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_pt_b8_l4096_k4096",
-      "label": "f32_pt_b8_l4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.9397018277168736,
-        "flashinfer": 2.933718772726037
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_rag_b16_l16384_k256",
-      "label": "f32_rag_b16_l16384_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 13.351923925198077,
-        "flashinfer": 13.930256621474793
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_rag_b16_l16384_k256_rowvar",
-      "label": "f32_rag_b16_l16384_k256_rowvar",
-      "status": "ok",
-      "impls": {
-        "tirx": 11.592190640733152,
-        "flashinfer": 11.901982678247125
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fast_topk_clusters",
-      "config": "f32_rag_b8_l4096_k4096",
-      "label": "f32_rag_b8_l4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.101097896651712,
-        "flashinfer": 2.2161202971603635
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:18+00:00"
     },
     {
       "kernel": "filtered_topk",
       "config": "f32_plain_det_r2_l524288_k256_endbit",
       "label": "f32_plain_det_r2_l524288_k256_endbit",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1943544,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:52+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 116.88407736044608,
-        "flashinfer": 128.47340505093595
+        "tirx": 114.97156229708197,
+        "flashinfer": 125.93237497922232
+      },
+      "round_samples": {
+        "tirx": [
+          114.9257205882353,
+          114.99661783439491,
+          114.9495585023401,
+          114.9838857142857,
+          115.00202884615385
+        ],
+        "flashinfer": [
+          125.94345973154361,
+          125.90278762541807,
+          125.95074666666667,
+          125.90844966442951,
+          125.95643120805369
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:35+00:00"
     },
     {
       "kernel": "filtered_topk",
       "config": "f32_plain_r4_l8192_k256",
       "label": "f32_plain_r4_l8192_k256",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1943140,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:50+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 8.241476387555622,
-        "flashinfer": 9.563901958120834
+        "tirx": 7.772870342784602,
+        "flashinfer": 9.038917714673856
+      },
+      "round_samples": {
+        "tirx": [
+          7.771099195710455,
+          7.767734715576821,
+          7.7679706321553015,
+          7.787305894308943,
+          7.770241276171486
+        ],
+        "flashinfer": [
+          9.066176631925398,
+          9.022806176783813,
+          9.030676056338027,
+          9.05282496116002,
+          9.022104747162023
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:22+00:00"
     },
     {
       "kernel": "filtered_topk",
       "config": "f32_plain_r64_l8192_k256",
       "label": "f32_plain_r64_l8192_k256",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1943545,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:52+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 8.479418874979165,
-        "flashinfer": 9.790764905560959
+        "tirx": 8.47060586763458,
+        "flashinfer": 9.760281031797199
+      },
+      "round_samples": {
+        "tirx": [
+          8.470218146718146,
+          8.467528467908902,
+          8.473134674922601,
+          8.478717908902691,
+          8.46343013972056
+        ],
+        "flashinfer": [
+          9.782857142857143,
+          9.745262433862433,
+          9.754253699788585,
+          9.767768146214099,
+          9.751263736263738
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv16",
-      "label": "s1024_h32kv16",
-      "status": "ok",
-      "impls": {
-        "tir": 19.622706209009856,
-        "flashattn_sm100": 20.190236566456036
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv16_causal",
-      "label": "s1024_h32kv16_causal",
       "status": "ok",
-      "impls": {
-        "tir": 20.13354999446009,
-        "flashattn_sm100": 20.350983083122
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv32",
-      "label": "s1024_h32kv32",
-      "status": "ok",
-      "impls": {
-        "tir": 32.19668325662588,
-        "flashattn_sm100": 33.08789279560541
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv32_causal",
-      "label": "s1024_h32kv32_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 21.145367314803092,
-        "flashattn_sm100": 21.50641314172613
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:22+00:00"
     },
     {
       "kernel": "flash_attention4",
       "config": "s1024_h32kv4",
       "label": "s1024_h32kv4",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1898699,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:24+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tir": 19.119215903046165,
-        "flashattn_sm100": 19.95998956362048
+        "tir": 19.374315264179362,
+        "flashattn_sm100": 20.071733770547187
+      },
+      "round_samples": {
+        "tir": [
+          19.359811751904246,
+          19.393160637645618,
+          19.377001236093946,
+          19.374418435415404,
+          19.3671842598376
+        ],
+        "flashattn_sm100": [
+          20.06609587123863,
+          20.07626384567517,
+          20.068791666666666,
+          20.07553354632588,
+          20.07198392282958
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv4_causal",
-      "label": "s1024_h32kv4_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 18.74307156178781,
-        "flashattn_sm100": 19.72897304349583
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv8",
-      "label": "s1024_h32kv8",
       "status": "ok",
-      "impls": {
-        "tir": 19.507159880706148,
-        "flashattn_sm100": 20.05002496864092
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s1024_h32kv8_causal",
-      "label": "s1024_h32kv8_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 19.171127749880306,
-        "flashattn_sm100": 19.774441728191118
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv16",
-      "label": "s2048_h32kv16",
-      "status": "ok",
-      "impls": {
-        "tir": 57.60034429419795,
-        "flashattn_sm100": 57.77014798328905
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv16_causal",
-      "label": "s2048_h32kv16_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 36.341962937539606,
-        "flashattn_sm100": 38.584821421413004
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv32",
-      "label": "s2048_h32kv32",
-      "status": "ok",
-      "impls": {
-        "tir": 59.82622735783065,
-        "flashattn_sm100": 60.087654924984555
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv32_causal",
-      "label": "s2048_h32kv32_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 64.46897712395965,
-        "flashattn_sm100": 64.64071822299219
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv4",
-      "label": "s2048_h32kv4",
-      "status": "ok",
-      "impls": {
-        "tir": 94.36120696979806,
-        "flashattn_sm100": 94.93032015244819
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv4_causal",
-      "label": "s2048_h32kv4_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 35.27854815126657,
-        "flashattn_sm100": 37.75655696579062
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv8",
-      "label": "s2048_h32kv8",
-      "status": "ok",
-      "impls": {
-        "tir": 56.12409457420478,
-        "flashattn_sm100": 56.68271696472439
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s2048_h32kv8_causal",
-      "label": "s2048_h32kv8_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 35.4594099914157,
-        "flashattn_sm100": 37.85745144236734
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv16",
-      "label": "s4096_h32kv16",
-      "status": "ok",
-      "impls": {
-        "tir": 211.95962282649407,
-        "flashattn_sm100": 213.8200864009712
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv16_causal",
-      "label": "s4096_h32kv16_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 113.29376365747846,
-        "flashattn_sm100": 118.44286700249714
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv32",
-      "label": "s4096_h32kv32",
-      "status": "ok",
-      "impls": {
-        "tir": 218.1090828087181,
-        "flashattn_sm100": 220.09986006020958
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv32_causal",
-      "label": "s4096_h32kv32_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 121.49132471996914,
-        "flashattn_sm100": 120.10967038151428
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv4",
-      "label": "s4096_h32kv4",
-      "status": "ok",
-      "impls": {
-        "tir": 208.26159867992916,
-        "flashattn_sm100": 210.20807770165334
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:58+00:00"
     },
     {
       "kernel": "flash_attention4",
       "config": "s4096_h32kv4_causal",
       "label": "s4096_h32kv4_causal",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1899550,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:29+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tir": 174.56192110249785,
-        "flashattn_sm100": 182.6274724740556
+        "tir": 112.43414801465542,
+        "flashattn_sm100": 115.80627140223733
+      },
+      "round_samples": {
+        "tir": [
+          112.48513651877133,
+          112.452625,
+          112.77589772727273,
+          112.4977358184765,
+          111.95934500875657
+        ],
+        "flashattn_sm100": [
+          116.57009464285714,
+          115.67257867132867,
+          116.10149638989171,
+          115.6035981981982,
+          115.0835891089109
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv8",
-      "label": "s4096_h32kv8",
-      "status": "ok",
-      "impls": {
-        "tir": 207.41343718369058,
-        "flashattn_sm100": 209.5260361168412
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s4096_h32kv8_causal",
-      "label": "s4096_h32kv8_causal",
       "status": "ok",
-      "impls": {
-        "tir": 112.0451616547465,
-        "flashattn_sm100": 117.5551025633046
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv16",
-      "label": "s8192_h32kv16",
-      "status": "ok",
-      "impls": {
-        "tir": 780.7841605066445,
-        "flashattn_sm100": 779.7321397075366
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv16_causal",
-      "label": "s8192_h32kv16_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 422.05941179917215,
-        "flashattn_sm100": 428.6702767406787
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:02+00:00"
     },
     {
       "kernel": "flash_attention4",
       "config": "s8192_h32kv32",
       "label": "s8192_h32kv32",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1899979,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:30+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tir": 796.6754431885039,
-        "flashattn_sm100": 800.0534830748592
+        "tir": 778.739252678353,
+        "flashattn_sm100": 785.1522853499284
+      },
+      "round_samples": {
+        "tir": [
+          774.4936612903226,
+          776.026890909091,
+          781.1239375,
+          773.5918839285715,
+          788.4598897637795
+        ],
+        "flashattn_sm100": [
+          780.9269065420561,
+          780.4316296296297,
+          787.9356422018349,
+          790.9215188679245,
+          785.5457295081967
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv32_causal",
-      "label": "s8192_h32kv32_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 440.1180114066291,
-        "flashattn_sm100": 436.97894684644075
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv4",
-      "label": "s8192_h32kv4",
       "status": "ok",
-      "impls": {
-        "tir": 984.6223762963186,
-        "flashattn_sm100": 989.6464337550854
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv4_causal",
-      "label": "s8192_h32kv4_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 564.6176646719641,
-        "flashattn_sm100": 582.7476214874674
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv8",
-      "label": "s8192_h32kv8",
-      "status": "ok",
-      "impls": {
-        "tir": 766.1722874252914,
-        "flashattn_sm100": 773.2630560524747
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention4",
-      "config": "s8192_h32kv8_causal",
-      "label": "s8192_h32kv8_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 415.705961412266,
-        "flashattn_sm100": 425.85634552785353
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:03+00:00"
     },
     {
       "kernel": "flash_attention_backward_sm100",
       "config": "b1_s2048_h16_causal",
       "label": "b1_s2048_h16_causal",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1900320,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:31+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tir": 81.89506931534702,
-        "flashattn_sm100": 81.98154225772377
+        "tir": 82.14065890739143,
+        "flashattn_sm100": 82.10891515818902
+      },
+      "round_samples": {
+        "tir": [
+          82.1071517857143,
+          82.16838413098236,
+          82.14754394904459,
+          82.12687717121588,
+          82.15333749999999
+        ],
+        "flashattn_sm100": [
+          82.14939455782313,
+          82.1224251968504,
+          82.08661019108281,
+          82.08087113402061,
+          82.10527471116816
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention_backward_sm100",
-      "config": "b1_s4096_h16_causal",
-      "label": "b1_s4096_h16_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 323.10044835511286,
-        "flashattn_sm100": 328.2526935532348
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention_backward_sm100",
-      "config": "b1_s8192_h16_causal",
-      "label": "b1_s8192_h16_causal",
       "status": "ok",
-      "impls": {
-        "tir": 931.6855501117853,
-        "flashattn_sm100": 935.901570822734
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:14+00:00"
     },
     {
       "kernel": "flash_attention_backward_sm100",
       "config": "b1_s8192_h16_noncausal",
       "label": "b1_s8192_h16_noncausal",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1900438,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:32+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tir": 1100.8997301149425,
-        "flashattn_sm100": 1117.1258008431832
+        "tir": 1081.8105352405541,
+        "flashattn_sm100": 1092.8710941061552
+      },
+      "round_samples": {
+        "tir": [
+          1055.7136545454546,
+          1091.6331075268818,
+          1085.4921847826088,
+          1073.916675,
+          1102.2970543478261
+        ],
+        "flashattn_sm100": [
+          1044.4388888888889,
+          1106.5957582417582,
+          1116.973988235294,
+          1094.077021978022,
+          1102.269813186813
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention_backward_sm100",
-      "config": "b2_s4096_h16_causal",
-      "label": "b2_s4096_h16_causal",
-      "status": "ok",
-      "impls": {
-        "tir": 388.0338760420659,
-        "flashattn_sm100": 390.3185021584446
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flash_attention_backward_sm100",
-      "config": "b4_s8192_h16_causal",
-      "label": "b4_s8192_h16_causal",
       "status": "ok",
-      "impls": {
-        "tir": 2473.1056140428677,
-        "flashattn_sm100": 2496.385656282051
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:15+00:00"
     },
     {
       "kernel": "flash_attention_backward_sm100",
       "config": "b4_s8192_h16_noncausal",
       "label": "b4_s8192_h16_noncausal",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1900474,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:32+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tir": 5549.111992647058,
-        "flashattn_sm100": 5662.155411764706
+        "tir": 4370.637998626012,
+        "flashattn_sm100": 4471.562743636364
+      },
+      "round_samples": {
+        "tir": [
+          4290.604761904761,
+          4444.142318181818,
+          4289.5177826086965,
+          4401.736782608696,
+          4427.188347826087
+        ],
+        "flashattn_sm100": [
+          4353.6757333333335,
+          4503.230681818181,
+          4508.7564999999995,
+          4474.322666666667,
+          4517.828136363637
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashattn_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.720722131127593,
-        "flashinfer_cutedsl": 7.886697324960348
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
       "status": "ok",
-      "impls": {
-        "tirx": 7.6994118407291845,
-        "flashinfer_cutedsl": 7.875118813744586
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:17+00:00"
     },
     {
       "kernel": "flashinfer_add_rmsnorm_fp4quant",
       "config": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1929321,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:48+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 2.9510970245915575,
-        "flashinfer_cutedsl": 2.998385455950631
+        "tirx": 2.959971288057411,
+        "flashinfer_cutedsl": 2.8960153407017533
+      },
+      "round_samples": {
+        "tirx": [
+          2.952141182738412,
+          2.9654762120525597,
+          2.9508231292517006,
+          2.9641663602941177,
+          2.967249555950266
+        ],
+        "flashinfer_cutedsl": [
+          2.9126158424908426,
+          2.8849699146834307,
+          2.8865327530920752,
+          2.910143811219947,
+          2.8858143820224718
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:20+00:00"
     },
     {
       "kernel": "flashinfer_add_rmsnorm_fp4quant",
       "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 3,
+      "process_pid": 1929061,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:47+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 5.637615117253418,
-        "flashinfer_cutedsl": 5.775713977805708
+        "tirx": 5.810448456751161,
+        "flashinfer_cutedsl": 5.812406075994109
+      },
+      "round_samples": {
+        "tirx": [
+          5.818475432849789,
+          5.807252960682141,
+          5.813729439252337,
+          5.8062634032634035,
+          5.806521047708138
+        ],
+        "flashinfer_cutedsl": [
+          5.809595115077501,
+          5.810973327094057,
+          5.816946778711485,
+          5.813945065629557,
+          5.810570093457944
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.741885649567213,
-        "flashinfer_cutedsl": 5.889707903937606
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random",
-      "label": "bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random",
       "status": "ok",
-      "impls": {
-        "tirx": 5.685883698758787,
-        "flashinfer_cutedsl": 5.819831426804824
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.099396045275293,
-        "flashinfer_cutedsl": 6.15851926123798
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random",
-      "label": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.635236709029221,
-        "flashinfer_cutedsl": 5.769568938570171
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:28:12+00:00"
     },
     {
       "kernel": "flashinfer_add_rmsnorm_fp4quant",
       "config": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1929320,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:48+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 5.963950825946344,
-        "flashinfer_cutedsl": 6.053008608825112
+        "tirx": 6.016334899890449,
+        "flashinfer_cutedsl": 6.02255283754604
+      },
+      "round_samples": {
+        "tirx": [
+          6.003860702875399,
+          6.008746568627451,
+          6.029243257261411,
+          6.031995551161641,
+          6.007828419526342
+        ],
+        "flashinfer_cutedsl": [
+          6.021905033238366,
+          6.018966794995188,
+          6.025496364517693,
+          6.0186325036603225,
+          6.02776349131863
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_add_rmsnorm_fp4quant",
-      "config": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.689546898829335,
-        "flashinfer_cutedsl": 5.821100472708933
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "fused_bf16_m32_h4096_xc_rc_pdl0",
-      "label": "fused_bf16_m32_h4096_xc_rc_pdl0",
       "status": "ok",
-      "impls": {
-        "tirx": 3.6032831305010378,
-        "flashinfer_cutedsl": 3.6118395209343883
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "fused_bf16_m32_h4096_xc_rc_pdl1",
-      "label": "fused_bf16_m32_h4096_xc_rc_pdl1",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.7216245682399927,
-        "flashinfer_cutedsl": 3.702989458777208
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "fused_bf16_m64_h8192_xc_rc_pdl0",
-      "label": "fused_bf16_m64_h8192_xc_rc_pdl0",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.7879947375304193,
-        "flashinfer_cutedsl": 3.7898716428934125
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "gemma_bf16_m32_h4096_xc_rc_pdl0",
-      "label": "gemma_bf16_m32_h4096_xc_rc_pdl0",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.571021015346193,
-        "flashinfer_cutedsl": 3.5449109046493725
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "gemma_bf16_m32_h4096_xc_rc_pdl1",
-      "label": "gemma_bf16_m32_h4096_xc_rc_pdl1",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.724107989166657,
-        "flashinfer_cutedsl": 3.7072597055790313
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_add_rmsnorm",
-      "config": "gemma_bf16_m64_h8192_xc_rc_pdl0",
-      "label": "gemma_bf16_m64_h8192_xc_rc_pdl0",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.8722115224442737,
-        "flashinfer_cutedsl": 3.8764929662039616
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:17+00:00"
     },
     {
       "kernel": "flashinfer_fused_add_rmsnorm_quant",
       "config": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1",
       "label": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1930080,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:51+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 3.366179520133326,
-        "flashinfer_cutedsl": 3.4006142445911527
+        "tirx": 3.5368254738011826,
+        "flashinfer_cutedsl": 3.5665790138313134
+      },
+      "round_samples": {
+        "tirx": [
+          3.5452172523961663,
+          3.5261622232263896,
+          3.5427817845584837,
+          3.5447261088248743,
+          3.5252399999999997
+        ],
+        "flashinfer_cutedsl": [
+          3.5677061015370284,
+          3.5645618408437203,
+          3.5672393911439113,
+          3.5631513067400276,
+          3.57023642889188
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:21+00:00"
     },
     {
       "kernel": "flashinfer_fused_add_rmsnorm_quant",
       "config": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1",
       "label": "bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1930776,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 3.7141793588824346,
-        "flashinfer_cutedsl": 3.7284191995608156
+        "tirx": 3.571732894439308,
+        "flashinfer_cutedsl": 3.610932225895571
+      },
+      "round_samples": {
+        "tirx": [
+          3.5652581678411277,
+          3.566448712155445,
+          3.578586129753915,
+          3.574295302013423,
+          3.5740761604326274
+        ],
+        "flashinfer_cutedsl": [
+          3.6067563499529633,
+          3.6114772214704556,
+          3.615756022777048,
+          3.609487442337263,
+          3.611184092940125
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:25+00:00"
     },
     {
       "kernel": "flashinfer_fused_add_rmsnorm_quant",
       "config": "bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1",
       "label": "bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1930339,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:52+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 3.8162779479448434,
-        "flashinfer_cutedsl": 3.898806482512027
+        "tirx": 3.7283472200575325,
+        "flashinfer_cutedsl": 3.7939616558958646
+      },
+      "round_samples": {
+        "tirx": [
+          3.731124079915878,
+          3.72615016424214,
+          3.724209052729818,
+          3.7312476147205818,
+          3.7290051886792455
+        ],
+        "flashinfer_cutedsl": [
+          3.7846331360946746,
+          3.802578493647913,
+          3.784905800464037,
+          3.796887818969668,
+          3.80080303030303
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:25+00:00"
     },
     {
       "kernel": "flashinfer_fused_dit_layernorm",
       "config": "grgb_bf16_b1_r1920",
       "label": "grgb_bf16_b1_r1920",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1931560,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:59+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 16.554921760341088,
-        "flashinfer_cuda": 16.926425777612465
+        "tirx": 16.600757544685816,
+        "flashinfer_cuda": 16.844181034123896
+      },
+      "round_samples": {
+        "tirx": [
+          16.589657644476954,
+          16.60738355376653,
+          16.60683381924198,
+          16.600280395578825,
+          16.599632310364797
+        ],
+        "flashinfer_cuda": [
+          16.84594565859421,
+          16.842083430571762,
+          16.84784342857143,
+          16.84624941588785,
+          16.838783236994217
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grgb_bf16_b1_r768",
-      "label": "grgb_bf16_b1_r768",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.48553728484952,
-        "flashinfer_cuda": 8.684978720650145
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grgb_bf16_b2_r1920",
-      "label": "grgb_bf16_b2_r1920",
       "status": "ok",
-      "impls": {
-        "tirx": 28.90225468781187,
-        "flashinfer_cuda": 29.403238043442887
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grgb_bf16_b2_r768",
-      "label": "grgb_bf16_b2_r768",
-      "status": "ok",
-      "impls": {
-        "tirx": 13.510463037885032,
-        "flashinfer_cuda": 13.948722863275776
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grgb_bf16_b4_r1920",
-      "label": "grgb_bf16_b4_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 52.180766932723905,
-        "flashinfer_cuda": 53.37378188564974
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grss_bf16_b1_r1920",
-      "label": "grss_bf16_b1_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 23.081869985737896,
-        "flashinfer_cuda": 23.093724749260456
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grss_bf16_b1_r768",
-      "label": "grss_bf16_b1_r768",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.959134800138894,
-        "flashinfer_cuda": 11.070855048127719
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grss_bf16_b2_r1920",
-      "label": "grss_bf16_b2_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 40.82137864634635,
-        "flashinfer_cuda": 40.96453618088016
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "grss_bf16_b2_r768",
-      "label": "grss_bf16_b2_r768",
-      "status": "ok",
-      "impls": {
-        "tirx": 18.593254022557513,
-        "flashinfer_cuda": 18.69461194098422
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:26+00:00"
     },
     {
       "kernel": "flashinfer_fused_dit_layernorm",
       "config": "grss_bf16_b4_r1920",
       "label": "grss_bf16_b4_r1920",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1932081,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:01+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 73.00627573783414,
-        "flashinfer_cuda": 73.5403711990731
+        "tirx": 72.98350284578183,
+        "flashinfer_cuda": 73.46692504214626
+      },
+      "round_samples": {
+        "tirx": [
+          72.83810661764706,
+          73.1024506387921,
+          72.84429248554913,
+          73.16033609467455,
+          72.9723283922463
+        ],
+        "flashinfer_cuda": [
+          73.44763741339493,
+          73.47228901734104,
+          73.46066627497062,
+          73.48015558194774,
+          73.47387692307693
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "rss_bf16_b1_r1920",
-      "label": "rss_bf16_b1_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 17.416447890523088,
-        "flashinfer_cuda": 17.585854350378437
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:31+00:00"
     },
     {
       "kernel": "flashinfer_fused_dit_layernorm",
       "config": "rss_bf16_b1_r768",
       "label": "rss_bf16_b1_r768",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1931592,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:59+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 8.537359069073187,
-        "flashinfer_cuda": 8.684042477341125
+        "tirx": 8.74671915241157,
+        "flashinfer_cuda": 8.665451747561834
+      },
+      "round_samples": {
+        "tirx": [
+          8.748557271557273,
+          8.750887192118226,
+          8.74367556675063,
+          8.744361923648983,
+          8.74611380798274
+        ],
+        "flashinfer_cuda": [
+          8.671595944609297,
+          8.660090252707581,
+          8.667663371230846,
+          8.661996818663837,
+          8.66591235059761
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "rss_bf16_b2_r1920",
-      "label": "rss_bf16_b2_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 31.54825560820634,
-        "flashinfer_cuda": 31.731525016773265
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "rss_bf16_b2_r768",
-      "label": "rss_bf16_b2_r768",
       "status": "ok",
-      "impls": {
-        "tirx": 14.448186534199149,
-        "flashinfer_cuda": 14.67498084331852
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_fused_dit_layernorm",
-      "config": "rss_bf16_b4_r1920",
-      "label": "rss_bf16_b4_r1920",
-      "status": "ok",
-      "impls": {
-        "tirx": 57.34849170808811,
-        "flashinfer_cuda": 57.70744821067791
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:30+00:00"
     },
     {
       "kernel": "flashinfer_layernorm",
       "config": "bf16_m128_h1024_xc_yc_pdl0_eps1e6",
       "label": "bf16_m128_h1024_xc_yc_pdl0_eps1e6",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1932932,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:05+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 3.078044790176154,
-        "flashinfer_cutedsl": 3.0617348327678933
+        "tirx": 3.1304530624089204,
+        "flashinfer_cutedsl": 3.1159943826116674
+      },
+      "round_samples": {
+        "tirx": [
+          3.1346300963676796,
+          3.1271640798226166,
+          3.1253370245546463,
+          3.130061763319189,
+          3.1350723479804703
+        ],
+        "flashinfer_cutedsl": [
+          3.1135347766006447,
+          3.10990178163545,
+          3.117655692729767,
+          3.1190548007246375,
+          3.1198248613678374
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m128_h128_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m128_h128_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.4434706360235405,
-        "flashinfer_cutedsl": 2.4455248950463506
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m128_h129_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m128_h129_xc_yc_pdl0_eps1e6",
       "status": "ok",
-      "impls": {
-        "tirx": 2.8534939835927684,
-        "flashinfer_cutedsl": 2.8579195937745405
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:40+00:00"
     },
     {
       "kernel": "flashinfer_layernorm",
       "config": "bf16_m128_h16384_xc_yc_pdl0_eps1e6",
       "label": "bf16_m128_h16384_xc_yc_pdl0_eps1e6",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1933194,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:06+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 8.948368212843627,
-        "flashinfer_cutedsl": 8.942759484215717
+        "tirx": 8.97138750195792,
+        "flashinfer_cutedsl": 8.967978195084784
+      },
+      "round_samples": {
+        "tirx": [
+          8.961070604209098,
+          8.975380555555557,
+          8.976516535433072,
+          8.971576464208244,
+          8.972393350383632
+        ],
+        "flashinfer_cutedsl": [
+          8.969951143451144,
+          8.966510095642933,
+          8.964541139240506,
+          8.97025647805394,
+          8.968632119035401
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m1_h1024_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m1_h1024_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.9720230571507775,
-        "flashinfer_cutedsl": 2.968002248222724
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:34+00:00"
     },
     {
       "kernel": "flashinfer_layernorm",
       "config": "bf16_m1_h128_xc_yc_pdl0_eps1e6",
       "label": "bf16_m1_h128_xc_yc_pdl0_eps1e6",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1932282,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:02+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 2.049317271435883,
-        "flashinfer_cutedsl": 2.0524189789453113
+        "tirx": 2.249420561466353,
+        "flashinfer_cutedsl": 2.256605600199046
+      },
+      "round_samples": {
+        "tirx": [
+          2.2564884410195614,
+          2.2564658413571754,
+          2.243590789473684,
+          2.2375830078125,
+          2.252974727668845
+        ],
+        "flashinfer_cutedsl": [
+          2.2555577281191805,
+          2.2557669946332735,
+          2.2555938489371328,
+          2.2580631290027444,
+          2.2580463003028988
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m1_h129_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m1_h129_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.7931047184268443,
-        "flashinfer_cutedsl": 2.796024503594549
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m1_h16384_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m1_h16384_xc_yc_pdl0_eps1e6",
       "status": "ok",
-      "impls": {
-        "tirx": 8.25753044039432,
-        "flashinfer_cutedsl": 8.250688795963889
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m2_h1024_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m2_h1024_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.796584245962813,
-        "flashinfer_cutedsl": 2.808288917696446
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m2_h128_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m2_h128_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.035999937686912,
-        "flashinfer_cutedsl": 2.0559761592891403
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m2_h129_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m2_h129_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.0461868868557516,
-        "flashinfer_cutedsl": 3.044687034878098
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m2_h16384_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m2_h16384_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.609502131257391,
-        "flashinfer_cutedsl": 7.624619378887564
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m3_h1024_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m3_h1024_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.1946847040140542,
-        "flashinfer_cutedsl": 3.188364216401223
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m3_h128_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m3_h128_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.244549753506697,
-        "flashinfer_cutedsl": 2.2462553695363647
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m3_h129_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m3_h129_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.811327220719155,
-        "flashinfer_cutedsl": 2.8114798688863067
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_layernorm",
-      "config": "bf16_m3_h16384_xc_yc_pdl0_eps1e6",
-      "label": "bf16_m3_h16384_xc_yc_pdl0_eps1e6",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.021095590241375,
-        "flashinfer_cutedsl": 8.060368782716147
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:35+00:00"
     },
     {
       "kernel": "flashinfer_qk_rmsnorm",
       "config": "gemma_bf16_b32_n32_h128_xc_yc_pdl0",
       "label": "gemma_bf16_b32_n32_h128_xc_yc_pdl0",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1934511,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:12+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 2.7995781554448302,
-        "flashinfer_cutedsl": 2.8284792865098316
+        "tirx": 2.769687846819642,
+        "flashinfer_cutedsl": 2.80563495093844
+      },
+      "round_samples": {
+        "tirx": [
+          2.75372559214327,
+          2.7843666228646518,
+          2.7748627705627706,
+          2.7814599351551643,
+          2.754024313372355
+        ],
+        "flashinfer_cutedsl": [
+          2.7990118829981716,
+          2.8147592345349355,
+          2.808568493150685,
+          2.7905565462224304,
+          2.8152785977859778
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:43+00:00"
     },
     {
       "kernel": "flashinfer_qk_rmsnorm",
       "config": "rms_bf16_b32_n32_h128_xc_yc_pdl0",
       "label": "rms_bf16_b32_n32_h128_xc_yc_pdl0",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1933411,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 2.81395213561397,
-        "flashinfer_cutedsl": 2.8319596705043817
+        "tirx": 2.6323512394144695,
+        "flashinfer_cutedsl": 2.6516232668744855
+      },
+      "round_samples": {
+        "tirx": [
+          2.6354217008797653,
+          2.6324047512326314,
+          2.6299709355131697,
+          2.6341959090909093,
+          2.6297629003558716
+        ],
+        "flashinfer_cutedsl": [
+          2.6458351648351646,
+          2.6440882882882883,
+          2.6775532994923856,
+          2.644700419972002,
+          2.6459391617845878
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:40+00:00"
     },
     {
       "kernel": "flashinfer_qk_rmsnorm",
       "config": "rms_f16_b16_n64_h128_xc_yc_pdl0",
       "label": "rms_f16_b16_n64_h128_xc_yc_pdl0",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1934242,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:11+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 2.818395580977495,
-        "flashinfer_cutedsl": 2.827004542309699
+        "tirx": 2.585177547238259,
+        "flashinfer_cutedsl": 2.596322724669231
+      },
+      "round_samples": {
+        "tirx": [
+          2.591016611295681,
+          2.5938245535714284,
+          2.591529117379436,
+          2.5740365275142314,
+          2.5754809264305174
+        ],
+        "flashinfer_cutedsl": [
+          2.591139814814815,
+          2.6026321995464854,
+          2.5843278008298753,
+          2.600738343141693,
+          2.602775465013286
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_rmsnorm",
-      "config": "gemma_bf16_m32_h4096_xc_yc_pdl0",
-      "label": "gemma_bf16_m32_h4096_xc_yc_pdl0",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.3629560297147543,
-        "flashinfer_cutedsl": 3.4510390326071674
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:39+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm",
       "config": "gemma_bf16_m64_h8192_xc_yc_pdl0",
       "label": "gemma_bf16_m64_h8192_xc_yc_pdl0",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1935520,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:16+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 3.4773465698180908,
-        "flashinfer_cutedsl": 3.452984607375942
+        "tirx": 3.4717927665799273,
+        "flashinfer_cutedsl": 3.5704239351703784
+      },
+      "round_samples": {
+        "tirx": [
+          3.463485137408861,
+          3.480769583142464,
+          3.4692384014699127,
+          3.46569431051109,
+          3.4797764003673097
+        ],
+        "flashinfer_cutedsl": [
+          3.5694627983153953,
+          3.5684205697730564,
+          3.565765161878705,
+          3.575312159709619,
+          3.5731589861751156
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:47+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm",
       "config": "rms_bf16_m32_h4096_xc_yc_pdl0",
       "label": "rms_bf16_m32_h4096_xc_yc_pdl0",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1935057,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:14+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 3.364439676928304,
-        "flashinfer_cutedsl": 3.452695622404946
+        "tirx": 3.2981290533931658,
+        "flashinfer_cutedsl": 3.4360655110700575
+      },
+      "round_samples": {
+        "tirx": [
+          3.290679577464789,
+          3.3073942523574313,
+          3.295888748419722,
+          3.3025295486272683,
+          3.2941531400966184
+        ],
+        "flashinfer_cutedsl": [
+          3.42722247706422,
+          3.4384502977553826,
+          3.442222378937471,
+          3.4294691597863043,
+          3.442963241806909
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:44+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm",
       "config": "rms_bf16_m32_h4096_xc_yc_pdl1",
       "label": "rms_bf16_m32_h4096_xc_yc_pdl1",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1935077,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:14+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 3.3515764867977045,
-        "flashinfer_cutedsl": 3.3558080135711537
+        "tirx": 3.328502318776166,
+        "flashinfer_cutedsl": 3.3228977466769205
+      },
+      "round_samples": {
+        "tirx": [
+          3.3247863720073663,
+          3.33225703200776,
+          3.3315154686078254,
+          3.3289085898024804,
+          3.325044131455399
+        ],
+        "flashinfer_cutedsl": [
+          3.3220933694181327,
+          3.321225557071396,
+          3.321245954692557,
+          3.3300319963947724,
+          3.319891855807744
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_rmsnorm",
-      "config": "rms_bf16_m64_h8192_xc_yc_pdl0",
-      "label": "rms_bf16_m64_h8192_xc_yc_pdl0",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.4584417197769426,
-        "flashinfer_cutedsl": 3.4412295032725257
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_rmsnorm_fp4quant",
-      "config": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random",
       "status": "ok",
-      "impls": {
-        "tirx": 4.001454621638744,
-        "flashinfer_cutedsl": 4.073269817270862
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:49+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm_fp4quant",
       "config": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1936412,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:21+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 2.648938698993347,
-        "flashinfer_cutedsl": 2.737106204933017
+        "tirx": 2.776168156822907,
+        "flashinfer_cutedsl": 2.7550583150613788
+      },
+      "round_samples": {
+        "tirx": [
+          2.7759159369527144,
+          2.77418068833652,
+          2.7800255834829444,
+          2.7751478458049883,
+          2.7755707295373666
+        ],
+        "flashinfer_cutedsl": [
+          2.7554163636363636,
+          2.7543258527827645,
+          2.753285907248987,
+          2.756951473922902,
+          2.7553119777158774
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:47+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm_fp4quant",
       "config": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1935882,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:18+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 4.568517369546825,
-        "flashinfer_cutedsl": 4.751573483387964
+        "tirx": 4.8425585551241435,
+        "flashinfer_cutedsl": 4.870439368492566
+      },
+      "round_samples": {
+        "tirx": [
+          4.837079354404842,
+          4.848335827876521,
+          4.8449867172675525,
+          4.841458025830258,
+          4.840932850241545
+        ],
+        "flashinfer_cutedsl": [
+          4.871085647058824,
+          4.877533584094573,
+          4.877870123691722,
+          4.858310027598896,
+          4.867397460018815
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashinfer_rmsnorm_fp4quant",
-      "config": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random",
-      "label": "bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.647691026547789,
-        "flashinfer_cutedsl": 4.8623331023772165
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:51+00:00"
     },
     {
       "kernel": "flashinfer_rmsnorm_fp4quant",
       "config": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
       "label": "bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1936012,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:18+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 4.834194894089477,
-        "flashinfer_cutedsl": 5.034695922873405
+        "tirx": 4.942843947295947,
+        "flashinfer_cutedsl": 4.93944229047522
+      },
+      "round_samples": {
+        "tirx": [
+          4.937387974683545,
+          4.9466543624161075,
+          4.947682646212847,
+          4.941970785440613,
+          4.940523967726626
+        ],
+        "flashinfer_cutedsl": [
+          4.946822397631968,
+          4.938883825738608,
+          4.932325636192271,
+          4.950554653937948,
+          4.928624938875306
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:51+00:00"
     },
     {
-      "kernel": "flashinfer_rmsnorm_fp4quant",
-      "config": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random",
-      "label": "bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random",
-      "status": "ok",
+      "kernel": "flashinfer_rmsnorm_quant",
+      "config": "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1",
+      "label": "bf16_e4m3_m32_h4096_xc_yc_pdl0_s1",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 3,
+      "process_pid": 1936536,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:22+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 4.671817443687989,
-        "flashinfer_cutedsl": 4.757455522012428
+        "tirx": 3.2765817819741074,
+        "flashinfer_cutedsl": 3.2203866377663153
+      },
+      "round_samples": {
+        "tirx": [
+          3.2738440629470675,
+          3.2847838383838384,
+          3.2804260563380283,
+          3.2601949622166244,
+          3.2836599899849777
+        ],
+        "flashinfer_cutedsl": [
+          3.2224908629441624,
+          3.231316474712068,
+          3.220158617183528,
+          3.225733834586466,
+          3.2022333994053516
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:26+00:00"
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_quant",
+      "config": "bf16_e4m3_m64_h8192_xc_yc_pdl0_s1",
+      "label": "bf16_e4m3_m64_h8192_xc_yc_pdl0_s1",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1936783,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:24+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
+      "impls": {
+        "tirx": 3.4049175085983503,
+        "flashinfer_cutedsl": 3.3867219358074983
+      },
+      "round_samples": {
+        "tirx": [
+          3.3976208358570563,
+          3.404844890510949,
+          3.4032352410995945,
+          3.4074065149486836,
+          3.411480060575467
+        ],
+        "flashinfer_cutedsl": [
+          3.3821053909664887,
+          3.3891944570649706,
+          3.3849416856492027,
+          3.3876650414431984,
+          3.3897031039136305
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:53+00:00"
+    },
+    {
+      "kernel": "flashinfer_rmsnorm_quant",
+      "config": "bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync",
+      "label": "bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1937138,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:26+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
+      "impls": {
+        "tirx": 16.642669876631317,
+        "flashinfer_cutedsl": 16.574812711783956
+      },
+      "round_samples": {
+        "tirx": [
+          16.639406647807636,
+          16.638154645124065,
+          16.65057872596154,
+          16.64082024539877,
+          16.644389118864577
+        ],
+        "flashinfer_cutedsl": [
+          16.5794376119403,
+          16.5915860579889,
+          16.57568445747801,
+          16.57395798816568,
+          16.553397443346892
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:57+00:00"
     },
     {
       "kernel": "flashkda_bf16_fused_m128",
       "config": "h64_mixed",
       "label": "h64_mixed",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1911220,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:20+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 268.2399169248605,
-        "flashinfer_m128": 271.9394696038769,
-        "flashkda_raw": 667.1472797983383
+        "tirx": 267.8366552047329,
+        "flashinfer_m128": 272.7128090813134,
+        "flashkda_raw": 665.3760013401804
+      },
+      "round_samples": {
+        "tirx": [
+          267.7781241830066,
+          267.9390408805031,
+          267.9020503144654,
+          267.76222468354433,
+          267.8018359621451
+        ],
+        "flashinfer_m128": [
+          272.7432837370242,
+          272.8112,
+          272.7299278688525,
+          272.60530921052634,
+          272.67432459016396
+        ],
+        "flashkda_raw": [
+          665.3513687943262,
+          665.4014436619718,
+          665.3451942446044,
+          665.4934084507042,
+          665.2885915492958
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_m128",
+          "flashkda_raw"
+        ]
+      },
+      "flashkda_raw_provenance": {
+        "repository": "https://github.com/MoonshotAI/FlashKDA.git",
+        "package_version": "0.0.1+1ce47ea",
+        "package_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda/__init__.py",
+        "package_sha256": "9cb9bd39186f6993f0067a8ff720cd233ef4b474444f1fd0fcd2bf06cab5fb84",
+        "extension_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda_C.cpython-311-x86_64-linux-gnu.so",
+        "extension_sha256": "d135616c39cf02ddc842fc01fe08984184a0447fdf90a5b1c15760b6a02faf81",
+        "source_dir": "/home/bohanhou/kernel-libs/FlashKDA",
+        "source_commit": "1ce47ea3bb22c84eb9cc665028399cf35e8ffb0b",
+        "cutlass_commit": "5c149f52a436782210263fb2f19b354443a61c6a",
+        "timing_scope": "flash_kda._fwd_raw",
+        "workspace_bytes": 458293376,
+        "use_initial_state": true,
+        "store_final_state": true
+      },
+      "flashkda_raw_correctness": {
+        "output_max_abs": 0.0009765625,
+        "final_state_max_abs": 0.015625
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_bf16_fused_m128",
-      "config": "h64_uniform",
-      "label": "h64_uniform",
-      "status": "ok",
-      "impls": {
-        "tirx": 465.6187226940271,
-        "flashinfer_m128": 473.59608972204967,
-        "flashkda_raw": 764.6675884297521
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:07+00:00"
     },
     {
       "kernel": "flashkda_bf16_fused_m128",
       "config": "h96_fixed8192",
       "label": "h96_fixed8192",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1910584,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:18+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 500.8359226974748,
-        "flashinfer_m128": 508.1553400020987,
-        "flashkda_raw": 1075.1109167773238
+        "tirx": 500.9242875570791,
+        "flashinfer_m128": 506.0954848944336,
+        "flashkda_raw": 1073.3853640449438
+      },
+      "round_samples": {
+        "tirx": [
+          500.9595480225989,
+          500.9548444444445,
+          500.88007303370784,
+          500.86946666666665,
+          500.95750561797746
+        ],
+        "flashinfer_m128": [
+          506.2270059171598,
+          506.0968628571428,
+          506.12696571428575,
+          505.95024712643675,
+          506.0763428571429
+        ],
+        "flashkda_raw": [
+          1073.3532584269662,
+          1073.3780337078651,
+          1073.3911123595506,
+          1073.3808876404494,
+          1073.4235280898877
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_m128",
+          "flashkda_raw"
+        ]
+      },
+      "flashkda_raw_provenance": {
+        "repository": "https://github.com/MoonshotAI/FlashKDA.git",
+        "package_version": "0.0.1+1ce47ea",
+        "package_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda/__init__.py",
+        "package_sha256": "9cb9bd39186f6993f0067a8ff720cd233ef4b474444f1fd0fcd2bf06cab5fb84",
+        "extension_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda_C.cpython-311-x86_64-linux-gnu.so",
+        "extension_sha256": "d135616c39cf02ddc842fc01fe08984184a0447fdf90a5b1c15760b6a02faf81",
+        "source_dir": "/home/bohanhou/kernel-libs/FlashKDA",
+        "source_commit": "1ce47ea3bb22c84eb9cc665028399cf35e8ffb0b",
+        "cutlass_commit": "5c149f52a436782210263fb2f19b354443a61c6a",
+        "timing_scope": "flash_kda._fwd_raw",
+        "workspace_bytes": 680804480,
+        "use_initial_state": true,
+        "store_final_state": true
+      },
+      "flashkda_raw_correctness": {
+        "output_max_abs": 0.0009765625,
+        "final_state_max_abs": 0.0078125
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_bf16_fused_m128",
-      "config": "h96_mixed",
-      "label": "h96_mixed",
-      "status": "ok",
-      "impls": {
-        "tirx": 609.2198309309309,
-        "flashinfer_m128": 622.6901362192892,
-        "flashkda_raw": 1403.8306617647058
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:54+00:00"
     },
     {
       "kernel": "flashkda_bf16_fused_m128",
       "config": "h96_uniform",
       "label": "h96_uniform",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1910956,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:20+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 432.01961649433497,
-        "flashinfer_m128": 436.53779708036194,
-        "flashkda_raw": 708.6739694284662
+        "tirx": 434.0923183457765,
+        "flashinfer_m128": 436.1191422458041,
+        "flashkda_raw": 705.6305179104478
+      },
+      "round_samples": {
+        "tirx": [
+          434.09796097560974,
+          434.1919038461539,
+          434.1060531400966,
+          433.9928173076923,
+          434.0728564593301
+        ],
+        "flashinfer_m128": [
+          436.16231818181814,
+          436.12417085427137,
+          436.1250541871921,
+          436.09644117647053,
+          436.08772682926826
+        ],
+        "flashkda_raw": [
+          705.6146641791045,
+          705.5020298507462,
+          705.5764850746269,
+          705.7002462686567,
+          705.7591641791045
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_m128",
+          "flashkda_raw"
+        ]
+      },
+      "flashkda_raw_provenance": {
+        "repository": "https://github.com/MoonshotAI/FlashKDA.git",
+        "package_version": "0.0.1+1ce47ea",
+        "package_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda/__init__.py",
+        "package_sha256": "9cb9bd39186f6993f0067a8ff720cd233ef4b474444f1fd0fcd2bf06cab5fb84",
+        "extension_path": "/home/bohanhou/my/lib/python3.11/site-packages/flash_kda_C.cpython-311-x86_64-linux-gnu.so",
+        "extension_sha256": "d135616c39cf02ddc842fc01fe08984184a0447fdf90a5b1c15760b6a02faf81",
+        "source_dir": "/home/bohanhou/kernel-libs/FlashKDA",
+        "source_commit": "1ce47ea3bb22c84eb9cc665028399cf35e8ffb0b",
+        "cutlass_commit": "5c149f52a436782210263fb2f19b354443a61c6a",
+        "timing_scope": "flash_kda._fwd_raw",
+        "workspace_bytes": 690094208,
+        "use_initial_state": true,
+        "store_final_state": true
+      },
+      "flashkda_raw_correctness": {
+        "output_max_abs": 0.0009765625,
+        "final_state_max_abs": 0.01171875
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv12h12_b64_s8",
-      "label": "hv12h12_b64_s8",
-      "status": "ok",
-      "impls": {
-        "tirx": 14.339483202981903,
-        "flashinfer_cake": 15.70338554328622
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv12h12_b8_s16",
-      "label": "hv12h12_b8_s16",
       "status": "ok",
-      "impls": {
-        "tirx": 4.7702013154223275,
-        "flashinfer_cake": 6.446833962335925
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:01+00:00"
     },
     {
       "kernel": "flashkda_decode_t1_precomputed",
       "config": "hv16h16_b128_s8",
       "label": "hv16h16_b128_s8",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1912240,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:26+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 28.748726959138207,
-        "flashinfer_cake": 31.495596942173464
+        "tirx": 26.619947845919867,
+        "flashinfer_cake": 31.540762575863823
+      },
+      "round_samples": {
+        "tirx": [
+          26.60526880934989,
+          26.625892276422764,
+          26.62729574468085,
+          26.62175539083558,
+          26.61952700831025
+        ],
+        "flashinfer_cake": [
+          31.559447786131997,
+          31.410586466165416,
+          31.571407816482587,
+          31.577601836393992,
+          31.584768974145117
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv16h16_b16_s16",
-      "label": "hv16h16_b16_s16",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.301943875449133,
-        "flashinfer_cake": 7.854504115629423
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:06+00:00"
     },
     {
       "kernel": "flashkda_decode_t1_precomputed",
       "config": "hv16h16_b1_s16",
       "label": "hv16h16_b1_s16",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1911833,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:24+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 4.011037211573264,
-        "flashinfer_cake": 5.609428760453247
+        "tirx": 4.115886739292655,
+        "flashinfer_cake": 5.85357326980452
+      },
+      "round_samples": {
+        "tirx": [
+          4.110502204801567,
+          4.112666216216216,
+          4.119145988805971,
+          4.112367327211214,
+          4.124751959428308
+        ],
+        "flashinfer_cake": [
+          5.847958121109224,
+          5.855640336134454,
+          5.854441528807758,
+          5.854261563876652,
+          5.855564799094511
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv16h16_b32_s8",
-      "label": "hv16h16_b32_s8",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.965755244470524,
-        "flashinfer_cake": 13.344626777624649
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv16h16_b4_s16",
-      "label": "hv16h16_b4_s16",
       "status": "ok",
-      "impls": {
-        "tirx": 4.425668303444357,
-        "flashinfer_cake": 6.013968566001348
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv16h16_b64_s8",
-      "label": "hv16h16_b64_s8",
-      "status": "ok",
-      "impls": {
-        "tirx": 16.485547640087454,
-        "flashinfer_cake": 19.3742274750777
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv16h16_b8_s16",
-      "label": "hv16h16_b8_s16",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.947001416376249,
-        "flashinfer_cake": 6.825502754014199
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:05+00:00"
     },
     {
       "kernel": "flashkda_decode_t1_precomputed",
       "config": "hv32h16_b32_s8",
       "label": "hv32h16_b32_s8",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1912437,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:27+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 16.80393459426296,
-        "flashinfer_cake": 19.170531987141658
+        "tirx": 15.238983564744842,
+        "flashinfer_cake": 19.403758214584414
+      },
+      "round_samples": {
+        "tirx": [
+          15.2381353115727,
+          15.2499176119403,
+          15.231703569267998,
+          15.240075056433408,
+          15.235086274509804
+        ],
+        "flashinfer_cake": [
+          19.457614336917562,
+          19.439698979591835,
+          19.198513855898653,
+          19.458502793296088,
+          19.46446110721794
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t1_precomputed",
-      "config": "hv32h16_b8_s16",
-      "label": "hv32h16_b8_s16",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.209117871436839,
-        "flashinfer_cake": 8.327738443563472
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv12h12_b64_t2",
-      "label": "hv12h12_b64_t2",
       "status": "ok",
-      "impls": {
-        "tirx": 20.849174827140168,
-        "flashinfer_cake": 24.28899769693229
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:12+00:00"
     },
     {
       "kernel": "flashkda_decode_t2_precomputed",
       "config": "hv12h12_b8_t2",
       "label": "hv12h12_b8_t2",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1913760,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:34+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 6.374156442481507,
-        "flashinfer_cake": 8.377837915302791
+        "tirx": 6.376186084843852,
+        "flashinfer_cake": 8.784459040890397
+      },
+      "round_samples": {
+        "tirx": [
+          6.376747908533185,
+          6.3731469366562825,
+          6.36942059252064,
+          6.37484022460439,
+          6.386774761904762
+        ],
+        "flashinfer_cake": [
+          8.785584688346884,
+          8.783792406613594,
+          8.788666666666668,
+          8.779446654611212,
+          8.784804788213629
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:15+00:00"
     },
     {
       "kernel": "flashkda_decode_t2_precomputed",
       "config": "hv16h16_b64_t2",
       "label": "hv16h16_b64_t2",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 3,
+      "process_pid": 1913523,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:32+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 25.414999029017768,
-        "flashinfer_cake": 29.988170488854422
+        "tirx": 25.106391529218598,
+        "flashinfer_cake": 30.296320636088126
+      },
+      "round_samples": {
+        "tirx": [
+          25.098583333333334,
+          25.102140186915886,
+          25.109822027716994,
+          25.10696843615495,
+          25.114443661971833
+        ],
+        "flashinfer_cake": [
+          30.27514195867026,
+          30.30623189734189,
+          30.309281981981982,
+          30.290555956678702,
+          30.30039138576779
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv16h16_b8_t2",
-      "label": "hv16h16_b8_t2",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.032893290308618,
-        "flashinfer_cake": 9.311554206473549
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:26+00:00"
     },
     {
       "kernel": "flashkda_decode_t2_precomputed",
       "config": "hv32h16_b128_t2",
       "label": "hv32h16_b128_t2",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1913139,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:31+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 83.1121574697481,
-        "flashinfer_cake": 95.18804950568678
+        "tirx": 81.60014918452865,
+        "flashinfer_cake": 95.24808759697191
+      },
+      "round_samples": {
+        "tirx": [
+          81.60842730720606,
+          81.61258808618504,
+          81.56584538653367,
+          81.61737654320987,
+          81.5965085995086
+        ],
+        "flashinfer_cake": [
+          95.21319019316493,
+          95.24657607090103,
+          95.28302055800293,
+          95.25254505813955,
+          95.24510610465116
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv32h16_b16_t2",
-      "label": "hv32h16_b16_t2",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.66989601299443,
-        "flashinfer_cake": 18.241979632674116
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv32h16_b32_t2",
-      "label": "hv32h16_b32_t2",
       "status": "ok",
-      "impls": {
-        "tirx": 25.640840713336193,
-        "flashinfer_cake": 30.02172307480613
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv32h16_b64_t2",
-      "label": "hv32h16_b64_t2",
-      "status": "ok",
-      "impls": {
-        "tirx": 44.91374631310782,
-        "flashinfer_cake": 51.739787532167675
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t2_precomputed",
-      "config": "hv32h16_b8_t2",
-      "label": "hv32h16_b8_t2",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.007080987034804,
-        "flashinfer_cake": 11.312913600352381
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:11+00:00"
     },
     {
       "kernel": "flashkda_decode_t3_lower_bound",
       "config": "hv16h16_b16_t3",
       "label": "hv16h16_b16_t3",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1915799,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:43+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 13.581029397577948,
-        "flashinfer_cake": 14.016056104796148
+        "tirx": 13.419368463263787,
+        "flashinfer_cake": 14.06649908145092
+      },
+      "round_samples": {
+        "tirx": [
+          13.422499679692505,
+          13.41669899103139,
+          13.420550417827299,
+          13.412442191780823,
+          13.424651035986914
+        ],
+        "flashinfer_cake": [
+          14.055828983516482,
+          14.007061403508773,
+          14.095968329374506,
+          14.108937989556136,
+          14.064698701298703
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:16+00:00"
     },
     {
       "kernel": "flashkda_decode_t3_lower_bound",
       "config": "hv16h16_b1_t3",
       "label": "hv16h16_b1_t3",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1914657,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:39+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 5.924036915949224,
-        "flashinfer_cake": 6.077056287911471
+        "tirx": 5.556455606531107,
+        "flashinfer_cake": 6.002619933676609
+      },
+      "round_samples": {
+        "tirx": [
+          5.550306065664997,
+          5.551496037296038,
+          5.5506878208119454,
+          5.573515251055842,
+          5.556272857826712
+        ],
+        "flashinfer_cake": [
+          5.989763142692086,
+          5.991609580838324,
+          6.0657453161592505,
+          5.96889115250291,
+          5.997090476190476
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t3_lower_bound",
-      "config": "hv16h16_b2_t3",
-      "label": "hv16h16_b2_t3",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.0873213148889,
-        "flashinfer_cake": 6.293167199493816
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:11+00:00"
     },
     {
       "kernel": "flashkda_decode_t3_lower_bound",
       "config": "hv16h16_b4_t3",
       "label": "hv16h16_b4_t3",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1914999,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 6.761728764387974,
-        "flashinfer_cake": 6.974412798265498
+        "tirx": 6.682236778598995,
+        "flashinfer_cake": 6.97106407301093
+      },
+      "round_samples": {
+        "tirx": [
+          6.675436424208773,
+          6.677712876171682,
+          6.69409414024976,
+          6.685043867924528,
+          6.678896584440228
+        ],
+        "flashinfer_cake": [
+          6.961022302591923,
+          6.955473427000611,
+          7.001879503839338,
+          6.973222090962788,
+          6.963723040659988
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t3_lower_bound",
-      "config": "hv16h16_b8_t3",
-      "label": "hv16h16_b8_t3",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.886985979694978,
-        "flashinfer_cake": 7.969388697231371
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv12h12_b64_t4",
-      "label": "hv12h12_b64_t4",
       "status": "ok",
-      "impls": {
-        "tirx": 32.185142335409466,
-        "flashinfer_cake": 33.9351206883906
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:16+00:00"
     },
     {
       "kernel": "flashkda_decode_t4_precomputed",
       "config": "hv12h12_b8_t4",
       "label": "hv12h12_b8_t4",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1916605,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 8.818268273311162,
-        "flashinfer_cake": 10.481047852053491
+        "tirx": 8.761285749614059,
+        "flashinfer_cake": 11.059588710085368
+      },
+      "round_samples": {
+        "tirx": [
+          8.783308394160585,
+          8.755598639455782,
+          8.755674002047083,
+          8.76013777325877,
+          8.751709939148073
+        ],
+        "flashinfer_cake": [
+          11.046909275558564,
+          11.072532984977139,
+          11.076174300254452,
+          11.081682458386684,
+          11.02064453125
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:25+00:00"
     },
     {
       "kernel": "flashkda_decode_t4_precomputed",
       "config": "hv16h16_b64_t4",
       "label": "hv16h16_b64_t4",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1916376,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:45+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 40.82463446971685,
-        "flashinfer_cake": 42.53704180234865
+        "tirx": 39.33324022679419,
+        "flashinfer_cake": 42.01299984529615
+      },
+      "round_samples": {
+        "tirx": [
+          39.37703688181056,
+          39.299480257856565,
+          39.32612962962963,
+          39.33219036144579,
+          39.33136400322841
+        ],
+        "flashinfer_cake": [
+          42.04755429650614,
+          42.01598872180451,
+          42.0034531835206,
+          42.00501515151515,
+          41.99298787313433
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv16h16_b8_t4",
-      "label": "hv16h16_b8_t4",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.15147500667413,
-        "flashinfer_cake": 10.821097204367238
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:24+00:00"
     },
     {
       "kernel": "flashkda_decode_t4_precomputed",
       "config": "hv32h16_b128_t4",
       "label": "hv32h16_b128_t4",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1915946,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:43+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 136.04335459411334,
-        "flashinfer_cake": 138.298075534864
+        "tirx": 132.01862156660457,
+        "flashinfer_cake": 137.96930216638336
+      },
+      "round_samples": {
+        "tirx": [
+          132.03768458781363,
+          132.02307304347826,
+          132.00862283737024,
+          132.02903812824957,
+          131.9946892361111
+        ],
+        "flashinfer_cake": [
+          138.0437236084453,
+          138.00566351606804,
+          137.91448113207548,
+          137.8977202268431,
+          137.98492234848487
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv32h16_b16_t4",
-      "label": "hv32h16_b16_t4",
-      "status": "ok",
-      "impls": {
-        "tirx": 22.369841016036652,
-        "flashinfer_cake": 24.63347483171318
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv32h16_b32_t4",
-      "label": "hv32h16_b32_t4",
       "status": "ok",
-      "impls": {
-        "tirx": 40.46614351015531,
-        "flashinfer_cake": 41.808063391071784
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv32h16_b64_t4",
-      "label": "hv32h16_b64_t4",
-      "status": "ok",
-      "impls": {
-        "tirx": 71.71584813869262,
-        "flashinfer_cake": 73.734534104721
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t4_precomputed",
-      "config": "hv32h16_b8_t4",
-      "label": "hv32h16_b8_t4",
-      "status": "ok",
-      "impls": {
-        "tirx": 12.766413260734272,
-        "flashinfer_cake": 14.745371736659923
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv12h12_b64_s1",
-      "label": "hv12h12_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 36.1510371254478,
-        "flashinfer_cake": 38.32829333904619
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv12h12_b8_s4",
-      "label": "hv12h12_b8_s4",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.669738480597802,
-        "flashinfer_cake": 10.189374955525105
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv16h16_b2_s8",
-      "label": "hv16h16_b2_s8",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.674385458877931,
-        "flashinfer_cake": 9.609337139041145
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv16h16_b5_s4",
-      "label": "hv16h16_b5_s4",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.601157209006193,
-        "flashinfer_cake": 10.065586214393935
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv16h16_b64_s1",
-      "label": "hv16h16_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 45.355691766974545,
-        "flashinfer_cake": 46.932935995056724
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv16h16_b8_s2",
-      "label": "hv16h16_b8_s2",
-      "status": "ok",
-      "impls": {
-        "tirx": 9.71949928041993,
-        "flashinfer_cake": 11.458234216395514
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:23+00:00"
     },
     {
       "kernel": "flashkda_decode_t5_gram",
       "config": "hv32h16_b128_s1",
       "label": "hv32h16_b128_s1",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1917482,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:52+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 157.7329388841835,
-        "flashinfer_cake": 160.06139548741302
+        "tirx": 158.97760532956445,
+        "flashinfer_cake": 160.03851571829097
+      },
+      "round_samples": {
+        "tirx": [
+          158.95094069529654,
+          158.9053541247485,
+          159.06540881763527,
+          158.884108,
+          159.082215010142
+        ],
+        "flashinfer_cake": [
+          160.08882869379016,
+          160.06565170940172,
+          159.9873354564756,
+          160.03349464668094,
+          160.0172680851064
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv32h16_b16_s1",
-      "label": "hv32h16_b16_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 24.79908811773751,
-        "flashinfer_cake": 26.708729977899676
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:27+00:00"
     },
     {
       "kernel": "flashkda_decode_t5_gram",
       "config": "hv32h16_b1_s8",
       "label": "hv32h16_b1_s8",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1917856,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:53+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 7.611494501660651,
-        "flashinfer_cake": 9.328511323359672
+        "tirx": 7.029549386726056,
+        "flashinfer_cake": 9.312128803592886
+      },
+      "round_samples": {
+        "tirx": [
+          7.02646905876235,
+          7.031326043737574,
+          7.033521844660195,
+          7.02547931382442,
+          7.03095067264574
+        ],
+        "flashinfer_cake": [
+          9.316641781681305,
+          9.315092604101928,
+          9.31211448019802,
+          9.30745471349353,
+          9.309340438489647
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv32h16_b2_s2",
-      "label": "hv32h16_b2_s2",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.8625942489277465,
-        "flashinfer_cake": 9.350423591783107
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv32h16_b32_s1",
-      "label": "hv32h16_b32_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 45.413918972428526,
-        "flashinfer_cake": 46.60646318216883
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:34+00:00"
     },
     {
       "kernel": "flashkda_decode_t5_gram",
       "config": "hv32h16_b3_s4",
       "label": "hv32h16_b3_s4",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1918336,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:55+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 8.782956599934174,
-        "flashinfer_cake": 10.192771113296926
+        "tirx": 8.599438674959845,
+        "flashinfer_cake": 10.235061098422312
+      },
+      "round_samples": {
+        "tirx": [
+          8.593447714464622,
+          8.598746329113924,
+          8.602512939958592,
+          8.59062978953049,
+          8.611856601731601
+        ],
+        "flashinfer_cake": [
+          10.26388284789644,
+          10.257120329322355,
+          10.121495970241785,
+          10.271638871857755,
+          10.261167472793227
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv32h16_b64_s1",
-      "label": "hv32h16_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 81.50379606666836,
-        "flashinfer_cake": 83.4039683537322
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t5_gram",
-      "config": "hv32h16_b8_s1",
-      "label": "hv32h16_b8_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 14.163372720071113,
-        "flashinfer_cake": 16.052781192062394
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv12h12_b64_s1",
-      "label": "hv12h12_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 40.5521320751403,
-        "flashinfer_cake": 42.673299305884
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv12h12_b8_s4",
-      "label": "hv12h12_b8_s4",
-      "status": "ok",
-      "impls": {
-        "tirx": 14.615648386630369,
-        "flashinfer_cake": 16.384643510863956
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv16h16_b2_s8",
-      "label": "hv16h16_b2_s8",
-      "status": "ok",
-      "impls": {
-        "tirx": 7.26483245403878,
-        "flashinfer_cake": 8.809267001413495
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv16h16_b5_s4",
-      "label": "hv16h16_b5_s4",
-      "status": "ok",
-      "impls": {
-        "tirx": 14.045094567892448,
-        "flashinfer_cake": 15.577077671005771
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv16h16_b64_s1",
-      "label": "hv16h16_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 50.32821562431621,
-        "flashinfer_cake": 53.056791933355655
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv16h16_b8_s2",
-      "label": "hv16h16_b8_s2",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.60759211461361,
-        "flashinfer_cake": 12.131849202161726
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:36+00:00"
     },
     {
       "kernel": "flashkda_decode_t6_gram",
       "config": "hv32h16_b128_s1",
       "label": "hv32h16_b128_s1",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1918344,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:56+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 176.96006420089253,
-        "flashinfer_cake": 179.937822178715
+        "tirx": 181.68061918725348,
+        "flashinfer_cake": 195.86782700018006
+      },
+      "round_samples": {
+        "tirx": [
+          178.37773170731708,
+          179.27489999999997,
+          178.55836807095343,
+          187.80646341463415,
+          184.38563274336283
+        ],
+        "flashinfer_cake": [
+          180.69435817307692,
+          181.4535,
+          184.08832167832168,
+          186.94657142857145,
+          246.15638372093025
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv32h16_b16_s1",
-      "label": "hv32h16_b16_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 27.768000909471162,
-        "flashinfer_cake": 29.509279309002515
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:36+00:00"
     },
     {
       "kernel": "flashkda_decode_t6_gram",
       "config": "hv32h16_b1_s8",
       "label": "hv32h16_b1_s8",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1919204,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:00+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 7.435627763992436,
-        "flashinfer_cake": 9.314902195755867
+        "tirx": 7.297816968887659,
+        "flashinfer_cake": 8.735185912694362
+      },
+      "round_samples": {
+        "tirx": [
+          7.292769700332964,
+          7.301606454720616,
+          7.294057926829268,
+          7.296356259277585,
+          7.304294503277862
+        ],
+        "flashinfer_cake": [
+          8.765503037667072,
+          8.756875958188154,
+          8.608627788400256,
+          8.785468072289156,
+          8.759454706927176
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv32h16_b2_s2",
-      "label": "hv32h16_b2_s2",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.667163230824096,
-        "flashinfer_cake": 9.626263705886325
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv32h16_b32_s1",
-      "label": "hv32h16_b32_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 48.977497779910045,
-        "flashinfer_cake": 52.20792178219764
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:29+00:00"
     },
     {
       "kernel": "flashkda_decode_t6_gram",
       "config": "hv32h16_b3_s4",
       "label": "hv32h16_b3_s4",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1919419,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:01+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 14.536727618229927,
-        "flashinfer_cake": 16.372589466273045
+        "tirx": 14.060653855427015,
+        "flashinfer_cake": 16.251151026673593
+      },
+      "round_samples": {
+        "tirx": [
+          14.034050889025137,
+          14.062012429378532,
+          14.085978587962964,
+          14.035129432624114,
+          14.08609793814433
+        ],
+        "flashinfer_cake": [
+          16.35783344996501,
+          16.092810321715817,
+          16.17179424977538,
+          16.340008168822326,
+          16.293308943089432
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cake"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv32h16_b64_s1",
-      "label": "hv32h16_b64_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 91.65201766854545,
-        "flashinfer_cake": 92.83441768126445
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "flashkda_decode_t6_gram",
-      "config": "hv32h16_b8_s1",
-      "label": "hv32h16_b8_s1",
       "status": "ok",
-      "impls": {
-        "tirx": 15.283695022425709,
-        "flashinfer_cake": 17.01846355341056
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fp16_bf16_gemm",
-      "config": "bf16_1024x1024x1024",
-      "label": "bf16_1024x1024x1024",
-      "status": "ok",
-      "impls": {
-        "tir": 6.871880320281342,
-        "torch-cublas": 5.995853025510167,
-        "deepgemm-cublaslt": 6.003759691576505,
-        "deepgemm-bf16": 6.873510510967577
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fp16_bf16_gemm",
-      "config": "bf16_16384x16384x16384",
-      "label": "bf16_16384x16384x16384",
-      "status": "ok",
-      "impls": {
-        "tir": 5423.817821052632,
-        "torch-cublas": 5486.077789473684,
-        "deepgemm-cublaslt": 5488.144989473684,
-        "deepgemm-bf16": 5934.2415
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "fp16_bf16_gemm",
-      "config": "bf16_2048x2048x2048",
-      "label": "bf16_2048x2048x2048",
-      "status": "ok",
-      "impls": {
-        "tir": 27.41909432089643,
-        "torch-cublas": 26.482929203128446,
-        "deepgemm-cublaslt": 26.490081688348784,
-        "deepgemm-bf16": 29.160709508041677
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:40+00:00"
     },
     {
       "kernel": "fp16_bf16_gemm",
       "config": "bf16_4096x4096x4096",
       "label": "bf16_4096x4096x4096",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889088,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tir": 90.74577631271823,
-        "torch-cublas": 88.74320325412603,
-        "deepgemm-cublaslt": 88.14318768423185,
-        "deepgemm-bf16": 87.51857828092288
+        "tir": 92.49522758505691,
+        "torch-cublas": 90.32389657738804,
+        "deepgemm-cublaslt": 90.71902864935852,
+        "deepgemm-bf16": 89.9498264744218
+      },
+      "round_samples": {
+        "tir": [
+          91.77102816901409,
+          92.78301923076923,
+          93.16366527196652,
+          93.08841209563995,
+          91.67001315789473
+        ],
+        "torch-cublas": [
+          88.96618068535827,
+          90.95516449086162,
+          90.86741248303936,
+          90.99599735449736,
+          89.83472787318362
+        ],
+        "deepgemm-cublaslt": [
+          90.58947883597884,
+          90.80675066312998,
+          90.58479784366577,
+          90.82754485488127,
+          90.78657104913678
+        ],
+        "deepgemm-bf16": [
+          89.88787412587412,
+          90.23201432291667,
+          89.86159430122116,
+          89.71876842105263,
+          90.04888120104438
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "torch-cublas",
+          "deepgemm-cublaslt",
+          "deepgemm-bf16"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "fp16_bf16_gemm",
-      "config": "bf16_8192x8192x8192",
-      "label": "bf16_8192x8192x8192",
-      "status": "ok",
-      "impls": {
-        "tir": 694.8819568041341,
-        "torch-cublas": 712.9988071418807,
-        "deepgemm-cublaslt": 708.0455876652915,
-        "deepgemm-bf16": 732.9954468518519
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:23+00:00"
     },
     {
       "kernel": "fp16_bf16_gemm",
       "config": "fp16_1024x1024x1024",
       "label": "fp16_1024x1024x1024",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889083,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tir": 10.379672822556806,
-        "torch-cublas": 8.773001276036995
+        "tir": 6.62570803763942,
+        "torch-cublas": 5.839524464501438
+      },
+      "round_samples": {
+        "tir": [
+          6.619978798586573,
+          6.623805022156573,
+          6.628272640153329,
+          6.627712062256809,
+          6.628771665043817
+        ],
+        "torch-cublas": [
+          5.841601958525346,
+          5.838772217025257,
+          5.84172060857538,
+          5.835366477272728,
+          5.840161061108479
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "torch-cublas"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:17+00:00"
     },
     {
       "kernel": "fp16_bf16_gemm",
       "config": "fp16_16384x16384x16384",
       "label": "fp16_16384x16384x16384",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889087,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tir": 5957.473633333333,
-        "torch-cublas": 5888.475066666667
+        "tir": 5702.039350980393,
+        "torch-cublas": 5612.535011111111
+      },
+      "round_samples": {
+        "tir": [
+          5776.221555555556,
+          5750.277,
+          5662.750388888889,
+          5658.197222222222,
+          5662.750588235294
+        ],
+        "torch-cublas": [
+          5746.8242222222225,
+          5405.657222222222,
+          5663.483166666667,
+          5629.7354444444445,
+          5616.975
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "torch-cublas"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:21+00:00"
     },
     {
-      "kernel": "fp16_bf16_gemm",
-      "config": "fp16_2048x2048x2048",
-      "label": "fp16_2048x2048x2048",
-      "status": "ok",
+      "kernel": "gdn_cp_prefill_sm100",
+      "config": "fp16_q16_k16_v16_s4096+4096_init_f16_i64",
+      "label": "fp16_q16_k16_v16_s4096+4096_init_f16_i64",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1908247,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tir": 16.47839254182674,
-        "torch-cublas": 15.859051076759114
+        "tirx": 117.78482648531048,
+        "flashinfer_cutedsl": 128.46451478438382
+      },
+      "round_samples": {
+        "tirx": [
+          117.76485740740742,
+          117.79462703583062,
+          117.78823393739704,
+          117.74790507364975,
+          117.82850897226754
+        ],
+        "flashinfer_cutedsl": [
+          128.47806595365418,
+          128.48426666666668,
+          128.41801061946904,
+          128.4523950177936,
+          128.48983566433566
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:59+00:00"
     },
     {
-      "kernel": "fp16_bf16_gemm",
-      "config": "fp16_4096x4096x4096",
-      "label": "fp16_4096x4096x4096",
-      "status": "ok",
+      "kernel": "gdn_cp_prefill_sm100",
+      "config": "fp16_q16_k16_v64_s192+64_initfinal_f16_i64",
+      "label": "fp16_q16_k16_v64_s192+64_initfinal_f16_i64",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1908716,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:09+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tir": 148.52792221912634,
-        "torch-cublas": 140.27741586075706
+        "tirx": 82.5471126015706,
+        "flashinfer_cutedsl": 83.7373291129267
+      },
+      "round_samples": {
+        "tirx": [
+          82.59612669683258,
+          82.5233426395939,
+          82.4856282853567,
+          82.53768956743004,
+          82.59277581863981
+        ],
+        "flashinfer_cutedsl": [
+          83.6747191780822,
+          83.96176684636119,
+          83.6039610738255,
+          83.75663157894738,
+          83.68956688741721
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:59+00:00"
     },
     {
-      "kernel": "fp16_bf16_gemm",
-      "config": "fp16_8192x8192x8192",
-      "label": "fp16_8192x8192x8192",
-      "status": "ok",
+      "kernel": "gdn_cp_prefill_sm100",
+      "config": "fp16_q1_k1_v1_s2048_none_i32",
+      "label": "fp16_q1_k1_v1_s2048_none_i32",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1907641,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:04+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tir": 738.8704168141325,
-        "torch-cublas": 762.3583936990991
+        "tirx": 53.781922462726364,
+        "flashinfer_cutedsl": 67.56015020292548
+      },
+      "round_samples": {
+        "tirx": [
+          53.770227008149014,
+          53.79829857819905,
+          53.767004712535346,
+          53.78244174757282,
+          53.79164026717557
+        ],
+        "flashinfer_cutedsl": [
+          67.60740902872776,
+          67.59338013698631,
+          67.58170731707317,
+          67.68880329799765,
+          67.32945123384255
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:43+00:00"
     },
     {
-      "kernel": "gdn_prefill_sm100",
-      "config": "hq16_hv16_s4096+4096",
-      "label": "hq16_hv16_s4096+4096",
-      "status": "ok",
+      "kernel": "gdn_decode_bf16_ilp4",
+      "config": "t1_b1_h2_hv4_tv16",
+      "label": "t1_b1_h2_hv4_tv16",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1903160,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:43+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 127.31569312087893,
-        "flashinfer_cutedsl": 133.4356792655095
+        "tirx": 3.070377307513451,
+        "flashinfer_cutedsl": 3.2716098310974875
+      },
+      "round_samples": {
+        "tirx": [
+          3.066726755218216,
+          3.0712069143446854,
+          3.069766682006443,
+          3.070281818181818,
+          3.073904367816092
+        ],
+        "flashinfer_cutedsl": [
+          3.3015242206235014,
+          3.3086222329162656,
+          3.1439960278053625,
+          3.2994400373308443,
+          3.3044666368114646
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:23+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_ilp4",
+      "config": "t4_b8_h4_hv8_tv16",
+      "label": "t4_b8_h4_hv8_tv16",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1903231,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:44+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
+      "impls": {
+        "tirx": 6.663030798239581,
+        "flashinfer_cutedsl": 7.121643587824312
+      },
+      "round_samples": {
+        "tirx": [
+          6.6715451595457,
+          6.65772203765227,
+          6.6648692743180655,
+          6.657461095100865,
+          6.663556424581006
+        ],
+        "flashinfer_cutedsl": [
+          7.140116598778004,
+          7.050657639243741,
+          7.139638118811882,
+          7.141282788883471,
+          7.136522793404462
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:24+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_ilp4",
+      "config": "t8_b4_h8_hv16_tv16",
+      "label": "t8_b4_h8_hv16_tv16",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1903921,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:48+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
+      "impls": {
+        "tirx": 10.386068068084958,
+        "flashinfer_cutedsl": 11.718994706845438
+      },
+      "round_samples": {
+        "tirx": [
+          10.382821180555556,
+          10.382651918976546,
+          10.389668253968253,
+          10.3920663507109,
+          10.383132636213539
+        ],
+        "flashinfer_cutedsl": [
+          11.719659066232357,
+          11.719659090909092,
+          11.725423271500842,
+          11.7197643454039,
+          11.710467760180995
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:26+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_mtp",
+      "config": "t2_b4_h16_hv32_tv32",
+      "label": "t2_b4_h16_hv32_tv32",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1904159,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:49+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
+      "impls": {
+        "tirx": 6.331199762977026,
+        "flashinfer_cutedsl": 6.844215516459584
+      },
+      "round_samples": {
+        "tirx": [
+          6.333308498896248,
+          6.336572088250385,
+          6.322348227294803,
+          6.327231614135626,
+          6.336538386308068
+        ],
+        "flashinfer_cutedsl": [
+          6.841482982982983,
+          6.846771126760563,
+          6.835662727720335,
+          6.845390673575129,
+          6.851770071258907
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:30+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_mtp",
+      "config": "t4_b64_h8_hv16_tv128",
+      "label": "t4_b64_h8_hv16_tv128",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1904530,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:51+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
+      "impls": {
+        "tirx": 33.810277053220226,
+        "flashinfer_cutedsl": 46.73738356118992
+      },
+      "round_samples": {
+        "tirx": [
+          33.81207220496894,
+          33.80228335832084,
+          33.82620483749056,
+          33.80796853415196,
+          33.80285633116883
+        ],
+        "flashinfer_cutedsl": [
+          46.73057695690414,
+          46.720441523118765,
+          46.77708165057068,
+          46.74770420017873,
+          46.71111347517731
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:45+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_mtp",
+      "config": "t8_b512_h16_hv32_tv128",
+      "label": "t8_b512_h16_hv32_tv128",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1905105,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:53+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
+      "impls": {
+        "tirx": 1163.7200382684737,
+        "flashinfer_cutedsl": 1330.072014251911
+      },
+      "round_samples": {
+        "tirx": [
+          884.0670454545455,
+          1193.1254594594593,
+          902.251009009009,
+          1969.227,
+          869.9296774193548
+        ],
+        "flashinfer_cutedsl": [
+          1029.5622978723404,
+          1068.2412978723403,
+          1523.272694736842,
+          1391.018391304348,
+          1638.2653894736843
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:46+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_t1",
+      "config": "b128_h8_hv16_tv128",
+      "label": "b128_h8_hv16_tv128",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1905384,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:54+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
+      "impls": {
+        "tirx": 24.893564959575468,
+        "flashinfer_cutedsl": 25.635826808402857
+      },
+      "round_samples": {
+        "tirx": [
+          24.899212006079026,
+          24.893713903743315,
+          24.900715258855588,
+          24.88567637326274,
+          24.888507255936677
+        ],
+        "flashinfer_cutedsl": [
+          25.63539972991222,
+          25.629920580110497,
+          25.639845182724255,
+          25.639254362416107,
+          25.634714186851213
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:31+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_t1",
+      "config": "b16_h16_hv32_tv64",
+      "label": "b16_h16_hv32_tv64",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 2,
+      "process_pid": 1905252,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:54+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
+      "impls": {
+        "tirx": 11.252379157049628,
+        "flashinfer_cutedsl": 20.288697787619263
+      },
+      "round_samples": {
+        "tirx": [
+          8.947412462908012,
+          8.937176088044021,
+          8.92605875769446,
+          8.940834469931804,
+          20.510414006669844
+        ],
+        "flashinfer_cutedsl": [
+          9.103487179487178,
+          9.099386025768087,
+          9.10433942980097,
+          33.489936170212765,
+          40.64634013282732
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:16+00:00"
+    },
+    {
+      "kernel": "gdn_decode_bf16_wide_vec_t1",
+      "config": "b512_h4_hv8_tv128",
+      "label": "b512_h4_hv8_tv128",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1906301,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:58+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
+      "impls": {
+        "tirx": 46.15119112948673,
+        "flashinfer_cutedsl": 47.084496385860724
+      },
+      "round_samples": {
+        "tirx": [
+          46.139663442940034,
+          46.14478010471204,
+          46.14835676625659,
+          46.169587765957445,
+          46.15356756756757
+        ],
+        "flashinfer_cutedsl": [
+          47.08218744551003,
+          47.085588179218306,
+          47.07727715355806,
+          47.08513777777778,
+          47.09229137323943
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:33+00:00"
+    },
+    {
+      "kernel": "gdn_decode_fp32_mtp_warp",
+      "config": "t2_b4_h16_hv64_tv16_ilp2_sv0",
+      "label": "t2_b4_h16_hv64_tv16_ilp2_sv0",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1906543,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:59+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
+      "impls": {
+        "tirx": 14.341158050432998,
+        "flashinfer_cutedsl": 15.831951728501215
+      },
+      "round_samples": {
+        "tirx": [
+          14.342819201995013,
+          14.337778085224128,
+          14.34711388727484,
+          14.346207296849089,
+          14.331871780821917
+        ],
+        "flashinfer_cutedsl": [
+          15.831454490657023,
+          15.82715985576923,
+          15.832157264957264,
+          15.83691547687036,
+          15.832071554252199
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:38+00:00"
+    },
+    {
+      "kernel": "gdn_decode_fp32_mtp_warp",
+      "config": "t4_b64_h8_hv32_tv64_ilp4_sv1",
+      "label": "t4_b64_h8_hv32_tv64_ilp4_sv1",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 4,
+      "process_pid": 1907500,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:03+00:00",
+      "retry_in_place": true,
+      "status": "FAIL",
+      "error": "prepared child exited None without a terminal message",
+      "finished_at": "2026-08-22T02:28:15+00:00"
+    },
+    {
+      "kernel": "gdn_decode_fp32_mtp_warp",
+      "config": "t8_b256_h16_hv64_tv64_ilp4_sv1",
+      "label": "t8_b256_h16_hv64_tv64_ilp4_sv1",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1907139,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:02+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
+      "impls": {
+        "tirx": 1773.3916557575758,
+        "flashinfer_cutedsl": 1778.8056653198653
+      },
+      "round_samples": {
+        "tirx": [
+          1773.7473333333332,
+          1773.0977454545455,
+          1773.434690909091,
+          1773.187490909091,
+          1773.4910181818182
+        ],
+        "flashinfer_cutedsl": [
+          1778.735,
+          1779.1433636363636,
+          1778.87,
+          1778.598777777778,
+          1778.681185185185
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:32+00:00"
     },
     {
       "kernel": "gdn_prefill_sm100",
       "config": "hq16_hv64_s1x8192",
       "label": "hq16_hv64_s1x8192",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1909153,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:12+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 385.72281067220337,
-        "flashinfer_cutedsl": 402.02581143078567
+        "tirx": 240.62530246316646,
+        "flashinfer_cutedsl": 250.77490564500553
+      },
+      "round_samples": {
+        "tirx": [
+          240.6516,
+          240.65907407407408,
+          240.5276153846154,
+          240.68293428571428,
+          240.60528857142856
+        ],
+        "flashinfer_cutedsl": [
+          250.74749112426036,
+          250.8322603550296,
+          250.77423668639054,
+          250.75828189910982,
+          250.7622581602374
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "gdn_prefill_sm100",
-      "config": "hq2_hv8_s1x65536",
-      "label": "hq2_hv8_s1x65536",
-      "status": "ok",
-      "impls": {
-        "tirx": 1758.8465536700337,
-        "flashinfer_cutedsl": 1781.1827185185186
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:54+00:00"
     },
     {
       "kernel": "gdn_prefill_sm100",
       "config": "hq32_hv32_s8192x16",
       "label": "hq32_hv32_s8192x16",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1909521,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:14+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 1558.4999836065574,
-        "flashinfer_cutedsl": 1622.4509661016948
+        "tirx": 1084.1738989247312,
+        "flashinfer_cutedsl": 1109.631677777778
+      },
+      "round_samples": {
+        "tirx": [
+          1081.990032967033,
+          1088.887494623656,
+          1084.316967032967,
+          1087.3201720430109,
+          1078.3548279569893
+        ],
+        "flashinfer_cutedsl": [
+          1107.014449438202,
+          1115.814388888889,
+          1105.5854831460674,
+          1117.0992696629214,
+          1102.6447977528092
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:52+00:00"
     },
     {
       "kernel": "gdn_prefill_sm100",
       "config": "hq8_hv32_s1024x8",
       "label": "hq8_hv32_s1024x8",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 3,
+      "process_pid": 1908910,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:10+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 92.2448261997059,
-        "flashinfer_cutedsl": 95.88029242961628
+        "tirx": 159.09580247366955,
+        "flashinfer_cutedsl": 187.62313805476367
+      },
+      "round_samples": {
+        "tirx": [
+          90.50428899835796,
+          90.47821632653061,
+          213.66085375494072,
+          189.17287270341208,
+          211.66278058510636
+        ],
+        "flashinfer_cutedsl": [
+          95.41873342736248,
+          191.94637587657783,
+          221.7833945945946,
+          217.63355013550137,
+          211.333636239782
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:20+00:00"
     },
     {
-      "kernel": "gemm_reduce_scatter",
-      "config": "tp1_m8192_n16384_k53248_fp16_dynamic",
-      "label": "tp1_m8192_n16384_k53248_fp16_dynamic",
-      "status": "ok",
+      "kernel": "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+      "config": "ring48k_bf16q_qh16_t16",
+      "label": "ring48k_bf16q_qh16_t16",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1950727,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:23+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 11267.02220000002,
-        "cublas_nccl_cudagraph": 10951.680099999992,
-        "cublasmp_split_p2p": 12201.002900000012
+        "tirx": 1029.3983312061403,
+        "msa": 1387.746949603073
+      },
+      "round_samples": {
+        "tirx": [
+          1037.2669789473684,
+          1036.0691770833332,
+          1027.8664270833333,
+          1013.2721979166665,
+          1032.516875
+        ],
+        "msa": [
+          1392.0023521126761,
+          1378.3273818181817,
+          1389.4889014084506,
+          1390.7621549295775,
+          1388.153957746479
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:00+00:00"
     },
     {
-      "kernel": "gemm_reduce_scatter",
-      "config": "tp1_m8192_n4096_k12288_fp16_dynamic",
-      "label": "tp1_m8192_n4096_k12288_fp16_dynamic",
-      "status": "ok",
+      "kernel": "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+      "config": "ring48k_fp8q_qh16_t16",
+      "label": "ring48k_fp8q_qh16_t16",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1951222,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:25+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 1000.4833000000042,
-        "cublas_nccl_cudagraph": 943.5558999999841,
-        "cublasmp_split_p2p": 1243.5104999999967
+        "tirx": 1384.613915942029
       },
-      "aggregated": {
+      "round_samples": {
+        "tirx": [
+          1384.3204782608695,
+          1384.4253623188406,
+          1385.046304347826,
+          1384.7306666666666,
+          1384.546768115942
+        ]
+      },
+      "errors": {
+        "msa": "DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: Failure while executing pass pipeline:\nerror: unknown: NVPTX compiler invocation failed, error log: ptxas application ptx input, line 1320; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1322; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1333; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1335; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1346; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1348; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1359; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1361; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4737; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4739; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4750; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4752; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4763; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4765; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4776; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4778; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas fatal   : Ptx assembly aborted due to errors\n  \nerror: unknown: An error happened while serializing the module."
+      },
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
         "rounds": 5,
-        "method": "mean"
-      }
+        "round_aggregate": "mean",
+        "order": [
+          "tirx"
+        ]
+      },
+      "status": "FAIL",
+      "error": "baseline error(s): msa: DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: Failure while executing pass pipeline:\nerror: unknown: NVPTX compiler invocation failed, error log: ptxas application ptx input, line 1320; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1322; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1333; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1335; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1346; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1348; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1359; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 1361; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4737; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4739; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4750; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4752; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4763; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4765; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4776; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas application ptx input, line 4778; error   : Illegal modifier '.satfinite' for instruction 'mul'\n  ptxas fatal   : Ptx assembly aborted due to errors\n  \nerror: unknown: An error happened while serializing the module.",
+      "finished_at": "2026-08-22T02:28:02+00:00"
     },
     {
-      "kernel": "gemm_reduce_scatter",
-      "config": "tp1_m8192_n5120_k25600_fp16_dynamic",
-      "label": "tp1_m8192_n5120_k25600_fp16_dynamic",
-      "status": "ok",
+      "kernel": "msa_sparse_atten_fwd_nvfp4_kv_sm100",
+      "config": "varlen_b3_s8192_bf16q_qh4_t16",
+      "label": "varlen_b3_s8192_bf16q_qh4_t16",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1951012,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:24+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 1493.212999999999,
-        "cublas_nccl_cudagraph": 1436.5056999999856,
-        "cublasmp_split_p2p": 1840.6236999999971
+        "tirx": 255.1578141474808
       },
-      "aggregated": {
+      "round_samples": {
+        "tirx": [
+          254.7127283950617,
+          255.6146186186186,
+          255.63274774774774,
+          254.7705795795796,
+          255.05839639639638
+        ]
+      },
+      "errors": {
+        "msa": "DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: NVVM Compilation Error:\n----------------------\n\n\u001b[94m\u2699\ufe0f  Current Settings:\u001b[0m\n\u001b[1m- Target Architecture: sm_100a\u001b[0m\n\nIR Context (truncated):\n\"gpu.module\"() <{sym_name = \"kernels\", targets = [#nvvm.target<O = 3, chip = \"sm_100a\", features = \"\">]}> ({\n    \"llvm.mlir.global\"() <{addr_space = 3 : i32, alignment = 1024 : i64, dso_local, global_type = !llvm.array<0 x i8>, linkage = #llvm.linkage<external>, sym_name = \"__dynamic_shmem__0\", visibility_ = 0 : i64}> ({\n    }) : () -> ()\n    \"llvm.func\"() <{CConv = #llvm.cconv<ccc>, arg_attrs = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {}, {}, {}, {}, {}, {}], function_type = !llvm.func<void (struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, f32, f32, f32, ptr, ptr, ptr, struct<(i1, i1, i1, vector<4xi32>)>, struct<(i1, i1, i1, vector<4xi32>)>, i32, i32, i32, i32)>, linkage = #llvm.linkage<external>, sym_name = \"kernel_cutlass_kernel_srcsm100fwdatten_fwd_nvfp4_kvSparseAttentionForwardNvfp4KvSm100_object_at__tensor000o111012_tensor000o101112_tensorptri8gmemalign16oi64div161_tensorptri8gmemalign16o_0\", visibility_ = 0 : i64}> ({\n    ^bb0(%arg0: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg1: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg2: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg3: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg4: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg5: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg6: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg7: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg8: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg9: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg10: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg11: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, %arg12: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg13: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg14: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg15: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg16: f32, %arg17: f32, %arg18: f32, %arg19: !llvm.ptr, %arg20: !llvm.ptr, %arg21: !llvm.ptr, %arg22: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg23: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg24: i32, %arg25: i32, %arg26: i32, %arg27: i32):\n  ...\n    ^bb2460:  // 2 preds: ^bb1331, ^bb2459\n      \"llvm.return\"() : () -> ()\n    }) {cu_attrs = {max_dynamic_shared_size_bytes = #cuda.dev_max_shared_memory_optin, non_portable_cluster_size_allowed = 1 : i32}, gpu.kernel, nvvm.kernel, nvvm.minctasm = 1 : i32, nvvm.reqntid = array<i32: 512, 1, 1>, smem.config_smem_size = 154624 : i64} : () -> ()\n  }) : () -> ()\nerror: unknown: An error happened while serializing the module.\n\n\u001b[93m\ud83d\udca1 Possible Solutions:\u001b[0m\n\u001b[92m1. Check if CUDA_TOOLKIT_PATH is set correctly\n2. Verify target architecture (sm_100a) is supported by your CUDA toolkit\n3. Make sure CUDA toolkit version matches the target architecture requirements\u001b[0m"
+      },
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
         "rounds": 5,
-        "method": "mean"
-      }
+        "round_aggregate": "mean",
+        "order": [
+          "tirx"
+        ]
+      },
+      "status": "FAIL",
+      "error": "baseline error(s): msa: DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: NVVM Compilation Error:\n----------------------\n\n\u001b[94m\u2699\ufe0f  Current Settings:\u001b[0m\n\u001b[1m- Target Architecture: sm_100a\u001b[0m\n\nIR Context (truncated):\n\"gpu.module\"() <{sym_name = \"kernels\", targets = [#nvvm.target<O = 3, chip = \"sm_100a\", features = \"\">]}> ({\n    \"llvm.mlir.global\"() <{addr_space = 3 : i32, alignment = 1024 : i64, dso_local, global_type = !llvm.array<0 x i8>, linkage = #llvm.linkage<external>, sym_name = \"__dynamic_shmem__0\", visibility_ = 0 : i64}> ({\n    }) : () -> ()\n    \"llvm.func\"() <{CConv = #llvm.cconv<ccc>, arg_attrs = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {}, {}, {}, {}, {}, {}], function_type = !llvm.func<void (struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, f32, f32, f32, ptr, ptr, ptr, struct<(i1, i1, i1, vector<4xi32>)>, struct<(i1, i1, i1, vector<4xi32>)>, i32, i32, i32, i32)>, linkage = #llvm.linkage<external>, sym_name = \"kernel_cutlass_kernel_srcsm100fwdatten_fwd_nvfp4_kvSparseAttentionForwardNvfp4KvSm100_object_at__tensor000o111012_tensor000o101112_tensorptri8gmemalign16oi64div161_tensorptri8gmemalign16o_0\", visibility_ = 0 : i64}> ({\n    ^bb0(%arg0: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg1: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg2: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg3: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg4: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg5: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg6: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg7: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg8: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg9: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg10: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg11: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, %arg12: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg13: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg14: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg15: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg16: f32, %arg17: f32, %arg18: f32, %arg19: !llvm.ptr, %arg20: !llvm.ptr, %arg21: !llvm.ptr, %arg22: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg23: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg24: i32, %arg25: i32, %arg26: i32, %arg27: i32):\n  ...\n    ^bb2460:  // 2 preds: ^bb1331, ^bb2459\n      \"llvm.return\"() : () -> ()\n    }) {cu_attrs = {max_dynamic_shared_size_bytes = #cuda.dev_max_shared_memory_optin, non_portable_cluster_size_allowed = 1 : i32}, gpu.kernel, nvvm.kernel, nvvm.minctasm = 1 : i32, nvvm.reqntid = array<i32: 512, 1, 1>, smem.config_smem_size = 154624 : i64} : () -> ()\n  }) : () -> ()\nerror: unknown: An error happened while serializing the module.\n\n\u001b[93m\ud83d\udca1 Possible Solutions:\u001b[0m\n\u001b[92m1. Check if CUDA_TOOLKIT_PATH is set correctly\n2. Verify target architecture (sm_100a) is supported by your CUDA toolkit\n3. Make sure CUDA toolkit version matches the target architecture requirements\u001b[0m",
+      "finished_at": "2026-08-22T02:27:58+00:00"
     },
     {
-      "kernel": "gemm_reduce_scatter",
-      "config": "tp1_m8192_n8192_k28672_fp16_dynamic",
-      "label": "tp1_m8192_n8192_k28672_fp16_dynamic",
-      "status": "ok",
+      "kernel": "msa_sparse_atten_fwd_sm100",
+      "config": "ring48k_bf16_qh16_t16",
+      "label": "ring48k_bf16_qh16_t16",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1951381,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:26+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 2402.020700000003,
-        "cublas_nccl_cudagraph": 2383.3390000000063,
-        "cublasmp_split_p2p": 2819.750900000002
+        "tirx": 1361.073217947686,
+        "msa": 1832.0996308874912
+      },
+      "round_samples": {
+        "tirx": [
+          1370.7323714285715,
+          1366.3826056338028,
+          1359.194,
+          1358.81061971831,
+          1350.2464929577466
+        ],
+        "msa": [
+          1828.9206603773584,
+          1835.307462962963,
+          1823.8279811320754,
+          1830.4856981132075,
+          1841.9563518518519
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:05+00:00"
+    },
+    {
+      "kernel": "msa_sparse_atten_fwd_sm100",
+      "config": "ring48k_fp8_qh16_t16",
+      "label": "ring48k_fp8_qh16_t16",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1952538,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:33+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
+      "impls": {
+        "tirx": 1334.788072769953,
+        "msa": 1526.887895238095
+      },
+      "round_samples": {
+        "tirx": [
+          1335.0741971830987,
+          1334.853138888889,
+          1334.8025416666667,
+          1334.4100694444446,
+          1334.8004166666667
+        ],
+        "msa": [
+          1526.8968571428572,
+          1526.8730634920635,
+          1526.899619047619,
+          1527.178476190476,
+          1526.5914603174604
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:12+00:00"
+    },
+    {
+      "kernel": "msa_sparse_atten_fwd_sm100",
+      "config": "varlen_b3_s8192_qh4_t16",
+      "label": "varlen_b3_s8192_qh4_t16",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1952001,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:31+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
+      "impls": {
+        "tirx": 266.39371173525376
+      },
+      "round_samples": {
+        "tirx": [
+          266.4268301282051,
+          266.3105745341615,
+          266.32273981191224,
+          266.60795652173914,
+          266.3004576802508
+        ]
+      },
+      "errors": {
+        "msa": "DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: NVVM Compilation Error:\n----------------------\n\n\u001b[94m\u2699\ufe0f  Current Settings:\u001b[0m\n\u001b[1m- Target Architecture: sm_100a\u001b[0m\n\nIR Context (truncated):\n\"gpu.module\"() <{sym_name = \"kernels\", targets = [#nvvm.target<O = 3, chip = \"sm_100a\", features = \"\">]}> ({\n    \"llvm.mlir.global\"() <{addr_space = 3 : i32, alignment = 1024 : i64, dso_local, global_type = !llvm.array<0 x i8>, linkage = #llvm.linkage<external>, sym_name = \"__dynamic_shmem__0\", visibility_ = 0 : i64}> ({\n    }) : () -> ()\n    \"llvm.func\"() <{CConv = #llvm.cconv<ccc>, arg_attrs = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {}, {}, {}, {}, {}, {}], function_type = !llvm.func<void (struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, f32, f32, f32, ptr, ptr, ptr, struct<(i1, i1, i1, vector<4xi32>)>, struct<(i1, i1, i1, vector<4xi32>)>, i32, i32, i32, i32)>, linkage = #llvm.linkage<external>, sym_name = \"kernel_cutlass_kernel_srcsm100fwdatten_fwdSparseAttentionForwardSm100_object_at__tensor000o111012_tensor000o101112_tensorptri32gmemalign16oi641_tensorptri32gmemalign16oi641_tensorptri32gm_0\", visibility_ = 0 : i64}> ({\n    ^bb0(%arg0: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg1: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg2: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg3: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg4: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg5: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg6: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg7: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg8: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, %arg9: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg10: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg11: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg12: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg13: f32, %arg14: f32, %arg15: f32, %arg16: !llvm.ptr, %arg17: !llvm.ptr, %arg18: !llvm.ptr, %arg19: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg20: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg21: i32, %arg22: i32, %arg23: i32, %arg24: i32):\n  ...\n    ^bb2446:  // 2 preds: ^bb1326, ^bb2445\n      \"llvm.return\"() : () -> ()\n    }) {cu_attrs = {max_dynamic_shared_size_bytes = #cuda.dev_max_shared_memory_optin, non_portable_cluster_size_allowed = 1 : i32}, gpu.kernel, nvvm.kernel, nvvm.minctasm = 1 : i32, nvvm.reqntid = array<i32: 512, 1, 1>, smem.config_smem_size = 138240 : i64} : () -> ()\n  }) : () -> ()\nerror: unknown: An error happened while serializing the module.\n\n\u001b[93m\ud83d\udca1 Possible Solutions:\u001b[0m\n\u001b[92m1. Check if CUDA_TOOLKIT_PATH is set correctly\n2. Verify target architecture (sm_100a) is supported by your CUDA toolkit\n3. Make sure CUDA toolkit version matches the target architecture requirements\u001b[0m"
+      },
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx"
+        ]
+      },
+      "status": "FAIL",
+      "error": "baseline error(s): msa: DSLRuntimeError: \ud83e\uddca\ud83e\uddca\ud83e\uddca ICE \ud83e\uddca\ud83e\uddca\ud83e\uddca\nCaused exception: NVVM Compilation Error:\n----------------------\n\n\u001b[94m\u2699\ufe0f  Current Settings:\u001b[0m\n\u001b[1m- Target Architecture: sm_100a\u001b[0m\n\nIR Context (truncated):\n\"gpu.module\"() <{sym_name = \"kernels\", targets = [#nvvm.target<O = 3, chip = \"sm_100a\", features = \"\">]}> ({\n    \"llvm.mlir.global\"() <{addr_space = 3 : i32, alignment = 1024 : i64, dso_local, global_type = !llvm.array<0 x i8>, linkage = #llvm.linkage<external>, sym_name = \"__dynamic_shmem__0\", visibility_ = 0 : i64}> ({\n    }) : () -> ()\n    \"llvm.func\"() <{CConv = #llvm.cconv<ccc>, arg_attrs = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {llvm.align = 64 : i64, llvm.byval = !llvm.struct<(struct<(array<16 x i64>)>)>, nvvm.grid_constant}, {}, {}, {}, {}, {}, {}], function_type = !llvm.func<void (struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, struct<(ptr<1>, struct<(i32, struct<()>)>)>, f32, f32, f32, ptr, ptr, ptr, struct<(i1, i1, i1, vector<4xi32>)>, struct<(i1, i1, i1, vector<4xi32>)>, i32, i32, i32, i32)>, linkage = #llvm.linkage<external>, sym_name = \"kernel_cutlass_kernel_srcsm100fwdatten_fwdSparseAttentionForwardSm100_object_at__tensor000o111012_tensor000o101112_tensorptri32gmemalign16oi641_tensorptri32gmemalign16oi641_tensorptri32gm_0\", visibility_ = 0 : i64}> ({\n    ^bb0(%arg0: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg1: !llvm.struct<(struct<()>, struct<(struct<(i32, i32, i32)>, struct<()>)>)>, %arg2: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg3: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg4: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg5: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg6: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg7: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg8: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32, i32)>, struct<(i64, i64)>)>)>, %arg9: !llvm.struct<(ptr<1>, struct<(struct<(i32, i32)>, i64)>)>, %arg10: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg11: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg12: !llvm.struct<(ptr<1>, struct<(i32, struct<()>)>)>, %arg13: f32, %arg14: f32, %arg15: f32, %arg16: !llvm.ptr, %arg17: !llvm.ptr, %arg18: !llvm.ptr, %arg19: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg20: !llvm.struct<(i1, i1, i1, vector<4xi32>)>, %arg21: i32, %arg22: i32, %arg23: i32, %arg24: i32):\n  ...\n    ^bb2446:  // 2 preds: ^bb1326, ^bb2445\n      \"llvm.return\"() : () -> ()\n    }) {cu_attrs = {max_dynamic_shared_size_bytes = #cuda.dev_max_shared_memory_optin, non_portable_cluster_size_allowed = 1 : i32}, gpu.kernel, nvvm.kernel, nvvm.minctasm = 1 : i32, nvvm.reqntid = array<i32: 512, 1, 1>, smem.config_smem_size = 138240 : i64} : () -> ()\n  }) : () -> ()\nerror: unknown: An error happened while serializing the module.\n\n\u001b[93m\ud83d\udca1 Possible Solutions:\u001b[0m\n\u001b[92m1. Check if CUDA_TOOLKIT_PATH is set correctly\n2. Verify target architecture (sm_100a) is supported by your CUDA toolkit\n3. Make sure CUDA toolkit version matches the target architecture requirements\u001b[0m",
+      "finished_at": "2026-08-22T02:28:03+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_flat_schedule_sm100",
       "config": "decode_b128_k65536_h4",
       "label": "decode_b128_k65536_h4",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1953650,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:38+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 8696.164327272727,
-        "msa": 12215.634825
+        "tirx": 8694.062490909091,
+        "msa": 12213.3396
+      },
+      "round_samples": {
+        "tirx": [
+          8693.730818181817,
+          8693.932636363636,
+          8694.693,
+          8693.636363636364,
+          8694.319636363636
+        ],
+        "msa": [
+          12213.738625,
+          12212.712625,
+          12213.14,
+          12213.327,
+          12213.77975
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_flat_schedule_sm100",
-      "config": "decode_b32_k8192_h4",
-      "label": "decode_b32_k8192_h4",
-      "status": "ok",
-      "impls": {
-        "tirx": 64.8932896644268,
-        "msa": 88.77687308114474
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:09+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_flat_schedule_sm100",
       "config": "decode_b64_k16384_h4_varlen",
       "label": "decode_b64_k16384_h4_varlen",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 3,
+      "process_pid": 1953381,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:36+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 313.4034835031489,
-        "msa": 433.91322952380955
+        "tirx": 318.73488814570857
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_flat_schedule_sm100",
-      "config": "edge_b1_k512_h1",
-      "label": "edge_b1_k512_h1",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.455311589071658,
-        "msa": 4.077763250856866
+      "round_samples": {
+        "tirx": [
+          313.4199713261649,
+          313.3884820143885,
+          313.40442805755396,
+          340.0545770609319,
+          313.40698226950354
+        ]
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_flat_schedule_sm100",
-      "config": "prefill_b1_k131072_h1",
-      "label": "prefill_b1_k131072_h1",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.032725268214635,
-        "msa": 5.44735974978227
+      "errors": {
+        "msa": "partially initialized module 'torch._dynamo' has no attribute 'decorators' (most likely due to a circular import)"
       },
-      "aggregated": {
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
         "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_flat_schedule_sm100",
-      "config": "prefill_b1_k32768_h2",
-      "label": "prefill_b1_k32768_h2",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.418306228674191,
-        "msa": 4.793938262198714
+        "round_aggregate": "mean",
+        "order": [
+          "tirx"
+        ]
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "FAIL",
+      "error": "baseline error(s): msa: partially initialized module 'torch._dynamo' has no attribute 'decorators' (most likely due to a circular import)",
+      "finished_at": "2026-08-22T02:28:38+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_flat_schedule_sm100",
       "config": "prefill_b1_k8192_h2",
       "label": "prefill_b1_k8192_h2",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1953066,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:35+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 3.954828094130232,
-        "msa": 4.296019171185297
+        "tirx": 3.8855873188247,
+        "msa": 4.241717051894573
+      },
+      "round_samples": {
+        "tirx": [
+          3.8861610211094746,
+          3.8883711433756805,
+          3.8804013483146065,
+          3.8851826750448835,
+          3.887820406278855
+        ],
+        "msa": [
+          4.23920920502092,
+          4.241511948529412,
+          4.242859207459207,
+          4.238695549242424,
+          4.246309349220898
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_flat_schedule_sm100",
-      "config": "prefill_b3_k8192_h2_varlen",
-      "label": "prefill_b3_k8192_h2_varlen",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.104288343425731,
-        "msa": 5.981656413391014
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:00+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
       "config": "decode_b128_k65536_h4",
       "label": "decode_b128_k65536_h4",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1954584,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:42+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 217.28074204704527,
-        "msa": 219.68232452074372
+        "tirx": 216.89288166246612,
+        "msa": 219.22945982613993
+      },
+      "round_samples": {
+        "tirx": [
+          216.90297704081632,
+          216.8600888888889,
+          216.88723514851486,
+          216.91478465346535,
+          216.89932258064516
+        ],
+        "msa": [
+          219.21595261845385,
+          219.26881,
+          219.23151629072683,
+          219.20181772151898,
+          219.22920249999999
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
-      "config": "decode_b32_k8192_h4",
-      "label": "decode_b32_k8192_h4",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.11112974095685,
-        "msa": 15.411196760328396
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
-      "config": "decode_b64_k16384_h4_varlen",
-      "label": "decode_b64_k16384_h4_varlen",
       "status": "ok",
-      "impls": {
-        "tirx": 29.64779907220087,
-        "msa": 30.254163280826035
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
-      "config": "edge_b1_k512_h1",
-      "label": "edge_b1_k512_h1",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.342684901524134,
-        "msa": 4.398679375281474
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:28:11+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
       "config": "prefill_b1_k131072_h1",
       "label": "prefill_b1_k131072_h1",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1954169,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 33.2527484426999,
-        "msa": 33.43431891075929
+        "tirx": 33.16335251364306,
+        "msa": 33.34733420362744
+      },
+      "round_samples": {
+        "tirx": [
+          33.18522361219703,
+          33.17345509433962,
+          33.14327922561429,
+          33.145562500000004,
+          33.169242136064376
+        ],
+        "msa": [
+          33.33750447761194,
+          33.35390327380952,
+          33.34868662232077,
+          33.35248997772829,
+          33.34408666666667
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
-      "config": "prefill_b1_k32768_h2",
-      "label": "prefill_b1_k32768_h2",
-      "status": "ok",
-      "impls": {
-        "tirx": 16.556753578263546,
-        "msa": 16.84091493152361
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:10+00:00"
     },
     {
       "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
       "config": "prefill_b1_k8192_h2",
       "label": "prefill_b1_k8192_h2",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1953922,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:39+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 7.146323571670095,
-        "msa": 7.3066606137813555
+        "tirx": 7.191969530426992,
+        "msa": 7.336416114167769
+      },
+      "round_samples": {
+        "tirx": [
+          7.176916327716444,
+          7.190460317460317,
+          7.178866,
+          7.202332009925558,
+          7.211272997032641
+        ],
+        "msa": [
+          7.31691528066528,
+          7.344250129198967,
+          7.3181455092824885,
+          7.355045567112432,
+          7.34772408457968
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "msa"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "msa_sparse_prepare_fwd_split_atomic_sm100",
-      "config": "prefill_b3_k8192_h2_varlen",
-      "label": "prefill_b3_k8192_h2_varlen",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.7838855016142,
-        "msa": 10.998679620186552
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "bf16_128x4_m4096_k4096",
-      "label": "bf16_128x4_m4096_k4096",
       "status": "ok",
-      "impls": {
-        "tirx": 10.741981915988175,
-        "flashinfer": 10.72188199714278
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "bf16_linear_m4096_k4096",
-      "label": "bf16_linear_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.330799395756868,
-        "flashinfer": 10.69235683840988
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "fp16_128x4_m1024_k2048",
-      "label": "fp16_128x4_m1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.728838041021632,
-        "flashinfer": 3.75323771071675
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:28:07+00:00"
     },
     {
       "kernel": "mxfp4_quantize",
       "config": "fp16_128x4_m128_k1024",
       "label": "fp16_128x4_m128_k1024",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1937695,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:28+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 2.8413576928538404,
-        "flashinfer": 2.8667838955654825
+        "tirx": 2.49074204169368,
+        "flashinfer": 2.5396728132140254
+      },
+      "round_samples": {
+        "tirx": [
+          2.3872,
+          2.5159123036649214,
+          2.519271840354767,
+          2.512523266022827,
+          2.5188027984258854
+        ],
+        "flashinfer": [
+          2.537685210312076,
+          2.5418930254476906,
+          2.5355112128146455,
+          2.542740080249666,
+          2.54053453724605
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:57+00:00"
     },
     {
       "kernel": "mxfp4_quantize",
       "config": "fp16_128x4_m16384_k7168",
       "label": "fp16_128x4_m16384_k7168",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1937685,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:28+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 66.85048091669319,
-        "flashinfer": 68.29744603576859
+        "tirx": 52.500126240582766,
+        "flashinfer": 52.88365661645681
+      },
+      "round_samples": {
+        "tirx": [
+          52.57722727272728,
+          52.485693032015064,
+          52.47856456173421,
+          52.47974653098982,
+          52.47939980544747
+        ],
+        "flashinfer": [
+          52.87643445692884,
+          52.881049856184084,
+          52.88251717557252,
+          52.90419213973799,
+          52.87408945386064
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "fp16_128x4_m4096_k4096",
-      "label": "fp16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.73702444926463,
-        "flashinfer": 10.684920528344085
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "fp16_linear_m1024_k2048",
-      "label": "fp16_linear_m1024_k2048",
       "status": "ok",
-      "impls": {
-        "tirx": 3.5864197281594485,
-        "flashinfer": 3.6517344090847113
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "fp16_linear_m128_k1024",
-      "label": "fp16_linear_m128_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.3680044821586907,
-        "flashinfer": 2.4078891241745604
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp4_quantize",
-      "config": "fp16_linear_m16384_k7168",
-      "label": "fp16_linear_m16384_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 50.5177126640784,
-        "flashinfer": 50.60187030261501
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:56+00:00"
     },
     {
       "kernel": "mxfp4_quantize",
       "config": "fp16_linear_m4096_k4096",
       "label": "fp16_linear_m4096_k4096",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1937286,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:27+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 13.941653691989622,
-        "flashinfer": 14.001186539886143
+        "tirx": 10.282161076542948,
+        "flashinfer": 10.628632786086737
+      },
+      "round_samples": {
+        "tirx": [
+          10.26,
+          10.288377151799686,
+          10.284776863753214,
+          10.28579519918284,
+          10.291856167979002
+        ],
+        "flashinfer": [
+          10.623973287671232,
+          10.626683716075156,
+          10.62796400625978,
+          10.630309461578673,
+          10.634233458848843
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "bf16_128x4_m4096_k4096",
-      "label": "bf16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 11.764310499883965,
-        "flashinfer": 11.827816100088876
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "bf16_linear_m4096_k4096",
-      "label": "bf16_linear_m4096_k4096",
       "status": "ok",
-      "impls": {
-        "tirx": 11.287215964678518,
-        "flashinfer": 11.193300809329948
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "fp16_128x4_m1024_k2048",
-      "label": "fp16_128x4_m1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.8630096045909035,
-        "flashinfer": 3.944670239533885
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:26:53+00:00"
     },
     {
       "kernel": "mxfp8_quantize",
       "config": "fp16_128x4_m128_k1024",
       "label": "fp16_128x4_m128_k1024",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1939386,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:36+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 3.617635255161168,
-        "flashinfer": 3.7710771115705253
+        "tirx": 2.6790178707849908,
+        "flashinfer": 2.7309365588147467
+      },
+      "round_samples": {
+        "tirx": [
+          2.6758076923076923,
+          2.6865859030837003,
+          2.6842451641925322,
+          2.6744448036951503,
+          2.6740057906458796
+        ],
+        "flashinfer": [
+          2.7396648476580263,
+          2.7402180312787485,
+          2.7171880146386096,
+          2.7176510464058232,
+          2.739960854092527
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:03+00:00"
     },
     {
       "kernel": "mxfp8_quantize",
       "config": "fp16_128x4_m16384_k7168",
       "label": "fp16_128x4_m16384_k7168",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1939136,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:34+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 71.56044409911007,
-        "flashinfer": 76.62970149782174
+        "tirx": 60.633818644259605,
+        "flashinfer": 60.519201272268916
+      },
+      "round_samples": {
+        "tirx": [
+          60.831999999999994,
+          60.57057578840285,
+          60.58209470468432,
+          60.59119424460432,
+          60.59322848360656
+        ],
+        "flashinfer": [
+          60.49655589430894,
+          60.5280523613963,
+          60.50915368196371,
+          60.53425155925156,
+          60.52799286442406
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "fp16_128x4_m4096_k4096",
-      "label": "fp16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 11.761660008513795,
-        "flashinfer": 11.831877885956274
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "fp16_linear_m1024_k2048",
-      "label": "fp16_linear_m1024_k2048",
       "status": "ok",
-      "impls": {
-        "tirx": 3.7723720977603974,
-        "flashinfer": 3.8231208299798993
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "fp16_linear_m128_k1024",
-      "label": "fp16_linear_m128_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.6199674218081723,
-        "flashinfer": 2.6024787886424035
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "mxfp8_quantize",
-      "config": "fp16_linear_m16384_k7168",
-      "label": "fp16_linear_m16384_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 62.30706806862382,
-        "flashinfer": 63.252581805240325
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:00+00:00"
     },
     {
       "kernel": "mxfp8_quantize",
       "config": "fp16_linear_m4096_k4096",
       "label": "fp16_linear_m4096_k4096",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1938501,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:31+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 13.834615213376882,
-        "flashinfer": 13.53412707180106
+        "tirx": 11.315961334245,
+        "flashinfer": 11.265033183341012
+      },
+      "round_samples": {
+        "tirx": [
+          11.283434782608696,
+          11.327628374801483,
+          11.327143773383218,
+          11.318298437500001,
+          11.323301302931595
+        ],
+        "flashinfer": [
+          11.265094409282701,
+          11.265780331373596,
+          11.261306696679798,
+          11.267084952803998,
+          11.265899526564967
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:00+00:00"
     },
     {
       "kernel": "nvfp4_gemm",
       "config": "1024x1024x1024",
       "label": "1024x1024x1024",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889089,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tir": 5.451408991103202,
-        "flashinfer": 4.5366402997678295,
-        "cublaslt_nvfp4": 4.527226842928446
+        "tir": 5.210589689181428,
+        "flashinfer": 4.470817699641622,
+        "cublaslt_nvfp4": 4.380573074696612
+      },
+      "round_samples": {
+        "tir": [
+          5.208267833981842,
+          5.207825174825175,
+          5.2074133709981165,
+          5.214175178997613,
+          5.215266887104393
+        ],
+        "flashinfer": [
+          4.469409691629956,
+          4.464754512635379,
+          4.492367704280156,
+          4.465374771480804,
+          4.4621818181818185
+        ],
+        "cublaslt_nvfp4": [
+          4.380327272727273,
+          4.3921152790484905,
+          4.373926601215521,
+          4.378617419060648,
+          4.377878801431127
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer",
+          "cublaslt_nvfp4"
+        ]
+      },
+      "metadata": {
+        "flashinfer_autotune_cache": "hit",
+        "flashinfer_tuning_bucket": 1024,
+        "flashinfer_requested_backend": "auto",
+        "flashinfer_runner": "CudnnFp4GemmRunner",
+        "flashinfer_tactic": [
+          0,
+          []
+        ],
+        "flashinfer_cosine_similarity": 0.9908143281936646
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:29+00:00"
     },
     {
       "kernel": "nvfp4_gemm",
       "config": "16384x16384x16384",
       "label": "16384x16384x16384",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889091,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tir": 1516.7496151515152,
-        "flashinfer": 1445.1355016734508,
-        "cublaslt_nvfp4": 1431.061484057971
+        "tir": 1528.9626681139757,
+        "flashinfer": 1443.7832053537543,
+        "cublaslt_nvfp4": 1445.3852131135532
+      },
+      "round_samples": {
+        "tir": [
+          1541.9167272727273,
+          1523.3058955223883,
+          1488.0780909090909,
+          1550.2379552238806,
+          1541.2746716417912
+        ],
+        "flashinfer": [
+          1448.227612903226,
+          1462.0408235294117,
+          1367.6194285714284,
+          1471.0370294117647,
+          1469.9911323529411
+        ],
+        "cublaslt_nvfp4": [
+          1440.3265999999999,
+          1459.8078571428573,
+          1413.3653846153845,
+          1446.1165571428571,
+          1467.3096666666668
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer",
+          "cublaslt_nvfp4"
+        ]
+      },
+      "metadata": {
+        "flashinfer_autotune_cache": "miss",
+        "flashinfer_tuning_bucket": 16384,
+        "flashinfer_requested_backend": "auto",
+        "flashinfer_runner": "CudnnFp4GemmRunner",
+        "flashinfer_tactic": [
+          0,
+          [
+            [
+              12,
+              0
+            ]
+          ]
+        ],
+        "flashinfer_cosine_similarity": 0.9909311532974243
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_gemm",
-      "config": "2048x2048x2048",
-      "label": "2048x2048x2048",
-      "status": "ok",
-      "impls": {
-        "tir": 8.831212382555414,
-        "flashinfer": 7.712315936879144,
-        "cublaslt_nvfp4": 8.584625005684115
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:41+00:00"
     },
     {
       "kernel": "nvfp4_gemm",
       "config": "4096x4096x4096",
       "label": "4096x4096x4096",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889090,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tir": 29.86659948520413,
-        "flashinfer": 28.9586459157378,
-        "cublaslt_nvfp4": 27.797899178933086
+        "tir": 29.30459717527406,
+        "flashinfer": 28.59225792742113,
+        "cublaslt_nvfp4": 27.388531592753466
+      },
+      "round_samples": {
+        "tir": [
+          29.297420954162767,
+          29.306814285714285,
+          29.28993714285714,
+          29.319189845474614,
+          29.3096236481615
+        ],
+        "flashinfer": [
+          28.60746875,
+          28.57218318965517,
+          28.582981412639406,
+          28.529140900195692,
+          28.669515384615384
+        ],
+        "cublaslt_nvfp4": [
+          27.397254697286012,
+          27.397548050139275,
+          27.40272588480222,
+          27.370664819944597,
+          27.37446451159522
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer",
+          "cublaslt_nvfp4"
+        ]
+      },
+      "metadata": {
+        "flashinfer_autotune_cache": "hit",
+        "flashinfer_tuning_bucket": 4096,
+        "flashinfer_requested_backend": "auto",
+        "flashinfer_runner": "CudnnFp4GemmRunner",
+        "flashinfer_tactic": [
+          0,
+          []
+        ],
+        "flashinfer_cosine_similarity": 0.990825891494751
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_gemm",
-      "config": "8192x8192x8192",
-      "label": "8192x8192x8192",
-      "status": "ok",
-      "impls": {
-        "tir": 253.09630511869082,
-        "flashinfer": 240.3198387896596,
-        "cublaslt_nvfp4": 238.70126227998276
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "bf16_128x4_m4096_k3584_silu",
-      "label": "bf16_128x4_m4096_k3584_silu",
       "status": "ok",
-      "impls": {
-        "tirx": 20.60978545635845,
-        "flashinfer": 22.35939700667101
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "bf16_128x4_m4096_k4096",
-      "label": "bf16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.782398435770277,
-        "flashinfer": 11.145288204935733
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "bf16_linear_m4096_k4096",
-      "label": "bf16_linear_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.012884392806544,
-        "flashinfer": 10.28621734866838
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_128x4_m1024_k2048",
-      "label": "fp16_128x4_m1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.691138695545344,
-        "flashinfer": 3.680208739606475
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:23:31+00:00"
     },
     {
       "kernel": "nvfp4_quantize",
       "config": "fp16_128x4_m128_k1024",
       "label": "fp16_128x4_m128_k1024",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1940348,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 3.4539905471135466,
-        "flashinfer": 3.4874629788706333
+        "tirx": 2.4971541741130245,
+        "flashinfer": 2.513955433971107
+      },
+      "round_samples": {
+        "tirx": [
+          2.500185185185185,
+          2.490173231871083,
+          2.486780185758514,
+          2.5065723742277144,
+          2.5020598935226266
+        ],
+        "flashinfer": [
+          2.5247902193784277,
+          2.507581582476531,
+          2.508183072677093,
+          2.5212065265981227,
+          2.5080157687253615
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:07+00:00"
     },
     {
       "kernel": "nvfp4_quantize",
       "config": "fp16_128x4_m16384_k7168",
       "label": "fp16_128x4_m16384_k7168",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1940223,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 54.64615814257812,
-        "flashinfer": 55.10400546011442
+        "tirx": 55.27250548363322,
+        "flashinfer": 54.88864009349445
+      },
+      "round_samples": {
+        "tirx": [
+          55.281438095238094,
+          55.26349472674976,
+          55.26122319688109,
+          55.28565738963532,
+          55.27071400966183
+        ],
+        "flashinfer": [
+          54.89489268292683,
+          54.86440737148399,
+          54.910545454545456,
+          54.91432785299806,
+          54.85902710551791
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_128x4_m4096_k3584_silu",
-      "label": "fp16_128x4_m4096_k3584_silu",
-      "status": "ok",
-      "impls": {
-        "tirx": 20.37738613389982,
-        "flashinfer": 21.847355758020374
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_128x4_m4096_k4096",
-      "label": "fp16_128x4_m4096_k4096",
       "status": "ok",
-      "impls": {
-        "tirx": 11.086091182631979,
-        "flashinfer": 10.855659965200573
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_linear_m1024_k2048",
-      "label": "fp16_linear_m1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.625298426666291,
-        "flashinfer": 3.590256242590162
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_linear_m128_k1024",
-      "label": "fp16_linear_m128_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.4948882057356987,
-        "flashinfer": 2.4903840782201088
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize",
-      "config": "fp16_linear_m16384_k7168",
-      "label": "fp16_linear_m16384_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 50.58837977575804,
-        "flashinfer": 51.1227070010989
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:05+00:00"
     },
     {
       "kernel": "nvfp4_quantize",
       "config": "fp16_linear_m4096_k4096",
       "label": "fp16_linear_m4096_k4096",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1939663,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:38+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 10.342779364110909,
-        "flashinfer": 10.479985421079382
+        "tirx": 10.25272204260493,
+        "flashinfer": 10.37607426159619
+      },
+      "round_samples": {
+        "tirx": [
+          10.266563636363637,
+          10.25606907378336,
+          10.255015135699374,
+          10.244785714285715,
+          10.241176652892563
+        ],
+        "flashinfer": [
+          10.369491829204005,
+          10.373940968122787,
+          10.376072546972859,
+          10.38376866066702,
+          10.37709730301428
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "bf16_128x4_m4096_k4096",
-      "label": "bf16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 12.711220526597488,
-        "flashinfer": 13.769429308128275
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "bf16_linear_m4096_k4096",
-      "label": "bf16_linear_m4096_k4096",
       "status": "ok",
-      "impls": {
-        "tirx": 12.199949697487087,
-        "flashinfer": 13.229440163867482
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "fp16_128x4_m1024_k2048",
-      "label": "fp16_128x4_m1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.981262831186381,
-        "flashinfer": 4.121173445377401
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:03+00:00"
     },
     {
       "kernel": "nvfp4_quantize_per_token",
       "config": "fp16_128x4_m128_k1024",
       "label": "fp16_128x4_m128_k1024",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1941640,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:45+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 2.8930088266348584,
-        "flashinfer": 3.056386203777648
+        "tirx": 2.6892155422888977,
+        "flashinfer": 2.8469692646014173
+      },
+      "round_samples": {
+        "tirx": [
+          2.6885211352657006,
+          2.6960474308300397,
+          2.690016806722689,
+          2.68707915921288,
+          2.684413179413179
+        ],
+        "flashinfer": [
+          2.8483643482266237,
+          2.8476496385542167,
+          2.8468761180679785,
+          2.8415620575743272,
+          2.8503941605839413
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:11+00:00"
     },
     {
       "kernel": "nvfp4_quantize_per_token",
       "config": "fp16_128x4_m16384_k7168",
       "label": "fp16_128x4_m16384_k7168",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1941526,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:44+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 57.82274159610344,
-        "flashinfer": 59.31966214233625
+        "tirx": 57.76577090833158,
+        "flashinfer": 59.191685869218624
+      },
+      "round_samples": {
+        "tirx": [
+          57.73923014959724,
+          57.75368910891089,
+          57.77421850393701,
+          57.788551448551445,
+          57.77316533066133
+        ],
+        "flashinfer": [
+          59.18520061412487,
+          59.19332183908046,
+          59.193094512195124,
+          59.19214922279792,
+          59.19466315789473
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "fp16_128x4_m4096_k4096",
-      "label": "fp16_128x4_m4096_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 12.693946952971398,
-        "flashinfer": 13.59443061604728
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "fp16_linear_m1024_k2048",
-      "label": "fp16_linear_m1024_k2048",
       "status": "ok",
-      "impls": {
-        "tirx": 3.8548659987704696,
-        "flashinfer": 3.9801304713245607
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "fp16_linear_m128_k1024",
-      "label": "fp16_linear_m128_k1024",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.906611630846872,
-        "flashinfer": 3.066980796635296
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "nvfp4_quantize_per_token",
-      "config": "fp16_linear_m16384_k7168",
-      "label": "fp16_linear_m16384_k7168",
-      "status": "ok",
-      "impls": {
-        "tirx": 55.82576586992781,
-        "flashinfer": 57.46954903323014
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:12+00:00"
     },
     {
       "kernel": "nvfp4_quantize_per_token",
       "config": "fp16_linear_m4096_k4096",
       "label": "fp16_linear_m4096_k4096",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1940462,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:41+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 17.34466253221987,
-        "flashinfer": 19.51631078654821
+        "tirx": 12.110280620722179,
+        "flashinfer": 12.994220324061825
+      },
+      "round_samples": {
+        "tirx": [
+          12.097898454746138,
+          12.105139295392954,
+          12.11806953642384,
+          12.110406569736133,
+          12.119889247311827
+        ],
+        "flashinfer": [
+          12.99207008830022,
+          12.987745098039216,
+          12.999814921920185,
+          13.003680418041805,
+          12.987791094007695
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:07+00:00"
     },
     {
       "kernel": "radix_topk_multi_cta",
       "config": "f32_basic_r2_l524288_k256_large",
       "label": "f32_basic_r2_l524288_k256_large",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1944883,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:57+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 41.364342740848215,
-        "flashinfer": 42.88360400321807
+        "tirx": 40.01400591608337,
+        "flashinfer": 42.45666141423478
+      },
+      "round_samples": {
+        "tirx": [
+          40.00118855534709,
+          40.014208881578945,
+          40.02399677158999,
+          40.015080000000005,
+          40.015555371900824
+        ],
+        "flashinfer": [
+          42.45570068027211,
+          42.45981742043551,
+          42.45659380234506,
+          42.45258297506449,
+          42.45861219305673
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:25+00:00"
     },
     {
       "kernel": "radix_topk_multi_cta",
       "config": "f32_basic_r4_l115188_k256_ctas3",
       "label": "f32_basic_r4_l115188_k256_ctas3",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1943961,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:54+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 34.65635158641088,
-        "flashinfer": 35.5113124483128
+        "tirx": 35.370440840548014,
+        "flashinfer": 35.92629465274118
+      },
+      "round_samples": {
+        "tirx": [
+          35.35820733788396,
+          35.37106982343499,
+          35.366189168573605,
+          35.37137846153846,
+          35.38535941130906
+        ],
+        "flashinfer": [
+          35.92983374485597,
+          35.91542062193126,
+          35.93574980813508,
+          35.93615020080321,
+          35.91431888798038
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:24+00:00"
     },
     {
       "kernel": "radix_topk_multi_cta",
       "config": "f32_basic_r4_l57596_k256_vec4",
       "label": "f32_basic_r4_l57596_k256_vec4",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1943928,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:54+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 29.87169685656104,
-        "flashinfer": 31.979396742514172
+        "tirx": 30.172781129461647,
+        "flashinfer": 31.838730255894674
+      },
+      "round_samples": {
+        "tirx": [
+          30.172824146981625,
+          30.15990625,
+          30.175727338651196,
+          30.177441394658754,
+          30.178006517016655
+        ],
+        "flashinfer": [
+          31.840504531722054,
+          31.833367994100296,
+          31.8365580693816,
+          31.838647540983608,
+          31.84457314328582
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:24+00:00"
     },
     {
       "kernel": "radix_topk_single_cta",
       "config": "f32_basic_r256_l57592_k1024_maxchunk",
       "label": "f32_basic_r256_l57592_k1024_maxchunk",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1945745,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:01+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 80.34493217942311,
-        "flashinfer": 80.68494376264324
+        "tirx": 80.21374821911454,
+        "flashinfer": 80.44781061804181
+      },
+      "round_samples": {
+        "tirx": [
+          80.21305440414508,
+          80.2149622411693,
+          80.21544254278729,
+          80.20595465686274,
+          80.21932725060827
+        ],
+        "flashinfer": [
+          80.43644302176696,
+          80.44932266009852,
+          80.45456088560886,
+          80.44886832298137,
+          80.4498581997534
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:30+00:00"
     },
     {
       "kernel": "radix_topk_single_cta",
       "config": "f32_basic_r64_l32768_k512",
       "label": "f32_basic_r64_l32768_k512",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1945239,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:59+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 22.88106695379889,
-        "flashinfer": 25.486936008509723
+        "tirx": 23.182183474857936,
+        "flashinfer": 25.745543496345395
+      },
+      "round_samples": {
+        "tirx": [
+          23.17257498171178,
+          23.17683644558918,
+          23.190433311646064,
+          23.18793890675241,
+          23.18313372859025
+        ],
+        "flashinfer": [
+          25.748647664835165,
+          25.737767224080265,
+          25.7424811827957,
+          25.752839752407155,
+          25.745981657608695
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:26+00:00"
     },
     {
       "kernel": "radix_topk_single_cta",
       "config": "f32_basic_r8_l8192_k256",
       "label": "f32_basic_r8_l8192_k256",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1945232,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:26:59+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 11.107215302783398,
-        "flashinfer": 12.515171040244965
+        "tirx": 11.142605863833564,
+        "flashinfer": 12.50803905649261
+      },
+      "round_samples": {
+        "tirx": [
+          11.140762437810945,
+          11.141463978494622,
+          11.139339682539683,
+          11.15003612565445,
+          11.141427094668117
+        ],
+        "flashinfer": [
+          12.512225592939878,
+          12.504023134759978,
+          12.509370048833423,
+          12.515069328896283,
+          12.499507177033491
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "dec_hv12_b4",
-      "label": "dec_hv12_b4",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.6504416104104775,
-        "flashinfer_cutedsl": 3.9219190126523285
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "dec_hv12_b8",
-      "label": "dec_hv12_b8",
       "status": "ok",
-      "impls": {
-        "tirx": 4.258375216340218,
-        "flashinfer_cutedsl": 4.613711138436537
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:34+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_grouped",
       "config": "dec_hv16_b1",
       "label": "dec_hv16_b1",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1920495,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:05+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 3.238843675914427,
-        "flashinfer_cutedsl": 3.5627867976997543
+        "tirx": 3.3087835936096788,
+        "flashinfer_cutedsl": 3.516648344187727
+      },
+      "round_samples": {
+        "tirx": [
+          3.306939179632249,
+          3.308025466120964,
+          3.308532152842498,
+          3.311864381520119,
+          3.3085567879325644
+        ],
+        "flashinfer_cutedsl": [
+          3.508341818181818,
+          3.5109565217391308,
+          3.52567112431897,
+          3.5174997353096877,
+          3.520772521389029
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "dec_hv16_b4",
-      "label": "dec_hv16_b4",
-      "status": "ok",
-      "impls": {
-        "tirx": 3.7758930700028097,
-        "flashinfer_cutedsl": 4.078077874576345
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t2_hv16_b8",
-      "label": "ver_t2_hv16_b8",
       "status": "ok",
-      "impls": {
-        "tirx": 6.837621219998657,
-        "flashinfer_cutedsl": 7.342065714437408
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t4_hv16_b32",
-      "label": "ver_t4_hv16_b32",
-      "status": "ok",
-      "impls": {
-        "tirx": 24.71303785423106,
-        "flashinfer_cutedsl": 33.888392143740184
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:29+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_grouped",
       "config": "ver_t8_hv12_b16",
       "label": "ver_t8_hv12_b16",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1920891,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:07+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 22.030900675719998,
-        "flashinfer_cutedsl": 31.35296382096456
+        "tirx": 22.114498266793994,
+        "flashinfer_cutedsl": 31.185668536919728
+      },
+      "round_samples": {
+        "tirx": [
+          22.08805586592179,
+          22.11016731770833,
+          22.133436980166348,
+          22.15274418604651,
+          22.088086984126985
+        ],
+        "flashinfer_cutedsl": [
+          31.213198920585967,
+          31.19486914498141,
+          31.177146037399822,
+          31.1610110701107,
+          31.182117511520737
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv12_b64",
-      "label": "ver_t8_hv12_b64",
-      "status": "ok",
-      "impls": {
-        "tirx": 65.91840010332494,
-        "flashinfer_cutedsl": 92.41587041159222
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv16_b1",
-      "label": "ver_t8_hv16_b1",
       "status": "ok",
-      "impls": {
-        "tirx": 9.030776714313049,
-        "flashinfer_cutedsl": 14.815819035086784
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:45+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_grouped",
       "config": "ver_t8_hv16_b128",
       "label": "ver_t8_hv16_b128",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1920692,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:06+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 161.9328744940579,
-        "flashinfer_cutedsl": 219.33161768748658
+        "tirx": 161.22106135754197,
+        "flashinfer_cutedsl": 222.84990094496018
+      },
+      "round_samples": {
+        "tirx": [
+          161.17317418032786,
+          161.17707346938775,
+          161.2394244897959,
+          161.26004115226337,
+          161.25559349593496
+        ],
+        "flashinfer_cutedsl": [
+          222.86929347826086,
+          222.91542245989305,
+          222.90917741935485,
+          222.81948,
+          222.73613136729222
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv16_b16",
-      "label": "ver_t8_hv16_b16",
-      "status": "ok",
-      "impls": {
-        "tirx": 26.017330854831492,
-        "flashinfer_cutedsl": 34.95134749109404
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv16_b32",
-      "label": "ver_t8_hv16_b32",
       "status": "ok",
-      "impls": {
-        "tirx": 44.59754916822601,
-        "flashinfer_cutedsl": 63.672738997515964
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv16_b4",
-      "label": "ver_t8_hv16_b4",
-      "status": "ok",
-      "impls": {
-        "tirx": 10.247886679654943,
-        "flashinfer_cutedsl": 16.928763980944666
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_grouped",
-      "config": "ver_t8_hv16_b64",
-      "label": "ver_t8_hv16_b64",
-      "status": "ok",
-      "impls": {
-        "tirx": 83.1183969763617,
-        "flashinfer_cutedsl": 112.71690537963232
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_one_warp",
-      "config": "hv12_b16_tr16_lb",
-      "label": "hv12_b16_tr16_lb",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.695114378452278,
-        "flashinfer_cutedsl": 5.972974484759209
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:45+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_one_warp",
       "config": "hv12_b64_tr16_lb",
       "label": "hv12_b64_tr16_lb",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1921831,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:12+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 12.836577688146386,
-        "flashinfer_cutedsl": 13.868974685205652
+        "tirx": 12.6430292531037,
+        "flashinfer_cutedsl": 13.837930235021101
+      },
+      "round_samples": {
+        "tirx": [
+          12.644921485088252,
+          12.637124386252045,
+          12.64994120819849,
+          12.641283233857841,
+          12.641875952121872
+        ],
+        "flashinfer_cutedsl": [
+          13.840535836177473,
+          13.845319727891157,
+          13.833491189427312,
+          13.837075900277009,
+          13.833228521332554
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:47+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_one_warp",
       "config": "hv16_b128_tr16_lb",
       "label": "hv16_b128_tr16_lb",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1921803,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:12+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 26.685145709501946,
-        "flashinfer_cutedsl": 29.18576589228665
+        "tirx": 26.660725315874384,
+        "flashinfer_cutedsl": 29.81464383930463
+      },
+      "round_samples": {
+        "tirx": [
+          26.663307863501483,
+          26.66416825613079,
+          26.664342068965517,
+          26.655546195652175,
+          26.65626219512195
+        ],
+        "flashinfer_cutedsl": [
+          29.82226633165829,
+          29.828534801136364,
+          29.806283703703702,
+          29.81200145772595,
+          29.80413290229885
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_one_warp",
-      "config": "hv16_b16_tr16_lb",
-      "label": "hv16_b16_tr16_lb",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.347254102290438,
-        "flashinfer_cutedsl": 6.483835513635386
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_one_warp",
-      "config": "hv16_b32_tr16_lb",
-      "label": "hv16_b32_tr16_lb",
       "status": "ok",
-      "impls": {
-        "tirx": 9.69739584957777,
-        "flashinfer_cutedsl": 10.239276177315428
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "recurrent_kda_decode_one_warp",
-      "config": "hv16_b64_tr16_lb",
-      "label": "hv16_b64_tr16_lb",
-      "status": "ok",
-      "impls": {
-        "tirx": 15.268888603603104,
-        "flashinfer_cutedsl": 16.90398539436306
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:25:47+00:00"
     },
     {
       "kernel": "recurrent_kda_decode_one_warp",
       "config": "hv16_b8_tr8_lb",
       "label": "hv16_b8_tr8_lb",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 2,
+      "process_pid": 1921060,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:09+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 5.247230154049852,
-        "flashinfer_cutedsl": 5.337711133525542
+        "tirx": 5.247412550360518,
+        "flashinfer_cutedsl": 5.446350079265613
+      },
+      "round_samples": {
+        "tirx": [
+          5.241560584629892,
+          5.240622484045165,
+          5.251326064908723,
+          5.252607632093934,
+          5.250945986124876
+        ],
+        "flashinfer_cutedsl": [
+          5.439398313027179,
+          5.4551591939546595,
+          5.452947550717467,
+          5.438514903846153,
+          5.445730434782608
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cutedsl"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:45+00:00"
+    },
+    {
+      "kernel": "rmsnorm",
+      "config": "hs128_bs32",
+      "label": "hs128_bs32",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889094,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
+      "impls": {
+        "tir": 2.312924182293846,
+        "flashinfer": 2.043766799724435
+      },
+      "round_samples": {
+        "tir": [
+          2.311145115753811,
+          2.3112492307692305,
+          2.310501334519573,
+          2.30743711790393,
+          2.324288112522686
+        ],
+        "flashinfer": [
+          2.0431256077795785,
+          2.043248055315471,
+          2.046719758932415,
+          2.0451137440758296,
+          2.0406268325188806
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:07+00:00"
+    },
+    {
+      "kernel": "rmsnorm",
+      "config": "hs4096_bs128",
+      "label": "hs4096_bs128",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889095,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
+      "impls": {
+        "tir": 3.5200331071183797,
+        "flashinfer": 3.4994394956104955
+      },
+      "round_samples": {
+        "tir": [
+          3.5269239864864868,
+          3.51548826507133,
+          3.517934484285082,
+          3.519410587188612,
+          3.5204082125603864
+        ],
+        "flashinfer": [
+          3.5027511627906978,
+          3.4965379464285715,
+          3.4965267857142854,
+          3.500410927456382,
+          3.5009706556625404
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:07+00:00"
+    },
+    {
+      "kernel": "rmsnorm",
+      "config": "hs8192_bs4113",
+      "label": "hs8192_bs4113",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1889096,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:22:47+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
+      "impls": {
+        "tir": 71.7584503890037,
+        "flashinfer": 23.9442407901515
+      },
+      "round_samples": {
+        "tir": [
+          71.77508864696735,
+          71.73114301801802,
+          71.71778216704288,
+          71.7804920993228,
+          71.78774601366743
+        ],
+        "flashinfer": [
+          23.952399856424982,
+          23.92865699208443,
+          23.938567532467534,
+          23.947115731115733,
+          23.954463838664815
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tir",
+          "flashinfer"
+        ]
+      },
+      "aggregated": {
+        "rounds": 5,
+        "method": "mean"
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:23:10+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_horizontal",
       "config": "b1_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b1_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1922093,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:13+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 7.03506387242043,
-        "flashinfer_cuda": 7.5238848576372375
+        "tirx": 6.950265149646404,
+        "flashinfer_cuda": 7.435956086993047
+      },
+      "round_samples": {
+        "tirx": [
+          6.944443813847901,
+          6.945164519326066,
+          6.954847263681592,
+          6.955409644670051,
+          6.951460506706408
+        ],
+        "flashinfer_cuda": [
+          7.434494840294841,
+          7.431073300970874,
+          7.430986348122867,
+          7.441680103359173,
+          7.441545842217484
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:50+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_horizontal",
       "config": "b2048_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b2048_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1923020,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:17+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 1388.3802754865424,
-        "flashinfer_cuda": 1509.4559214285714
+        "tirx": 1658.4259407225966,
+        "flashinfer_cuda": 1814.701046875
+      },
+      "round_samples": {
+        "tirx": [
+          1466.6772112676056,
+          2108.451929577465,
+          1442.0046056338028,
+          1791.3044788732395,
+          1483.6914782608696
+        ],
+        "flashinfer_cuda": [
+          2030.1516875,
+          1619.448046875,
+          1649.3885625,
+          2161.5105156249997,
+          1613.006421875
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:51+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_horizontal",
       "config": "b512_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b512_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1922626,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:16+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 352.2851652358125,
-        "flashinfer_cuda": 382.57111305208747
+        "tirx": 347.0377251719523,
+        "flashinfer_cuda": 382.41048025208175
+      },
+      "round_samples": {
+        "tirx": [
+          347.0293897637795,
+          347.05370472440944,
+          347.0281739130435,
+          347.06079446640314,
+          347.01656299212596
+        ],
+        "flashinfer_cuda": [
+          382.4141837606838,
+          382.40845493562233,
+          382.41749333333337,
+          382.41354273504277,
+          382.39872649572646
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_mtp_horizontal",
-      "config": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "label": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
-      "impls": {
-        "tirx": 82.98455014621565,
-        "flashinfer_cuda": 89.37539663471149
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:52+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_simple",
       "config": "b1_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b1_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1923116,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:17+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 6.52801279876243,
-        "flashinfer_cuda": 7.8631118903926325
+        "tirx": 4.316443569523875,
+        "flashinfer_cuda": 5.169473587030536
+      },
+      "round_samples": {
+        "tirx": [
+          4.318795604395604,
+          4.313835650446872,
+          4.316401225114855,
+          4.316452578268876,
+          4.316732789393167
+        ],
+        "flashinfer_cuda": [
+          5.179337371854613,
+          5.17617766258247,
+          5.184361372180452,
+          5.177515080113101,
+          5.129976448422044
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:58+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_simple",
       "config": "b2048_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b2048_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1924217,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:24+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 1520.457164732143,
-        "flashinfer_cuda": 1584.4758032786885
+        "tirx": 1494.97508,
+        "flashinfer_cuda": 1584.5817901639343
+      },
+      "round_samples": {
+        "tirx": [
+          1495.0232461538462,
+          1495.0104,
+          1494.9613384615386,
+          1494.9192307692308,
+          1494.9611846153846
+        ],
+        "flashinfer_cuda": [
+          1584.573819672131,
+          1584.613704918033,
+          1584.5695901639344,
+          1584.5786393442622,
+          1584.5731967213114
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:01+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_simple",
       "config": "b512_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b512_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1923908,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:22+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 384.8072893102383,
-        "flashinfer_cuda": 400.90954093136673
+        "tirx": 378.01396181391993,
+        "flashinfer_cuda": 400.7631294007937
+      },
+      "round_samples": {
+        "tirx": [
+          378.0219404255319,
+          378.0088262711864,
+          378.01164830508475,
+          378.01179237288136,
+          378.0156016949153
+        ],
+        "flashinfer_cuda": [
+          400.7490669642857,
+          400.76171555555555,
+          400.7489508928572,
+          400.7755580357143,
+          400.78035555555556
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_mtp_simple",
-      "config": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "label": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
-      "impls": {
-        "tirx": 89.65411590298844,
-        "flashinfer_cuda": 93.70834057229396
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:25:58+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_vertical",
       "config": "b1_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b1_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1924559,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:26+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 28.432781167152203,
-        "flashinfer_cuda": 29.82309729006109
+        "tirx": 17.26454308742395,
+        "flashinfer_cuda": 18.194717624092263
+      },
+      "round_samples": {
+        "tirx": [
+          17.269343541944075,
+          17.26686920332937,
+          17.267464014043302,
+          17.262638561320752,
+          17.256400116482236
+        ],
+        "flashinfer_cuda": [
+          18.190601183431955,
+          18.198716470588234,
+          18.19798230628432,
+          18.18948178613396,
+          18.19680637402285
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:00+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_vertical",
       "config": "b2048_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b2048_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1925056,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:28+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 2826.8122151260504,
-        "flashinfer_cuda": 2905.60693885918
+        "tirx": 2689.2282444444445,
+        "flashinfer_cuda": 2903.487200356506
+      },
+      "round_samples": {
+        "tirx": [
+          2689.190527777778,
+          2689.231611111111,
+          2689.219111111111,
+          2689.2873055555556,
+          2689.212666666667
+        ],
+        "flashinfer_cuda": [
+          2903.4995,
+          2903.477882352941,
+          2903.5485,
+          2903.5100588235296,
+          2903.4000606060604
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:03+00:00"
     },
     {
       "kernel": "selective_state_update_mtp_vertical",
       "config": "b512_h64_d64_s128_t6_r8_statebf16_official",
       "label": "b512_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
-      "impls": {
-        "tirx": 1208.480582051282,
-        "flashinfer_cuda": 1242.4535657894737
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_mtp_vertical",
-      "config": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "label": "b64_h64_d64_s128_t6_r8_statebf16_official",
-      "status": "ok",
-      "impls": {
-        "tirx": 98.61741711189175,
-        "flashinfer_cuda": 101.23164180448805
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1924591,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:26+00:00",
+      "retry_in_place": false,
+      "status": "FAIL",
+      "error": "prepared child exited None without a terminal message",
+      "finished_at": "2026-08-22T02:25:46+00:00"
     },
     {
       "kernel": "selective_state_update_stp_horizontal",
       "config": "b64_h64_d128_s128_r8",
       "label": "b64_h64_d128_s128_r8",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1925659,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:32+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 48.868166643982974,
-        "flashinfer_cuda": 49.72360849594007
+        "tirx": 47.80654303371052,
+        "flashinfer_cuda": 49.79712762303909
+      },
+      "round_samples": {
+        "tirx": [
+          47.79283809523809,
+          47.80516079494129,
+          47.81519258589512,
+          47.81660321715818,
+          47.80292047531993
+        ],
+        "flashinfer_cuda": [
+          49.79273168498168,
+          49.79968248175182,
+          49.80071731123389,
+          49.79830790190736,
+          49.794198735320684
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_stp_horizontal",
-      "config": "b64_h64_d64_s128_r64",
-      "label": "b64_h64_d64_s128_r64",
-      "status": "ok",
-      "impls": {
-        "tirx": 40.55163848679775,
-        "flashinfer_cuda": 42.56608008784445
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:10+00:00"
     },
     {
       "kernel": "selective_state_update_stp_horizontal",
       "config": "b64_h64_d64_s128_r8_base",
       "label": "b64_h64_d64_s128_r8_base",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1925627,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:31+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 41.894321027732786,
-        "flashinfer_cuda": 43.21392006150808
+        "tirx": 26.500037738349153,
+        "flashinfer_cuda": 30.020448076581207
+      },
+      "round_samples": {
+        "tirx": [
+          26.429832713754646,
+          26.543610054347827,
+          26.571333802816902,
+          26.46750852272727,
+          26.48790359809912
+        ],
+        "flashinfer_cuda": [
+          28.55676950105411,
+          35.0683813559322,
+          28.56976487455197,
+          28.636070972320795,
+          29.27125367904695
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:05+00:00"
     },
     {
       "kernel": "selective_state_update_stp_horizontal",
       "config": "b64_h64_d64_s256_r8",
       "label": "b64_h64_d64_s256_r8",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1926062,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:33+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 67.76274619579912,
-        "flashinfer_cuda": 68.34214557499813
+        "tirx": 47.44909862087935,
+        "flashinfer_cuda": 47.3090362554624
+      },
+      "round_samples": {
+        "tirx": [
+          47.431406189555126,
+          47.46371849865952,
+          47.44168654019874,
+          47.4547265987025,
+          47.453955277280855
+        ],
+        "flashinfer_cuda": [
+          47.31900916590284,
+          47.3139910952805,
+          47.31747123287671,
+          47.30352466367712,
+          47.29118511957484
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:06+00:00"
     },
     {
       "kernel": "selective_state_update_stp_simple",
       "config": "b64_h64_d128_s128_r8",
       "label": "b64_h64_d128_s128_r8",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1927302,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:37+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 65.49057718954039,
-        "flashinfer_cuda": 67.44032045894582
+        "tirx": 65.27895968912749,
+        "flashinfer_cuda": 67.50188559650526
+      },
+      "round_samples": {
+        "tirx": [
+          65.25635280095352,
+          65.26848474576272,
+          65.31308485499463,
+          65.27043147751606,
+          65.28644456641054
+        ],
+        "flashinfer_cuda": [
+          67.47035095613047,
+          67.52454706533777,
+          67.48918481848185,
+          67.53159292035399,
+          67.49375222222221
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_stp_simple",
-      "config": "b64_h64_d64_s128_r64",
-      "label": "b64_h64_d64_s128_r64",
-      "status": "ok",
-      "impls": {
-        "tirx": 54.23220525236384,
-        "flashinfer_cuda": 58.53786415215318
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:13+00:00"
     },
     {
       "kernel": "selective_state_update_stp_simple",
       "config": "b64_h64_d64_s128_r8_base",
       "label": "b64_h64_d64_s128_r8_base",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1927005,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:36+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 37.45720978887859,
-        "flashinfer_cuda": 38.1160303505917
+        "tirx": 37.33744930725825,
+        "flashinfer_cuda": 38.124314523855475
+      },
+      "round_samples": {
+        "tirx": [
+          37.338291164658635,
+          37.33149269480519,
+          37.33434499593165,
+          37.3453607748184,
+          37.337756906077345
+        ],
+        "flashinfer_cuda": [
+          38.133967741935486,
+          38.12565705128205,
+          38.12002627388535,
+          38.120744939271255,
+          38.12117661290323
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:11+00:00"
     },
     {
       "kernel": "selective_state_update_stp_simple",
       "config": "b64_h64_d64_s256_r8",
       "label": "b64_h64_d64_s256_r8",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1927762,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:40+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 74.99515751144263,
-        "flashinfer_cuda": 83.56176644464162
+        "tirx": 54.06603983315199,
+        "flashinfer_cuda": 61.23854377991938
+      },
+      "round_samples": {
+        "tirx": [
+          54.07230111111111,
+          54.07196689386563,
+          54.05534731707317,
+          54.053866346153846,
+          54.07671749755621
+        ],
+        "flashinfer_cuda": [
+          61.241939896373054,
+          61.241630658436215,
+          61.236545643153526,
+          61.23725960539979,
+          61.23534309623431
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:13+00:00"
     },
     {
       "kernel": "selective_state_update_stp_vertical",
       "config": "b64_h64_d128_s128_r8",
       "label": "b64_h64_d128_s128_r8",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1928695,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:45+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 47.53551398495868,
-        "flashinfer_cuda": 54.34336390855547
+        "tirx": 47.35342800133307,
+        "flashinfer_cuda": 54.24969630446823
+      },
+      "round_samples": {
+        "tirx": [
+          47.35184189325277,
+          47.35886188340807,
+          47.33289865470852,
+          47.362707692307694,
+          47.3608298829883
+        ],
+        "flashinfer_cuda": [
+          54.25085976789168,
+          54.24720863309353,
+          54.24068007850834,
+          54.25354961089494,
+          54.256183431952664
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "selective_state_update_stp_vertical",
-      "config": "b64_h64_d64_s128_r64",
-      "label": "b64_h64_d64_s128_r64",
-      "status": "ok",
-      "impls": {
-        "tirx": 27.59956346757774,
-        "flashinfer_cuda": 31.318342438988534
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:15+00:00"
     },
     {
       "kernel": "selective_state_update_stp_vertical",
       "config": "b64_h64_d64_s128_r8_base",
       "label": "b64_h64_d64_s128_r8_base",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 4,
+      "process_pid": 1928296,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:43+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 27.631759079258945,
-        "flashinfer_cuda": 31.337787635438428
+        "tirx": 27.078507477439924,
+        "flashinfer_cuda": 31.360807521140245
+      },
+      "round_samples": {
+        "tirx": [
+          27.080433263452132,
+          27.07699070764832,
+          27.07829178470255,
+          27.074955096222382,
+          27.08186653517423
+        ],
+        "flashinfer_cuda": [
+          31.29514343598055,
+          31.291344350499614,
+          31.62950464396285,
+          31.29935647425897,
+          31.288688700999234
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:28:23+00:00"
     },
     {
       "kernel": "selective_state_update_stp_vertical",
       "config": "b64_h64_d64_s256_r8",
       "label": "b64_h64_d64_s256_r8",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1928732,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:25:46+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 67.94841861080144,
-        "flashinfer_cuda": 79.15386177667794
+        "tirx": 46.241652486948695,
+        "flashinfer_cuda": 48.750022128862796
+      },
+      "round_samples": {
+        "tirx": [
+          46.24828056872038,
+          46.23819781221513,
+          46.249844522968196,
+          46.24094312796208,
+          46.2309964028777
+        ],
+        "flashinfer_cuda": [
+          48.752258034894396,
+          48.74888898916967,
+          48.74241025641025,
+          48.75217486338798,
+          48.75437850045167
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_cuda"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "silu_and_mul_nvfp4_experts_quantize",
-      "config": "bf16_b128_m2048_k2048",
-      "label": "bf16_b128_m2048_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 285.16402632578644,
-        "flashinfer": 319.4269765350086
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:26:17+00:00"
     },
     {
       "kernel": "silu_and_mul_nvfp4_experts_quantize",
       "config": "bf16_b8_m512_k2048",
       "label": "bf16_b8_m512_k2048",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1902994,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:43+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 13.566554877009285,
-        "flashinfer": 16.030452206780463
+        "tirx": 9.048190885865866,
+        "flashinfer": 10.84252179002535
+      },
+      "round_samples": {
+        "tirx": [
+          8.838475,
+          8.891912016088487,
+          9.668827010622156,
+          8.883739384288747,
+          8.958001018329938
+        ],
+        "flashinfer": [
+          10.79073947789025,
+          10.868770700636942,
+          10.847157725321889,
+          10.852088299024919,
+          10.853852747252747
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:19+00:00"
     },
     {
       "kernel": "silu_and_mul_nvfp4_experts_quantize",
       "config": "fp16_b128_m2048_k2048",
       "label": "fp16_b128_m2048_k2048",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1902658,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:41+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 421.61700064166797,
-        "flashinfer": 503.8166946302269
+        "tirx": 273.84174608740324,
+        "flashinfer": 301.9139250160099
+      },
+      "round_samples": {
+        "tirx": [
+          273.80848837209305,
+          273.67753627760254,
+          273.74395541401276,
+          273.93968454258675,
+          274.03906583072103
+        ],
+        "flashinfer": [
+          301.88268750000003,
+          301.68664111498254,
+          302.6813801369863,
+          301.62290940766553,
+          301.6960069204152
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "silu_and_mul_nvfp4_experts_quantize",
-      "config": "fp16_b4_m128_k4096",
-      "label": "fp16_b4_m128_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.5832737173856675,
-        "flashinfer": 5.794213109593231
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:16+00:00"
     },
     {
       "kernel": "silu_and_mul_nvfp4_experts_quantize",
       "config": "fp16_b8_m16_k2048",
       "label": "fp16_b8_m16_k2048",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1903090,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:43+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 4.803755044712158,
-        "flashinfer": 6.045599889321381
+        "tirx": 3.3409331230267805,
+        "flashinfer": 4.189322427814295
+      },
+      "round_samples": {
+        "tirx": [
+          3.3310775862068964,
+          3.3435760722347627,
+          3.3400709706959706,
+          3.3436844262295082,
+          3.346256559766764
+        ],
+        "flashinfer": [
+          4.188875642823749,
+          4.18765069124424,
+          4.189810174281678,
+          4.188648112294288,
+          4.191627518427518
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "silu_and_mul_nvfp4_experts_quantize",
-      "config": "fp16_b8_m512_k2048",
-      "label": "fp16_b8_m512_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 8.849228298409693,
-        "flashinfer": 10.284468588054423
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:20+00:00"
     },
     {
       "kernel": "sm100_fp8_fp4_mega_moe",
       "config": "t64_m64_h7168_i3072_e384_k6_g1",
       "label": "t64_m64_h7168_i3072_e384_k6_g1",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1898158,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:21+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "status": "ok",
+      "reference_source": "installed",
       "impls": {
-        "tirx": 1298.4,
-        "deepgemm": 1288.0
+        "tirx": 1326.6,
+        "deepgemm": 1308.0
       },
+      "round_samples": {
+        "tirx": [
+          1336.9999999999998,
+          1319.9999999999998,
+          1321.0,
+          1326.0000000000002,
+          1328.9999999999998
+        ],
+        "deepgemm": [
+          1315.0,
+          1303.0,
+          1306.0,
+          1307.0,
+          1308.9999999999998
+        ]
+      },
+      "errors": {},
+      "timer": "megamoe",
+      "benchmark_protocol": {
+        "source": "deep_gemm.testing.bench_kineto",
+        "kernel_names": {
+          "tirx": "mega_moe_kernel",
+          "deepgemm": "sm100_fp8_fp4_mega_moe_impl"
+        },
+        "num_tests": 30,
+        "flush_l2": true,
+        "flush_l2_bytes": 8000000000,
+        "gpu_sleep_cycles": 20000000,
+        "rank_barrier_outside_kernel_timing": true,
+        "paired_profile_session": true,
+        "cold_setup_per_implementation": true,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "round_cooldown_s": 0.0,
+        "round_orders": [
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ]
+        ]
+      },
+      "deepgemm_max_abs_diff": 0.0,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sm100_fp8_fp4_mega_moe",
-      "config": "t64_m64_h7168_i3072_e384_k6_g1_s1",
-      "label": "t64_m64_h7168_i3072_e384_k6_g1_s1",
-      "status": "ok",
-      "impls": {
-        "tirx": 1280.0,
-        "deepgemm": 1270.8
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:03+00:00"
     },
     {
       "kernel": "sm100_fp8_fp4_mega_moe",
       "config": "t8192_m8192_h7168_i3072_e384_k6_g1",
       "label": "t8192_m8192_h7168_i3072_e384_k6_g1",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1898434,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:23+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "status": "ok",
+      "reference_source": "installed",
       "impls": {
-        "tirx": 3406.2,
-        "deepgemm": 3406.2
+        "tirx": 3359.2,
+        "deepgemm": 3363.4
       },
+      "round_samples": {
+        "tirx": [
+          3356.0,
+          3359.0,
+          3361.0000000000005,
+          3359.9999999999995,
+          3359.9999999999995
+        ],
+        "deepgemm": [
+          3359.9999999999995,
+          3364.0,
+          3365.0000000000005,
+          3364.0,
+          3364.0
+        ]
+      },
+      "errors": {},
+      "timer": "megamoe",
+      "benchmark_protocol": {
+        "source": "deep_gemm.testing.bench_kineto",
+        "kernel_names": {
+          "tirx": "mega_moe_kernel",
+          "deepgemm": "sm100_fp8_fp4_mega_moe_impl"
+        },
+        "num_tests": 30,
+        "flush_l2": true,
+        "flush_l2_bytes": 8000000000,
+        "gpu_sleep_cycles": 20000000,
+        "rank_barrier_outside_kernel_timing": true,
+        "paired_profile_session": true,
+        "cold_setup_per_implementation": true,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "round_cooldown_s": 0.0,
+        "round_orders": [
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ]
+        ]
+      },
+      "deepgemm_max_abs_diff": 0.0,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "finished_at": "2026-08-22T02:24:09+00:00"
     },
     {
       "kernel": "sm100_fp8_fp4_mega_moe",
       "config": "t8192_m8192_h7168_i3072_e384_k6_g1_s1",
       "label": "t8192_m8192_h7168_i3072_e384_k6_g1_s1",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1898584,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:23:23+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "status": "ok",
+      "reference_source": "installed",
       "impls": {
-        "tirx": 3842.7999999999997,
-        "deepgemm": 3845.4
+        "tirx": 3742.4,
+        "deepgemm": 3746.0
       },
+      "round_samples": {
+        "tirx": [
+          3743.0000000000005,
+          3742.0,
+          3743.0000000000005,
+          3743.0000000000005,
+          3741.0
+        ],
+        "deepgemm": [
+          3747.0,
+          3744.0000000000005,
+          3747.0,
+          3746.0,
+          3746.0
+        ]
+      },
+      "errors": {},
+      "timer": "megamoe",
+      "benchmark_protocol": {
+        "source": "deep_gemm.testing.bench_kineto",
+        "kernel_names": {
+          "tirx": "mega_moe_kernel",
+          "deepgemm": "sm100_fp8_fp4_mega_moe_impl"
+        },
+        "num_tests": 30,
+        "flush_l2": true,
+        "flush_l2_bytes": 8000000000,
+        "gpu_sleep_cycles": 20000000,
+        "rank_barrier_outside_kernel_timing": true,
+        "paired_profile_session": true,
+        "cold_setup_per_implementation": true,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "round_cooldown_s": 0.0,
+        "round_orders": [
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ],
+          [
+            "deepgemm",
+            "tirx"
+          ],
+          [
+            "tirx",
+            "deepgemm"
+          ]
+        ]
+      },
+      "deepgemm_max_abs_diff": 0.0,
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sm100_fp8_fp4_mega_moe",
-      "config": "t8192_m8192_h7168_i3072_e384_k6_g2_s1",
-      "label": "t8192_m8192_h7168_i3072_e384_k6_g2_s1",
-      "status": "ok",
-      "impls": {
-        "deepgemm": 3557.2,
-        "tirx": 3577.0
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sm100_fp8_fp4_mega_moe",
-      "config": "t8192_m8192_h7168_i3072_e384_k6_g4_s1",
-      "label": "t8192_m8192_h7168_i3072_e384_k6_g4_s1",
-      "status": "ok",
-      "impls": {
-        "deepgemm": 3116.0000000000005,
-        "tirx": 3132.4
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sm100_fp8_fp4_mega_moe",
-      "config": "t8192_m8192_h7168_i3072_e384_k6_g6_s1",
-      "label": "t8192_m8192_h7168_i3072_e384_k6_g6_s1",
-      "status": "ok",
-      "impls": {
-        "deepgemm": 3075.2,
-        "tirx": 3096.6
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:12+00:00"
     },
     {
       "kernel": "sparse_flashmla_decode_head64",
       "config": "deepseek_v4_v32_b128_sq2_sk32768_topk2048_p64",
       "label": "deepseek_v4_v32_b128_sq2_sk32768_topk2048_p64",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1946670,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:06+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 136.8763069659897,
-        "flashmla": 144.2463595225123
+        "tirx": 136.73930397764695,
+        "flashmla": 144.73483044282915
+      },
+      "round_samples": {
+        "tirx": [
+          136.76570199999998,
+          136.7786848816029,
+          136.69174128440366,
+          136.73275735294118,
+          136.72763436928705
+        ],
+        "flashmla": [
+          144.7556525735294,
+          144.65214389799635,
+          144.80298161764708,
+          144.71811213235296,
+          144.74526199261993
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_decode_head64",
-      "config": "model1_b148_sq2_sk16384_topk128_p256_xsk16384_xtopk1024_xp2_xtopklen",
-      "label": "model1_b148_sq2_sk16384_topk128_p256_xsk16384_xtopk1024_xp2_xtopklen",
-      "status": "ok",
-      "impls": {
-        "tirx": 74.96007095952966,
-        "flashmla": 78.15962933431028
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_decode_head64",
-      "config": "model1_b256_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64",
-      "label": "model1_b256_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64",
       "status": "ok",
-      "impls": {
-        "tirx": 153.61549237648944,
-        "flashmla": 163.36482876670456
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:37+00:00"
     },
     {
       "kernel": "sparse_flashmla_decode_head64",
       "config": "model1_b2_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64",
       "label": "model1_b2_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1947117,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 28.578347602893913,
-        "flashmla": 34.10255503439965
+        "tirx": 16.70628347551714,
+        "flashmla": 21.124824309093643
+      },
+      "round_samples": {
+        "tirx": [
+          16.71088548951049,
+          16.700770174306005,
+          16.704555992141454,
+          16.701775184275185,
+          16.713430537352558
+        ],
+        "flashmla": [
+          21.304653482880756,
+          20.514885859226382,
+          21.283386253041364,
+          21.27346658711217,
+          21.247729363207547
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:39+00:00"
     },
     {
       "kernel": "sparse_flashmla_decode_head64",
       "config": "v32_b148_sq2_sk32768_topk16384_p64",
       "label": "v32_b148_sq2_sk32768_topk16384_p64",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1947154,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 910.671313564715,
-        "flashmla": 953.2394711538461
+        "tirx": 1526.2412953695914,
+        "flashmla": 1817.5149205406435
+      },
+      "round_samples": {
+        "tirx": [
+          951.2067047619047,
+          1945.9781588785047,
+          1168.465424528302,
+          1039.9114905660379,
+          2525.6446981132076
+        ],
+        "flashmla": [
+          1031.2539514563107,
+          2122.458572815534,
+          2014.9117450980393,
+          1921.1552941176471,
+          1997.7950392156863
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head128_phase1",
-      "config": "bench_regular_dqk512_hq128_s4096_kv32768_topk2048",
-      "label": "bench_regular_dqk512_hq128_s4096_kv32768_topk2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 1728.4820190677965,
-        "flashmla": 1761.249475862069
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:41+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_phase1",
       "config": "bench_regular_dqk512_hq128_s4096_kv65536_topk2048",
       "label": "bench_regular_dqk512_hq128_s4096_kv65536_topk2048",
-      "status": "ok",
+      "gpu": "0",
+      "gpus": [
+        "0"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1947814,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:11+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-ef5a8300-fa8a-64f7-b6a5-ca2d0dbb6128"
+      ],
       "impls": {
-        "tirx": 2489.6684535809018,
-        "flashmla": 2492.2068205128203
+        "tirx": 1813.1112507518797,
+        "flashmla": 1871.2985293181819
+      },
+      "round_samples": {
+        "tirx": [
+          1733.6677894736843,
+          1810.3436964285715,
+          1850.8556071428573,
+          1816.5508928571428,
+          1854.1382678571429
+        ],
+        "flashmla": [
+          1883.6957272727273,
+          1887.2824181818182,
+          1846.9438363636364,
+          1868.3939375,
+          1870.1767272727272
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:46+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_phase1",
       "config": "bench_regular_dqk512_hq128_s4096_kv8192_topk2048",
       "label": "bench_regular_dqk512_hq128_s4096_kv8192_topk2048",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1947156,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:08+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 1729.9882853620954,
-        "flashmla": 1768.0809728813558
+        "tirx": 1676.5177142424243,
+        "flashmla": 1732.7518881355932
+      },
+      "round_samples": {
+        "tirx": [
+          1603.9574545454545,
+          1709.12435,
+          1702.0285166666667,
+          1710.5435666666667,
+          1656.9346833333334
+        ],
+        "flashmla": [
+          1740.0562881355931,
+          1720.0428813559322,
+          1741.9927966101695,
+          1738.5350508474578,
+          1723.1324237288136
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:38+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_phase1",
       "config": "bench_regular_dqk576_hq128_s4096_kv32768_topk2048",
       "label": "bench_regular_dqk576_hq128_s4096_kv32768_topk2048",
-      "status": "ok",
+      "gpu": "7",
+      "gpus": [
+        "7"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1947829,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:11+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-aff76307-71d5-37df-fd90-83fe611b5e73"
+      ],
       "impls": {
-        "tirx": 1859.8778849999999,
-        "flashmla": 1867.4770964285715,
-        "trtllm_gen": 2090.3867514492754
+        "tirx": 1775.0253719298246,
+        "flashmla": 1816.8809678571429,
+        "trtllm_gen": 2033.6983666666665
+      },
+      "round_samples": {
+        "tirx": [
+          1734.3047192982458,
+          1784.2234035087718,
+          1782.6099122807018,
+          1790.5904561403509,
+          1783.3983684210525
+        ],
+        "flashmla": [
+          1822.5908214285714,
+          1819.2650892857143,
+          1810.085,
+          1811.90525,
+          1820.5586785714286
+        ],
+        "trtllm_gen": [
+          2042.1072448979594,
+          2028.9358333333332,
+          2022.7783061224488,
+          2030.5161836734694,
+          2044.1542653061222
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla",
+          "trtllm_gen"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head128_phase1",
-      "config": "bench_regular_dqk576_hq128_s4096_kv65536_topk2048",
-      "label": "bench_regular_dqk576_hq128_s4096_kv65536_topk2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 1990.8173803921568,
-        "flashmla": 1991.3281960784313,
-        "trtllm_gen": 2192.8898304040404
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head128_phase1",
-      "config": "bench_regular_dqk576_hq128_s4096_kv8192_topk2048",
-      "label": "bench_regular_dqk576_hq128_s4096_kv8192_topk2048",
       "status": "ok",
-      "impls": {
-        "tirx": 2421.34911,
-        "flashmla": 2408.309225,
-        "trtllm_gen": 2839.983903030303
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:49+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_small_topk_phase1",
       "config": "bench_smalltopk_dqk512_hq128_s4096_kv32768_topk1280",
       "label": "bench_smalltopk_dqk512_hq128_s4096_kv32768_topk1280",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1948696,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:13+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 1152.0657958625904,
-        "flashmla": 1171.3120953488371
+        "tirx": 1126.81275293667,
+        "flashmla": 1152.5680272727272
+      },
+      "round_samples": {
+        "tirx": [
+          1076.3615,
+          1146.4415280898877,
+          1149.3117078651685,
+          1146.1324719101124,
+          1115.8165568181817
+        ],
+        "flashmla": [
+          1159.774806818182,
+          1154.6153068181818,
+          1160.3190795454545,
+          1154.5728295454544,
+          1133.5581136363637
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:47+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_small_topk_phase1",
       "config": "bench_smalltopk_dqk512_hq128_s4096_kv65536_topk1280",
       "label": "bench_smalltopk_dqk512_hq128_s4096_kv65536_topk1280",
-      "status": "ok",
+      "gpu": "3",
+      "gpus": [
+        "3"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1948972,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:15+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-51c31609-c1ae-1fa6-14b9-da2a172ffd67"
+      ],
       "impls": {
-        "tirx": 1668.59513598862,
-        "flashmla": 1677.7430280701756
+        "tirx": 1196.729377401838,
+        "flashmla": 1216.7861975903613
+      },
+      "round_samples": {
+        "tirx": [
+          1143.9315555555556,
+          1200.565605263158,
+          1212.6090833333335,
+          1208.0784404761905,
+          1218.4622023809525
+        ],
+        "flashmla": [
+          1225.0117469879517,
+          1220.9796987951806,
+          1197.0006987951806,
+          1219.3776506024096,
+          1221.5611927710843
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:49+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head128_small_topk_phase1",
       "config": "bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280",
       "label": "bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280",
-      "status": "ok",
+      "gpu": "2",
+      "gpus": [
+        "2"
+      ],
+      "num_gpus": 1,
+      "attempt": 2,
+      "process_pid": 1948107,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:12+00:00",
+      "retry_in_place": true,
+      "physical_gpu_uuids": [
+        "GPU-f8a4f1df-8b46-4cbf-3244-a33b90e06aa9"
+      ],
       "impls": {
-        "tirx": 1149.5009681034483,
-        "flashmla": 1161.5816367816092
+        "tirx": 1191.661179763576,
+        "flashmla": 1205.0408372548864
+      },
+      "round_samples": {
+        "tirx": [
+          1187.9212584269662,
+          1195.7304819277108,
+          1202.634875,
+          1192.87287012987,
+          1179.1464133333334
+        ],
+        "flashmla": [
+          1207.8379733333334,
+          1184.9013108108109,
+          1205.164594936709,
+          1218.0332439024392,
+          1209.2670632911393
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head64_phase1",
-      "config": "bench_dqk512_hq64_s4096_kv32768_topk512",
-      "label": "bench_dqk512_hq64_s4096_kv32768_topk512",
-      "status": "ok",
-      "impls": {
-        "tirx": 370.0398169407973,
-        "flashmla": 378.49102582945
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head64_phase1",
-      "config": "bench_dqk512_hq64_s4096_kv49152_topk512",
-      "label": "bench_dqk512_hq64_s4096_kv49152_topk512",
       "status": "ok",
-      "impls": {
-        "tirx": 377.41045630232423,
-        "flashmla": 383.64258743626425
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:28:25+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head64_phase1",
       "config": "bench_dqk512_hq64_s4096_kv65536_topk512",
       "label": "bench_dqk512_hq64_s4096_kv65536_topk512",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1949776,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:18+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 582.4459887926888,
-        "flashmla": 595.1229135594915
+        "tirx": 381.8446625099607,
+        "flashmla": 390.15916203273474
+      },
+      "round_samples": {
+        "tirx": [
+          374.62126315789476,
+          385.33041596638657,
+          380.9578781512605,
+          384.22257805907174,
+          384.0911772151899
+        ],
+        "flashmla": [
+          389.47269811320757,
+          390.0173433476395,
+          391.1109227467811,
+          390.14373819742485,
+          390.0511077586207
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:51+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head64_phase1",
       "config": "bench_dqk512_hq64_s4096_kv8192_topk512",
       "label": "bench_dqk512_hq64_s4096_kv8192_topk512",
-      "status": "ok",
+      "gpu": "5",
+      "gpus": [
+        "5"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1949540,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:18+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-087b0f09-0d22-7908-e4cb-bb49fd81a455"
+      ],
       "impls": {
-        "tirx": 572.5332530675981,
-        "flashmla": 585.4489516435361
+        "tirx": 366.51728409586053,
+        "flashmla": 372.71725294117647
+      },
+      "round_samples": {
+        "tirx": [
+          366.6682352941176,
+          366.298341563786,
+          367.7065390946502,
+          365.43658024691354,
+          366.4767242798354
+        ],
+        "flashmla": [
+          376.4012142857143,
+          371.8708823529412,
+          371.55507983193274,
+          371.850987394958,
+          371.90810084033615
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:27:49+00:00"
     },
     {
       "kernel": "sparse_flashmla_prefill_head64_phase1",
       "config": "bench_dqk576_hq64_s4096_kv32768_topk512",
       "label": "bench_dqk576_hq64_s4096_kv32768_topk512",
-      "status": "ok",
+      "gpu": "1",
+      "gpus": [
+        "1"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1950565,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:22+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e8754e6d-624e-e1d0-595a-f9444588960a"
+      ],
       "impls": {
-        "tirx": 388.0183750296135,
-        "flashmla": 401.0920492027142,
-        "trtllm_gen": 464.0309379889522
+        "tirx": 861.8449821291326,
+        "flashmla": 763.261569695808,
+        "trtllm_gen": 775.0954634231471
+      },
+      "round_samples": {
+        "tirx": [
+          571.1985324675325,
+          960.8864401709402,
+          715.0621272727273,
+          1282.9581666666668,
+          779.1196440677967
+        ],
+        "flashmla": [
+          718.76755625,
+          719.9911460176991,
+          849.3611101321585,
+          1062.875898148148,
+          465.3121379310345
+        ],
+        "trtllm_gen": [
+          827.1411764705882,
+          570.9469090909091,
+          1208.900835443038,
+          459.19673469387754,
+          809.2916614173228
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashmla",
+          "trtllm_gen"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head64_phase1",
-      "config": "bench_dqk576_hq64_s4096_kv49152_topk512",
-      "label": "bench_dqk576_hq64_s4096_kv49152_topk512",
-      "status": "ok",
-      "impls": {
-        "tirx": 584.6850177730244,
-        "flashmla": 605.9564272957425,
-        "trtllm_gen": 719.6943995160334
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head64_phase1",
-      "config": "bench_dqk576_hq64_s4096_kv65536_topk512",
-      "label": "bench_dqk576_hq64_s4096_kv65536_topk512",
       "status": "ok",
-      "impls": {
-        "tirx": 405.1608659655584,
-        "flashmla": 418.77212054090313,
-        "trtllm_gen": 488.0644359897633
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "sparse_flashmla_prefill_head64_phase1",
-      "config": "bench_dqk576_hq64_s4096_kv8192_topk512",
-      "label": "bench_dqk576_hq64_s4096_kv8192_topk512",
-      "status": "ok",
-      "impls": {
-        "tirx": 372.2002015786201,
-        "flashmla": 381.5992557718094,
-        "trtllm_gen": 447.2224965399249
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:27:56+00:00"
     },
     {
       "kernel": "stable_sort_topk_by_value",
       "config": "f32_r4_k128",
       "label": "f32_r4_k128",
-      "status": "ok",
-      "impls": {
-        "tirx": 5.271642221827065,
-        "flashinfer": 5.316647623418739
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "gpu": "",
+      "gpus": [],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1945776,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:02+00:00",
+      "retry_in_place": false,
+      "status": "FAIL",
+      "error": "prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True\nTraceback (most recent call last):\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/bench/__main__.py\", line 140, in _prepared_child_main\n    prepared = prepare_kernel_bench(\n               ^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 766, in prepare_kernel_bench\n    with cuda_initialization_guard(require_uninitialized=require_cuda_uninitialized):\n  File \"/home/bohanhou/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/contextlib.py\", line 144, in __exit__\n    next(self.gen)\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 667, in cuda_initialization_guard\n    raise RuntimeError(\nRuntimeError: CPU prepare changed CUDA initialization state from False to True\n",
+      "finished_at": "2026-08-22T02:27:08+00:00"
     },
     {
       "kernel": "stable_sort_topk_by_value",
       "config": "f32_r64_k2048",
       "label": "f32_r64_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 11.826882154201103,
-        "flashinfer": 11.916382144374955
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "gpu": "",
+      "gpus": [],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1946262,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:04+00:00",
+      "retry_in_place": false,
+      "status": "FAIL",
+      "error": "prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True\nTraceback (most recent call last):\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/bench/__main__.py\", line 140, in _prepared_child_main\n    prepared = prepare_kernel_bench(\n               ^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 766, in prepare_kernel_bench\n    with cuda_initialization_guard(require_uninitialized=require_cuda_uninitialized):\n  File \"/home/bohanhou/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/contextlib.py\", line 144, in __exit__\n    next(self.gen)\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 667, in cuda_initialization_guard\n    raise RuntimeError(\nRuntimeError: CPU prepare changed CUDA initialization state from False to True\n",
+      "finished_at": "2026-08-22T02:27:11+00:00"
     },
     {
       "kernel": "stable_sort_topk_by_value",
       "config": "f32_r64_k256",
       "label": "f32_r64_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 6.383161970012927,
-        "flashinfer": 6.848107788050225
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "tinygemm2_sm100",
-      "config": "b13_o1024_k2048",
-      "label": "b13_o1024_k2048",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.266552543505503,
-        "flashinfer_sm100": 4.25095446781299
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "gpu": "",
+      "gpus": [],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1946252,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:27:04+00:00",
+      "retry_in_place": false,
+      "status": "FAIL",
+      "error": "prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True\nTraceback (most recent call last):\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/bench/__main__.py\", line 140, in _prepared_child_main\n    prepared = prepare_kernel_bench(\n               ^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 766, in prepare_kernel_bench\n    with cuda_initialization_guard(require_uninitialized=require_cuda_uninitialized):\n  File \"/home/bohanhou/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/contextlib.py\", line 144, in __exit__\n    next(self.gen)\n  File \"/home/bohanhou/worktree/bench-suite-baseline/tirx-kernels/tirx_kernels/runner.py\", line 667, in cuda_initialization_guard\n    raise RuntimeError(\nRuntimeError: CPU prepare changed CUDA initialization state from False to True\n",
+      "finished_at": "2026-08-22T02:27:11+00:00"
     },
     {
       "kernel": "tinygemm2_sm100",
       "config": "b16_o2880_k2880",
       "label": "b16_o2880_k2880",
-      "status": "ok",
+      "gpu": "4",
+      "gpus": [
+        "4"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1910160,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:16+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-feda1f0f-e1ab-30f7-dd6d-65c8ebe11acc"
+      ],
       "impls": {
-        "tirx": 7.959312495379765,
-        "flashinfer_sm100": 8.037453571042414
+        "tirx": 7.935945395311874,
+        "flashinfer_sm100": 8.042032804918342
+      },
+      "round_samples": {
+        "tirx": [
+          7.936290839205638,
+          7.937224419179436,
+          7.935898338220919,
+          7.934603589743589,
+          7.935709790209791
+        ],
+        "flashinfer_sm100": [
+          8.037935929029079,
+          8.046384842519684,
+          8.036414146341464,
+          8.042096758104737,
+          8.04733234859675
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
+      },
+      "status": "ok",
+      "finished_at": "2026-08-22T02:24:42+00:00"
     },
     {
       "kernel": "tinygemm2_sm100",
       "config": "b1_o128_k720",
       "label": "b1_o128_k720",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1909821,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:15+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 2.949728580547922,
-        "flashinfer_sm100": 2.9315512266747152
+        "tirx": 2.9564327731623834,
+        "flashinfer_sm100": 2.9851252106714097
+      },
+      "round_samples": {
+        "tirx": [
+          2.9579946200403495,
+          2.9569865410497984,
+          2.9592608695652176,
+          2.9514474988733665,
+          2.956474336283186
+        ],
+        "flashinfer_sm100": [
+          2.9849717592592593,
+          2.9894920844327175,
+          2.9850035026269706,
+          2.9817033935654473,
+          2.9844553134726546
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "tinygemm2_sm100",
-      "config": "b2_o16_k256",
-      "label": "b2_o16_k256",
-      "status": "ok",
-      "impls": {
-        "tirx": 2.7903376372032684,
-        "flashinfer_sm100": 2.8247362970219956
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "tinygemm2_sm100",
-      "config": "b4_o2880_k2880",
-      "label": "b4_o2880_k2880",
       "status": "ok",
-      "impls": {
-        "tirx": 9.686487393938153,
-        "flashinfer_sm100": 9.799709516016218
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:38+00:00"
     },
     {
       "kernel": "tinygemm2_sm100",
       "config": "b64_o4096_k3072",
       "label": "b64_o4096_k3072",
-      "status": "ok",
+      "gpu": "6",
+      "gpus": [
+        "6"
+      ],
+      "num_gpus": 1,
+      "attempt": 1,
+      "process_pid": 1910403,
+      "execution_mode": "pipeline",
+      "process_model": "one_shot_child_per_workload",
+      "started_at": "2026-08-22T02:24:17+00:00",
+      "retry_in_place": false,
+      "physical_gpu_uuids": [
+        "GPU-e56ad157-72b3-2e86-4cd9-5769dc1f229c"
+      ],
       "impls": {
-        "tirx": 35.26487028616604,
-        "flashinfer_sm100": 35.4421757329919
+        "tirx": 21.916969515916335,
+        "flashinfer_sm100": 22.091779796191208
+      },
+      "round_samples": {
+        "tirx": [
+          21.914783980582524,
+          21.92244858044164,
+          21.916139055222885,
+          21.916271705184258,
+          21.915204258150368
+        ],
+        "flashinfer_sm100": [
+          22.099767546683836,
+          22.087787341772152,
+          22.09770992366412,
+          22.090293059125965,
+          22.083341109709963
+        ]
+      },
+      "errors": {},
+      "timer": "proton",
+      "benchmark_protocol": {
+        "warmup": 25,
+        "repeat": 100,
+        "cooldown_s": 0.0,
+        "rounds": 5,
+        "round_aggregate": "mean",
+        "order": [
+          "tirx",
+          "flashinfer_sm100"
+        ]
       },
       "aggregated": {
         "rounds": 5,
         "method": "mean"
-      }
-    },
-    {
-      "kernel": "tinygemm2_sm100",
-      "config": "b7_o128_k4096",
-      "label": "b7_o128_k4096",
-      "status": "ok",
-      "impls": {
-        "tirx": 4.961921075855419,
-        "flashinfer_sm100": 4.919688248531012
       },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
-    },
-    {
-      "kernel": "tinygemm2_sm100",
-      "config": "b8_o1024_k1024",
-      "label": "b8_o1024_k1024",
       "status": "ok",
-      "impls": {
-        "tirx": 4.811050320174237,
-        "flashinfer_sm100": 4.813476270158662
-      },
-      "aggregated": {
-        "rounds": 5,
-        "method": "mean"
-      }
+      "finished_at": "2026-08-22T02:24:47+00:00"
     }
   ]
 }

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -1,9 +1,9 @@
 # bench-suite baseline view: `baseline.json`
 
-- Timestamp: `14`
-- Label:     `post-refactor`
-- Git:       `{'tir': '135a054f', 'tirx-kernels': 'f2210e41-dirty', 'tirx-bench-ci': None}`
-- Workloads: 453 ok, 0 failed
+- Timestamp: `4`
+- Label:     `f727de3d-dirty`
+- Git:       `{'tir': '73e38d3f', 'tirx-kernels': 'f727de3d-dirty', 'tirx-bench-ci': None}`
+- Workloads: 182 ok, 9 failed
 
 Grouped workloads show one row per config and one timing column per implementation. Single-TIR workloads show ref/ours against the fastest reference implementation.
 
@@ -11,756 +11,512 @@ Grouped workloads show one row per config and one timing column per implementati
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `gelu_fp16_d11008_t8192` | tirx | 154.2156 | flashinfer | 253.8506 | 1.646 | — |
-| `gelu_tanh_fp16_d11008_t8192` | tirx | 97.4212 | flashinfer | 109.3614 | 1.123 | — |
-| `silu_bf16_d16384_t32768` | tirx | 615.7810 | flashinfer | 686.5466 | 1.115 | — |
-| `silu_bf16_d4096_t8192` | tirx | 33.2499 | flashinfer | 36.5619 | 1.100 | — |
-| `silu_fp16_d11008_t8192` | tirx | 97.6846 | flashinfer | 107.9017 | 1.105 | — |
-| `silu_fp16_d16384_t32768` | tirx | 453.6279 | flashinfer | 470.2372 | 1.037 | — |
-| `silu_fp16_d4096_t1` | tirx | 2.5687 | flashinfer | 2.7795 | 1.082 | — |
-| `silu_fp16_d4096_t8192` | tirx | 41.3473 | flashinfer | 46.5259 | 1.125 | — |
-
-## allgather_gemm
-
-| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
-|---|---|---:|---|---:|---:|---|
-| `tp1_m8192_n106496_k16384_fp16_dynamic` | tirx | 21469.3738 | cublas_nccl_cudagraph | 21463.2041 | 1.000 | cublasmp_split_p2p=21790.5044 |
-| `tp1_m8192_n24576_k4096_fp16_dynamic` | tirx | 1066.3879 | cublas_nccl_cudagraph | 1034.9734 | 0.971 | cublasmp_split_p2p=1079.9175 |
-| `tp1_m8192_n51200_k5120_fp16_dynamic` | tirx | 2876.2938 | cublas_nccl_cudagraph | 2717.1455 | 0.945 | cublasmp_split_p2p=2772.5312 |
-| `tp1_m8192_n57344_k8192_fp16_dynamic` | tirx | 6103.6119 | cublas_nccl_cudagraph | 5984.3328 | 0.980 | cublasmp_split_p2p=6148.8383 |
-
-## deepep_combine
-
-| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
-|---|---|---:|---|---:|---:|---|
-| `t4096_h7168_e256_k6` | tirx | 1098.7105 | deepep | 989.9300 | 0.901 | — |
-
-## deepep_dispatch
-
-| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
-|---|---|---:|---|---:|---:|---|
-| `t4096_h7168_e256_k6` | tirx | 638.0497 | deepep | 616.1592 | 0.966 | — |
+| `gelu_tanh_fp16_d11008_t8192` | tirx | 97.6374 | flashinfer | 109.4522 | 1.121 | — |
+| `silu_bf16_d16384_t32768` | tirx | 617.3432 | flashinfer | 1296.4386 | 2.100 | — |
+| `silu_fp16_d4096_t1` | tirx | 2.0772 | flashinfer | 2.2879 | 1.101 | — |
 
 ## deepgemm_sm100_fp4_mqa_logits
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `s2048_skv4096_h64_d128_f32_dense_cp` | tirx | 61.4546 | deepgemm | 63.9326 | 1.040 | — |
-| `s4096_skv8192_h64_d128_bf16_compressed_nocp` | tirx | 184.3678 | deepgemm | 182.3390 | 0.989 | — |
+| `s2048_skv4096_h64_d128_f32_dense_cp` | tirx | 37.5576 | deepgemm | 39.7304 | 1.058 | — |
+| `s4096_skv8192_h64_d128_bf16_compressed_nocp` | tirx | 183.7198 | deepgemm | 187.3286 | 1.020 | — |
 
 ## deepgemm_sm100_fp4_paged_mqa_logits
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b16_n1_mp128_ps64_h64_d128_bf16_fixed` | tirx | 6.2063 | deepgemm | 6.5250 | 1.051 | — |
-| `b1_n1_mp1_ps32_h64_d128_f32_fixed` | tirx | 6.2833 | deepgemm | 7.2835 | 1.159 | — |
+| `b16_n1_mp128_ps64_h64_d128_bf16_fixed` | tirx | 6.3495 | deepgemm | 6.5476 | 1.031 | — |
+| `b1_n1_mp1_ps32_h64_d128_f32_fixed` | tirx | 4.0313 | deepgemm | 4.7520 | 1.179 | — |
 
 ## deepgemm_sm100_fp8_bmm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bhd_bhr_hdr_b4096_h8_r4096_d1024` | tirx | 176.1994 | deepgemm | 188.5498 | 1.070 | — |
-| `bhd_hdr_bhr_b8192_h8_r4096_d1024` | tirx | 227.1852 | deepgemm | 253.6922 | 1.117 | — |
-| `bhr_hdr_bhd_b4096_h8_r4096_d1024` | tirx | 138.1472 | deepgemm | 139.6637 | 1.011 | — |
-| `bhr_hdr_bhd_b8192_h8_r4096_d1024` | tirx | 197.2879 | deepgemm | 196.8100 | 0.998 | — |
+| `bhd_bhr_hdr_b4096_h8_r4096_d1024` | tirx | 136.5538 | deepgemm | 139.1567 | 1.019 | — |
+| `bhd_hdr_bhr_b8192_h8_r4096_d1024` | tirx | 222.8038 | deepgemm | 244.7085 | 1.098 | — |
+| `bhr_hdr_bhd_b4096_h8_r4096_d1024` | tirx | 99.4255 | deepgemm | 99.3295 | 0.999 | — |
 
 ## deepgemm_sm100_fp8_gemm_1d1d
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `m4096_n2112_k7168` | tirx | 49.7282 | deepgemm | 49.7913 | 1.001 | — |
-| `m4096_n24576_k1536` | tirx | 148.6603 | deepgemm | 148.3340 | 0.998 | — |
-| `m4096_n24576_k1536_bfp4` | tirx | 150.7022 | deepgemm | 149.7895 | 0.994 | — |
-| `m4096_n32768_k512` | tirx | 70.6411 | deepgemm | 72.2801 | 1.023 | — |
-| `m4096_n4096_k7168` | tirx | 123.2633 | deepgemm | 124.5363 | 1.010 | — |
-| `m4096_n4096_k7168_bfp4` | tirx | 81.0394 | deepgemm | 77.0748 | 0.951 | — |
-| `m4096_n576_k7168` | tirx | 18.6026 | deepgemm | 18.9120 | 1.017 | — |
-| `m4096_n7168_k16384` | tirx | 325.3169 | deepgemm | 323.9807 | 0.996 | — |
-| `m4096_n7168_k16384_bfp4` | tirx | 300.5845 | deepgemm | 297.4391 | 0.990 | — |
-| `m4096_n7168_k2048` | tirx | 42.2952 | deepgemm | 42.3046 | 1.000 | — |
+| `m4096_n4096_k7168_bfp4` | tirx | 130.6360 | deepgemm | 91.0264 | 0.697 | — |
+| `m4096_n576_k7168` | tirx | 18.8025 | deepgemm | 19.0987 | 1.016 | — |
+| `m4096_n7168_k16384` | tirx | 336.4438 | deepgemm | 325.5337 | 0.968 | — |
 
 ## deepgemm_sm100_fp8_mqa_logits
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `s2048_skv4096_h64_d128_f32_dense_cp` | tirx | 66.4714 | deepgemm | 68.1229 | 1.025 | — |
-| `s4096_skv8192_h64_d128_bf16_compressed_nocp` | tirx | 181.8032 | deepgemm | 191.9038 | 1.056 | — |
+| `s2048_skv4096_h64_d128_f32_dense_cp` | tirx | 47.2485 | deepgemm | 54.2831 | 1.149 | — |
+| `s4096_skv8192_h64_d128_bf16_compressed_nocp` | tirx | 176.4521 | deepgemm | 186.8705 | 1.059 | — |
 
 ## deepgemm_sm100_fp8_paged_mqa_logits
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b16_n1_mp128_ps64_h64_d128_bf16_fixed` | tirx | 6.7193 | deepgemm | 6.9450 | 1.034 | sglang_cutedsl=7.0011 |
-| `b1_n1_mp1_ps64_h64_d128_f32_fixed` | tirx | 4.5840 | sglang_cutedsl | 4.7747 | 1.042 | deepgemm=5.3156 |
+| `b16_n1_mp128_ps64_h64_d128_bf16_fixed` | tirx | 6.7530 | deepgemm | 6.8781 | 1.019 | sglang_cutedsl=6.9006 |
+| `b1_n1_mp1_ps64_h64_d128_f32_fixed` | tirx | 4.2384 | sglang_cutedsl | 4.7356 | 1.117 | deepgemm=5.0161 |
 
 ## deepgemm_sm100_k_grouped_fp8_gemm_contiguous
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `g16_m7168_n2048_k2048_gran128_al128` | tirx | 579.1164 | deepgemm | 581.8843 | 1.005 | — |
-| `g4_m4096_n7168_k8192_gran128_al128` | tirx | 1013.3178 | deepgemm | 1009.7449 | 0.996 | — |
-| `g4_m4096_n7168_k8192_gran128_al128_psum` | tirx | 859.9106 | deepgemm | 876.6517 | 1.019 | — |
-| `g4_m4096_n7168_k8192_gran32_al32` | tirx | 834.9966 | deepgemm | 868.6466 | 1.040 | — |
-| `g8_m4096_n7168_k4096_gran128_al128` | tirx | 876.7165 | deepgemm | 872.7994 | 0.996 | — |
-| `g8_m4096_n7168_k4096_gran32_al160` | tirx | 1126.3837 | deepgemm | 1181.2470 | 1.049 | — |
+| `g16_m7168_n2048_k2048_gran128_al128` | tirx | 912.2861 | deepgemm | 918.9562 | 1.007 | — |
+| `g4_m4096_n7168_k8192_gran128_al128_psum` | tirx | 857.4816 | deepgemm | 860.4166 | 1.003 | — |
+| `g8_m4096_n7168_k4096_gran32_al160` | tirx | 907.9104 | deepgemm | 930.4703 | 1.025 | — |
 
 ## deepgemm_sm100_m_grouped_fp8_gemm_contiguous
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `g4_m8192_n4096_k2048` | tirx | 205.5935 | deepgemm | 207.5108 | 1.009 | — |
-| `g4_m8192_n4096_k4096` | tirx | 363.9075 | deepgemm | 367.8614 | 1.011 | — |
-| `g4_m8192_n4096_k4096_psum` | tirx | 452.7249 | deepgemm | 452.4756 | 0.999 | — |
-| `g4_m8192_n6144_k7168` | tirx | 1001.1147 | deepgemm | 983.4413 | 0.982 | — |
-| `g4_m8192_n6144_k7168_bfp4` | tirx | 977.0830 | deepgemm | 963.9919 | 0.987 | — |
-| `g4_m8192_n7168_k3072` | tirx | 580.0537 | deepgemm | 582.0827 | 1.003 | — |
-| `g8_m4096_n4096_k2048` | tirx | 194.3954 | deepgemm | 197.0576 | 1.014 | — |
-| `g8_m4096_n4096_k2048_bfp4` | tirx | 232.1981 | deepgemm | 234.1759 | 1.009 | — |
-| `g8_m4096_n4096_k4096` | tirx | 361.9380 | deepgemm | 369.1489 | 1.020 | — |
-| `g8_m4096_n6144_k7168` | tirx | 1109.6160 | deepgemm | 1105.3470 | 0.996 | — |
-| `g8_m4096_n7168_k3072` | tirx | 594.7954 | deepgemm | 594.0340 | 0.999 | — |
-| `g8_m4096_n7168_k3072_psum_zp` | tirx | 601.4369 | deepgemm | 603.6703 | 1.004 | — |
+| `g4_m8192_n6144_k7168` | tirx | 1000.2049 | deepgemm | 1029.7921 | 1.030 | — |
+| `g8_m4096_n4096_k2048_bfp4` | tirx | 186.0463 | deepgemm | 187.4825 | 1.008 | — |
+| `g8_m4096_n7168_k3072_psum_zp` | tirx | 511.4467 | deepgemm | 507.7964 | 0.993 | — |
 
 ## deepgemm_sm100_m_grouped_fp8_gemm_masked
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `g32_m192_n4096_k2048` | tirx | 72.7861 | deepgemm | 72.9036 | 1.002 | — |
-| `g32_m192_n4096_k4096_bfp4` | tirx | 114.2318 | deepgemm | 113.9582 | 0.998 | — |
-| `g32_m192_n6144_k7168` | tirx | 336.2360 | deepgemm | 329.7036 | 0.981 | — |
-| `g6_m1024_n4096_k2048` | tirx | 60.6740 | deepgemm | 60.5707 | 0.998 | — |
-| `g6_m1024_n6144_k7168` | tirx | 200.7467 | deepgemm | 200.6686 | 1.000 | — |
+| `g32_m192_n4096_k4096_bfp4` | tirx | 115.2601 | deepgemm | 114.5373 | 0.994 | — |
+| `g32_m192_n6144_k7168` | tirx | 338.7765 | deepgemm | 326.7344 | 0.964 | — |
+| `g6_m1024_n4096_k2048` | tirx | 39.1687 | deepgemm | 39.2882 | 1.003 | — |
 
 ## deepgemm_sm100_tf32_hc_prenorm_gemm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `m128_n24_k16384_s64` | tirx | 5.3073 | deepgemm | 5.2196 | 0.983 | — |
-| `m137_n24_k7680_s16` | tirx | 5.3061 | deepgemm | 5.3535 | 1.009 | — |
-| `m13_n24_k7168_s1` | tirx | 33.8115 | deepgemm | 33.4763 | 0.990 | — |
-| `m4096_n24_k28672_s16` | tirx | 57.8921 | deepgemm | 62.8364 | 1.085 | — |
-| `m4096_n24_k7168_s1` | tirx | 36.0125 | deepgemm | 35.7021 | 0.991 | — |
-| `m64_n24_k28672_s112` | tirx | 7.2039 | deepgemm | 7.2959 | 1.013 | — |
-| `m8192_n24_k16384_s1` | tirx | 50.5342 | deepgemm | 60.5773 | 1.199 | — |
-| `m8192_n24_k28672_s1` | tirx | 83.9610 | deepgemm | 91.6330 | 1.091 | — |
+| `m128_n24_k16384_s64` | tirx | 5.2401 | deepgemm | 5.2343 | 0.999 | — |
+| `m4096_n24_k7168_s1` | tirx | 23.1650 | deepgemm | 23.8279 | 1.029 | — |
+| `m8192_n24_k28672_s1` | tirx | 84.4301 | deepgemm | 92.6280 | 1.097 | — |
 
 ## fast_topk_clusters
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_plain_b16_l16384_k256` | tirx | 9.3154 | flashinfer | 10.6364 | 1.142 | — |
-| `bf16_plain_b64_l16384_k1024_tie_heavy` | tirx | 11.8087 | flashinfer | 12.8890 | 1.091 | — |
-| `bf16_plain_b64_l65536_k1024` | tirx | 15.9838 | flashinfer | 17.3796 | 1.087 | — |
-| `bf16_pt_b16_l16384_k256` | tirx | 10.1353 | flashinfer | 11.3160 | 1.116 | — |
-| `bf16_rag_b16_l16384_k256` | tirx | 9.1481 | flashinfer | 10.1417 | 1.109 | — |
-| `bf16_rag_b300_l16384_k256` | tirx | 17.7368 | flashinfer | 18.8113 | 1.061 | — |
-| `f16_plain_b16_l16384_k256` | tirx | 9.3304 | flashinfer | 10.3677 | 1.111 | — |
-| `f16_plain_b16_l4096_k256` | tirx | 4.7626 | flashinfer | 5.7208 | 1.201 | — |
-| `f16_plain_b64_l16384_k1024_tie_heavy` | tirx | 10.3107 | flashinfer | 10.8340 | 1.051 | — |
-| `f16_plain_b64_l65536_k2048_i64` | tirx | 17.8662 | flashinfer | 18.9118 | 1.059 | — |
-| `f16_pt_b16_l16384_k256` | tirx | 9.9901 | flashinfer | 10.8917 | 1.090 | — |
-| `f16_rag_b16_l16384_k256` | tirx | 9.0958 | flashinfer | 9.9043 | 1.089 | — |
-| `f32_plain_b16_l16384_k2048_all_equal` | tirx | 17.0291 | flashinfer | 18.8449 | 1.107 | — |
-| `f32_plain_b16_l16384_k256` | tirx | 13.4667 | flashinfer | 14.4000 | 1.069 | — |
-| `f32_plain_b16_l16384_k256_all_equal` | tirx | 16.6239 | flashinfer | 18.1541 | 1.092 | — |
-| `f32_plain_b16_l16384_k256_i64` | tirx | 13.4207 | flashinfer | 14.4828 | 1.079 | — |
-| `f32_plain_b16_l16384_k256_neg` | tirx | 13.5699 | flashinfer | 15.4026 | 1.135 | — |
-| `f32_plain_b16_l16384_k256_tie_heavy` | tirx | 15.3688 | flashinfer | 16.3504 | 1.064 | — |
-| `f32_plain_b16_l4096_k256` | tirx | 6.7054 | flashinfer | 7.2985 | 1.088 | — |
-| `f32_plain_b200_l16384_k256` | tirx | 24.8602 | flashinfer | 25.4059 | 1.022 | — |
-| `f32_plain_b200_l65536_k1024` | tirx | 45.5855 | flashinfer | 46.1854 | 1.013 | — |
-| `f32_plain_b300_l16384_k256` | tirx | 20.9741 | flashinfer | 22.0863 | 1.053 | — |
-| `f32_plain_b64_l16384_k1024` | tirx | 14.8711 | flashinfer | 15.6528 | 1.053 | — |
-| `f32_plain_b64_l16384_k2048` | tirx | 15.0511 | flashinfer | 15.8014 | 1.050 | — |
-| `f32_plain_b64_l16384_k256` | tirx | 13.6511 | flashinfer | 14.2689 | 1.045 | — |
-| `f32_plain_b64_l65536_k1024` | tirx | 20.9928 | flashinfer | 21.4147 | 1.020 | — |
-| `f32_plain_b8_l4096_k4096` | tirx | 2.6726 | flashinfer | 2.7113 | 1.014 | — |
-| `f32_pt_b16_l16384_k256` | tirx | 14.1769 | flashinfer | 15.3828 | 1.085 | — |
-| `f32_pt_b16_l16384_k256_rowvar` | tirx | 12.4331 | flashinfer | 12.9034 | 1.038 | — |
-| `f32_pt_b200_l16384_k256` | tirx | 26.7335 | flashinfer | 26.7933 | 1.002 | — |
-| `f32_pt_b8_l4096_k4096` | tirx | 2.9397 | flashinfer | 2.9337 | 0.998 | — |
-| `f32_rag_b16_l16384_k256` | tirx | 13.3519 | flashinfer | 13.9303 | 1.043 | — |
-| `f32_rag_b16_l16384_k256_rowvar` | tirx | 11.5922 | flashinfer | 11.9020 | 1.027 | — |
-| `f32_rag_b8_l4096_k4096` | tirx | 2.1011 | flashinfer | 2.2161 | 1.055 | — |
+| `f32_plain_b16_l4096_k256` | tirx | 6.6451 | flashinfer | 7.2568 | 1.092 | — |
+| `f32_plain_b64_l16384_k256` | tirx | 13.7256 | flashinfer | 14.2128 | 1.035 | — |
+| `f32_plain_b64_l65536_k1024` | tirx | 20.8370 | flashinfer | 21.3537 | 1.025 | — |
 
 ## filtered_topk
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `f32_plain_det_r2_l524288_k256_endbit` | tirx | 116.8841 | flashinfer | 128.4734 | 1.099 | — |
-| `f32_plain_r4_l8192_k256` | tirx | 8.2415 | flashinfer | 9.5639 | 1.160 | — |
-| `f32_plain_r64_l8192_k256` | tirx | 8.4794 | flashinfer | 9.7908 | 1.155 | — |
+| `f32_plain_det_r2_l524288_k256_endbit` | tirx | 114.9716 | flashinfer | 125.9324 | 1.095 | — |
+| `f32_plain_r4_l8192_k256` | tirx | 7.7729 | flashinfer | 9.0389 | 1.163 | — |
+| `f32_plain_r64_l8192_k256` | tirx | 8.4706 | flashinfer | 9.7603 | 1.152 | — |
 
 ## flash_attention4
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `s1024_h32kv16` | tir | 19.6227 | flashattn_sm100 | 20.1902 | 1.029 | — |
-| `s1024_h32kv16_causal` | tir | 20.1335 | flashattn_sm100 | 20.3510 | 1.011 | — |
-| `s1024_h32kv32` | tir | 32.1967 | flashattn_sm100 | 33.0879 | 1.028 | — |
-| `s1024_h32kv32_causal` | tir | 21.1454 | flashattn_sm100 | 21.5064 | 1.017 | — |
-| `s1024_h32kv4` | tir | 19.1192 | flashattn_sm100 | 19.9600 | 1.044 | — |
-| `s1024_h32kv4_causal` | tir | 18.7431 | flashattn_sm100 | 19.7290 | 1.053 | — |
-| `s1024_h32kv8` | tir | 19.5072 | flashattn_sm100 | 20.0500 | 1.028 | — |
-| `s1024_h32kv8_causal` | tir | 19.1711 | flashattn_sm100 | 19.7744 | 1.031 | — |
-| `s2048_h32kv16` | tir | 57.6003 | flashattn_sm100 | 57.7701 | 1.003 | — |
-| `s2048_h32kv16_causal` | tir | 36.3420 | flashattn_sm100 | 38.5848 | 1.062 | — |
-| `s2048_h32kv32` | tir | 59.8262 | flashattn_sm100 | 60.0877 | 1.004 | — |
-| `s2048_h32kv32_causal` | tir | 64.4690 | flashattn_sm100 | 64.6407 | 1.003 | — |
-| `s2048_h32kv4` | tir | 94.3612 | flashattn_sm100 | 94.9303 | 1.006 | — |
-| `s2048_h32kv4_causal` | tir | 35.2785 | flashattn_sm100 | 37.7566 | 1.070 | — |
-| `s2048_h32kv8` | tir | 56.1241 | flashattn_sm100 | 56.6827 | 1.010 | — |
-| `s2048_h32kv8_causal` | tir | 35.4594 | flashattn_sm100 | 37.8575 | 1.068 | — |
-| `s4096_h32kv16` | tir | 211.9596 | flashattn_sm100 | 213.8201 | 1.009 | — |
-| `s4096_h32kv16_causal` | tir | 113.2938 | flashattn_sm100 | 118.4429 | 1.045 | — |
-| `s4096_h32kv32` | tir | 218.1091 | flashattn_sm100 | 220.0999 | 1.009 | — |
-| `s4096_h32kv32_causal` | tir | 121.4913 | flashattn_sm100 | 120.1097 | 0.989 | — |
-| `s4096_h32kv4` | tir | 208.2616 | flashattn_sm100 | 210.2081 | 1.009 | — |
-| `s4096_h32kv4_causal` | tir | 174.5619 | flashattn_sm100 | 182.6275 | 1.046 | — |
-| `s4096_h32kv8` | tir | 207.4134 | flashattn_sm100 | 209.5260 | 1.010 | — |
-| `s4096_h32kv8_causal` | tir | 112.0452 | flashattn_sm100 | 117.5551 | 1.049 | — |
-| `s8192_h32kv16` | tir | 780.7842 | flashattn_sm100 | 779.7321 | 0.999 | — |
-| `s8192_h32kv16_causal` | tir | 422.0594 | flashattn_sm100 | 428.6703 | 1.016 | — |
-| `s8192_h32kv32` | tir | 796.6754 | flashattn_sm100 | 800.0535 | 1.004 | — |
-| `s8192_h32kv32_causal` | tir | 440.1180 | flashattn_sm100 | 436.9789 | 0.993 | — |
-| `s8192_h32kv4` | tir | 984.6224 | flashattn_sm100 | 989.6464 | 1.005 | — |
-| `s8192_h32kv4_causal` | tir | 564.6177 | flashattn_sm100 | 582.7476 | 1.032 | — |
-| `s8192_h32kv8` | tir | 766.1723 | flashattn_sm100 | 773.2631 | 1.009 | — |
-| `s8192_h32kv8_causal` | tir | 415.7060 | flashattn_sm100 | 425.8563 | 1.024 | — |
+| `s1024_h32kv4` | tir | 19.3743 | flashattn_sm100 | 20.0717 | 1.036 | — |
+| `s4096_h32kv4_causal` | tir | 112.4341 | flashattn_sm100 | 115.8063 | 1.030 | — |
+| `s8192_h32kv32` | tir | 778.7393 | flashattn_sm100 | 785.1523 | 1.008 | — |
 
 ## flash_attention_backward_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b1_s2048_h16_causal` | tir | 81.8951 | flashattn_sm100 | 81.9815 | 1.001 | — |
-| `b1_s4096_h16_causal` | tir | 323.1004 | flashattn_sm100 | 328.2527 | 1.016 | — |
-| `b1_s8192_h16_causal` | tir | 931.6856 | flashattn_sm100 | 935.9016 | 1.005 | — |
-| `b1_s8192_h16_noncausal` | tir | 1100.8997 | flashattn_sm100 | 1117.1258 | 1.015 | — |
-| `b2_s4096_h16_causal` | tir | 388.0339 | flashattn_sm100 | 390.3185 | 1.006 | — |
-| `b4_s8192_h16_causal` | tir | 2473.1056 | flashattn_sm100 | 2496.3857 | 1.009 | — |
-| `b4_s8192_h16_noncausal` | tir | 5549.1120 | flashattn_sm100 | 5662.1554 | 1.020 | — |
+| `b1_s2048_h16_causal` | tir | 82.1407 | flashattn_sm100 | 82.1089 | 1.000 | — |
+| `b1_s8192_h16_noncausal` | tir | 1081.8105 | flashattn_sm100 | 1092.8711 | 1.010 | — |
+| `b4_s8192_h16_noncausal` | tir | 4370.6380 | flashattn_sm100 | 4471.5627 | 1.023 | — |
 
 ## flashinfer_add_rmsnorm_fp4quant
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 7.7207 | flashinfer_cutedsl | 7.8867 | 1.021 | — |
-| `bench_mx_both_bf16_m32_h4096_b32_ue8m0_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 7.6994 | flashinfer_cutedsl | 7.8751 | 1.023 | — |
-| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.9511 | flashinfer_cutedsl | 2.9984 | 1.016 | — |
-| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.6376 | flashinfer_cutedsl | 5.7757 | 1.024 | — |
-| `bench_nv_both_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.7419 | flashinfer_cutedsl | 5.8897 | 1.026 | — |
-| `bench_nv_both_global_bf16_m32_h4096_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 5.6859 | flashinfer_cutedsl | 5.8198 | 1.024 | — |
-| `bench_nv_both_large_bf16_m64_h8192_b16_e4m3_sw0_both1_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 6.0994 | flashinfer_cutedsl | 6.1585 | 1.010 | — |
-| `bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 5.6352 | flashinfer_cutedsl | 5.7696 | 1.024 | — |
-| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.9640 | flashinfer_cutedsl | 6.0530 | 1.015 | — |
-| `bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.6895 | flashinfer_cutedsl | 5.8211 | 1.023 | — |
-
-## flashinfer_fused_add_rmsnorm
-
-| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
-|---|---|---:|---|---:|---:|---|
-| `fused_bf16_m32_h4096_xc_rc_pdl0` | tirx | 3.6033 | flashinfer_cutedsl | 3.6118 | 1.002 | — |
-| `fused_bf16_m32_h4096_xc_rc_pdl1` | tirx | 3.7216 | flashinfer_cutedsl | 3.7030 | 0.995 | — |
-| `fused_bf16_m64_h8192_xc_rc_pdl0` | tirx | 3.7880 | flashinfer_cutedsl | 3.7899 | 1.000 | — |
-| `gemma_bf16_m32_h4096_xc_rc_pdl0` | tirx | 3.5710 | flashinfer_cutedsl | 3.5449 | 0.993 | — |
-| `gemma_bf16_m32_h4096_xc_rc_pdl1` | tirx | 3.7241 | flashinfer_cutedsl | 3.7073 | 0.995 | — |
-| `gemma_bf16_m64_h8192_xc_rc_pdl0` | tirx | 3.8722 | flashinfer_cutedsl | 3.8765 | 1.001 | — |
+| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.9600 | flashinfer_cutedsl | 2.8960 | 0.978 | — |
+| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 5.8104 | flashinfer_cutedsl | 5.8124 | 1.000 | — |
+| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_both0_yn0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 6.0163 | flashinfer_cutedsl | 6.0226 | 1.001 | — |
 
 ## flashinfer_fused_add_rmsnorm_quant
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1` | tirx | 3.3662 | flashinfer_cutedsl | 3.4006 | 1.010 | — |
-| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1` | tirx | 3.7142 | flashinfer_cutedsl | 3.7284 | 1.004 | — |
-| `bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1` | tirx | 3.8163 | flashinfer_cutedsl | 3.8988 | 1.022 | — |
+| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl0_s1` | tirx | 3.5368 | flashinfer_cutedsl | 3.5666 | 1.008 | — |
+| `bf16_e4m3_m32_h4096_xc_rc_yc_pdl1_s1` | tirx | 3.5717 | flashinfer_cutedsl | 3.6109 | 1.011 | — |
+| `bf16_e4m3_m64_h8192_xc_rc_yc_pdl0_s1` | tirx | 3.7283 | flashinfer_cutedsl | 3.7940 | 1.018 | — |
 
 ## flashinfer_fused_dit_layernorm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `grgb_bf16_b1_r1920` | tirx | 16.5549 | flashinfer_cuda | 16.9264 | 1.022 | — |
-| `grgb_bf16_b1_r768` | tirx | 8.4855 | flashinfer_cuda | 8.6850 | 1.024 | — |
-| `grgb_bf16_b2_r1920` | tirx | 28.9023 | flashinfer_cuda | 29.4032 | 1.017 | — |
-| `grgb_bf16_b2_r768` | tirx | 13.5105 | flashinfer_cuda | 13.9487 | 1.032 | — |
-| `grgb_bf16_b4_r1920` | tirx | 52.1808 | flashinfer_cuda | 53.3738 | 1.023 | — |
-| `grss_bf16_b1_r1920` | tirx | 23.0819 | flashinfer_cuda | 23.0937 | 1.001 | — |
-| `grss_bf16_b1_r768` | tirx | 10.9591 | flashinfer_cuda | 11.0709 | 1.010 | — |
-| `grss_bf16_b2_r1920` | tirx | 40.8214 | flashinfer_cuda | 40.9645 | 1.004 | — |
-| `grss_bf16_b2_r768` | tirx | 18.5933 | flashinfer_cuda | 18.6946 | 1.005 | — |
-| `grss_bf16_b4_r1920` | tirx | 73.0063 | flashinfer_cuda | 73.5404 | 1.007 | — |
-| `rss_bf16_b1_r1920` | tirx | 17.4164 | flashinfer_cuda | 17.5859 | 1.010 | — |
-| `rss_bf16_b1_r768` | tirx | 8.5374 | flashinfer_cuda | 8.6840 | 1.017 | — |
-| `rss_bf16_b2_r1920` | tirx | 31.5483 | flashinfer_cuda | 31.7315 | 1.006 | — |
-| `rss_bf16_b2_r768` | tirx | 14.4482 | flashinfer_cuda | 14.6750 | 1.016 | — |
-| `rss_bf16_b4_r1920` | tirx | 57.3485 | flashinfer_cuda | 57.7074 | 1.006 | — |
+| `grgb_bf16_b1_r1920` | tirx | 16.6008 | flashinfer_cuda | 16.8442 | 1.015 | — |
+| `grss_bf16_b4_r1920` | tirx | 72.9835 | flashinfer_cuda | 73.4669 | 1.007 | — |
+| `rss_bf16_b1_r768` | tirx | 8.7467 | flashinfer_cuda | 8.6655 | 0.991 | — |
 
 ## flashinfer_layernorm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_m128_h1024_xc_yc_pdl0_eps1e6` | tirx | 3.0780 | flashinfer_cutedsl | 3.0617 | 0.995 | — |
-| `bf16_m128_h128_xc_yc_pdl0_eps1e6` | tirx | 2.4435 | flashinfer_cutedsl | 2.4455 | 1.001 | — |
-| `bf16_m128_h129_xc_yc_pdl0_eps1e6` | tirx | 2.8535 | flashinfer_cutedsl | 2.8579 | 1.002 | — |
-| `bf16_m128_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.9484 | flashinfer_cutedsl | 8.9428 | 0.999 | — |
-| `bf16_m1_h1024_xc_yc_pdl0_eps1e6` | tirx | 2.9720 | flashinfer_cutedsl | 2.9680 | 0.999 | — |
-| `bf16_m1_h128_xc_yc_pdl0_eps1e6` | tirx | 2.0493 | flashinfer_cutedsl | 2.0524 | 1.002 | — |
-| `bf16_m1_h129_xc_yc_pdl0_eps1e6` | tirx | 2.7931 | flashinfer_cutedsl | 2.7960 | 1.001 | — |
-| `bf16_m1_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.2575 | flashinfer_cutedsl | 8.2507 | 0.999 | — |
-| `bf16_m2_h1024_xc_yc_pdl0_eps1e6` | tirx | 2.7966 | flashinfer_cutedsl | 2.8083 | 1.004 | — |
-| `bf16_m2_h128_xc_yc_pdl0_eps1e6` | tirx | 2.0360 | flashinfer_cutedsl | 2.0560 | 1.010 | — |
-| `bf16_m2_h129_xc_yc_pdl0_eps1e6` | tirx | 3.0462 | flashinfer_cutedsl | 3.0447 | 1.000 | — |
-| `bf16_m2_h16384_xc_yc_pdl0_eps1e6` | tirx | 7.6095 | flashinfer_cutedsl | 7.6246 | 1.002 | — |
-| `bf16_m3_h1024_xc_yc_pdl0_eps1e6` | tirx | 3.1947 | flashinfer_cutedsl | 3.1884 | 0.998 | — |
-| `bf16_m3_h128_xc_yc_pdl0_eps1e6` | tirx | 2.2445 | flashinfer_cutedsl | 2.2463 | 1.001 | — |
-| `bf16_m3_h129_xc_yc_pdl0_eps1e6` | tirx | 2.8113 | flashinfer_cutedsl | 2.8115 | 1.000 | — |
-| `bf16_m3_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.0211 | flashinfer_cutedsl | 8.0604 | 1.005 | — |
+| `bf16_m128_h1024_xc_yc_pdl0_eps1e6` | tirx | 3.1305 | flashinfer_cutedsl | 3.1160 | 0.995 | — |
+| `bf16_m128_h16384_xc_yc_pdl0_eps1e6` | tirx | 8.9714 | flashinfer_cutedsl | 8.9680 | 1.000 | — |
+| `bf16_m1_h128_xc_yc_pdl0_eps1e6` | tirx | 2.2494 | flashinfer_cutedsl | 2.2566 | 1.003 | — |
 
 ## flashinfer_qk_rmsnorm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `gemma_bf16_b32_n32_h128_xc_yc_pdl0` | tirx | 2.7996 | flashinfer_cutedsl | 2.8285 | 1.010 | — |
-| `rms_bf16_b32_n32_h128_xc_yc_pdl0` | tirx | 2.8140 | flashinfer_cutedsl | 2.8320 | 1.006 | — |
-| `rms_f16_b16_n64_h128_xc_yc_pdl0` | tirx | 2.8184 | flashinfer_cutedsl | 2.8270 | 1.003 | — |
+| `gemma_bf16_b32_n32_h128_xc_yc_pdl0` | tirx | 2.7697 | flashinfer_cutedsl | 2.8056 | 1.013 | — |
+| `rms_bf16_b32_n32_h128_xc_yc_pdl0` | tirx | 2.6324 | flashinfer_cutedsl | 2.6516 | 1.007 | — |
+| `rms_f16_b16_n64_h128_xc_yc_pdl0` | tirx | 2.5852 | flashinfer_cutedsl | 2.5963 | 1.004 | — |
 
 ## flashinfer_rmsnorm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `gemma_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.3630 | flashinfer_cutedsl | 3.4510 | 1.026 | — |
-| `gemma_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4773 | flashinfer_cutedsl | 3.4530 | 0.993 | — |
-| `rms_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.3644 | flashinfer_cutedsl | 3.4527 | 1.026 | — |
-| `rms_bf16_m32_h4096_xc_yc_pdl1` | tirx | 3.3516 | flashinfer_cutedsl | 3.3558 | 1.001 | — |
-| `rms_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4584 | flashinfer_cutedsl | 3.4412 | 0.995 | — |
+| `gemma_bf16_m64_h8192_xc_yc_pdl0` | tirx | 3.4718 | flashinfer_cutedsl | 3.5704 | 1.028 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl0` | tirx | 3.2981 | flashinfer_cutedsl | 3.4361 | 1.042 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl1` | tirx | 3.3285 | flashinfer_cutedsl | 3.3229 | 0.998 | — |
 
 ## flashinfer_rmsnorm_fp4quant
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bench_mx_bf16_m32_h4096_b32_ue8m0_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.0015 | flashinfer_cutedsl | 4.0733 | 1.018 | — |
-| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.6489 | flashinfer_cutedsl | 2.7371 | 1.033 | — |
-| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.5685 | flashinfer_cutedsl | 4.7516 | 1.040 | — |
-| `bench_nv_global_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsone_preallocated_random` | tirx | 4.6477 | flashinfer_cutedsl | 4.8623 | 1.046 | — |
-| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.8342 | flashinfer_cutedsl | 5.0347 | 1.041 | — |
-| `bench_nv_swizzled_bf16_m32_h4096_b16_e4m3_sw1_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.6718 | flashinfer_cutedsl | 4.7575 | 1.018 | — |
+| `bench_nv_3d_bf16_b32_s32_h128_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 2.7762 | flashinfer_cutedsl | 2.7551 | 0.992 | — |
+| `bench_nv_bf16_m32_h4096_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.8426 | flashinfer_cutedsl | 4.8704 | 1.006 | — |
+| `bench_nv_large_bf16_m64_h8192_b16_e4m3_sw0_pdl0_eps1e6_gsnone_preallocated_random` | tirx | 4.9428 | flashinfer_cutedsl | 4.9394 | 0.999 | — |
+
+## flashinfer_rmsnorm_quant
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_e4m3_m32_h4096_xc_yc_pdl0_s1` | tirx | 3.2766 | flashinfer_cutedsl | 3.2204 | 0.983 | — |
+| `bf16_e4m3_m64_h8192_xc_yc_pdl0_s1` | tirx | 3.4049 | flashinfer_cutedsl | 3.3867 | 0.995 | — |
+| `bf16_e5m2_m3_h1048576_xc_yc_pdl1_s1_cluster16_sync` | tirx | 16.6427 | flashinfer_cutedsl | 16.5748 | 0.996 | — |
 
 ## flashkda_bf16_fused_m128
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `h64_mixed` | tirx | 268.2399 | flashinfer_m128 | 271.9395 | 1.014 | flashkda_raw=667.1473 |
-| `h64_uniform` | tirx | 465.6187 | flashinfer_m128 | 473.5961 | 1.017 | flashkda_raw=764.6676 |
-| `h96_fixed8192` | tirx | 500.8359 | flashinfer_m128 | 508.1553 | 1.015 | flashkda_raw=1075.1109 |
-| `h96_mixed` | tirx | 609.2198 | flashinfer_m128 | 622.6901 | 1.022 | flashkda_raw=1403.8307 |
-| `h96_uniform` | tirx | 432.0196 | flashinfer_m128 | 436.5378 | 1.010 | flashkda_raw=708.6740 |
+| `h64_mixed` | tirx | 267.8367 | flashinfer_m128 | 272.7128 | 1.018 | flashkda_raw=665.3760 |
+| `h96_fixed8192` | tirx | 500.9243 | flashinfer_m128 | 506.0955 | 1.010 | flashkda_raw=1073.3854 |
+| `h96_uniform` | tirx | 434.0923 | flashinfer_m128 | 436.1191 | 1.005 | flashkda_raw=705.6305 |
 
 ## flashkda_decode_t1_precomputed
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_s8` | tirx | 14.3395 | flashinfer_cake | 15.7034 | 1.095 | — |
-| `hv12h12_b8_s16` | tirx | 4.7702 | flashinfer_cake | 6.4468 | 1.351 | — |
-| `hv16h16_b128_s8` | tirx | 28.7487 | flashinfer_cake | 31.4956 | 1.096 | — |
-| `hv16h16_b16_s16` | tirx | 6.3019 | flashinfer_cake | 7.8545 | 1.246 | — |
-| `hv16h16_b1_s16` | tirx | 4.0110 | flashinfer_cake | 5.6094 | 1.398 | — |
-| `hv16h16_b32_s8` | tirx | 9.9658 | flashinfer_cake | 13.3446 | 1.339 | — |
-| `hv16h16_b4_s16` | tirx | 4.4257 | flashinfer_cake | 6.0140 | 1.359 | — |
-| `hv16h16_b64_s8` | tirx | 16.4855 | flashinfer_cake | 19.3742 | 1.175 | — |
-| `hv16h16_b8_s16` | tirx | 4.9470 | flashinfer_cake | 6.8255 | 1.380 | — |
-| `hv32h16_b32_s8` | tirx | 16.8039 | flashinfer_cake | 19.1705 | 1.141 | — |
-| `hv32h16_b8_s16` | tirx | 6.2091 | flashinfer_cake | 8.3277 | 1.341 | — |
+| `hv16h16_b128_s8` | tirx | 26.6199 | flashinfer_cake | 31.5408 | 1.185 | — |
+| `hv16h16_b1_s16` | tirx | 4.1159 | flashinfer_cake | 5.8536 | 1.422 | — |
+| `hv32h16_b32_s8` | tirx | 15.2390 | flashinfer_cake | 19.4038 | 1.273 | — |
 
 ## flashkda_decode_t2_precomputed
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_t2` | tirx | 20.8492 | flashinfer_cake | 24.2890 | 1.165 | — |
-| `hv12h12_b8_t2` | tirx | 6.3742 | flashinfer_cake | 8.3778 | 1.314 | — |
-| `hv16h16_b64_t2` | tirx | 25.4150 | flashinfer_cake | 29.9882 | 1.180 | — |
-| `hv16h16_b8_t2` | tirx | 7.0329 | flashinfer_cake | 9.3116 | 1.324 | — |
-| `hv32h16_b128_t2` | tirx | 83.1122 | flashinfer_cake | 95.1880 | 1.145 | — |
-| `hv32h16_b16_t2` | tirx | 15.6699 | flashinfer_cake | 18.2420 | 1.164 | — |
-| `hv32h16_b32_t2` | tirx | 25.6408 | flashinfer_cake | 30.0217 | 1.171 | — |
-| `hv32h16_b64_t2` | tirx | 44.9137 | flashinfer_cake | 51.7398 | 1.152 | — |
-| `hv32h16_b8_t2` | tirx | 9.0071 | flashinfer_cake | 11.3129 | 1.256 | — |
+| `hv12h12_b8_t2` | tirx | 6.3762 | flashinfer_cake | 8.7845 | 1.378 | — |
+| `hv16h16_b64_t2` | tirx | 25.1064 | flashinfer_cake | 30.2963 | 1.207 | — |
+| `hv32h16_b128_t2` | tirx | 81.6001 | flashinfer_cake | 95.2481 | 1.167 | — |
 
 ## flashkda_decode_t3_lower_bound
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv16h16_b16_t3` | tirx | 13.5810 | flashinfer_cake | 14.0161 | 1.032 | — |
-| `hv16h16_b1_t3` | tirx | 5.9240 | flashinfer_cake | 6.0771 | 1.026 | — |
-| `hv16h16_b2_t3` | tirx | 6.0873 | flashinfer_cake | 6.2932 | 1.034 | — |
-| `hv16h16_b4_t3` | tirx | 6.7617 | flashinfer_cake | 6.9744 | 1.031 | — |
-| `hv16h16_b8_t3` | tirx | 7.8870 | flashinfer_cake | 7.9694 | 1.010 | — |
+| `hv16h16_b16_t3` | tirx | 13.4194 | flashinfer_cake | 14.0665 | 1.048 | — |
+| `hv16h16_b1_t3` | tirx | 5.5565 | flashinfer_cake | 6.0026 | 1.080 | — |
+| `hv16h16_b4_t3` | tirx | 6.6822 | flashinfer_cake | 6.9711 | 1.043 | — |
 
 ## flashkda_decode_t4_precomputed
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_t4` | tirx | 32.1851 | flashinfer_cake | 33.9351 | 1.054 | — |
-| `hv12h12_b8_t4` | tirx | 8.8183 | flashinfer_cake | 10.4810 | 1.189 | — |
-| `hv16h16_b64_t4` | tirx | 40.8246 | flashinfer_cake | 42.5370 | 1.042 | — |
-| `hv16h16_b8_t4` | tirx | 9.1515 | flashinfer_cake | 10.8211 | 1.182 | — |
-| `hv32h16_b128_t4` | tirx | 136.0434 | flashinfer_cake | 138.2981 | 1.017 | — |
-| `hv32h16_b16_t4` | tirx | 22.3698 | flashinfer_cake | 24.6335 | 1.101 | — |
-| `hv32h16_b32_t4` | tirx | 40.4661 | flashinfer_cake | 41.8081 | 1.033 | — |
-| `hv32h16_b64_t4` | tirx | 71.7158 | flashinfer_cake | 73.7345 | 1.028 | — |
-| `hv32h16_b8_t4` | tirx | 12.7664 | flashinfer_cake | 14.7454 | 1.155 | — |
+| `hv12h12_b8_t4` | tirx | 8.7613 | flashinfer_cake | 11.0596 | 1.262 | — |
+| `hv16h16_b64_t4` | tirx | 39.3332 | flashinfer_cake | 42.0130 | 1.068 | — |
+| `hv32h16_b128_t4` | tirx | 132.0186 | flashinfer_cake | 137.9693 | 1.045 | — |
 
 ## flashkda_decode_t5_gram
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_s1` | tirx | 36.1510 | flashinfer_cake | 38.3283 | 1.060 | — |
-| `hv12h12_b8_s4` | tirx | 8.6697 | flashinfer_cake | 10.1894 | 1.175 | — |
-| `hv16h16_b2_s8` | tirx | 7.6744 | flashinfer_cake | 9.6093 | 1.252 | — |
-| `hv16h16_b5_s4` | tirx | 8.6012 | flashinfer_cake | 10.0656 | 1.170 | — |
-| `hv16h16_b64_s1` | tirx | 45.3557 | flashinfer_cake | 46.9329 | 1.035 | — |
-| `hv16h16_b8_s2` | tirx | 9.7195 | flashinfer_cake | 11.4582 | 1.179 | — |
-| `hv32h16_b128_s1` | tirx | 157.7329 | flashinfer_cake | 160.0614 | 1.015 | — |
-| `hv32h16_b16_s1` | tirx | 24.7991 | flashinfer_cake | 26.7087 | 1.077 | — |
-| `hv32h16_b1_s8` | tirx | 7.6115 | flashinfer_cake | 9.3285 | 1.226 | — |
-| `hv32h16_b2_s2` | tirx | 7.8626 | flashinfer_cake | 9.3504 | 1.189 | — |
-| `hv32h16_b32_s1` | tirx | 45.4139 | flashinfer_cake | 46.6065 | 1.026 | — |
-| `hv32h16_b3_s4` | tirx | 8.7830 | flashinfer_cake | 10.1928 | 1.161 | — |
-| `hv32h16_b64_s1` | tirx | 81.5038 | flashinfer_cake | 83.4040 | 1.023 | — |
-| `hv32h16_b8_s1` | tirx | 14.1634 | flashinfer_cake | 16.0528 | 1.133 | — |
+| `hv32h16_b128_s1` | tirx | 158.9776 | flashinfer_cake | 160.0385 | 1.007 | — |
+| `hv32h16_b1_s8` | tirx | 7.0295 | flashinfer_cake | 9.3121 | 1.325 | — |
+| `hv32h16_b3_s4` | tirx | 8.5994 | flashinfer_cake | 10.2351 | 1.190 | — |
 
 ## flashkda_decode_t6_gram
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12h12_b64_s1` | tirx | 40.5521 | flashinfer_cake | 42.6733 | 1.052 | — |
-| `hv12h12_b8_s4` | tirx | 14.6156 | flashinfer_cake | 16.3846 | 1.121 | — |
-| `hv16h16_b2_s8` | tirx | 7.2648 | flashinfer_cake | 8.8093 | 1.213 | — |
-| `hv16h16_b5_s4` | tirx | 14.0451 | flashinfer_cake | 15.5771 | 1.109 | — |
-| `hv16h16_b64_s1` | tirx | 50.3282 | flashinfer_cake | 53.0568 | 1.054 | — |
-| `hv16h16_b8_s2` | tirx | 10.6076 | flashinfer_cake | 12.1318 | 1.144 | — |
-| `hv32h16_b128_s1` | tirx | 176.9601 | flashinfer_cake | 179.9378 | 1.017 | — |
-| `hv32h16_b16_s1` | tirx | 27.7680 | flashinfer_cake | 29.5093 | 1.063 | — |
-| `hv32h16_b1_s8` | tirx | 7.4356 | flashinfer_cake | 9.3149 | 1.253 | — |
-| `hv32h16_b2_s2` | tirx | 8.6672 | flashinfer_cake | 9.6263 | 1.111 | — |
-| `hv32h16_b32_s1` | tirx | 48.9775 | flashinfer_cake | 52.2079 | 1.066 | — |
-| `hv32h16_b3_s4` | tirx | 14.5367 | flashinfer_cake | 16.3726 | 1.126 | — |
-| `hv32h16_b64_s1` | tirx | 91.6520 | flashinfer_cake | 92.8344 | 1.013 | — |
-| `hv32h16_b8_s1` | tirx | 15.2837 | flashinfer_cake | 17.0185 | 1.114 | — |
+| `hv32h16_b128_s1` | tirx | 181.6806 | flashinfer_cake | 195.8678 | 1.078 | — |
+| `hv32h16_b1_s8` | tirx | 7.2978 | flashinfer_cake | 8.7352 | 1.197 | — |
+| `hv32h16_b3_s4` | tirx | 14.0607 | flashinfer_cake | 16.2512 | 1.156 | — |
 
 ## fp16_bf16_gemm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_1024x1024x1024` | tir | 6.8719 | torch-cublas | 5.9959 | 0.873 | deepgemm-bf16=6.8735, deepgemm-cublaslt=6.0038 |
-| `bf16_16384x16384x16384` | tir | 5423.8178 | torch-cublas | 5486.0778 | 1.011 | deepgemm-bf16=5934.2415, deepgemm-cublaslt=5488.1450 |
-| `bf16_2048x2048x2048` | tir | 27.4191 | torch-cublas | 26.4829 | 0.966 | deepgemm-bf16=29.1607, deepgemm-cublaslt=26.4901 |
-| `bf16_4096x4096x4096` | tir | 90.7458 | deepgemm-bf16 | 87.5186 | 0.964 | deepgemm-cublaslt=88.1432, torch-cublas=88.7432 |
-| `bf16_8192x8192x8192` | tir | 694.8820 | deepgemm-cublaslt | 708.0456 | 1.019 | deepgemm-bf16=732.9954, torch-cublas=712.9988 |
-| `fp16_1024x1024x1024` | tir | 10.3797 | torch-cublas | 8.7730 | 0.845 | — |
-| `fp16_16384x16384x16384` | tir | 5957.4736 | torch-cublas | 5888.4751 | 0.988 | — |
-| `fp16_2048x2048x2048` | tir | 16.4784 | torch-cublas | 15.8591 | 0.962 | — |
-| `fp16_4096x4096x4096` | tir | 148.5279 | torch-cublas | 140.2774 | 0.944 | — |
-| `fp16_8192x8192x8192` | tir | 738.8704 | torch-cublas | 762.3584 | 1.032 | — |
+| `bf16_4096x4096x4096` | tir | 92.4952 | deepgemm-bf16 | 89.9498 | 0.972 | deepgemm-cublaslt=90.7190, torch-cublas=90.3239 |
+| `fp16_1024x1024x1024` | tir | 6.6257 | torch-cublas | 5.8395 | 0.881 | — |
+| `fp16_16384x16384x16384` | tir | 5702.0394 | torch-cublas | 5612.5350 | 0.984 | — |
+
+## gdn_cp_prefill_sm100
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `fp16_q16_k16_v16_s4096+4096_init_f16_i64` | tirx | 117.7848 | flashinfer_cutedsl | 128.4645 | 1.091 | — |
+| `fp16_q16_k16_v64_s192+64_initfinal_f16_i64` | tirx | 82.5471 | flashinfer_cutedsl | 83.7373 | 1.014 | — |
+| `fp16_q1_k1_v1_s2048_none_i32` | tirx | 53.7819 | flashinfer_cutedsl | 67.5602 | 1.256 | — |
+
+## gdn_decode_bf16_ilp4
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `t1_b1_h2_hv4_tv16` | tirx | 3.0704 | flashinfer_cutedsl | 3.2716 | 1.066 | — |
+| `t4_b8_h4_hv8_tv16` | tirx | 6.6630 | flashinfer_cutedsl | 7.1216 | 1.069 | — |
+| `t8_b4_h8_hv16_tv16` | tirx | 10.3861 | flashinfer_cutedsl | 11.7190 | 1.128 | — |
+
+## gdn_decode_bf16_wide_vec_mtp
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `t2_b4_h16_hv32_tv32` | tirx | 6.3312 | flashinfer_cutedsl | 6.8442 | 1.081 | — |
+| `t4_b64_h8_hv16_tv128` | tirx | 33.8103 | flashinfer_cutedsl | 46.7374 | 1.382 | — |
+| `t8_b512_h16_hv32_tv128` | tirx | 1163.7200 | flashinfer_cutedsl | 1330.0720 | 1.143 | — |
+
+## gdn_decode_bf16_wide_vec_t1
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `b128_h8_hv16_tv128` | tirx | 24.8936 | flashinfer_cutedsl | 25.6358 | 1.030 | — |
+| `b16_h16_hv32_tv64` | tirx | 11.2524 | flashinfer_cutedsl | 20.2887 | 1.803 | — |
+| `b512_h4_hv8_tv128` | tirx | 46.1512 | flashinfer_cutedsl | 47.0845 | 1.020 | — |
+
+## gdn_decode_fp32_mtp_warp
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `t2_b4_h16_hv64_tv16_ilp2_sv0` | tirx | 14.3412 | flashinfer_cutedsl | 15.8320 | 1.104 | — |
+| `t8_b256_h16_hv64_tv64_ilp4_sv1` | tirx | 1773.3917 | flashinfer_cutedsl | 1778.8057 | 1.003 | — |
 
 ## gdn_prefill_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hq16_hv16_s4096+4096` | tirx | 127.3157 | flashinfer_cutedsl | 133.4357 | 1.048 | — |
-| `hq16_hv64_s1x8192` | tirx | 385.7228 | flashinfer_cutedsl | 402.0258 | 1.042 | — |
-| `hq2_hv8_s1x65536` | tirx | 1758.8466 | flashinfer_cutedsl | 1781.1827 | 1.013 | — |
-| `hq32_hv32_s8192x16` | tirx | 1558.5000 | flashinfer_cutedsl | 1622.4510 | 1.041 | — |
-| `hq8_hv32_s1024x8` | tirx | 92.2448 | flashinfer_cutedsl | 95.8803 | 1.039 | — |
+| `hq16_hv64_s1x8192` | tirx | 240.6253 | flashinfer_cutedsl | 250.7749 | 1.042 | — |
+| `hq32_hv32_s8192x16` | tirx | 1084.1739 | flashinfer_cutedsl | 1109.6317 | 1.023 | — |
+| `hq8_hv32_s1024x8` | tirx | 159.0958 | flashinfer_cutedsl | 187.6231 | 1.179 | — |
 
-## gemm_reduce_scatter
+## msa_sparse_atten_fwd_nvfp4_kv_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `tp1_m8192_n16384_k53248_fp16_dynamic` | tirx | 11267.0222 | cublas_nccl_cudagraph | 10951.6801 | 0.972 | cublasmp_split_p2p=12201.0029 |
-| `tp1_m8192_n4096_k12288_fp16_dynamic` | tirx | 1000.4833 | cublas_nccl_cudagraph | 943.5559 | 0.943 | cublasmp_split_p2p=1243.5105 |
-| `tp1_m8192_n5120_k25600_fp16_dynamic` | tirx | 1493.2130 | cublas_nccl_cudagraph | 1436.5057 | 0.962 | cublasmp_split_p2p=1840.6237 |
-| `tp1_m8192_n8192_k28672_fp16_dynamic` | tirx | 2402.0207 | cublas_nccl_cudagraph | 2383.3390 | 0.992 | cublasmp_split_p2p=2819.7509 |
+| `ring48k_bf16q_qh16_t16` | tirx | 1029.3983 | msa | 1387.7469 | 1.348 | — |
+
+## msa_sparse_atten_fwd_sm100
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `ring48k_bf16_qh16_t16` | tirx | 1361.0732 | msa | 1832.0996 | 1.346 | — |
+| `ring48k_fp8_qh16_t16` | tirx | 1334.7881 | msa | 1526.8879 | 1.144 | — |
 
 ## msa_sparse_prepare_flat_schedule_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `decode_b128_k65536_h4` | tirx | 8696.1643 | msa | 12215.6348 | 1.405 | — |
-| `decode_b32_k8192_h4` | tirx | 64.8933 | msa | 88.7769 | 1.368 | — |
-| `decode_b64_k16384_h4_varlen` | tirx | 313.4035 | msa | 433.9132 | 1.385 | — |
-| `edge_b1_k512_h1` | tirx | 3.4553 | msa | 4.0778 | 1.180 | — |
-| `prefill_b1_k131072_h1` | tirx | 5.0327 | msa | 5.4474 | 1.082 | — |
-| `prefill_b1_k32768_h2` | tirx | 4.4183 | msa | 4.7939 | 1.085 | — |
-| `prefill_b1_k8192_h2` | tirx | 3.9548 | msa | 4.2960 | 1.086 | — |
-| `prefill_b3_k8192_h2_varlen` | tirx | 5.1043 | msa | 5.9817 | 1.172 | — |
+| `decode_b128_k65536_h4` | tirx | 8694.0625 | msa | 12213.3396 | 1.405 | — |
+| `prefill_b1_k8192_h2` | tirx | 3.8856 | msa | 4.2417 | 1.092 | — |
 
 ## msa_sparse_prepare_fwd_split_atomic_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `decode_b128_k65536_h4` | tirx | 217.2807 | msa | 219.6823 | 1.011 | — |
-| `decode_b32_k8192_h4` | tirx | 15.1111 | msa | 15.4112 | 1.020 | — |
-| `decode_b64_k16384_h4_varlen` | tirx | 29.6478 | msa | 30.2542 | 1.020 | — |
-| `edge_b1_k512_h1` | tirx | 4.3427 | msa | 4.3987 | 1.013 | — |
-| `prefill_b1_k131072_h1` | tirx | 33.2527 | msa | 33.4343 | 1.005 | — |
-| `prefill_b1_k32768_h2` | tirx | 16.5568 | msa | 16.8409 | 1.017 | — |
-| `prefill_b1_k8192_h2` | tirx | 7.1463 | msa | 7.3067 | 1.022 | — |
-| `prefill_b3_k8192_h2_varlen` | tirx | 10.7839 | msa | 10.9987 | 1.020 | — |
+| `decode_b128_k65536_h4` | tirx | 216.8929 | msa | 219.2295 | 1.011 | — |
+| `prefill_b1_k131072_h1` | tirx | 33.1634 | msa | 33.3473 | 1.006 | — |
+| `prefill_b1_k8192_h2` | tirx | 7.1920 | msa | 7.3364 | 1.020 | — |
 
 ## mxfp4_quantize
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_128x4_m4096_k4096` | tirx | 10.7420 | flashinfer | 10.7219 | 0.998 | — |
-| `bf16_linear_m4096_k4096` | tirx | 10.3308 | flashinfer | 10.6924 | 1.035 | — |
-| `fp16_128x4_m1024_k2048` | tirx | 3.7288 | flashinfer | 3.7532 | 1.007 | — |
-| `fp16_128x4_m128_k1024` | tirx | 2.8414 | flashinfer | 2.8668 | 1.009 | — |
-| `fp16_128x4_m16384_k7168` | tirx | 66.8505 | flashinfer | 68.2974 | 1.022 | — |
-| `fp16_128x4_m4096_k4096` | tirx | 10.7370 | flashinfer | 10.6849 | 0.995 | — |
-| `fp16_linear_m1024_k2048` | tirx | 3.5864 | flashinfer | 3.6517 | 1.018 | — |
-| `fp16_linear_m128_k1024` | tirx | 2.3680 | flashinfer | 2.4079 | 1.017 | — |
-| `fp16_linear_m16384_k7168` | tirx | 50.5177 | flashinfer | 50.6019 | 1.002 | — |
-| `fp16_linear_m4096_k4096` | tirx | 13.9417 | flashinfer | 14.0012 | 1.004 | — |
+| `fp16_128x4_m128_k1024` | tirx | 2.4907 | flashinfer | 2.5397 | 1.020 | — |
+| `fp16_128x4_m16384_k7168` | tirx | 52.5001 | flashinfer | 52.8837 | 1.007 | — |
+| `fp16_linear_m4096_k4096` | tirx | 10.2822 | flashinfer | 10.6286 | 1.034 | — |
 
 ## mxfp8_quantize
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_128x4_m4096_k4096` | tirx | 11.7643 | flashinfer | 11.8278 | 1.005 | — |
-| `bf16_linear_m4096_k4096` | tirx | 11.2872 | flashinfer | 11.1933 | 0.992 | — |
-| `fp16_128x4_m1024_k2048` | tirx | 3.8630 | flashinfer | 3.9447 | 1.021 | — |
-| `fp16_128x4_m128_k1024` | tirx | 3.6176 | flashinfer | 3.7711 | 1.042 | — |
-| `fp16_128x4_m16384_k7168` | tirx | 71.5604 | flashinfer | 76.6297 | 1.071 | — |
-| `fp16_128x4_m4096_k4096` | tirx | 11.7617 | flashinfer | 11.8319 | 1.006 | — |
-| `fp16_linear_m1024_k2048` | tirx | 3.7724 | flashinfer | 3.8231 | 1.013 | — |
-| `fp16_linear_m128_k1024` | tirx | 2.6200 | flashinfer | 2.6025 | 0.993 | — |
-| `fp16_linear_m16384_k7168` | tirx | 62.3071 | flashinfer | 63.2526 | 1.015 | — |
-| `fp16_linear_m4096_k4096` | tirx | 13.8346 | flashinfer | 13.5341 | 0.978 | — |
+| `fp16_128x4_m128_k1024` | tirx | 2.6790 | flashinfer | 2.7309 | 1.019 | — |
+| `fp16_128x4_m16384_k7168` | tirx | 60.6338 | flashinfer | 60.5192 | 0.998 | — |
+| `fp16_linear_m4096_k4096` | tirx | 11.3160 | flashinfer | 11.2650 | 0.995 | — |
 
 ## nvfp4_gemm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `1024x1024x1024` | tir | 5.4514 | cublaslt_nvfp4 | 4.5272 | 0.830 | flashinfer=4.5366 |
-| `16384x16384x16384` | tir | 1516.7496 | cublaslt_nvfp4 | 1431.0615 | 0.944 | flashinfer=1445.1355 |
-| `2048x2048x2048` | tir | 8.8312 | flashinfer | 7.7123 | 0.873 | cublaslt_nvfp4=8.5846 |
-| `4096x4096x4096` | tir | 29.8666 | cublaslt_nvfp4 | 27.7979 | 0.931 | flashinfer=28.9586 |
-| `8192x8192x8192` | tir | 253.0963 | cublaslt_nvfp4 | 238.7013 | 0.943 | flashinfer=240.3198 |
+| `1024x1024x1024` | tir | 5.2106 | cublaslt_nvfp4 | 4.3806 | 0.841 | flashinfer=4.4708 |
+| `16384x16384x16384` | tir | 1528.9627 | flashinfer | 1443.7832 | 0.944 | cublaslt_nvfp4=1445.3852 |
+| `4096x4096x4096` | tir | 29.3046 | cublaslt_nvfp4 | 27.3885 | 0.935 | flashinfer=28.5923 |
 
 ## nvfp4_quantize
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_128x4_m4096_k3584_silu` | tirx | 20.6098 | flashinfer | 22.3594 | 1.085 | — |
-| `bf16_128x4_m4096_k4096` | tirx | 10.7824 | flashinfer | 11.1453 | 1.034 | — |
-| `bf16_linear_m4096_k4096` | tirx | 10.0129 | flashinfer | 10.2862 | 1.027 | — |
-| `fp16_128x4_m1024_k2048` | tirx | 3.6911 | flashinfer | 3.6802 | 0.997 | — |
-| `fp16_128x4_m128_k1024` | tirx | 3.4540 | flashinfer | 3.4875 | 1.010 | — |
-| `fp16_128x4_m16384_k7168` | tirx | 54.6462 | flashinfer | 55.1040 | 1.008 | — |
-| `fp16_128x4_m4096_k3584_silu` | tirx | 20.3774 | flashinfer | 21.8474 | 1.072 | — |
-| `fp16_128x4_m4096_k4096` | tirx | 11.0861 | flashinfer | 10.8557 | 0.979 | — |
-| `fp16_linear_m1024_k2048` | tirx | 3.6253 | flashinfer | 3.5903 | 0.990 | — |
-| `fp16_linear_m128_k1024` | tirx | 2.4949 | flashinfer | 2.4904 | 0.998 | — |
-| `fp16_linear_m16384_k7168` | tirx | 50.5884 | flashinfer | 51.1227 | 1.011 | — |
-| `fp16_linear_m4096_k4096` | tirx | 10.3428 | flashinfer | 10.4800 | 1.013 | — |
+| `fp16_128x4_m128_k1024` | tirx | 2.4972 | flashinfer | 2.5140 | 1.007 | — |
+| `fp16_128x4_m16384_k7168` | tirx | 55.2725 | flashinfer | 54.8886 | 0.993 | — |
+| `fp16_linear_m4096_k4096` | tirx | 10.2527 | flashinfer | 10.3761 | 1.012 | — |
 
 ## nvfp4_quantize_per_token
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_128x4_m4096_k4096` | tirx | 12.7112 | flashinfer | 13.7694 | 1.083 | — |
-| `bf16_linear_m4096_k4096` | tirx | 12.1999 | flashinfer | 13.2294 | 1.084 | — |
-| `fp16_128x4_m1024_k2048` | tirx | 3.9813 | flashinfer | 4.1212 | 1.035 | — |
-| `fp16_128x4_m128_k1024` | tirx | 2.8930 | flashinfer | 3.0564 | 1.056 | — |
-| `fp16_128x4_m16384_k7168` | tirx | 57.8227 | flashinfer | 59.3197 | 1.026 | — |
-| `fp16_128x4_m4096_k4096` | tirx | 12.6939 | flashinfer | 13.5944 | 1.071 | — |
-| `fp16_linear_m1024_k2048` | tirx | 3.8549 | flashinfer | 3.9801 | 1.032 | — |
-| `fp16_linear_m128_k1024` | tirx | 2.9066 | flashinfer | 3.0670 | 1.055 | — |
-| `fp16_linear_m16384_k7168` | tirx | 55.8258 | flashinfer | 57.4695 | 1.029 | — |
-| `fp16_linear_m4096_k4096` | tirx | 17.3447 | flashinfer | 19.5163 | 1.125 | — |
+| `fp16_128x4_m128_k1024` | tirx | 2.6892 | flashinfer | 2.8470 | 1.059 | — |
+| `fp16_128x4_m16384_k7168` | tirx | 57.7658 | flashinfer | 59.1917 | 1.025 | — |
+| `fp16_linear_m4096_k4096` | tirx | 12.1103 | flashinfer | 12.9942 | 1.073 | — |
 
 ## radix_topk_multi_cta
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `f32_basic_r2_l524288_k256_large` | tirx | 41.3643 | flashinfer | 42.8836 | 1.037 | — |
-| `f32_basic_r4_l115188_k256_ctas3` | tirx | 34.6564 | flashinfer | 35.5113 | 1.025 | — |
-| `f32_basic_r4_l57596_k256_vec4` | tirx | 29.8717 | flashinfer | 31.9794 | 1.071 | — |
+| `f32_basic_r2_l524288_k256_large` | tirx | 40.0140 | flashinfer | 42.4567 | 1.061 | — |
+| `f32_basic_r4_l115188_k256_ctas3` | tirx | 35.3704 | flashinfer | 35.9263 | 1.016 | — |
+| `f32_basic_r4_l57596_k256_vec4` | tirx | 30.1728 | flashinfer | 31.8387 | 1.055 | — |
 
 ## radix_topk_single_cta
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `f32_basic_r256_l57592_k1024_maxchunk` | tirx | 80.3449 | flashinfer | 80.6849 | 1.004 | — |
-| `f32_basic_r64_l32768_k512` | tirx | 22.8811 | flashinfer | 25.4869 | 1.114 | — |
-| `f32_basic_r8_l8192_k256` | tirx | 11.1072 | flashinfer | 12.5152 | 1.127 | — |
+| `f32_basic_r256_l57592_k1024_maxchunk` | tirx | 80.2137 | flashinfer | 80.4478 | 1.003 | — |
+| `f32_basic_r64_l32768_k512` | tirx | 23.1822 | flashinfer | 25.7455 | 1.111 | — |
+| `f32_basic_r8_l8192_k256` | tirx | 11.1426 | flashinfer | 12.5080 | 1.123 | — |
 
 ## recurrent_kda_decode_grouped
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `dec_hv12_b4` | tirx | 3.6504 | flashinfer_cutedsl | 3.9219 | 1.074 | — |
-| `dec_hv12_b8` | tirx | 4.2584 | flashinfer_cutedsl | 4.6137 | 1.083 | — |
-| `dec_hv16_b1` | tirx | 3.2388 | flashinfer_cutedsl | 3.5628 | 1.100 | — |
-| `dec_hv16_b4` | tirx | 3.7759 | flashinfer_cutedsl | 4.0781 | 1.080 | — |
-| `ver_t2_hv16_b8` | tirx | 6.8376 | flashinfer_cutedsl | 7.3421 | 1.074 | — |
-| `ver_t4_hv16_b32` | tirx | 24.7130 | flashinfer_cutedsl | 33.8884 | 1.371 | — |
-| `ver_t8_hv12_b16` | tirx | 22.0309 | flashinfer_cutedsl | 31.3530 | 1.423 | — |
-| `ver_t8_hv12_b64` | tirx | 65.9184 | flashinfer_cutedsl | 92.4159 | 1.402 | — |
-| `ver_t8_hv16_b1` | tirx | 9.0308 | flashinfer_cutedsl | 14.8158 | 1.641 | — |
-| `ver_t8_hv16_b128` | tirx | 161.9329 | flashinfer_cutedsl | 219.3316 | 1.354 | — |
-| `ver_t8_hv16_b16` | tirx | 26.0173 | flashinfer_cutedsl | 34.9513 | 1.343 | — |
-| `ver_t8_hv16_b32` | tirx | 44.5975 | flashinfer_cutedsl | 63.6727 | 1.428 | — |
-| `ver_t8_hv16_b4` | tirx | 10.2479 | flashinfer_cutedsl | 16.9288 | 1.652 | — |
-| `ver_t8_hv16_b64` | tirx | 83.1184 | flashinfer_cutedsl | 112.7169 | 1.356 | — |
+| `dec_hv16_b1` | tirx | 3.3088 | flashinfer_cutedsl | 3.5166 | 1.063 | — |
+| `ver_t8_hv12_b16` | tirx | 22.1145 | flashinfer_cutedsl | 31.1857 | 1.410 | — |
+| `ver_t8_hv16_b128` | tirx | 161.2211 | flashinfer_cutedsl | 222.8499 | 1.382 | — |
 
 ## recurrent_kda_decode_one_warp
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `hv12_b16_tr16_lb` | tirx | 5.6951 | flashinfer_cutedsl | 5.9730 | 1.049 | — |
-| `hv12_b64_tr16_lb` | tirx | 12.8366 | flashinfer_cutedsl | 13.8690 | 1.080 | — |
-| `hv16_b128_tr16_lb` | tirx | 26.6851 | flashinfer_cutedsl | 29.1858 | 1.094 | — |
-| `hv16_b16_tr16_lb` | tirx | 6.3473 | flashinfer_cutedsl | 6.4838 | 1.022 | — |
-| `hv16_b32_tr16_lb` | tirx | 9.6974 | flashinfer_cutedsl | 10.2393 | 1.056 | — |
-| `hv16_b64_tr16_lb` | tirx | 15.2689 | flashinfer_cutedsl | 16.9040 | 1.107 | — |
-| `hv16_b8_tr8_lb` | tirx | 5.2472 | flashinfer_cutedsl | 5.3377 | 1.017 | — |
+| `hv12_b64_tr16_lb` | tirx | 12.6430 | flashinfer_cutedsl | 13.8379 | 1.095 | — |
+| `hv16_b128_tr16_lb` | tirx | 26.6607 | flashinfer_cutedsl | 29.8146 | 1.118 | — |
+| `hv16_b8_tr8_lb` | tirx | 5.2474 | flashinfer_cutedsl | 5.4464 | 1.038 | — |
+
+## rmsnorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `hs128_bs32` | tir | 2.3129 | flashinfer | 2.0438 | 0.884 | — |
+| `hs4096_bs128` | tir | 3.5200 | flashinfer | 3.4994 | 0.994 | — |
+| `hs8192_bs4113` | tir | 71.7585 | flashinfer | 23.9442 | 0.334 | — |
 
 ## selective_state_update_mtp_horizontal
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 7.0351 | flashinfer_cuda | 7.5239 | 1.069 | — |
-| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 1388.3803 | flashinfer_cuda | 1509.4559 | 1.087 | — |
-| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 352.2852 | flashinfer_cuda | 382.5711 | 1.086 | — |
-| `b64_h64_d64_s128_t6_r8_statebf16_official` | tirx | 82.9846 | flashinfer_cuda | 89.3754 | 1.077 | — |
+| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 6.9503 | flashinfer_cuda | 7.4360 | 1.070 | — |
+| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 1658.4259 | flashinfer_cuda | 1814.7010 | 1.094 | — |
+| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 347.0377 | flashinfer_cuda | 382.4105 | 1.102 | — |
 
 ## selective_state_update_mtp_simple
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 6.5280 | flashinfer_cuda | 7.8631 | 1.205 | — |
-| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 1520.4572 | flashinfer_cuda | 1584.4758 | 1.042 | — |
-| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 384.8073 | flashinfer_cuda | 400.9095 | 1.042 | — |
-| `b64_h64_d64_s128_t6_r8_statebf16_official` | tirx | 89.6541 | flashinfer_cuda | 93.7083 | 1.045 | — |
+| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 4.3164 | flashinfer_cuda | 5.1695 | 1.198 | — |
+| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 1494.9751 | flashinfer_cuda | 1584.5818 | 1.060 | — |
+| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 378.0140 | flashinfer_cuda | 400.7631 | 1.060 | — |
 
 ## selective_state_update_mtp_vertical
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 28.4328 | flashinfer_cuda | 29.8231 | 1.049 | — |
-| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 2826.8122 | flashinfer_cuda | 2905.6069 | 1.028 | — |
-| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 1208.4806 | flashinfer_cuda | 1242.4536 | 1.028 | — |
-| `b64_h64_d64_s128_t6_r8_statebf16_official` | tirx | 98.6174 | flashinfer_cuda | 101.2316 | 1.027 | — |
+| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 17.2645 | flashinfer_cuda | 18.1947 | 1.054 | — |
+| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 2689.2282 | flashinfer_cuda | 2903.4872 | 1.080 | — |
 
 ## selective_state_update_stp_horizontal
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b64_h64_d128_s128_r8` | tirx | 48.8682 | flashinfer_cuda | 49.7236 | 1.018 | — |
-| `b64_h64_d64_s128_r64` | tirx | 40.5516 | flashinfer_cuda | 42.5661 | 1.050 | — |
-| `b64_h64_d64_s128_r8_base` | tirx | 41.8943 | flashinfer_cuda | 43.2139 | 1.031 | — |
-| `b64_h64_d64_s256_r8` | tirx | 67.7627 | flashinfer_cuda | 68.3421 | 1.009 | — |
+| `b64_h64_d128_s128_r8` | tirx | 47.8065 | flashinfer_cuda | 49.7971 | 1.042 | — |
+| `b64_h64_d64_s128_r8_base` | tirx | 26.5000 | flashinfer_cuda | 30.0204 | 1.133 | — |
+| `b64_h64_d64_s256_r8` | tirx | 47.4491 | flashinfer_cuda | 47.3090 | 0.997 | — |
 
 ## selective_state_update_stp_simple
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b64_h64_d128_s128_r8` | tirx | 65.4906 | flashinfer_cuda | 67.4403 | 1.030 | — |
-| `b64_h64_d64_s128_r64` | tirx | 54.2322 | flashinfer_cuda | 58.5379 | 1.079 | — |
-| `b64_h64_d64_s128_r8_base` | tirx | 37.4572 | flashinfer_cuda | 38.1160 | 1.018 | — |
-| `b64_h64_d64_s256_r8` | tirx | 74.9952 | flashinfer_cuda | 83.5618 | 1.114 | — |
+| `b64_h64_d128_s128_r8` | tirx | 65.2790 | flashinfer_cuda | 67.5019 | 1.034 | — |
+| `b64_h64_d64_s128_r8_base` | tirx | 37.3374 | flashinfer_cuda | 38.1243 | 1.021 | — |
+| `b64_h64_d64_s256_r8` | tirx | 54.0660 | flashinfer_cuda | 61.2385 | 1.133 | — |
 
 ## selective_state_update_stp_vertical
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b64_h64_d128_s128_r8` | tirx | 47.5355 | flashinfer_cuda | 54.3434 | 1.143 | — |
-| `b64_h64_d64_s128_r64` | tirx | 27.5996 | flashinfer_cuda | 31.3183 | 1.135 | — |
-| `b64_h64_d64_s128_r8_base` | tirx | 27.6318 | flashinfer_cuda | 31.3378 | 1.134 | — |
-| `b64_h64_d64_s256_r8` | tirx | 67.9484 | flashinfer_cuda | 79.1539 | 1.165 | — |
+| `b64_h64_d128_s128_r8` | tirx | 47.3534 | flashinfer_cuda | 54.2497 | 1.146 | — |
+| `b64_h64_d64_s128_r8_base` | tirx | 27.0785 | flashinfer_cuda | 31.3608 | 1.158 | — |
+| `b64_h64_d64_s256_r8` | tirx | 46.2417 | flashinfer_cuda | 48.7500 | 1.054 | — |
 
 ## silu_and_mul_nvfp4_experts_quantize
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_b128_m2048_k2048` | tirx | 285.1640 | flashinfer | 319.4270 | 1.120 | — |
-| `bf16_b8_m512_k2048` | tirx | 13.5666 | flashinfer | 16.0305 | 1.182 | — |
-| `fp16_b128_m2048_k2048` | tirx | 421.6170 | flashinfer | 503.8167 | 1.195 | — |
-| `fp16_b4_m128_k4096` | tirx | 5.5833 | flashinfer | 5.7942 | 1.038 | — |
-| `fp16_b8_m16_k2048` | tirx | 4.8038 | flashinfer | 6.0456 | 1.259 | — |
-| `fp16_b8_m512_k2048` | tirx | 8.8492 | flashinfer | 10.2845 | 1.162 | — |
+| `bf16_b8_m512_k2048` | tirx | 9.0482 | flashinfer | 10.8425 | 1.198 | — |
+| `fp16_b128_m2048_k2048` | tirx | 273.8417 | flashinfer | 301.9139 | 1.103 | — |
+| `fp16_b8_m16_k2048` | tirx | 3.3409 | flashinfer | 4.1893 | 1.254 | — |
 
 ## sm100_fp8_fp4_mega_moe
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `t64_m64_h7168_i3072_e384_k6_g1` | tirx | 1298.4000 | deepgemm | 1288.0000 | 0.992 | — |
-| `t64_m64_h7168_i3072_e384_k6_g1_s1` | tirx | 1280.0000 | deepgemm | 1270.8000 | 0.993 | — |
-| `t8192_m8192_h7168_i3072_e384_k6_g1` | tirx | 3406.2000 | deepgemm | 3406.2000 | 1.000 | — |
-| `t8192_m8192_h7168_i3072_e384_k6_g1_s1` | tirx | 3842.8000 | deepgemm | 3845.4000 | 1.001 | — |
-| `t8192_m8192_h7168_i3072_e384_k6_g2_s1` | tirx | 3577.0000 | deepgemm | 3557.2000 | 0.994 | — |
-| `t8192_m8192_h7168_i3072_e384_k6_g4_s1` | tirx | 3132.4000 | deepgemm | 3116.0000 | 0.995 | — |
-| `t8192_m8192_h7168_i3072_e384_k6_g6_s1` | tirx | 3096.6000 | deepgemm | 3075.2000 | 0.993 | — |
+| `t64_m64_h7168_i3072_e384_k6_g1` | tirx | 1326.6000 | deepgemm | 1308.0000 | 0.986 | — |
+| `t8192_m8192_h7168_i3072_e384_k6_g1` | tirx | 3359.2000 | deepgemm | 3363.4000 | 1.001 | — |
+| `t8192_m8192_h7168_i3072_e384_k6_g1_s1` | tirx | 3742.4000 | deepgemm | 3746.0000 | 1.001 | — |
 
 ## sparse_flashmla_decode_head64
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `deepseek_v4_v32_b128_sq2_sk32768_topk2048_p64` | tirx | 136.8763 | flashmla | 144.2464 | 1.054 | — |
-| `model1_b148_sq2_sk16384_topk128_p256_xsk16384_xtopk1024_xp2_xtopklen` | tirx | 74.9601 | flashmla | 78.1596 | 1.043 | — |
-| `model1_b256_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64` | tirx | 153.6155 | flashmla | 163.3648 | 1.063 | — |
-| `model1_b2_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64` | tirx | 28.5783 | flashmla | 34.1026 | 1.193 | — |
-| `v32_b148_sq2_sk32768_topk16384_p64` | tirx | 910.6713 | flashmla | 953.2395 | 1.047 | — |
+| `deepseek_v4_v32_b128_sq2_sk32768_topk2048_p64` | tirx | 136.7393 | flashmla | 144.7348 | 1.058 | — |
+| `model1_b2_sq2_sk16384_topk128_p256_xsk16384_xtopk512_xp64` | tirx | 16.7063 | flashmla | 21.1248 | 1.264 | — |
+| `v32_b148_sq2_sk32768_topk16384_p64` | tirx | 1526.2413 | flashmla | 1817.5149 | 1.191 | — |
 
 ## sparse_flashmla_prefill_head128_phase1
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bench_regular_dqk512_hq128_s4096_kv32768_topk2048` | tirx | 1728.4820 | flashmla | 1761.2495 | 1.019 | — |
-| `bench_regular_dqk512_hq128_s4096_kv65536_topk2048` | tirx | 2489.6685 | flashmla | 2492.2068 | 1.001 | — |
-| `bench_regular_dqk512_hq128_s4096_kv8192_topk2048` | tirx | 1729.9883 | flashmla | 1768.0810 | 1.022 | — |
-| `bench_regular_dqk576_hq128_s4096_kv32768_topk2048` | tirx | 1859.8779 | flashmla | 1867.4771 | 1.004 | trtllm_gen=2090.3868 |
-| `bench_regular_dqk576_hq128_s4096_kv65536_topk2048` | tirx | 1990.8174 | flashmla | 1991.3282 | 1.000 | trtllm_gen=2192.8898 |
-| `bench_regular_dqk576_hq128_s4096_kv8192_topk2048` | tirx | 2421.3491 | flashmla | 2408.3092 | 0.995 | trtllm_gen=2839.9839 |
+| `bench_regular_dqk512_hq128_s4096_kv65536_topk2048` | tirx | 1813.1113 | flashmla | 1871.2985 | 1.032 | — |
+| `bench_regular_dqk512_hq128_s4096_kv8192_topk2048` | tirx | 1676.5177 | flashmla | 1732.7519 | 1.034 | — |
+| `bench_regular_dqk576_hq128_s4096_kv32768_topk2048` | tirx | 1775.0254 | flashmla | 1816.8810 | 1.024 | trtllm_gen=2033.6984 |
 
 ## sparse_flashmla_prefill_head128_small_topk_phase1
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bench_smalltopk_dqk512_hq128_s4096_kv32768_topk1280` | tirx | 1152.0658 | flashmla | 1171.3121 | 1.017 | — |
-| `bench_smalltopk_dqk512_hq128_s4096_kv65536_topk1280` | tirx | 1668.5951 | flashmla | 1677.7430 | 1.005 | — |
-| `bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280` | tirx | 1149.5010 | flashmla | 1161.5816 | 1.011 | — |
+| `bench_smalltopk_dqk512_hq128_s4096_kv32768_topk1280` | tirx | 1126.8128 | flashmla | 1152.5680 | 1.023 | — |
+| `bench_smalltopk_dqk512_hq128_s4096_kv65536_topk1280` | tirx | 1196.7294 | flashmla | 1216.7862 | 1.017 | — |
+| `bench_smalltopk_dqk512_hq128_s4096_kv8192_topk1280` | tirx | 1191.6612 | flashmla | 1205.0408 | 1.011 | — |
 
 ## sparse_flashmla_prefill_head64_phase1
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bench_dqk512_hq64_s4096_kv32768_topk512` | tirx | 370.0398 | flashmla | 378.4910 | 1.023 | — |
-| `bench_dqk512_hq64_s4096_kv49152_topk512` | tirx | 377.4105 | flashmla | 383.6426 | 1.017 | — |
-| `bench_dqk512_hq64_s4096_kv65536_topk512` | tirx | 582.4460 | flashmla | 595.1229 | 1.022 | — |
-| `bench_dqk512_hq64_s4096_kv8192_topk512` | tirx | 572.5333 | flashmla | 585.4490 | 1.023 | — |
-| `bench_dqk576_hq64_s4096_kv32768_topk512` | tirx | 388.0184 | flashmla | 401.0920 | 1.034 | trtllm_gen=464.0309 |
-| `bench_dqk576_hq64_s4096_kv49152_topk512` | tirx | 584.6850 | flashmla | 605.9564 | 1.036 | trtllm_gen=719.6944 |
-| `bench_dqk576_hq64_s4096_kv65536_topk512` | tirx | 405.1609 | flashmla | 418.7721 | 1.034 | trtllm_gen=488.0644 |
-| `bench_dqk576_hq64_s4096_kv8192_topk512` | tirx | 372.2002 | flashmla | 381.5993 | 1.025 | trtllm_gen=447.2225 |
-
-## stable_sort_topk_by_value
-
-| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
-|---|---|---:|---|---:|---:|---|
-| `f32_r4_k128` | tirx | 5.2716 | flashinfer | 5.3166 | 1.009 | — |
-| `f32_r64_k2048` | tirx | 11.8269 | flashinfer | 11.9164 | 1.008 | — |
-| `f32_r64_k256` | tirx | 6.3832 | flashinfer | 6.8481 | 1.073 | — |
+| `bench_dqk512_hq64_s4096_kv65536_topk512` | tirx | 381.8447 | flashmla | 390.1592 | 1.022 | — |
+| `bench_dqk512_hq64_s4096_kv8192_topk512` | tirx | 366.5173 | flashmla | 372.7173 | 1.017 | — |
+| `bench_dqk576_hq64_s4096_kv32768_topk512` | tirx | 861.8450 | flashmla | 763.2616 | 0.886 | trtllm_gen=775.0955 |
 
 ## tinygemm2_sm100
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `b13_o1024_k2048` | tirx | 4.2666 | flashinfer_sm100 | 4.2510 | 0.996 | — |
-| `b16_o2880_k2880` | tirx | 7.9593 | flashinfer_sm100 | 8.0375 | 1.010 | — |
-| `b1_o128_k720` | tirx | 2.9497 | flashinfer_sm100 | 2.9316 | 0.994 | — |
-| `b2_o16_k256` | tirx | 2.7903 | flashinfer_sm100 | 2.8247 | 1.012 | — |
-| `b4_o2880_k2880` | tirx | 9.6865 | flashinfer_sm100 | 9.7997 | 1.012 | — |
-| `b64_o4096_k3072` | tirx | 35.2649 | flashinfer_sm100 | 35.4422 | 1.005 | — |
-| `b7_o128_k4096` | tirx | 4.9619 | flashinfer_sm100 | 4.9197 | 0.991 | — |
-| `b8_o1024_k1024` | tirx | 4.8111 | flashinfer_sm100 | 4.8135 | 1.001 | — |
+| `b16_o2880_k2880` | tirx | 7.9359 | flashinfer_sm100 | 8.0420 | 1.013 | — |
+| `b1_o128_k720` | tirx | 2.9564 | flashinfer_sm100 | 2.9851 | 1.010 | — |
+| `b64_o4096_k3072` | tirx | 21.9170 | flashinfer_sm100 | 22.0918 | 1.008 | — |
+
+## Failed (9)
+
+- `gdn_decode_fp32_mtp_warp/t4_b64_h8_hv32_tv64_ilp4_sv1`: prepared child exited None without a terminal message
+- `msa_sparse_atten_fwd_nvfp4_kv_sm100/ring48k_fp8q_qh16_t16`: baseline error(s): msa: DSLRuntimeError: 🧊🧊🧊 ICE 🧊🧊🧊
+- `msa_sparse_atten_fwd_nvfp4_kv_sm100/varlen_b3_s8192_bf16q_qh4_t16`: baseline error(s): msa: DSLRuntimeError: 🧊🧊🧊 ICE 🧊🧊🧊
+- `msa_sparse_atten_fwd_sm100/varlen_b3_s8192_qh4_t16`: baseline error(s): msa: DSLRuntimeError: 🧊🧊🧊 ICE 🧊🧊🧊
+- `msa_sparse_prepare_flat_schedule_sm100/decode_b64_k16384_h4_varlen`: baseline error(s): msa: partially initialized module 'torch._dynamo' has no attribute 'decorators' (most likely due to a circular import)
+- `selective_state_update_mtp_vertical/b512_h64_d64_s128_t6_r8_statebf16_official`: prepared child exited None without a terminal message
+- `stable_sort_topk_by_value/f32_r4_k128`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True
+- `stable_sort_topk_by_value/f32_r64_k2048`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True
+- `stable_sort_topk_by_value/f32_r64_k256`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -310,8 +310,9 @@ class GpuPool:
     orchestrator GPU stage owns a card at a time, including multi-GPU jobs.
 
     A card is ineligible when internally owned or when the background external
-    occupancy snapshot exceeds the utilization/memory gates. Startup probing
-    filters broken cards into `allowed` before the pool is created.
+    occupancy snapshot exceeds the utilization gate or the foreign-process
+    memory gate. Startup probing filters broken cards into `allowed` before the
+    pool is created.
     """
 
     def __init__(
@@ -331,6 +332,8 @@ class GpuPool:
         self._change_generation = 0
         self.util_threshold = util_threshold
         self.mem_threshold = mem_threshold
+        self._mem_total_mib: dict[str, float] | None = None
+        self._index_by_uuid: dict[str, str] | None = None
 
     @staticmethod
     def _nvidia_smi(args: list[str]) -> list[str]:
@@ -390,10 +393,60 @@ class GpuPool:
                     pass
         return out
 
+    def _foreign_mem_pct(self) -> dict[str, float]:
+        """Map GPU index -> foreign compute-app VRAM above the idle floor (percent).
+
+        Only processes outside this orchestrator's tree count toward the memory
+        gate. An interference-parked bench child keeps a residual CUDA context
+        on its affinity card until it reacquires it; counting that residency as
+        external occupancy would permanently starve the exact card the child is
+        waiting for.
+        """
+        if self._mem_total_mib is None:
+            totals: dict[str, float] = {}
+            for line in self._nvidia_smi(["--query-gpu=index,memory.total"]):
+                parts = [p.strip() for p in line.split(",")]
+                if len(parts) >= 2:
+                    try:
+                        totals[parts[0]] = float(parts[1])
+                    except ValueError:
+                        pass
+            if not totals:
+                return {}
+            self._mem_total_mib = totals
+        if self._index_by_uuid is None:
+            rows = self._all_gpus()
+            if not rows:
+                return {}
+            self._index_by_uuid = {uuid: index for index, uuid in rows}
+        foreign_mib = dict.fromkeys(self._mem_total_mib, 0.0)
+        ours = _our_pids()
+        for line in self._nvidia_smi(["--query-compute-apps=pid,gpu_uuid,used_memory"]):
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) < 3:
+                continue
+            try:
+                pid = int(parts[0])
+                used = float(parts[2])
+            except ValueError:
+                continue
+            index = self._index_by_uuid.get(parts[1])
+            if index is None or pid in ours:
+                continue
+            foreign_mib[index] = foreign_mib.get(index, 0.0) + used
+        return {
+            index: (
+                100.0 * max(0.0, foreign_mib.get(index, 0.0) - IDLE_GPU_MEMORY_FLOOR_MIB) / total
+                if total > 0
+                else 0.0
+            )
+            for index, total in self._mem_total_mib.items()
+        }
+
     def _occupied_indices(self) -> set[str]:
-        """GPU indices over the configured SM or memory threshold."""
+        """GPU indices over the configured SM or foreign-process memory threshold."""
         util_busy = {idx for idx, u in self._utils().items() if u > self.util_threshold}
-        mem_busy = {idx for idx, m in self._mem_used_pct().items() if m > self.mem_threshold}
+        mem_busy = {idx for idx, m in self._foreign_mem_pct().items() if m > self.mem_threshold}
         return util_busy | mem_busy
 
     def total_visible(self) -> int:
@@ -449,9 +502,10 @@ class GpuPool:
             if self._allowed is None:
                 self._known_indices = tuple(sorted((idx for idx, _uuid in rows), key=int))
             previous = self._external_occupied or set()
-            # Aggregate utilization/memory includes our RUNNING children. Keep
-            # each internally-owned card's pre-claim external state; the per-PID
-            # monitor below detects new foreign activity on owned cards.
+            # Aggregate utilization includes our RUNNING children (memory is
+            # already foreign-only per PID). Keep each internally-owned card's
+            # pre-claim external state; the per-PID monitor below detects new
+            # foreign activity on owned cards.
             occupied = {
                 idx
                 for idx in self._known_indices

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -75,7 +75,9 @@ GENERATED_WORKLOADS_NAME = "workloads.generated.yaml"
 MAX_DEFAULT_CONFIGS_PER_KERNEL = 3
 DEFAULT_SELECTION_ROLES = ("small", "medium", "large")
 # Single pinned baseline: every suite run benches our kernel directly. External
-# references remain an explicit diagnostic in ``python -m tirx_kernels.bench``.
+# references run only under the explicit ``--with-references`` diagnostic flag
+# (also available on ``python -m tirx_kernels.bench``) and feed the ratio
+# report; they never replace the direct before/after verdict.
 DEFAULT_BASELINE = SCRIPT_DIR / "baseline.json"
 DEFAULT_REGRESSION_THRESHOLD = 1.0
 POLL_INTERVAL = 5.0  # seconds between GPU re-checks when none is free
@@ -850,7 +852,7 @@ def _attempt_strangers(
 
 
 def _prepared_child_command(
-    workload: dict, *, control_fd: int, rounds: int, cooldown: float
+    workload: dict, *, control_fd: int, rounds: int, cooldown: float, with_references: bool
 ) -> list[str]:
     command = [
         sys.executable,
@@ -875,6 +877,8 @@ def _prepared_child_command(
         command += ["--repeat", str(workload["repeat"])]
     if workload.get("timer") is not None:
         command += ["--timer", workload["timer"]]
+    if with_references:
+        command.append("--with-references")
     return command
 
 
@@ -886,6 +890,7 @@ def _spawn_prepared_attempt(
     rounds: int,
     cooldown: float,
     compile_profile: dict,
+    with_references: bool,
 ) -> _PreparedAttempt:
     """Spawn a GPU-unbound child that immediately begins CPU prepare."""
     parent_control, child_control = socket.socketpair()
@@ -913,7 +918,11 @@ def _spawn_prepared_attempt(
     cache_dir.mkdir(parents=True, exist_ok=True)
     env["TIRX_BENCH_CACHE_DIR"] = str(cache_dir)
     command = _prepared_child_command(
-        workload, control_fd=child_control.fileno(), rounds=rounds, cooldown=cooldown
+        workload,
+        control_fd=child_control.fileno(),
+        rounds=rounds,
+        cooldown=cooldown,
+        with_references=with_references,
     )
     process_started = time.time()
     try:
@@ -1325,6 +1334,7 @@ def write_run(
     label: str | None,
     *,
     selection: dict,
+    references_enabled: bool,
     probe: dict | None = None,
     pipeline: dict | None = None,
 ) -> Path:
@@ -1333,9 +1343,10 @@ def write_run(
     payload = {
         "timestamp": stamp,
         "label": label,
+        "references_enabled": references_enabled,
         "git": collect_repo_git(),
         "kernel_tree": collect_kernel_fingerprint(),
-        "baselines": collect_baseline_provenance(),
+        "baselines": collect_baseline_provenance() if references_enabled else {},
         "selection": selection,
         "probe": probe or {},
         "pipeline": pipeline or {},
@@ -1512,7 +1523,9 @@ def load_baseline(path=None):
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 
-def _finalize_bench_record(row: dict, *, rounds: int, cooldown: float) -> None:
+def _finalize_bench_record(
+    row: dict, *, rounds: int, cooldown: float, references_enabled: bool
+) -> None:
     """Validate in-bench round samples and write aggregated impl times (microseconds)."""
     required_fields = ("round_samples", "errors", "timer", "benchmark_protocol")
     missing_fields = [field for field in required_fields if field not in row]
@@ -1568,6 +1581,15 @@ def _finalize_bench_record(row: dict, *, rounds: int, cooldown: float) -> None:
         row["status"] = "FAIL"
         row["error"] = "bench result field 'round_samples' must be a non-empty mapping"
         return
+    if not references_enabled:
+        external_impls = [name for name in samples if name not in our_impls(samples)]
+        if external_impls:
+            row["status"] = "FAIL"
+            row["error"] = (
+                "reference-disabled benchmark reported external implementation(s): "
+                f"{external_impls}"
+            )
+            return
     bad = {
         impl: len(vals) if isinstance(vals, list) else type(vals).__name__
         for impl, vals in samples.items()
@@ -1630,6 +1652,7 @@ def run_scheduled_jobs(
     rounds: int,
     cooldown: float,
     compile_profile: dict,
+    with_references: bool,
     max_prepare_processes: int | None = None,
     ready_backlog: int | None = None,
 ) -> tuple[list[dict], list[dict[str, Any]], dict]:
@@ -1742,6 +1765,7 @@ def run_scheduled_jobs(
                 rounds=rounds,
                 cooldown=cooldown,
                 compile_profile=compile_profile,
+                with_references=with_references,
             )
             active[item.control.fileno()] = item
             log(f"[bench-suite] {now_iso()} prepare pid={item.process.pid} START {item.label}")
@@ -1940,7 +1964,12 @@ def run_scheduled_jobs(
                         if status in ("SKIP", "FAIL"):
                             record.update(result)
                         else:
-                            _finalize_bench_record(result, rounds=rounds, cooldown=cooldown)
+                            _finalize_bench_record(
+                                result,
+                                rounds=rounds,
+                                cooldown=cooldown,
+                                references_enabled=with_references,
+                            )
                             record.update(result)
                         record.setdefault("label", item.workload["config"])
                         record["finished_at"] = now_iso()
@@ -2092,6 +2121,11 @@ def main() -> None:
     )
     ap.add_argument("--no-report", action="store_true", help="Skip regression report generation")
     ap.add_argument(
+        "--with-references",
+        action="store_true",
+        help="Run and benchmark external reference implementations (off by default)",
+    )
+    ap.add_argument(
         "--no-probe",
         action="store_true",
         help="Skip the per-GPU probe (use nvidia-smi free-status only)",
@@ -2216,6 +2250,13 @@ def main() -> None:
     if args.ab_before:
         if args.baseline is not None:
             print("[bench-suite] --baseline cannot be combined with --ab-before", file=sys.stderr)
+            sys.exit(2)
+        if args.with_references:
+            print(
+                "[bench-suite] --with-references cannot be combined with --ab-before; "
+                "the A/B verdict is direct before/after time on our implementation only",
+                file=sys.stderr,
+            )
             sys.exit(2)
         if args.max_prepare_processes is not None or args.ready_backlog is not None:
             print(
@@ -2360,6 +2401,7 @@ def main() -> None:
         rounds=args.rounds,
         cooldown=args.cooldown,
         compile_profile=compile_profile,
+        with_references=args.with_references,
         max_prepare_processes=args.max_prepare_processes,
         ready_backlog=args.ready_backlog,
     )
@@ -2382,6 +2424,7 @@ def main() -> None:
         results,
         label,
         selection=selection,
+        references_enabled=args.with_references,
         probe=probe_meta,
         pipeline=pipeline_meta,
     )
@@ -2409,6 +2452,13 @@ def main() -> None:
         sys.exit(1)
 
     if args.no_report:
+        return
+
+    if not args.with_references:
+        print(
+            "[bench-suite] references are disabled; skipping the reference-ratio "
+            "regression report (rerun with --with-references to compare ratios)"
+        )
         return
 
     # Single pinned baseline (baseline.json). Promote a fresh run over it via

--- a/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
+++ b/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
@@ -365,10 +365,12 @@ void stable_sort_ref(at::Tensor indices, at::Tensor values, int64_t num_rows, in
 
 
 def load_reference_ext():
-    """Build and load the shape-independent reference before READY.
+    """Build and load the shape-independent reference extension.
 
-    Runs in the CPU prepare stage, so it must not touch CUDA: the arch comes from
-    the prepare-stage env, never from the device.
+    JIT-compiling the extension initializes CUDA, so this must only run in the
+    GPU stage (the lazy `references` builder) or in `run_test`, never in the
+    CPU prepare stage. The arch still comes from the prepare-stage env rather
+    than the device so the build matches the suite's compile profile.
     """
     global _REFERENCE_EXT
     if _REFERENCE_EXT is not None:
@@ -617,18 +619,20 @@ def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
 # Benchmark entry points.
 # ---------------------------------------------------------------------------
 def prepare_bench(**kwargs: Any):
-    """Specialize, compile, and build the reference before the workload owns a GPU."""
-    from tirx_kernels.runner import (
-        compile_kernel,
-        external_references_enabled,
-        prepared_gpu_benchmark,
-    )
+    """Specialize and compile before the workload receives a GPU.
+
+    The reference is NOT built here. `load_reference_ext()` JITs a CUDA
+    extension, which initializes CUDA, and the suite fails any workload whose
+    CPU prepare does that ("CPU prepare changed CUDA initialization state from
+    False to True"). It is built by the lazy `references` builder in `run_gpu`
+    instead, which is what the bench API expects and what the sibling ports do.
+    """
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
 
     cfg = _normalize_config(kwargs)
-    state = {"config": cfg, "executable": compile_kernel(get_kernel(**cfg))}
-    if external_references_enabled():
-        state["reference_ext"] = load_reference_ext()
-    return prepared_gpu_benchmark(run_gpu, state)
+    return prepared_gpu_benchmark(
+        run_gpu, {"config": cfg, "executable": compile_kernel(get_kernel(**cfg))}
+    )
 
 
 def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
@@ -680,7 +684,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         ex(*tirx_args[step & 1])
 
     def build_reference():
-        ext = prepared["reference_ext"]
+        ext = load_reference_ext()
         flat = tuple(
             (buffers["indices"].reshape(-1), buffers["values"].reshape(-1)) for buffers in clones
         )

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib
 import os
 import shlex
+import signal
 import sys
 import threading
 from collections.abc import Callable, Mapping, Sequence
@@ -445,6 +446,49 @@ def validate_current_cuda_assignment(stage: str, *, restore: bool = False) -> tu
     return actual
 
 
+_GPU_INTERRUPT_DEFER_DEPTH = 0
+_GPU_INTERRUPT_DEFERRED = False
+
+
+def gpu_interrupt_should_defer() -> bool:
+    """Record a GPU-attempt interrupt when inside an uninterruptible region.
+
+    Called from the bench child's SIGUSR1 handler. Returns True when the
+    interrupt was recorded for redelivery at the region's exit; the handler
+    must then return instead of raising, so an in-flight import or JIT
+    completes atomically. Signal handlers run only in the main thread, so the
+    module-level flags need no locking.
+    """
+    global _GPU_INTERRUPT_DEFERRED
+    if _GPU_INTERRUPT_DEFER_DEPTH > 0:
+        _GPU_INTERRUPT_DEFERRED = True
+        return True
+    return False
+
+
+@contextmanager
+def defer_gpu_interrupts():
+    """Delay SIGUSR1 attempt interrupts until this region completes.
+
+    Reference builders import large packages (torch._dynamo, CuTeDSL's MLIR
+    toolkit) and JIT-compile extensions. An asynchronous interrupt landing
+    mid-import unwinds through the module body and leaves sys.modules holding
+    partially initialized modules, which kills the child or poisons every
+    later retry in the same process. Imports and host-side JIT do not occupy
+    the GPU, so delaying the discard of an already-doomed sample is harmless;
+    a deferred interrupt is redelivered at this safe point instead.
+    """
+    global _GPU_INTERRUPT_DEFER_DEPTH, _GPU_INTERRUPT_DEFERRED
+    _GPU_INTERRUPT_DEFER_DEPTH += 1
+    try:
+        yield
+    finally:
+        _GPU_INTERRUPT_DEFER_DEPTH -= 1
+        if _GPU_INTERRUPT_DEFER_DEPTH == 0 and _GPU_INTERRUPT_DEFERRED:
+            _GPU_INTERRUPT_DEFERRED = False
+            os.kill(os.getpid(), signal.SIGUSR1)
+
+
 def bench(*args: Any, references: Mapping[str, Any] | None = None, **kwargs: Any):
     """Run the canonical timer, admitting references only in explicit diagnostic mode."""
     from tvm.tirx.bench import bench as canonical_bench
@@ -459,7 +503,8 @@ def bench(*args: Any, references: Mapping[str, Any] | None = None, **kwargs: Any
 
             def checked_builder(builder=builder, name=name):
                 try:
-                    return builder()
+                    with defer_gpu_interrupts():
+                        return builder()
                 finally:
                     if _CUDA_ASSIGNMENT is not None:
                         validate_current_cuda_assignment(


### PR DESCRIPTION
## Summary

- **Restore the `--with-references` suite switch** (removed from `bench_suite/run.py` by d132501 while the flag survived on `tirx_kernels.bench`): forwarded to every prepared child, recorded as `references_enabled` in run JSON, reference-disabled rows reporting external impls fail hard, and the reference-ratio report is gated on the flag instead of failing every row of a references-off run.
- **Fix a deterministic deadlock in interference retries**: the occupancy gate sampled aggregate `memory.used`, so an interference-parked child's residual CUDA context (over the 512 MiB idle floor, zero threshold) marked its own affinity card externally occupied and starved the retry forever. The memory gate now sums per-PID compute-app memory excluding the orchestrator tree; regression tests in `tests/test_bench_suite_run.py`.
- **Fix reference-enabled prepare in `stable_sort_topk_by_value`**: the cpp_extension reference was built during CPU prepare, initializing CUDA and tripping the prepare guard on every reference-enabled run. It now builds in the lazy `references` builder in `run_gpu`, matching `fast_topk_clusters`.
- **Defer attempt interrupts across reference builders**: the interference SIGUSR1 raised at arbitrary bytecodes; landing inside a builder's import chain (torch._dynamo via sglang, CuTeDSL's MLIR toolkit) killed children or left partially initialized modules that poisoned retry-in-place. Builders now run in a critical section; a pending interrupt is redelivered at its exit. Unit tests in `tests/test_runner_interrupts.py`.
- **Promote run 4 (with references) as the pinned baseline**: 182 ok rows with full evidence + 9 recorded failures. Of those, the 3 `stable_sort_topk_by_value` rows and the 3 interference casualties are fixed/re-verified by the commits above; the remaining 3 `msa` configs are deterministic CuTeDSL ICEs to address separately.

## Testing

- `python -m pytest tests/test_bench_suite_run.py tests/test_runner_interrupts.py` (8 passed)
- `python -m tirx_kernels.bench_suite --check-imports`
- Full sweeps on 8x B200: references-off run exits clean with the skip notice; `--with-references` benches every declared reference (ratio column populated in `summary.md`); previously deadlocked workloads pass after the occupancy fix
- Targeted re-runs: the 3 `stable_sort_topk_by_value` configs pass with references; the 3 interference casualties pass, including one workload interrupted mid-run by a live foreign process and retried cleanly under the new defer path
- `pre-commit run` clean on all touched files