### PR TITLE
feat(kernel): port cuDNN persistent block-scaled GEMM amax

### DIFF
--- a/.agents/sketch/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.md
+++ b/.agents/sketch/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.md
@@ -1,0 +1,758 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 dense block-scaled persistent GEMM + amax: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch. It freezes the storage, six-warp
+role split, persistent scheduling, asynchronous protocols, tile dataflow, C
+epilogue, and FP32 amax path for the single parameterized TIRx module
+[`tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py`](../../tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py).
+After the reviewer gate that module is the executable source of truth; this
+sketch remains frozen.
+
+The source is
+`python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py`
+at commit `7b5327b32907b9dd21d85a393d62f9573d7f0116`, SHA256
+`637088ed4fb7db391d7e9325b3e9f952265ff206ebfc96aed0cdfd1d3365d7f1`.
+Source-line citations below are to that file. The primary evidence is the
+writer's exact line-info export under
+`.porting/dense_blockscaled_gemm_persistent_amax/writer_source_export/`, PTX
+SHA256 `c3bf02ae4c6affaff3f9aef132eff81815a4b6fbb58bec3b2f3fff40eb87d6bb`.
+`PTX n` means the numbered line in that 1,348-line artifact.
+
+The instruction-annotated body is the fixed primary specialization:
+
+| axis | anchor value |
+| --- | --- |
+| problem | `M=N=K=1024`, `L=1` |
+| A/B | FP4 E2M1, K-major/K-major |
+| scale | E8M0, vector size 16 |
+| C | FP16, N-major |
+| MMA tile / cluster | `(128,128)` / `(2,1)` |
+| fixed | FP32 accumulator, M tile 128, overlap margin 0 |
+
+The same sketch owns every accepted compile-time branch listed in **Static
+specialization boundary**. Those branches alter shapes, descriptor constants,
+conversion families, pipeline depths, and predicates; they do not add a role,
+kernel, or workflow. M tile 256/two-CTA MMA and the non-working public `uint8`
+FP4 alias are out of scope.
+
+First-class layouts are forbidden throughout both this sketch and the device
+kernel. No layout object is constructed, passed, returned, stored on a buffer,
+or manipulated by layout algebra. Source layouts are resolved before device
+tracing into ordinary integer extents, byte strides, byte offsets, swizzle
+enum fields, TensorMap bytes, and raw MMA descriptor bits. Every device-side
+SMEM buffer is linear, every TMEM region is named by integer row/column
+addresses, and every address helper below returns scalar integers or raw
+pointers only. Abstract `tile` wording means a logical rectangular region of
+the algorithm; it never denotes a TIRx tile primitive or a layout-bearing
+value.
+
+## Pipeline at a glance
+
+| warp / role | tile program | publication / reuse edges |
+| --- | --- | --- |
+| warps 0-3, epilogue | warp 0 allocates all 512 TMEM columns; all four wait on named barrier 3, persistently consume one accumulator tile, load four anchor subtiles TMEM -> registers, accumulate absolute FP32 maxima, convert C, stage C in a five-stage SMEM ring, and TMA-store it; then reduce amax warp -> CTA -> global atomic | accumulator-full mbarrier -> TMEM load; named barrier 2 brackets each SMEM C stage and the four-warp amax handoff; elected consumer release publishes accumulator-empty; TMA bulk-group wait protects C-stage reuse |
+| warp 4, MMA | waits for the TMEM pointer on named barrier 3; for each persistent output tile, waits for an accumulator stage and each AB stage, copies SFA/SFB SMEM -> TMEM, issues four block-scaled MMA instructions per anchor K tile, releases AB, and commits the accumulator | AB-full -> scale copy/MMA; `tcgen05.commit` publishes AB-empty after each K tile and accumulator-full after each output tile; accumulator-empty gates reuse |
+| warp 5, TMA | prefetches all five TensorMaps, then the warp walks the same persistent tiles and K tiles; its waits/control are warp-uniform and each arrive/TMA issue selects one lane | AB-empty -> four TMA loads -> AB-full transaction completion; producer tail waits until all five stages are reusable |
+| whole CTA/cluster prologue | initialize and publish AB mbarriers, independently initialize and publish accumulator mbarriers, then perform the source's third publication arrive before descriptor/address setup and its matching wait afterward | three `fence.mbarrier_init.release.cluster` epochs; the first two each perform cluster arrive/wait, while the third separates arrive from the later wait; named barrier 3 publishes TMEM pointer to MMA+epilogue |
+
+The three persistent role-local scheduler cursors traverse the identical static
+work list. They communicate tiles only through the two pipelines; there is no
+extra scheduler handoff. Source `833-917`, `984-1107`, `1160-1320`; anchor PTX
+`221-559`, `587-956`, `974-1334`.
+
+## Primitive vocabulary
+
+Structural forms describe placement and views without moving data:
+
+```python
+specialize(...)                 # compile-time dtype/major/tile/cluster branch
+launch(...)                     # grid, six warps, cluster, dynamic SMEM, min occupancy
+gmem_region(name, shape, dtype, major)
+smem_bytes(name, offset, byte_count, alignment)
+tmem_region(name, start_column, row_count, column_count, dtype)
+rmem_words(name, count, dtype)
+byte_ptr(base, scalar_byte_offset)
+raw_mma_descriptor(base_ptr, ldo, sdo, swizzle_enum)
+mbarrier_array(name, stages, arrivals)
+pipeline_state(name, stages, phase, index, count)
+persistent_scheduler(problem_tiles, cluster_shape, grid)
+logical_region(tensor, scalar_coordinates, scalar_extents)
+```
+
+Directional movement is explicit:
+
+```python
+copy_g2s(src_gmem, dst_smem, tensor_map, mbarrier, multicast_mask)
+copy_s2t(raw_smem_descriptor_u64, dst_tmem)
+copy_t2r(src_tmem, dst_rmem)
+copy_r2s(src_rmem, dst_smem)
+copy_s2g(src_smem, dst_gmem, tensor_map)
+load_smem(src, dst)
+store_smem(src, dst)
+```
+
+Basic computation remains decomposed:
+
+```python
+gemm(acc_tmem, a_smem, sfa_tmem, b_smem, sfb_tmem, accumulate)
+abs(src_f32, dst_f32)
+reduce_max(src, dst, nan_semantics)
+cast(src_f32, dst_c)
+atomic_max_bits(src_nonnegative_f32, dst_f32)
+```
+
+Schedule operations stay visible:
+
+```python
+elect_one(); wait(barrier, phase); arrive_expect_tx(barrier, bytes)
+try_wait_acquire(barrier, phase); wait_plain_if_not_ready(barrier, phase, token)
+reset_count(state); advance(state.index, state.phase, state.count)
+commit(barrier, cta_mask); release(barrier, cta_mask)
+fence_mbarrier_init_cluster(); cluster_arrive(); cluster_wait(); cta_sync()
+fence_async_shared_cta(); named_barrier(id, threads)
+tma_commit_group(); tma_wait_group(pending)
+alloc_tmem(columns); dealloc_tmem(columns)
+```
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# source 134-200, 201-338, 340-580; PTX 14-42
+# ===========================================================================
+P = specialize(
+    M, N, K, L,
+    ab_dtype, sf_dtype, sf_vec_size, c_dtype,
+    a_major, b_major, c_major,
+    n_tile, cluster_m, cluster_n,
+)
+M_TILE = 128
+K_TILE = 4 * mma_instruction_k(P)       # anchor: 4 * 64 == 256
+N_TILE = P.n_tile                       # 128 or 256
+ACC_DTYPE = f32
+CTA_GROUP = 1                           # M tile 256 is excluded
+WARPS = 6
+EPI_WARPS = (0, 1, 2, 3)
+MMA_WARP = 4
+TMA_WARP = 5
+AB_STAGES = compute_source_ab_stages(P) # anchor: 5
+ACC_STAGES = 2 if N_TILE == 128 else 1
+C_STAGES = compute_source_c_stages(P)   # anchor: 5
+
+# Raw tensor pointers remain in the launch ABI because amax is not a TensorMap.
+# Five opaque TensorMaps describe A/B/SFA/SFB/C, including runtime shapes,
+# strides, OOB fill, boxes, swizzle enum fields, and multicast-capable load
+# forms. They are already-encoded descriptors, not first-class layouts.
+ABI = (
+    A_ptr, B_ptr, SFA_ptr, SFB_ptr, C_ptr, amax_ptr,
+    map_A, map_B, map_SFA, map_SFB, map_C,
+    scheduler_shape_and_fast_divmod,
+)
+
+launch(
+    grid=persistent_grid(ceil_div(M, 128), ceil_div(N, N_TILE), L,
+                         (cluster_m, cluster_n)),
+    block=(192, 1, 1),
+    cluster=(cluster_m, cluster_n, 1),
+    arch="sm_100a",
+    min_blocks_per_sm=1,
+    dynamic_smem=source_shared_storage_size(P),
+)
+# instruction_selection: `.reqntid 192,1,1`, `.minnctapersm 1`, and
+#   `.extern .shared .align 1024`; extent: one launch specialization
+#   (anchor PTX 14, 36-37; source 574-580)
+
+# ===========================================================================
+# Storage and synchronization objects
+# source 504-548, 643-706, 809-816; PTX 122-218, 563-586
+# ===========================================================================
+AB_FULL  = mbarrier_array(stages=AB_STAGES, arrivals=1)
+AB_EMPTY = mbarrier_array(stages=AB_STAGES,
+                          arrivals=cluster_n + cluster_m - 1)
+ACC_FULL = mbarrier_array(stages=ACC_STAGES, arrivals=1)
+ACC_EMPTY = mbarrier_array(stages=ACC_STAGES, arrivals=4)
+TMEM_DEALLOC = smem_scalar(i64)          # reserved; inactive for CTA_GROUP=1
+TMEM_PTR = smem_scalar(u32)
+
+# Anchor dynamic-SMEM byte map. Non-anchor offsets are recomputed from the same
+# declaration order and alignments; no two live objects alias.
+#   AB_FULL 0..39; AB_EMPTY 40..79; ACC_FULL 80..95; ACC_EMPTY 96..111
+#   TMEM_DEALLOC 112..119; TMEM_PTR 120..123; padding to 1024
+#   sC 1024..41983; sA 41984..123903; sB 123904..205823
+#   sSFA 205824..216063; sSFB 216064..226303; sAmax 226304..226319
+#   shared struct rounded to 227328 bytes.
+sC = smem_bytes("sC", source_sC_offset(P), source_sC_bytes(P), alignment=1024)
+sA = smem_bytes("sA", source_sA_offset(P), source_sA_bytes(P), alignment=1024)
+sB = smem_bytes("sB", source_sB_offset(P), source_sB_bytes(P), alignment=1024)
+sSFA = smem_bytes("sSFA", source_sSFA_offset(P), source_sSFA_bytes(P), alignment=1024)
+sSFB = smem_bytes("sSFB", source_sSFB_offset(P), source_sSFB_bytes(P), alignment=1024)
+sAmax = smem_bytes("sAmax", source_sAmax_offset(P), 4 * sizeof(f32), alignment=16)
+
+# These are pure compile-time/scalar-integer address formulas. They neither
+# create nor consume a layout value. Each returns a raw address in its linear
+# byte buffer; swizzle XOR and stage strides are folded into integer arithmetic.
+sC_addr = scalar_address_formula(P, region="C")
+sA_addr = scalar_address_formula(P, region="A")
+sB_addr = scalar_address_formula(P, region="B")
+sSFA_addr = scalar_address_formula(P, region="SFA")
+sSFB_addr = scalar_address_formula(P, region="SFB")
+sAmax_addr = lambda warp_or_slot: 4 * warp_or_slot
+
+# The MMA shared descriptors are raw u64 values. Their base address, LDO, SDO,
+# transposition bit, and swizzle enum are ordinary integers fixed by P.
+a_desc = raw_mma_descriptor(sA, A_LDO(P), A_SDO(P), A_SWIZZLE_ENUM(P))
+b_desc = raw_mma_descriptor(sB, B_LDO(P), B_SDO(P), B_SWIZZLE_ENUM(P))
+sfa_desc = raw_mma_descriptor(sSFA, SF_LDO(P), SF_SDO(P), 0)
+sfb_desc = raw_mma_descriptor(sSFB, SF_LDO(P), SF_SDO(P), 0)
+def sfa_desc_for(stage, sf_chunk):
+    return raw_descriptor_address_formula(sfa_desc, stage, sf_chunk)
+
+def sfb_desc_for(stage, sf_chunk):
+    return raw_descriptor_address_formula(sfb_desc, stage, sf_chunk)
+
+# All 512 columns are allocated. ACC_STAGES selects disjoint accumulator
+# stages; SFA then SFB occupy the following source-computed column regions.
+tAcc = tmem_region("acc", start_column=0, row_count=128,
+                   column_count=accumulator_columns(P, ACC_STAGES), dtype=f32)
+tSFA = tmem_region("SFA", start_column=after_accumulator_columns(P),
+                   row_count=128, column_count=SFA_COLUMNS(P), dtype=sf_dtype)
+tSFB = tmem_region("SFB", start_column=after_accumulator_and_SFA_columns(P),
+                   row_count=128, column_count=SFB_COLUMNS(P), dtype=sf_dtype)
+
+rAcc = rmem_words("acc", source_thread_acc_word_count(P), f32)
+rC = rmem_words("C", source_thread_c_word_count(P), c_dtype)
+
+# ===========================================================================
+# Coordinates, descriptor prefetch, and barrier initialization
+# source 614-719, 819-824; PTX 82-218
+# ===========================================================================
+warp = warp_uniform(warp_id())
+lane = lane_id()
+cluster_rank = block_idx_in_cluster()
+cluster_m_coord = cluster_rank % cluster_m
+cluster_n_coord = (cluster_rank // cluster_m) % cluster_n
+
+# Integer CTA masks replace every source-side inferred cluster mapping. The AB
+# mask is the union of the same-M row and same-N column, with rank encoded as
+# `m + cluster_m * n`; duplicate self bits collapse under integer OR. Its
+# anchor value is 0b11. The accumulator mask is the one-hot local CTA rank.
+ab_consumer_mask = 0
+for peer_n in range(cluster_n):
+    ab_consumer_mask |= 1 << (cluster_m_coord + cluster_m * peer_n)
+for peer_m in range(cluster_m):
+    ab_consumer_mask |= 1 << (peer_m + cluster_m * cluster_n_coord)
+acc_producer_mask = 1 << cluster_rank
+
+if warp == TMA_WARP:
+    for descriptor in (map_A, map_B, map_SFA, map_SFB, map_C):
+        prefetch(descriptor)
+        # instruction_selection: `prefetch.tensormap`; extent: five scalar
+        #   descriptor prefetches (source 620-625; PTX 93-111)
+
+if warp == 0 and elect_one():
+    for stage in range(AB_STAGES):
+        init(AB_FULL[stage], arrivals=1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: five
+        #   anchor barriers at offsets 0..32 (source 648-659; PTX 126-135)
+if warp == 0 and elect_one():
+    for stage in range(AB_STAGES):
+        init(AB_EMPTY[stage], arrivals=cluster_n + cluster_m - 1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: five
+        #   anchor barriers, arrival count 2, offsets 40..72 (PTX 140-149)
+
+# Publication epoch 1 belongs to PipelineTmaUmma construction. AB full and
+# empty initialization have independent elected issuers, and the complete AB
+# group is published before any accumulator barrier is initialized.
+fence_mbarrier_init_cluster()
+# instruction_selection: `fence.mbarrier_init.release.cluster`; extent:
+#   AB-pipeline publication (source 648-659 plus PipelineTmaUmma.create;
+#   PTX 157)
+if cluster_m * cluster_n > 1:
+    cluster_arrive()
+    cluster_wait()
+    # instruction_selection: `barrier.cluster.arrive.relaxed` then
+    #   `barrier.cluster.wait`; extent: first cluster synchronization
+    #   (PTX 158-159)
+else:
+    cta_sync()
+    # instruction_selection: `bar.sync 0`; extent: default CTA-wide singleton
+    #   fallback from PipelineTmaUmma.create
+
+if warp == 0 and elect_one():
+    for stage in range(ACC_STAGES):
+        init(ACC_FULL[stage], arrivals=1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: two
+        #   anchor barriers at offsets 80,88 (source 661-671; PTX 163-170)
+if warp == 0 and elect_one():
+    for stage in range(ACC_STAGES):
+        init(ACC_EMPTY[stage], arrivals=4)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: two
+        #   anchor barriers at offsets 96,104 (PTX 176-182)
+
+# Publication epoch 2 belongs to PipelineUmmaAsync construction and is
+# separate from both AB publication and the explicit source publication.
+fence_mbarrier_init_cluster()
+# instruction_selection: `fence.mbarrier_init.release.cluster`; extent:
+#   accumulator-pipeline publication (source 661-671 plus
+#   PipelineUmmaAsync.create; PTX 187)
+if cluster_m * cluster_n > 1:
+    cluster_arrive()
+    cluster_wait()
+    # instruction_selection: `barrier.cluster.arrive.relaxed` then
+    #   `barrier.cluster.wait`; extent: second cluster synchronization
+    #   (PTX 188-189)
+else:
+    cta_sync()
+    # instruction_selection: `bar.sync 0`; extent: default CTA-wide singleton
+    #   fallback from PipelineUmmaAsync.create
+
+# Publication epoch 3 is the explicit source fence/arrive. Its matching wait
+# intentionally occurs only after the scalar address, descriptor, partition,
+# and mask setup represented above; it is not adjacent to this arrive.
+fence_mbarrier_init_cluster()
+# instruction_selection: `fence.mbarrier_init.release.cluster`; extent:
+#   explicit publication (source 673-687; PTX 191)
+if cluster_m * cluster_n > 1:
+    cluster_arrive()
+    # instruction_selection: `barrier.cluster.arrive.relaxed`; extent: third
+    #   cluster arrival (source 685-687; PTX 193)
+
+perform_scalar_address_descriptor_partition_and_mask_setup()
+
+if cluster_m * cluster_n > 1:
+    cluster_wait()
+    # instruction_selection: `barrier.cluster.wait`; extent: delayed matching
+    #   wait before role-local staged-tensor use (source 819-824; PTX 218)
+else:
+    named_barrier(id=1, threads=192)
+    # instruction_selection: `bar.sync 1, 192`; extent: the third epoch's CTA
+    #   fallback at the delayed wait site
+
+# Multicast ownership is structural and independent of CTA_GROUP:
+#   A and SFA multicast across equal M coordinates (cluster N dimension);
+#   B and SFB multicast across equal N coordinates (cluster M dimension).
+# A one-element multicast dimension selects the non-multicast CTA destination.
+
+# ===========================================================================
+# Role 1: warp 5, persistent TMA producer with elected issue sites
+# source 829-917; PTX 221-559
+# ===========================================================================
+if warp == TMA_WARP:
+    sched = persistent_scheduler(problem_tiles=(ceil_div(M, 128),
+                                                ceil_div(N, N_TILE), L),
+                                 cluster_shape=(cluster_m, cluster_n),
+                                 grid=grid_dim())
+    ab_prod = pipeline_state(stages=AB_STAGES, phase=1, index=0, count=0)
+
+    while sched.valid:
+        tile_m, tile_n, tile_l = sched.current_tile()
+        # cluster-local CTA coordinates choose this CTA's A/B/SF partitions;
+        # TensorMap OOB fill supplies aligned M/N/K tails.
+        reset_count(ab_prod)
+        ab_empty_ready = True
+        if ab_prod.count < ceil_div(K, K_TILE):
+            ab_empty_ready = try_wait_acquire(AB_EMPTY[ab_prod.index],
+                                              ab_prod.phase)
+            # instruction_selection:
+            #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+            #   extent: initial speculative AB-empty probe (source 860-864;
+            #   PTX 290-297)
+
+        while ab_prod.count < ceil_div(K, K_TILE): # anchor body is nounroll
+            k_tile = ab_prod.count
+            wait_plain_if_not_ready(AB_EMPTY[ab_prod.index], ab_prod.phase,
+                                    ab_empty_ready)
+            # instruction_selection: only when the speculative token is false,
+            #   retry loop containing `mbarrier.try_wait.parity.shared.b64
+            #   ...,10000000`; extent: conditional blocking retry per K tile
+            #   (source 868-870; PTX 305-327)
+
+            if elect_one():
+                arrive_expect_tx(AB_FULL[ab_prod.index], source_stage_bytes(P))
+                # instruction_selection: `mbarrier.arrive.expect_tx.shared.b64`;
+                #   extent: one elected-lane arrival, anchor 36,864 bytes
+                #   (source 870; PTX 330-336)
+
+            if elect_one():
+                copy_g2s(logical_region(A, A_coords(tile_m, k_tile, tile_l), A_box(P)),
+                         byte_ptr(sA, sA_addr(ab_prod.index, 0, 0)),
+                         map_A, AB_FULL[ab_prod.index], multicast_A_mask)
+            # instruction_selection: anchor
+            #   `cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+            #   extent: one FP4 A tile (source 873-879; PTX 342-351)
+            if elect_one():
+                copy_g2s(logical_region(B, B_coords(tile_n, k_tile, tile_l), B_box(P)),
+                         byte_ptr(sB, sB_addr(ab_prod.index, 0, 0)),
+                         map_B, AB_FULL[ab_prod.index], multicast_B_mask)
+            # instruction_selection: anchor
+            #   `cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.L2::cache_hint`;
+            #   extent: one FP4 B tile, mask 0b11 (source 880-886; PTX 353-364)
+            if elect_one():
+                copy_g2s(logical_region(SFA, SFA_coords(tile_m, k_tile, tile_l), SFA_box(P)),
+                         byte_ptr(sSFA, sSFA_addr(ab_prod.index, 0, 0)),
+                         map_SFA, AB_FULL[ab_prod.index], multicast_SFA_mask)
+            # instruction_selection: anchor
+            #   `cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+            #   extent: one E8M0 SFA tile (source 887-893; PTX 370-380)
+            if elect_one():
+                copy_g2s(logical_region(SFB, SFB_coords(tile_n, k_tile, tile_l), SFB_box(P)),
+                         byte_ptr(sSFB, sSFB_addr(ab_prod.index, 0, 0)),
+                         map_SFB, AB_FULL[ab_prod.index], multicast_SFB_mask)
+            # instruction_selection: anchor
+            #   `cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.L2::cache_hint`;
+            #   extent: one E8M0 SFB tile, mask 0b11 (source 894-900; PTX 382-397)
+
+            advance(ab_prod.index, ab_prod.phase, ab_prod.count, AB_STAGES)
+            ab_empty_ready = True
+            if ab_prod.count < ceil_div(K, K_TILE):
+                ab_empty_ready = try_wait_acquire(AB_EMPTY[ab_prod.index],
+                                                  ab_prod.phase)
+                # instruction_selection:
+                #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+                #   extent: next-stage speculative probe after the full cursor
+                #   advance (source 902-906; PTX 398-413)
+        sched.advance()
+
+    for live_stage in producer_tail(ab_prod, AB_STAGES):
+        wait(AB_EMPTY[live_stage.index], live_stage.phase)
+        # instruction_selection: five retry loops containing
+        #   `mbarrier.try_wait.parity.shared.b64 ...,10000000`; extent: producer
+        #   tail over the five anchor stages (source 914-917; PTX 451-559)
+
+# ===========================================================================
+# Role 2: warp 4, persistent block-scaled MMA consumer/producer
+# source 922-1107; PTX 563-956
+# ===========================================================================
+if warp == MMA_WARP:
+    named_barrier(id=3, threads=160)
+    # instruction_selection: `bar.sync 3,160`; extent: MMA plus four epilogue
+    #   warps (source 922-926; PTX 566-572)
+    load_smem(TMEM_PTR, acc_tmem_base)
+    # instruction_selection: `ld.shared.b32`; extent: one pointer word
+    #   (source 929-966; PTX 571-586)
+
+    sched = persistent_scheduler(...same work list...)
+    ab_cons = pipeline_state(stages=AB_STAGES, phase=0, index=0, count=0)
+    acc_prod = pipeline_state(stages=ACC_STAGES, phase=1, index=0, count=0)
+
+    while sched.valid:
+        reset_count(ab_cons)
+        ab_full_ready = True
+        if ab_cons.count < ceil_div(K, K_TILE):
+            ab_full_ready = try_wait_acquire(AB_FULL[ab_cons.index],
+                                             ab_cons.phase)
+            # instruction_selection:
+            #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+            #   extent: initial speculative AB-full probe before the ACC wait
+            #   (source 1003-1007; PTX 664-675)
+
+        wait(ACC_EMPTY[acc_prod.index], acc_prod.phase)
+        # instruction_selection: blocking retry loop containing plain
+        #   `mbarrier.try_wait.parity.shared.b64 ...,10000000`; extent: one
+        #   accumulator-stage acquire per output tile (source 1010-1013;
+        #   PTX 679-697)
+        accumulate = False
+        while ab_cons.count < ceil_div(K, K_TILE):
+            k_tile = ab_cons.count
+            wait_plain_if_not_ready(AB_FULL[ab_cons.index], ab_cons.phase,
+                                    ab_full_ready)
+            # instruction_selection: only when the speculative token is false,
+            #   retry loop containing `mbarrier.try_wait.parity.shared.b64
+            #   ...,10000000`; extent: conditional AB-full retry per K tile
+            #   (source 1023-1027; PTX 705-723)
+
+            for sf_chunk in range(4):
+                copy_s2t(sfa_desc_for(ab_cons.index, sf_chunk),
+                         tmem_addr(tSFA, sf_chunk))
+                # instruction_selection:
+                #   `tcgen05.cp.cta_group::1.32x128b.warpx4`; extent: four
+                #   elected-lane SFA issues consuming stage/chunk-specific raw
+                #   u64 SMEM descriptors (source 1028-1042; PTX 728-760)
+            for sf_chunk in range(4):
+                copy_s2t(sfb_desc_for(ab_cons.index, sf_chunk),
+                         tmem_addr(tSFB, sf_chunk))
+                # instruction_selection:
+                #   `tcgen05.cp.cta_group::1.32x128b.warpx4`; extent: four
+                #   elected-lane SFB issues consuming stage/chunk-specific raw
+                #   u64 SMEM descriptors (source 1043-1047; PTX 762-792)
+
+            for kblock in range(4):
+                gemm(tmem_addr(tAcc, acc_prod.index),
+                     a_desc_for(ab_cons.index, kblock), tmem_addr(tSFA, kblock),
+                     b_desc_for(ab_cons.index, kblock), tmem_addr(tSFB, kblock),
+                     accumulate=accumulate)
+                # instruction_selection: anchor
+                #   `tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16`;
+                #   extent: four elected-lane MMA issues per 256-wide K tile,
+                #   first issue uses the clear predicate and later issues
+                #   accumulate (source 1049-1079; PTX 800-870)
+                accumulate = True
+
+            release(AB_EMPTY[ab_cons.index], cta_mask=ab_consumer_mask)
+            # instruction_selection:
+            #   `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64`;
+            #   extent: one elected-lane AB-stage release with explicit anchor
+            #   CTA mask 0b11; no intervening warp barrier exists (source
+            #   1081-1082; PTX 869-877)
+            advance(ab_cons.index, ab_cons.phase, ab_cons.count, AB_STAGES)
+            ab_full_ready = True
+            if ab_cons.count < ceil_div(K, K_TILE):
+                ab_full_ready = try_wait_acquire(AB_FULL[ab_cons.index],
+                                                 ab_cons.phase)
+                # instruction_selection:
+                #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+                #   extent: next-stage speculative probe after the full cursor
+                #   advance (source 1084-1089; PTX 878-893)
+
+        commit(ACC_FULL[acc_prod.index], cta_mask=acc_producer_mask)
+        # instruction_selection:
+        #   `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64`;
+        #   extent: one elected-lane accumulator publication per output tile,
+        #   with explicit one-hot local CTA-rank mask (source 1091-1096;
+        #   PTX 903-908)
+        advance(acc_prod.index, acc_prod.phase, acc_prod.count, ACC_STAGES)
+        sched.advance()
+
+    if cluster_rank % 2 == 0:
+        for unused in range(ACC_STAGES - 1):
+            advance(acc_prod.index, acc_prod.phase, acc_prod.count, ACC_STAGES)
+        wait(ACC_EMPTY[acc_prod.index], acc_prod.phase)
+        # instruction_selection: rank-even predicate, exactly ACC_STAGES-1
+        #   state advances, then one retry loop containing
+        #   `mbarrier.try_wait.parity.shared.b64 ...,10000000`; extent: one
+        #   terminal accumulator wait (source 1104-1107 plus
+        #   PipelineUmmaAsync.producer_tail; PTX 927-956)
+
+# ===========================================================================
+# Role 3: warps 0-3, persistent C + amax epilogue
+# source 1111-1342; PTX 958-1342
+# ===========================================================================
+if warp in EPI_WARPS:
+    if warp == 0:
+        alloc_tmem(columns=512, dst=TMEM_PTR)
+        # instruction_selection:
+        #   `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`;
+        #   extent: one 512-column allocation (source 1113-1120; PTX 962-969)
+    named_barrier(id=3, threads=160)
+    # instruction_selection: `bar.sync 3,160`; extent: pointer publication
+    #   (source 1122-1126; PTX 970-973)
+    load_smem(TMEM_PTR, acc_tmem_base)
+    # instruction_selection: `ld.shared.b32`; extent: one pointer word
+    #   (source 1129-1137; PTX 972-973)
+
+    sched = persistent_scheduler(...same work list...)
+    acc_cons = pipeline_state(stages=ACC_STAGES, phase=0, index=0, count=0)
+    c_stage = 0
+
+    while sched.valid:
+        wait(ACC_FULL[acc_cons.index], acc_cons.phase)
+        # instruction_selection: retry loop containing
+        #   `mbarrier.try_wait.parity.shared.b64 ...,10000000`; extent: one
+        #   accumulator wait per tile (source 1201-1205; PTX 1075-1089)
+        thread_tile_amax = 0.0f
+
+        for subtile in range(source_epilogue_subtiles(P)): # anchor: four
+            copy_t2r(tmem_addr(tAcc, acc_cons.index, subtile), rAcc)
+            # instruction_selection:
+            #   `tcgen05.ld.sync.aligned.32x32b.x32.b32`; extent: one 32-register
+            #   FP32 tile per epilogue thread and subtile (source 1219-1224;
+            #   PTX 1103-1107)
+
+            for value in rAcc: # anchor: 32 FP32 values
+                abs(value, abs_value)
+                # instruction_selection: `abs.f32`; extent: 32 scalar values
+                #   per thread/subtile (source 1226-1231; PTX 1125-1172)
+            reduce_max(abs_rAcc, subtile_amax, nan_semantics="source")
+            # instruction_selection: `max.NaN.f32` reduction tree followed by
+            #   `max.NaN.f32` against zero; only the subsequent running update
+            #   is plain `max.f32`; extent: one 32-value register tile (source
+            #   1232-1237; PTX 1173-1192)
+            thread_tile_amax = max(thread_tile_amax, subtile_amax)
+            # instruction_selection: `max.f32`; extent: one scalar running max
+            #   (source 1237; PTX 1191-1192)
+
+            cast(rAcc, rC, dtype=c_dtype)
+            # instruction_selection: anchor `cvt.rn.f16x2.f32`; extent: 16
+            #   packed pair conversions per thread/subtile (source 1239-1244;
+            #   PTX 1193-1209)
+            for vector in range(4):
+                copy_r2s(rC[vector], byte_ptr(sC, sC_addr(c_stage, warp, lane, vector)))
+                # instruction_selection: `st.shared.v4.b32`; extent: four
+                #   16-byte vector stores per thread/subtile (source 1247-1254;
+                #   PTX 1210-1221)
+
+            fence_async_shared_cta()
+            # instruction_selection: `fence.proxy.async.shared::cta`; extent:
+            #   one visibility fence (source 1255-1259; PTX 1222-1223)
+            named_barrier(id=2, threads=128)
+            # instruction_selection: `bar.sync 2,128`; extent: all epilogue
+            #   threads before TMA reads sC (source 1260; PTX 1224-1225)
+
+            if warp == 0:
+                copy_s2g(byte_ptr(sC, sC_addr(c_stage, 0, 0, 0)),
+                         C_coords(sched.tile, subtile), map_C)
+                # instruction_selection: anchor
+                #   `cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint`;
+                #   extent: one FP16 C subtile (source 1263-1270; PTX 1228-1234)
+                tma_commit_group()
+                # instruction_selection: `cp.async.bulk.commit_group`; extent:
+                #   one store group (source 1272; PTX 1235-1236)
+                tma_wait_group(C_STAGES - 1)
+                # instruction_selection: `cp.async.bulk.wait_group.read 4`;
+                #   extent: anchor keeps four older groups pending
+                #   (source 1273; PTX 1237-1238)
+            named_barrier(id=2, threads=128)
+            # instruction_selection: `bar.sync 2,128`; extent: sC-stage reuse
+            #   after issue (source 1274; PTX 1240-1241)
+            c_stage = (c_stage + 1) % C_STAGES
+
+        warp_amax = reduce_max(thread_tile_amax, lanes=32,
+                               nan_semantics="source")
+        # instruction_selection: `redux.sync.max.NaN.f32`; extent: one
+        #   warp-wide reduction per output tile (source 1276-1282; PTX 1252-1259)
+        if lane == 0:
+            store_smem(warp_amax, byte_ptr(sAmax, sAmax_addr(warp)), dtype=f32)
+            # instruction_selection: `st.shared.b32`; extent: one scalar per
+            #   epilogue warp (source 1284-1286; PTX 1260-1263)
+        named_barrier(id=2, threads=128)
+        # instruction_selection: `bar.sync 2,128`; extent: four-warp amax
+        #   publication (source 1288-1289; PTX 1264-1267)
+
+        if warp == 0 and lane == 0:
+            for i in range(4):
+                load_smem(byte_ptr(sAmax, sAmax_addr(i)), warp_max[i], dtype=f32)
+                # instruction_selection: `ld.shared.b32`; extent: four scalar
+                #   loads (source 1291-1296; PTX 1270-1284)
+            reduce_max(warp_max, block_amax, nan_semantics="source")
+            # instruction_selection: `max.f32`; extent: four scalar inputs
+            #   with zero identity (source 1293-1296; PTX 1272-1285)
+            atomic_max_bits(block_amax, amax_ptr)
+            # instruction_selection: `atom.global.max.s32`; extent: one scalar
+            #   signed integer-bit atomic on non-negative FP32 (source
+            #   1298-1308; PTX 1286-1287)
+
+        if elect_one():
+            release(ACC_EMPTY[acc_cons.index])
+            # instruction_selection: `mbarrier.arrive.shared.b64`; extent: one
+            #   elected arrival per epilogue warp, four arrivals complete the
+            #   stage (source 1310-1314; PTX 1289-1296)
+        advance(acc_cons.index, acc_cons.phase, acc_cons.count, ACC_STAGES)
+        sched.advance()
+
+    named_barrier(id=2, threads=128)
+    # instruction_selection: `bar.sync 2,128`; extent: final epilogue rendezvous
+    #   before TMEM teardown (source 1322-1326; PTX 1335-1337)
+    dealloc_tmem(columns=512)
+    # instruction_selection:
+    #   `tcgen05.dealloc.cta_group::1.sync.aligned.b32`; extent: one 512-column
+    #   deallocation reached by the source's four-warp epilogue domain
+    #   (source 1333-1338; PTX 1338-1340)
+    tma_wait_group(0)
+    # instruction_selection: `cp.async.bulk.wait_group.read 0`; extent: drain
+    #   every C store before return (source 1340-1342; PTX 1341-1342)
+```
+
+## Pipeline inventory
+
+| pipeline | anchor stages | producer | consumer | full publication | reuse publication |
+| --- | ---: | --- | --- | --- | --- |
+| AB/SF | 5 | elected lane, warp 5 | elected lane, warp 4 | TMA transaction completion on `AB_FULL`, 36,864 destination bytes | `tcgen05.commit` to `AB_EMPTY` after four MMAs |
+| accumulator | 2 | elected lane, warp 4 | four epilogue warps | `tcgen05.commit` to `ACC_FULL` after all K tiles | one elected `mbarrier.arrive` per epilogue warp completes `ACC_EMPTY` |
+| C store ring | 5 | all four epilogue warps stage; every lane of warp 0 collectively issues the TMA store/commit/wait path | TMA engine | SMEM fence + named barrier 2 + bulk-group commit | `wait_group.read 4` before the ring advances; second named barrier prevents early overwrite |
+
+Every AB and accumulator cursor has `(index, phase, count)`. Index wraps at its
+stage count and toggles phase; the producer and consumer use complementary
+initial phases exactly as the source pipeline constructors do. The C cursor has
+no mbarrier phase: it is `(tiles_executed * subtile_count + subtile) % C_STAGES`.
+
+## TensorMap fields and tail behavior
+
+| map | logical GMEM tensor | anchor rank | box / SMEM destination | multicast axis |
+| --- | --- | ---: | --- | --- |
+| A | `(M,K,L)` in source major mode | 3 | CTA A tile in the selected AB stage | cluster N; anchor extent one, so CTA destination |
+| B | `(N,K,L)` in source major mode | 3 | CTA B tile in the selected AB stage | cluster M; anchor mask `0b11` |
+| SFA | physical block-scaled atom byte order for `(M,ceil_div(K,V),L)` | 4 | CTA SFA tile in the selected AB stage | cluster N; anchor extent one |
+| SFB | physical block-scaled atom byte order for `(N,ceil_div(K,V),L)` | 4 | CTA SFB tile in the selected AB stage | cluster M under the SFB-specific integer coordinate formula; anchor mask `0b11` |
+| C | `(M,N,L)` in source major mode | 3 | one C epilogue subtile | none; shared CTA -> global |
+
+M/N/K tails remain valid only when the source's 16-byte contiguous-dimension
+alignment predicate holds. TensorMap bounds/OOB fill and the scheduler's
+ceil-div tile counts carry the tail; the device sketch does not invent an
+independent scalar cleanup role. L is the third logical scheduler coordinate.
+
+## Static specialization boundary
+
+There is one builder and one device-kernel definition. The following are one
+compile key, not separate kernels:
+
+| axis | accepted values | emitted-code consequence |
+| --- | --- | --- |
+| A/B dtype | FP4 E2M1; FP8 E4M3; FP8 E5M2, matching | TMA element/packing, SMEM descriptor, block-scaled MMA kind |
+| SF | FP4 input: E8M0/V16, E8M0/V32, E4M3/V16; FP8 input: E8M0/V32 | physical SF descriptor, SF TMEM column addresses, block16/block32 MMA descriptor |
+| C dtype | FP32, FP16, BF16, FP8 E4M3/E5M2, FP4 E2M1 | epilogue register conversion/packing, C SMEM size/swizzle/TensorMap; FP4 output only with FP4 input and N-major C |
+| A/B major | FP4 K/K; FP8 A K/M and B K/N | TensorMap strides, shared byte-address formulas, MMA operand descriptor/transposition |
+| C major | M or N, except FP4 output N only | epilogue tile, TMEM load partition, shared swizzle, C TensorMap |
+| N tile | 128 or 256 | accumulator columns/stages, epilogue partition; N256 has one accumulator stage |
+| cluster | `{1,2,4} x {1,2,4}` | launch cluster, cluster coordinate, A/SFA and B/SFB multicast masks and AB-empty arrival count |
+| shape | aligned positive M/N/K and positive L | TensorMap extents, persistent tile count, K loop, tail predicates |
+
+The source's known failing combinations stay outside the compile key: FP8
+input with FP8 output; N tile 256 + SF vector 16 + FP32/FP16/BF16 output; M tile
+256; and the `uint8` packed-FP4 public alias. The working `int8` scale alias is
+normalized to the identical E8M0 bits before specialization, so it creates no
+device branch.
+
+The anchor proves the exact instructions annotated above. Each non-anchor
+branch must be source-exported during implementation/correctness validation to
+verify its conversion, MMA descriptor, TensorMap rank/major mode, stage counts,
+and predicates; no branch may change this role/pipeline skeleton.
+
+## TIRx module and benchmark contract
+
+- Registry name: `cudnn_sm100_dense_blockscaled_gemm_persistent_amax`, category
+  `cudnn`, compute capability 10.
+- The device definition imports only `tirx_kernels.kern as K` and uses
+  `K.kernel`, `K.specialize`, `K.Pipeline`/barrier state, `K.TensorMap`, and
+  `K.ptx`. Direct `T`, `Tx`, `I`, tile primitives, and `tirx.tile.*` are absent.
+- The module exports `KERNEL_META`, deterministic `CONFIGS`/`BENCH_CONFIGS`,
+  `get_kernel`, `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, and
+  `run_bench`. The 1,350 structural modes are a coverage universe, never 1,350
+  kernel definitions.
+- Correctness compares C against both the pinned standalone cuDNN source kernel
+  and a dequantized FP32 mathematical reference. Tolerances are 0.01 for
+  FP32/FP16/BF16 C, 0.1 for FP8/FP4 C, and 0.1 for FP32 amax. The E8M0 `int8`
+  alias is also checked bitwise after normalization.
+- `prepare_bench` compiles only TIRx and performs no Torch/cuDNN/CuTeDSL import
+  or CUDA initialization. `run_gpu` lazily verifies and compiles the source
+  after a CUDA context exists. Both timed closures use identical inputs,
+  independent C/amax outputs, and the canonical Proton timer.
+- Final performance is one complete `bench_suite` run with references, five
+  rounds, zero cooldown. A pure JSON validator reads only those raw samples and
+  requires `mean(cudnn_frontend_us) / mean(tirx_us) > 0.99` independently on
+  every workload row.
+
+## Instruction selection is a lowering consequence
+
+The anchor export, rather than source API names, fixes the instruction families:
+
+| placement / schedule | anchor PTX consequence |
+| --- | --- |
+| dynamic staged storage | `.extern .shared .align 1024`; concrete regions listed above |
+| TensorMap producer | A/SFA use CTA destinations; B/SFB use cluster multicast; one expected-byte mbarrier completes all four |
+| scale SMEM -> TMEM placement | eight `tcgen05.cp.cta_group::1.32x128b.warpx4` per K tile |
+| FP4 + E8M0/V16 + 128x128 | four `tcgen05.mma...kind::mxf4nvf4.block_scale.block16` per K tile |
+| FP32 TMEM fragment shape | one `tcgen05.ld.sync.aligned.32x32b.x32.b32` per thread/subtile |
+| FP16 N-major epilogue | 16 `cvt.rn.f16x2.f32`, four `st.shared.v4.b32`, one 3-D TMA store per thread/subtile/tile ownership described above |
+| absolute maximum semantics | 32 `abs.f32`, `max.NaN.f32` register tree, `redux.sync.max.NaN.f32`, four scalar SMEM loads/maxima, `atom.global.max.s32` |
+| stage reuse | mbarrier parity waits/commits for AB and accumulator; `wait_group.read 4` for the five-stage C ring; `wait_group.read 0` at tail |
+
+All counts are per static occurrence or per explicit loop iteration as stated;
+they are evidence for the semantic operations, not hidden computation.

--- a/.agents/skills/tirx-codegen-tuning/references/db/bind-the-cluster-scope-or-lose-the-attribute.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/bind-the-cluster-scope-or-lose-the-attribute.md
@@ -4,9 +4,11 @@
 
 ## Symptom
 
-A requested cluster launch that silently falls back to cluster (1,1,1).
-Correctness is unaffected, so the drift surfaces only when launch metadata or a
-profiled comparison against a cluster-launched reference disagrees.
+A requested cluster launch that silently falls back to an ordinary launch.
+Correctness can be unaffected, so the drift surfaces only when launch metadata
+or a profiled comparison against a cluster-launched reference disagrees. This
+also applies to an explicitly requested cluster `(1,1,1)`: extent one does not
+make the launch mechanism equivalent.
 
 ## What to change
 
@@ -15,11 +17,19 @@ cluster launch: the resolved `tirx.kernel_launch_params` carries the cluster
 dimension only when the kernel body binds the scope.
 
 ```python
-# The binding is what materializes the attribute -- keep it even when the
-# value is never used.
+# before: an extent-one specialization silently loses cluster presence.
 if CLUSTER_N > 1:
     cbx = T.cta_id_in_cluster([CLUSTER_N])
+
+# after: the binding remains even when every extent is one and the value is
+# never used.
+if USE_CLUSTER_LAUNCH:
+    cbx = T.cta_id_in_cluster([CLUSTER_N])
 ```
+
+Lowering and the runtime must preserve presence separately from value. Do not
+decide whether to emit `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` by testing
+whether any resolved dimension differs from one.
 
 ## Rationale
 
@@ -28,12 +38,25 @@ kernels; adding the dead binding restored
 `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION = (2,1,1)`, verified through the real
 lowering path.
 
+An extent-one persistent specialization provided the complementary case. The
+target initially profiled as Cluster Size 0 while the reference reported 1.
+Preserving its explicit cluster scope through lowering and keying the runtime
+attribute on scope presence made both report Cluster Size 1. Five singleton
+rows improved by about 0.2-3.0%, all 13 affected and guard rows passed at a
+minimum 0.9905x, and all correctness specializations passed. A later complete
+matrix had one unrelated high-persistence epilogue failure; the explicit
+cluster mechanism remained in the final passing implementation.
+
 ## Boundary
 
 Treat every launch-tag request as unproven until the resolved params are
-inspected; the request and the realized attribute are different objects.
+inspected; the request and the realized attribute are different objects. An
+ordinary `(1,1,1)` launch and an explicit cluster `(1,1,1)` launch must remain
+distinguishable in the launch metadata.
 
 ## Verification
 
 Inspect the resolved launch params through the real lowering path, not the
-requested tag list.
+requested tag list. Profile the realized Cluster Size for the extent-one case
+as well as a multi-CTA guard, then run every specialization sharing the launch
+path.

--- a/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
@@ -36,6 +36,14 @@ for no in T.unroll(MMA_N // EPI_TILE):
 One measured FP32 bias hoist regressed 6.6%; by contrast, staging a larger load
 set won when it created enough outstanding DRAM misses.
 
+The same tradeoff applies to persistent reductions. Moving a nonnegative amax
+from a per-work shared reduction and atomic into a per-lane value carried across
+the persistent loop reduced the number of global atomics, but the loop-carried
+dependency stayed live across every epilogue. After repairing collective
+deallocation ordering, the once-per-CTA form was still about 0.1 us slower on
+the FP8 guards and only 2/5 targeted rows passed. Reducing a tail operation
+count did not repay the longer recurrent live range.
+
 ## Boundary
 
 Do not shorten a fragment lifetime across an ordering that belongs to the
@@ -44,6 +52,11 @@ to 94 and moved a ratio from 0.979x to 0.981x, but it also stored each vector
 before the remaining fragment had completed its multiply, bias, and narrowing
 phases. The measured gain was rejected and the full-fragment phase order was
 restored.
+
+State hoisted across persistent work also creates a dependency between work
+items that were previously independent. Measure both one-work CTAs, where the
+hoist can only add lifetime, and high-trip-count CTAs, where removing repeated
+tail operations has a chance to repay it.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/cap-a-persistent-cluster-grid-by-concurrent-residency.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/cap-a-persistent-cluster-grid-by-concurrent-residency.md
@@ -1,0 +1,65 @@
+# Cap a persistent cluster grid by concurrent residency
+
+**Symptoms:** `persistent_grid_regression`, `launch_config_drift`, `concurrency_capped`, `low_occupancy`
+
+## Symptom
+
+A persistent clustered kernel is near parity for one- and two-CTA clusters but
+falls into a much slower band as the cluster grows. The grid was sized as
+`num_sms // cluster_size`, so its scheduler stride assumes every launched
+cluster is resident at once even though the hardware admits fewer concurrent
+clusters.
+
+## What to change
+
+Resolve the maximum simultaneously active cluster count for the compiled
+cluster shape and resource usage, then cap the persistent grid by that count.
+Do not derive the cap by dividing the SM count by CTAs per cluster.
+
+```python
+# before: geometric capacity is not concurrent residency.
+num_clusters = min(cluster_work, NUM_SMS // cluster_size)
+
+# after: use a source- or occupancy-certified active-cluster cap.
+active_cap = ACTIVE_CLUSTERS[cluster_size]
+num_clusters = min(cluster_work, active_cap)
+
+@K.kernel(grid=[CLUSTER_M, CLUSTER_N, num_clusters])
+def kernel(...):
+    _, _, cluster_work_id = K.cta_id()
+    work = K.local_scalar("int32", init=cluster_work_id)
+    with K.While(work < cluster_work):
+        ...
+        K.assign(work, work + num_clusters)
+```
+
+## Rationale
+
+One measured SM100 persistent grid used `floor(148 / cluster_size)`, while the
+source's certified active-cluster counts for sizes 1, 2, 4, 8, and 16 were 148,
+74, 33, 15, and 7. The geometric rule launched delayed second-wave clusters;
+because the grid size was also the persistent scheduler stride, those late
+clusters received a different amount of work.
+
+Replacing only the grid cap moved three large-cluster guards from the
+0.62-0.67x band to 0.992-0.998x. Across the complete 66-shape matrix, strict
+passes rose from 27 to 46 and the worst ratio rose from 0.5546x to 0.9618x,
+with all correctness configurations passing.
+
+## Boundary
+
+Active-cluster capacity is specific to the device, cluster shape, dynamic
+shared memory, registers, and launch contract. The measured constants above are
+evidence for one compiled family, not portable architecture constants. Obtain
+the cap from the reference's hardware query or an occupancy result for the
+actual specialization.
+
+This changes work distribution, not only occupancy. Re-prove the grid-stride
+mapping and tail coverage whenever the cap changes.
+
+## Verification
+
+Compare the realized grid and cluster dimensions with the reference, then
+profile the actual active-cluster count. Run correctness across every cluster
+shape and benchmark both the large-cluster failures and the small-cluster
+guards before keeping the cap.

--- a/.agents/skills/tirx-codegen-tuning/references/db/derive-a-periodic-stage-from-the-loop-index.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/derive-a-periodic-stage-from-the-loop-index.md
@@ -1,0 +1,61 @@
+# Derive a periodic stage from the loop index
+
+**Symptoms:** `manual_stage_arithmetic`, `redundant_modulo`, `long_scoreboard`, `dispatch_specific_deficit`
+
+## Symptom
+
+A small epilogue ring carries a mutable stage scalar through every persistent
+work item. The stage feeds shared-memory addresses, its update remains on the
+loop-back dependency chain, and the number of subtiles per work item always
+returns the ring to its initial stage.
+
+## What to change
+
+When the stage starts at zero and the subtile count is a multiple of the ring
+depth, derive the stage from the subtile index and delete the loop-carried
+cursor. Use a mask for a power-of-two depth.
+
+```python
+# before: the next work item depends on the previous cursor update.
+stage = K.local_scalar("int32", init=0)
+with K.While(subtile < SUBTILES):
+    _store(fragment, stage)
+    K.assign(stage, K.bitwise_and(stage + 1, K.int32(STAGES - 1)))
+    K.assign(subtile, subtile + 1)
+
+# after: no mutable stage survives the iteration.
+with K.While(subtile < SUBTILES):
+    stage_index = K.bitwise_and(subtile, K.int32(STAGES - 1))
+    _store(fragment, stage_index)
+    K.assign(subtile, subtile + 1)
+```
+
+## Rationale
+
+On a high-persistence two-stage FP8 epilogue, the generated CUDA lost the local
+stage variable and its update, and every store address used `subtile & 1`
+directly. The active E5M2 path moved from 0.9889x to 0.9919x. After applying the
+same proven recurrence to the sibling FP8 conversion path, six active,
+boundary, and control rows passed on two GPUs, and the retained implementation
+passed the complete correctness and 66-row performance matrices.
+
+The same transformation was not automatically useful for a four-stage FP32
+path: both long-batch guards remained near 0.988x. Removing a recurrence is a
+dependency-graph lever, not a guarantee that the resulting schedule improves.
+
+## Boundary
+
+Prove all three invariants: the stage starts at a known value, `SUBTILES` is a
+multiple of `STAGES`, and no barrier phase or cross-work protocol observes the
+mutable cursor. Otherwise deriving from the inner index changes the ring phase.
+
+Scope the rewrite to the persistence and dtype/fragment regimes where the
+cursor is actually on the critical path. Keep inactive boundary
+specializations on the original trace.
+
+## Verification
+
+Check generated CUDA/PTX for removal of the local cursor and loop-back update,
+then inspect SASS addresses for the direct index. Test the first wrap, the next
+work item, the specialization boundary, and sibling dtypes before running the
+complete matrix.

--- a/.agents/skills/tirx-codegen-tuning/references/db/fold-static-persistent-scheduler-coordinates.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/fold-static-persistent-scheduler-coordinates.md
@@ -1,0 +1,67 @@
+# Fold static persistent scheduler coordinates
+
+**Symptoms:** `repeated_divide_fixup`, `excess_integer_math`, `persistent_grid_regression`, `latency_bound_fixup`
+
+## Symptom
+
+A persistent work index is decoded with quotient/remainder operations even when
+the batch count is one or a tile count is a compile-time power of two. The
+decode repeats for every work item and sits on the address path for the next
+TMA or epilogue transaction.
+
+## What to change
+
+Fold the statically known batch coordinate, and use mask/shift only where the
+counter is non-negative and the divisor is an exact power of two. Keep the
+generic division path as a compile-time alternative for specializations whose
+scheduled binary regresses.
+
+```python
+# before: generic decode on every persistent work item.
+n_index = quotient % N_TILES
+batch = quotient // N_TILES
+
+# after: a single batch makes both operations dead.
+if BATCHES == 1:
+    n_index = quotient
+    batch = 0
+# after: exact non-negative power-of-two decode.
+elif N_TILES & (N_TILES - 1) == 0:
+    n_index = K.bitwise_and(quotient, K.int32(N_TILES - 1))
+    batch = K.shift_right(quotient, K.uint32(N_TILES.bit_length() - 1))
+else:
+    n_index = quotient % N_TILES
+    batch = quotient // N_TILES
+```
+
+## Rationale
+
+Folding the one-batch decode removed a large-shape BF16 failure: the affected
+and guard rows both passed at 0.9981-1.0102x. Extending the exact mask/shift
+decode to power-of-two tile counts reduced one FP32 target by about 0.925 us;
+paired profiling measured 0.9928x even though a separate canonical timing
+window remained narrowly below its gate.
+
+The arithmetic identity was not universally a scheduling win. One packed
+output path became about 1 us slower at the largest one-batch shape. Restoring
+the original divmod only for that compile-time path reduced the target from
+about 35.6 to 34.35 us and passed at 1.0004x, while the other output paths kept
+the fold. The reusable change is therefore a specialized decode, not a global
+source rewrite.
+
+## Boundary
+
+The shift/mask equivalence requires a non-negative counter and an exact
+power-of-two divisor. The one-batch fold also requires the quotient to already
+be in the N-tile range after the preceding coordinate decode.
+
+Equivalent integer math can still change register lifetimes and ptxas
+scheduling around a large epilogue. Retain a generic compile-time path when an
+output or fragment family measures worse.
+
+## Verification
+
+Confirm the removed divide/fixup chain in SASS and compare the complete address
+dependency path, not only static instruction totals. Validate the scheduler's
+work-to-tile mapping and tails, then measure both low- and high-trip-count
+shapes for every specialization that selects the fold.

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-conversion-and-packing-idioms.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-conversion-and-packing-idioms.md
@@ -65,6 +65,25 @@ The store keeps its own width independent of both:
 T.evaluate(T.ptx.st.global_.v4.b32(buf.ptr_to([index]), w[0], w[1], w[2], w[3]))
 ```
 
+If a paired conversion already produces final 16-bit carriers in memory byte
+order, do not repack them into 32-bit words only to reach a wide shared store.
+Store the halves directly at the same byte addresses:
+
+```python
+# before: eight pair carriers are repacked into four words.
+for pair in T.unroll(4):
+    T.ptx.mov.b32(words[pair], halves[2 * pair], halves[2 * pair + 1])
+T.ptx.st.shared.v4.b32(dst, words[0], words[1], words[2], words[3])
+
+# after: the pair carriers already are the final bytes.
+T.ptx["st.shared.v4.b16"](
+    dst, halves[0], halves[1], halves[2], halves[3]
+)
+T.ptx["st.shared.v4.b16"](
+    dst + 8, halves[4], halves[5], halves[6], halves[7]
+)
+```
+
 Keep the conversion selector independent from the store selector. A fragment
 may require scalar narrowing and still use a packed transaction after an
 explicit register pack:
@@ -129,6 +148,15 @@ Where the state update is naturally in place, the missing primitive is a native
 tied read-write operand; a kernel-local asm wrapper is not an
 instruction-selection fix.
 
+In a measured FP8 epilogue, sixteen paired conversions already produced the
+final halfword sequence. Four direct `st.shared.v4.b16` operations removed
+eight PRMT-equivalent repacks while preserving the shared bytes. All five
+focused rows passed at a 0.9909x minimum, the direct stores survived the full
+correctness matrix, and the retained implementation passed the final 66-row
+suite. A broader candidate initially failed elsewhere because of an unrelated
+global register policy; separating store width from register selection kept the
+packing result usable.
+
 ## Boundary
 
 The exact packed/scalar selector is a property of the source fragment layout
@@ -141,6 +169,11 @@ operand class. A byte store consuming the low byte of a uint32 register does not
 justify weakening every b8 operation's dtype contract. Likewise, use a compound
 intrinsic for a native multi-output packing idiom, not as a container for an
 arbitrary workload-specific instruction sequence.
+
+Direct halfword stores require exact byte-order and alignment equivalence.
+Confirm that no later consumer expects the temporary 32-bit packed words, and
+do not infer the rewrite from output dtype alone; it applies only when the
+conversion result is already the final memory representation.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/reuse-one-elected-lane-predicate-across-a-transfer-group.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/reuse-one-elected-lane-predicate-across-a-transfer-group.md
@@ -1,0 +1,59 @@
+# Reuse one elected-lane predicate across a transfer group
+
+**Symptoms:** `repeated_expression`, `instruction_count_bloat`, `branch_reconvergence`, `slow_latency_bound_shape`
+
+## Symptom
+
+A warp-specialized loop elects a leader separately around several adjacent
+single-lane transfers.  The transfers belong to one logical issue group and no
+operation between them changes warp membership or the active mask, but generated
+SASS contains multiple `ELECT` instructions per loop iteration.
+
+## What to change
+
+Elect the leader once before the transfer group and reuse the resulting predicate
+for every guarded issue in that group.
+
+```python
+# before: each helper call emits another warp election.
+with K.If(_elect_one()):
+    issue_first_transfer(...)
+with K.If(_elect_one()):
+    issue_second_transfer(...)
+
+# after: one election owns the complete transfer group.
+leader = _elect_one()
+with K.If(leader):
+    issue_first_transfer(...)
+with K.If(leader):
+    issue_second_transfer(...)
+```
+
+## Rationale
+
+An elected-lane helper is an effectful warp operation, not a common scalar
+expression that later compiler passes can reliably merge.  Repeating it in a
+deep transfer loop duplicated both election and control-flow work.
+
+In one measured rewrite, dynamic warp instructions fell from 6.61 million to
+5.33 million, static SASS fell from 928 to 824 instructions, and static `ELECT`
+sites matched the reference at three.  Register allocation and spill behavior
+were unchanged.  The affected 4096-square row moved from 0.962x to 1.010x, all
+14 affected and guard workloads passed, the complete 88-workload matrix had a
+minimum ratio of 0.9959x, and all 59 correctness configurations passed.
+
+## Boundary
+
+Reuse is valid only while every lane that participates in the election remains
+in the same active warp and no intervening divergence can change the active
+mask.  Re-elect after reconvergence boundaries, changes in participating lanes,
+or control flow whose inactive lanes do not execute the original election.  Do
+not extend one predicate across unrelated pipeline phases merely to reduce the
+static instruction count.
+
+## Verification
+
+Confirm in SASS that the hot loop contains one election for the logical transfer
+group, compare reconvergence instructions, registers, stack, and spills, then run
+both the affected and guard performance workloads plus the complete correctness
+matrix.

--- a/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
@@ -36,7 +36,32 @@ Producer, compute, and epilogue warps can need materially different register
 budgets. Compiler register level can also trade spills, address hoisting, and
 occupancy differently across shape regimes.
 
+One four-warp epilogue sweep was sharply non-monotonic. Requested budgets 48,
+56, and 64 passed 1/5, 4/5, and 2/5 targeted rows respectively. Applying 56 to
+every output later drove one packed-output specialization to a ptxas allocation
+failure at 255 entry registers and regressed several non-singleton paths.
+Keeping 56 only on its measured single-cluster BF16 beneficiary and restoring
+native allocation elsewhere removed the compile cliff and recovered every FP8
+output guard.
+
+A separate FP32 path was limited to one CTA per SM by shared memory and was
+long-scoreboard dominated, so raising its epilogue budget from 56 to 64 could
+not reduce occupancy. The scoped 64-register form passed all 12 affected FP32
+rows on two GPUs, retained zero failures across the correctness matrix, and
+helped the final 66-row suite clear its strict gate at a 0.9907x minimum. The
+same value had regressed other outputs when applied globally.
+
+## Boundary
+
+An occupancy proof only shows that a larger budget is affordable; it does not
+show that its schedule is better. Scope a budget by the compile-time role,
+fragment/output family, cluster regime, and resource limit that produced the
+measured response. Let unrelated paths use native allocation when a shared
+budget changes their entry allocation or trips an allocator limit.
+
 ## Verification
 
 Record realized allocation and dynamic local traffic, not only the requested
-cap.
+cap. Compile every specialization touched by the selector so allocator cliffs
+cannot hide outside the timing set, then measure the beneficiary and guard
+paths at adjacent budgets.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,12 @@
 tirx-kernels
 Copyright (c) 2026 TIRx authors
 
+This product includes modified software from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend):
+
+cuDNN Frontend
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 This product includes modified software from FlashInfer
 (https://github.com/flashinfer-ai/flashinfer):
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ License 2.0; see [LICENSE](LICENSE). Required Apache attribution notices are
 collected in [NOTICE](NOTICE).
 
 Every Python source file carries SPDX tags. Kernel ports derived from third-party projects
-(DeepGEMM, FlashMLA, flash-attention, FlashInfer, MSA) additionally cite the upstream
+(cuDNN Frontend, DeepGEMM, FlashMLA, flash-attention, FlashInfer, MSA) additionally cite the upstream
 project and the exact commit ported, retain the upstream copyright notice, and
 declare the combined terms — for example `Apache-2.0 AND MIT`. Where an upstream
 license requires its conditions text to travel with the source, that text is kept

--- a/licenses/LICENSE.cudnn-frontend.txt
+++ b/licenses/LICENSE.cudnn-frontend.txt
@@ -1,3 +1,6 @@
+Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +181,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +189,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,37 +202,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-------------------------------------------------------------------------------------
-This product bundles various third-party components under other open source licenses.
-This section summarizes those components and their licenses. See licenses/ for text
-of these licenses.
-
-
-Apache Software Foundation License 2.0
---------------------------------------
-
-tirx_kernels/cudnn/ (ports of NVIDIA/cudnn-frontend kernels; the upstream
-                     license text and copyright notice are reproduced in
-                     licenses/LICENSE.cudnn-frontend.txt)
-tirx_kernels/flashinfer/ (ports of flashinfer-ai/flashinfer kernels, including
-                          kernels FlashInfer itself derived from NVIDIA
-                          TensorRT-LLM; except the BSD-3 file listed below)
-
-
-MIT License
------------
-
-tirx_kernels/deepgemm/ (ports of deepseek-ai/DeepGEMM kernels)
-tirx_kernels/flashmla/ (ports of deepseek-ai/FlashMLA kernels)
-tirx_kernels/msa/ (ports of MiniMax-AI/MSA kernels)
-
-
-BSD 3-Clause "New" or "Revised" License
----------------------------------------
-
-tirx_kernels/flashattention/ (ports of Dao-AILab/flash-attention kernels; the
-                              AUTHORS file its copyright notice refers to is
-                              licenses/AUTHORS.flash-attention.txt)
-tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py (full license text is
-                              reproduced in the file header)

--- a/reference-dependencies.json
+++ b/reference-dependencies.json
@@ -75,18 +75,6 @@
       "url": "https://github.com/MiniMax-AI/MSA.git",
       "revision": "80434d7f67877c6570ca19cac444b84bc9855dac",
       "install_subdirectory": "python"
-    },
-    {
-      "name": "cudnn-frontend",
-      "url": "https://github.com/NVIDIA/cudnn-frontend.git",
-      "revision": "7b5327b32907b9dd21d85a393d62f9573d7f0116",
-      "source_only": true,
-      "files": [
-        {
-          "path": "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py",
-          "sha256": "637088ed4fb7db391d7e9325b3e9f952265ff206ebfc96aed0cdfd1d3365d7f1"
-        }
-      ]
     }
   ]
 }

--- a/reference-dependencies.json
+++ b/reference-dependencies.json
@@ -75,6 +75,18 @@
       "url": "https://github.com/MiniMax-AI/MSA.git",
       "revision": "80434d7f67877c6570ca19cac444b84bc9855dac",
       "install_subdirectory": "python"
+    },
+    {
+      "name": "cudnn-frontend",
+      "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+      "revision": "7b5327b32907b9dd21d85a393d62f9573d7f0116",
+      "source_only": true,
+      "files": [
+        {
+          "path": "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py",
+          "sha256": "637088ed4fb7db391d7e9325b3e9f952265ff206ebfc96aed0cdfd1d3365d7f1"
+        }
+      ]
     }
   ]
 }

--- a/scripts/install_reference_dependencies.py
+++ b/scripts/install_reference_dependencies.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import importlib.util
 import json
 import os
@@ -60,7 +59,7 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
             "git",
             "status",
             "--porcelain",
-            f"--untracked-files={'all' if source.get('source_only', False) else 'no'}",
+            "--untracked-files=no",
             "--ignore-submodules=untracked",
             cwd=checkout,
         )
@@ -75,8 +74,7 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
     except subprocess.CalledProcessError:
         run("git", "fetch", "--filter=blob:none", "origin", revision, cwd=checkout)
     run("git", "checkout", "--detach", revision, cwd=checkout)
-    if not source.get("source_only", False):
-        run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
+    run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
     actual = output("git", "rev-parse", "HEAD", cwd=checkout)
     if actual != revision:
         raise RuntimeError(f"{source['name']} resolved to {actual}, expected {revision}")
@@ -142,9 +140,6 @@ def install(lock: dict[str, Any], source_root: Path) -> None:
     for source in lock["sources"]:
         checkout = checkout_source(source, source_root)
         materialize_source_links(source, checkout)
-        if source.get("source_only", False):
-            print(f"{source['name']} is source-only; skipping package installation", flush=True)
-            continue
         if import_uses_checkout(source, checkout):
             print(f"{source['name']} already imports from its pinned checkout", flush=True)
             continue
@@ -176,10 +171,6 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
             failures.append(f"{package}=={actual}, expected {expected}")
 
     for source in lock["sources"]:
-        source_only = source.get("source_only", False)
-        if not isinstance(source_only, bool):
-            failures.append(f"{source['name']} source_only must be a bool")
-            continue
         checkout = source_root / source["name"]
         if not (checkout / ".git").exists():
             failures.append(f"missing checkout: {checkout}")
@@ -196,29 +187,16 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
             "git",
             "status",
             "--porcelain",
-            f"--untracked-files={'all' if source_only else 'no'}",
+            "--untracked-files=no",
             "--ignore-submodules=untracked",
             cwd=checkout,
         )
         if dirty:
             failures.append(f"reference source checkout has local changes: {checkout}")
-        for locked_file in source.get("files", []):
-            path = checkout / locked_file["path"]
-            if not path.is_file():
-                failures.append(f"missing locked source file: {path}")
-                continue
-            actual_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
-            if actual_sha256 != locked_file["sha256"]:
-                failures.append(
-                    f"{source['name']} {locked_file['path']} sha256 is {actual_sha256}, "
-                    f"expected {locked_file['sha256']}"
-                )
         try:
             materialize_source_links(source, checkout)
         except (FileNotFoundError, RuntimeError) as error:
             failures.append(str(error))
-        if source_only:
-            continue
         resolved_import_paths = import_paths(source["import_name"])
         if not resolved_import_paths:
             failures.append(f"cannot find import {source['import_name']!r}")

--- a/scripts/install_reference_dependencies.py
+++ b/scripts/install_reference_dependencies.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import json
 import os
@@ -38,7 +39,7 @@ def load_lock() -> dict[str, Any]:
     return lock
 
 
-def checkout_source(source: dict[str, str], source_root: Path) -> Path:
+def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
     checkout = source_root / source["name"]
     revision = source["revision"]
     if not checkout.exists():
@@ -52,13 +53,17 @@ def checkout_source(source: dict[str, str], source_root: Path) -> Path:
     except subprocess.CalledProcessError:
         has_head = False
     materialized = any(path.name != ".git" for path in checkout.iterdir())
-    if has_head and materialized and output(
-        "git",
-        "status",
-        "--porcelain",
-        "--untracked-files=no",
-        "--ignore-submodules=untracked",
-        cwd=checkout,
+    if (
+        has_head
+        and materialized
+        and output(
+            "git",
+            "status",
+            "--porcelain",
+            f"--untracked-files={'all' if source.get('source_only', False) else 'no'}",
+            "--ignore-submodules=untracked",
+            cwd=checkout,
+        )
     ):
         raise RuntimeError(f"reference source checkout has local changes: {checkout}")
     origin = output("git", "remote", "get-url", "origin", cwd=checkout)
@@ -70,7 +75,8 @@ def checkout_source(source: dict[str, str], source_root: Path) -> Path:
     except subprocess.CalledProcessError:
         run("git", "fetch", "--filter=blob:none", "origin", revision, cwd=checkout)
     run("git", "checkout", "--detach", revision, cwd=checkout)
-    run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
+    if not source.get("source_only", False):
+        run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
     actual = output("git", "rev-parse", "HEAD", cwd=checkout)
     if actual != revision:
         raise RuntimeError(f"{source['name']} resolved to {actual}, expected {revision}")
@@ -124,9 +130,7 @@ def import_paths(import_name: str) -> list[Path]:
 
 def import_uses_checkout(source: dict[str, str], checkout: Path) -> bool:
     install_path = (checkout / source["install_subdirectory"]).resolve()
-    return any(
-        path.is_relative_to(install_path) for path in import_paths(source["import_name"])
-    )
+    return any(path.is_relative_to(install_path) for path in import_paths(source["import_name"]))
 
 
 def install(lock: dict[str, Any], source_root: Path) -> None:
@@ -138,6 +142,9 @@ def install(lock: dict[str, Any], source_root: Path) -> None:
     for source in lock["sources"]:
         checkout = checkout_source(source, source_root)
         materialize_source_links(source, checkout)
+        if source.get("source_only", False):
+            print(f"{source['name']} is source-only; skipping package installation", flush=True)
+            continue
         if import_uses_checkout(source, checkout):
             print(f"{source['name']} already imports from its pinned checkout", flush=True)
             continue
@@ -169,6 +176,10 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
             failures.append(f"{package}=={actual}, expected {expected}")
 
     for source in lock["sources"]:
+        source_only = source.get("source_only", False)
+        if not isinstance(source_only, bool):
+            failures.append(f"{source['name']} source_only must be a bool")
+            continue
         checkout = source_root / source["name"]
         if not (checkout / ".git").exists():
             failures.append(f"missing checkout: {checkout}")
@@ -176,10 +187,38 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
         actual = output("git", "rev-parse", "HEAD", cwd=checkout)
         if actual != source["revision"]:
             failures.append(f"{source['name']} checkout is {actual}, expected {source['revision']}")
+        origin = output("git", "remote", "get-url", "origin", cwd=checkout)
+        if origin.rstrip("/").removesuffix(".git") != source["url"].rstrip("/").removesuffix(
+            ".git"
+        ):
+            failures.append(f"unexpected origin for {checkout}: {origin}")
+        dirty = output(
+            "git",
+            "status",
+            "--porcelain",
+            f"--untracked-files={'all' if source_only else 'no'}",
+            "--ignore-submodules=untracked",
+            cwd=checkout,
+        )
+        if dirty:
+            failures.append(f"reference source checkout has local changes: {checkout}")
+        for locked_file in source.get("files", []):
+            path = checkout / locked_file["path"]
+            if not path.is_file():
+                failures.append(f"missing locked source file: {path}")
+                continue
+            actual_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+            if actual_sha256 != locked_file["sha256"]:
+                failures.append(
+                    f"{source['name']} {locked_file['path']} sha256 is {actual_sha256}, "
+                    f"expected {locked_file['sha256']}"
+                )
         try:
             materialize_source_links(source, checkout)
         except (FileNotFoundError, RuntimeError) as error:
             failures.append(str(error))
+        if source_only:
+            continue
         resolved_import_paths = import_paths(source["import_name"])
         if not resolved_import_paths:
             failures.append(f"cannot find import {source['import_name']!r}")

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -59,6 +59,11 @@ CITATION_RE = re.compile(r"\((https://\S+) @ [0-9a-f]{7,40}\)")
 # Path-bound expectations: project name, upstream URL, and the SPDX expression
 # a port under this bucket must carry.
 PORT_BUCKETS = {
+    "tirx_kernels/cudnn/": (
+        "cuDNN Frontend",
+        "https://github.com/NVIDIA/cudnn-frontend",
+        "Apache-2.0",
+    ),
     "tirx_kernels/deepgemm/": (
         "DeepGEMM",
         "https://github.com/deepseek-ai/DeepGEMM",
@@ -219,6 +224,7 @@ def self_test() -> int:
         "# ({url} @ 559d79fb), Copyright (c) 2025 Upstream\n" + pair + "\n\nx = 1\n"
     )
     dg = dict(project="DeepGEMM", url="https://github.com/deepseek-ai/DeepGEMM")
+    cudnn = dict(project="cuDNN Frontend", url="https://github.com/NVIDIA/cudnn-frontend")
     fi = dict(project="FlashInfer", url="https://github.com/flashinfer-ai/flashinfer")
     msa = dict(project="MSA", url="https://github.com/MiniMax-AI/MSA")
     gdn = "tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py"
@@ -235,6 +241,34 @@ def self_test() -> int:
             "tirx_kernels/deepgemm/x.py",
             port.format(spdx="Apache-2.0 AND MIT", **dg),
             False,
+        ),
+        (
+            "valid cudnn-frontend port",
+            "tirx_kernels/cudnn/amax/x.py",
+            port.format(spdx="Apache-2.0", **cudnn),
+            False,
+        ),
+        (
+            "cudnn-frontend port tagged MIT",
+            "tirx_kernels/cudnn/amax/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **cudnn),
+            True,
+        ),
+        (
+            "cudnn-frontend port citing another URL",
+            "tirx_kernels/cudnn/amax/x.py",
+            port.format(
+                spdx="Apache-2.0",
+                project="cuDNN Frontend",
+                url="https://github.com/deepseek-ai/DeepGEMM",
+            ),
+            True,
+        ),
+        (
+            "cudnn-frontend port with no upstream copyright",
+            "tirx_kernels/cudnn/amax/x.py",
+            port.format(spdx="Apache-2.0", **cudnn).replace(", Copyright (c) 2025 Upstream", ""),
+            True,
         ),
         ("valid native", "tirx_kernels/x.py", f"{TIRX_HEADER}\n\nx = 1\n", False),
         (

--- a/tirx_kernels/bench_suite/config/cudnn/amax/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/amax/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.yaml
@@ -1,0 +1,71 @@
+# Complete deterministic performance-path covering matrix for the single
+# parameterized cuDNN Frontend persistent block-scaled GEMM+amax port.
+kernel: cudnn_sm100_dense_blockscaled_gemm_persistent_amax
+selection_rationale: The selected defaults span small/medium/large GEMMs while the complete 66-row matrix covers every input, scale, output, major, tile, cluster, stage, TMA, MMA, store, and L=1/2 path required by the port gate.
+configs:
+  - {config: perf00_m1024_n1024_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: true, selection_role: small}
+  - {config: perf00_m1024_n1024_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf00_m4096_n4096_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
+  - {config: perf00_m4096_n4096_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf00_m8192_n8192_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
+  - {config: perf00_m8192_n8192_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf01_m1024_n1024_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m1024_n1024_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf01_m4096_n4096_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m4096_n4096_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf01_m8192_n8192_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m8192_n8192_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf02_m1024_n1024_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m1024_n1024_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf02_m4096_n4096_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m4096_n4096_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf02_m8192_n8192_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m8192_n8192_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf03_m1024_n1024_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
+  - {config: perf03_m1024_n1024_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf03_m4096_n4096_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: true, selection_role: medium}
+  - {config: perf03_m4096_n4096_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf03_m8192_n8192_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
+  - {config: perf03_m8192_n8192_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf04_m1024_n1024_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m1024_n1024_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf04_m4096_n4096_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m4096_n4096_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf04_m8192_n8192_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m8192_n8192_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf05_m1024_n1024_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m1024_n1024_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf05_m4096_n4096_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m4096_n4096_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf05_m8192_n8192_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m8192_n8192_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf06_m1024_n1024_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m1024_n1024_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf06_m4096_n4096_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m4096_n4096_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf06_m8192_n8192_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m8192_n8192_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf07_m1024_n1024_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m1024_n1024_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
+  - {config: perf07_m4096_n4096_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m4096_n4096_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
+  - {config: perf07_m8192_n8192_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m8192_n8192_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: true, selection_role: large}
+  - {config: perf08_m1024_n1024_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m1024_n1024_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf08_m4096_n4096_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m4096_n4096_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf08_m8192_n8192_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m8192_n8192_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf09_m1024_n1024_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m1024_n1024_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf09_m4096_n4096_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m4096_n4096_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf09_m8192_n8192_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m8192_n8192_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m1024_n1024_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m1024_n1024_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m4096_n4096_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m4096_n4096_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m8192_n8192_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m8192_n8192_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}

--- a/tirx_kernels/bench_suite/config/cudnn/amax/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/amax/cudnn_sm100_dense_blockscaled_gemm_persistent_amax.yaml
@@ -1,71 +1,93 @@
 # Complete deterministic performance-path covering matrix for the single
 # parameterized cuDNN Frontend persistent block-scaled GEMM+amax port.
 kernel: cudnn_sm100_dense_blockscaled_gemm_persistent_amax
-selection_rationale: The selected defaults span small/medium/large GEMMs while the complete 66-row matrix covers every input, scale, output, major, tile, cluster, stage, TMA, MMA, store, and L=1/2 path required by the port gate.
+selection_rationale: The selected defaults span small/medium/large square GEMMs while the complete 88-row matrix covers 1024/2048/4096/8192 square shapes, every input, scale, output, major, tile, cluster, stage, TMA, MMA, store, and L=1/2 path required by the port gate.
 configs:
   - {config: perf00_m1024_n1024_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: true, selection_role: small}
   - {config: perf00_m1024_n1024_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
-  - {config: perf00_m4096_n4096_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
-  - {config: perf00_m4096_n4096_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
-  - {config: perf00_m8192_n8192_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
-  - {config: perf00_m8192_n8192_k1024_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf00_m2048_n2048_k2048_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
+  - {config: perf00_m2048_n2048_k2048_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf00_m4096_n4096_k4096_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
+  - {config: perf00_m4096_n4096_k4096_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
+  - {config: perf00_m8192_n8192_k8192_e4_e8v32_bf16_kk_m_t128x128_c1x1_l1, default: false}
+  - {config: perf00_m8192_n8192_k8192_e4_e8v32_bf16_kk_m_t128x128_c1x1_l2, default: false}
   - {config: perf01_m1024_n1024_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
   - {config: perf01_m1024_n1024_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
-  - {config: perf01_m4096_n4096_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
-  - {config: perf01_m4096_n4096_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
-  - {config: perf01_m8192_n8192_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
-  - {config: perf01_m8192_n8192_k1024_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf01_m2048_n2048_k2048_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m2048_n2048_k2048_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf01_m4096_n4096_k4096_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m4096_n4096_k4096_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
+  - {config: perf01_m8192_n8192_k8192_f4_e4v16_e4_kk_m_t128x256_c1x2_l1, default: false}
+  - {config: perf01_m8192_n8192_k8192_f4_e4v16_e4_kk_m_t128x256_c1x2_l2, default: false}
   - {config: perf02_m1024_n1024_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
   - {config: perf02_m1024_n1024_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
-  - {config: perf02_m4096_n4096_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
-  - {config: perf02_m4096_n4096_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
-  - {config: perf02_m8192_n8192_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
-  - {config: perf02_m8192_n8192_k1024_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf02_m2048_n2048_k2048_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m2048_n2048_k2048_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf02_m4096_n4096_k4096_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m4096_n4096_k4096_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
+  - {config: perf02_m8192_n8192_k8192_e5_e8v32_f32_kk_m_t128x256_c1x4_l1, default: false}
+  - {config: perf02_m8192_n8192_k8192_e5_e8v32_f32_kk_m_t128x256_c1x4_l2, default: false}
   - {config: perf03_m1024_n1024_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
   - {config: perf03_m1024_n1024_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
-  - {config: perf03_m4096_n4096_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: true, selection_role: medium}
-  - {config: perf03_m4096_n4096_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
-  - {config: perf03_m8192_n8192_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
-  - {config: perf03_m8192_n8192_k1024_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf03_m2048_n2048_k2048_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
+  - {config: perf03_m2048_n2048_k2048_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf03_m4096_n4096_k4096_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: true, selection_role: medium}
+  - {config: perf03_m4096_n4096_k4096_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
+  - {config: perf03_m8192_n8192_k8192_f4_e8v16_f16_kk_m_t128x128_c2x1_l1, default: false}
+  - {config: perf03_m8192_n8192_k8192_f4_e8v16_f16_kk_m_t128x128_c2x1_l2, default: false}
   - {config: perf04_m1024_n1024_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
   - {config: perf04_m1024_n1024_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
-  - {config: perf04_m4096_n4096_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
-  - {config: perf04_m4096_n4096_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
-  - {config: perf04_m8192_n8192_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
-  - {config: perf04_m8192_n8192_k1024_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf04_m2048_n2048_k2048_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m2048_n2048_k2048_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf04_m4096_n4096_k4096_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m4096_n4096_k4096_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
+  - {config: perf04_m8192_n8192_k8192_e4_e8v32_bf16_mn_n_t128x128_c2x2_l1, default: false}
+  - {config: perf04_m8192_n8192_k8192_e4_e8v32_bf16_mn_n_t128x128_c2x2_l2, default: false}
   - {config: perf05_m1024_n1024_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
   - {config: perf05_m1024_n1024_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
-  - {config: perf05_m4096_n4096_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
-  - {config: perf05_m4096_n4096_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
-  - {config: perf05_m8192_n8192_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
-  - {config: perf05_m8192_n8192_k1024_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf05_m2048_n2048_k2048_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m2048_n2048_k2048_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf05_m4096_n4096_k4096_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m4096_n4096_k4096_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
+  - {config: perf05_m8192_n8192_k8192_e5_e8v32_f16_mn_n_t128x128_c2x4_l1, default: false}
+  - {config: perf05_m8192_n8192_k8192_e5_e8v32_f16_mn_n_t128x128_c2x4_l2, default: false}
   - {config: perf06_m1024_n1024_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
   - {config: perf06_m1024_n1024_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
-  - {config: perf06_m4096_n4096_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
-  - {config: perf06_m4096_n4096_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
-  - {config: perf06_m8192_n8192_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
-  - {config: perf06_m8192_n8192_k1024_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf06_m2048_n2048_k2048_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m2048_n2048_k2048_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf06_m4096_n4096_k4096_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m4096_n4096_k4096_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
+  - {config: perf06_m8192_n8192_k8192_f4_e8v32_e5_kk_m_t128x128_c4x1_l1, default: false}
+  - {config: perf06_m8192_n8192_k8192_f4_e8v32_e5_kk_m_t128x128_c4x1_l2, default: false}
   - {config: perf07_m1024_n1024_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
   - {config: perf07_m1024_n1024_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
-  - {config: perf07_m4096_n4096_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
-  - {config: perf07_m4096_n4096_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
-  - {config: perf07_m8192_n8192_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
-  - {config: perf07_m8192_n8192_k1024_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: true, selection_role: large}
+  - {config: perf07_m2048_n2048_k2048_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m2048_n2048_k2048_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
+  - {config: perf07_m4096_n4096_k4096_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m4096_n4096_k4096_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: false}
+  - {config: perf07_m8192_n8192_k8192_f4_e4v16_f4_kk_n_t128x128_c4x2_l1, default: false}
+  - {config: perf07_m8192_n8192_k8192_f4_e4v16_f4_kk_n_t128x128_c4x2_l2, default: true, selection_role: large}
   - {config: perf08_m1024_n1024_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
   - {config: perf08_m1024_n1024_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
-  - {config: perf08_m4096_n4096_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
-  - {config: perf08_m4096_n4096_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
-  - {config: perf08_m8192_n8192_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
-  - {config: perf08_m8192_n8192_k1024_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf08_m2048_n2048_k2048_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m2048_n2048_k2048_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf08_m4096_n4096_k4096_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m4096_n4096_k4096_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
+  - {config: perf08_m8192_n8192_k8192_e4_e8v32_f32_kk_n_t128x128_c4x4_l1, default: false}
+  - {config: perf08_m8192_n8192_k8192_e4_e8v32_f32_kk_n_t128x128_c4x4_l2, default: false}
   - {config: perf09_m1024_n1024_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
   - {config: perf09_m1024_n1024_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
-  - {config: perf09_m4096_n4096_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
-  - {config: perf09_m4096_n4096_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
-  - {config: perf09_m8192_n8192_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
-  - {config: perf09_m8192_n8192_k1024_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf09_m2048_n2048_k2048_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m2048_n2048_k2048_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf09_m4096_n4096_k4096_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m4096_n4096_k4096_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf09_m8192_n8192_k8192_f4_e4v16_e4_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf09_m8192_n8192_k8192_f4_e4v16_e4_kk_n_t128x128_c1x1_l2, default: false}
   - {config: perf10_m1024_n1024_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
   - {config: perf10_m1024_n1024_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
-  - {config: perf10_m4096_n4096_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
-  - {config: perf10_m4096_n4096_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
-  - {config: perf10_m8192_n8192_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
-  - {config: perf10_m8192_n8192_k1024_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m2048_n2048_k2048_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m2048_n2048_k2048_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m4096_n4096_k4096_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m4096_n4096_k4096_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}
+  - {config: perf10_m8192_n8192_k8192_f4_e4v16_e5_kk_n_t128x128_c1x1_l1, default: false}
+  - {config: perf10_m8192_n8192_k8192_f4_e4v16_e5_kk_n_t128x128_c1x1_l2, default: false}

--- a/tirx_kernels/cudnn/__init__.py
+++ b/tirx_kernels/cudnn/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/amax/__init__.py
+++ b/tirx_kernels/cudnn/amax/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -9,28 +9,19 @@ Upstream source:
 ``python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py``.
 """
 
-import hashlib
 import importlib
 import importlib.util
 import json
 import os
-import subprocess
 import sys
 from functools import cache
 from itertools import combinations, product
-from pathlib import Path
 
 import tirx_kernels.kern as K
 
 _TRY_WAIT_TICKS = 10_000_000
 _SMEM_CAPACITY = 232_448
 _MAX_ACTIVE_CLUSTERS = {1: 148, 2: 74, 4: 33, 8: 15, 16: 7}
-_SOURCE_COMMIT = "7b5327b32907b9dd21d85a393d62f9573d7f0116"
-_SOURCE_SHA256 = "637088ed4fb7db391d7e9325b3e9f952265ff206ebfc96aed0cdfd1d3365d7f1"
-_SOURCE_RELATIVE = Path(
-    "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py"
-)
-
 _AB_DTYPES = ("float4_e2m1fn", "float8_e4m3fn", "float8_e5m2")
 _SF_MODES = (("float8_e8m0fnu", 16), ("float8_e8m0fnu", 32), ("float8_e4m3fn", 16))
 _C_DTYPES = ("bfloat16", "float16", "float32", "float4_e2m1fn", "float8_e4m3fn", "float8_e5m2")
@@ -1767,31 +1758,14 @@ def prepare_data(**config):
     }
 
 
-def _git_output(root, *args):
-    return subprocess.check_output(["git", "-C", str(root), *args], text=True).strip()
-
-
 @cache
 def _load_reference_source():
-    default_root = Path(__file__).resolve().parents[3] / ".reference-deps" / "cudnn-frontend"
-    root = Path(os.environ.get("CUDNN_FRONTEND_PATH", default_root)).resolve()
-    origin = _git_output(root, "remote", "get-url", "origin").rstrip("/")
-    if origin.removesuffix(".git") != "https://github.com/NVIDIA/cudnn-frontend":
-        raise RuntimeError(f"unexpected cuDNN Frontend origin: {origin}")
-    actual_commit = _git_output(root, "rev-parse", "HEAD")
-    if actual_commit != _SOURCE_COMMIT:
-        raise RuntimeError(f"cuDNN Frontend commit is {actual_commit}, expected {_SOURCE_COMMIT}")
-    dirty = _git_output(
-        root, "status", "--porcelain", "--untracked-files=no", "--ignore-submodules=untracked"
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    source_path = os.path.join(
+        root, "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py"
     )
-    if dirty:
-        raise RuntimeError(f"cuDNN Frontend checkout is dirty: {root}")
-    source_path = root / _SOURCE_RELATIVE
-    actual_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
-    if actual_sha256 != _SOURCE_SHA256:
-        raise RuntimeError(
-            f"cuDNN Frontend source SHA256 is {actual_sha256}, expected {_SOURCE_SHA256}"
-        )
     spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_amax_source", source_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -57,36 +57,6 @@ def _align_up(value, alignment):
     return _ceil_div(value, alignment) * alignment
 
 
-class _LinearSmemPool:
-    """Integer-cursor adapter for protocol objects over one linear SMEM buffer.
-
-    Allocations become ordinary default buffers with explicit byte offsets into
-    ``base``. No device value representing an arrangement is ever constructed
-    or passed.
-    """
-
-    def __init__(self, base):
-        self.base = base
-        self.cursor = 0
-
-    def alloc(self, shape, dtype, align=1):
-        self.cursor = _align_up(self.cursor, align)
-        offset = self.cursor
-        count = 1
-        for extent in shape:
-            count *= int(extent)
-        bits = {"uint8": 8, "uint32": 32, "uint64": 64}[str(dtype)]
-        self.cursor += count * bits // 8
-        return K.decl_buffer(
-            shape,
-            str(dtype),
-            data=self.base.data,
-            byte_offset=offset,
-            scope="shared.dyn",
-            align=align,
-        )
-
-
 def _descriptor_base(ldo, sdo, swizzle):
     """Fold the SM100 shared descriptor fields except its 14-bit address."""
     arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
@@ -382,7 +352,7 @@ def _performance_representatives():
 
 
 def _benchmark_configs():
-    shapes = ((1024, 1024, 1024), (4096, 4096, 1024), (8192, 8192, 1024))
+    shapes = tuple((size, size, size) for size in (1024, 2048, 4096, 8192))
     configs = []
     for representative_index, base_mode in enumerate(_performance_representatives()):
         for M, N, K_dim in shapes:
@@ -692,7 +662,7 @@ def _make_kernel(
         tma_role = roles.role("tma", warps=[5])
 
         smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
-        protocol_pool = _LinearSmemPool(smem)
+        protocol_pool = K.smem_pool(base=smem)
         ab_pipe = K.Pipeline(
             protocol_pool, ab_stages, full="tma", empty="tcgen05", leader=K.bool(False)
         )
@@ -704,11 +674,11 @@ def _make_kernel(
             init_empty=4,
             leader=K.bool(False),
         )
-        if protocol_pool.cursor != tmem_dealloc_offset:
+        if protocol_pool.bytes != tmem_dealloc_offset:
             raise AssertionError("protocol storage offsets changed")
         tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
         tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
-        if protocol_pool.cursor != tmem_ptr_offset + 4:
+        if protocol_pool.bytes != tmem_ptr_offset + 4:
             raise AssertionError("protocol storage header changed")
         del tmem_dealloc
 

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -1,0 +1,2076 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Persistent SM100 block-scaled GEMM with an FP32 absolute-maximum output.
+
+Upstream source:
+``python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py``.
+"""
+
+import hashlib
+import importlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from functools import cache
+from itertools import combinations, product
+from pathlib import Path
+
+import tirx_kernels.kern as K
+
+_TRY_WAIT_TICKS = 10_000_000
+_SMEM_CAPACITY = 232_448
+_MAX_ACTIVE_CLUSTERS = {1: 148, 2: 74, 4: 33, 8: 15, 16: 7}
+_SOURCE_COMMIT = "7b5327b32907b9dd21d85a393d62f9573d7f0116"
+_SOURCE_SHA256 = "637088ed4fb7db391d7e9325b3e9f952265ff206ebfc96aed0cdfd1d3365d7f1"
+_SOURCE_RELATIVE = Path(
+    "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py"
+)
+
+_AB_DTYPES = ("float4_e2m1fn", "float8_e4m3fn", "float8_e5m2")
+_SF_MODES = (("float8_e8m0fnu", 16), ("float8_e8m0fnu", 32), ("float8_e4m3fn", 16))
+_C_DTYPES = ("bfloat16", "float16", "float32", "float4_e2m1fn", "float8_e4m3fn", "float8_e5m2")
+_CLUSTERS = tuple(product((1, 2, 4), repeat=2))
+_MODE_KEYS = (
+    "ab_dtype",
+    "sf_dtype",
+    "sf_vec_size",
+    "c_dtype",
+    "a_major",
+    "b_major",
+    "c_major",
+    "mma_tiler_mn",
+    "cluster_shape_mn",
+    "L",
+)
+
+
+def _ceil_div(value, divisor):
+    return (value + divisor - 1) // divisor
+
+
+def _align_up(value, alignment):
+    return _ceil_div(value, alignment) * alignment
+
+
+class _LinearSmemPool:
+    """Integer-cursor adapter for protocol objects over one linear SMEM buffer.
+
+    Allocations become ordinary default buffers with explicit byte offsets into
+    ``base``. No device value representing an arrangement is ever constructed
+    or passed.
+    """
+
+    def __init__(self, base):
+        self.base = base
+        self.cursor = 0
+
+    def alloc(self, shape, dtype, align=1):
+        self.cursor = _align_up(self.cursor, align)
+        offset = self.cursor
+        count = 1
+        for extent in shape:
+            count *= int(extent)
+        bits = {"uint8": 8, "uint32": 32, "uint64": 64}[str(dtype)]
+        self.cursor += count * bits // 8
+        return K.decl_buffer(
+            shape,
+            str(dtype),
+            data=self.base.data,
+            byte_offset=offset,
+            scope="shared.dyn",
+            align=align,
+        )
+
+
+def _descriptor_base(ldo, sdo, swizzle):
+    """Fold the SM100 shared descriptor fields except its 14-bit address."""
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _instruction_descriptor(M, N, ab_dtype, sf_dtype, a_major, b_major):
+    """Fold the static fields of the source block-scaled MMA descriptor."""
+    if M != 128 or N not in (128, 256):
+        raise ValueError(f"unsupported instruction shape {(M, N)}")
+    sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1}[sf_dtype]
+    value = 0
+    if ab_dtype in {"float4_e2m1fn", "float8_e5m2"}:
+        value |= 1 << 7
+        value |= 1 << 10
+    if a_major == "m":
+        value |= 1 << 15
+    if b_major == "n":
+        value |= 1 << 16
+    value |= ((N >> 3) & 0x3F) << 17
+    value |= (sf_format & 1) << 23
+    value |= ((M >> 4) & 0x1F) << 24
+    return value & 0xFFFFFFFF
+
+
+def _advance(state):
+    state.advance()
+
+
+def _try_wait_acquire(dst, barrier, phase):
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready):
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _descriptor_with_address(base, shared_address):
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), address_field)
+
+
+def _dtype_bits(dtype):
+    return {
+        "float4_e2m1fn": 4,
+        "float8_e4m3fn": 8,
+        "float8_e5m2": 8,
+        "bfloat16": 16,
+        "float16": 16,
+        "float32": 32,
+    }[dtype]
+
+
+def _valid_mode(mode):
+    fp4_ab = mode["ab_dtype"] == "float4_e2m1fn"
+    fp4_c = mode["c_dtype"] == "float4_e2m1fn"
+    fp8_c = mode["c_dtype"].startswith("float8_")
+    if fp4_ab:
+        if mode["a_major"] != "k" or mode["b_major"] != "k":
+            return False
+    else:
+        if mode["sf_dtype"] != "float8_e8m0fnu" or mode["sf_vec_size"] != 32:
+            return False
+        if fp4_c or fp8_c:
+            return False
+    if fp4_c and (not fp4_ab or mode["c_major"] != "n"):
+        return False
+    if (
+        mode["mma_tiler_mn"][1] == 256
+        and mode["sf_vec_size"] == 16
+        and mode["c_dtype"] in {"float32", "float16", "bfloat16"}
+    ):
+        return False
+    return True
+
+
+def _structural_modes(include_batch=True):
+    modes = []
+    batches = (1, 2) if include_batch else (1,)
+    for ab_dtype in _AB_DTYPES:
+        a_majors = ("k",) if ab_dtype == "float4_e2m1fn" else ("k", "m")
+        b_majors = ("k",) if ab_dtype == "float4_e2m1fn" else ("k", "n")
+        for (
+            sf_dtype,
+            sf_vec_size,
+        ), c_dtype, a_major, b_major, c_major, tile_n, cluster_shape_mn, batch in product(
+            _SF_MODES, _C_DTYPES, a_majors, b_majors, ("m", "n"), (128, 256), _CLUSTERS, batches
+        ):
+            mode = {
+                "ab_dtype": ab_dtype,
+                "sf_dtype": sf_dtype,
+                "sf_vec_size": sf_vec_size,
+                "c_dtype": c_dtype,
+                "a_major": a_major,
+                "b_major": b_major,
+                "c_major": c_major,
+                "mma_tiler_mn": (128, tile_n),
+                "cluster_shape_mn": cluster_shape_mn,
+                "L": batch,
+            }
+            if _valid_mode(mode):
+                modes.append(mode)
+    return sorted(modes, key=_mode_label)
+
+
+def _mode_label(mode):
+    short = {
+        "float4_e2m1fn": "f4",
+        "float8_e4m3fn": "e4",
+        "float8_e5m2": "e5",
+        "float8_e8m0fnu": "e8",
+        "float16": "f16",
+        "bfloat16": "bf16",
+        "float32": "f32",
+    }
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    return (
+        f"{short[mode['ab_dtype']]}_{short[mode['sf_dtype']]}v{mode['sf_vec_size']}_"
+        f"{short[mode['c_dtype']]}_{mode['a_major']}{mode['b_major']}_{mode['c_major']}_"
+        f"t{tile_m}x{tile_n}_c{cluster_m}x{cluster_n}_l{mode['L']}"
+    )
+
+
+def _pair_tokens(mode):
+    return frozenset(
+        (left, json.dumps(mode[left]), right, json.dumps(mode[right]))
+        for left, right in combinations(_MODE_KEYS, 2)
+    )
+
+
+def _minimal_pairwise_modes():
+    candidates = _structural_modes(include_batch=True)
+    cover = [_pair_tokens(mode) for mode in candidates]
+    uncovered = set().union(*cover)
+    selected = []
+    while uncovered:
+        best_coverage = max(len(tokens & uncovered) for tokens in cover)
+        best = min(
+            (
+                index
+                for index in range(len(candidates))
+                if len(cover[index] & uncovered) == best_coverage
+            ),
+            key=lambda index: _mode_label(candidates[index]),
+        )
+        if not (cover[best] & uncovered):
+            raise AssertionError("pairwise structural coverage did not converge")
+        selected.append(best)
+        uncovered.difference_update(cover[best])
+    counts = {}
+    for index in selected:
+        for token in cover[index]:
+            counts[token] = counts.get(token, 0) + 1
+    kept = []
+    for index in reversed(selected):
+        if all(counts[token] > 1 for token in cover[index]):
+            for token in cover[index]:
+                counts[token] -= 1
+        else:
+            kept.append(index)
+    return [candidates[index] for index in reversed(kept)]
+
+
+def _make_case(mode, *, shape=(256, 256, 256), prefix="pair"):
+    M, N, K_dim = shape
+    return {
+        "label": f"{prefix}_m{M}_n{N}_k{K_dim}_{_mode_label(mode)}",
+        "M": M,
+        "N": N,
+        "K": K_dim,
+        **mode,
+    }
+
+
+def _correctness_configs():
+    configs = [_make_case(mode) for mode in _minimal_pairwise_modes()]
+    tail_modes = [
+        mode
+        for mode in _structural_modes(include_batch=True)
+        if (
+            (mode["ab_dtype"], mode["mma_tiler_mn"][1], mode["L"])
+            in {
+                ("float4_e2m1fn", 128, 1),
+                ("float4_e2m1fn", 256, 2),
+                ("float8_e4m3fn", 128, 2),
+                ("float8_e5m2", 256, 1),
+            }
+        )
+    ]
+    chosen = {}
+    for mode in tail_modes:
+        key = mode["ab_dtype"], mode["mma_tiler_mn"][1], mode["L"]
+        chosen.setdefault(key, mode)
+    configs.extend(
+        _make_case(mode, shape=(144, 160, 160), prefix="tail") for mode in chosen.values()
+    )
+    return sorted(configs, key=lambda config: config["label"])
+
+
+def _performance_tokens(mode):
+    ab_bits = _dtype_bits(mode["ab_dtype"])
+    c_bits = _dtype_bits(mode["c_dtype"])
+    n_tile = mode["mma_tiler_mn"][1]
+    k_tile = 256 if ab_bits == 4 else 128
+    c_epi_n = 64 if c_bits == 4 else 32
+    ab_stage_bytes = (
+        128 * k_tile * ab_bits // 8
+        + n_tile * k_tile * ab_bits // 8
+        + 128 * k_tile // mode["sf_vec_size"]
+        + n_tile * k_tile // mode["sf_vec_size"]
+    )
+    c_stage_bytes = 128 * c_epi_n * c_bits // 8
+    ab_stages = (_SMEM_CAPACITY - (1024 + 2 * c_stage_bytes)) // ab_stage_bytes
+    c_stages = (
+        2
+        + (_SMEM_CAPACITY - ab_stage_bytes * ab_stages - (1024 + 2 * c_stage_bytes))
+        // c_stage_bytes
+    )
+    return frozenset(
+        {
+            ("ab", mode["ab_dtype"]),
+            ("sf", mode["sf_dtype"], mode["sf_vec_size"]),
+            ("mma", "fp4" if ab_bits == 4 else "fp8", mode["sf_vec_size"]),
+            ("c", mode["c_dtype"]),
+            ("a_tma", mode["ab_dtype"], mode["a_major"]),
+            ("b_tma", mode["ab_dtype"], mode["b_major"]),
+            ("store", mode["c_dtype"], mode["c_major"]),
+            ("tile_n", n_tile),
+            ("cluster", mode["cluster_shape_mn"]),
+            ("acc_stages", 1 if n_tile == 256 else 2),
+            ("ab_stages", ab_stages),
+            ("c_stages", c_stages),
+        }
+    )
+
+
+def _performance_representatives():
+    candidates = _structural_modes(include_batch=False)
+    cover = [_performance_tokens(mode) for mode in candidates]
+    uncovered = set().union(*cover)
+    selected = []
+    while uncovered:
+        best_coverage = max(len(tokens & uncovered) for tokens in cover)
+        best = min(
+            (
+                index
+                for index in range(len(candidates))
+                if len(cover[index] & uncovered) == best_coverage
+            ),
+            key=lambda index: _mode_label(candidates[index]),
+        )
+        selected.append(best)
+        uncovered.difference_update(cover[best])
+    counts = {}
+    for index in selected:
+        for token in cover[index]:
+            counts[token] = counts.get(token, 0) + 1
+    kept = []
+    for index in reversed(selected):
+        if all(counts[token] > 1 for token in cover[index]):
+            for token in cover[index]:
+                counts[token] -= 1
+        else:
+            kept.append(index)
+    return [candidates[index] for index in reversed(kept)]
+
+
+def _benchmark_configs():
+    shapes = ((1024, 1024, 1024), (4096, 4096, 1024), (8192, 8192, 1024))
+    configs = []
+    for representative_index, base_mode in enumerate(_performance_representatives()):
+        for M, N, K_dim in shapes:
+            for batch in (1, 2):
+                mode = {**base_mode, "L": batch}
+                configs.append(
+                    _make_case(mode, shape=(M, N, K_dim), prefix=f"perf{representative_index:02d}")
+                )
+    return sorted(configs, key=lambda config: config["label"])
+
+
+KERNEL_META = {
+    "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_amax",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _correctness_configs()
+BENCH_CONFIGS = _benchmark_configs()
+
+
+@cache
+def _make_kernel(
+    M,
+    N,
+    K_dim,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+):
+    if ab_dtype == "uint8" or c_dtype == "uint8":
+        raise ValueError("the non-running public uint8 packed-FP4 alias is not supported")
+    if sf_dtype == "int8":
+        sf_dtype = "float8_e8m0fnu"
+    mma_tiler_mn = tuple(mma_tiler_mn)
+    cluster_shape_mn = tuple(cluster_shape_mn)
+    mode = {
+        "ab_dtype": ab_dtype,
+        "sf_dtype": sf_dtype,
+        "sf_vec_size": sf_vec_size,
+        "c_dtype": c_dtype,
+        "a_major": a_major,
+        "b_major": b_major,
+        "c_major": c_major,
+        "mma_tiler_mn": mma_tiler_mn,
+        "cluster_shape_mn": cluster_shape_mn,
+        "L": L,
+    }
+    if min(M, N, K_dim, L) <= 0:
+        raise ValueError("M/N/K/L must be positive")
+    if not _valid_mode(mode):
+        raise ValueError(f"unsupported source specialization: {_mode_label(mode)}")
+    ab_bits = _dtype_bits(ab_dtype)
+    c_bits = _dtype_bits(c_dtype)
+    alignment = 128
+    if (M if a_major == "m" else K_dim) % (alignment // ab_bits):
+        raise ValueError("A's contiguous dimension must be 16-byte aligned")
+    if (N if b_major == "n" else K_dim) % (alignment // ab_bits):
+        raise ValueError("B's contiguous dimension must be 16-byte aligned")
+    if (M if c_major == "m" else N) % (alignment // c_bits):
+        raise ValueError("C's contiguous dimension must be 16-byte aligned")
+    if ab_dtype == "float4_e2m1fn" and mma_tiler_mn[1] == 256 and K_dim <= 128:
+        raise ValueError("FP4 N=256 instruction tiles require K > 128")
+
+    m_tile = 128
+    n_tile = mma_tiler_mn[1]
+    k_tile = 256 if ab_dtype == "float4_e2m1fn" else 128
+    cluster_m, cluster_n = cluster_shape_mn
+    cluster_size = cluster_m * cluster_n
+    m_tiles = _ceil_div(M, m_tile)
+    n_tiles = _ceil_div(N, n_tile)
+    cluster_m_tiles = _ceil_div(m_tiles, cluster_m)
+    cluster_n_tiles = _ceil_div(n_tiles, cluster_n)
+    cluster_work = cluster_m_tiles * cluster_n_tiles * L
+    num_clusters = min(cluster_work, _MAX_ACTIVE_CLUSTERS[cluster_size])
+    k_tiles = _ceil_div(K_dim, k_tile)
+
+    acc_stages = 1 if n_tile == 256 else 2
+    a_stage_bytes = m_tile * k_tile * ab_bits // 8
+    b_stage_bytes = n_tile * k_tile * ab_bits // 8
+    sfa_stage_bytes = m_tile * k_tile // sf_vec_size
+    sfb_stage_bytes = n_tile * k_tile // sf_vec_size
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes + sfa_stage_bytes + sfb_stage_bytes
+    epi_m = 128
+    epi_n = 64 if c_dtype == "float4_e2m1fn" else 32
+    epilogue_subtiles = n_tile // epi_n
+    epilogue_values = 64 if c_dtype == "float4_e2m1fn" else 32
+    c_packed_words = 32 if c_bits == 32 else 16 if c_bits == 16 else 8
+    c_store_vectors = c_packed_words // 4
+    c_stage_bytes = epi_m * epi_n * c_bits // 8
+    ab_stages = (_SMEM_CAPACITY - (1024 + 2 * c_stage_bytes)) // ab_stage_bytes
+    c_stages = (
+        2
+        + (_SMEM_CAPACITY - ab_stage_bytes * ab_stages - (1024 + 2 * c_stage_bytes))
+        // c_stage_bytes
+    )
+    use_derived_c_stage = (
+        c_dtype in {"float8_e4m3fn", "float8_e5m2"}
+        and c_stages == 2
+        and epilogue_subtiles % 2 == 0
+        and cluster_work > 16 * num_clusters
+    )
+    if min(ab_stages, c_stages) <= 0:
+        raise ValueError("source stage heuristic exceeds the SM100 shared-memory capacity")
+
+    ab_full_offset = 0
+    ab_empty_offset = ab_full_offset + ab_stages * 8
+    acc_full_offset = ab_empty_offset + ab_stages * 8
+    acc_empty_offset = acc_full_offset + acc_stages * 8
+    tmem_dealloc_offset = acc_empty_offset + acc_stages * 8
+    tmem_ptr_offset = tmem_dealloc_offset + 8
+    c_offset = 1024
+    a_offset = c_offset + c_stages * c_stage_bytes
+    b_offset = a_offset + ab_stages * a_stage_bytes
+    sfa_offset = b_offset + ab_stages * b_stage_bytes
+    sfb_offset = sfa_offset + ab_stages * sfa_stage_bytes
+    amax_offset = sfb_offset + ab_stages * sfb_stage_bytes
+    shared_bytes = _align_up(amax_offset + 16, 1024)
+    if shared_bytes > _SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {_SMEM_CAPACITY}")
+
+    a_desc_base = _descriptor_base(ldo=1 if a_major == "k" else 0, sdo=64, swizzle=3)
+    b_desc_base = _descriptor_base(
+        ldo=(
+            b_stage_bytes // 32 if b_major == "n" and n_tile == 256 else 1 if b_major == "k" else 0
+        ),
+        sdo=64,
+        swizzle=3,
+    )
+    sf_desc_base = _descriptor_base(ldo=1, sdo=8, swizzle=0)
+    instr_desc = _instruction_descriptor(128, n_tile, ab_dtype, sf_dtype, a_major, b_major)
+    acc_columns = acc_stages * n_tile
+    sfa_tmem_column = acc_columns
+    sfa_chunks = sfa_stage_bytes // 512
+    sfb_chunks = sfb_stage_bytes // 512
+    sfb_tmem_column = sfa_tmem_column + sfa_chunks * 4
+    tma_cache_hint = 0
+    a_cluster_piece = (k_tile if a_major == "m" else m_tile) // cluster_n
+    b_cluster_piece = (k_tile if b_major == "n" else n_tile) // cluster_m
+    b_tma_copies = n_tile // 128 if b_major == "n" else 1
+    b_tma_copy_bytes = b_stage_bytes // b_tma_copies
+    sf_k_box = k_tile // (4 * sf_vec_size)
+    sfa_piece_values = 256 * sf_k_box // cluster_n
+    sfb_n_box = n_tile // 128
+    sfb_piece_values = 256 * sf_k_box * sfb_n_box // cluster_m
+
+    def host_prelude(params):
+        a = params["a"]
+        b = params["b"]
+        sfa = params["sfa"]
+        sfb = params["sfb"]
+        c = params["c"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        sfa_map = K.stack_alloca("tensormap", 1)
+        sfb_map = K.stack_alloca("tensormap", 1)
+        c_map = K.stack_alloca("tensormap", 1)
+
+        def encode(descriptor, dtype, rank, data, *fields):
+            K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+        a_contiguous_bytes = (M if a_major == "m" else K_dim) * ab_bits // 8
+        b_contiguous_bytes = (N if b_major == "n" else K_dim) * ab_bits // 8
+        a_fields = (
+            (M, K_dim, L, a_contiguous_bytes, M * K_dim * ab_bits // 8, m_tile, a_cluster_piece, 1)
+            if a_major == "m"
+            else (
+                K_dim,
+                M,
+                L,
+                a_contiguous_bytes,
+                M * K_dim * ab_bits // 8,
+                k_tile,
+                a_cluster_piece,
+                1,
+            )
+        )
+        b_fields = (
+            (
+                N,
+                K_dim,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                n_tile // b_tma_copies,
+                b_cluster_piece,
+                1,
+            )
+            if b_major == "n"
+            else (
+                K_dim,
+                N,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                k_tile,
+                b_cluster_piece,
+                1,
+            )
+        )
+        ab_tail = (1, 1, 1, 0, 3, 2, 0)
+        if ab_dtype == "float4_e2m1fn":
+            ab_tail += (13,)
+        encode(a_map, ab_dtype, 3, a.data, *a_fields, *ab_tail)
+        encode(b_map, ab_dtype, 3, b.data, *b_fields, *ab_tail)
+        sf_k_groups = _ceil_div(K_dim, 4 * sf_vec_size)
+        sf_m_groups = _ceil_div(M, 128)
+        sf_n_groups = _ceil_div(N, 128)
+        sfa_box_0 = min(256, sfa_piece_values)
+        sfa_box_1 = sfa_piece_values // sfa_box_0
+        encode(
+            sfa_map,
+            "uint16",
+            4,
+            sfa.data,
+            256,
+            sf_k_groups,
+            sf_m_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_m_groups * sf_k_groups * 512,
+            sfa_box_0,
+            sfa_box_1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        sfb_box_0 = min(256, sfb_piece_values)
+        sfb_remaining = sfb_piece_values // sfb_box_0
+        sfb_box_1 = min(sf_k_box, sfb_remaining)
+        sfb_box_2 = sfb_remaining // sfb_box_1
+        encode(
+            sfb_map,
+            "uint16",
+            4,
+            sfb.data,
+            256,
+            sf_k_groups,
+            sf_n_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_n_groups * sf_k_groups * 512,
+            sfb_box_0,
+            sfb_box_1,
+            sfb_box_2,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        c_contiguous = (M if c_major == "m" else N) * c_bits // 8
+        c_batch_stride = M * N * c_bits // 8
+        if c_major == "m":
+            c_row_copies = c_bits // 8
+            c_fields = (M, N, L, c_contiguous, c_batch_stride, epi_m // c_row_copies, epi_n, 1)
+            c_swizzle = 3
+        else:
+            c_fields = (N, M, L, c_contiguous, c_batch_stride, epi_n, epi_m, 1)
+            c_swizzle = 3 if c_bits == 32 else 2 if c_bits == 16 else 1
+        c_tail = (1, 1, 1, 0, c_swizzle, 2, 0)
+        if c_dtype == "float4_e2m1fn":
+            c_tail += (13,)
+        encode(c_map, c_dtype, 3, c.data, *c_fields, *c_tail)
+        return a_map, b_map, sfa_map, sfb_map, c_map
+
+    def kernel(a, b, sfa, sfb, c, amax, *, host):
+        del a, b, sfa, sfb, c
+        a_map, b_map, sfa_map, sfb_map, c_map = host
+        block_x, block_y, cluster_work_id = K.cta_id()
+        cluster_x, cluster_y = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        cluster_rank = cluster_x + cluster_m * cluster_y
+        del block_x, block_y
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        if c_dtype == "float32":
+            epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3], regs=64)
+        elif c_dtype == "bfloat16" and cluster_size == 1:
+            epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3], regs=56)
+        else:
+            epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = _LinearSmemPool(smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool, ab_stages, full="tma", empty="tcgen05", leader=K.bool(False)
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=4,
+            leader=K.bool(False),
+        )
+        if protocol_pool.cursor != tmem_dealloc_offset:
+            raise AssertionError("protocol storage offsets changed")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.cursor != tmem_ptr_offset + 4:
+            raise AssertionError("protocol storage header changed")
+        del tmem_dealloc
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfa_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfb_map))
+            K.ptx.prefetch.tensormap(K.address_of(c_map))
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(cluster_m + cluster_n - 1)
+                            )
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(4)
+                            )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.arrive.relaxed()
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        cluster_smem_base_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_base_u64, smem.ptr_to([0]))
+        cluster_smem_base = K.local_scalar("uint32", init=K.cast(cluster_smem_base_u64, "uint32"))
+        a_shared_base = K.local_scalar("uint32", init=smem_base + a_offset)
+        b_shared_base = K.local_scalar("uint32", init=smem_base + b_offset)
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, a_shared_base)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, b_shared_base)
+        )
+
+        a_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_n in range(cluster_n):
+            K.assign(
+                a_mcast_mask,
+                K.bitwise_or(
+                    a_mcast_mask, K.uint32(1) << K.cast(cluster_x + cluster_m * peer_n, "uint32")
+                ),
+            )
+        b_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_m in range(cluster_m):
+            K.assign(
+                b_mcast_mask,
+                K.bitwise_or(
+                    b_mcast_mask, K.uint32(1) << K.cast(peer_m + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        ab_consumer_mask = K.local_scalar("uint32", init=K.bitwise_or(a_mcast_mask, b_mcast_mask))
+        acc_producer_mask = K.local_scalar(
+            "uint32", init=K.uint32(1) << K.cast(cluster_rank, "uint32")
+        )
+
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.wait()
+        else:
+            K.ptx.bar.sync(K.uint32(0))
+
+        def scheduler_coords(work):
+            if c_dtype == "float4_e2m1fn":
+                cluster_m_idx = work % cluster_m_tiles
+                quotient = work // cluster_m_tiles
+            elif cluster_m_tiles & (cluster_m_tiles - 1) == 0:
+                cluster_m_idx = K.bitwise_and(work, K.int32(cluster_m_tiles - 1))
+                quotient = K.shift_right(work, K.uint32(cluster_m_tiles.bit_length() - 1))
+            else:
+                cluster_m_idx = work % cluster_m_tiles
+                quotient = work // cluster_m_tiles
+            if c_dtype == "float4_e2m1fn":
+                cluster_n_idx = quotient % cluster_n_tiles
+                batch_idx = quotient // cluster_n_tiles
+            elif L == 1:
+                cluster_n_idx = quotient
+                batch_idx = 0
+            elif cluster_n_tiles & (cluster_n_tiles - 1) == 0:
+                cluster_n_idx = K.bitwise_and(quotient, K.int32(cluster_n_tiles - 1))
+                batch_idx = K.shift_right(quotient, K.uint32(cluster_n_tiles.bit_length() - 1))
+            else:
+                cluster_n_idx = quotient % cluster_n_tiles
+                batch_idx = quotient // cluster_n_tiles
+            tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+            tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+            return tile_m_idx, tile_n_idx, batch_idx
+
+        def advance_work(work):
+            K.assign(work, work + num_clusters)
+
+        with tma_role:
+            tma_state = K.PipelineState(ab_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase
+                        )
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
+                    )
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                ab_pipe.full.ptr_to([tma_state.stage]), K.uint32(ab_stage_bytes)
+                            )
+                    with K.If(_elected()):
+                        with K.Then():
+                            a_coord_m = tile_m_idx * m_tile
+                            a_coord_k = count * k_tile
+                            if a_major == "m":
+                                a_coord_k = a_coord_k + cluster_y * a_cluster_piece
+                            else:
+                                a_coord_m = a_coord_m + cluster_y * a_cluster_piece
+                            a_coord_0 = a_coord_m if a_major == "m" else a_coord_k
+                            a_coord_1 = a_coord_k if a_major == "m" else a_coord_m
+                            if cluster_n == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([a_offset + tma_state.stage * a_stage_bytes]),
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_0, "int32"),
+                                    K.cast(a_coord_1, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint"
+                                ](
+                                    cluster_smem_base
+                                    + a_offset
+                                    + tma_state.stage * a_stage_bytes
+                                    + cluster_y * (a_stage_bytes // cluster_n),
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_0, "int32"),
+                                    K.cast(a_coord_1, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    with K.If(_elected()):
+                        with K.Then():
+                            for b_copy in range(b_tma_copies):
+                                b_coord_n = tile_n_idx * n_tile
+                                if b_major == "n":
+                                    b_coord_n = b_coord_n + b_copy * 128
+                                b_coord_k = count * k_tile
+                                if b_major == "n":
+                                    b_coord_k = b_coord_k + cluster_x * b_cluster_piece
+                                else:
+                                    b_coord_n = b_coord_n + cluster_x * b_cluster_piece
+                                b_coord_0 = b_coord_n if b_major == "n" else b_coord_k
+                                b_coord_1 = b_coord_k if b_major == "n" else b_coord_n
+                                b_smem_offset = (
+                                    b_offset
+                                    + tma_state.stage * b_stage_bytes
+                                    + b_copy * b_tma_copy_bytes
+                                )
+                                if cluster_m == 1:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                    ](
+                                        smem.ptr_to([b_smem_offset]),
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint"
+                                    ](
+                                        cluster_smem_base
+                                        + b_smem_offset
+                                        + cluster_x * (b_tma_copy_bytes // cluster_m),
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                    with K.If(_elected()):
+                        with K.Then():
+                            sfa_linear = cluster_y * sfa_piece_values
+                            sfa_coord_0 = sfa_linear % 256
+                            sfa_coord_1 = count * sf_k_box + sfa_linear // 256
+                            if cluster_n == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([sfa_offset + tma_state.stage * sfa_stage_bytes]),
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint"
+                                ](
+                                    cluster_smem_base
+                                    + sfa_offset
+                                    + tma_state.stage * sfa_stage_bytes
+                                    + cluster_y * (sfa_stage_bytes // cluster_n),
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    with K.If(_elected()):
+                        with K.Then():
+                            sfb_linear = cluster_x * sfb_piece_values
+                            sfb_coord_0 = sfb_linear % 256
+                            sfb_quotient = sfb_linear // 256
+                            sfb_coord_1 = count * sf_k_box + sfb_quotient % sf_k_box
+                            sfb_coord_2 = tile_n_idx * sfb_n_box + sfb_quotient // sf_k_box
+                            if cluster_m == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([sfb_offset + tma_state.stage * sfb_stage_bytes]),
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint"
+                                ](
+                                    cluster_smem_base
+                                    + sfb_offset
+                                    + tma_state.stage * sfb_stage_bytes
+                                    + cluster_x * (sfb_stage_bytes // cluster_m),
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    _advance(tma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative,
+                                ab_pipe.empty.ptr_to([tma_state.stage]),
+                                tma_state.phase,
+                            )
+                advance_work(work)
+            with K.unroll(0, ab_stages) as unused_stage:
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+            del unused_stage
+
+        with mma_role:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            sfa_shared_base = K.local_scalar("uint32", init=smem_base + sfa_offset)
+            sfb_shared_base = K.local_scalar("uint32", init=smem_base + sfb_offset)
+            sfa_descriptor = K.local_scalar(
+                "uint64", init=_descriptor_with_address(sf_desc_base, sfa_shared_base)
+            )
+            sfb_descriptor = K.local_scalar(
+                "uint64", init=_descriptor_with_address(sf_desc_base, sfb_shared_base)
+            )
+            mma_state = K.PipelineState(ab_stages, phase=0)
+            acc_state = K.PipelineState(acc_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            accumulate = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                        )
+                _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(accumulate, K.uint32(0))
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase, speculative
+                    )
+                    for sf_chunk in range(sfa_chunks):
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](
+                                    K.cast(tmem_base + sfa_tmem_column + sf_chunk * 4, "uint32"),
+                                    sfa_descriptor
+                                    + K.cast(
+                                        mma_state.stage * (sfa_stage_bytes // 16) + sf_chunk * 32,
+                                        "uint64",
+                                    ),
+                                )
+                    for sf_chunk in range(sfb_chunks):
+                        sfb_shared_chunk = (sf_chunk % sfb_n_box) * sf_k_box + sf_chunk // sfb_n_box
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](
+                                    K.cast(tmem_base + sfb_tmem_column + sf_chunk * 4, "uint32"),
+                                    sfb_descriptor
+                                    + K.cast(
+                                        mma_state.stage * (sfb_stage_bytes // 16)
+                                        + sfb_shared_chunk * 32,
+                                        "uint64",
+                                    ),
+                                )
+                    for kblock in range(4):
+                        if sf_vec_size == 16:
+                            sfa_scale_offset = kblock * 4
+                            sfb_scale_offset = kblock * 4 * (n_tile // 128)
+                            sf_selector = 0
+                        elif ab_dtype == "float4_e2m1fn":
+                            sfa_scale_offset = (kblock // 2) * 4
+                            sfb_scale_offset = (kblock // 2) * 4 * (n_tile // 128)
+                            sf_selector = (kblock % 2) * 0x80000000
+                        else:
+                            sfa_scale_offset = 0
+                            sfb_scale_offset = 0
+                            sf_selector = kblock * 0x40000000
+                        sfa_tmem_addr = K.cast(
+                            tmem_base + sfa_tmem_column + sfa_scale_offset + K.uint32(sf_selector),
+                            "uint32",
+                        )
+                        sfb_tmem_addr = K.cast(
+                            tmem_base + sfb_tmem_column + sfb_scale_offset + K.uint32(sf_selector),
+                            "uint32",
+                        )
+                        runtime_instr_desc = K.bitwise_and(
+                            K.uint32(instr_desc), K.uint32(0x9FFFFFCF)
+                        )
+                        runtime_instr_desc = K.bitwise_or(
+                            runtime_instr_desc,
+                            K.bitwise_and(
+                                K.shift_right(sfa_tmem_addr, K.uint32(1)), K.uint32(0x60000000)
+                            ),
+                        )
+                        runtime_instr_desc = K.bitwise_or(
+                            runtime_instr_desc,
+                            K.bitwise_and(
+                                K.shift_right(sfb_tmem_addr, K.uint32(26)), K.uint32(0x30)
+                            ),
+                        )
+                        with K.If(_elected()):
+                            with K.Then():
+                                mma_kind = "mxf4nvf4" if ab_dtype == "float4_e2m1fn" else "mxf8f6f4"
+                                K.ptx[
+                                    "tcgen05.mma.cta_group::1.kind::"
+                                    + mma_kind
+                                    + ".block_scale.block"
+                                    + str(sf_vec_size)
+                                ](
+                                    K.cast(tmem_base + acc_state.stage * n_tile, "uint32"),
+                                    a_descriptor
+                                    + K.cast(
+                                        mma_state.stage * (a_stage_bytes // 16)
+                                        + kblock * (2 if a_major == "k" else 256),
+                                        "uint64",
+                                    ),
+                                    b_descriptor
+                                    + K.cast(
+                                        mma_state.stage * (b_stage_bytes // 16)
+                                        + kblock * (2 if b_major == "k" else 256),
+                                        "uint64",
+                                    ),
+                                    runtime_instr_desc,
+                                    sfa_tmem_addr,
+                                    sfb_tmem_addr,
+                                    K.ptx.pred(K.cast(accumulate, "bool")),
+                                )
+                        K.assign(accumulate, K.uint32(1))
+                    with K.If(_elected()):
+                        with K.Then():
+                            if cluster_size == 1:
+                                K.ptx[
+                                    "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                    ".shared::cluster.b64"
+                                ](ab_pipe.empty.ptr_to([mma_state.stage]))
+                            else:
+                                K.ptx[
+                                    "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                    ".shared::cluster.multicast::cluster.b64"
+                                ](
+                                    ab_pipe.empty.ptr_to([mma_state.stage]),
+                                    K.cast(ab_consumer_mask, "uint16"),
+                                )
+                    _advance(mma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        if cluster_size == 1:
+                            K.ptx[
+                                "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                ".shared::cluster.b64"
+                            ](acc_pipe.full.ptr_to([acc_state.stage]))
+                        else:
+                            K.ptx[
+                                "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                ".shared::cluster.multicast::cluster.b64"
+                            ](
+                                acc_pipe.full.ptr_to([acc_state.stage]),
+                                K.cast(acc_producer_mask, "uint16"),
+                            )
+                _advance(acc_state)
+                advance_work(work)
+            with K.If((cluster_rank % 2) == 0):
+                with K.Then():
+                    for _ in range(acc_stages - 1):
+                        _advance(acc_state)
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        with epilogue_role:
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+                        tmem_slot.ptr_to([0]), K.uint32(512)
+                    )
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            acc_state = K.PipelineState(acc_stages, phase=0)
+            if use_derived_c_stage:
+                c_stage = None
+            else:
+                c_stage = K.local_scalar("int32", init=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            values = K.alloc_local((epilogue_values,), "float32")
+            absolute = K.alloc_local((epilogue_values,), "float32")
+            maxima = K.alloc_local((epilogue_values // 2,), "float32")
+            packed_pair_dtype = (
+                "uint8"
+                if c_dtype == "float4_e2m1fn"
+                else "uint16"
+                if c_dtype.startswith("float8_")
+                else "uint32"
+            )
+            packed_pairs = K.alloc_local((epilogue_values // 2,), packed_pair_dtype)
+            packed = K.alloc_local((epilogue_values,), "uint32")
+            if c_major == "n":
+                c_store_offsets = K.alloc_local((c_store_vectors,), "int32")
+            tile_amax = K.local_scalar("float32")
+            warp_amax = K.local_scalar("float32")
+
+            def emit_epilogue_subtile(subtile):
+                if use_derived_c_stage:
+                    c_stage_index = K.bitwise_and(subtile, K.int32(1))
+                else:
+                    c_stage_index = c_stage
+                tmem_load_addr = K.local_scalar(
+                    "uint32",
+                    init=tmem_base + (warp << 21) + acc_state.stage * n_tile + subtile * epi_n,
+                )
+                if c_dtype == "float4_e2m1fn":
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x64.b32"](
+                        *[values[index] for index in range(64)], tmem_load_addr
+                    )
+                elif c_major == "m" and c_bits <= 16:
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                        *[values[index] for index in range(16)], tmem_load_addr
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                        *[values[index] for index in range(16, 32)],
+                        tmem_load_addr + K.uint32(1 << 20),
+                    )
+                else:
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                        *[values[index] for index in range(32)], tmem_load_addr
+                    )
+                if c_major == "n":
+                    bytes_per_thread = c_packed_words * 4
+                    swizzle_mask = {32: 16, 64: 48, 128: 112}[bytes_per_thread]
+                    for vector in range(c_store_vectors):
+                        unswizzled = (
+                            smem_base
+                            + c_offset
+                            + c_stage_index * c_stage_bytes
+                            + warp * (32 * bytes_per_thread)
+                            + lane * bytes_per_thread
+                            + vector * 16
+                        )
+                        swizzled = K.bitwise_xor(
+                            unswizzled,
+                            K.bitwise_and(
+                                K.shift_right(unswizzled, K.uint32(3)), K.uint32(swizzle_mask)
+                            ),
+                        )
+                        K.assign(c_store_offsets[vector], K.cast(swizzled - smem_base, "int32"))
+                for index in range(epilogue_values):
+                    K.ptx.abs.f32(absolute[index], values[index])
+                ternary_groups = epilogue_values // 3
+                for index in range(ternary_groups):
+                    K.ptx.max.NaN.f32(
+                        maxima[index],
+                        absolute[index * 3],
+                        absolute[index * 3 + 1],
+                        absolute[index * 3 + 2],
+                    )
+                remainder = epilogue_values % 3
+                if remainder == 1:
+                    K.ptx.max.NaN.f32(
+                        maxima[ternary_groups - 1],
+                        maxima[ternary_groups - 1],
+                        absolute[epilogue_values - 1],
+                    )
+                    reduction_width = ternary_groups
+                elif remainder == 2:
+                    K.ptx.max.NaN.f32(
+                        maxima[ternary_groups],
+                        absolute[epilogue_values - 2],
+                        absolute[epilogue_values - 1],
+                    )
+                    reduction_width = ternary_groups + 1
+                else:
+                    reduction_width = ternary_groups
+                while reduction_width > 1:
+                    ternary_groups = reduction_width // 3
+                    for index in range(ternary_groups):
+                        K.ptx.max.NaN.f32(
+                            maxima[index],
+                            maxima[index * 3],
+                            maxima[index * 3 + 1],
+                            maxima[index * 3 + 2],
+                        )
+                    remainder = reduction_width % 3
+                    if remainder == 1:
+                        K.ptx.max.NaN.f32(
+                            maxima[ternary_groups - 1],
+                            maxima[ternary_groups - 1],
+                            maxima[reduction_width - 1],
+                        )
+                        reduction_width = ternary_groups
+                    elif remainder == 2:
+                        K.ptx.max.NaN.f32(
+                            maxima[ternary_groups],
+                            maxima[reduction_width - 2],
+                            maxima[reduction_width - 1],
+                        )
+                        reduction_width = ternary_groups + 1
+                    else:
+                        reduction_width = ternary_groups
+                K.ptx.max.NaN.f32(maxima[0], maxima[0], K.float32(0.0))
+                K.ptx.max.f32(tile_amax, tile_amax, maxima[0])
+
+                if c_dtype == "float32":
+                    for index in range(32):
+                        K.assign(packed[index], K.reinterpret("uint32", values[index]))
+                    packed_words = 32
+                elif c_dtype in {"float16", "bfloat16"}:
+                    for index in range(16):
+                        if c_dtype == "float16":
+                            K.ptx.cvt.rn.f16x2.f32(
+                                packed[index], values[index * 2 + 1], values[index * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                packed[index], values[index * 2 + 1], values[index * 2]
+                            )
+                    packed_words = 16
+                elif c_dtype in {"float8_e4m3fn", "float8_e5m2"}:
+                    for index in range(16):
+                        if c_dtype == "float8_e4m3fn":
+                            K.ptx.cvt.rn.satfinite.e4m3x2.f32(
+                                packed_pairs[index], values[index * 2 + 1], values[index * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.satfinite.e5m2x2.f32(
+                                packed_pairs[index], values[index * 2 + 1], values[index * 2]
+                            )
+                    if c_major != "n":
+                        for index in range(8):
+                            K.assign(
+                                packed[index],
+                                K.bitwise_or(
+                                    K.bitwise_and(
+                                        K.cast(packed_pairs[index * 2], "uint32"), K.uint32(0xFFFF)
+                                    ),
+                                    K.shift_left(
+                                        K.bitwise_and(
+                                            K.cast(packed_pairs[index * 2 + 1], "uint32"),
+                                            K.uint32(0xFFFF),
+                                        ),
+                                        K.uint32(16),
+                                    ),
+                                ),
+                            )
+                    packed_words = 8
+                else:
+                    for index in range(32):
+                        K.ptx.cvt.rn.satfinite.e2m1x2.f32(
+                            packed_pairs[index], values[index * 2 + 1], values[index * 2]
+                        )
+                    for index in range(8):
+                        K.assign(
+                            packed[index],
+                            K.bitwise_or(
+                                K.bitwise_or(
+                                    K.bitwise_and(
+                                        K.cast(packed_pairs[index * 4], "uint32"), K.uint32(0xFF)
+                                    ),
+                                    K.shift_left(
+                                        K.bitwise_and(
+                                            K.cast(packed_pairs[index * 4 + 1], "uint32"),
+                                            K.uint32(0xFF),
+                                        ),
+                                        K.uint32(8),
+                                    ),
+                                ),
+                                K.bitwise_or(
+                                    K.shift_left(
+                                        K.bitwise_and(
+                                            K.cast(packed_pairs[index * 4 + 2], "uint32"),
+                                            K.uint32(0xFF),
+                                        ),
+                                        K.uint32(16),
+                                    ),
+                                    K.shift_left(
+                                        K.bitwise_and(
+                                            K.cast(packed_pairs[index * 4 + 3], "uint32"),
+                                            K.uint32(0xFF),
+                                        ),
+                                        K.uint32(24),
+                                    ),
+                                ),
+                            ),
+                        )
+                    packed_words = 8
+
+                if c_major == "n":
+                    if c_dtype in {"float8_e4m3fn", "float8_e5m2"}:
+                        for vector in range(c_store_vectors):
+                            pair = vector * 8
+                            K.ptx["st.shared.v4.b16"](
+                                smem.ptr_to([c_store_offsets[vector]]),
+                                packed_pairs[pair],
+                                packed_pairs[pair + 1],
+                                packed_pairs[pair + 2],
+                                packed_pairs[pair + 3],
+                            )
+                            K.ptx["st.shared.v4.b16"](
+                                smem.ptr_to([c_store_offsets[vector] + 8]),
+                                packed_pairs[pair + 4],
+                                packed_pairs[pair + 5],
+                                packed_pairs[pair + 6],
+                                packed_pairs[pair + 7],
+                            )
+                    else:
+                        for vector in range(c_store_vectors):
+                            K.ptx.st.shared.v4.b32(
+                                smem.ptr_to([c_store_offsets[vector]]),
+                                packed[vector * 4],
+                                packed[vector * 4 + 1],
+                                packed[vector * 4 + 2],
+                                packed[vector * 4 + 3],
+                            )
+                elif c_dtype == "float32":
+                    scalar_base = (
+                        smem_base
+                        + c_offset
+                        + c_stage_index * c_stage_bytes
+                        + warp * 4096
+                        + lane * 4
+                    )
+                    for index in range(32):
+                        unswizzled = scalar_base + (index % 8) * 128 + (index // 8) * 1024
+                        swizzled = K.bitwise_xor(
+                            unswizzled,
+                            K.bitwise_and(K.shift_right(unswizzled, K.uint32(3)), K.uint32(112)),
+                        )
+                        K.ptx.st.shared.b32(
+                            smem.ptr_to([K.cast(swizzled - smem_base, "int32")]), packed[index]
+                        )
+                elif c_bits == 16:
+                    thread = warp * 32 + lane
+                    temporary = K.bitwise_or(
+                        K.bitwise_and(thread << 5, K.int32(6144)),
+                        K.bitwise_and(thread, K.int32(40)),
+                    )
+                    raw_address = K.bitwise_or(
+                        K.bitwise_or(K.bitwise_and(thread << 7, K.int32(896)), temporary << 1),
+                        K.bitwise_and(thread << 6, K.int32(1024)),
+                    )
+                    first_unswizzled = (
+                        smem_base + c_offset + c_stage_index * c_stage_bytes + raw_address
+                    )
+                    first_swizzled = K.bitwise_xor(
+                        first_unswizzled,
+                        K.bitwise_and(K.shift_right(first_unswizzled, K.uint32(3)), K.uint32(112)),
+                    )
+                    second_unswizzled = first_unswizzled + 32
+                    second_swizzled = K.bitwise_xor(
+                        second_unswizzled,
+                        K.bitwise_and(K.shift_right(second_unswizzled, K.uint32(3)), K.uint32(112)),
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        smem.ptr_to([K.cast(first_swizzled - smem_base, "int32")]),
+                        packed[0],
+                        packed[1],
+                        packed[2],
+                        packed[3],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        smem.ptr_to([K.cast(first_swizzled - smem_base + 2048, "int32")]),
+                        packed[4],
+                        packed[5],
+                        packed[6],
+                        packed[7],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        smem.ptr_to([K.cast(second_swizzled - smem_base, "int32")]),
+                        packed[8],
+                        packed[9],
+                        packed[10],
+                        packed[11],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        smem.ptr_to([K.cast(second_swizzled - smem_base + 2048, "int32")]),
+                        packed[12],
+                        packed[13],
+                        packed[14],
+                        packed[15],
+                    )
+                else:
+                    thread = warp * 32 + lane
+                    raw_address = K.bitwise_or(
+                        K.bitwise_and(thread, K.int32(224)),
+                        K.bitwise_and(thread << 7, K.int32(3968)),
+                    )
+                    first_unswizzled = (
+                        smem_base + c_offset + c_stage_index * c_stage_bytes + raw_address
+                    )
+                    first_swizzled = K.bitwise_xor(
+                        first_unswizzled,
+                        K.bitwise_and(K.shift_right(first_unswizzled, K.uint32(3)), K.uint32(112)),
+                    )
+                    second_unswizzled = first_unswizzled + 16
+                    second_swizzled = K.bitwise_xor(
+                        second_unswizzled,
+                        K.bitwise_and(K.shift_right(second_unswizzled, K.uint32(3)), K.uint32(112)),
+                    )
+                    K.ptx.stmatrix.sync.aligned.m16n8.x4.trans.shared.b8(
+                        smem.ptr_to([K.cast(first_swizzled - smem_base, "int32")]),
+                        packed[0],
+                        packed[1],
+                        packed[2],
+                        packed[3],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m16n8.x4.trans.shared.b8(
+                        smem.ptr_to([K.cast(second_swizzled - smem_base, "int32")]),
+                        packed[4],
+                        packed[5],
+                        packed[6],
+                        packed[7],
+                    )
+                K.ptx.fence.proxy.async_.shared__cta()
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                with K.If(warp == 0):
+                    with K.Then():
+                        if c_major == "n":
+                            K.ptx[
+                                "cp.async.bulk.tensor.3d.global.shared::cta.tile"
+                                ".bulk_group.L2::cache_hint"
+                            ](
+                                K.address_of(c_map),
+                                K.cast(tile_n_idx * n_tile + subtile * epi_n, "int32"),
+                                K.cast(tile_m_idx * m_tile, "int32"),
+                                K.cast(batch_idx, "int32"),
+                                smem.ptr_to([c_offset + c_stage_index * c_stage_bytes]),
+                                K.uint64(tma_cache_hint),
+                            )
+                        else:
+                            for row_copy in range(c_bits // 8):
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.global.shared::cta.tile"
+                                    ".bulk_group.L2::cache_hint"
+                                ](
+                                    K.address_of(c_map),
+                                    K.cast(
+                                        tile_m_idx * m_tile + row_copy * (epi_m // (c_bits // 8)),
+                                        "int32",
+                                    ),
+                                    K.cast(tile_n_idx * n_tile + subtile * epi_n, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    smem.ptr_to(
+                                        [c_offset + c_stage_index * c_stage_bytes + row_copy * 4096]
+                                    ),
+                                    K.uint64(tma_cache_hint),
+                                )
+                        K.ptx.cp.async_.bulk.commit_group()
+                        K.ptx.cp.async_.bulk.wait_group.read(c_stages - 1)
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                if not use_derived_c_stage:
+                    if (c_stages & (c_stages - 1)) == 0:
+                        K.assign(c_stage, K.bitwise_and(c_stage + 1, c_stages - 1))
+                    else:
+                        K.assign(c_stage, K.Select(c_stage == c_stages - 1, 0, c_stage + 1))
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                _wait_plain(acc_pipe.full.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(tile_amax, K.float32(0.0))
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    emit_epilogue_subtile(subtile)
+                    K.assign(subtile, subtile + 1)
+
+                K.ptx.redux_sync.max.NaN.f32(warp_amax, tile_amax, K.uint32(0xFFFFFFFF))
+                with K.If(lane == 0):
+                    with K.Then():
+                        K.ptx.st.shared.b32(smem.ptr_to([amax_offset + warp * 4]), warp_amax)
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                with K.If((warp == 0) & (lane == 0)):
+                    with K.Then():
+                        block_amax = K.local_scalar("float32")
+                        next_amax = K.local_scalar("float32")
+                        K.ptx.ld.shared.b32(block_amax, smem.ptr_to([amax_offset]))
+                        K.ptx.max.f32(block_amax, block_amax, K.float32(0.0))
+                        for slot in range(1, 4):
+                            K.ptx.ld.shared.b32(next_amax, smem.ptr_to([amax_offset + slot * 4]))
+                            K.ptx.max.f32(block_amax, block_amax, next_amax)
+                        atomic_old = K.local_scalar("int32")
+                        K.ptx.atom.global_.max.s32(
+                            atomic_old, amax.ptr_to([0]), K.reinterpret("int32", block_amax)
+                        )
+                with K.If(_elected()):
+                    with K.Then():
+                        K.ptx.mbarrier.arrive.shared.b64(
+                            acc_pipe.empty.ptr_to([acc_state.stage]), K.uint32(1)
+                        )
+                _advance(acc_state)
+                advance_work(work)
+
+            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+            K.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](tmem_base, K.uint32(512))
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+
+    kernel.__annotations__ = {
+        "a": K.gptr[K.u8, (M * K_dim * L * ab_bits // 8,)],
+        "b": K.gptr[K.u8, (N * K_dim * L * ab_bits // 8,)],
+        "sfa": K.gptr[K.u8, (L * _ceil_div(M, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "sfb": K.gptr[K.u8, (L * _ceil_div(N, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "c": K.gptr[K.u8, (M * N * L * c_bits // 8,)],
+        "amax": K.gptr[K.f32, (1,)],
+    }
+    return K.kernel(
+        warps=6,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=[cluster_m, cluster_n, num_clusters],
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(
+    M,
+    N,
+    K,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+):
+    return _make_kernel(
+        M,
+        N,
+        K,
+        L,
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        a_major,
+        b_major,
+        c_major,
+        mma_tiler_mn,
+        cluster_shape_mn,
+    ).func
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _torch_dtype(torch, dtype):
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e5m2": torch.float8_e5m2,
+        "float8_e8m0fnu": torch.float8_e8m0fnu,
+    }[dtype]
+
+
+def _regular_tensor(torch, rows, columns, batch, dtype, first_major):
+    bits = _dtype_bits(dtype)
+    raw = torch.empty(rows * columns * batch * bits // 8, dtype=torch.uint8, device="cuda")
+    storage = raw.view(_torch_dtype(torch, dtype))
+    strides = (1, rows, rows * columns) if first_major else (columns, 1, rows * columns)
+    logical = torch.as_strided(storage, (rows, columns, batch), strides)
+    return raw, logical
+
+
+def _fp4_tensor(torch, rows, columns, batch, *, zero=False):
+    raw = (
+        torch.zeros(batch * rows * columns // 2, dtype=torch.uint8, device="cuda")
+        if zero
+        else torch.empty(batch * rows * columns // 2, dtype=torch.uint8, device="cuda")
+    )
+    physical = raw.view(batch, rows, columns // 2)
+    logical = physical.view(torch.float4_e2m1fn_x2).permute(1, 2, 0)
+    return raw, logical, physical
+
+
+def _sparse_input(torch, rows, K_dim, batch, dtype, major, salt):
+    row_ids = torch.arange(rows, device="cuda", dtype=torch.int64)
+    k_indices = []
+    input_values = []
+    if dtype == "float4_e2m1fn":
+        raw, logical, physical = _fp4_tensor(torch, rows, K_dim, batch, zero=True)
+        for batch_index in range(batch):
+            k_index = (row_ids * (17 + salt) + batch_index * 7 + salt) % K_dim
+            value = 1 + ((row_ids + batch_index + salt) % 2)
+            code = value.to(torch.uint8) * 2
+            physical[batch_index, row_ids, k_index // 2] = code << (
+                (k_index % 2).to(torch.uint8) * 4
+            )
+            k_indices.append(k_index)
+            input_values.append(value.to(torch.float32))
+    else:
+        raw, logical = _regular_tensor(torch, rows, K_dim, batch, dtype, first_major=major != "k")
+        logical.zero_()
+        for batch_index in range(batch):
+            k_index = (row_ids * (17 + salt) + batch_index * 7 + salt) % K_dim
+            value = 1 + ((row_ids + batch_index + salt) % 2)
+            logical[row_ids, k_index, batch_index] = value.to(logical.dtype)
+            k_indices.append(k_index)
+            input_values.append(value.to(torch.float32))
+    return {"raw": raw, "source": logical, "k_indices": k_indices, "values": input_values}
+
+
+def _output_tensor(torch, M, N, L, dtype, major):
+    if dtype == "float4_e2m1fn":
+        raw, logical, _ = _fp4_tensor(torch, M, N, L, zero=True)
+        return {"raw": raw, "source": logical}
+    raw, logical = _regular_tensor(torch, M, N, L, dtype, first_major=major == "m")
+    logical.zero_()
+    return {"raw": raw, "source": logical}
+
+
+def _decode_fp4_output(torch, raw, M, N, L):
+    physical = raw.view(L, M, N // 2)
+    low = physical & 0xF
+    high = physical >> 4
+    codes = torch.stack((low, high), dim=-1).reshape(L, M, N).to(torch.int64)
+    lookup = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    return lookup[codes].permute(1, 2, 0)
+
+
+def _output_as_float(torch, output, M, N, L, dtype):
+    if dtype == "float4_e2m1fn":
+        return _decode_fp4_output(torch, output["raw"], M, N, L)
+    return output["source"].float()
+
+
+def prepare_data(**config):
+    """Allocate one input set shared by TIRx, the source kernel, and the oracle."""
+    import torch
+
+    config = _without_label(config)
+    M, N, K_dim, L = (config[key] for key in ("M", "N", "K", "L"))
+    sf_dtype = "float8_e8m0fnu" if config["sf_dtype"] == "int8" else config["sf_dtype"]
+    a_data = _sparse_input(torch, M, K_dim, L, config["ab_dtype"], config["a_major"], 0)
+    b_data = _sparse_input(torch, N, K_dim, L, config["ab_dtype"], config["b_major"], 6)
+    sf_shape_a = (L, _ceil_div(M, 128), _ceil_div(K_dim, 4 * config["sf_vec_size"]), 32, 4, 4)
+    sf_shape_b = (L, _ceil_div(N, 128), _ceil_div(K_dim, 4 * config["sf_vec_size"]), 32, 4, 4)
+    sf_torch_dtype = _torch_dtype(torch, sf_dtype)
+    sfa = torch.ones(sf_shape_a, dtype=torch.float32, device="cuda").to(sf_torch_dtype)
+    sfb = torch.ones(sf_shape_b, dtype=torch.float32, device="cuda").to(sf_torch_dtype)
+    tirx_output = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
+    source_output = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
+    expected_batches = []
+    for batch_index in range(L):
+        matches = (
+            a_data["k_indices"][batch_index][:, None] == b_data["k_indices"][batch_index][None, :]
+        )
+        expected_batches.append(
+            matches.to(torch.float32)
+            * a_data["values"][batch_index][:, None]
+            * b_data["values"][batch_index][None, :]
+        )
+    expected = torch.stack(expected_batches, dim=2)
+    return {
+        "a": a_data,
+        "b": b_data,
+        "sfa": sfa,
+        "sfb": sfb,
+        "tirx_output": tirx_output,
+        "source_output": source_output,
+        "tirx_amax": torch.zeros(1, dtype=torch.float32, device="cuda"),
+        "source_amax": torch.zeros(1, dtype=torch.float32, device="cuda"),
+        "expected": expected,
+    }
+
+
+def _git_output(root, *args):
+    return subprocess.check_output(["git", "-C", str(root), *args], text=True).strip()
+
+
+@cache
+def _load_reference_source():
+    default_root = Path(__file__).resolve().parents[3] / ".reference-deps" / "cudnn-frontend"
+    root = Path(os.environ.get("CUDNN_FRONTEND_PATH", default_root)).resolve()
+    origin = _git_output(root, "remote", "get-url", "origin").rstrip("/")
+    if origin.removesuffix(".git") != "https://github.com/NVIDIA/cudnn-frontend":
+        raise RuntimeError(f"unexpected cuDNN Frontend origin: {origin}")
+    actual_commit = _git_output(root, "rev-parse", "HEAD")
+    if actual_commit != _SOURCE_COMMIT:
+        raise RuntimeError(f"cuDNN Frontend commit is {actual_commit}, expected {_SOURCE_COMMIT}")
+    dirty = _git_output(
+        root, "status", "--porcelain", "--untracked-files=no", "--ignore-submodules=untracked"
+    )
+    if dirty:
+        raise RuntimeError(f"cuDNN Frontend checkout is dirty: {root}")
+    source_path = root / _SOURCE_RELATIVE
+    actual_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    if actual_sha256 != _SOURCE_SHA256:
+        raise RuntimeError(
+            f"cuDNN Frontend source SHA256 is {actual_sha256}, expected {_SOURCE_SHA256}"
+        )
+    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_amax_source", source_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _import_cutlass_reference():
+    """Recover from CuTeDSL's non-idempotent generated builder imports."""
+    try:
+        return importlib.import_module("cutlass")
+    except RuntimeError as exc:
+        message = str(exc)
+        if "Attribute builder for '" not in message or "is already registered" not in message:
+            raise
+        mlir_ir = sys.modules.get("cutlass._mlir.ir")
+        if mlir_ir is None:
+            raise
+        register_attribute_builder = mlir_ir.register_attribute_builder
+
+        def register_replacing_builder(kind, replace=False):
+            del replace
+            return register_attribute_builder(kind, replace=True)
+
+        mlir_ir.register_attribute_builder = register_replacing_builder
+        try:
+            return importlib.import_module("cutlass")
+        finally:
+            mlir_ir.register_attribute_builder = register_attribute_builder
+
+
+def _compile_reference(data, config):
+    cutlass = _import_cutlass_reference()
+    import cutlass.cute as cute
+    import torch
+    from cuda.bindings import driver as cuda
+    from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+    if os.environ.get("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0") != "0":
+        raise RuntimeError("CUDNNFE_CLUSTER_OVERLAP_MARGIN must be 0")
+    module = _load_reference_source()
+    config = _without_label(config)
+    a = data["a"]["source"]
+    b = data["b"]["source"]
+    sfa = data["sfa"]
+    sfb = data["sfb"]
+    c = data["source_output"]["source"]
+    amax = data["source_amax"]
+    a_cute = from_dlpack(a, assumed_align=16).mark_layout_dynamic(
+        leading_dim=0 if config["a_major"] == "m" else 1
+    )
+    b_cute = from_dlpack(b, assumed_align=16).mark_layout_dynamic(
+        leading_dim=0 if config["b_major"] == "n" else 1
+    )
+    sfa_cute = from_dlpack(sfa, assumed_align=16)
+    sfb_cute = from_dlpack(sfb, assumed_align=16)
+    c_cute = from_dlpack(c, assumed_align=16).mark_layout_dynamic(
+        leading_dim=0 if config["c_major"] == "m" else 1
+    )
+    amax_cute = from_dlpack(amax, assumed_align=16)
+    kernel = module.Sm100BlockScaledPersistentDenseGemmKernel(
+        sf_vec_size=config["sf_vec_size"],
+        mma_tiler_mn=tuple(config["mma_tiler_mn"]),
+        cluster_shape_mn=tuple(config["cluster_shape_mn"]),
+    )
+    cluster_size = config["cluster_shape_mn"][0] * config["cluster_shape_mn"][1]
+    max_active_clusters = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size)
+    executable = cute.compile(
+        kernel,
+        a_tensor=a_cute,
+        b_tensor=b_cute,
+        sfa_tensor=sfa_cute,
+        sfb_tensor=sfb_cute,
+        c_tensor=c_cute,
+        amax_tensor=amax_cute,
+        max_active_clusters=max_active_clusters,
+        stream=make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        executable(a, b, sfa, sfb, c, amax, stream)
+
+    launch._keep_alive = (executable, a, b, sfa, sfb, c, amax, stream)
+    return launch
+
+
+def _tirx_launch(executable, data):
+    import torch
+
+    a = data["a"]["raw"]
+    b = data["b"]["raw"]
+    sfa = data["sfa"].view(torch.uint8).reshape(-1)
+    sfb = data["sfb"].view(torch.uint8).reshape(-1)
+    c = data["tirx_output"]["raw"]
+    amax = data["tirx_amax"]
+
+    def launch():
+        executable(a, b, sfa, sfb, c, amax)
+
+    launch._keep_alive = (a, b, sfa, sfb, c, amax)
+    return launch
+
+
+def _assert_close(torch, actual, expected, *, atol, rtol, label):
+    if actual.shape != expected.shape:
+        raise AssertionError(f"{label} shape mismatch: {actual.shape} != {expected.shape}")
+    if actual.device != expected.device:
+        raise AssertionError(f"{label} device mismatch: {actual.device} != {expected.device}")
+    if actual.dtype != expected.dtype:
+        raise AssertionError(f"{label} dtype mismatch: {actual.dtype} != {expected.dtype}")
+    close = torch.isclose(actual, expected, atol=atol, rtol=rtol)
+    if bool(torch.all(close).item()):
+        return
+    absolute_error = torch.abs(actual - expected)
+    allowed_error = atol + rtol * torch.abs(expected)
+    excess = absolute_error - allowed_error
+    worst_index = int(torch.argmax(excess).item())
+    worst_absolute = float(absolute_error.reshape(-1)[worst_index].item())
+    worst_allowed = float(allowed_error.reshape(-1)[worst_index].item())
+    raise AssertionError(
+        f"{label} mismatch: worst absolute error {worst_absolute} exceeds {worst_allowed}"
+    )
+
+
+def _validate_outputs(data, config, *, with_source):
+    import torch
+
+    config = _without_label(config)
+    M, N, L = (config[key] for key in ("M", "N", "L"))
+    tolerance = 0.1 if _dtype_bits(config["c_dtype"]) <= 8 else 0.01
+    tirx_output = _output_as_float(torch, data["tirx_output"], M, N, L, config["c_dtype"])
+    _assert_close(
+        torch,
+        tirx_output,
+        data["expected"],
+        atol=tolerance,
+        rtol=tolerance,
+        label="TIRx output versus FP32 oracle",
+    )
+    expected_amax = data["expected"].abs().amax().reshape(1)
+    _assert_close(
+        torch,
+        data["tirx_amax"],
+        expected_amax,
+        atol=0.1,
+        rtol=0.1,
+        label="TIRx amax versus FP32 oracle",
+    )
+    if with_source:
+        source_output = _output_as_float(torch, data["source_output"], M, N, L, config["c_dtype"])
+        _assert_close(
+            torch,
+            source_output,
+            data["expected"],
+            atol=tolerance,
+            rtol=tolerance,
+            label="source output versus FP32 oracle",
+        )
+        _assert_close(
+            torch,
+            tirx_output,
+            source_output,
+            atol=tolerance,
+            rtol=tolerance,
+            label="TIRx output versus source output",
+        )
+        _assert_close(
+            torch,
+            data["source_amax"],
+            expected_amax,
+            atol=0.1,
+            rtol=0.1,
+            label="source amax versus FP32 oracle",
+        )
+
+
+def run_test(**config):
+    """Compare TIRx with both the pinned source and the FP32 oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _tirx_launch(compile_kernel(get_kernel(**kernel_config)), data)
+    source_launch = _compile_reference(data, kernel_config)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, kernel_config, with_source=True)
+    return {"max_abs": float(data["expected"].abs().amax().item())}
+
+
+def prepare_bench(**config):
+    """Compile only TIRx; reference imports and CUDA work stay in ``run_gpu``."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {"config": kernel_config, "executable": compile_kernel(get_kernel(**kernel_config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then time pure launches with the canonical timer."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _tirx_launch(prepared["executable"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    with_source = external_references_enabled()
+    references = None
+    if with_source:
+        source_launch = _compile_reference(data, kernel_config)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"cudnn_frontend": lambda: source_launch}
+    _validate_outputs(data, kernel_config, with_source=with_source)
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -809,12 +809,13 @@ def _make_kernel(
                     _wait_plain_if_needed(
                         ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
                     )
-                    with K.If(_elected()):
+                    tma_elected = _elected()
+                    with K.If(tma_elected):
                         with K.Then():
                             K.ptx.mbarrier.arrive.expect_tx.shared.b64(
                                 ab_pipe.full.ptr_to([tma_state.stage]), K.uint32(ab_stage_bytes)
                             )
-                    with K.If(_elected()):
+                    with K.If(tma_elected):
                         with K.Then():
                             a_coord_m = tile_m_idx * m_tile
                             a_coord_k = count * k_tile
@@ -855,7 +856,7 @@ def _make_kernel(
                                     K.cast(a_mcast_mask, "uint16"),
                                     K.uint64(tma_cache_hint),
                                 )
-                    with K.If(_elected()):
+                    with K.If(tma_elected):
                         with K.Then():
                             for b_copy in range(b_tma_copies):
                                 b_coord_n = tile_n_idx * n_tile
@@ -903,7 +904,7 @@ def _make_kernel(
                                         K.cast(b_mcast_mask, "uint16"),
                                         K.uint64(tma_cache_hint),
                                     )
-                    with K.If(_elected()):
+                    with K.If(tma_elected):
                         with K.Then():
                             sfa_linear = cluster_y * sfa_piece_values
                             sfa_coord_0 = sfa_linear % 256
@@ -941,7 +942,7 @@ def _make_kernel(
                                     K.cast(a_mcast_mask, "uint16"),
                                     K.uint64(tma_cache_hint),
                                 )
-                    with K.If(_elected()):
+                    with K.If(tma_elected):
                         with K.Then():
                             sfb_linear = cluster_x * sfb_piece_values
                             sfb_coord_0 = sfb_linear % 256

--- a/tirx_kernels/kern/smem.py
+++ b/tirx_kernels/kern/smem.py
@@ -485,10 +485,16 @@ class KTileView:
 class SmemPool:
     """Session-bound wrapper over the in-tree :class:`SMEMPool`."""
 
-    def __init__(self, session):
+    def __init__(self, session, base=None):
         self.session = session
-        self.pool = SMEMPool()
+        self.pool = SMEMPool() if base is None else SMEMPool(base.data)
+        self._max_offset = 0
         self._committed = False
+
+    def _alloc(self, *args, **kwargs):
+        result = self.pool.alloc(*args, **kwargs)
+        self._max_offset = max(self._max_offset, self.pool.offset)
+        return result
 
     def alloc(self, shape, dtype="float32", swizzle=None, align=0):
         """Allocate a tile.
@@ -501,14 +507,14 @@ class SmemPool:
         for a 3-D shape, or a :class:`KTileView` directly for a 2-D one.
         """
         if swizzle is None or swizzle == SwizzleMode.SWIZZLE_NONE:
-            return self.pool.alloc(tuple(shape), dtype, align=align)
+            return self._alloc(tuple(shape), dtype, align=align)
         if isinstance(swizzle, int):
             swizzle = SwizzleMode(swizzle)
         if len(shape) < 2:
             raise ValueError(f"swizzled alloc shape={tuple(shape)} must have at least two dims")
         _validate_mma_alloc_shape(list(shape), dtype, swizzle)
         layout = mma_shared_layout(dtype, swizzle, list(shape))
-        buf = self.pool.alloc(tuple(shape), dtype, align=align or 1024, layout=layout)
+        buf = self._alloc(tuple(shape), dtype, align=align or 1024, layout=layout)
         if len(shape) > 3:
             return buf
         tile = KTile(buf, shape, dtype, swizzle)
@@ -526,13 +532,18 @@ class SmemPool:
     @property
     def bytes(self):
         """High-water mark of the pool so far."""
-        return self.pool.max_offset
+        return max(self.pool.max_offset, self._max_offset)
 
 
-def smem_pool():
-    """The kernel's shared-memory pool. One per kernel; committed at trace end."""
+def smem_pool(base=None):
+    """The kernel's shared-memory pool, optionally over a caller-owned backing buffer.
+
+    ``base=None`` creates and sizes the dynamic-SMEM allocation automatically.
+    Passing a buffer uses its data pointer and leaves allocation and sizing to
+    the caller.
+    """
     session = _entry.current()
     if session.pool is not None:
         raise RuntimeError("K.smem_pool() was already called for this kernel")
-    session.pool = SmemPool(session)
+    session.pool = SmemPool(session, base)
     return session.pool


### PR DESCRIPTION
## Summary

- add one parameterized SM100 persistent block-scaled GEMM + FP32 amax kernel using only the Kern API, with no first-class layouts or tile primitives
- cover FP4/FP8 inputs, all supported scale/output formats and majors, 128x128/128x256 tiles, nine cluster shapes, L=1/2, and aligned tail shapes
- use the native linear `K.smem_pool(base=...)` allocator for the caller-owned dynamic shared-memory buffer
- add deterministic 59-case correctness coverage and an 88-workload performance gate spanning 1024, 2048, 4096, and 8192 square GEMMs across 11 representative modes and L=1/2
- load the cuDNN Frontend source reference lazily from an explicit `CUDNN_FRONTEND_PATH`, and retain the frozen implementation sketch, Apache-2.0 attribution, and license checker coverage
- record measured codegen guidance for persistent scheduling, role-specific register budgets, pipeline state, generated-binary matching, and elected-lane predicate reuse

## Correctness

- all 59 configurations pass against both the cuDNN Frontend source reference and the dequantized FP32 oracle
- the working int8/E8M0 bit alias is structurally and numerically equivalent; unsupported uint8 packed-FP4 aliases are rejected
- registry/import, low-level IR, K-only/no-layout/no-tile checks, license checks, and scoped pre-commit checks pass

## Performance

The complete 88-workload suite used the canonical Proton timer, five rounds, no cooldown, and one indivisible raw run. Every row satisfies:

`mean(cudnn_frontend_us) / mean(tirx_us) > 0.99`

- minimum ratio: 0.9958941452
- mean ratio: 1.0168528237
- maximum ratio: 1.0652177285

Materializing one elected-lane predicate per TMA K-loop iteration reduced the profiled dynamic warp instruction count from 6.61M to 5.33M, reduced static SASS from 928 to 824 instructions, and left register allocation and spill behavior unchanged.

## TVM dependency

Validated against TVM commit `73e38d3f4447aa507cf795542aeffcc0948368b5` with paired changes for:

- preserving explicit 1x1 cluster launches when a kernel declares cluster CTA scope
- CUDA 12.8 packed `16U4_ALIGN8B` / `16U4_ALIGN16B` TensorMap dtype overrides for FP4

The paired TVM core TIRx suite passes with 2,624 passed, 73 skipped, and 3 xpassed; the target kernel correctness sweep is run separately as described above.
