### PR TITLE
feat(kernel): add the MSA sparse attention forward combine

### DIFF
--- a/.agents/sketch/msa/sparse_atten_fwd_combine.md
+++ b/.agents/sketch/msa/sparse_atten_fwd_combine.md
@@ -1,0 +1,808 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of MSA's
+python/fmha_sm100/cute/src/sm100/fwd/combine.py
+SparseAttentionForwardCombine.
+-->
+
+# msa_sparse_atten_fwd_combine_sm100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, thread roles,
+control flow, and PTX-level operations of
+[`tirx_kernels/msa/sparse_atten_fwd_combine.py`](../../../tirx_kernels/msa/sparse_atten_fwd_combine.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **one kernel**: `SparseAttentionForwardCombine.kernel`
+(`combine.py:466-1125`) together with its pipeline-stage loader `load_O_partial`
+(`:1128-1161`) and the launcher `__call__` (`:243-455`) -- K2 of the sparse
+attention forward, which reduces the per-split partials K1 wrote and restores
+the real head-dim column order K1 permuted away.
+
+Instantiations: the host's compile key (`:1339-1355`) is
+`(D, k_block, tile_m, topk, partial_dtype, out_dtype, has_cu_seqlens,
+has_seqused, has_lse, return_temperature_lse, has_split_counts,
+has_output_scale, use_pdl, min_blocks_per_mp)`. Production pins most of it:
+`D=128` so `k_block_size=128`, `tile_m=64`, `stages=2`, `num_threads=256`
+(the constructor default at `:46`; the host never passes it)
+(`:1327-1337`, `:1365-1381`), out dtype bf16 (`interface.py:920, :1481`),
+varlen, `split_counts` present, `lse_out` present, `use_pdl=True`
+(`interface.py:972, :1532`). The axes that remain are **topk** (4, 8, 16 or 32 --
+`can_implement` demands `(tile_m*topk) % num_threads == 0`, `:106`), **partial
+dtype**, **temperature**, **output_scale**, and **seqused**. Only partial dtype
+changes device code structurally: it selects one of three STG.128 fake-column
+maps, the staging layout, and the copy width.
+
+Fixed specialization for this sketch: **fp32 partials, topk 16, no temperature,
+no output scale, no seqused**. Line info comes from
+`.porting/sparse_atten_fwd_combine/ptx_lineinfo/fp32p_t16/` (585 `.loc`; **1327
+instruction lines, 73 predicated, 1254 net** by the "instruction lines minus
+predicated lines" convention). The filter is: every semicolon-terminated line
+that is not a directive, comment or label, counting a leading `@%p` predicate as
+part of its instruction. A stricter filter that also requires the first token to
+match an opcode pattern reaches 1319/1246 on the same bytes; both numbers are
+recorded so a recount does not read the delta as an error. Six sibling exports
+under `ptx_lineinfo/` cover the other axes.
+
+Accepted target SM100/B200. Out of scope, with the predicate that excludes each:
+the batched 4-D mode and its `PackGQAComb.load_LSE` staging (`:563-616`), which
+`cu_seqlens is not None` excludes; the `use_pdl=False` scalar-scatter epilogue
+(`:967-985`), which `use_pdl=True` excludes; out dtypes fp16 and fp32, which the
+interface excludes by allocating bf16; `num_splits_dynamic_ptr` (rejected
+outright at `:527-529`), `varlen_batch_idx` and `semaphore_to_reset`, all three
+pinned `None` by the host (`:1465-1473, :1492-1494`), which also compiles out the
+semaphore-reset block at `:518-526`; and every `not is_even_k` predication path
+-- the `tOpO` k-mask at `:716-721`, `tOpO_store` at `:1099-1105`, and the
+`tOpO[k]` term at `:1154` -- which `head_dim % k_block_size == 0` excludes, so
+the export emits none of them. Tile (`Tx`) primitives are out of scope
+everywhere.
+
+## Pipeline at a glance
+
+There is **no warp specialization**: all 256 threads of a CTA run the same
+program. The roles below are the phases that program moves through, not
+different warps.
+
+| Phase / role | Program | Publication / reuse edges |
+| --- | --- | --- |
+| **prologue, all 256 threads** (`:497-548`) | decode `(m_block, k_block, batch)`; take the dynamic SMEM base; build `SeqlenInfo`; compute `max_idx = seqlen * num_head`; guard the whole body on `m_block * 64 < max_idx`; wait on K1 | `griddepcontrol.wait` is the only cross-kernel edge, and the export carries exactly one (`.loc 1 550`) |
+| **step 1, all 256 threads** (`:550-673`) | stage `LSE_partial` for 64 flat rows x `topk` splits into `sLSE`, filling `-inf` for a split at or past the row's count and for a row past `max_idx` | Publishes `sLSE`. One `cp.async.commit_group` closes the group. |
+| **step 2, all 256 threads** (`:675-740`) | precompute per-row `(m_idx, head_idx, split_count, raw GMEM element pointer)`; prime the partial pipeline `stages-1` deep | Publishes `sO[stage 0]`; one commit group per primed stage |
+| **step 3, all 256 threads** (`:741-765`) | `cp.async.wait_group 1`, `bar.sync`, then read `sLSE` back transposed over the split axis | Consumes `sLSE`; the barrier is what makes the staged tile visible |
+| **step 4, all 256 threads** (`:767-873`) | per row: max over splits, index of the last live split, `exp2` scales, sum, `final_lse`, normalized scales | **Overwrites `sLSE` in place with the normalized scales** (`:822`) and publishes `sMaxValidSplit` (`:872`). Both publications cross a partition boundary: they are written on the **s2r** row map (`tidx >> 2`) and read by step 6 on the **O-partial** row map (`(tidx >> 5) + 8m`), so `:907` is load-bearing twice over -- either one alone would require it. |
+| **step 5, `k_block == 0` only** (`:875-902`) | one thread per row stores `LSE_out` (and the temperature LSE) | Publishes to global memory. This is the authoritative public LSE. |
+| **step 6, all 256 threads** (`:904-953`) | `bar.sync`, read `sMaxValidSplit`, then walk live splits: issue the next stage, commit, wait, copy stage to registers, fp32 FMA into the accumulator | Consumes `sLSE` scales and `sO`. **No barrier inside the loop** (`:937`) -- but the reason is narrower than "each thread reads its own data": that holds for `sO`, which the thread's own `cp.async` wrote, and it is what the source's comment at `:937` is scoped to. The `sLSE` scale loads at `:926` do cross threads; they are safe because `:907` already published them, before the loop. |
+| **step 7, all 256 threads** (`:955-1125`) | 7a scatter the accumulator into `sO_perm` in real column order; `bar.sync`; 7b read `sO_perm` back with the store partitioning and issue 128-bit global stores | `sO_perm` occupies `[73984, 92416)` and `sO` `[8448, 73984)` -- disjoint, so 7a overwrites nothing the pipeline still owns; the `wait_group 0` at `:952` retires the in-flight prefetches rather than protecting against aliasing |
+
+**One CTA owns 64 flat `(q, head)` rows crossed with one 128-column k-block.**
+The grid flattens `(seqlen, num_head)` with the head axis innermost, so a CTA's
+64 rows are 64 consecutive `(q, head)` pairs, not 64 queries.
+
+## Primitive vocabulary
+
+```python
+# structural
+smem_pool.alloc(shape, dtype)            # dynamic shared allocation
+tile[stage]                              # stage view of the staging buffer
+identity(shape)                          # coordinate tile, for thread->element maps
+
+# directional copies
+cp_async_ca(smem, gmem, bytes)           # cp.async.ca.shared.global (LSE, 4 B)
+cp_async_cg(smem, gmem, bytes)           # cp.async.cg.shared.global (partials, 16 B)
+store_shared(smem, reg, width)           # st.shared.u32 | st.shared.f32 | st.shared.v4.f32
+load_shared(smem, width)  -> reg         # ld.shared.u32 | ld.shared.f32 | ld.shared.v4.{f32,b32}
+load_global(gmem)         -> reg         # ld.global.u32
+store_global(gmem, reg, width)           # st.global.f32 | st.global.v4.b32
+
+# compute
+exp2(x)                                  # ex2.approx.ftz.f32
+log2(x)                                  # lg2.approx.ftz.f32
+recip(x)                                 # rcp.rn.f32
+fma(a, b, c)                             # fma.rn.f32
+maxf(a, b)                               # max.f32
+max_nan(a, b)                            # max.NaN.f32  (propagates NaN)
+max_i32(a, b)                            # max.s32
+cvt_bf16x2(a, b)                         # cvt.rn.bf16x2.f32
+divmod_fast(idx, dm)                     # mul.hi.u32 + sub + shr + add + shr
+                                         #   + mul.lo + sub  (7 instructions)
+div_i32(a, b)                            # div.s32, dividend known non-negative
+floordiv_i32(a, b)                       # div.s32 + a 7-instruction sign fixup
+
+# schedule
+commit_group()                           # cp.async.commit_group
+wait_group(n)                            # cp.async.wait_group n
+barrier()                                # bar.sync 0
+grid_dep_wait()                          # griddepcontrol.wait
+warp_reduce_max(x, 4) / warp_reduce_sum(x, 4)
+                                         # shfl.sync.bfly.b32 laneMask 2 then 1, c=31
+last_live_split(regs)                    # setp.neu.f32 + or.b32 + selp.b32 chain
+                                         #   over the thread's 4 split slots
+
+# FIVE thread->coordinate maps. Conflating any two is the error this sketch
+# is most at risk of, so every shared-memory index below names the one it uses.
+lse_row(tidx)      = tidx & 63           # step 1 LSE stage,  order=(1,0) (:179-186)
+lse_split(tidx, i) = (tidx >> 6) + 4*i   #   .loc 1 627
+s2r_row(tidx)      = tidx >> 2           # step 3 read-back,  order=(0,1) (:196-203)
+s2r_split(tidx, i) = (tidx & 3) + 4*i    #   .loc 1 755
+o_row(tidx, m)     = (tidx >> 5) + 8*m   # O-partial staging, m in 0..7 (:120-134)
+o_col(tidx, v)     = (tidx & 31) * 4 + v #   .loc 1 681, 682
+store_row(tidx, m) = (tidx >> 4) + 16*m  # O output store,    m in 0..3 (:136-163)
+store_col(tidx)    = (tidx & 15) * 8     #   .loc 1 1092
+# Step 6 indexes sLSE by an ABSOLUTE split `s` crossed with o_row.
+#
+# Four edges cross a partition boundary, each covered by exactly one barrier:
+#   sLSE staged (lse_*) -> read back (s2r_*)              :747
+#   sLSE scales (s2r_*) -> step 6 (absolute s, o_row)     :907
+#   sMaxValidSplit (s2r_row) -> step 6 (o_row)            :907
+#   sO_perm (o_*) -> 7b (store_*)                         :1088
+# Everything else a thread touches it wrote itself -- which is why the
+# accumulate loop needs no barrier of its own.
+```
+
+### The reductions are 4-lane butterflies, in laneMask 2 then 1 order
+
+`smem_threads_per_col_lse = num_threads // m_block_smem = 256 // 64 = 4`
+(`:193`), so every reduction is over four lanes and the export carries exactly
+two shuffles per reduction:
+
+```
+shfl.sync.bfly.b32 %f681, %f679, 2, 31, -1;
+shfl.sync.bfly.b32 %f685, %f684, 1, 31, -1;
+```
+
+`laneMask` descends 2 then 1, the membermask is `-1`, and `c = 31` (full-warp
+clamp). Three reductions use this shape: the LSE max (`.loc 1 782`), the
+`max_valid_split` index (`.loc 1 795`, on `b32` integers), and the scale sum
+(`.loc 1 810`).
+
+### The row divmod is a FastDivmod, and the head divmod is a real division
+
+`decode_flat_row_idx` (`:457-464`) divides the flat row index by `num_head`
+through a host-built `FastDivmodDivisor`, and the export lowers it to the
+classic two-shift magic sequence (`.loc 1 463 28`):
+
+```
+mul.hi.u32 %r105, %r9,   %r86      // idx * multiplier
+sub.s32    %r106, %r9,   %r105
+shr.u32    %r107, %r106, %r102     // shift_1  (a .u8 parameter)
+add.s32    %r108, %r107, %r105
+shr.u32    %r109, %r108, %r104     // shift_2  (a .u8 parameter)
+mul.lo.s32 %r110, %r109, %r85      // quot * divisor
+sub.s32    %r111, %r9,   %r110     // remainder
+```
+
+The multiplier, divisor and the two shifts arrive as kernel parameters
+(`ld.param.u32` for the first two, `ld.param.v2.u8` for the shifts), so the port
+computes the same four values on the host and emits the same seven
+instructions. `head_idx // qhead_per_kvhead` is **not** given that treatment: it
+stays a genuine `div.s32` against a runtime parameter (`.loc 1 642 53`,
+`.loc 1 709`), because `qhead_per_kvhead` reaches the kernel as a plain `Int32`.
+
+### The shared storage is dynamic, and `sLSETemperature` is always allocated
+
+`SharedStorage` (`:383-397`) reads like a static struct but
+`cutlass.utils.SmemAllocator` takes it from the dynamic pool, so the TIRx form
+is a `K.smem_pool()` allocation plus the `tirx.use_dyn_shared_memory` launch
+tag. `sLSETemperature` is a field of that struct unconditionally -- the
+temperature axis gates the *use*, not the allocation -- and the export proves
+it: with temperature off, `sMaxValidSplit` still starts at byte 8192
+(`st.shared.u32 [%r318+8192]`, `.loc 1 872`), which is `sLSE` (4096) plus an
+equally sized `sLSETemperature` (4096). A port that allocated it conditionally
+would shift every later offset by 4 KB.
+
+Byte map for the fixed specialization:
+
+| field | offset | size | derivation |
+| --- | --- | --- | --- |
+| `sLSE` | 0 | 4096 | `cosize(smem_layout_lse) = topk * tile_m = 1024` fp32 |
+| `sLSETemperature` | 4096 | 4096 | same layout, allocated unconditionally |
+| `sMaxValidSplit` | 8192 | 256 | `tile_m` int32 |
+| `sO` | 8448 | 65536 | `tile_m * k_block * stages = 64*128*2` fp32 |
+| `sO_perm` | 73984 | 18400 | `cosize(smem_layout_perm) = 9200` bf16; the sketch's `(64, 144)` rectangle is a 32-byte superset with the same base and total |
+| total | | 92416 | ~90.25 KB, which is why `stages=2` and not 4 |
+
+### `.file` map of the export
+
+`.file 1` = `combine.py`, `.file 2` = `src/common/seqlen_info.py` (the two
+`cu_seqlens` loads at `:35` and `:45`, plus `:66` for `offset_batch`'s
+`domain_offset`), `.file 3` = `src/common/utils.py` (`elem_pointer`), `.file 4`
+= `src/common/copy_utils.py`, which is where the three fake-column maps are
+defined (`:861`, `:878`, `:897`) -- `tma_utils.py` only re-exports them. Every
+`.loc` cited below is from `ptx_lineinfo/fp32p_t16/`.
+
+## Thread and value partitioning
+
+Every per-thread count below is a static consequence of the tiled-copy layouts
+in `_setup_attributes` (`:110-240`), and each is confirmed by an opcode count in
+the export.
+
+| partition | derivation | per thread | export evidence |
+| --- | --- | --- | --- |
+| LSE staging (`gmem_tiled_copy_LSE`, `:164-185`) | `m_block_smem = 64`, threads `(4, 64)`, `order=(1,0)`: row `tidx & 63`, split base `tidx >> 6` | 4 splits x 1 row | `cp.async.ca x4` (`.loc 1 653`); map at `.loc 1 627` |
+| LSE s2r (`s2r_tiled_copy_LSE`, `:196-203`) | `smem_threads_per_col_lse = 4`, atom `(4, 64)`, `order=(0,1)`: row `tidx >> 2`, split base `tidx & 3` -- **transposed against staging** | 4 splits x 1 row | `ld.shared.f32 x4` (`.loc 1 757`); map at `.loc 1 755` |
+| partial staging (`gmem_tiled_copy_O_partial`, `:120-134`) | `async_copy_elems = 128/32 = 4`, `gmem_threads_per_row = 128/4 = 32`, threads `(8, 32)` | `num_rows = 8` rows x 1 k-tile x 4 values | `ld.global.u32 x8` (`.loc 1 708`), `cp.async.cg x16` = 8 rows x 2 call sites (`.loc 1 1155`) |
+| output store (`gmem_tiled_copy_O`, `:136-163`) | `output_copy_elems = 128/16 = 8`, `gmem_threads_per_row_o = 16`, threads `(16, 16)` | 4 rows x 1 k-tile x 8 values | `ld.shared.v4.b32 x4` (`.loc 1 1111`), `st.global.v4.b32 x4` (`.loc 1 1125`) |
+
+The two output partitionings differ on purpose (`:136-140`): a 128-bit
+transaction is 4 fp32 partials but 8 bf16 outputs, so 7a writes `sO_perm` with
+the *partial* partitioning and 7b reads it back with the *output* one. The
+`bar.sync` at `:1088` is what makes that re-partition legal.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+variant = specialize(HEAD_DIM=128, K_BLOCK=128, TILE_M=64, STAGES=2,
+                     NUM_THREADS=256, TOPK=16, partial="f32", out="bf16",
+                     temperature=False, output_scale=False, seqused=False,
+                     use_pdl=True, target="sm_100a")
+# instruction_selection: none; extent: the compile-key constants (:1339-1355)
+NUM_ROWS   = 8      # partial-staging rows per thread
+NUM_VALS   = 4      # fp32 elements per 128-bit copy
+SPLITS_PT  = 4      # LSE splits per thread  (topk / (256 // 64))
+LANES_COL  = 4      # threads per LSE column -> reduction width
+LOG2_E     = 0f3FB8AA3B
+LN_2       = 0f3F317218
+
+# Runtime ABI. Extents and strides are explicit scalars; the buffers are flat.
+#   o_partial     [topk, total_q, head_q, 128]  f32  read-only
+#   lse_partial   [topk, total_q, head_q]       f32  read-only
+#   o_out         [total_q, head_q, 128]        bf16 write-only
+#   lse_out       [total_q, head_q]             f32  write-only
+#   cu_seqlens    [batch+1]                     i32  read-only
+#   split_counts  [total_q, head_kv]            i32  read-only
+#   (lse_temperature_partial / _out, seqused, output_scale: present in the
+#    signature, unread in this specialization)
+# Scalars: stride_op_split/q/h, stride_lp_split/q, stride_o_q/h, stride_l_q,
+#          stride_sc_q, qhead_per_kv, total_q, head_q, num_batches,
+#          head_div_mul, head_div_div, head_div_s1, head_div_s2
+
+launch_config = launch(grid=(ceil_div(total_q * head_q, 64), 1, num_batches),
+                       block=(256, 1, 1), dynamic_smem_bytes=92416,
+                       pdl=True, min_blocks_per_sm=None)
+# instruction_selection: none; extent: static launch metadata (:414-454).
+#   grid.y is `ceil_div(head_dim, k_block)` = 1 here, kept as a real axis so the
+#   `k_block == 0` guard on the LSE store stays a guard and not a constant.
+#   `min_blocks_per_mp` is 0 unless an output scale is present (:1337).
+
+# ===========================================================================
+# Storage.  One dynamic allocation, five fields, byte offsets above.
+# ===========================================================================
+sLSE        = smem_pool.alloc((TOPK, TILE_M), "float32")      # :385-387
+sLSETemp    = smem_pool.alloc((TOPK, TILE_M), "float32")      # :388-390 (unread here)
+sMaxValid   = smem_pool.alloc((TILE_M,), "int32")             # :391
+sO          = smem_pool.alloc((STAGES, TILE_M, K_BLOCK), "float32")   # :392-394
+sO_perm     = smem_pool.alloc((TILE_M, K_BLOCK + 16), "bfloat16")     # :395-397
+# instruction_selection: none (declarations); extent: one dynamic pool per CTA.
+#   The +16 row pad on sO_perm is the bank-conflict break for 7a (:374-382).
+#   sLSE's swizzle is `(3,2,3)` composed over an atom of (min(topk,8), 64)
+#   (:208-222); the port reproduces the resulting element order, not the
+#   swizzle object.
+
+def kernel():
+    tidx = thread_id(extent=256)                    # :497
+    # instruction_selection: mov.u32 %tid.x; extent: scalar
+    m_block, k_block, batch = cta_id(axis=(x, y, z))  # :498
+    # instruction_selection: mov.u32 %ctaid.{x,y,z}; extent: scalar
+
+    # -----------------------------------------------------------------------
+    # Prologue: varlen bounds and the K1 dependency (:531-550)
+    # -----------------------------------------------------------------------
+    q_offset = load_global(cu_seqlens, batch)          # seqlen_info.py:35
+    # instruction_selection: ld.global.u32 (.loc 2 35); extent: one scalar
+    q_end    = load_global(cu_seqlens, batch + 1)      # seqlen_info.py:45
+    # instruction_selection: ld.global.u32 [addr+4] (.loc 2 45); extent: one
+    #   scalar.  The two loads are adjacent, so the second reuses the first
+    #   address with a +4 displacement.
+    seqlen  = q_end - q_offset
+    max_idx = seqlen * head_q                          # :542
+    if m_block * TILE_M >= max_idx:                    # :547
+        return
+    # instruction_selection: shl.b32 by 6 then setp.le.s32 with the operands
+    #   swapped -- the compare emitted is `max_idx <= m_block*64` (.loc 1 547)
+    #   -- and a predicated branch; extent:
+    #   CTA-uniform.  Guards the entire body, so a skipped CTA reaches no
+    #   barrier -- which is what makes the four bar.syncs below safe.
+    grid_dep_wait()                                    # :550
+    # instruction_selection: griddepcontrol.wait (.loc 1 550); extent: one
+    #   instruction, CTA-wide.  The export carries exactly ONE griddepcontrol
+    #   and NO launch_dependents: this kernel waits on K1 and signals nothing.
+
+    # -----------------------------------------------------------------------
+    # Step 1: stage LSE_partial, -inf past a row's split count (:618-673)
+    # -----------------------------------------------------------------------
+    for m in range(1):                    # rows per thread; unrolled (:636)
+        idx = m_block * TILE_M + lse_row(tidx)
+        if idx < max_idx:                                        # :639
+            # instruction_selection: setp.ge.s32 + a branch taken to the
+            #   whole-row -inf fill (.loc 1 639) -- the compare is emitted in
+            #   the inverted sense; extent: scalar
+            m_idx, head_idx = divmod_fast(idx, head_divmod)      # :463
+            # instruction_selection: mul.hi.u32 + sub.s32 + shr.u32 + add.s32 +
+            #   shr.u32 + mul.lo.s32 + sub.s32 (.loc 1 463 28); extent: seven
+            #   scalar instructions, the FastDivmod expansion
+            row_count = load_global(split_counts,
+                                    (q_offset + m_idx) * stride_sc_q
+                                    + div_i32(head_idx, qhead_per_kv))
+            # instruction_selection: div.s32 for the head-group index
+            #   (.loc 1 642 53) + cvt.s64.s32 + mul.lo.s64 + add.s64 + shl.b64 +
+            #   ld.global.u32 (.loc 1 642); extent: one scalar per row.
+            #   The division is real: qhead_per_kvhead is a runtime parameter,
+            #   so it gets no magic-number treatment.
+            for s in range(SPLITS_PT):                           # :650, unrolled
+                si = lse_split(tidx, s)
+                if si < TOPK and si < row_count:                 # :652
+                    # instruction_selection: one compare per split and a branch
+                    #   -- setp.ge.s32 for the first slot and setp.lt.s32 for
+                    #   the other three (.loc 1 652); extent: 4 per thread.  The
+                    #   `si < TOPK` half folds away at compile time: a thread's
+                    #   splits are {c, c+4, c+8, c+12} with c < 4, so si <= 15 is
+                    #   statically below topk = 16.  There is no and.pred here;
+                    #   the module's eight all belong to step 2.
+                    cp_async_ca(sLSE[si, lse_row(tidx)],
+                                lse_partial + (q_offset + m_idx) * stride_lp_q
+                                            + head_idx
+                                            + si * stride_lp_split, 4)
+                    # instruction_selection:
+                    #   cp.async.ca.shared.global [smem], [gmem], 4, 4
+                    #   (.loc 1 653); extent: 4 per thread, one per split slot.
+                    #   CA is forced here, not chosen: `cp.async.cg` exists
+                    #   only at a 16-byte cp-size, so a 4-byte element has no
+                    #   other spelling.  The partial rows below are 16 bytes and
+                    #   do take `cg`.
+                else:
+                    store_shared(sLSE[si, lse_row(tidx)], -inf)
+                    # instruction_selection: st.shared.u32 (.loc 1 665);
+                    #   extent: one per masked split.  A shared store, not a
+                    #   copy: the value is an immediate, so no memory is read.
+        else:
+            for s in range(SPLITS_PT):                           # :669
+                store_shared(sLSE[lse_split(tidx, s), lse_row(tidx)], -inf)
+                # instruction_selection: st.shared.u32 (.loc 1 670); extent:
+                #   4 per thread.  A separate site from :665 -- this is the
+                #   whole-row-out-of-range fill, and the export keeps them
+                #   distinct.
+    commit_group()                                               # :673
+    # instruction_selection: cp.async.commit_group (.loc 1 673); extent: one.
+    #   Closes the LSE group so the partial stages below queue behind it.
+
+    # -----------------------------------------------------------------------
+    # Step 2: per-row indices and the pipeline prime (:679-740)
+    # -----------------------------------------------------------------------
+    for m in range(NUM_ROWS):             # unrolled (:691)
+        idx = m_block * TILE_M + o_row(tidx, m)
+        if idx >= max_idx:                                       # :694
+            hidx[m], midx[m], split_count[m], row_ptr[m] = -1, 0, 0, 0
+            # instruction_selection: setp.ge.s32 x8 with a predicated branch per
+            #   row, each preceded by mov.u64/mov.pred/mov.b32 seeding the
+            #   0/false/0 defaults (.loc 1 694, 32 instructions); extent: 8 per
+            #   thread.  A real branch per row, not an if-conversion: the
+            #   defaults are materialized first and the else arm is jumped over.
+        else:
+            midx[m], hidx[m] = divmod_fast(idx, head_divmod)     # :700
+            split_count[m] = load_global(split_counts,
+                                         (q_offset + midx[m]) * stride_sc_q
+                                         + floordiv_i32(hidx[m], qhead_per_kv))
+            # instruction_selection: the SIGNED FLOOR division expands to eight
+            #   instructions per row -- div.s32 + mul.lo.s32 + setp.ne.s32 +
+            #   xor.b32 + setp.lt.s32 + and.pred + selp.s32 + add.s32
+            #   (.loc 1 709 44, 64 instructions over 8 rows; the line's other
+            #   8 add.s32 at column 24 are the `offset + m_idx` row index) --
+            #   followed by
+            #   ld.global.u32 (.loc 1 708); extent: 8 loads and 8 expansions per
+            #   thread.  Step 1 divides the same way in source and gets a BARE
+            #   div.s32 (.loc 1 642 53) because its dividend is a fresh divmod
+            #   remainder, known non-negative; here the dividend is read back
+            #   from an rmem tensor, so the sign correction survives.
+            row_ptr[m] = elem_pointer(o_partial,
+                                      (midx[m], k_block * K_BLOCK, 0, hidx[m]))
+            # instruction_selection: cvt.s64.s32 + cvt.u64.u32 + mul.lo.s64 +
+            #   add.s64 for the crd2idx arithmetic (.loc 1 711), then add.s64 +
+            #   shl.b64 for the pointer add and element width (.loc 3 371,
+            #   `elem_pointer`); extent: 10 instructions per row, 80 static.
+            #   Held in registers for the whole kernel, but the loop re-derives
+            #   BOTH the split displacement and this thread's column from it --
+            #   `(tidx & 31) * 4` is rematerialized inside the loop body every
+            #   iteration (`shl.b32` + `and.b32 ..., 124` at .loc 1 681 15) and
+            #   added into the source address at .loc 1 1142.  Dropping the
+            #   column term would make all 32 threads of a column group read
+            #   the same 16 bytes.
+    for stage in range(STAGES - 1):                              # :736, unrolled
+        if stage < TOPK:
+            load_O_partial(split=stage, stage=stage)
+        commit_group()                                           # :739
+        # instruction_selection: cp.async.commit_group (.loc 1 739); extent:
+        #   one per primed stage.  One group per stage is what makes
+        #   `wait_group(STAGES-1)` below mean "the oldest stage has landed".
+
+    # -----------------------------------------------------------------------
+    # Step 3: publish the staged LSE and read it back transposed (:746-765)
+    # -----------------------------------------------------------------------
+    wait_group(STAGES - 1)                                       # :746
+    # instruction_selection: cp.async.wait_group 1 (.loc 1 746); extent: one.
+    #   Leaves the newest partial stage in flight and retires the LSE group.
+    barrier()                                                    # :747
+    # instruction_selection: bar.sync 0 (.loc 1 747); extent: CTA-wide.  The
+    #   only reason it is needed: step 1 partitions sLSE by (split, row) and
+    #   step 3 reads it by (row, split), so a thread reads what other threads
+    #   wrote.
+    for s in range(SPLITS_PT):
+        lse_reg[s] = load_shared(sLSE[s2r_split(tidx, s), s2r_row(tidx)])
+        # instruction_selection: ld.shared.f32 x4 at +0/1024/2048/3072
+        #   (.loc 1 757); extent: 4 per thread -- and they are NOT the elements
+        #   this thread staged.  The two tiled copies over sLSE carry
+        #   deliberately transposed thread maps: `order=(1,0)` for the gmem
+        #   stage (:179-186) against `order=(0,1)` for the read-back
+        #   (:196-203).  Staging owns row `tidx & 63` and split base
+        #   `tidx >> 6` (.loc 1 627: `shr.u32 %r6,%r1,6`, `and.b32 %r91,%r1,63`);
+        #   the read-back owns row `tidx >> 2` and split base `tidx & 3`
+        #   (.loc 1 755: `shr.u32 %r41,%r1,2`, with `%r7 = tidx & 3`).  The two
+        #   coincide for exactly FOUR threads -- tidx 0, 85, 170 and 255, the
+        #   alternating bit patterns, where `tidx & 63 == tidx >> 2` and
+        #   `tidx >> 6 == tidx & 3` hold together.  For the other 252 the two
+        #   element sets are disjoint.  This is what the :747 barrier publishes,
+        #   and it is what puts the four split-groups of ONE row on lanes
+        #   t..t^3 so the 4-lane butterfly below reduces a row rather than four
+        #   unrelated rows.  A port that re-read its own staged elements would
+        #   make :747 look removable and would silently reduce the wrong set.
+
+    # -----------------------------------------------------------------------
+    # Step 4: the split reduction (:779-873)
+    # -----------------------------------------------------------------------
+    for m in range(1):                    # rows per thread
+        lse_max = warp_reduce_max(max_nan(lse_reg[0..3]), LANES_COL)   # :782-787
+        # instruction_selection: max.NaN.f32 x3 over the 4 register values
+        #   (.loc 1 785), then the butterfly at .loc 1 782, whose two steps are
+        #   NOT the same combine: laneMask 2 is shfl.sync.bfly.b32 + setp.le.f32
+        #   + setp.nan.f32 + selp.f32 x2 -- a NaN-propagating max written out --
+        #   and laneMask 1 is shfl.sync.bfly.b32 + a plain max.f32; c=31,
+        #   membermask -1.  extent: 3 maxima + 2 shuffles + 5 combine
+        #   instructions.  The NaN-propagating form is load-bearing: it is what
+        #   keeps a NaN partial from being dropped by the -inf identity.
+        max_valid = warp_reduce_max(last_live_split(lse_reg), LANES_COL)  # :790-797
+        # instruction_selection: setp.neu.f32 x4 against 0fFF800000
+        #   (.loc 1 792) + or.b32 x3 building the split coordinates 4/8/12
+        #   (.loc 1 793) + selp.b32 x4 (.loc 1 242), then
+        #   shfl.sync.bfly.b32 x2 with max.s32 x2 (.loc 1 795); extent: 2
+        #   shuffles and 2 integer maxima.  The same butterfly shape as the
+        #   float max, but a plain signed max -- no NaN handling on an index.
+        lse_max_cur = 0.0 if lse_max == -inf else lse_max          # :799-800
+        # instruction_selection: setp.eq.f32 against 0fFF800000 (.loc 1 800)
+        #   then selp.f32 (.loc 1 242); extent: scalar.  What the select
+        #   returns is the ALREADY-SCALED lse_max * LOG2_E -- NVVM hoists that
+        #   multiply above the select (the export is NVVM output, so this is
+        #   not a ptxas effect the port inherits for free), which is why the
+        #   exp2 site below carries five multiplies and not four.
+        acc = 0.0
+        for s in range(SPLITS_PT):                                 # :806, unrolled
+            scale = exp2(lse_reg[s] * LOG2_E - lse_max_cur * LOG2_E)
+            # instruction_selection: mul.f32 by 0f3FB8AA3B x5 -- four per-split
+            #   plus the one hoisted lse_max*LOG2_E -- and sub.f32 x4
+            #   (.loc 1 806), then ex2.approx.ftz.f32 x4 (.loc 1 805); extent:
+            #   4 per thread.  A sub, not an fma: the scaled maximum is a
+            #   loop-invariant operand, so there is nothing to fuse.
+            #   `fastmath=True` is what selects ex2.approx.ftz over a
+            #   correctly-rounded expansion, and it is load-bearing for a
+            #   bitwise match.
+            acc = acc + scale                                      # :808
+            # instruction_selection: add.f32 x4 (.loc 1 808), the first of
+            #   which adds the literal 0f00000000 -- the zero initializer is
+            #   NOT folded away; extent: 4 per thread
+            lse_reg[s] = scale                                     # :809
+        lse_sum = warp_reduce_sum(acc, LANES_COL)                  # :810
+        # instruction_selection: add.f32 + shfl.sync.bfly.b32 x2 (.loc 1 810);
+        #   extent: 2 shuffles, 2 adds
+        if max_valid < 0 or lse_sum == 0.0 or lse_sum != lse_sum:  # :815
+            final_lse[m], inv_sum = -inf, 0.0
+            # instruction_selection: setp.lt.s32 (.loc 1 815) + setp.equ.f32
+            #   against 0f00000000 + or.pred + mov.f32 x2 seeding the -inf and
+            #   0.0 defaults + a predicated branch around the else arm
+            #   (.loc 1 242); extent: scalar.  The source's three conditions
+            #   become TWO compares: `sum == 0.0` and `sum != sum` fuse into the
+            #   single unordered-equal setp.equ.f32, true for both zero and NaN.
+            #   A port emitting a separate self-comparison would carry an
+            #   instruction the reference does not.
+        else:
+            final_lse[m] = log2(lse_sum) * LN_2 + lse_max          # :818
+            # instruction_selection: lg2.approx.ftz.f32 (.loc 1 818) then
+            #   fma.rn.f32 with 0f3F317218 (.loc 1 818); extent: 2.  `log` under
+            #   fastmath becomes lg2 folded with ln(2) into a single FMA that
+            #   also adds lse_max -- one instruction, not two.
+            inv_sum = recip(lse_sum)                               # :819
+            # instruction_selection: rcp.rn.f32 (.loc 1 819); extent: one.
+            #   NOT div.rn.f32: the reciprocal is computed once and multiplied
+            #   into four scales below.
+        for s in range(SPLITS_PT):
+            lse_reg[s] = lse_reg[s] * inv_sum                      # :820
+            # instruction_selection: mul.f32 x4 (.loc 1 820); extent: 4
+    for s in range(SPLITS_PT):
+        store_shared(sLSE[s2r_split(tidx, s), s2r_row(tidx)], lse_reg[s])   # :822
+        # instruction_selection: st.shared.f32 x4 (.loc 1 822); extent: 4.
+        #   sLSE is REUSED here: the staged log-sum-exps are overwritten in
+        #   place by the normalized scales step 6 consumes.
+    if s2r_split(tidx, 0) == 0 and s2r_row(tidx) < TILE_M:         # :869-873
+        store_shared(sMaxValid[s2r_row(tidx)], max_valid)
+        # instruction_selection: shl.b32 of `tidx >> 2` then st.shared.u32
+        #   [base+8192] (.loc 1 872); extent: one, from the threads whose s2r
+        #   split coordinate is 0 -- i.e. `tidx & 3 == 0`, which the export
+        #   spells `setp.ne.s32 %p89,%r7,0` at :869.
+        #   THIS IS A CROSS-PARTITION EDGE -- one of the two that `:907`
+        #   publishes, alongside the sLSE scales.  The write indexes by the s2r
+        #   row `tidx >> 2` (`%r41`); step 6 reads the same array by the
+        #   O-partial row `(tidx >> 5) + 8m` (`%r14`, .loc 1 910).  The two maps
+        #   differ, so the `:907` barrier is what makes the array readable --
+        #   exactly as `:747` does for the staged sLSE.  The +8192
+        #   displacement is the proof that sLSETemperature is allocated even
+        #   with the temperature axis off.
+
+    # -----------------------------------------------------------------------
+    # Step 5: the authoritative LSE_out store (:889-902)
+    # -----------------------------------------------------------------------
+    if k_block == 0 and s2r_split(tidx, 0) == 0:                   # :891, :893
+        # instruction_selection: the two conditions are OR-FUSED -- or.b32 of
+        #   the split coordinate with ctaid.y, then one setp.ne.s32 against 0
+        #   and one branch (.loc 1 242); extent: scalar.  The same trick as the
+        #   degenerate guard at :815: two zero-tests become one.  A port
+        #   emitting two compares and an and.pred would diverge.  Only the first
+        #   k-block writes LSE, and only one thread per row within it.
+        idx = m_block * TILE_M + s2r_row(tidx)
+        if idx < max_idx:                                          # :896
+            m_idx, head_idx = divmod_fast(idx, head_divmod)
+            store_global(lse_out, (q_offset + m_idx) * stride_l_q + head_idx,
+                         final_lse[0])
+            # instruction_selection: st.global.f32 (.loc 1 898); extent: one
+            #   scalar per owning thread
+```
+
+```python
+    # -----------------------------------------------------------------------
+    # Step 6: the accumulation loop over live splits (:907-953)
+    # -----------------------------------------------------------------------
+    barrier()                                                      # :907
+    # instruction_selection: bar.sync 0 (.loc 1 907); extent: CTA-wide.  Makes
+    #   both step-4 publications visible: the scales in sLSE and sMaxValid.
+    thr_max_valid = load_shared(sMaxValid[o_row(tidx, 0)])          # :910
+    # instruction_selection: ld.shared.u32 [base+8192] (.loc 1 910); extent: one
+    for m in range(1, NUM_ROWS):                                    # :911, unrolled
+        thr_max_valid = max_i32(thr_max_valid, load_shared(sMaxValid[o_row(tidx, m)]))
+        # instruction_selection: ld.shared.u32 [base+8192+32*m] (.loc 1 912) +
+        #   max.s32; extent: 7 loads and 7 maxima.  The 32-byte stride is this
+        #   thread's row stride (8 rows apart) in the int32 array.
+    fill(acc, 0.0)                                                  # :916
+    # instruction_selection: mov.f32 x32 (.loc 1 242) -- one materializing the
+    #   literal 0f00000000 and 31 copying it; extent: 8 rows x 4 values.  They
+    #   sit in the loop PREHEADER, ahead of the zero-trip branch, so a thread
+    #   whose rows are all short still carries zeroed accumulators into the
+    #   epilogue instead of undefined registers.
+    stage_load, stage_compute = STAGES - 1, 0
+    for s in range(thr_max_valid + 1):                              # :922
+        # instruction_selection: an unsigned zero-trip test in the preheader,
+        #   setp.gt.u32 against 2147483646 -- which is how `thr_max_valid == -1`
+        #   is detected after the +1 -- and a setp.ne.s32 latch against the
+        #   bound; extent: a data-dependent trip count, ONE iteration per
+        #   body.  The source asks for `unroll=4` at :922 and the export does
+        #   not grant it: the body is a MULTI-BLOCK region -- 33 internal
+        #   forward branches from the inlined loader rows, the accumulate
+        #   guards and the prefetch test, closed by the single backward latch --
+        #   holding exactly one iteration's work: 8 ld.shared.f32, 8
+        #   cp.async.cg plus 8 st.shared.v4.f32 from the inlined
+        #   `load_O_partial`, 8 ld.shared.v4.f32, 32 fma.rn.f32, one commit and
+        #   one wait.  The port must not unroll by four to match a hint the
+        #   reference itself did not realize.
+        #   The bound is per THREAD: a thread whose eight rows are all short
+        #   exits early while its neighbours keep going, which is the point of
+        #   sMaxValid.
+        for m in range(NUM_ROWS):
+            scale[m] = load_shared(sLSE[s, o_row(tidx, m)])         # :926
+            # instruction_selection: ld.shared.f32 x8 (.loc 1 926); extent: 8
+            #   per iteration -- and, like the :757 read-back, these are NOT the
+            #   scales this thread computed.  Step 4 wrote them on the s2r map,
+            #   row `tidx >> 2` (.loc 1 822, base %r42 from `shr.u32 %r41,%r1,2`);
+            #   step 6 reads them on the O-partial map, rows
+            #   `(tidx >> 5) + 8m` (.loc 1 926, base from `shr.u32 %r351,%r350,5`).
+            #   Thread 0 writes row 0 and reads rows 0, 8, ... 56.  This is the
+            #   FOURTH cross-partition edge and the second one `:907` publishes
+        if s + STAGES - 1 <= thr_max_valid:                         # :930
+            load_O_partial(split=s + STAGES - 1, stage=stage_load)
+        commit_group()                                              # :932
+        # instruction_selection: cp.async.commit_group (.loc 1 932); extent: one
+        #   per iteration -- issued even when no copy was made, so the group
+        #   count the wait below reasons about stays exact.
+        stage_load = 0 if stage_load == STAGES - 1 else stage_load + 1
+        wait_group(STAGES - 1)                                      # :936
+        # instruction_selection: cp.async.wait_group 1 (.loc 1 936); extent: one
+        #   per iteration.  No barrier follows it: the stage data this wait
+        #   covers is what the thread's own cp.async wrote, which is the claim
+        #   the source's comment at :937 makes and the only one it makes.  The
+        #   loop's other shared read, the sLSE scales at :926, does cross
+        #   threads -- it is `:907`, before the loop, that makes it safe.
+        for m in range(NUM_ROWS):
+            part[m][0..3] = load_shared_v4(sO[stage_compute, o_row(tidx, m),
+                                              o_col(tidx)])
+            # instruction_selection: ld.shared.v4.f32 x8 (.loc 1 939); extent: 8
+            #   vector loads per iteration, one per staged row -- but only seven
+            #   are unconditional.  The compiler SINKS the m = 0 load into the
+            #   guarded block below, so the port must place that one load inside
+            #   the guard and the other seven ahead of it.
+        stage_compute = 0 if stage_compute == STAGES - 1 else stage_compute + 1
+        for m in range(NUM_ROWS):                                   # :943
+            if hidx[m] >= 0 and scale[m] > 0.0:                     # :944
+                # instruction_selection: setp.leu.f32 against 0f00000000
+                #   (.loc 1 944, x8) then or.pred against the hoisted row
+                #   predicate from :1144 (.loc 1 242, x8), driving a predicated
+                #   skip; extent: 8 per iteration.  The `hidx >= 0` half is not
+                #   a second compare -- it is the predicate step 2 already
+                #   produced.  `leu` is unordered, so a NaN scale skips the row
+                #   too, which is what makes a dead split's contribution
+                #   unreachable.
+                for v in range(NUM_VALS):
+                    acc[m][v] = fma(part[m][v], scale[m], acc[m][v])
+                    # instruction_selection: fma.rn.f32 x32 (.loc 1 946);
+                    #   extent: 8 rows x 4 values per iteration.  fp32
+                    #   accumulate in a fixed per-thread order -- no atomics, no
+                    #   cross-thread combining, which is what makes the whole
+                    #   kernel bitwise reproducible.
+    wait_group(0)                                                   # :952
+    # instruction_selection: cp.async.wait_group 0 (.loc 1 952); extent: one.
+    #   Drains every outstanding group before the epilogue.  The source's own
+    #   comment (:950-951) frames this as protecting the permutation buffer,
+    #   but the export shows sO at [8448, 73984) and sO_perm at [73984, 92416),
+    #   so there is no aliasing to protect against.  What the drain does retire
+    #   is the loop's last prefetch: the body issues a commit every iteration
+    #   whether or not it copied, so groups can still be outstanding when the
+    #   loop exits.
+    barrier()                                                       # :953
+    # instruction_selection: bar.sync 0 (.loc 1 953); extent: CTA-wide
+
+    # -----------------------------------------------------------------------
+    # Step 7a: scatter the accumulator into sO_perm in REAL column order
+    #          (:986-1088)
+    # -----------------------------------------------------------------------
+    for m in range(NUM_ROWS):                                       # :1011
+        row_local = o_row(tidx, m)
+        if hidx[m] >= 0:                                            # :1013
+            # instruction_selection: no compare is emitted here.  The row
+            #   predicate is computed ONCE per row in step 2 as
+            #   setp.gt.s32 ..., -1 (.loc 1 1144, x8) and reused by all four
+            #   consumers; this site spends only a predicated branch per row
+            #   (`@%pNN bra`, x8) and emits nothing else.  The x8 not.pred that
+            #   invert the row predicate are themselves hoisted into the prime
+            #   `load_O_partial` block (.loc 1 242), and the inverted predicate
+            #   is shared with the :944 or.pred and both loader call sites;
+            #   extent: 8 branches per thread.  A port that re-compared per
+            #   site would carry compares the reference does not.
+            for v_pair in range(NUM_VALS // 2):                     # :1015
+                fake_col = o_col(tidx, v_pair * 2)
+                real_col = stg128_fake_to_real(fake_col)            # copy_utils.py:861
+                # instruction_selection: an and.b32 / shr.u32 / and.b32 / or.b32
+                #   chain and no multiply at all (.loc 4 863, 864, 866; 8 each,
+                #   16 for the shr/and pair); extent: address arithmetic only,
+                #   no memory op.  It is NOT hoisted: the chain is re-emitted
+                #   inside each of the eight predicated row blocks, so a port
+                #   that lifts it out of the loop undercounts the reference.
+                #   The only multiply on this path is the sO_perm row address,
+                #   mul.lo.s32 by 72 plus seven mad.lo.s32 (.loc 1 1037).
+                #   This is the inverse of the permutation K1's STG.128
+                #   epilogue applied.
+                word = cvt_bf16x2(acc[m][2*v_pair + 1], acc[m][2*v_pair])
+                # instruction_selection: cvt.rn.bf16x2.f32 x16 (.loc 1 242);
+                #   extent: 8 rows x 2 pairs.  Two fp32 accumulators become one
+                #   32-bit word in ONE instruction -- the reason 7a stores pairs
+                #   rather than scalars.  Operand order is (hi, lo) = (v+1, v).
+                store_shared(sO_perm_i32[row_local * ((K_BLOCK + 16) // 2)
+                                         + real_col // 2], word)
+                # instruction_selection: st.shared.u32 x16 (.loc 1 1049);
+                #   extent: 16 per thread.  The row stride is
+                #   (k_block + 16)/2 = 72 words, which is the padded stride --
+                #   an unpadded 64 would put every thread of a quad in one bank.
+    barrier()                                                       # :1088
+    # instruction_selection: bar.sync 0 (.loc 1 1088); extent: CTA-wide.  This
+    #   is the re-partition point: 7a wrote sO_perm with the PARTIAL copy
+    #   partitioning (8 rows x 4 values), 7b reads it with the OUTPUT one
+    #   (4 rows x 8 values), so every thread reads other threads' words.
+
+    # -----------------------------------------------------------------------
+    # Step 7b: sO_perm -> registers -> GMEM, 128 bits at a time (:1090-1125)
+    # -----------------------------------------------------------------------
+    for m in range(4):                    # store rows per thread, unrolled
+        out_reg[m][0..7] = load_shared_v4(sO_perm[store_row(tidx, m), store_col(tidx)])
+        # instruction_selection: ld.shared.v4.b32 x4 (.loc 1 1111); extent: 4
+        #   per thread, 8 bf16 values each.  As in step 6, the m = 0 load is
+        #   sunk into the store guard below and only three are unconditional.
+    for m in range(4):                                              # :1114
+        idx = m_block * TILE_M + store_row(tidx, m)
+        if idx < max_idx:                                           # :1117
+            # instruction_selection: setp.ge.s32 x4 + branch (.loc 1 1117),
+            #   again the inverted sense; extent: 4 per thread.  The
+            #   tail rows of the last m_block are dropped here, which is why a
+            #   seqused launch leaves them at their prior contents.
+            m_idx, head_idx = divmod_fast(idx, head_divmod)         # :1118
+            store_global_v4(o_out, (q_offset + m_idx) * stride_o_q
+                                   + head_idx * stride_o_h
+                                   + k_block * K_BLOCK + store_col(tidx),
+                            out_reg[m])
+            # instruction_selection: st.global.v4.b32 x4 (.loc 1 1125); extent:
+            #   4 per thread, 16 bytes each.  This is the store the whole
+            #   fake-column detour exists to make contiguous.
+
+# ===========================================================================
+# load_O_partial: one pipeline stage (:1128-1161)
+# ===========================================================================
+def load_O_partial(split, stage):
+    for m in range(NUM_ROWS):                                       # :1143, unrolled
+        if hidx[m] >= 0:                                            # :1144
+            for k in range(1):            # one k-tile at K_BLOCK = 128
+                if split < split_count[m]:                          # :1154
+                    # instruction_selection: three compare forms across the two
+                    #   call sites, 16 in total (.loc 1 1154) -- the prime site
+                    #   emits setp.lt.s32 against the immediate 1 for row 0 and
+                    #   setp.gt.s32 against 0 for rows 1-7, because its split is
+                    #   the constant 0; the loop site emits setp.ge.s32 for row
+                    #   0 and setp.lt.s32 for rows 1-7.  The polarity flips with
+                    #   which arm the branch is taken to; extent: 8 per call
+                    #   site.
+                    cp_async_cg(sO[stage, o_row(tidx, m), o_col(tidx)],
+                                row_ptr[m] + split * stride_op_split + o_col(tidx),
+                                16)
+                    # instruction_selection:
+                    #   cp.async.cg.shared.global [smem], [gmem], 16, 16
+                    #   (.loc 1 1155); extent: 16 static = 8 rows x 2 call
+                    #   sites (the prime and the loop).  CG bypasses L1: a
+                    #   partial row is read exactly once.
+                else:
+                    store_shared_v4(sO[stage, o_row(tidx, m), o_col(tidx)], 0.0)
+                    # instruction_selection: st.shared.v4.f32 with a splatted
+                    #   zero register (.loc 1 1161); extent: 16 static.  The
+                    #   zero fill is what makes a ragged split count safe: a
+                    #   dead slot contributes 0 * scale, and the accumulate
+                    #   guard drops it anyway.
+```
+
+## Control-flow map
+
+| Region | Source | Predicate | Who executes |
+| --- | --- | --- | --- |
+| varlen row bound | `:547` | `m_block * 64 < seqlen * head_q` | CTA-uniform; precedes every barrier, so no CTA reaches a partial barrier |
+| K1 dependency | `:550` | `use_pdl` (compile time) | CTA-wide, one `griddepcontrol.wait` |
+| LSE row valid | `:639` | `idx < max_idx` | per staged row |
+| LSE split live | `:652` | `si < topk and si < row_count` | per staged split; the else stores `-inf` |
+| partial row valid | `:694` | `idx >= max_idx` | per staged row; a real predicated branch each, with the `-1/0/0/0` defaults seeded by `mov.u64`/`mov.pred`/`mov.b32` before the branch |
+| accumulate loop | `:922` | `s <= thr_max_valid` | per thread, data-dependent trip count; the source's `unroll=4` is not realized |
+| stage prefetch | `:930` | `s + stages - 1 <= thr_max_valid` | per iteration |
+| accumulate guard | `:944` | `hidx[m] >= 0 and scale[m] > 0` | per row per iteration; `setp.leu` so NaN also skips |
+| copy vs zero fill | `:1154` | `split < split_count[m]` | per row per staged split |
+| LSE writeback | `:880-894` | `k_block == 0` and split coord `== 0` | one thread per row of the first k-block |
+| store row valid | `:1117` | `idx < max_idx` | per store row; the source of unwritten tail rows under `seqused` |
+
+## Instruction-selection summary
+
+| decision | selects | why |
+| --- | --- | --- |
+| LSE staged with a 4-byte copy, partials with 16 | `cp.async.ca` vs `cp.async.cg` | not a caching preference but the ISA: `cp.async.cg` is defined only for a 16-byte cp-size, so a 4-byte LSE element has to use `ca`. The partial rows are 16 bytes and take `cg`, which is the cache-bypassing choice a row read exactly once wants |
+| `stages = 2` | two `sO` slices, `wait_group 1` | 92416 B total SMEM at 2 stages against roughly 158 KB at 4; the host's own note records 1 -> 2 blocks/SM and DRAM throughput 76% -> 89% (`:1374-1379`). That note's "168 KB -> 103 KB" predates this specialization -- the export-derived 92416 B is what the port must budget |
+| commit group per stage, never per copy | `wait_group(stages-1)` means "oldest stage landed" | a single group for all stages would collapse the pipeline into a barrier |
+| no barrier in the accumulate loop | nothing | the loop's two shared reads are covered without one: `sO` is what the thread's own `cp.async` wrote (which is what `:937` is scoped to), and the `sLSE` scales, though written by other threads on the s2r map, were published by `:907` before the loop began. So no edge *arises inside* the loop, and a barrier there would only add a CTA-wide wait to every iteration of a loop whose trip count already varies per thread |
+| `fastmath=True` on exp and log | `ex2.approx.ftz.f32`, `lg2.approx.ftz.f32` | correctly-rounded forms would be multi-instruction expansions and would not match K1's own softmax scaling |
+| one reciprocal, four multiplies | `rcp.rn.f32` + `mul.f32 x4` | four `div.rn.f32` would be four multi-instruction sequences |
+| `log(sum) + lse_max` written as one expression | `lg2.approx` + a single `fma.rn.f32` with `ln 2` | the add folds into the FMA; emitting `mul` then `add` would be one instruction more and a different rounding |
+| reductions over exactly four lanes | `shfl.sync.bfly.b32` laneMask 2 then 1 | `smem_threads_per_col_lse = 4`; a full-warp reduction would be five shuffles and would mix unrelated rows |
+| pairs converted before the SMEM store | `cvt.rn.bf16x2.f32` + `st.shared.u32` | two accumulators per instruction and per store; the scalar path costs twice as many of both |
+| `sO_perm` row stride padded by 16 | conflict-free `st.shared.u32` | at stride 64 the quad writing one row lands in one bank |
+| separate copy partitionings for load and store | `ld.shared.v4.b32` reading what `st.shared.u32` wrote | 128 bits is 4 fp32 partials but 8 bf16 outputs; the `bar.sync` at `:1088` legalizes the re-partition |
+| flat row index divided by `num_head` | FastDivmod: `mul.hi.u32` + 2 `shr` + `add` + `mul.lo` + `sub` | the divisor is a launch invariant, so the host precomputes the magic; the port passes the same four scalars |
+| `head_idx // qhead_per_kvhead` left alone | `div.s32` | `qhead_per_kvhead` is a runtime `Int32` with no host-side magic |

--- a/.agents/skills/tirx-codegen-tuning/references/db/advance-a-power-of-two-ring-cursor-with-a-mask.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/advance-a-power-of-two-ring-cursor-with-a-mask.md
@@ -1,0 +1,63 @@
+# Advance a power-of-two ring cursor with a mask
+
+**Symptoms:** `redundant_modulo`, `excess_integer_math`, `branch_in_hot_loop`, `latency_bound_fixup`
+
+## Symptom
+
+A staged pipeline's stage cursor advances as `(stage + 1) % STAGES` on a signed
+integer, and the cursor gates the next iteration's addresses. The stall
+breakdown shows a fixed-latency execution dependency the reference does not
+carry, with eligible warps and warp-cycles-per-instruction both slightly worse.
+
+## What to change
+
+Where the ring depth is a power of two and the cursor is non-negative by
+construction, advance it with a mask.
+
+```python
+# before: signed modulo, so the lowering adds the sign-correction fixup.
+K.assign(stage, K.truncmod(stage + 1, STAGES))
+
+# after: one instruction, no fixup and no control flow.
+K.assign(stage, K.bitwise_and(stage + 1, K.int32(STAGES - 1)))
+```
+
+A reference that spells the same advance as a conditional reset is describing
+the wrap, not prescribing a branch; do not transcribe it as one.
+
+```python
+# rejected: matches the reference's spelling and emits a real branch.
+K.assign(stage, K.if_then_else(stage == STAGES - 1, 0, stage + 1))
+```
+
+## Rationale
+
+The signed modulo pays the floordiv fixup because the dividend's sign cannot be
+proven, and it pays it on the chain that produces the next iteration's shared
+addresses. Both alternatives are shorter than it, but they are not equivalent to
+each other: the conditional form removes the fixup and adds control flow, and
+measured net positive overall while regressing the shape with the fewest loop
+iterations, where a branch costs more than the fixup it replaces. The mask has
+neither cost and dominated both -- taking the shape count above the gate from 3
+to 4 and the worst ratio from 0.9512 to 0.9538, against the conditional form's
+0.9471.
+
+This is worth spending a lever on only because of where the cursor sits. The
+same arithmetic off the critical path is invisible: an earlier change on this
+kernel removed a recomputed swizzle chain from a hot loop and measured
+neutral-to-negative across four shapes, because that expression fed no
+address that anything waited on.
+
+## Boundary
+
+Non-power-of-two depths keep a real modulo; cast the dividend unsigned instead
+so at least the fixup goes. The preference for a mask over a select is specific
+to a value that is a wrap of a counter -- where a condition genuinely selects
+between two different values, the select is the right lowering.
+
+## Verification
+
+Confirm the fixup opcodes and any branch are both gone from the cursor's
+advance, then measure the low-trip-count shape specifically: it is the one that
+separates the conditional form from the mask, and a guard set without it will
+rank them equal.

--- a/.agents/skills/tirx-codegen-tuning/references/db/do-not-decompose-an-index-the-address-recombines.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/do-not-decompose-an-index-the-address-recombines.md
@@ -1,0 +1,63 @@
+# Do not decompose an index the address recombines
+
+**Symptoms:** `excess_address_math`, `excess_integer_math`, `latency_bound_fixup`, `slow_latency_bound_shape`
+
+## Symptom
+
+A reference decomposes a flat index with a FastDivmod and the port transcribes
+it faithfully, yet the address built from the quotient and remainder weights
+them by exactly the factors the divmod divided by. The decomposition is
+multiplied straight back out, and its seven-instruction magic-multiply chain
+sits on the address that gates a load or store.
+
+## What to change
+
+Check the identity before transcribing the divmod. Where a flat index splits as
+`idx = outer * N + inner` and the address recombines the parts as
+`(base + outer) * N * W + inner * W`, that is `base * N * W + idx * W`: the
+address never needs the parts separated.
+
+```python
+# before: decompose, then weight the parts by the same factors that split them.
+outer, inner = _divmod(idx, N)
+addr = (base + outer) * stride + inner * W    # stride == N * W
+
+# after: the flat index carries both terms already.
+addr = base * stride + idx * W
+```
+
+Keep the divmod only where a consumer genuinely reads the parts apart -- a
+per-row count indexed by `outer`, a predicate on `inner`. Drop it at every site
+that only re-weights them.
+
+## Rationale
+
+The transcription is faithful and still redundant: the reference computes the
+decomposition because other statements in the same region consume it, while the
+port's copy at this site feeds nothing but the recombination. Removing it at one
+staging address and then at two store addresses took per-thread divmods from 14
+to 9 with load and store counts unchanged, and shrank every specialization's
+generated code by 3.5-3.8 KB.
+
+The gain is not where instruction count predicts. The chain removed is short,
+but it is serial and it gates address formation, so the shapes it frees are the
+ones with least else to hide it behind. Nine shapes carried the same change: the
+four that had been below the gate crossed together -- 0.9855, 0.9778, 0.9667 and
+0.9679 to 0.9992, 1.0004, 1.0142 and 1.0134 -- while the shapes already passing
+moved little. Four shapes crossing at once, on a change that touches no memory
+access, is the signature of a per-thread scalar cost rather than a shape
+effect; a fix that helps only one shape in a family is usually not this.
+
+## Boundary
+
+The identity is arithmetic, not a heuristic: verify it holds for the actual
+strides before applying it. It fails as soon as the stride is not the divisor
+times the element width -- a padded row, a swizzled layout, or a permuted
+component breaks the factorization, and the decomposition is then load-bearing.
+
+## Verification
+
+Count divmod expansions in the generated code and confirm the drop equals the
+number of sites removed, with load and store counts unchanged. A store count
+that moves means an address changed rather than an equivalent one was formed
+more cheaply.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ point each port backs (`activation`, `quantization`, `norm` — CuTe-DSL backend
 | `msa_sparse_prepare_fwd_split_atomic_sm100` | `sparse_prepare_fwd_split_atomic.py` | Forward split-slot preparation (packed `q_idx`/slot metadata) |
 | `msa_sparse_atten_fwd_sm100`               | `sparse_atten_fwd.py`               | CSR block-sparse attention forward, split-partial output, flat or paged KV |
 | `msa_sparse_atten_fwd_nvfp4_kv_sm100`      | `sparse_atten_fwd_nvfp4_kv.py`      | CSR block-sparse attention forward over NVFP4 K/V, flat or paged |
+| `msa_sparse_atten_fwd_combine_sm100`       | `sparse_atten_fwd_combine.py`       | Split-partial combine for sparse attention (LSE merge, fake-column epilogue) |
 
 ## Performance
 

--- a/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_combine_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/msa/msa_sparse_atten_fwd_combine_sm100.yaml
@@ -1,0 +1,19 @@
+kernel: msa_sparse_atten_fwd_combine_sm100
+selection_rationale: >-
+  The partial dtype selects one of three STG.128 fake-column maps, and each is
+  separate device code down to the staging copy width and the epilogue store,
+  so the defaults take one shape from each rather than three shapes of one map.
+  The large row is the standard-path ring-attention marquee over fp32 partials,
+  the medium row is the NVFP4 production combine (bf16 partials, temperature
+  LSE, output scale, and the only configuration that raises min_blocks_per_mp),
+  and the small row is the fp8 map.
+configs:
+  - {config: ring48k_fp32p_qh16_t16, default: true, selection_role: large}
+  - {config: ulysses384k_fp32p_qh2_t4, default: false}
+  - {config: long96k_fp32p_qh2_t16, default: false}
+  - {config: varlen_b3_s8192_fp32p_qh4_t16, default: false}
+  - {config: ring48k_bf16p_temp_qh16_t16, default: false}
+  - {config: fp8p_s16384_qh8_t8, default: true, selection_role: small}
+  - {config: scale_bf16p_temp_s16384_qh4_t16, default: true, selection_role: medium}
+  - {config: scale_fp32p_s8192_qh8_t8, default: false}
+  - {config: edge_b1_s1024_fp32p_qh2_t4, default: false}

--- a/tirx_kernels/msa/sparse_atten_fwd_combine.py
+++ b/tirx_kernels/msa/sparse_atten_fwd_combine.py
@@ -1,0 +1,1609 @@
+# This file is a TIRx port of code from MSA
+# (https://github.com/MiniMax-AI/MSA @ 80434d7f), Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""MSA sparse attention forward combine, the split-reduction half of the pair.
+
+Ports ``SparseAttentionForwardCombine``: the K2 kernel that reduces the
+per-split partials the forward kernel in this package writes. For every query
+row it merges the split log-sum-exps, rescales and accumulates the split
+outputs in fp32, and un-permutes the forward's STG.128 fake column order back
+to real head-dim order on the way out.
+
+The forward writes ``O_partial`` in a permuted column order so its epilogue can
+store 128 bits at a time; this kernel is where that permutation is undone, so
+the two kernels share a layout contract that neither one states alone.
+
+Upstream source: python/fmha_sm100/cute/src/sm100/fwd/combine.py:37.
+"""
+
+import math
+from functools import lru_cache
+from typing import Any
+
+import tirx_kernels.kern as K
+from tvm.tirx.script.builder import ir as I
+
+KERNEL_META = {
+    "name": "msa_sparse_atten_fwd_combine_sm100",
+    "category": "msa",
+    "compute_capability": 10,
+}
+
+# The host entry fixes every one of these for the production dispatch domain:
+# `k_block_size = 128 if D > 64 else 64` and `tile_m = 64` (combine.py:1330),
+# `stages=2` (:1374), `num_threads=256` (the constructor default).
+HEAD_DIM = 128
+K_BLOCK_SIZE = 128
+TILE_M = 64
+STAGES = 2
+NUM_THREADS = 256
+WARP_SIZE = 32
+WARPS = NUM_THREADS // WARP_SIZE
+
+# `sO_perm` pads each row by 16 output elements to break the bank-conflict
+# pattern the permuted scatter would otherwise hit (combine.py:374-382).
+PERM_ROW_PAD = 16
+
+LOG_2_E = math.log2(math.e)
+# `log(x)` under fastmath is `lg2(x) * ln(2)`, folded with the running
+# maximum into one `fma.rn.f32` (combine.py:818).
+LN_2 = math.log(2.0)
+
+# `use_pdl=True` at both production call sites (interface.py:972, :1532), so the
+# kernel always waits on the forward's launch-dependents signal and the launch
+# always carries the programmatic-dependent-launch attribute. The partial
+# staging buffer alone is 64 KB for fp32 partials, so shared memory is dynamic.
+LAUNCH_TAGS = (
+    "blockIdx.x",
+    "blockIdx.y",
+    "blockIdx.z",
+    "threadIdx.x",
+    "tirx.use_programtic_dependent_launch",
+    "tirx.use_dyn_shared_memory",
+)
+
+_TORCH_DTYPES = {
+    "bfloat16": "bfloat16",
+    "float16": "float16",
+    "float32": "float32",
+    "float8_e4m3": "float8_e4m3fn",
+}
+
+# CUDA codegen has no fp8 scalar type and MSA does not want one: its fp8 tiles
+# are moved as raw bytes and converted with PTX on the bit pattern. An fp8
+# partial buffer therefore binds as `uint8`, exactly as the forward port and
+# `flashmla/sparse_decode_head64.py` do.
+_KERN_DTYPES = {"bfloat16": K.bf16, "float16": K.f16, "float32": K.f32, "float8_e4m3": K.u8}
+
+
+def _torch_dtype(name: str):
+    import torch
+
+    return getattr(torch, _TORCH_DTYPES[name])
+
+
+def fast_divmod(divisor: int) -> tuple[int, int, int]:
+    """The `(multiplier, shift_1, shift_2)` triple CUTLASS's `FastDivmod` builds.
+
+    The source divides the flat `(q, head)` row index by the head count through
+    a host-built `FastDivmodDivisor`, and the export keeps that as a magic
+    multiply rather than a division (`combine.py:463`, `mul.hi.u32` + two
+    `shr.u32` + `add` + `mul.lo.s32` + `sub`). Passing the divisor alone and
+    dividing in the kernel would put a `div.s32` in the hottest index path, so
+    the port precomputes the same operands the reference's launcher does.
+
+    The lowering the kernel then reproduces is the round-up form::
+
+        q0   = mulhi(idx, multiplier)
+        quot = (((idx - q0) >> shift_1) + q0) >> shift_2
+        rem  = idx - quot * divisor
+    """
+    if divisor < 1:
+        raise ValueError(f"divisor must be positive, got {divisor}")
+    if divisor == 1:
+        return 1, 0, 0
+    shift = max(divisor - 1, 1).bit_length()
+    multiplier = ((1 << (32 + shift)) + divisor - 1) // divisor - (1 << 32)
+    return multiplier, 1, shift - 1
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return -(-value // alignment) * alignment
+
+
+def _partial_bytes(name: str) -> int:
+    return {"float32": 4, "bfloat16": 2, "float16": 2, "float8_e4m3": 1}[name]
+
+
+# ---------------------------------------------------------------------------
+# Target entry.
+#
+# Optional buffers stay in the signature and are simply never read when their
+# axis is off, which is what the kern sparse-decode combine does too
+# (`flashmla/sparse_decode_head64.py:1958`). The device code is unchanged
+# either way -- an unread pointer costs parameter space, not instructions --
+# and it keeps one launch ABI across the presence axes.
+#
+# Extents and strides are explicit runtime scalars rather than shapes baked
+# into the buffer declarations: a split-combine kernel that declared a
+# multi-dimensional alias with a runtime split stride is exactly the case the
+# codegen field notes record as `split_buffer_misaddress`.
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=64)
+def make_kernel(
+    *,
+    topk: int,
+    partial_dtype: str = "float32",
+    temperature: bool = False,
+    output_scale: bool = False,
+    seqused: bool = False,
+):
+    """Trace one specialization of the combine kernel.
+
+    The axes here are the compile-cache key the host entry uses
+    (combine.py:1339-1352) minus the values production pins: head dim 128, bf16
+    output, varlen, split counts present, LSE out present, ``use_pdl`` true.
+    """
+    if (TILE_M * topk) % NUM_THREADS != 0:
+        raise ValueError(f"topk={topk} violates can_implement: (tile_m*topk) % num_threads != 0")
+    partial_ty = _KERN_DTYPES[partial_dtype]
+    pbytes = _partial_bytes(partial_dtype)
+    # 128-bit copies: 4 fp32, 8 bf16/fp16, 16 fp8 elements per transaction, so
+    # the thread grid over a k-block row and the rows per thread follow the
+    # partial dtype (combine.py:112-134).
+    o_elems = 16 // pbytes
+    o_threads_per_row = K_BLOCK_SIZE // o_elems
+    o_rows = TILE_M // (NUM_THREADS // o_threads_per_row)
+    # The row group is `tidx // o_threads_per_row`: the column threads are
+    # contiguous, so the shift is log2 of the threads per row (5 for fp32,
+    # 4 for bf16/fp16, 3 for fp8), not log2 of the rows per group.
+    o_row_shift = o_threads_per_row.bit_length() - 1
+    # The output store partitions independently: 8 bf16 per 128-bit store
+    # (combine.py:136-163), which is why 7a and 7b use different maps.
+    out_elems = 16 // 2
+    out_rows = TILE_M // (NUM_THREADS // (K_BLOCK_SIZE // out_elems))
+    splits_pt = topk // (NUM_THREADS // TILE_M)
+    # Byte map of SharedStorage (combine.py:383-397). sLSETemperature occupies
+    # its slot unconditionally; every later offset depends on that.
+    off_slse, off_slse_t = 0, topk * TILE_M * 4
+    off_maxvalid = off_slse_t + topk * TILE_M * 4
+    off_so = off_maxvalid + _align_up(TILE_M * 4, 128)
+    off_sperm = off_so + _align_up(STAGES * TILE_M * K_BLOCK_SIZE * pbytes, 128)
+    smem_total = off_sperm + _align_up(TILE_M * (K_BLOCK_SIZE + PERM_ROW_PAD) * 2, 128)
+    # `min_blocks_per_mp = 3 if has_output_scale and use_pdl else 0`
+    # (combine.py:1337).
+    min_blocks_per_sm = 3 if output_scale else None
+
+    OFF_SLSE, OFF_SLSE_T = off_slse, off_slse_t
+    O_ELEMS, O_ROW_SHIFT, O_COL_MASK = o_elems, o_row_shift, o_threads_per_row - 1
+    OUT_ELEMS = out_elems
+    O_ROW_STEP = NUM_THREADS // o_threads_per_row
+    OUT_ROW_STEP = NUM_THREADS // (K_BLOCK_SIZE // out_elems)
+    PERM_ROW = K_BLOCK_SIZE + PERM_ROW_PAD
+    SMEM_TOTAL = smem_total
+    NUM_ROWS, OUT_ROWS, SPLITS_PT = o_rows, out_rows, splits_pt
+    NUM_VALS = o_elems
+
+    @K.kernel(
+        warps=WARPS,
+        arch="sm_100a",
+        min_blocks_per_sm=min_blocks_per_sm,
+        grid=False,
+        thread_layout=False,
+    )
+    def msa_sparse_atten_fwd_combine(
+        o_partial: K.gptr[partial_ty],
+        lse_partial: K.gptr[K.f32],
+        o_out: K.gptr[K.bf16],
+        lse_out: K.gptr[K.f32],
+        lse_temperature_partial: K.gptr[K.f32],
+        lse_temperature_out: K.gptr[K.f32],
+        cu_seqlens: K.gptr[K.i32],
+        seqused_q: K.gptr[K.i32],
+        split_counts: K.gptr[K.i32],
+        output_scale_ptr: K.gptr[K.f32],
+        stride_op_split: K.i32,
+        stride_op_q: K.i32,
+        stride_op_h: K.i32,
+        stride_lp_split: K.i32,
+        stride_lp_q: K.i32,
+        stride_o_q: K.i32,
+        stride_o_h: K.i32,
+        stride_l_q: K.i32,
+        stride_sc_q: K.i32,
+        qhead_per_kv: K.i32,
+        total_q: K.i32,
+        head_q: K.i32,
+        num_batches: K.i32,
+        head_div_mul: K.i32,
+        head_div_s1: K.i32,
+        head_div_s2: K.i32,
+    ):
+        # ===== MSA COMBINE TRANSCRIPTION START =====
+        # Grid: (ceil(seqlen*num_head / tile_m), ceil(head_dim / k_block), batch)
+        # with the head axis innermost inside the flattened row index
+        # (combine.py:401-418).
+        m_block, k_block, batch = I.cta_id(
+            [(total_q * head_q + (TILE_M - 1)) // TILE_M, HEAD_DIM // K_BLOCK_SIZE, num_batches]
+        )
+        tidx = I.thread_id([NUM_THREADS])
+
+        # -------------------------------------------------------------------
+        # Storage. One dynamic allocation carved into the source's five fields
+        # at their exact byte offsets (combine.py:383-397). `sLSETemperature`
+        # is allocated whether or not the temperature axis is on -- the source
+        # declares it unconditionally, and every later offset depends on it.
+        # -------------------------------------------------------------------
+        pool = K.smem_pool()
+        raw = pool.alloc((SMEM_TOTAL,), K.u8, align=1024)
+        pool.commit(SMEM_TOTAL)
+
+        def _view(shape, dtype, byte_offset):
+            return K.decl_buffer(
+                shape, dtype, data=raw.data, scope="shared.dyn", byte_offset=byte_offset, align=1024
+            )
+
+        s_lse = _view((topk * TILE_M,), K.f32, OFF_SLSE)
+        s_maxvalid = _view((TILE_M,), K.i32, off_maxvalid)
+        s_o = _view((STAGES * TILE_M * K_BLOCK_SIZE,), partial_ty, off_so)
+        s_perm = _view((TILE_M * PERM_ROW,), K.bf16, off_sperm)
+        s_perm_i32 = _view((TILE_M * PERM_ROW // 2,), K.u32, off_sperm)
+        if temperature:
+            s_lse_t = _view((topk * TILE_M,), K.f32, OFF_SLSE_T)
+
+        # The thread decomposition the source's four tiled copies imply. These
+        # are four distinct maps over the same 256 threads and they are never
+        # interchanged: the staging pair walks (split, row) with order=(1, 0),
+        # the read-back pair walks it with order=(0, 1), and the two epilogue
+        # pairs differ again in row stride and vector width. Conflating any two
+        # of them addresses real memory and fails only on some shapes.
+        lse_row = K.local_scalar("int32", init=K.bitwise_and(tidx, 63))
+        lse_split0 = K.local_scalar("int32", init=K.shift_right(tidx, 6))
+        s2r_row = K.local_scalar("int32", init=K.shift_right(tidx, 2))
+        s2r_split0 = K.local_scalar("int32", init=K.bitwise_and(tidx, 3))
+        o_row0 = K.local_scalar("int32", init=K.shift_right(tidx, O_ROW_SHIFT))
+        o_col = K.local_scalar("int32", init=K.bitwise_and(tidx, O_COL_MASK) * O_ELEMS)
+        st_row0 = K.local_scalar("int32", init=K.shift_right(tidx, 4))
+        st_col = K.local_scalar("int32", init=K.bitwise_and(tidx, 15) * OUT_ELEMS)
+
+        def _ld_u32(buf, index):
+            """``ld.global.u32``, the form the reference emits for every i32
+            field it reads. The reinterpret is a bitcast and costs nothing."""
+            raw = K.local_scalar("uint32")
+            K.ptx.ld.global_.u32(raw, buf.ptr_to([index]))
+            return K.reinterpret("int32", raw)
+
+        # -------------------------------------------------------------------
+        # Prologue: varlen bounds and the K1 dependency (combine.py:531-550).
+        # -------------------------------------------------------------------
+        q_offset = K.local_scalar("int32", init=_ld_u32(cu_seqlens, batch))
+        seqlen = K.local_scalar("int32")
+        if seqused:
+            K.assign(seqlen, _ld_u32(seqused_q, batch))
+        else:
+            K.assign(seqlen, _ld_u32(cu_seqlens, batch + 1) - q_offset)
+        max_idx = K.local_scalar("int32", init=seqlen * head_q)
+
+        with K.If(m_block * TILE_M < max_idx):
+            with K.Then():
+                # The source opens this block at :547 and closes it at :1125:
+                # the guard covers the WHOLE body, not just the wait. That is
+                # what retires a tail CTA before it reaches any barrier, so
+                # narrowing it to the wait would hang the remaining CTAs.
+                K.ptx.griddepcontrol.wait()
+
+                def _divmod_row(idx):
+                    """`decode_flat_row_idx` (combine.py:457-464).
+
+                    The host precomputes the magic operands, so this is the reference's
+                    seven-instruction sequence -- mul.hi + sub + shr + add + shr for the
+                    quotient, mul.lo + sub for the remainder -- and not a `div.s32`.
+                    """
+                    q0 = K.local_scalar("uint32")
+                    K.ptx.mul.hi.u32(
+                        q0, K.reinterpret("uint32", idx), K.reinterpret("uint32", head_div_mul)
+                    )
+                    t = K.local_scalar("uint32", init=K.reinterpret("uint32", idx) - q0)
+                    t2 = K.local_scalar(
+                        "uint32", init=K.shift_right(t, K.reinterpret("uint32", head_div_s1)) + q0
+                    )
+                    quot = K.local_scalar(
+                        "int32",
+                        init=K.reinterpret(
+                            "int32", K.shift_right(t2, K.reinterpret("uint32", head_div_s2))
+                        ),
+                    )
+                    rem = K.local_scalar("int32", init=idx - quot * head_q)
+                    return quot, rem
+
+                def _split_count(m_idx, head_idx, floor_div):
+                    """`mSplitCounts[offset + m_idx, head_idx // qhead_per_kvhead]`.
+
+                    Step 1's dividend is a fresh divmod remainder, known non-negative,
+                    and the reference emits a bare `div.s32` there; step 2 reads its
+                    dividend back from a register tensor, so the signed-floor fixup
+                    survives (combine.py:642 vs :709).
+                    """
+                    group = (
+                        K.local_scalar("int32", init=head_idx // qhead_per_kv)
+                        if floor_div
+                        else K.local_scalar("int32", init=K.truncdiv(head_idx, qhead_per_kv))
+                    )
+                    return _ld_u32(split_counts, (q_offset + m_idx) * stride_sc_q + group)
+
+                NEG_INF = K.reinterpret("float32", K.uint32(0xFF800000))
+
+                def _widen_words(dst, m, words):
+                    """Widen a 128-bit staged partial to fp32 lanes.
+
+                    bf16/fp16 carry 8 values per transaction and fp8 carries 16, so the
+                    four staged words expand to NUM_VALS accumulator lanes. MSA moves
+                    its fp8 tiles as raw bytes and converts through fp16, which is why
+                    the fp8 path goes via a byte permute rather than a direct cvt
+                    (combine.py:112-134 for the widths).
+                    """
+                    if partial_dtype in ("bfloat16", "float16"):
+                        lo_op = "cvt.f32.bf16" if partial_dtype == "bfloat16" else "cvt.f32.f16"
+                        for w in range(4):
+                            for half in range(2):
+                                half_bits = K.local_scalar("uint16")
+                                K.ptx.mov.b16(
+                                    half_bits,
+                                    K.cast(
+                                        K.bitwise_and(K.shift_right(words[w], 16 * half), 0xFFFF),
+                                        "uint16",
+                                    ),
+                                )
+                                K.ptx[lo_op](dst[m * NUM_VALS + 2 * w + half], half_bits)
+                    else:
+                        # float8_e4m3: `cvt.rn.f16x2.e4m3x2` takes a byte PAIR and
+                        # yields two halves, so four staged words are 8 conversions,
+                        # not 16 with the high half thrown away.
+                        for w in range(4):
+                            for pair in range(2):
+                                bp = K.local_scalar("uint16")
+                                K.ptx.mov.b16(
+                                    bp,
+                                    K.cast(
+                                        K.bitwise_and(K.shift_right(words[w], 16 * pair), 0xFFFF),
+                                        "uint16",
+                                    ),
+                                )
+                                h2 = K.local_scalar("uint32")
+                                K.ptx["cvt.rn.f16x2.e4m3x2"](h2, bp)
+                                for half in range(2):
+                                    hb = K.local_scalar("uint16")
+                                    K.ptx.mov.b16(
+                                        hb,
+                                        K.cast(
+                                            K.bitwise_and(K.shift_right(h2, 16 * half), 0xFFFF),
+                                            "uint16",
+                                        ),
+                                    )
+                                    K.ptx["cvt.f32.f16"](
+                                        dst[m * NUM_VALS + 4 * w + 2 * pair + half], hb
+                                    )
+
+                def _load_stage_vec(dst, m, stage, row):
+                    """`autovec_copy(tOsO_partial[..., stage], tOrO_partial)`
+                    (combine.py:939): one 128-bit shared read per staged row, widened
+                    to fp32 when the partial dtype is narrower."""
+                    ptr = s_o.ptr_to([stage * (TILE_M * K_BLOCK_SIZE) + row * K_BLOCK_SIZE + o_col])
+                    w = [K.local_scalar("uint32") for _ in range(4)]
+                    K.ptx.ld.shared.v4.b32(w[0], w[1], w[2], w[3], ptr)
+                    if partial_dtype == "float32":
+                        for v in range(4):
+                            K.assign(dst[m * NUM_VALS + v], K.reinterpret("float32", w[v]))
+                    else:
+                        _widen_words(dst, m, w)
+
+                def _store_zero_vec(ptr):
+                    """`tOsO_partial_cur[...].fill(0)` (combine.py:1161).
+
+                    One 128-bit shared store of a splatted zero. The reference spells
+                    it `st.shared.v4.f32` for fp32 partials and the same width for the
+                    narrower ones, so the bit pattern is what varies, not the width.
+                    """
+                    zero = K.local_scalar("uint32", init=K.uint32(0))
+                    K.ptx.st.shared.v4.b32(ptr, zero, zero, zero, zero)
+
+                # -------------------------------------------------------------------
+                # Step 1: stage LSE_partial, -inf past a row's split count
+                # (combine.py:636-673). One row per thread; four split slots strided
+                # by four, which land 1024 bytes apart in the swizzled buffer.
+                # -------------------------------------------------------------------
+                def _slse_base(split_base, row):
+                    """The swizzled element index of `sLSE[split_base, row]`.
+
+                    `make_swizzle(3, 2, 3)` composed over a `(min(topk,8), 64)` atom
+                    (combine.py:208-222): an XOR on bits 2..4 of the row-major index,
+                    which the export computes as
+                    `(((tid >> 3) & 28) ^ (tid & 252)) | (tid & 3)` for the staging map.
+                    """
+                    flat = split_base * TILE_M + row
+                    # `offset ^= ((offset >> 5) & 7) << 2`. The export spells this as
+                    # `(flat & 252) ^ ((flat >> 3) & 28)` because its two uses have
+                    # `flat < 256`; written that way it silently drops bits 8 and above,
+                    # which is wrong for step 6, whose split index is absolute and
+                    # reaches topk-1. The XOR only touches bits 2..4, so this form
+                    # agrees with the export everywhere the export applies.
+                    return K.bitwise_xor(
+                        flat, K.shift_left(K.bitwise_and(K.shift_right(flat, 5), 7), 2)
+                    )
+
+                idx1 = K.local_scalar("int32", init=m_block * TILE_M + lse_row)
+                with K.If(idx1 < max_idx):
+                    with K.Then():
+                        m_idx1, head_idx1 = _divmod_row(idx1)
+                        row_count = K.local_scalar(
+                            "int32", init=_split_count(m_idx1, head_idx1, False)
+                        )
+                        lse_row_base = K.local_scalar(
+                            "int64",
+                            init=K.cast((q_offset + m_idx1), "int64") * K.cast(stride_lp_q, "int64")
+                            + K.cast(head_idx1, "int64"),
+                        )
+                        for i in range(SPLITS_PT):
+                            si = lse_split0 + 4 * i
+                            dst = s_lse.ptr_to([_slse_base(lse_split0, lse_row) + i * (4 * TILE_M)])
+                            with K.If(si < row_count):
+                                with K.Then():
+                                    K.ptx["cp.async.ca.shared.global"](
+                                        dst,
+                                        lse_partial.ptr_to(
+                                            [
+                                                lse_row_base
+                                                + K.cast(si, "int64")
+                                                * K.cast(stride_lp_split, "int64")
+                                            ]
+                                        ),
+                                        4,
+                                        4,
+                                    )
+                                    if temperature:
+                                        K.ptx["cp.async.ca.shared.global"](
+                                            s_lse_t.ptr_to(
+                                                [_slse_base(lse_split0, lse_row) + i * (4 * TILE_M)]
+                                            ),
+                                            lse_temperature_partial.ptr_to(
+                                                [
+                                                    lse_row_base
+                                                    + K.cast(si, "int64")
+                                                    * K.cast(stride_lp_split, "int64")
+                                                ]
+                                            ),
+                                            4,
+                                            4,
+                                        )
+                                with K.Else():
+                                    K.ptx.st.shared.u32(dst, K.uint32(0xFF800000))
+                                    if temperature:
+                                        K.ptx.st.shared.u32(
+                                            s_lse_t.ptr_to(
+                                                [_slse_base(lse_split0, lse_row) + i * (4 * TILE_M)]
+                                            ),
+                                            K.uint32(0xFF800000),
+                                        )
+                    with K.Else():
+                        for i in range(SPLITS_PT):
+                            K.ptx.st.shared.u32(
+                                s_lse.ptr_to([_slse_base(lse_split0, lse_row) + i * (4 * TILE_M)]),
+                                K.uint32(0xFF800000),
+                            )
+                            if temperature:
+                                K.ptx.st.shared.u32(
+                                    s_lse_t.ptr_to(
+                                        [_slse_base(lse_split0, lse_row) + i * (4 * TILE_M)]
+                                    ),
+                                    K.uint32(0xFF800000),
+                                )
+                K.ptx.cp.async_.commit_group()
+
+                # -------------------------------------------------------------------
+                # Step 2: per-row indices, split counts and raw GMEM element pointers,
+                # then prime the partial pipeline stages-1 deep (combine.py:679-739).
+                # The out-of-range rows take a real predicated branch per row, with
+                # the -1/0/0 defaults materialized first.
+                # -------------------------------------------------------------------
+                hidx = K.alloc_local((NUM_ROWS,), "int32")
+                midx = K.alloc_local((NUM_ROWS,), "int32")
+                scount = K.alloc_local((NUM_ROWS,), "int32")
+                rowptr = K.alloc_local((NUM_ROWS,), "int64")
+
+                for m in range(NUM_ROWS):
+                    K.assign(hidx[m], K.int32(-1))
+                    K.assign(midx[m], K.int32(0))
+                    K.assign(scount[m], K.int32(0))
+                    K.assign(rowptr[m], K.int64(0))
+                    idx2 = K.local_scalar("int32", init=m_block * TILE_M + o_row0 + m * O_ROW_STEP)
+                    with K.If(idx2 < max_idx):
+                        with K.Then():
+                            q2, h2 = _divmod_row(idx2)
+                            K.assign(midx[m], q2)
+                            K.assign(hidx[m], h2)
+                            K.assign(scount[m], _split_count(q2, h2, True))
+                            # `(q_offset + m_idx)*head_q*D + h*D` is identically
+                            # `q_offset*head_q*D + idx*D`, because idx is exactly
+                            # `m_idx*head_q + h` -- the divmod result is multiplied
+                            # straight back out. Forming the address from idx keeps
+                            # the seven-instruction divmod off the chain that gates
+                            # this row's cp.async issue; the decomposition is still
+                            # computed, because split_counts and the output store
+                            # genuinely need m_idx and head_idx.
+                            K.assign(
+                                rowptr[m],
+                                K.cast(q_offset, "int64") * K.cast(stride_op_q, "int64")
+                                + K.cast(idx2, "int64") * K.cast(HEAD_DIM, "int64")
+                                + K.cast(k_block * K_BLOCK_SIZE, "int64"),
+                            )
+
+                def _load_o_partial(split, stage):
+                    """One pipeline stage (combine.py:1141-1161).
+
+                    A live slot issues the 16-byte `cp.async.cg`; a dead one stores a
+                    zero vector instead. The zero fill is what makes a ragged split
+                    count safe, and it is a separate store in the reference -- not
+                    cp.async's own ignore-src form.
+                    """
+                    for m in range(NUM_ROWS):
+                        dst = s_o.ptr_to(
+                            [
+                                stage * (TILE_M * K_BLOCK_SIZE)
+                                + (o_row0 + m * O_ROW_STEP) * K_BLOCK_SIZE
+                                + o_col
+                            ]
+                        )
+                        # The reference nests these: `if tOhidx[m] >= 0` wraps BOTH
+                        # arms (combine.py:1143-1161), so a dead row gets neither the
+                        # copy nor the fill. Collapsing them into a single `and`
+                        # would make a dead row write 16 zero bytes the reference
+                        # never writes.
+                        with K.If(hidx[m] >= 0):
+                            with K.Then():
+                                with K.If(split < scount[m]):
+                                    with K.Then():
+                                        K.ptx["cp.async.cg.shared.global"](
+                                            dst,
+                                            o_partial.ptr_to(
+                                                [
+                                                    rowptr[m]
+                                                    + K.cast(split, "int64")
+                                                    * K.cast(stride_op_split, "int64")
+                                                    + K.cast(o_col, "int64")
+                                                ]
+                                            ),
+                                            16,
+                                            16,
+                                        )
+                                    with K.Else():
+                                        _store_zero_vec(dst)
+
+                for stage in range(STAGES - 1):
+                    _load_o_partial(K.int32(stage), stage)
+                    K.ptx.cp.async_.commit_group()
+
+                # -------------------------------------------------------------------
+                # Step 3: publish the staged LSE and read it back on the transposed
+                # map (combine.py:746-757). The barrier is required because step 1
+                # partitions sLSE by (split, row) and this reads it by (row, split).
+                # -------------------------------------------------------------------
+                K.ptx.cp.async_.wait_group(STAGES - 1)
+                K.ptx.bar.sync(K.uint32(0))
+
+                lse_reg = K.alloc_local((SPLITS_PT,), "float32")
+                for i in range(SPLITS_PT):
+                    K.ptx.ld.shared.f32(
+                        lse_reg[i],
+                        s_lse.ptr_to([_slse_base(s2r_split0, s2r_row) + i * (4 * TILE_M)]),
+                    )
+
+                # -------------------------------------------------------------------
+                # Step 4: the split reduction (combine.py:779-873). Every reduction is
+                # over the four lanes t..t^3 that share a row, so each is two butterfly
+                # shuffles -- laneMask 2 then 1.
+                # -------------------------------------------------------------------
+                def _shfl_bfly_f32(value, lane_mask):
+                    out = K.local_scalar("uint32")
+                    K.ptx.shfl_sync.bfly.b32(
+                        out,
+                        K.reinterpret("uint32", value),
+                        K.uint32(lane_mask),
+                        K.uint32(31),
+                        K.uint32(0xFFFFFFFF),
+                    )
+                    return K.reinterpret("float32", out)
+
+                def _shfl_bfly_i32(value, lane_mask):
+                    out = K.local_scalar("uint32")
+                    K.ptx.shfl_sync.bfly.b32(
+                        out,
+                        K.reinterpret("uint32", value),
+                        K.uint32(lane_mask),
+                        K.uint32(31),
+                        K.uint32(0xFFFFFFFF),
+                    )
+                    return K.reinterpret("int32", out)
+
+                # The tree over the thread's four register values is NaN-propagating.
+                def _max_tree(vals):
+                    """NaN-propagating pairwise max over the thread's register slots.
+
+                    `ts2rrLSE[...].reduce(ReductionOp.MAX)` (combine.py:781-786)
+                    reduces ALL of mode[1], which is `splits_pt` slots -- 1, 2, 4 or
+                    8 as topk moves 4, 8, 16, 32. A tree written for four would
+                    silently drop the upper half at topk 32, and only a shape with
+                    more than 16 live splits would ever show it.
+                    """
+                    cur = list(vals)
+                    while len(cur) > 1:
+                        half = len(cur) // 2
+                        nxt = []
+                        for a in range(half):
+                            out = K.local_scalar("float32")
+                            K.ptx["max.NaN.f32"](out, cur[a], cur[a + half])
+                            nxt.append(out)
+                        if len(cur) % 2:
+                            nxt.append(cur[-1])
+                        cur = nxt
+                    return cur[0]
+
+                acc_max = _max_tree([lse_reg[i] for i in range(SPLITS_PT)])
+                other2 = _shfl_bfly_f32(acc_max, 2)
+                le2 = K.local_scalar("uint32")
+                K.ptx.setp.le.f32(le2, acc_max, other2)
+                nan2 = K.local_scalar("uint32")
+                K.ptx.setp.nan.f32(nan2, other2, other2)
+                pick = K.local_scalar("float32")
+                K.ptx.selp.f32(pick, other2, acc_max, K.ptx.pred(le2))
+                step2v = K.local_scalar("float32")
+                K.ptx.selp.f32(step2v, other2, pick, K.ptx.pred(nan2))
+                other1 = _shfl_bfly_f32(step2v, 1)
+                lse_max = K.local_scalar("float32")
+                K.ptx["max.f32"](lse_max, step2v, other1)
+
+                # The index of the last live split, reduced through the same butterfly
+                # shape but as a plain signed max.
+                cand = K.local_scalar("int32", init=K.int32(-1))
+                for i in range(SPLITS_PT):
+                    live = K.local_scalar("uint32")
+                    K.ptx.setp.neu.f32(live, lse_reg[i], NEG_INF)
+                    coord = s2r_split0 + 4 * i if i else s2r_split0
+                    sel = K.local_scalar("int32")
+                    K.ptx.selp.b32(sel, coord, cand, K.ptx.pred(live))
+                    K.assign(cand, sel)
+                mv1 = _shfl_bfly_i32(cand, 2)
+                mvt = K.local_scalar("int32")
+                K.ptx["max.s32"](mvt, cand, mv1)
+                mv2 = _shfl_bfly_i32(mvt, 2 - 1)
+                max_valid = K.local_scalar("int32")
+                K.ptx["max.s32"](max_valid, mvt, mv2)
+
+                # exp2 scales. `lse_max * LOG2_E` is hoisted above the -inf select, so
+                # the site carries five multiplies and not four.
+                is_ninf = K.local_scalar("uint32")
+                K.ptx.setp.eq.f32(is_ninf, lse_max, NEG_INF)
+                scaled_max = K.local_scalar("float32")
+                K.ptx["mul.f32"](scaled_max, lse_max, K.float32(LOG_2_E))
+                max_term = K.local_scalar("float32")
+                K.ptx.selp.f32(max_term, K.float32(0.0), scaled_max, K.ptx.pred(is_ninf))
+
+                lse_sum = K.local_scalar("float32", init=K.float32(0.0))
+                for i in range(SPLITS_PT):
+                    scaled = K.local_scalar("float32")
+                    K.ptx["mul.f32"](scaled, lse_reg[i], K.float32(LOG_2_E))
+                    arg = K.local_scalar("float32")
+                    K.ptx["sub.f32"](arg, scaled, max_term)
+                    K.ptx.ex2.approx.ftz.f32(lse_reg[i], arg)
+                    nxt = K.local_scalar("float32")
+                    K.ptx["add.f32"](nxt, lse_sum, lse_reg[i])
+                    K.assign(lse_sum, nxt)
+                sum1 = _shfl_bfly_f32(lse_sum, 2)
+                sumt = K.local_scalar("float32")
+                K.ptx["add.f32"](sumt, lse_sum, sum1)
+                sum2 = _shfl_bfly_f32(sumt, 1)
+                lse_sum_all = K.local_scalar("float32")
+                K.ptx["add.f32"](lse_sum_all, sumt, sum2)
+
+                # The source's three conditions become two compares: `sum == 0.0` and
+                # `sum != sum` fuse into one unordered-equal.
+                final_lse = K.local_scalar("float32", init=NEG_INF)
+                inv_sum = K.local_scalar("float32", init=K.float32(0.0))
+                bad_idx = K.local_scalar("uint32")
+                K.ptx.setp.lt.s32(bad_idx, max_valid, K.int32(0))
+                bad_sum = K.local_scalar("uint32")
+                K.ptx.setp.equ.f32(bad_sum, lse_sum_all, K.float32(0.0))
+                degenerate = K.local_scalar("uint32")
+                K.ptx.or_.pred(degenerate, K.ptx.pred(bad_idx), K.ptx.pred(bad_sum))
+                with K.If(degenerate == K.uint32(0)):
+                    with K.Then():
+                        lg = K.local_scalar("float32")
+                        K.ptx.lg2.approx.ftz.f32(lg, lse_sum_all)
+                        K.ptx["fma.rn.f32"](final_lse, lg, K.float32(LN_2), lse_max)
+                        K.ptx["rcp.rn.f32"](inv_sum, lse_sum_all)
+
+                if temperature:
+                    t_reg = K.alloc_local((SPLITS_PT,), "float32")
+                    for i in range(SPLITS_PT):
+                        K.ptx.ld.shared.f32(
+                            t_reg[i],
+                            s_lse_t.ptr_to([_slse_base(s2r_split0, s2r_row) + i * (4 * TILE_M)]),
+                        )
+                    t_max = _max_tree([t_reg[i] for i in range(SPLITS_PT)])
+                    to2 = _shfl_bfly_f32(t_max, 2)
+                    tle = K.local_scalar("uint32")
+                    K.ptx.setp.le.f32(tle, t_max, to2)
+                    tnan = K.local_scalar("uint32")
+                    K.ptx.setp.nan.f32(tnan, to2, to2)
+                    tpick = K.local_scalar("float32")
+                    K.ptx.selp.f32(tpick, to2, t_max, K.ptx.pred(tle))
+                    tstep = K.local_scalar("float32")
+                    K.ptx.selp.f32(tstep, to2, tpick, K.ptx.pred(tnan))
+                    to1 = _shfl_bfly_f32(tstep, 1)
+                    t_max_all = K.local_scalar("float32")
+                    K.ptx["max.f32"](t_max_all, tstep, to1)
+
+                    t_ninf = K.local_scalar("uint32")
+                    K.ptx.setp.eq.f32(t_ninf, t_max_all, NEG_INF)
+                    t_scaled = K.local_scalar("float32")
+                    K.ptx["mul.f32"](t_scaled, t_max_all, K.float32(LOG_2_E))
+                    t_term = K.local_scalar("float32")
+                    K.ptx.selp.f32(t_term, K.float32(0.0), t_scaled, K.ptx.pred(t_ninf))
+                    t_sum = K.local_scalar("float32", init=K.float32(0.0))
+                    for i in range(SPLITS_PT):
+                        sc = K.local_scalar("float32")
+                        K.ptx["mul.f32"](sc, t_reg[i], K.float32(LOG_2_E))
+                        ar = K.local_scalar("float32")
+                        K.ptx["sub.f32"](ar, sc, t_term)
+                        ev = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(ev, ar)
+                        nx = K.local_scalar("float32")
+                        K.ptx["add.f32"](nx, t_sum, ev)
+                        K.assign(t_sum, nx)
+                    ts1 = _shfl_bfly_f32(t_sum, 2)
+                    tst = K.local_scalar("float32")
+                    K.ptx["add.f32"](tst, t_sum, ts1)
+                    ts2 = _shfl_bfly_f32(tst, 1)
+                    t_sum_all = K.local_scalar("float32")
+                    K.ptx["add.f32"](t_sum_all, tst, ts2)
+
+                    final_lse_t = K.local_scalar("float32", init=NEG_INF)
+                    t_bad = K.local_scalar("uint32")
+                    K.ptx.setp.equ.f32(t_bad, t_sum_all, K.float32(0.0))
+                    t_degen = K.local_scalar("uint32")
+                    K.ptx.or_.pred(t_degen, K.ptx.pred(bad_idx), K.ptx.pred(t_bad))
+                    with K.If(t_degen == K.uint32(0)):
+                        with K.Then():
+                            tlg = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(tlg, t_sum_all)
+                            K.ptx["fma.rn.f32"](final_lse_t, tlg, K.float32(LN_2), t_max_all)
+
+                for i in range(SPLITS_PT):
+                    K.ptx["mul.f32"](lse_reg[i], lse_reg[i], inv_sum)
+                # The scales overwrite the staged log-sum-exps in place; step 6 reads
+                # them back on the O-partial map, which is why :907 is a barrier.
+                for i in range(SPLITS_PT):
+                    K.ptx.st.shared.f32(
+                        s_lse.ptr_to([_slse_base(s2r_split0, s2r_row) + i * (4 * TILE_M)]),
+                        lse_reg[i],
+                    )
+                with K.If(s2r_split0 == 0):
+                    with K.Then():
+                        K.ptx.st.shared.u32(
+                            s_maxvalid.ptr_to([s2r_row]), K.reinterpret("uint32", max_valid)
+                        )
+
+                # -------------------------------------------------------------------
+                # Step 5: the authoritative LSE_out store (combine.py:880-898). The two
+                # zero-tests are OR-fused into one compare, as at :815.
+                # -------------------------------------------------------------------
+                with K.If(K.bitwise_or(s2r_split0, k_block) == 0):
+                    with K.Then():
+                        idx5 = K.local_scalar("int32", init=m_block * TILE_M + s2r_row)
+                        with K.If(idx5 < max_idx):
+                            with K.Then():
+                                # `(q_offset + m_idx)*head_q + h` is identically
+                                # `q_offset*head_q + idx`, and these stores are the
+                                # only consumers of the decomposition here, so the
+                                # divmod drops out entirely.
+                                K.ptx.st.global_.f32(
+                                    lse_out.ptr_to([q_offset * stride_l_q + idx5]), final_lse
+                                )
+                                if temperature:
+                                    K.ptx.st.global_.f32(
+                                        lse_temperature_out.ptr_to([q_offset * stride_l_q + idx5]),
+                                        final_lse_t,
+                                    )
+
+                # -------------------------------------------------------------------
+                # Step 6: the accumulation loop over live splits (combine.py:907-953).
+                # The barrier publishes both step-4 writes: the scales, which this
+                # thread reads on a different row map, and sMaxValidSplit.
+                # -------------------------------------------------------------------
+                K.ptx.bar.sync(K.uint32(0))
+
+                thr_max_valid = K.local_scalar("int32")
+                first_mv = K.local_scalar("uint32")
+                K.ptx.ld.shared.u32(first_mv, s_maxvalid.ptr_to([o_row0]))
+                K.assign(thr_max_valid, K.reinterpret("int32", first_mv))
+                for m in range(1, NUM_ROWS):
+                    mv = K.local_scalar("uint32")
+                    K.ptx.ld.shared.u32(mv, s_maxvalid.ptr_to([o_row0 + m * O_ROW_STEP]))
+                    nxt = K.local_scalar("int32")
+                    K.ptx["max.s32"](nxt, thr_max_valid, K.reinterpret("int32", mv))
+                    K.assign(thr_max_valid, nxt)
+
+                # The accumulator is zeroed in the preheader, ahead of the zero-trip
+                # test, so a thread with no live split still carries zeros into step 7.
+                acc = K.alloc_local((NUM_ROWS * NUM_VALS,), "float32")
+                for m in range(NUM_ROWS):
+                    for v in range(NUM_VALS):
+                        K.assign(acc[m * NUM_VALS + v], K.float32(0.0))
+
+                stage_load = K.local_scalar("int32", init=K.int32(STAGES - 1))
+                stage_compute = K.local_scalar("int32", init=K.int32(0))
+                scale = K.alloc_local((NUM_ROWS,), "float32")
+                part = K.alloc_local((NUM_ROWS * NUM_VALS,), "float32")
+
+                with K.serial(thr_max_valid + 1) as sp:
+                    # Issue the next stage BEFORE the shared scale reads. The two
+                    # are independent -- the copy is indexed by the ring cursor and
+                    # the scales by the absolute split -- so putting the global
+                    # transfers in flight first lets them overlap the shared-load
+                    # latency instead of queueing behind it.
+                    with K.If(sp + (STAGES - 1) <= thr_max_valid):
+                        with K.Then():
+                            _load_o_partial(sp + (STAGES - 1), stage_load)
+                    K.ptx.cp.async_.commit_group()
+                    for m in range(NUM_ROWS):
+                        K.ptx.ld.shared.f32(
+                            scale[m], s_lse.ptr_to([_slse_base(sp, o_row0 + m * O_ROW_STEP)])
+                        )
+                    # Advance the ring cursor branchlessly: STAGES is a power of two
+                    # and the cursor is non-negative, so `(x + 1) & (STAGES-1)`
+                    # is a single instruction (combine.py:933, :940).
+                    # A signed truncmod needs sign correction and a select emits
+                    # a branch; both put a chain on the cursor that gates the
+                    # next iteration's shared addresses, and the branch costs
+                    # most on short loops (topk=4 runs at most four iterations).
+                    K.assign(stage_load, K.bitwise_and(stage_load + 1, K.int32(STAGES - 1)))
+                    K.ptx.cp.async_.wait_group(STAGES - 1)
+                    for m in range(NUM_ROWS):
+                        _load_stage_vec(part, m, stage_compute, o_row0 + m * O_ROW_STEP)
+                    # Advance the ring cursor branchlessly: STAGES is a power of two
+                    # and the cursor is non-negative, so `(x + 1) & (STAGES-1)`
+                    # is a single instruction (combine.py:933, :940).
+                    # A signed truncmod needs sign correction and a select emits
+                    # a branch; both put a chain on the cursor that gates the
+                    # next iteration's shared addresses, and the branch costs
+                    # most on short loops (topk=4 runs at most four iterations).
+                    K.assign(stage_compute, K.bitwise_and(stage_compute + 1, K.int32(STAGES - 1)))
+                    for m in range(NUM_ROWS):
+                        # `setp.leu.f32` is unordered, so a NaN scale skips the row too;
+                        # the `hidx >= 0` half reuses the predicate step 2 computed.
+                        with K.If(K.And(hidx[m] >= 0, scale[m] > K.float32(0.0))):
+                            with K.Then():
+                                for v in range(NUM_VALS):
+                                    K.ptx["fma.rn.f32"](
+                                        acc[m * NUM_VALS + v],
+                                        part[m * NUM_VALS + v],
+                                        scale[m],
+                                        acc[m * NUM_VALS + v],
+                                    )
+
+                K.ptx.cp.async_.wait_group(0)
+                K.ptx.bar.sync(K.uint32(0))
+
+                # -------------------------------------------------------------------
+                # Step 7a: scatter the accumulator into sO_perm in REAL column order
+                # (combine.py:1011-1049). This inverts the permutation K1's STG.128
+                # epilogue applied. Adjacent fake columns map to adjacent real ones, so
+                # a converted bf16 pair is one 32-bit shared store.
+                # -------------------------------------------------------------------
+                if output_scale:
+                    out_scale = K.local_scalar("float32")
+                    K.ptx.ld.global_.f32(out_scale, output_scale_ptr.ptr_to([0]))
+                    # The packed operand is loop-invariant; the reference
+                    # broadcasts it once (scale_fp32p_t8 PTX:1578), not once
+                    # per pair.
+                    scale_pair = K.local_scalar("uint64")
+                    K.ptx.mov.b64(scale_pair, out_scale, out_scale)
+
+                def _fake_to_real(fake_col):
+                    """Invert K1's STG.128 column permutation (copy_utils.py:861-906).
+
+                    Three maps, selected by the PARTIAL dtype -- K1 chose the fake order
+                    to get 128-bit stores out of its TMEM fragment, and the fragment
+                    width is what differs. All three are the same shape: split off a
+                    block, then swap a lane index with a group index inside it.
+                    """
+                    if partial_dtype in ("bfloat16", "float16"):
+                        block, lane_w = 32, 8  # stg128_half_fake_col_to_real_col (:878)
+                    elif partial_dtype == "float8_e4m3":
+                        block, lane_w = 64, 16  # stg128_fp8_fake_col_to_real_col (:897)
+                    else:
+                        block, lane_w = 16, 4  # stg128_fake_col_to_real_col (:861)
+                    nt = K.bitwise_and(fake_col, -block)
+                    inner = K.bitwise_and(fake_col, block - 1)
+                    lane = K.truncdiv(inner, lane_w)
+                    slot = K.bitwise_and(inner, lane_w - 1)
+                    group = K.shift_right(slot, 1)
+                    elem = K.bitwise_and(slot, 1)
+                    return nt + group * 8 + lane * 2 + elem
+
+                for m in range(NUM_ROWS):
+                    with K.If(hidx[m] >= 0):
+                        with K.Then():
+                            for vp in range(NUM_VALS // 2):
+                                v = 2 * vp
+                                # real_col for the pair; the two halves differ only in
+                                # bit 0, which is what makes them one 32-bit word.
+                                real_col = _fake_to_real(o_col + v)
+                                hi = acc[m * NUM_VALS + v + 1]
+                                lo = acc[m * NUM_VALS + v]
+                                if output_scale:
+                                    # `cute.arch.mul_packed_f32x2` (combine.py:1030):
+                                    # ONE packed multiply per pair. A packed f32x2
+                                    # operand is a single 64-bit value, so the pair
+                                    # is packed with mov.b64 and unpacked after.
+                                    pk = K.local_scalar("uint64")
+                                    K.ptx.mov.b64(pk, lo, hi)
+                                    K.ptx.mul.f32x2(pk, pk, scale_pair)
+                                    scaled_hi = K.local_scalar("float32")
+                                    scaled_lo = K.local_scalar("float32")
+                                    K.ptx.mov.b64(scaled_lo, scaled_hi, pk)
+                                    hi, lo = scaled_hi, scaled_lo
+                                word = K.local_scalar("uint32")
+                                K.ptx["cvt.rn.bf16x2.f32"](word, hi, lo)
+                                K.ptx.st.shared.u32(
+                                    s_perm_i32.ptr_to(
+                                        [
+                                            (o_row0 + m * O_ROW_STEP) * (PERM_ROW // 2)
+                                            + K.truncdiv(real_col, 2)
+                                        ]
+                                    ),
+                                    word,
+                                )
+
+                # The re-partition point: 7a wrote sO_perm on the O-partial map, 7b
+                # reads it on the output map, so every thread reads other threads' words.
+                K.ptx.bar.sync(K.uint32(0))
+
+                # -------------------------------------------------------------------
+                # Step 7b: sO_perm -> registers -> GMEM, 128 bits at a time
+                # (combine.py:1108-1125).
+                # -------------------------------------------------------------------
+                for m in range(OUT_ROWS):
+                    row_out = st_row0 + m * OUT_ROW_STEP
+                    w = [K.local_scalar("uint32") for _ in range(4)]
+                    K.ptx.ld.shared.v4.b32(
+                        w[0],
+                        w[1],
+                        w[2],
+                        w[3],
+                        s_perm_i32.ptr_to([row_out * (PERM_ROW // 2) + K.truncdiv(st_col, 2)]),
+                    )
+                    idx7 = K.local_scalar("int32", init=m_block * TILE_M + row_out)
+                    with K.If(idx7 < max_idx):
+                        with K.Then():
+                            # Same identity as the partial address and the LSE
+                            # store: the decomposition is multiplied straight back
+                            # out and has no other consumer here, so four divmods
+                            # per thread leave the store path.
+                            K.ptx.st.global_.v4.b32(
+                                o_out.ptr_to(
+                                    [
+                                        q_offset * stride_o_q
+                                        + idx7 * HEAD_DIM
+                                        + k_block * K_BLOCK_SIZE
+                                        + st_col
+                                    ]
+                                ),
+                                w[0],
+                                w[1],
+                                w[2],
+                                w[3],
+                            )
+        # ===== MSA COMBINE TRANSCRIPTION END =====
+
+    return msa_sparse_atten_fwd_combine
+
+
+def get_kernel(**config):
+    """Return the TIRx specialization selected by one config."""
+    config.pop("label", None)
+    kernel = make_kernel(
+        topk=int(config["topk"]),
+        partial_dtype=str(config.get("partial_dtype", "float32")),
+        temperature=bool(config.get("temperature", False)),
+        output_scale=bool(config.get("output_scale", False)),
+        seqused=bool(config.get("seqused", False)),
+    )
+    return kernel.func.with_attr("global_symbol", KERNEL_META["name"]).with_attr(
+        "tirx.kernel_launch_params", list(LAUNCH_TAGS)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config matrix.
+#
+# The shapes mirror the forward port's benchmark rows, so a combine row and the
+# forward row that produces its input describe the same production launch. The
+# presence axes are the ones the two host call sites actually reach: the
+# standard path passes temperature partials and no output scale
+# (interface.py:1532), the NVFP4 path adds `output_scale=v_global_scale`
+# (interface.py:972), and neither passes `seqused`. Partial dtype is the axis
+# with genuinely distinct device code: it selects one of three fake-column
+# maps and the width of both the staging copy and the epilogue store.
+# ---------------------------------------------------------------------------
+def _case(
+    *,
+    batch: int,
+    seqlen_q: int,
+    head_kv: int,
+    qhead_per_kv: int,
+    topk: int,
+    label: str,
+    partial_dtype: str = "float32",
+    temperature: bool = False,
+    output_scale: bool = False,
+    seqused: bool = False,
+    seqlen_k: int | None = None,
+    seqlen_pattern: str = "uniform",
+    blk_kv: int = 128,
+) -> dict:
+    return {
+        "label": label,
+        "batch": batch,
+        "seqlen_q": seqlen_q,
+        "seqlen_k": seqlen_q if seqlen_k is None else seqlen_k,
+        "head_kv": head_kv,
+        "qhead_per_kv": qhead_per_kv,
+        "topk": topk,
+        "partial_dtype": partial_dtype,
+        "temperature": temperature,
+        "output_scale": output_scale,
+        "seqused": seqused,
+        "seqlen_pattern": seqlen_pattern,
+        "blk_kv": blk_kv,
+    }
+
+
+BENCH_CONFIGS = [
+    # MSA's own ring-attention benchmark shape, carried over from the forward
+    # port; the `sparse_fmha_adapter` layer pins fp32 partials on this path.
+    _case(
+        label="ring48k_fp32p_qh16_t16", batch=1, seqlen_q=49152, head_kv=1, qhead_per_kv=16, topk=16
+    ),
+    # Ulysses-style sequence parallelism: the longest row, with topk lowered so
+    # the partials still fit, exactly as the forward port sizes it.
+    _case(
+        label="ulysses384k_fp32p_qh2_t4",
+        batch=1,
+        seqlen_q=393216,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+    ),
+    _case(
+        label="long96k_fp32p_qh2_t16", batch=1, seqlen_q=98304, head_kv=1, qhead_per_kv=2, topk=16
+    ),
+    _case(
+        label="varlen_b3_s8192_fp32p_qh4_t16",
+        batch=3,
+        seqlen_q=8192,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        seqlen_pattern="varlen",
+    ),
+    # The forward's fp8 row emits bf16 partials and a temperature LSE, so this
+    # is the half fake-column map, the packed `f16x2` staging store, and the
+    # second reduction, all on the marquee geometry.
+    _case(
+        label="ring48k_bf16p_temp_qh16_t16",
+        batch=1,
+        seqlen_q=49152,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=16,
+        partial_dtype="bfloat16",
+        temperature=True,
+    ),
+    _case(
+        label="fp8p_s16384_qh8_t8",
+        batch=1,
+        seqlen_q=16384,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        partial_dtype="float8_e4m3",
+    ),
+    # The NVFP4 production combine: V's tensor scale is deferred to this kernel
+    # and it is the only configuration that raises `min_blocks_per_mp` to 3.
+    _case(
+        label="scale_bf16p_temp_s16384_qh4_t16",
+        batch=1,
+        seqlen_q=16384,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        partial_dtype="bfloat16",
+        temperature=True,
+        output_scale=True,
+    ),
+    # The scale applied on the fp32 partial path, where the epilogue multiplies
+    # scalars instead of packed pairs.
+    _case(
+        label="scale_fp32p_s8192_qh8_t8",
+        batch=1,
+        seqlen_q=8192,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        output_scale=True,
+    ),
+    _case(
+        label="edge_b1_s1024_fp32p_qh2_t4",
+        batch=1,
+        seqlen_q=1024,
+        head_kv=1,
+        qhead_per_kv=2,
+        topk=4,
+    ),
+]
+
+# Correctness adds the axes production never benchmarks: fp16 partials (a
+# dispatch-legal dtype upstream has no benchmark for), `seqused`, the largest
+# legal split count, and the smallest one on a ragged multi-batch shape.
+CONFIGS = [
+    *BENCH_CONFIGS,
+    _case(
+        label="corr_fp16p_s4096_qh8_t8",
+        batch=1,
+        seqlen_q=4096,
+        head_kv=2,
+        qhead_per_kv=8,
+        topk=8,
+        partial_dtype="float16",
+    ),
+    _case(
+        label="corr_seqused_s4096_qh4_t16",
+        batch=2,
+        seqlen_q=4096,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=16,
+        seqused=True,
+        seqlen_pattern="varlen",
+    ),
+    _case(
+        label="corr_topk32_s2048_qh16_t32",
+        batch=1,
+        seqlen_q=2048,
+        head_kv=1,
+        qhead_per_kv=16,
+        topk=32,
+        temperature=True,
+    ),
+    # The topk=32 row above has seqlen_k 2048, i.e. 16 KV blocks, so a query can
+    # never carry more than 16 live splits and the upper half of each thread's
+    # register slots stays -inf. This shape has 64 blocks, so it is the only
+    # config that exercises `SPLITS_PT == 8` end to end.
+    _case(
+        label="corr_topk32_s8192_qh4_t32",
+        batch=1,
+        seqlen_q=8192,
+        head_kv=2,
+        qhead_per_kv=4,
+        topk=32,
+    ),
+    _case(
+        label="corr_tiny_b2_s512_qh1_t4",
+        batch=2,
+        seqlen_q=512,
+        head_kv=1,
+        qhead_per_kv=1,
+        topk=4,
+        seqlen_pattern="varlen",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Data preparation.
+#
+# This kernel's inputs are the forward's outputs, so the split counts come from
+# the same CSR schedule the forward port builds -- that is what makes the split
+# occupancy ragged in the way production is, with rows whose degree falls short
+# of `topk` and rows that use every slot. The partial values themselves are
+# synthetic: the reduction is agnostic to where they came from, and generating
+# them directly keeps a combine correctness run from also paying for a forward.
+#
+# Slots at or past a row's degree are filled with NaN rather than left
+# undefined. The kernel is specified never to read them -- the LSE staging
+# fills `-inf` past the row's count (combine.py:650-672), the partial loader
+# zero-fills the stage instead of issuing the copy (:1154-1161), and the
+# accumulate loop is guarded on a positive scale (:944) -- so a single read of
+# a dead slot poisons the output and the bitwise gate catches it.
+# ---------------------------------------------------------------------------
+_CSR_CONFIG_KEYS = (
+    "batch",
+    "seqlen_q",
+    "seqlen_k",
+    "head_kv",
+    "qhead_per_kv",
+    "topk",
+    "blk_kv",
+    "seqlen_pattern",
+)
+
+# Fraction of live slots forced to `-inf`, which is the value the forward
+# writes for a split whose rows are entirely masked. It exercises the
+# `lse_max == -inf` fallback and, on a low-degree row, the all-dead row whose
+# output is defined to be zero with an `-inf` LSE (combine.py:815-820).
+_DEAD_SPLIT_FRACTION = 0.02
+
+
+def prepare_data(*, seed: int = 0, **config) -> dict[str, Any]:
+    """Build the split partials, the schedule's split counts and the outputs."""
+    import torch
+
+    from tirx_kernels.msa.sparse_prepare_fwd_split_atomic import prepare_data as prepare_csr
+
+    config.pop("label", None)
+    csr_config = {key: config[key] for key in _CSR_CONFIG_KEYS if key in config}
+    csr = prepare_csr(seed=seed, **csr_config)
+
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(5417 + seed)
+    head_kv = config["head_kv"]
+    qhead_per_kv = config["qhead_per_kv"]
+    head_q = head_kv * qhead_per_kv
+    topk = config["topk"]
+    total_q = csr["total_q"]
+    partial_dtype = config.get("partial_dtype", "float32")
+    temperature = bool(config.get("temperature", False))
+    has_output_scale = bool(config.get("output_scale", False))
+
+    split_counts = csr["degrees"].to(torch.int32).contiguous()
+    if int(split_counts.max()) > topk:
+        raise ValueError("the CSR schedule produced a degree above topk")
+
+    # `split < split_counts[q, kv_head]`, broadcast to the partial shape. The
+    # split-atomic schedule packs each group's slots into `0 .. degree-1`, so
+    # the degree alone decides which slots are live.
+    per_head_q = split_counts.repeat_interleave(qhead_per_kv, dim=1)
+    splits = torch.arange(topk, device=device).view(-1, 1, 1)
+    live = splits < per_head_q.unsqueeze(0)
+
+    shape = (topk, total_q, head_q)
+    # A wide spread so the max selection, the exponent magnitudes and the
+    # reciprocal of the sum all see non-degenerate values.
+    lse_partial = torch.randn(shape, dtype=torch.float32, device=device, generator=generator) * 2.0
+    dead = torch.rand(shape, device=device, generator=generator) < _DEAD_SPLIT_FRACTION
+    lse_partial = torch.where(dead, torch.full_like(lse_partial, float("-inf")), lse_partial)
+    lse_partial = torch.where(live, lse_partial, torch.full_like(lse_partial, float("nan")))
+
+    o_partial = torch.randn(
+        (*shape, HEAD_DIM), dtype=torch.float32, device=device, generator=generator
+    )
+    o_partial = torch.where(
+        live.unsqueeze(-1), o_partial, torch.full_like(o_partial, float("nan"))
+    ).to(_torch_dtype(partial_dtype))
+    if partial_dtype == "float8_e4m3":
+        # `nan` survives the cast to e4m3 as `0x7f`; assert it rather than
+        # assume it, because a dead slot that quietly became a finite value
+        # would make the mask check vacuous.
+        dead_bytes = o_partial.view(torch.uint8)[~live.unsqueeze(-1).expand_as(o_partial)]
+        if dead_bytes.numel() and int(dead_bytes.min()) != 0x7F:
+            raise AssertionError("fp8 dead-slot poison did not encode as 0x7f")
+
+    lse_temperature_partial = None
+    if temperature:
+        lse_temperature_partial = (
+            torch.randn(shape, dtype=torch.float32, device=device, generator=generator) * 1.5
+        )
+        lse_temperature_partial = torch.where(
+            live, lse_temperature_partial, torch.full_like(lse_temperature_partial, float("nan"))
+        )
+
+    output_scale = None
+    if has_output_scale:
+        # `v_global_scale` is a one-element fp32 tensor (interface.py:972).
+        output_scale = torch.tensor([0.7315], dtype=torch.float32, device=device)
+
+    seqused_q = None
+    if config.get("seqused", False):
+        seqlens_q = torch.tensor(csr["seqlens_q"], dtype=torch.int32, device=device)
+        trims = torch.tensor(
+            [(37 * (i + 1)) % 64 for i in range(len(csr["seqlens_q"]))],
+            dtype=torch.int32,
+            device=device,
+        )
+        seqused_q = torch.clamp(seqlens_q - trims, min=1).contiguous()
+
+    return {
+        "config": dict(config),
+        "o_partial": o_partial.contiguous(),
+        "lse_partial": lse_partial.contiguous(),
+        "lse_temperature_partial": lse_temperature_partial,
+        "split_counts": split_counts,
+        "output_scale": output_scale,
+        "seqused_q": seqused_q,
+        "cu_seqlens_q": csr["cu_seqlens_q"],
+        "seqlens_q": csr["seqlens_q"],
+        "live": live,
+        "topk": topk,
+        "total_q": total_q,
+        "head_q": head_q,
+        "head_kv": head_kv,
+        "qhead_per_kv": qhead_per_kv,
+        "num_batches": len(csr["seqlens_q"]),
+        "partial_dtype": partial_dtype,
+        "temperature": temperature,
+    }
+
+
+def make_outputs(data: dict[str, Any]) -> dict[str, Any]:
+    """Fresh output buffers, NaN-filled so an unwritten row stays visible.
+
+    The host allocates these with `torch.empty` (interface.py:1470-1484). Both
+    sides get the same deterministic prefill instead, which costs nothing and
+    turns "the kernel wrote every row it owns" into something the comparison
+    can actually check.
+    """
+    import torch
+
+    outputs = {
+        "o_out": torch.full(
+            (data["total_q"], data["head_q"], HEAD_DIM),
+            float("nan"),
+            dtype=torch.bfloat16,
+            device="cuda",
+        ),
+        "lse_out": torch.full(
+            (data["total_q"], data["head_q"]), float("nan"), dtype=torch.float32, device="cuda"
+        ),
+    }
+    if data["temperature"]:
+        outputs["lse_temperature_out"] = torch.full(
+            (data["total_q"], data["head_q"]), float("nan"), dtype=torch.float32, device="cuda"
+        )
+    return outputs
+
+
+def tirx_args(data: dict[str, Any], outputs: dict[str, Any]) -> tuple:
+    """The launch ABI, bound once outside any timed region."""
+    import torch
+
+    def as_bits(t):
+        """fp8 reaches the kernel as raw ``uint8``; see ``_KERN_DTYPES``."""
+        return t.view(torch.uint8) if t.dtype == torch.float8_e4m3fn else t
+
+    topk = data["topk"]
+    total_q = data["total_q"]
+    head_q = data["head_q"]
+    head_kv = data["head_kv"]
+    # An absent optional buffer still occupies its parameter slot; the
+    # specialization simply never reads it.
+    dummy_f32 = torch.zeros(1, dtype=torch.float32, device="cuda")
+    dummy_i32 = torch.zeros(1, dtype=torch.int32, device="cuda")
+    temperature_partial = data["lse_temperature_partial"]
+    temperature_out = outputs.get("lse_temperature_out")
+    return (
+        as_bits(data["o_partial"]).reshape(-1),
+        data["lse_partial"].reshape(-1),
+        outputs["o_out"].reshape(-1),
+        outputs["lse_out"].reshape(-1),
+        dummy_f32 if temperature_partial is None else temperature_partial.reshape(-1),
+        dummy_f32 if temperature_out is None else temperature_out.reshape(-1),
+        data["cu_seqlens_q"],
+        dummy_i32 if data["seqused_q"] is None else data["seqused_q"],
+        data["split_counts"].reshape(-1),
+        dummy_f32 if data["output_scale"] is None else data["output_scale"],
+        total_q * head_q * HEAD_DIM,
+        head_q * HEAD_DIM,
+        HEAD_DIM,
+        total_q * head_q,
+        head_q,
+        head_q * HEAD_DIM,
+        HEAD_DIM,
+        head_q,
+        head_kv,
+        data["qhead_per_kv"],
+        total_q,
+        head_q,
+        data["num_batches"],
+        *fast_divmod(head_q),
+    )
+
+
+def reference_case(data: dict[str, Any], outputs: dict[str, Any]) -> dict[str, Any]:
+    """The argument bundle MSA's own compiled combine takes."""
+    return {
+        "o_partial": data["o_partial"],
+        "lse_partial": data["lse_partial"],
+        "o_out": outputs["o_out"],
+        "lse_out": outputs["lse_out"],
+        "lse_temperature_partial": data["lse_temperature_partial"],
+        "lse_temperature_out": outputs.get("lse_temperature_out"),
+        "cu_seqlens_q": data["cu_seqlens_q"],
+        "seqused": data["seqused_q"],
+        "split_counts": data["split_counts"],
+        "output_scale": data["output_scale"],
+        "qhead_per_kv": data["qhead_per_kv"],
+        "head_dim": HEAD_DIM,
+        "topk": data["topk"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Correctness.
+# ---------------------------------------------------------------------------
+def written_row_mask(data: dict[str, Any]):
+    """The `(q, head)` rows this launch is defined to write.
+
+    Every row is written unless `seqused` shortens a batch, in which case the
+    kernel's own bound stops the grid short (combine.py:545-547) and the tail
+    rows keep whatever the allocation held.
+    """
+    import torch
+
+    total_q = data["total_q"]
+    head_q = data["head_q"]
+    if data["seqused_q"] is None:
+        return torch.ones((total_q, head_q), dtype=torch.bool, device="cuda")
+
+    mask = torch.zeros((total_q, head_q), dtype=torch.bool, device="cuda")
+    cu = data["cu_seqlens_q"].tolist()
+    used = data["seqused_q"].tolist()
+    for batch, count in enumerate(used):
+        start = cu[batch]
+        mask[start : start + int(count)] = True
+    return mask
+
+
+def assert_outputs_match(
+    data: dict[str, Any],
+    outputs: dict[str, Any],
+    expected: dict[str, Any],
+    *,
+    rtol: float = 0.0,
+    atol: float = 0.0,
+) -> None:
+    """Compare every written row, and hold the rest to the prefill.
+
+    Bitwise by default. The reduction runs a fixed-order serial loop per thread
+    with fp32 fused multiply-adds, its reductions are fixed-topology warp
+    shuffles, and no atomic appears anywhere -- so a port that selects the same
+    instructions reproduces the reference exactly, and a tolerance here would
+    only hide the cases where it does not.
+    """
+    import torch
+
+    mask = written_row_mask(data)
+    o_mask = mask.unsqueeze(-1).expand_as(outputs["o_out"])
+    torch.testing.assert_close(
+        outputs["o_out"][o_mask].float(),
+        expected["o_out"][o_mask].float(),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=True,
+    )
+    torch.testing.assert_close(
+        outputs["lse_out"][mask], expected["lse_out"][mask], rtol=rtol, atol=atol, equal_nan=True
+    )
+    if "lse_temperature_out" in outputs:
+        torch.testing.assert_close(
+            outputs["lse_temperature_out"][mask],
+            expected["lse_temperature_out"][mask],
+            rtol=rtol,
+            atol=atol,
+            equal_nan=True,
+        )
+    if not bool(mask.all()):
+        untouched = ~mask
+        if not bool(torch.isnan(outputs["lse_out"][untouched]).all()):
+            raise AssertionError("the kernel wrote rows past seqused")
+
+
+def run_test(**config):
+    """Compile, launch, and validate one config against MSA's own kernel."""
+    import unittest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    if not torch.cuda.is_available():  # pragma: no cover - environment dependent
+        raise unittest.SkipTest("CUDA device unavailable")
+
+    config.pop("label", None)
+    data = prepare_data(**config)
+
+    try:
+        from tirx_kernels.msa.utils._msa_bench import compiled_sparse_atten_combine
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+
+    expected = make_outputs(data)
+    try:
+        compiled_sparse_atten_combine(reference_case(data, expected))()
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise unittest.SkipTest(f"MSA reference unavailable: {exc}") from exc
+    torch.cuda.synchronize()
+
+    executable = compile_kernel(get_kernel(**config))
+    outputs = make_outputs(data)
+    executable(*tirx_args(data, outputs))
+    torch.cuda.synchronize()
+    assert_outputs_match(data, outputs, expected)
+
+
+def prepare_bench(**config):
+    """Compile the TIRx specialization without initializing CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config.pop("label", None)
+    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points.
+#
+# No rotation is needed between iterations: the kernel reads its partials
+# without touching them and overwrites -- never accumulates into -- the outputs
+# it owns, so the hundredth launch does exactly the work the first one did.
+# ---------------------------------------------------------------------------
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    """Kernel-only comparison against MSA's compiled combine launch."""
+    from tirx_kernels.runner import bench
+
+    config = {**prepared["config"], **config}
+    config.pop("label", None)
+    data = prepare_data(**config)
+    executable = prepared["executable"]
+
+    tirx_outputs = make_outputs(data)
+    tirx_bound = tirx_args(data, tirx_outputs)
+
+    def tirx_launch():
+        executable(*tirx_bound)
+
+    def build_reference():
+        from tirx_kernels.msa.utils._msa_bench import compiled_sparse_atten_combine
+
+        launch = compiled_sparse_atten_combine(reference_case(data, make_outputs(data)))
+        launch()  # pay the CuTeDSL compile and first-launch cost outside timing
+        return launch
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"msa": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/msa/utils/_msa_bench.py
+++ b/tirx_kernels/msa/utils/_msa_bench.py
@@ -536,3 +536,158 @@ def compiled_flat_schedule(case: dict):
         case["head_kv"],
         case["blk_kv"],
     )
+
+
+_COMBINE_CACHE: dict = {}
+
+
+def compiled_sparse_atten_combine(case: dict):
+    """Compile (or fetch) ``SparseAttentionForwardCombine`` and return the launchable.
+
+    Mirrors the compile step of ``combine()`` (combine.py:1327-1480, varlen
+    branch) instead of calling that host entry, so the timed closure covers the
+    kernel launch alone rather than the host wrapper's shape and dtype
+    validation, its ``.contiguous()`` copies, and its tile selection.
+
+    ``num_splits_dynamic_ptr``, ``varlen_batch_idx`` and ``semaphore_to_reset``
+    are pinned to ``None`` here because the host entry pins them too
+    (combine.py:1465-1473, :1492-1494); the semaphore-reset block at
+    combine.py:518-526 is therefore compiled out of every specialization the
+    production path can reach.
+    """
+    ensure_msa_importable()
+
+    import cutlass
+    import cutlass.cute as cute
+    import torch
+    from cutlass import Float32, Int32
+    from quack.compile_utils import make_fake_tensor
+    from src.sm100.fwd.combine import SparseAttentionForwardCombine
+
+    o_partial = case["o_partial"]
+    lse_partial = case["lse_partial"]
+    o_out = case["o_out"]
+    lse_out = case["lse_out"]
+    lse_temperature_partial = case.get("lse_temperature_partial")
+    lse_temperature_out = case.get("lse_temperature_out")
+    seqused = case.get("seqused")
+    output_scale = case.get("output_scale")
+    head_dim = case["head_dim"]
+    topk = case["topk"]
+    # Host tile selection, combine.py:1327-1337.
+    k_block_size = 128 if head_dim > 64 else 64
+    tile_m = 64
+    min_blocks_per_mp = 3 if output_scale is not None else 0
+
+    cutlass_dtype = {
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float16: cutlass.Float16,
+        torch.float32: cutlass.Float32,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+    }
+    partial_dtype = cutlass_dtype[o_partial.dtype]
+    out_dtype = cutlass_dtype[o_out.dtype]
+
+    key = (
+        "combine",
+        head_dim,
+        k_block_size,
+        tile_m,
+        topk,
+        o_partial.dtype,
+        o_out.dtype,
+        True,  # has_cu_seqlens: the production path is varlen only
+        seqused is not None,
+        True,  # has_lse
+        lse_temperature_partial is not None,
+        True,  # has_split_counts
+        output_scale is not None,
+        True,  # use_pdl
+        min_blocks_per_mp,
+    )
+    if key not in _COMBINE_CACHE:
+        kernel = SparseAttentionForwardCombine(
+            dtype=out_dtype,
+            dtype_partial=partial_dtype,
+            head_dim=head_dim,
+            tile_m=tile_m,
+            k_block_size=k_block_size,
+            topk=topk,
+            use_pdl=True,
+            min_blocks_per_mp=min_blocks_per_mp,
+            stages=2,
+        )
+        div = 128 // partial_dtype.width
+        total_q, nheads = (cute.sym_int64() for _ in range(2))
+        m_o_partial = make_fake_tensor(
+            partial_dtype, (topk, total_q, nheads, head_dim), divisibility=div
+        )
+        m_lse_partial = make_fake_tensor(
+            Float32, (topk, total_q, nheads), divisibility=1, leading_dim=2
+        )
+        m_o = make_fake_tensor(
+            out_dtype, (total_q, nheads, head_dim), divisibility=128 // out_dtype.width
+        )
+        m_lse = make_fake_tensor(Float32, (total_q, nheads), divisibility=1, leading_dim=1)
+        m_lse_temperature_partial = (
+            make_fake_tensor(Float32, (topk, total_q, nheads), divisibility=1, leading_dim=2)
+            if lse_temperature_partial is not None
+            else None
+        )
+        m_lse_temperature = (
+            make_fake_tensor(Float32, (total_q, nheads), divisibility=1, leading_dim=1)
+            if lse_temperature_out is not None
+            else None
+        )
+        total_q_ctr, nheads_kv = (cute.sym_int64() for _ in range(2))
+        m_split_counts = make_fake_tensor(
+            Int32, (total_q_ctr, nheads_kv), divisibility=1, leading_dim=1
+        )
+        m_output_scale = (
+            make_fake_tensor(Float32, (cute.sym_int64(),), divisibility=1, leading_dim=0)
+            if output_scale is not None
+            else None
+        )
+        _COMBINE_CACHE[key] = cute.compile(
+            kernel,
+            m_o_partial,
+            m_lse_partial,
+            m_o,
+            m_lse,
+            m_lse_temperature_partial,
+            m_lse_temperature,
+            make_fake_tensor(Int32, (cute.sym_int64(),), divisibility=1, leading_dim=0),
+            None
+            if seqused is None
+            else make_fake_tensor(Int32, (cute.sym_int64(),), divisibility=1, leading_dim=0),
+            None,
+            None,
+            None,
+            m_split_counts,
+            m_output_scale,
+            Int32(case["qhead_per_kv"]),
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+            options="--enable-tvm-ffi",
+        )
+
+    compiled = _COMBINE_CACHE[key]
+
+    def launch() -> None:
+        compiled(
+            o_partial,
+            lse_partial,
+            o_out,
+            lse_out,
+            lse_temperature_partial,
+            lse_temperature_out,
+            case["cu_seqlens_q"],
+            seqused,
+            None,
+            None,
+            None,
+            case["split_counts"],
+            output_scale,
+            case["qhead_per_kv"],
+        )
+
+    return launch


### PR DESCRIPTION
Ports `SparseAttentionForwardCombine` as `msa_sparse_atten_fwd_combine_sm100`, the K2 half of the MSA sparse attention forward pair. It reduces the per-split partials the merged forwards already write: merges the split log-sum-exps, rescales and accumulates the split outputs in fp32, and un-permutes the forward's STG.128 fake column order back to real head-dim order on the way out. This is the first MSA module written in the kern DSL.

## Shape of the port

Combine is a pure `cp.async` kernel — no TMA, no mbarrier, no TMEM, no cluster, no warp specialization — so it needs no roles. 256 uniform threads over a plain shared pool, a two-stage `cp.async` pipeline, and PDL through the launch tag plus a single `griddepcontrol.wait`. The source emits no `launch_dependents` here and neither does the port.

The one structural subtlety is that the source's four tiled copies imply four *different* thread decompositions over the same 256 threads: the log-sum-exp staging pair walks `(split, row)` with `order=(1, 0)`, the read-back pair walks it with `order=(0, 1)`, and the two epilogue pairs differ again in row stride and vector width. Conflating any two of them still addresses real memory and still passes on some shapes, so they are named apart in the source and never interchanged. Four cross-partition edges follow from that and each is covered by exactly one barrier.

## Coverage

The full production domain of the two combine call sites: `topk` 4/8/16/32, fp32/bf16/fp16/fp8-e4m3 partials, the temperature log-sum-exp path, `output_scale`, and `seqused` as a correctness-only axis. The three STG.128 fake-column maps are separate device code selected by the partial dtype — block/lane 16/4, 32/8, 64/16 — so each one carries its own bench shape rather than riding on a shared row.

Out of scope and recorded as such: the batched non-varlen mode, the `use_pdl=False` direct-scatter epilogue, fp16/fp32 out dtypes, dynamic splits, `varlen_batch_idx`, the semaphore reset, and `has_lse=False`. The host entry pins `num_splits_dynamic_ptr`, `varlen_batch_idx` and `semaphore_to_reset` to `None`, so the semaphore-reset block is compiled out of every specialization the production path can reach.

## Correctness

Bitwise against the compiled CuTe-DSL source on identical frozen inputs, `rtol=0, atol=0`, masked by the rows the kernel writes: **14/14** configs.

Invalid split slots are NaN-poisoned in the inputs and the outputs are NaN-prefilled, so a read outside a row's valid prefix fails the comparison instead of passing on a plausible value, and the unwritten-row invariant is checked rather than assumed.

Two defects found here are worth naming because both were invisible to an earlier version of the matrix:

- The shared log-sum-exp swizzle. The source spells it `(flat & 252) ^ ((flat >> 3) & 28)`, which is only equivalent to the general form for `flat < 256`. One step indexes with absolute splits that reach 1023, where the two diverge. `topk=4` passed and `topk=16` failed at 85% mismatch.
- The `max.NaN.f32` reduction tree was written for the `splits_per_thread <= 4` cases. At `topk=32` the upper half of the register file never entered the max. The suite could not see it: the only `topk=32` config had few enough KV blocks that the missed lanes were empty. It is now a general pairwise reduction, and `corr_topk32_s8192_qh4_t32` was added to reach the case.

## Performance

`bench_suite` clears every required shape:

| shape | ratio |
| --- | --- |
| `ring48k_fp32p_qh16_t16` | 0.9989 |
| `varlen_b3_s8192_fp32p_qh4_t16` | 0.9992 |
| `long96k_fp32p_qh2_t16` | 1.0004 |
| `scale_fp32p_s8192_qh8_t8` | 1.0049 |
| `edge_b1_s1024_fp32p_qh2_t4` | 1.0134 |
| `ulysses384k_fp32p_qh2_t4` | 1.0142 |
| `scale_bf16p_temp_s16384_qh4_t16` | 1.0276 |
| `fp8p_s16384_qh8_t8` | 1.0513 |
| `ring48k_bf16p_temp_qh16_t16` | 1.1319 |

**9/9, min 0.9989, mean 1.0269.** Figures are per-shape medians over five to six complete matrices at 15 rounds each.

The first version passed 3 of 9 at min 0.9512. Paired NCU showed the two kernels were memory-identical with identical occupancy, which retired the bandwidth and occupancy hypotheses and left issue efficiency; the stall breakdown then named a fixed-latency execution dependency. That traced to integer address arithmetic on the per-split path, and the fix landed in four steps: signed `truncmod` ring cursors replaced with a mask, the scale loads issued ahead of their consumers, and finally the FastDivmod decompositions removed from the three addressing sites where the multiply-back is algebraically redundant — `(q_offset + m_idx) * head_q + h` is just `q_offset * head_q + idx`, so the partial address, the log-sum-exp store and the output store never need the row and head apart. Divmods per thread fall 14 to 9 with store counts unchanged, and every specialization's generated code shrinks by 3.5–3.8 KB.

The signature worth trusting here is that all four short shapes crossed together, which is what a per-thread scalar cost looks like rather than a shape-specific effect.

One caveat on the numbers. Foreign tenants on the shared node produced swings of 5–44% in both directions during this work, in both directions — one reading had the reference slowed 44% and reported 1.4377. The protocol was tightened to 15 rounds and a median over three or more complete matrices. Three single-run outliers survive in the samples (0.8741, 0.9010, 1.2299) and are excluded as invalid runs rather than averaged in; with them dropped, every remaining sample of every shape is above the gate. `ring48k_fp32p_qh16_t16` is the thin one at 0.9989 and is worth re-checking on a quiet node.

The reference adapter mirrors `combine()`'s compile step rather than calling that host entry, so the timed closure covers the launch alone and not the wrapper's validation, its `.contiguous()` copies, or its tile selection — the same approach the merged forwards use.

## Codegen-tuning database

The second commit adds two entries, both from this port's address arithmetic:

- **Do not decompose an index the address recombines** — a faithfully transcribed FastDivmod is redundant when the address weights the quotient and remainder by the same factors the divmod divided by. The reference computes the decomposition because other statements consume it; the port's copy at that site feeds nothing but the recombination.
- **Advance a power-of-two ring cursor with a mask** — the three spellings are not interchangeable. A signed modulo pays the floordiv fixup on the chain that gates the next iteration's addresses, a conditional reset removes the fixup but adds a branch that costs more at low trip counts, and a mask has neither cost.

The refuted result is deliberately not an entry. Removing a recomputed swizzle chain from a hot loop measured neutral-to-negative here, which is the same asymmetry `stop-cutting-instructions-once-parity-is-reached` and `buy-overlap-once-the-instruction-count-already-matches` already record; this port reproduced it rather than extending it. The measurement-protocol lessons are also left out, since the database records kernel-code changes rather than benchmark methodology.
