### PR TITLE
feat(kernel): port cuDNN KDA backward kernel

### DIFF
--- a/.agents/sketch/cudnn/sm100_kda_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_kda_bprop_f16.md
@@ -1,0 +1,2873 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 KDA BF16 backward: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch, not a Python module, builder API,
+mathematical reference, or alternate implementation.  The implementation it
+describes is maintained in
+[`tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py`](../../../tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
+which is the source of truth after the correctness gate.
+
+The source specialization is fixed to `BT=16`, `DK=DV=128`, BF16 I/O,
+FP32 accumulation, one CTA per cluster, 512 main-kernel threads, 1024 prologue
+threads, 196608 bytes of main dynamic SMEM, and 512 TMEM columns.  Capability
+is the following discrete, source-verified set rather than a Cartesian product:
+`basic`, `tail`, `grouped(HQ,HK,HV)=(4,1,2)`, `l2norm`, `safe_gate`,
+`beta_sigmoid`, `state`, `dynamic`, `order_scratch`, and
+`order_generate`.  Each label means the exact profile frozen in
+`.porting/kda_bprop_f16/capability_manifest.yaml`; combinations not present
+there are not claimed.  Source probes reject FP16 (NaN outputs) and the tested
+all-features profile (outside the frozen error envelope); neither is represented
+here.
+
+Writer line-info evidence is under
+`.porting/kda_bprop_f16/source_export/basic_debug_001/`.  Its two PTX files have
+both `.file` and `.loc`; branch deltas are under the sibling profile exports.
+Unless stated otherwise, PTX line numbers below refer to the debug anchor's
+`cutlass_host_KdaBwdCfg...sm_100a.ptx`.  Static counts use instruction lines
+minus predicated lines.
+
+## Pipeline at a glance
+
+| Warps | Register target | Role-local program | Main publication/reuse edges |
+| --- | ---: | --- | --- |
+| 0..3 | 144 | forward gate prefix, beta, Q/K normalization, decay/restore operands, state/diagonal restaging | raw Q/K/Gate, beta, state, decay, Q/K raw TMEM |
+| 4..7 | 168 | value-side TMEM drains/restages, dState recurrence, dBeta and dInitialState | raw V/dO, U/dY, dState, dV, dBeta |
+| 8..11 | 144 | drain dQ/dK TMEM, assemble dGate, reverse prefix reduction | dQ/dK/dGate output stages, dState reuse |
+| 12 | 56 | register `mma.sync` program for KK, beta-scaled strict-L power-series inverse, dM, positive/negative strict dM, and dBeta-M | beta, intermediate tiles, decay operands, dY/U |
+| 13 | 56 | allocate 512 TMEM columns and issue the 15 logical `tcgen05.mma` chains | every TMEM accumulator/input edge and teardown |
+| 14 | 56 | persistent scheduler plus Q/K/V/Gate/dO/checkpoint TensorMap loads | five raw rings, state ring, scheduler publication |
+| 15 | 56 | register `A=tril(Q_decay@K_inv^T)` and `dA=tril(dO@U^T)`, then one-behind dQ/dK/dV/dGate TensorMap stores | A/dA intermediate tiles, dO reuse, output-stage reuse |
+
+Role dispatch is the source-order `if/elif` chain: 14, 12, 13, 15, 0..3,
+8..11, then 4..7.  Every role constructs its own persistent scheduler cursor;
+the eight scheduler stages are never reset between work items.
+
+## Primitive vocabulary
+
+All storage is linear.  No declaration or operation carries a layout object,
+layout value, tile primitive, or first-class view.  Logical matrices below are
+only index ranges selected by scalar address functions.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(base, stage, row, col, stage_bytes, row_bytes, elem_bytes, xor_bits)
+tmem_cell(base, row, col)       # base + col + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch)  # workspace + (array*B+batch)*128
+```
+
+Directional movement primitives:
+
+```python
+copy_p2g(src, dst)                         # parameter descriptor -> GMEM
+copy_g2s(src, dst, predicate, completion) # GMEM -> SMEM
+copy_s2g(src, dst, predicate)             # SMEM -> GMEM
+copy_g2r(src, dst, predicate=True)
+copy_r2g(src, dst, predicate=True)
+copy_s2r(src, dst)
+copy_r2s(src, dst)
+copy_t2r(src, dst)
+copy_r2t(src, dst)
+```
+
+Computational primitives are only:
+
+```python
+fill(dst, value)
+cast(dst, src)
+add(dst, lhs, rhs)
+sub(dst, lhs, rhs)
+mul(dst, lhs, rhs)
+fma(dst, lhs, rhs, acc)
+div(dst, lhs, rhs)
+exp2(dst, src)
+tanh(dst, src)
+rsqrt(dst, src)
+min(dst, lhs, rhs)
+max(dst, lhs, rhs)
+select(dst, predicate, true_value, false_value)
+shuffle_xor(dst, src, delta)
+shuffle_up(dst, src, delta)
+gemm(dst, lhs, rhs, accumulate=False)
+```
+
+`init`, `wait`, `arrive`, `expect_bytes`, `commit`, `release`, `fence`,
+`barrier`, stage/phase advancement, register-budget changes, descriptor field
+replacement, directional-copy groups, and TMEM allocation are schedule
+operations.  Each key movement, computation, or synchronization occurrence
+below is immediately followed by the selected instruction or instruction
+family observed in the writer export.
+
+## Complete sketch
+
+```python
+# ==========================================================================
+# Static parameters and the two-launch runtime ABI
+# ==========================================================================
+
+@specialize(
+    IO_DTYPE="bf16", BT=16, DK=128, DV=128,
+    RAW_STAGES=2, STATE_STAGES=1, DECAY_STAGES=2,
+    INTERMEDIATE_STAGES=2, DQ_STAGES=1, DK_STAGES=1,
+    DGATE_STAGES=1, DV_STAGES=2, BETA_STAGES=4,
+    QK_TMEM_STAGES=4, SCHED_STAGES=8,
+    VERIFIED_PROFILE={
+        "basic", "tail", "grouped", "l2norm",
+        "safe_gate", "beta_sigmoid", "state", "dynamic",
+        "order_scratch", "order_generate",
+    },
+)
+def kda_bprop_f16_factory(...):
+    return descriptor_order_prologue, persistent_backward
+
+@kernel(grid=(1,1,1), block=(1024,1,1), warps=32, target="sm_100a")
+def descriptor_order_prologue(
+    base_maps[10], descriptor_workspace, cu_seqlens,
+    q, k, v, gate, do, dq, dk, dv, dgate, state_checkpoints,
+    staging_items, work_count, work_items, sched_all,
+    batch_count, row_strides[10], checkpoint_every_n,
+):
+    tid = thread_id()
+    warp = tid // 32
+
+    if RUN_ORDER:
+        # Exactly two rank-1 i32 arrays plus one two-cell i32 range.  The
+        # 4096-entry capacity is fixed; no logical layout is attached.
+        order_key = linear_buffer("smem", "i32", 4096, 0, 16,
+                                  "whole order pass")
+        order_idx = linear_buffer("smem", "i32", 4096, 16384, 16,
+                                  "whole order pass")
+        order_spread = linear_buffer("smem", "i32", 2, 32768, 8,
+                                     "whole order pass")
+
+        if tid == 0 and HAS_SCHED:
+            for i in range(len(sched_all)):
+                copy_r2g(i32(0), sched_all[i])
+                # instruction_selection: st.global.u32; extent: scalar loop
+
+        n = batch_count * HO if ORDER_GEN else copy_g2r(work_count[0], i32_reg())
+        # instruction_selection: ld.global.u32; extent: one elected scalar
+        if ORDER_GEN and tid == 0:
+            copy_r2g(n, work_count[0])
+            # instruction_selection: st.global.u32; extent: scalar
+
+        if n > 4096:
+            for item in range(tid, n, 1024):
+                if ORDER_GEN:
+                    synthesize_eight_i32_fields(item, row_regs)
+                    # instruction_selection: integer scalar arithmetic;
+                    # extent: one generated work row
+                    copy_r2g(row_regs[0:8], work_items[item,0:8])
+                    # instruction_selection: st.global.v4.b32 pairs;
+                    # extent: one generated row
+                else:
+                    for field in range(8):
+                        copy_g2r(staging_items[item,field], row_regs[field])
+                        # instruction_selection: ld.global.u32;
+                        # extent: scalar dynamic-stride loop
+                        copy_r2g(row_regs[field], work_items[item,field])
+                        # instruction_selection: st.global.u32;
+                        # extent: scalar dynamic-stride loop
+        else:
+            if tid == 0:
+                fill(order_spread[0:2], [INT_MAX, INT_MIN])
+                # instruction_selection: st.shared.v2.u32; extent: two scalars
+            barrier(0, 1024)
+            # instruction_selection: barrier.sync 0, 1024; extent: CTA,
+            # before any key write
+            for e in range(4):
+                item = tid + e * 1024
+                if item < next_power_of_two(n):
+                    key = item_chunk_span_or_negative_infinity(item)
+                    copy_r2s(key, order_key[item])
+                    # instruction_selection: st.shared.u32; extent: scalar
+                    copy_r2s(item, order_idx[item])
+                    # instruction_selection: st.shared.u32; extent: scalar
+            atomic_min(order_spread[0], local_key_min)
+            # instruction_selection: atom.shared::cta.min.s32; extent: scalar
+            atomic_max(order_spread[1], local_key_max)
+            # instruction_selection: atom.shared::cta.max.s32; extent: scalar
+            barrier(0, 1024)
+            # instruction_selection: barrier.sync 0, 1024; extent: CTA
+
+            if order_spread[0] == order_spread[1]:
+                if ORDER_GEN:
+                    for row in range(tid, n, 1024):
+                        synthesize_eight_i32_fields(row, row_regs)
+                        # instruction_selection: integer scalar arithmetic;
+                        # extent: one row
+                        copy_r2g(row_regs[0:8], work_items[row,0:8])
+                        # instruction_selection: st.global.v4.b32 pairs;
+                        # extent: generated eight-field row
+                else:
+                    for row in range(tid, n, 1024):
+                        for field in range(8):
+                            copy_g2r(staging_items[row,field], row_regs[field])
+                            # instruction_selection: ld.global.u32;
+                            # extent: scalar dynamic-stride loop
+                            copy_r2g(row_regs[field], work_items[row,field])
+                            # instruction_selection: st.global.u32;
+                            # extent: scalar dynamic-stride loop
+            else:
+                k = 2
+                while k <= next_power_of_two(n):
+                    j = k // 2
+                    while j > 0:
+                        for e in range(4):
+                            i = tid + e * 1024
+                            partner = i ^ j
+                            if partner > i and bitonic_swap_predicate(i, partner, k):
+                                copy_s2r(order_key[i], key_i)
+                                # instruction_selection: ld.shared.u32; extent: scalar
+                                copy_s2r(order_key[partner], key_j)
+                                # instruction_selection: ld.shared.u32; extent: scalar
+                                copy_r2s(key_j, order_key[i])
+                                # instruction_selection: st.shared.u32; extent: scalar
+                                copy_r2s(key_i, order_key[partner])
+                                # instruction_selection: st.shared.u32; extent: scalar
+                                swap_two_shared_indices(i, partner)
+                                # instruction_selection: ld.shared/st.shared.u32;
+                                # extent: one scalar pair
+                        barrier(0, 1024)
+                        # instruction_selection: barrier.sync 0, 1024; extent: CTA
+                        j //= 2
+                    k *= 2
+                for row in range(tid, n, 1024):
+                    copy_s2r(order_idx[row], source_row)
+                    # instruction_selection: ld.shared.u32; extent: scalar
+                    if ORDER_GEN:
+                        synthesize_eight_i32_fields(source_row, row_regs)
+                        # instruction_selection: integer scalar arithmetic;
+                        # extent: one row
+                        copy_r2g(row_regs[0:8], work_items[row,0:8])
+                        # instruction_selection: st.global.v4.b32 pairs;
+                        # extent: generated eight-field row
+                    else:
+                        for field in range(8):
+                            copy_g2r(staging_items[source_row,field], row_regs[field])
+                            # instruction_selection: ld.global.u32;
+                            # extent: scalar dynamic-stride loop
+                            copy_r2g(row_regs[field], work_items[row,field])
+                            # instruction_selection: st.global.u32;
+                            # extent: scalar dynamic-stride loop
+
+    # Warps 0..8 build packed-token descriptors.  Their address is the base
+    # tensor pointer plus cu_seqlens[b]*row_stride, and dim 2 is the exact
+    # per-sequence token count.
+    if warp < 9 and elected_lane():
+        for batch in range(batch_count):
+            dst = descriptor_slot(descriptor_workspace, warp, batch)
+            copy_p2g(base_maps[warp][0:128], dst[0:128])
+            # instruction_selection: 16 x st.global.b64 after descriptor
+            # parameter materialization; extent: one 128-byte descriptor
+            cu_b = copy_g2r(cu_seqlens[batch])
+            cu_next = copy_g2r(cu_seqlens[batch + 1])
+            sequence_address = tensor_base(warp)
+            sequence_address += i64(cu_b) * i64(row_strides[warp])
+            replace_descriptor_address(dst, sequence_address)
+            # instruction_selection:
+            # tensormap.replace.tile.global_address.global.b1024.b64;
+            # extent: one descriptor field
+            replace_descriptor_dim2(dst, cu_next - cu_b)
+            # instruction_selection:
+            # tensormap.replace.tile.global_dim.global.b1024.b32;
+            # extent: one descriptor field
+        fence("tensormap_generic_release_gpu")
+        # instruction_selection:
+        # one fence.proxy.tensormap::generic.release.gpu after the whole
+        # elected-warp batch loop
+
+    # Warp 9 uses a different scalar address/dimension recurrence.  Empty
+    # sequences contribute zero checkpoints; no token base is reused here.
+    if warp == 9 and elected_lane():
+        checkpoint_prefix = 0
+        for batch in range(batch_count):
+            dst = descriptor_slot(descriptor_workspace, 9, batch)
+            copy_p2g(base_maps[9][0:128], dst[0:128])
+            cu_b = copy_g2r(cu_seqlens[batch])
+            cu_next = copy_g2r(cu_seqlens[batch + 1])
+            seqlen_b = cu_next - cu_b
+            count_b = select(seqlen_b > 0,
+                             (seqlen_b - 1) // checkpoint_every_n + 1,
+                             0)
+            checkpoint_address = tensor_base(9)
+            checkpoint_address += i64(checkpoint_prefix) * i64(row_strides[9])
+            replace_descriptor_address(dst, checkpoint_address)
+            replace_descriptor_dim2(dst, count_b)
+            checkpoint_prefix += count_b
+        fence("tensormap_generic_release_gpu")
+        # instruction_selection: one generic-to-TensorMap release fence after
+        # all checkpoint descriptors
+
+# Descriptor arrays 0..8 are rank-3, BF16 boxes [64,1,16] except Gate and
+# dGate FP32 boxes [32,1,16].  Array 9 is rank-4 checkpoint BF16 with box
+# [64,128,1,1].  All use 128-byte swizzle and 128-byte GMEM slots.
+
+@kernel(
+    grid=(num_sms,1,1), block=(512,1,1), warps=16,
+    cluster=(1,1,1), cta_group=1, dynamic_smem_bytes=196608,
+    tmem_columns=512, min_blocks_per_sm=1, target="sm_100a",
+)
+def persistent_backward(
+    descriptor_workspace, n_desc, a_log, dt_bias, beta, cu_seqlens,
+    dgate, dbeta, d_initial_state, d_final_state,
+    work_items, work_count, sched_counter, scale,
+):
+    tid = thread_id()
+    warp = warp_uniform(tid // 32)
+    lane = tid % 32
+    cta = block_id_x()
+    grid_x = grid_dim_x()
+    total_tiles = copy_g2r(work_count[0], i32_reg())
+    # instruction_selection: ld.global.u32; extent: scalar, not hoisted across
+    # the persistent scheduler's atomic path
+
+    # ======================================================================
+    # One rank-1 u8 SMEM arena and explicit integer physical mappings
+    # ======================================================================
+
+    smem = linear_buffer("smem", "u8", 196608, 0, 1024, "whole CTA")
+
+    # No buffer below exists as a first-class multidimensional value.  These
+    # names are byte intervals consumed only through smem_byte(...).
+    BARRIERS_BASE = 0;       BARRIERS_END = 920       # 115 x 8-byte words
+    TMEM_MAILBOX_BASE = 920; TMEM_MAILBOX_END = 924   # one i32
+    SCHED_BASE = 928;        SCHED_END = 960          # eight i32 tickets
+    BETA_BASE = 960;         BETA_END = 1216          # 4*16 f32
+    NORM_BASE = 1216;        NORM_END = 1728          # 4*2*16 f32
+    RED0_BASE = 1728;        RED0_END = 1984          # 4*16 f32
+    RED1_BASE = 1984;        RED1_END = 2240          # 4*16 f32
+    BETAM_BASE = 2240;       BETAM_END = 2304         # 16 f32
+    PADDING_BASE = 2304;     PADDING_END = 3072
+    STATE_BASE = 3072;       STATE_END = 35840        # 128*128 bf16
+    DSTATE_BASE = 35840;     DSTATE_END = 68608       # 128*128 bf16
+    KDECAY_BASE = 68608;     KDECAY_END = 76800       # 2*16*128 bf16
+    KINV_BASE = 76800;       KINV_END = 84992
+    KRESTORE_BASE = 84992;   KRESTORE_END = 93184
+    QDECAY_BASE = 93184;     QDECAY_END = 101376
+    DIAG_BASE = 101376;      DIAG_END = 109568        # 2*8*256 bf16
+    INTER_BASE = 109568;     INTER_END = 114688       # 2*5*16*16 bf16
+    DO_BASE = 114688;        DO_END = 122880          # 2*16*128 bf16
+    DV_BASE = 122880;        DV_END = 131072          # 2*16*128 bf16
+    Q_BASE = 131072;         Q_END = 139264           # 2*16*128 bf16
+    K_BASE = 139264;         K_END = 147456
+    V_BASE = 147456;         V_END = 155648
+    GATE_BASE = 155648;      GATE_END = 172032        # 2*16*128 f32
+    DY_BASE = 172032;        DY_END = 176128          # 16*128 bf16
+    U_BASE = 176128;         U_END = 180224            # 16*128 bf16
+    DQ_BASE = 180224;        DQ_END = 184320           # 16*128 bf16
+    DK_BASE = 184320;        DK_END = 188416           # 16*128 bf16
+    DGATE_BASE = 188416;     DGATE_END = 196608        # 16*128 f32
+    assert DGATE_END == 196608
+
+    # All source mappings are scalar byte functions.  They deliberately stay
+    # separate because merging them changes selected bytes/descriptors.
+    def xor128_element(row, col_in_segment, elem_bytes):
+        return col_in_segment ^ ((row & 7) * (16 // elem_bytes))
+
+    def raw_bf16_byte(base, stage, row16, channel128):
+        segment = channel128 // 64
+        in_segment = channel128 - segment * 64
+        element = segment * (16 * 64) + row16 * 64
+        element += xor128_element(row16, in_segment, 2)
+        return base + stage * 4096 + element * 2
+
+    def raw_f32_byte(base, stage, row16, channel128):
+        segment = channel128 // 32
+        in_segment = channel128 - segment * 32
+        element = segment * (16 * 32) + row16 * 32
+        element += xor128_element(row16, in_segment, 4)
+        return base + stage * 8192 + element * 4
+
+    def state_physical_byte(base, key_row128, value_col128):
+        # TMA checkpoint storage: two 64-value segments, each with 128 key
+        # rows.  Both state descriptors below point at these exact bytes.
+        segment = value_col128 // 64
+        in_segment = value_col128 - segment * 64
+        element = segment * (128 * 64) + key_row128 * 64
+        element += xor128_element(key_row128, in_segment, 2)
+        return base + element * 2
+
+    def dstate_physical_byte(base, value_row128, key_col128):
+        # Recurrence storage: two 64-key segments, each with 128 value rows.
+        segment = key_col128 // 64
+        in_segment = key_col128 - segment * 64
+        element = segment * (128 * 64) + value_row128 * 64
+        element += xor128_element(value_row128, in_segment, 2)
+        return base + element * 2
+
+    def operand_lead16_byte(base, stage, row16, channel128):
+        return raw_bf16_byte(base, stage, row16, channel128)
+
+    def operand_amajor_byte(base, stage, channel128, row16):
+        return raw_bf16_byte(base, stage, row16, channel128)
+
+    def operand_transpose_byte(base, stage, channel128, row16):
+        return raw_bf16_byte(base, stage, row16, channel128)
+
+    def xor_linear_s(element_index, bbits, mbase, sshift):
+        y = (element_index >> (mbase + sshift)) & ((1 << bbits) - 1)
+        return element_index ^ (y << mbase)
+
+    def diagonal_bf16_byte(base, stage, block8, row16, col16):
+        logical = block8 * 256 + row16 * 16 + col16
+        return base + stage * 4096 + xor_linear_s(logical, 1, 3, 3) * 2
+
+    def intermediate_bf16_byte(base, stage, slot5, row16, col16):
+        logical = slot5 * 256 + row16 * 16 + col16
+        return base + stage * 2560 + xor_linear_s(logical, 1, 3, 3) * 2
+
+    # Named raw/output scalar mappings.  Every function returns one integer
+    # byte address; none returns a buffer, matrix, fragment, or view.
+    def q_raw_bf16_byte(stage, token, channel):
+        return raw_bf16_byte(Q_BASE, stage, token, channel)
+
+    def k_raw_bf16_byte(stage, token, channel):
+        return raw_bf16_byte(K_BASE, stage, token, channel)
+
+    def v_raw_bf16_byte(stage, token, channel):
+        return raw_bf16_byte(V_BASE, stage, token, channel)
+
+    def do_raw_bf16_byte(stage, token, channel):
+        return raw_bf16_byte(DO_BASE, stage, token, channel)
+
+    def gate_raw_f32_byte(stage, token, channel):
+        return raw_f32_byte(GATE_BASE, stage, token, channel)
+
+    def dv_output_bf16_byte(stage, token, channel):
+        return raw_bf16_byte(DV_BASE, stage, token, channel)
+
+    def dq_output_bf16_byte(token, channel):
+        return raw_bf16_byte(DQ_BASE, 0, token, channel)
+
+    def dk_output_bf16_byte(token, channel):
+        return raw_bf16_byte(DK_BASE, 0, token, channel)
+
+    def dgate_output_f32_byte(token, channel):
+        return raw_f32_byte(DGATE_BASE, 0, token, channel)
+
+    def beta_f32_byte(stage, token):
+        return BETA_BASE + (stage * 16 + token) * 4
+
+    def norm_f32_byte(qk_stage_id, is_k, token):
+        return NORM_BASE + (qk_stage_id * 32 + is_k * 16 + token) * 4
+
+    def reduction0_f32_byte(warp_in_group, token):
+        return RED0_BASE + (warp_in_group * 16 + token) * 4
+
+    def reduction1_f32_byte(warp_in_group, token):
+        return RED1_BASE + (warp_in_group * 16 + token) * 4
+
+    def beta_matrix_f32_byte(token):
+        return BETAM_BASE + token * 4
+
+    def state_bf16_byte(key_row, value_col):
+        return state_physical_byte(STATE_BASE, key_row, value_col)
+
+    def dstate_direct_bf16_byte(value_row, key_col):
+        return dstate_physical_byte(DSTATE_BASE, value_row, key_col)
+
+    def dstate_alt_transpose_bf16_byte(value_row, key_col):
+        # Alternate is a descriptor interpretation of the same physical byte.
+        return dstate_physical_byte(DSTATE_BASE, value_row, key_col)
+
+    def k_decay_operand_bf16_byte(stage, token, channel):
+        return operand_lead16_byte(KDECAY_BASE, stage, token, channel)
+
+    def k_inverse_operand_bf16_byte(stage, token, channel):
+        return operand_lead16_byte(KINV_BASE, stage, token, channel)
+
+    def k_restore_operand_bf16_byte(stage, token, channel):
+        return operand_lead16_byte(KRESTORE_BASE, stage, token, channel)
+
+    def q_decay_operand_bf16_byte(stage, token, channel):
+        return operand_lead16_byte(QDECAY_BASE, stage, token, channel)
+
+    def state_diag_bf16_byte(stage, block8, row, col):
+        return diagonal_bf16_byte(DIAG_BASE, stage, block8, row, col)
+
+    def intermediate_slot_bf16_byte(stage, slot, row, col):
+        return intermediate_bf16_byte(INTER_BASE, stage, slot, row, col)
+
+    # Raw descriptor integers.  The three address fields use hardware 16-byte
+    # granules.  `layout_code` is already the exact tcgen05 encoding (2 for
+    # the 128-byte raw/state/operand arrangement and 6 for the 32-byte
+    # diagonal/intermediate arrangement), so no TMA-swizzle remapping occurs.
+    # The result is one u64 integer, never a descriptor object.
+    def raw_descriptor(base_byte, leading_bytes, stride_bytes, layout_code):
+        value = ((base_byte >> 4) & 0x3FFF)
+        value |= ((leading_bytes >> 4) & 0x3FFF) << 16
+        value |= ((stride_bytes >> 4) & 0x3FFF) << 32
+        value |= 1 << 46
+        value |= (layout_code & 7) << 61
+        return value & 0xFFFFFFFFFFFFFFFF
+
+    def operand_lead16_desc(base_byte):
+        return raw_descriptor(base_byte, 16, 1024, 2)
+
+    def operand_amajor_desc(base_byte):
+        return raw_descriptor(base_byte, 2048, 1024, 2)
+
+    def operand_transpose_desc(base_byte):
+        return raw_descriptor(base_byte, 2048, 1024, 2)
+
+    def state_direct_desc(base_byte):
+        return raw_descriptor(base_byte, 16, 1024, 2)
+
+    def state_alt_desc(base_byte):
+        return raw_descriptor(base_byte, 16384, 1024, 2)
+
+    def diagonal_desc(base_byte):
+        return raw_descriptor(base_byte, 16, 256, 6)
+
+    def intermediate_desc(base_byte):
+        return raw_descriptor(base_byte, 16, 256, 6)
+
+    # TMEM operations take integer cells: low 16 bits are columns, high bits
+    # are rows.  Every function receives the allocated integer base/row; no
+    # closure refers to a later declaration and no function returns a view.
+    def tmem_cell(allocated_base, allocated_row, row_delta, col):
+        return allocated_base + col + ((allocated_row + row_delta) << 16)
+
+    def cg0_tmem_row_delta(warp_id):
+        return (warp_id % 4) * 32
+
+    def cg1_tmem_row_delta(warp_id):
+        return (warp_id % 4) * 32
+
+    def cg1_tmem_row_lo_delta():
+        return 0
+
+    def cg1_tmem_row_hi_delta():
+        return 16
+
+    def cg2_tmem_row_delta(warp_id):
+        # tcgen05.ld.32x32b distributes the 32 rows to lanes internally.
+        return (warp_id % 4) * 32
+
+    def cg0_qraw_tmem_cell(base, row, warp_id, qk_stage_id):
+        return tmem_cell(base, row, cg0_tmem_row_delta(warp_id),
+                         448 + qk_stage_id * 8)
+
+    def cg0_kraw_tmem_cell(base, row, warp_id, qk_stage_id):
+        return tmem_cell(base, row, cg0_tmem_row_delta(warp_id),
+                         480 + qk_stage_id * 8)
+
+    def cg0_state_tmem_cell(base, row, warp_id,
+                            state_input_stage_id, value_half, value_group8):
+        return tmem_cell(base, row, cg0_tmem_row_delta(warp_id),
+                         192 + state_input_stage_id * 64
+                         + value_half * 32 + value_group8 * 4)
+
+    def cg1_tmem_cell_lo(base, row, col):
+        return tmem_cell(base, row, cg1_tmem_row_lo_delta(), col)
+
+    def cg1_tmem_cell_hi(base, row, col):
+        return tmem_cell(base, row, cg1_tmem_row_hi_delta(), col)
+
+    def cg1_dstate_tmem_cell(base, row, warp_id, col):
+        return tmem_cell(base, row, cg1_tmem_row_delta(warp_id), col)
+
+    def cg1_projection_tmem_cell(base, row, warp_id, value_half, col):
+        return tmem_cell(base, row,
+                         cg1_tmem_row_delta(warp_id) + value_half * 16,
+                         col)
+
+    def cg2_tmem_channel_cell(base, row, warp_id, col):
+        return tmem_cell(base, row, cg2_tmem_row_delta(warp_id), col)
+
+    # Register-MMA and stmatrix scalar lane coordinates shared by warps 12/15.
+    def rhs_ldmatrix_row(lane_id):
+        return lane_id % 8 + select(lane_id // 16 != 0, 8, 0)
+
+    def rhs_ldmatrix_col(lane_id):
+        return select(((lane_id // 8) & 1) != 0, 8, 0)
+
+    def lhs_ldmatrix_row(lane_id):
+        return lane_id % 8 + select(((lane_id // 8) & 1) != 0, 8, 0)
+
+    def lhs_ldmatrix_col(lane_id):
+        return select(lane_id // 8 >= 2, 8, 0)
+
+    def stmatrix_row(lane_id):
+        return lane_id % 8 + select(((lane_id // 8) & 1) != 0, 8, 0)
+
+    def stmatrix_col(lane_id):
+        return select(lane_id // 8 >= 2, 8, 0)
+
+    def stmatrix_intermediate_byte(stage, slot, lane_id):
+        return intermediate_slot_bf16_byte(
+            stage, slot, stmatrix_row(lane_id), stmatrix_col(lane_id))
+
+    def super_row_lo(lane_id):
+        return lane_id // 4
+
+    def super_row_hi(lane_id):
+        return lane_id // 4 + 8
+
+    # Stage bases used by TMA are still scalar byte addresses.  Register and
+    # tcgen users select individual bytes/cells with the functions that follow.
+    def q_raw_stage(stage):
+        return q_raw_bf16_byte(stage, 0, 0)
+
+    def k_raw_stage(stage):
+        return k_raw_bf16_byte(stage, 0, 0)
+
+    def v_raw_stage(stage):
+        return v_raw_bf16_byte(stage, 0, 0)
+
+    def do_raw_stage(stage):
+        return do_raw_bf16_byte(stage, 0, 0)
+
+    def gate_raw_stage(stage):
+        return gate_raw_f32_byte(stage, 0, 0)
+
+    def dv_stage_at(stage):
+        return dv_output_bf16_byte(stage, 0, 0)
+
+    def state_region():
+        return state_bf16_byte(0, 0)
+
+    # Exact source descriptor start-address increments for the 15 tcgen rows.
+    # Each result below is a single u64 or TMEM integer address.
+    def state_smem_subtile(key_phase16):
+        return state_direct_desc(state_bf16_byte(key_phase16 * 16, 0))
+
+    def k_decay_smem_subtile(stage, key_phase16):
+        return operand_lead16_desc(
+            k_decay_operand_bf16_byte(stage, 0, key_phase16 * 16))
+
+    def do_smem_lead16_subtile(stage, value_phase16):
+        return operand_lead16_desc(
+            do_raw_bf16_byte(stage, 0, value_phase16 * 16))
+
+    def do_smem_amajor_desc(stage):
+        return operand_amajor_desc(do_raw_bf16_byte(stage, 0, 0))
+
+    def q_decay_smem_transpose_desc(stage):
+        return operand_transpose_desc(
+            q_decay_operand_bf16_byte(stage, 0, 0))
+
+    def k_decay_smem_transpose_desc(stage):
+        return operand_transpose_desc(
+            k_decay_operand_bf16_byte(stage, 0, 0))
+
+    def k_inverse_smem_amajor_desc(stage):
+        return operand_amajor_desc(
+            k_inverse_operand_bf16_byte(stage, 0, 0))
+
+    def k_restore_smem_subtile(stage, key_phase16):
+        return operand_lead16_desc(
+            k_restore_operand_bf16_byte(stage, 0, key_phase16 * 16))
+
+    def u_smem_lead16_subtile(value_phase16):
+        return operand_lead16_desc(raw_bf16_byte(
+            U_BASE, 0, 0, value_phase16 * 16))
+
+    def dv_smem_lead16_subtile(stage, value_phase16):
+        return operand_lead16_desc(
+            dv_output_bf16_byte(stage, 0, value_phase16 * 16))
+
+    def dstate_smem_alt_desc(value_phase16):
+        return state_alt_desc(
+            dstate_alt_transpose_bf16_byte(value_phase16 * 16, 0))
+
+    def state_diag_smem_subtile(stage, key_block16):
+        return diagonal_desc(state_diag_bf16_byte(stage, key_block16, 0, 0))
+
+    def intermediate_smem_desc(stage, slot):
+        return intermediate_desc(intermediate_slot_bf16_byte(
+            stage, slot, 0, 0))
+
+    def tmem_state_input_subtile(base, row, stage, key_phase16):
+        return tmem_cell(base, row, 0, 192 + stage * 64 + key_phase16 * 8)
+
+    def tmem_dstate_input_subtile(base, row, key_phase16):
+        return tmem_cell(base, row, 0, 128 + key_phase16 * 8)
+
+    def tmem_y_input(base, row):
+        return tmem_cell(base, row, 0, 432)
+
+    def tmem_du_input(base, row):
+        return tmem_cell(base, row, 0, 440)
+
+    def tmem_negative_beta_dy_input(base, row):
+        return tmem_cell(base, row, 0, 432)
+
+    # Raw BF16 tcgen descriptors: lead=16 B -> encoded 1, stride=1024 B ->
+    # encoded 64, layout code 2.  A-major/transpose variants encode
+    # lead=BT*128=2048 B -> 128 with the same encoded stride/layout.  State
+    # alternate encodes lead=16384 B -> 1024.  Diagonal/intermediate encode
+    # lead=1, stride=16, layout code 6.  These are raw integer descriptor
+    # fields, not first-class layouts.
+
+    # ======================================================================
+    # The 115-word protocol header
+    # ======================================================================
+
+    # Each row identifies every physical word.  `ready` and `done` offsets are
+    # independent arrays, each containing `stages` adjacent eight-byte words.
+    # `owner` is the elected initialization warp.  `None` means no paired word.
+    protocol = (
+      # name                    ready done stages ready_count done_count owner
+      ("q",                       0,  16, 2,   1, 128, 14),
+      ("k",                      32,  48, 2,   1, 128, 14),
+      ("gate",                   64,  80, 2,   1, 256, 14),
+      ("do",                     96, 112, 2,   1,  32, 14),
+      ("v",                     128, 144, 2,   1, 128, 14),
+      ("state",                 160, 168, 1,   1,   1, 14),
+      ("state_cg0_done",        176, None, 1, 128, None, 14),
+      ("beta",                  184, 216, 4,  32, 160, 14),
+      ("state_k_acc",           248, None, 1,   1, None, 13),
+      ("du_acc",                256, None, 1,   1, None, 13),
+      ("u_acc",                 264, None, 1,   1, None, 13),
+      ("dy_acc",                272, None, 1,   1, None, 13),
+      ("dq_acc",                280, None, 1,   1, None, 13),
+      ("dk_decay_acc",          288, None, 1,   1, None, 13),
+      ("dk_inv_acc",            296, None, 1,   1, None, 13),
+      ("dk_restore_acc",        304, None, 1,   1, None, 13),
+      ("dqk_done",              312, None, 1, 128, None, 13),
+      ("qk_raw",                320, 352, 4, 128, 128, 12),
+      ("state_input",           384, 400, 2, 128,   1, 14),
+      ("state_input_cg2_done",  416, None, 2, 128, None, 14),
+      ("y_input",               432, None, 1, 128, None, 13),
+      ("du_input",              440, None, 1, 128, None, 13),
+      ("neg_beta_dy_input",     448, None, 1, 128, None, 13),
+      ("k_decay_inv",           456, None, 2, 128, None, 12),
+      ("q_decay_k_restore",     472, None, 2, 128, None, 12),
+      ("decay_done",            488, None, 2,   1, None, 12),
+      ("t_inv",                 504, 520, 2,  32,   1, 12),
+      ("a",                     536, 552, 2,  32,   1, 12),
+      ("da",                    568, 584, 2,  32,   1, 12),
+      ("dm",                    600, 616, 2,  32,   1, 12),
+      ("u_smem",                632, None, 1, 128, None, 13),
+      ("dy_smem",               640, None, 1, 128, None, 13),
+      ("dbeta_matrix",          648, None, 1,  32, None, 13),
+      ("dstate_acc",            656, None, 1,   1, None, 13),
+      ("dstate_input",          664, None, 1, 128, None, 13),
+      ("dstate_smem",           672, 680, 1, 128,   1, 13),
+      ("dstate_smem_cg2_done",  688, None, 1, 128, None, 13),
+      ("dq_store",              696, 704, 1, 128,  32, 15),
+      ("dk_store",              712, 720, 1, 128,  32, 15),
+      ("dv_store",              728, 744, 2, 128,  32, 15),
+      ("dgate_store",           760, 768, 1, 128,  32, 15),
+      ("dstate0_stored",        776, None, 1, 128, None, 13),
+      ("tmem_done",             784, None, 1, 256, None, 13),
+      ("scheduler",             792, 856, 8,   1,  15, 15),
+    )
+    assert physical_words(protocol) == 115
+
+    # Participant cursors are `(stage,phase)` and persist across work items.
+    # The TMA raw/state/scheduler producers start `(0,1)`.  The CG0 QK-raw,
+    # decay/intermediate, beta, state-input, and output-stage producers wait on
+    # their paired done words with phase 1.  CG1's dState-SMEM and dV producers
+    # likewise start their done cursors at phase 1.  Tcgen's `dqk_done`
+    # consumer starts phase 1.  All ready consumers and remaining one-way
+    # consumers start phase 0.  Wrap toggles phase and no role resets a cursor.
+    initial_cursors = (
+      ("tma.raw",0,1), ("tma.state",0,1), ("tma.scheduler",0,1),
+      ("cg0.beta_done",0,1), ("cg0.qk_raw_done",0,1),
+      ("cg0.decay_done",0,1), ("cg0.state_input_done",0,1),
+      ("epilogue.a_done",0,1), ("epilogue.da_done",0,1),
+      ("super.tinv_done",0,1), ("super.dm_done",0,1),
+      ("cg1.dstate_smem_done",0,1), ("cg1.dv_done",0,1),
+      ("cg2.dq_done",0,1), ("cg2.dk_done",0,1),
+      ("cg2.dgate_done",0,1), ("tcgen.dqk_done",0,1),
+      ("all_ready_consumers",0,0),
+    )
+
+    # Barrier construction is distributed across warps 14, 13, 12, and 15.
+    # Every word is initialized exactly once by an elected lane.
+    for assigned_edge_stage in role_assigned_protocol_words(warp):
+        init(assigned_edge_stage, arrivals=assigned_arrival_count)
+        # instruction_selection: mbarrier.init.shared.b64; extent: one of 115 words
+    for diagonal_element in range(4096):
+        copy_r2s(bf16(0), DIAG_BASE + diagonal_element * 2)
+    # instruction_selection: st.shared.u16; extent: strided 8192-byte region
+    fence("mbarrier_init_release_cluster")
+    # instruction_selection: fence.mbarrier_init.release.cluster; extent: CTA protocol
+    barrier(0, 512)
+    # instruction_selection: barrier.sync 0, 512; extent: CTA
+
+    # Named barriers: ID 3 covers all TMEM users, not only allocation.
+    CG0_SYNC = (1,128)
+    CG2_SYNC = (2,128)
+    TMEM_LIFETIME = (3,416)
+    CG1_SYNC = (4,128)
+
+    # TMEM columns; BF16 inputs pack two elements per 32-bit cell.
+    tmem_allocated = integer_base_from_mailbox(TMEM_MAILBOX_BASE)
+    tmem_base = tmem_allocated & 0xFFFF
+    tmem_row = tmem_allocated >> 16
+    dstate_acc_col = 0
+    dstate_input_col = 128
+    state_input_col = 192
+    state_k_or_dy_col = 320
+    u_acc_col = 336
+    du_acc_col = 352
+    dq_acc_col = 368
+    dk_decay_col = 384
+    dk_inv_col = 400
+    dk_restore_col = 416
+    y_or_neg_beta_dy_col = 432
+    du_input_col = 440
+    qraw_col = 448                  # four stages, eight columns each
+    kraw_col = 480                  # four stages, eight columns each
+    assert kraw_col + 32 == 512
+
+    # Persistent descriptor arrays are ten contiguous n_desc-entry arrays.
+    desc_q = descriptor_array(0); desc_k = descriptor_array(1)
+    desc_v = descriptor_array(2); desc_gate = descriptor_array(3)
+    desc_do = descriptor_array(4); desc_dq = descriptor_array(5)
+    desc_dk = descriptor_array(6); desc_dv = descriptor_array(7)
+    desc_dgate = descriptor_array(8); desc_checkpoint = descriptor_array(9)
+
+    def wait_edge(edge, stage, phase):
+        wait(edge, stage, phase)
+        # instruction_selection:
+        # mbarrier.try_wait.parity.acquire.cta.shared::cta.b64;
+        # extent: polling loop for one stage
+
+    def arrive_edge(edge, stage):
+        arrive(edge, stage)
+        # instruction_selection: mbarrier.arrive.shared.b64; extent: one arrival
+
+    def scheduler_publish_at_tile_entry(cursor_phase1, current):
+        if DYN_SCHED:
+            wait_edge("scheduler_done", cursor_phase1.stage, cursor_phase1.phase)
+            if elected_lane():
+                old = atomic_add(sched_counter[0], 1)
+                # instruction_selection: atom.global.add.u32; extent: elected lane
+                copy_r2s(grid_x + old,
+                         SCHED_BASE + cursor_phase1.stage * 4)
+                # instruction_selection: st.shared.u32; extent: scalar
+            warp_sync(FULL_MASK)
+            # instruction_selection: bar.warp.sync 0xffffffff; extent: warp 14
+            copy_s2r(SCHED_BASE + cursor_phase1.stage * 4, next_tile)
+            # instruction_selection: ld.shared.u32; extent: all warp lanes
+            if elected_lane():
+                arrive_edge("scheduler_ready", cursor_phase1.stage)
+            return next_tile, advance(cursor_phase1)
+        return current + grid_x, cursor_phase1
+
+    def scheduler_consume_at_tile_exit(cursor_phase0, current):
+        if DYN_SCHED:
+            wait_edge("scheduler_ready", cursor_phase0.stage, cursor_phase0.phase)
+            copy_s2r(SCHED_BASE + cursor_phase0.stage * 4, next_tile)
+            # instruction_selection: ld.shared.u32; extent: scalar/all role lanes
+            if elected_lane():
+                arrive_edge("scheduler_done", cursor_phase0.stage)
+            return next_tile, advance(cursor_phase0)
+        return current + grid_x, cursor_phase0
+
+    def decode_work(tile):
+        row = copy_g2r(work_items[tile,0:8], eight_i32_regs)
+        # instruction_selection: ld.global.v4.u32 pairs; extent: one work row
+        return row  # batch, head, work-start/end, chunk-start/end, BOS/EOS
+
+    # Descriptor array entries 0..9 already fold `bos` into their GMEM base.
+    # TensorMap coordinates therefore remain sequence-relative.  Direct
+    # scalar beta/dBeta addressing is the only path that adds `bos` again.
+    def sequence_length(item):
+        return item.eos - item.bos
+
+    def chunk_start(chunk):
+        return chunk * 16
+
+    def token_valid(item, chunk, token):
+        return chunk_start(chunk) + token < sequence_length(item)
+
+    def global_token(item, chunk, token):
+        return item.bos + chunk_start(chunk) + token
+
+    def tensor_map_coordinate(head, chunk):
+        return (0, head, chunk_start(chunk))
+
+    def checkpoint_tensor_map_coordinate(head, chunk):
+        return (0, 0, chunk, head)
+
+    # ======================================================================
+    # Source-order role selection
+    # ======================================================================
+
+    if warp == 14:
+        # --------------------------------------------------------------
+        # TMA + persistent scheduler role, source lines 1521..1696
+        # anchor PTX 293, 380..629
+        # --------------------------------------------------------------
+        set_register_budget("decrease", 56)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 56; extent: warp
+        tile = cta
+        sched = producer_cursor(stages=8, phase=1)
+        raw = producer_cursor(stages=2, phase=1)
+        state_cursor = producer_cursor(stages=1, phase=1)
+        while tile < total_tiles:
+            item = decode_work(tile)
+            next_tile, sched = scheduler_publish_at_tile_entry(sched, tile)
+            batch, head, wstart, wend, cstart, cend, bos, eos = item
+            qh, kh, vh = grouped_input_heads(head, HQ, HK, HV, HO)
+            if elected_lane():
+                for desc in (
+                    desc_q[item.batch], desc_k[item.batch], desc_v[item.batch],
+                    desc_gate[item.batch], desc_do[item.batch],
+                    desc_checkpoint[item.batch],
+                ):
+                    fence("tensormap_generic_acquire_gpu", desc)
+                    # instruction_selection:
+                    # fence.proxy.tensormap::generic.acquire.gpu;
+                    # extent: six elected-lane descriptor fences
+            for chunk in reverse_range(cend - 1, wstart - 1):
+                input_coordinate_q = tensor_map_coordinate(qh, chunk)
+                input_coordinate_k = tensor_map_coordinate(kh, chunk)
+                input_coordinate_o = tensor_map_coordinate(head, chunk)
+                input_coordinate_v = tensor_map_coordinate(vh, chunk)
+                wait_edge("q_done", raw.stage, raw.phase)
+                expect_bytes("q_ready", raw.stage, 4096)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one raw stage transaction
+                copy_g2s(desc_q[batch, input_coordinate_q],
+                         q_raw_stage(raw.stage), True, "q_ready")
+                # instruction_selection:
+                # 2 x cp.async.bulk.tensor.3d.shared::cta.global.tile.
+                # mbarrier::complete_tx::bytes; extent: two 64-channel subtiles
+
+                wait_edge("k_done", raw.stage, raw.phase)
+                expect_bytes("k_ready", raw.stage, 4096)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one raw stage transaction
+                copy_g2s(desc_k[batch, input_coordinate_k],
+                         k_raw_stage(raw.stage), True, "k_ready")
+                # instruction_selection: 2 x rank-3 TMA g2s; extent: two subtiles
+
+                wait_edge("gate_done", raw.stage, raw.phase)
+                expect_bytes("gate_ready", raw.stage, 8192)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one raw stage transaction
+                copy_g2s(desc_gate[batch, input_coordinate_o],
+                         gate_raw_stage(raw.stage), True, "gate_ready")
+                # instruction_selection: 4 x rank-3 TMA g2s; extent: four 32-channel subtiles
+
+                wait_edge("do_done", raw.stage, raw.phase)
+                expect_bytes("do_ready", raw.stage, 4096)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one raw stage transaction
+                copy_g2s(desc_do[batch, input_coordinate_o],
+                         do_raw_stage(raw.stage), True, "do_ready")
+                # instruction_selection: 2 x rank-3 TMA g2s; extent: two subtiles
+
+                wait_edge("v_done", raw.stage, raw.phase)
+                expect_bytes("v_ready", raw.stage, 4096)
+                # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                # extent: one raw stage transaction
+                copy_g2s(desc_v[batch, input_coordinate_v],
+                         v_raw_stage(raw.stage), True, "v_ready")
+                # instruction_selection: 2 x rank-3 TMA g2s; extent: two subtiles
+
+                if chunk >= FIRST_STATE_CHUNK:
+                    wait_edge("state_cg0_done", state_cursor.stage, state_cursor.phase)
+                    wait_edge("state_done", state_cursor.stage, state_cursor.phase)
+                    expect_bytes("state_ready", state_cursor.stage, 32768)
+                    # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+                    # extent: one state transaction
+                    copy_g2s(desc_checkpoint[
+                                 batch,
+                                 checkpoint_tensor_map_coordinate(head, chunk)],
+                             state_region(), True, "state_ready")
+                    # instruction_selection: 2 x rank-4 TMA g2s;
+                    # extent: two 64-row state subtiles
+                    state_cursor = advance(state_cursor)
+                raw = advance(raw)
+            tile = next_tile
+
+    elif warp == 12:
+        # --------------------------------------------------------------
+        # Super-MMA role, source lines 622..871; anchor PTX 650..1855
+        # --------------------------------------------------------------
+        set_register_budget("decrease", 56)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 56; extent: warp
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        dy_smem_cursor = consumer_cursor(stages=1, phase=0)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                decay_stage = serial % 2
+                inter_stage = serial % 2
+                beta_stage_id = serial % 4
+                wait_edge("t_inv_done", inter_stage, (serial//2 + 1) & 1)
+                wait_edge("k_decay_inv", decay_stage, (serial//2) & 1)
+
+                # KK = K_decay @ K_inverse^T.
+                for k_block in range(8):
+                    a_col = k_block * 16 + lhs_ldmatrix_col(lane)
+                    b_col = k_block * 16 + rhs_ldmatrix_col(lane)
+                    copy_s2r(k_decay_operand_bf16_byte(
+                        decay_stage, lhs_ldmatrix_row(lane), a_col),
+                        kk_lhs_regs[k_block])
+                    copy_s2r(k_inverse_operand_bf16_byte(
+                        decay_stage, rhs_ldmatrix_row(lane), b_col),
+                        kk_rhs_regs[k_block])
+                # instruction_selection: 16 x
+                # ldmatrix.sync.aligned.m8n8.x4.shared.b16; extent: exact
+                # lane-coordinate base for both operands over eight K blocks
+                gemm(kk_regs, kk_lhs_regs, kk_rhs_regs)
+                # instruction_selection:
+                # mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32;
+                # extent: eight K blocks, two m16n8 instructions each
+
+                wait_edge("beta_ready", beta_stage_id, (serial//4) & 1)
+                copy_s2r(beta_f32_byte(
+                    beta_stage_id, super_row_lo(lane)), beta_rows.lo)
+                copy_s2r(beta_f32_byte(
+                    beta_stage_id, super_row_hi(lane)), beta_rows.hi)
+                # instruction_selection: 2 x ld.shared.f32; extent: exact
+                # row_lo=lane//4 and row_hi=row_lo+8 scalars
+                arrive_edge("beta_done", beta_stage_id)
+                # instruction_selection: mbarrier.arrive.shared.b64;
+                # extent: all 32 super-warp threads
+                select(strict_kk, strict_lower_mask, kk_regs, 0.0)
+                # instruction_selection: selp.b32; extent: eight accumulator lanes
+                mul(l_regs, strict_kk, beta_rows)
+                # instruction_selection: mul.rn.f32; extent: eight lanes
+                cast(l_bf16, l_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                cast(l_rounded_f32, l_bf16)
+                # instruction_selection: cvt.f32.bf16; extent: eight lanes
+                sub(tinv_regs, identity_fragment, l_rounded_f32)
+                # instruction_selection: sub.rn.f32; extent: eight lanes
+
+                # Three source power-series rounds:
+                # Lpow <- round_bf16(Lpow @ Lpow)
+                # Tinv <- round_bf16(Tinv) + round_bf16(Tinv) @ Lpow.
+                lpow_bf16 = l_bf16
+                for power_round in range(3):
+                    gemm(lpow_square, lpow_bf16, move_matrix(lpow_bf16))
+                    # instruction_selection: mma.sync m16n8k16 bf16;
+                    # extent: two m16n8 instructions for one 16x16 product
+                    cast(lpow_bf16, lpow_square)
+                    # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                    cast(tinv_bf16, tinv_regs)
+                    # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                    gemm(tinv_update, tinv_bf16, move_matrix(lpow_bf16))
+                    # instruction_selection: mma.sync m16n8k16 bf16;
+                    # extent: two m16n8 instructions for one 16x16 product
+                    cast(tinv_rounded, tinv_bf16)
+                    # instruction_selection: cvt.f32.bf16; extent: eight lanes
+                    add(tinv_regs, tinv_rounded, tinv_update)
+                    # instruction_selection: add.rn.f32x2; extent: four packed pairs
+                cast(inv_bf16_regs, tinv_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: packed fragment
+                copy_r2s(inv_bf16_regs,
+                         stmatrix_intermediate_byte(inter_stage, 1, lane))
+                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16;
+                # extent: one 16x16 tile
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("t_inv_ready", inter_stage)
+
+                # dM = dY @ U^T; warp 15, not this warp, owns A/dA.
+                wait_edge("dm_done", inter_stage, (serial//2 + 1) & 1)
+                wait_edge("dy_smem", 0, dy_smem_cursor.phase)
+                dy_smem_cursor = advance(dy_smem_cursor)
+                for k_block in range(8):
+                    a_col = k_block * 16 + lhs_ldmatrix_col(lane)
+                    b_col = k_block * 16 + rhs_ldmatrix_col(lane)
+                    copy_s2r(raw_bf16_byte(
+                        DY_BASE, 0, lhs_ldmatrix_row(lane), a_col),
+                        dy_regs[k_block])
+                    copy_s2r(raw_bf16_byte(
+                        U_BASE, 0, rhs_ldmatrix_row(lane), b_col),
+                        u_regs[k_block])
+                # instruction_selection: 16 x ldmatrix.sync.aligned.
+                # m8n8.x4.shared.b16; extent: dY/U over eight value blocks
+                gemm(dm_regs, dy_regs, u_regs)
+                # instruction_selection: mma.sync m16n8k16 bf16;
+                # extent: eight K blocks, two m16n8 instructions each
+                select(dm_strict, strict_lower_mask, dm_regs, 0.0)
+                # instruction_selection: selp.b32; extent: eight lanes
+                mul(dm_strict, dm_strict, beta_rows)
+                # instruction_selection: mul.rn.f32; extent: eight lanes
+                cast(dm_bf16, dm_strict)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                copy_r2s(dm_bf16,
+                         stmatrix_intermediate_byte(inter_stage, 3, lane))
+                # instruction_selection: stmatrix.sync...x4.shared.b16; extent: tile
+                sub(negative_dm, 0.0, dm_strict)
+                # instruction_selection: sub.rn.f32x2; extent: four packed pairs
+                cast(negative_dm_bf16, negative_dm)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                copy_r2s(negative_dm_bf16,
+                         stmatrix_intermediate_byte(inter_stage, 4, lane))
+                # instruction_selection: stmatrix.sync...x4.shared.b16; extent: tile
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("dm_ready", inter_stage)
+
+                # M term = -row_sum(strict(dM * KK)), one row per lane group.
+                mul(m_product, select(strict_lower_mask, dm_regs, 0.0), kk_regs)
+                # instruction_selection: mul.rn.f32; extent: eight lanes
+                add(m_partial, m_product_even_lanes, m_product_odd_lanes)
+                # instruction_selection: add.rn.f32x2; extent: packed pairs
+                for delta in (1,2):
+                    shuffle_xor(m_other, m_partial, delta)
+                    # instruction_selection: shfl.sync.bfly.b32;
+                    # extent: two fixed warp steps
+                    add(m_partial, m_partial, m_other)
+                    # instruction_selection: add.rn.f32; extent: two fixed steps
+                if lane % 4 == 0:
+                    sub(m_negative, 0.0, m_partial)
+                    # instruction_selection: neg.f32/sub.rn.f32; extent: two scalars
+                    copy_r2s(m_negative,
+                             beta_matrix_f32_byte(super_row_lo(lane)))
+                    copy_r2s(m_negative,
+                             beta_matrix_f32_byte(super_row_hi(lane)))
+                    # instruction_selection: st.shared.f32; extent: two scalars
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("dbeta_matrix", 0)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+
+    elif warp == 13:
+        # --------------------------------------------------------------
+        # tcgen05 issuer, source lines 873..1519; anchor PTX 1886..3302
+        # --------------------------------------------------------------
+        set_register_budget("decrease", 56)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 56; extent: warp
+        allocate_tmem_warp_level(TMEM_MAILBOX_BASE, columns=512)
+        # instruction_selection:
+        # tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32;
+        # extent: converged warp-level operation, not lane-predicated
+        barrier(3, 416)
+        # instruction_selection: barrier.sync 3, 416; extent: all TMEM users
+
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        state_cursor = consumer_cursor(stages=1, phase=0)
+        y_cursor = consumer_cursor(stages=1, phase=0)
+        dstate_input_cursor = consumer_cursor(stages=1, phase=0)
+        du_cursor = consumer_cursor(stages=1, phase=0)
+        neg_dy_cursor = consumer_cursor(stages=1, phase=0)
+        u_smem_cursor = consumer_cursor(stages=1, phase=0)
+        dstate_smem_cursor = consumer_cursor(stages=1, phase=0)
+        cg2_parts_done_cursor = consumer_cursor(stages=1, phase=1)
+        dstate0_cursor = consumer_cursor(stages=1, phase=0)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                has_dstate = (item.cend - 1 - chunk) > 0 or USE_DSTATE_IN
+                raw_stage = serial % 2
+                decay_stage = serial % 2
+                intermediate_stage = serial % 2
+                state_input_stage = serial % 2
+                dv_stage = serial % 2
+                raw_phase = (serial // 2) & 1
+                decay_phase = (serial // 2) & 1
+                inter_phase = (serial // 2) & 1
+                state_input_phase = (serial // 2) & 1
+                dv_ready_phase = (serial // 2) & 1
+                # Each logical GEMM expands only to its repeated tcgen05.mma
+                # instruction family.  Publication is a separate operation.
+                wait_edge("k_decay_inv", decay_stage, decay_phase)
+                if chunk >= FIRST_STATE_CHUNK:
+                    wait_edge("state_ready", state_cursor.stage, state_cursor.phase)
+                    for k_phase in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0, 320),
+                                   state_smem_subtile(k_phase),
+                                   k_decay_smem_subtile(decay_stage, k_phase),
+                                   accumulate=k_phase > 0)
+                    # instruction_selection: 8 x
+                    # tcgen05.mma.cta_group::1.kind::f16; extent: GEMM 1
+                    commit("state_k_acc")
+                    commit("state_done")
+                    # instruction_selection: one delayed tcgen05.commit to two
+                    # mbarriers after all eight issues
+                    state_cursor = advance(state_cursor)
+
+                wait_edge("dqk_acc_done", cg2_parts_done_cursor.stage,
+                          cg2_parts_done_cursor.phase)
+                cg2_parts_done_cursor = advance(cg2_parts_done_cursor)
+                wait_edge("state_input_ready", state_input_stage,
+                          state_input_phase)
+                wait_edge("do_ready", raw_stage, raw_phase)
+                if chunk >= FIRST_STATE_CHUNK:
+                    for k_phase in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0, 368),
+                                   tmem_state_input_subtile(
+                                       tmem_base, tmem_row,
+                                       state_input_stage, k_phase),
+                                   do_smem_lead16_subtile(raw_stage, k_phase),
+                                   accumulate=k_phase > 0)
+                    # instruction_selection: 8 x tcgen05.mma...kind::f16;
+                    # extent: GEMM 2, no commit at this point
+
+                wait_edge("q_decay_k_restore", decay_stage, decay_phase)
+                if has_dstate:
+                    wait_edge("dstate_input", dstate_input_cursor.stage,
+                              dstate_input_cursor.phase)
+                    for k_phase in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0, 352),
+                                   tmem_dstate_input_subtile(
+                                       tmem_base, tmem_row, k_phase),
+                                   k_restore_smem_subtile(
+                                       decay_stage, k_phase),
+                                   accumulate=k_phase > 0)
+                    # instruction_selection: 8 x tcgen05.mma...kind::f16;
+                    # extent: GEMM 3, no commit at this point
+                    for n_stripe in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0,
+                                       n_stripe * 16),
+                             tmem_dstate_input_subtile(
+                                 tmem_base, tmem_row, n_stripe),
+                             state_diag_smem_subtile(
+                                 decay_stage, n_stripe),
+                             accumulate=False)
+                        # instruction_selection: one independent
+                        # tcgen05.mma...kind::f16 per N stripe; extent: GEMM 4
+                    dstate_input_cursor = advance(dstate_input_cursor)
+
+                wait_edge("a_ready", intermediate_stage, inter_phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 352),
+                     do_smem_amajor_desc(raw_stage),
+                     intermediate_smem_desc(intermediate_stage, 0),
+                     accumulate=has_dstate)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 5
+                commit("du_acc")
+                commit("a_done")
+                # instruction_selection: one delayed tcgen05.commit carrying
+                # exactly two arrivals after GEMMs 2..5
+
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 0),
+                     do_smem_amajor_desc(raw_stage),
+                     q_decay_smem_transpose_desc(decay_stage),
+                     accumulate=has_dstate)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 6
+
+                wait_edge("t_inv_ready", intermediate_stage, inter_phase)
+                wait_edge("y_input", y_cursor.stage, y_cursor.phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 336),
+                     tmem_y_input(tmem_base, tmem_row),
+                     intermediate_smem_desc(intermediate_stage, 1))
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 7
+                commit("u_acc")
+                y_cursor = advance(y_cursor)
+
+                wait_edge("du_input", du_cursor.stage, du_cursor.phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 320),
+                     tmem_du_input(tmem_base, tmem_row),
+                     intermediate_smem_desc(intermediate_stage, 1))
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 8
+                commit("dy_acc")
+                commit("t_inv_done")
+                du_cursor = advance(du_cursor)
+
+                wait_edge("u_smem", u_smem_cursor.stage, u_smem_cursor.phase)
+                if has_dstate:
+                    wait_edge("dstate_smem", dstate_smem_cursor.stage,
+                              dstate_smem_cursor.phase)
+                    for k_phase in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0, 416),
+                                   dstate_smem_alt_desc(k_phase),
+                                   u_smem_lead16_subtile(k_phase),
+                                   accumulate=k_phase > 0)
+                    # instruction_selection: 8 x tcgen05.mma...kind::f16;
+                    # extent: GEMM 9; both operands come from SMEM
+                    commit("dk_restore_acc")
+                    commit("dstate_smem_done")
+                    dstate_smem_cursor = advance(dstate_smem_cursor)
+                u_smem_cursor = advance(u_smem_cursor)
+
+                wait_edge("neg_beta_dy_input", neg_dy_cursor.stage,
+                          neg_dy_cursor.phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 0),
+                     tmem_negative_beta_dy_input(tmem_base, tmem_row),
+                     k_decay_smem_transpose_desc(decay_stage),
+                     accumulate=True)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 10
+                commit("dstate_acc")
+                neg_dy_cursor = advance(neg_dy_cursor)
+
+                wait_edge("da_ready", intermediate_stage, inter_phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 400),
+                     q_decay_smem_transpose_desc(decay_stage),
+                     intermediate_smem_desc(intermediate_stage, 2))
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one runtime issue for GEMM 11; no commit
+
+                if chunk >= FIRST_STATE_CHUNK:
+                    gemm(tmem_cell(tmem_base, tmem_row, 0, 368),
+                         k_inverse_smem_amajor_desc(decay_stage),
+                         intermediate_smem_desc(intermediate_stage, 2),
+                         accumulate=True)
+                else:
+                    gemm(tmem_cell(tmem_base, tmem_row, 0, 368),
+                         k_inverse_smem_amajor_desc(decay_stage),
+                         intermediate_smem_desc(intermediate_stage, 2),
+                         accumulate=False)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: GEMM 12 has two mutually-exclusive static predicate
+                # sites but exactly one runtime issue
+                commit("dq_acc")
+                commit("da_done")
+
+                wait_edge("dv_store_ready", dv_stage, dv_ready_phase)
+                if chunk >= FIRST_STATE_CHUNK:
+                    for k_phase in range(8):
+                        gemm(tmem_cell(tmem_base, tmem_row, 0, 384),
+                                   tmem_state_input_subtile(
+                                       tmem_base, tmem_row,
+                                       state_input_stage, k_phase),
+                                   dv_smem_lead16_subtile(
+                                       dv_stage, k_phase),
+                                   accumulate=k_phase > 0)
+                    # instruction_selection: 8 x tcgen05.mma...kind::f16;
+                    # extent: GEMM 13, entering state in TMEM times sDv
+                commit("state_input_done")
+                # The commit is unconditional even when GEMM 13 is predicated
+                # away, so CG0 can reuse the state-input TMEM columns.
+
+                wait_edge("dm_ready", intermediate_stage, inter_phase)
+                gemm(tmem_cell(tmem_base, tmem_row, 0, 400),
+                     k_decay_smem_transpose_desc(decay_stage),
+                     intermediate_smem_desc(intermediate_stage, 4),
+                     accumulate=True)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: one 16-K instruction for GEMM 14
+                commit("dk_inv_acc")
+
+                if chunk >= FIRST_STATE_CHUNK:
+                    gemm(tmem_cell(tmem_base, tmem_row, 0, 384),
+                         k_inverse_smem_amajor_desc(decay_stage),
+                         intermediate_smem_desc(intermediate_stage, 3),
+                         accumulate=True)
+                else:
+                    gemm(tmem_cell(tmem_base, tmem_row, 0, 384),
+                         k_inverse_smem_amajor_desc(decay_stage),
+                         intermediate_smem_desc(intermediate_stage, 3),
+                         accumulate=False)
+                # instruction_selection: tcgen05.mma...kind::f16;
+                # extent: GEMM 15 has two mutually-exclusive static predicate
+                # sites but exactly one runtime issue
+                commit("dk_decay_acc")
+                commit("dm_done")
+                commit("decay_done")
+
+            wait_edge("dstate0_stored", dstate0_cursor.stage,
+                      dstate0_cursor.phase)
+            dstate0_cursor = advance(dstate0_cursor)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+        wait_edge("tmem_done", 0, phase=0)
+        relinquish_tmem_permit_warp_level()
+        # instruction_selection:
+        # tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;
+        # extent: converged warp-level operation
+        deallocate_tmem_warp_level(tmem_allocated, columns=512)
+        # instruction_selection:
+        # tcgen05.dealloc.cta_group::1.sync.aligned.b32;
+        # extent: converged warp-level operation
+
+    elif warp == 15:
+        # --------------------------------------------------------------
+        # Epilogue/store role, source lines 302..620; anchor PTX 3309..4254
+        # --------------------------------------------------------------
+        set_register_budget("decrease", 56)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 56; extent: warp
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        u_smem_cursor = consumer_cursor(stages=1, phase=0)
+        dq_store_cursor = consumer_cursor(stages=1, phase=0)
+        dk_store_cursor = consumer_cursor(stages=1, phase=0)
+        dgate_store_cursor = consumer_cursor(stages=1, phase=0)
+        dv_store_cursor = consumer_cursor(stages=2, phase=0)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            if elected_lane():
+                fence("tensormap_generic_acquire_gpu", desc_dq[item.batch])
+                fence("tensormap_generic_acquire_gpu", desc_dk[item.batch])
+                fence("tensormap_generic_acquire_gpu", desc_dv[item.batch])
+                fence("tensormap_generic_acquire_gpu", desc_dgate[item.batch])
+                # Exactly four output descriptor acquires, once per work item.
+            has_pending_output = False
+            pending_output_batch = 0
+            pending_output_coordinate = (0, 0, 0)
+            pending_output_writes = False
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                raw_stage = serial % 2
+                decay_stage = serial % 2
+                intermediate_stage = serial % 2
+                raw_phase = (serial // 2) & 1
+                decay_phase = (serial // 2) & 1
+
+                wait_edge("a_done", intermediate_stage,
+                          ((serial // 2) + 1) & 1)
+                wait_edge("q_decay_k_restore", decay_stage, decay_phase)
+                for k_block in range(8):
+                    a_col = k_block * 16 + lhs_ldmatrix_col(lane)
+                    b_col = k_block * 16 + rhs_ldmatrix_col(lane)
+                    copy_s2r(q_decay_operand_bf16_byte(
+                        decay_stage, lhs_ldmatrix_row(lane), a_col),
+                        q_regs[k_block])
+                    copy_s2r(k_inverse_operand_bf16_byte(
+                        decay_stage, rhs_ldmatrix_row(lane), b_col),
+                        k_regs[k_block])
+                # instruction_selection: 16 x ldmatrix.sync.aligned.
+                # m8n8.x4.shared.b16; extent: exact A operand lane bases
+                fill(a_regs, 0.0)
+                for k_block in range(8):
+                    gemm(a_regs, q_regs[k_block], transpose(k_regs[k_block]),
+                         accumulate=k_block > 0)
+                # instruction_selection: 16 x mma.sync m16n8k16 bf16;
+                # extent: A = Q-decay @ K-inverse^T over eight K blocks
+                for accum_lane in range(8):
+                    select(a_regs[accum_lane],
+                           tril_inclusive_mask_bit(accum_lane),
+                           a_regs[accum_lane], 0.0)
+                cast(a_bf16x2, a_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                copy_r2s(a_bf16x2,
+                         stmatrix_intermediate_byte(
+                             intermediate_stage, 0, lane))
+                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16;
+                # extent: one 16x16 A tile
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("a_ready", intermediate_stage)
+
+                wait_edge("u_smem", u_smem_cursor.stage,
+                          u_smem_cursor.phase)
+                for k_block in range(8):
+                    a_col = k_block * 16 + lhs_ldmatrix_col(lane)
+                    b_col = k_block * 16 + rhs_ldmatrix_col(lane)
+                    copy_s2r(do_raw_bf16_byte(
+                        raw_stage, lhs_ldmatrix_row(lane), a_col),
+                        do_regs[k_block])
+                    copy_s2r(raw_bf16_byte(
+                        U_BASE, 0, rhs_ldmatrix_row(lane), b_col),
+                        u_regs[k_block])
+                # instruction_selection: 16 x ldmatrix.sync.aligned.
+                # m8n8.x4.shared.b16; extent: exact dO/U lane bases
+                fill(da_regs, 0.0)
+                for k_block in range(8):
+                    gemm(da_regs, do_regs[k_block], transpose(u_regs[k_block]),
+                         accumulate=k_block > 0)
+                # instruction_selection: 16 x mma.sync m16n8k16 bf16;
+                # extent: dA = dO @ U^T over eight K blocks
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("do_done", raw_stage)
+                u_smem_cursor = advance(u_smem_cursor)
+                for accum_lane in range(8):
+                    select(da_regs[accum_lane],
+                           tril_inclusive_mask_bit(accum_lane),
+                           da_regs[accum_lane], 0.0)
+                wait_edge("da_done", intermediate_stage,
+                          ((serial // 2) + 1) & 1)
+                cast(da_bf16x2, da_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: four pairs
+                copy_r2s(da_bf16x2,
+                         stmatrix_intermediate_byte(
+                             intermediate_stage, 2, lane))
+                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16;
+                # extent: one 16x16 dA tile
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warp
+                arrive_edge("da_ready", intermediate_stage)
+
+                if has_pending_output:
+                    wait_edge("dq_store_ready", dq_store_cursor.stage,
+                              dq_store_cursor.phase)
+                    if pending_output_writes:
+                        copy_s2g(dq_output_bf16_byte(0, 0),
+                                 desc_dq[pending_output_batch,
+                                         pending_output_coordinate], True)
+                    # instruction_selection: 2 x
+                    # cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group;
+                    # extent: two 64-channel subtiles
+                        commit_directional_copy_group("dq")
+                    wait_edge("dk_store_ready", dk_store_cursor.stage,
+                              dk_store_cursor.phase)
+                    if pending_output_writes:
+                        copy_s2g(dk_output_bf16_byte(0, 0),
+                                 desc_dk[pending_output_batch,
+                                         pending_output_coordinate], True)
+                    # instruction_selection: 2 x rank-3 TMA s2g; extent: two subtiles
+                        commit_directional_copy_group("dk")
+                    wait_edge("dgate_store_ready", dgate_store_cursor.stage,
+                              dgate_store_cursor.phase)
+                    if pending_output_writes:
+                        copy_s2g(dgate_output_f32_byte(0, 0),
+                                 desc_dgate[pending_output_batch,
+                                            pending_output_coordinate], True)
+                    # instruction_selection: 4 x rank-3 TMA s2g; extent: four subtiles
+                        commit_directional_copy_group("dgate")
+                    wait_edge("dv_store_ready", dv_store_cursor.stage,
+                              dv_store_cursor.phase)
+                    if pending_output_writes:
+                        copy_s2g(dv_output_bf16_byte(
+                                     dv_store_cursor.stage, 0, 0),
+                                 desc_dv[pending_output_batch,
+                                         pending_output_coordinate], True)
+                    # instruction_selection: 2 x rank-3 TMA s2g; extent: two subtiles
+                        commit_directional_copy_group("dv")
+                    # instruction_selection: one cp.async.bulk.commit_group
+                    # immediately after each of dq/dk/dgate/dv
+                    wait_directional_copy_group(3)
+                    arrive_edge("dq_store_done", dq_store_cursor.stage)
+                    wait_directional_copy_group(2)
+                    arrive_edge("dk_store_done", dk_store_cursor.stage)
+                    wait_directional_copy_group(1)
+                    arrive_edge("dgate_store_done", dgate_store_cursor.stage)
+                    wait_directional_copy_group(0)
+                    arrive_edge("dv_store_done", dv_store_cursor.stage)
+                    # instruction_selection: cp.async.bulk.wait_group.read
+                    # ladder 3,2,1,0; release exactly the completed stage
+                    dq_store_cursor = advance(dq_store_cursor)
+                    dk_store_cursor = advance(dk_store_cursor)
+                    dgate_store_cursor = advance(dgate_store_cursor)
+                    dv_store_cursor = advance(dv_store_cursor)
+
+                has_pending_output = True
+                pending_output_batch = item.batch
+                pending_output_coordinate = tensor_map_coordinate(
+                    item.head, chunk)
+                pending_output_writes = chunk < item.wend
+            if has_pending_output:
+                wait_edge("dq_store_ready", dq_store_cursor.stage,
+                          dq_store_cursor.phase)
+                if pending_output_writes:
+                    copy_s2g(dq_output_bf16_byte(0, 0),
+                             desc_dq[pending_output_batch,
+                                     pending_output_coordinate], True)
+                    commit_directional_copy_group("dq")
+                wait_edge("dk_store_ready", dk_store_cursor.stage,
+                          dk_store_cursor.phase)
+                if pending_output_writes:
+                    copy_s2g(dk_output_bf16_byte(0, 0),
+                             desc_dk[pending_output_batch,
+                                     pending_output_coordinate], True)
+                    commit_directional_copy_group("dk")
+                wait_edge("dgate_store_ready", dgate_store_cursor.stage,
+                          dgate_store_cursor.phase)
+                if pending_output_writes:
+                    copy_s2g(dgate_output_f32_byte(0, 0),
+                             desc_dgate[pending_output_batch,
+                                        pending_output_coordinate], True)
+                    commit_directional_copy_group("dgate")
+                wait_edge("dv_store_ready", dv_store_cursor.stage,
+                          dv_store_cursor.phase)
+                if pending_output_writes:
+                    copy_s2g(dv_output_bf16_byte(
+                                 dv_store_cursor.stage, 0, 0),
+                             desc_dv[pending_output_batch,
+                                     pending_output_coordinate], True)
+                    commit_directional_copy_group("dv")
+                wait_directional_copy_group(3)
+                arrive_edge("dq_store_done", dq_store_cursor.stage)
+                wait_directional_copy_group(2)
+                arrive_edge("dk_store_done", dk_store_cursor.stage)
+                wait_directional_copy_group(1)
+                arrive_edge("dgate_store_done", dgate_store_cursor.stage)
+                wait_directional_copy_group(0)
+                arrive_edge("dv_store_done", dv_store_cursor.stage)
+                # Same explicit four-commit/3,2,1,0 ladder flushes the tail.
+                dq_store_cursor = advance(dq_store_cursor)
+                dk_store_cursor = advance(dk_store_cursor)
+                dgate_store_cursor = advance(dgate_store_cursor)
+                dv_store_cursor = advance(dv_store_cursor)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+
+    elif 0 <= warp <= 3:
+        # --------------------------------------------------------------
+        # CG0, source lines 1698..2107; anchor PTX 4299..6299
+        # --------------------------------------------------------------
+        set_register_budget("increase", 144)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 144; extent: warpgroup
+        barrier(3, 416)
+        # instruction_selection: barrier.sync 3, 416; extent: TMEM users
+        cg0_warp = warp
+        prefix_dim = cg0_warp * 32 + lane
+        row_group_start = cg0_warp * 4
+        lane_row_group = lane // 8
+        lane_in_row_group = lane - lane_row_group * 8
+        decay_row = row_group_start + lane_row_group
+        value_dim = cg0_warp * 32 + lane
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        beta_done_cursor = consumer_cursor(stages=4, phase=1)
+        qk_done_cursor = consumer_cursor(stages=4, phase=1)
+        state_input_done_cursor = consumer_cursor(stages=2, phase=1)
+        state_input_cg2_done_cursor = consumer_cursor(stages=2, phase=1)
+        state_cursor = consumer_cursor(stages=1, phase=0)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            num_compute_chunks = item.cend - item.wstart
+            safe_a_exp = 1.0
+            safe_dt_bias = 0.0
+            if SAFE_GATE and num_compute_chunks > 0:
+                copy_g2r(a_log[item.head], a_reg)
+                exp2(safe_a_exp, a_reg * LOG2_E, ftz=True)
+                # instruction_selection: one ex2.approx.ftz.f32 per nonempty
+                # work item, outside the chunk loop
+                copy_g2r(dt_bias[item.head, prefix_dim], safe_dt_bias)
+                # instruction_selection: one ld.global.f32 per channel and
+                # nonempty work item
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                raw_stage = serial % 2
+                decay_stage = serial % 2
+                qk_stage = serial % 4
+                state_input_stage = serial % 2
+                beta_stage_id = serial % 4
+                raw_phase = (serial // 2) & 1
+                decay_phase = (serial // 2) & 1
+                state_input_phase = (serial // 2) & 1
+                for token in range(16):
+                    valid_rows[token] = token_valid(item, chunk, token)
+
+                # Only CG0 warp 0 produces beta.  It cannot overwrite the
+                # stage until all 32 super-MMA threads and all 128 CG1 threads
+                # have arrived at beta_done (expected count 160).
+                if warp == 0:
+                    wait_edge("beta_done", beta_stage_id,
+                              beta_done_cursor.phase)
+                    if lane < 16:
+                        fill(beta_regs, 0.0)
+                        if valid_rows[lane]:
+                            copy_g2r(beta[global_token(item, chunk, lane),
+                                          item.head], beta_regs)
+                            # instruction_selection: ld.global.f32 or ld.global.b16
+                            if BETA_SIGMOID:
+                                tanh(beta_regs, beta_regs * 0.5)
+                                add(beta_regs, beta_regs * 0.5, 0.5)
+                                cast(beta_bf16, beta_regs)
+                                cast(beta_regs, beta_bf16)
+                                # instruction_selection: cvt.rn.bf16.f32 then
+                                # cvt.f32.bf16 before the FP32 shared store
+                        # Invalid tail beta stays exactly zero; sigmoid is not
+                        # evaluated for the invalid lane.
+                        copy_r2s(beta_regs,
+                                 beta_f32_byte(beta_stage_id, lane))
+                        # instruction_selection: st.shared.f32; extent: lanes 0..15
+                    arrive_edge("beta_ready", beta_stage_id)
+                    beta_done_cursor = advance(beta_done_cursor)
+
+                wait_edge("gate_ready", raw_stage, raw_phase)
+                wait_edge("q_ready", raw_stage, raw_phase)
+                wait_edge("k_ready", raw_stage, raw_phase)
+                for token in range(16):
+                    copy_s2r(gate_raw_f32_byte(
+                        raw_stage, token, prefix_dim), gate_regs[token])
+                # instruction_selection: ld.shared.f32; vectorized as
+                # ld.shared.v4.b32; extent: 16 rows for one key channel
+                if SAFE_GATE:
+                    tanh(sigmoid_regs,
+                         safe_a_exp * (gate_regs + safe_dt_bias) * 0.5)
+                    # instruction_selection: tanh.approx.f32; extent: fragment
+                    add(sigmoid_regs, sigmoid_regs * 0.5, 0.5)
+                    # instruction_selection: fma.rn.f32; extent: fragment
+                    mul(log_decay, sigmoid_regs, GATE_SCALE_LOG2)
+                    # instruction_selection: mul.rn.f32; extent: fragment
+                    select(log_decay, valid_rows, log_decay, 0.0)
+                else:
+                    select(gate_ln, valid_rows, gate_regs, 0.0)
+                    mul(log_decay, gate_ln, LOG2_E)
+                    # instruction_selection: selp.f32 + mul.rn.f32;
+                    # extent: raw natural-log gate, with only tail rows zeroed
+
+                prefix_acc = 0.0
+                for row_pair in range(8):
+                    row0 = 2 * row_pair
+                    row1 = row0 + 1
+                    add_packed_f32x2(pair_vec,
+                                     (prefix_acc, log_decay[row0]),
+                                     (log_decay[row0], log_decay[row1]))
+                    prefix0 = pair_vec[0]
+                    row_pair_sum = pair_vec[1]
+                    add(prefix1, prefix_acc, row_pair_sum)
+                    assign(log_decay[row0], prefix0)
+                    assign(log_decay[row1], prefix1)
+                    assign(prefix_acc, prefix1)
+                # instruction_selection: strict-order add.rn.f32x2 plus scalar
+                # add.rn.f32; extent: eight packed row pairs, no shuffle
+                exp2(gate_exp, log_decay, ftz=True)
+                # instruction_selection: ex2.approx.ftz.f32; extent: fragment
+                wait_edge("decay_done", decay_stage,
+                          ((serial // 2) + 1) & 1)
+                for token in range(16):
+                    copy_r2s(gate_exp[token], gate_raw_f32_byte(
+                        raw_stage, token, prefix_dim))
+                # instruction_selection: st.shared.f32; vectorized as
+                # st.shared.v4.b32; extent: 16 rows for one key channel
+                diag_block = prefix_dim // 16
+                diag_coord = prefix_dim - diag_block * 16
+                cast(diag_bf16, gate_exp[15])
+                copy_r2s(diag_bf16, state_diag_bf16_byte(
+                    decay_stage, diag_block, diag_coord, diag_coord))
+                # instruction_selection: cvt.rn.bf16.f32 + st.shared.u16;
+                # extent: one diagonal element per CG0 thread
+
+                for token in range(16):
+                    copy_s2r(q_raw_bf16_byte(raw_stage, token, prefix_dim),
+                             q_raw_column[token])
+                    copy_s2r(k_raw_bf16_byte(raw_stage, token, prefix_dim),
+                             k_raw_column[token])
+                # instruction_selection: ld.shared.u16; extent: exactly 16 Q
+                # and 16 K scalars selected by the BF16 xor mapping
+
+                # Publish the raw, unnormalized BF16 Q/K packs before any L2
+                # arithmetic.  CG2 consumes these exact values.
+                wait_edge("qk_raw_done", qk_stage, qk_done_cursor.phase)
+                cast(q_raw_words[0:8], q_raw_column[0:16])
+                cast(k_raw_words[0:8], k_raw_column[0:16])
+                # instruction_selection: cvt.rn.bf16x2.f32/mov.b32;
+                # extent: eight packed token pairs for each operand
+                copy_r2t(q_raw_words,
+                         cg0_qraw_tmem_cell(
+                             tmem_base, tmem_row, warp, qk_stage))
+                copy_r2t(k_raw_words,
+                         cg0_kraw_tmem_cell(
+                             tmem_base, tmem_row, warp, qk_stage))
+                # instruction_selection: 2 x
+                # tcgen05.st.sync.aligned.32x32b.x16.b32
+                wait_tmem_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive_edge("qk_raw_ready", qk_stage)
+                qk_done_cursor = advance(qk_done_cursor)
+                barrier(1, 128)
+                # instruction_selection: barrier.sync 1,128; all raw Q/K
+                # TMEM stores are issued before operand-fragment loads proceed
+
+                for dim_half in range(2):
+                    dim_base = dim_half * 64 + lane_in_row_group * 8
+                    for dim_offset in range(8):
+                        channel_i = dim_base + dim_offset
+                        copy_s2r(q_raw_bf16_byte(
+                            raw_stage, decay_row, channel_i),
+                            q_regs[dim_half, dim_offset])
+                        copy_s2r(k_raw_bf16_byte(
+                            raw_stage, decay_row, channel_i),
+                            k_regs[dim_half, dim_offset])
+                # instruction_selection: ld.shared.v4.b32; extent: two
+                # contiguous eight-BF16 fragments from each Q/K raw stage
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("q_done", raw_stage)
+                arrive_edge("k_done", raw_stage)
+
+                q_inv_norm = 1.0
+                k_inv_norm = 1.0
+                if L2NORM:
+                    qk0_lo = opaque_f32_zero()
+                    qk0_hi = opaque_f32_zero()
+                    qk1_lo = opaque_f32_zero()
+                    qk1_hi = opaque_f32_zero()
+                    for dim_half in range(2):
+                        for dim_offset in range(8):
+                            q_value = cast_f32(q_regs[dim_half, dim_offset])
+                            k_value = cast_f32(k_regs[dim_half, dim_offset])
+                            if dim_offset % 2 == 0:
+                                ffma2(qk0_lo, qk0_hi,
+                                      q_value, k_value,
+                                      q_value, k_value,
+                                      qk0_lo, qk0_hi)
+                            else:
+                                ffma2(qk1_lo, qk1_hi,
+                                      q_value, k_value,
+                                      q_value, k_value,
+                                      qk1_lo, qk1_hi)
+                    # instruction_selection: paired mad.rn.f32/FFMA2 ordering;
+                    # extent: both 64-channel halves and even/odd accumulators
+                    add(q_sum, qk0_lo, qk1_lo)
+                    add(k_sum, qk0_hi, qk1_hi)
+                    for step in (4,2,1):
+                        shuffle_xor(q_other, q_sum, step, width=8)
+                        shuffle_xor(k_other, k_sum, step, width=8)
+                        add(q_sum, q_sum, q_other)
+                        add(k_sum, k_sum, k_other)
+                    # instruction_selection: three fixed 8-lane
+                    # shfl.sync.bfly.b32 reductions, steps 4,2,1
+                    rsqrt(q_inv_norm,
+                          max(q_sum, L2_NORM_EPS * L2_NORM_EPS), ftz=True)
+                    # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar
+                    rsqrt(k_inv_norm,
+                          max(k_sum, L2_NORM_EPS * L2_NORM_EPS), ftz=True)
+                    # instruction_selection: rsqrt.approx.ftz.f32; extent: scalar
+                    if lane_in_row_group == 0:
+                        copy_r2s(q_inv_norm, norm_f32_byte(
+                            qk_stage, 0, decay_row))
+                        copy_r2s(k_inv_norm, norm_f32_byte(
+                            qk_stage, 1, decay_row))
+                        # instruction_selection: two st.shared.f32 by the
+                        # elected lane in each eight-lane row group
+                    # Only inverse norms, not normalized vectors, enter SMEM.
+
+                for dim_half in range(2):
+                    dim_base = dim_half * 64 + lane_in_row_group * 8
+                    for dim_offset in range(8):
+                        channel_i = dim_base + dim_offset
+                        copy_s2r(gate_raw_f32_byte(
+                            raw_stage, decay_row, channel_i),
+                            gate_exp_regs[dim_half, dim_offset])
+                        copy_s2r(gate_raw_f32_byte(
+                            raw_stage, 15, channel_i),
+                            gate_last_regs[dim_half, dim_offset])
+                # instruction_selection: ld.shared.v4.b32; extent: four
+                # aligned FP32 groups per dimension half for current/last row
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("gate_done", raw_stage)
+
+                # K-decay/K-inverse producer phase.  Every factor is rounded
+                # to a BF16 pair before packed multiplication.
+                for pair in range(8):
+                    mul(k_norm_f32x2, raw_k_f32x2[pair], k_inv_norm)
+                    cast(k_base_bf16x2, k_norm_f32x2)
+                    cast(gate_bf16x2, gate_exp_regs[pair])
+                    rcp(gate_rcp_f32x2, gate_exp_regs[pair], approx=True,
+                        ftz=True)
+                    cast(gate_rcp_bf16x2, gate_rcp_f32x2)
+                    mul_bf16x2(k_decay_bf16x2, k_base_bf16x2,
+                               gate_bf16x2)
+                    mul_bf16x2(k_inverse_bf16x2, k_base_bf16x2,
+                               gate_rcp_bf16x2)
+                    assign(saved_k_inverse_bf16x2[pair],
+                           k_inverse_bf16x2)
+                    # instruction_selection: cvt.rn.bf16x2.f32,
+                    # rcp.approx.ftz.f32, mul.bf16x2; extent: eight pairs
+                    token_pair = pair % 4
+                    dim_half = pair // 4
+                    channel0 = dim_half * 64 + lane_in_row_group * 8
+                    channel0 += token_pair * 2
+                    copy_r2s(k_decay_bf16x2,
+                             k_decay_operand_bf16_byte(
+                                 decay_stage, decay_row, channel0))
+                    copy_r2s(k_inverse_bf16x2,
+                             k_inverse_operand_bf16_byte(
+                                 decay_stage, decay_row, channel0))
+                    # instruction_selection: st.shared.v4.b32 across each
+                    # eight-element vector group
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("k_decay_inv", decay_stage)
+
+                # Q-decay/K-restore is a second, ordered producer phase.
+                for pair in range(8):
+                    mul(q_scaled_f32x2, raw_q_f32x2[pair],
+                        q_inv_norm * scale)
+                    cast(q_base_bf16x2, q_scaled_f32x2)
+                    cast(gate_bf16x2, gate_exp_regs[pair])
+                    cast(gate_last_bf16x2, gate_last_regs[pair])
+                    mul_bf16x2(q_decay_bf16x2, q_base_bf16x2,
+                               gate_bf16x2)
+                    mul_bf16x2(k_restore_bf16x2,
+                               saved_k_inverse_bf16x2[pair],
+                               gate_last_bf16x2)
+                    # instruction_selection: cvt.rn.bf16x2.f32 and
+                    # mul.bf16x2; K-restore consumes the rounded K-inverse
+                    token_pair = pair % 4
+                    dim_half = pair // 4
+                    channel0 = dim_half * 64 + lane_in_row_group * 8
+                    channel0 += token_pair * 2
+                    copy_r2s(q_decay_bf16x2,
+                             q_decay_operand_bf16_byte(
+                                 decay_stage, decay_row, channel0))
+                    copy_r2s(k_restore_bf16x2,
+                             k_restore_operand_bf16_byte(
+                                 decay_stage, decay_row, channel0))
+                    # instruction_selection: st.shared.v4.b32 vector groups
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("q_decay_k_restore", decay_stage)
+
+                wait_edge("state_input_done", state_input_stage,
+                          state_input_done_cursor.phase)
+                wait_edge("state_input_cg2_done", state_input_stage,
+                          state_input_cg2_done_cursor.phase)
+                if chunk >= FIRST_STATE_CHUNK:
+                    wait_edge("state_ready", state_cursor.stage,
+                              state_cursor.phase)
+                    for value_half in range(2):
+                        for value_group8 in range(8):
+                            for element in range(8):
+                                key_row = value_half * 64
+                                key_row += value_group8 * 8 + element
+                                copy_s2r(state_bf16_byte(
+                                    key_row, value_dim), state_fragment[element])
+                            # instruction_selection: ld.shared.v4.b32; extent:
+                            # one eight-BF16 vector selected by state mapping
+                            copy_r2t(state_fragment,
+                                     cg0_state_tmem_cell(
+                                         tmem_base, tmem_row, warp,
+                                         state_input_stage, value_half,
+                                         value_group8))
+                            # instruction_selection:
+                            # tcgen05.st.sync.aligned.32x32b.x4.b32;
+                            # extent: 16 vector stores per thread
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned
+                    arrive_edge("state_cg0_done", 0)
+                    state_cursor = advance(state_cursor)
+                arrive_edge("state_input_ready", state_input_stage)
+                # This ready edge is unconditional when state is absent.
+                state_input_done_cursor = advance(state_input_done_cursor)
+                state_input_cg2_done_cursor = advance(state_input_cg2_done_cursor)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+
+    elif 8 <= warp <= 11:
+        # --------------------------------------------------------------
+        # CG2, source lines 2546..2823; anchor PTX 6300..8329
+        # --------------------------------------------------------------
+        set_register_budget("increase", 144)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 144; extent: warpgroup
+        barrier(3,416)
+        # instruction_selection: barrier.sync 3, 416; extent: TMEM users
+        cg2_warp = warp - 8
+        channel = cg2_warp * 32 + lane
+        cg2_linear_thread = channel
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        dq_cursor = consumer_cursor(stages=1, phase=0)
+        dk_decay_cursor = consumer_cursor(stages=1, phase=0)
+        dk_inv_cursor = consumer_cursor(stages=1, phase=0)
+        dk_restore_cursor = consumer_cursor(stages=1, phase=0)
+        dstate_smem_cursor = consumer_cursor(stages=1, phase=0)
+        dq_output_cursor = consumer_cursor(stages=1, phase=1)
+        dk_output_cursor = consumer_cursor(stages=1, phase=1)
+        dgate_output_cursor = consumer_cursor(stages=1, phase=1)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                local_rev = item.cend - 1 - chunk
+                raw_stage = serial % 2
+                decay_stage = serial % 2
+                qk_stage = serial % 4
+                state_input_stage = serial % 2
+                decay_phase = (serial // 2) & 1
+                qk_phase = (serial // 4) & 1
+                state_input_phase = (serial // 2) & 1
+                has_dstate = local_rev > 0 or USE_DSTATE_IN
+
+                # CG0's decay publication is the visibility guard for the
+                # exponential gate values that overwrite the raw gate stage.
+                wait_edge("k_decay_inv", decay_stage, decay_phase)
+                for token in range(16):
+                    copy_s2r(gate_exp[token],
+                             gate_raw_f32_byte(raw_stage, token, channel))
+                    # instruction_selection: ld.shared.f32; extent: 16 rows
+                gate_last = gate_exp[15]
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("gate_done", raw_stage)
+
+                wait_edge("qk_raw_ready", qk_stage, qk_phase)
+                wait_edge("state_input_ready", state_input_stage,
+                          state_input_phase)
+                dgate_last_value = 0.0
+                if has_dstate:
+                    wait_edge("dstate_smem", dstate_smem_cursor.stage,
+                              dstate_smem_cursor.phase)
+                    for plane in range(2):
+                        for row_half in range(2):
+                            copy_t2r(cg2_tmem_channel_cell(
+                                         tmem_base, tmem_row, warp,
+                                         192 + state_input_stage * 64
+                                         + plane * 32 + row_half * 16),
+                                     state_words)
+                            # instruction_selection:
+                            # tcgen05.ld.sync.aligned.32x32b.x16.b32
+                            fill(hacc[0:8], opaque_f32_zero())
+                            for pair in range(16):
+                                copy_s2r(dstate_pair,
+                                         dstate_alt_transpose_bf16_byte(
+                                             plane * 64 + row_half * 32
+                                             + 2 * pair, channel))
+                                copy_s2r(dstate_pair_hi,
+                                         dstate_alt_transpose_bf16_byte(
+                                             plane * 64 + row_half * 32
+                                             + 2 * pair + 1, channel))
+                                # instruction_selection: 2 x ld.shared.u16;
+                                # extent: one dState pair per state word
+                                state_pair = unpack_bf16x2(
+                                    state_words[pair])
+                                fma(hacc[(2 * pair) % 8],
+                                    dstate_pair, state_pair.lo,
+                                    hacc[(2 * pair) % 8])
+                                fma(hacc[(2 * pair + 1) % 8],
+                                    dstate_pair_hi, state_pair.hi,
+                                    hacc[(2 * pair + 1) % 8])
+                                # instruction_selection: mad.rn.f32;
+                                # extent: 32 paired dState/state products
+                            fadd2(pa0, pb0, hacc[0], hacc[2],
+                                  hacc[4], hacc[6])
+                            fadd2(pa1, pb1, hacc[1], hacc[3],
+                                  hacc[5], hacc[7])
+                            fadd2(part_a, part_b, pa0, pb0, pa1, pb1)
+                            add(dgate_last_value, dgate_last_value,
+                                part_a + part_b)
+                            # instruction_selection: add.rn.f32x2 followed
+                            # by scalar add.rn.f32; extent: source tree
+                    arrive_edge("dstate_smem_cg2_done", 0)
+                    dstate_smem_cursor = advance(dstate_smem_cursor)
+                arrive_edge("state_input_cg2_done", state_input_stage)
+
+                fill(dk_regs, 0.0)
+                fill(dgate_last_kdot_parts, 0.0)
+                if has_dstate:
+                    wait_edge("dk_restore_acc", dk_restore_cursor.stage,
+                              dk_restore_cursor.phase)
+                    copy_t2r(cg2_tmem_channel_cell(
+                        tmem_base, tmem_row, warp, 416),
+                        dk_restore_part)
+                    copy_t2r(cg2_tmem_channel_cell(
+                        tmem_base, tmem_row, warp,
+                        480 + qk_stage * 8), raw_k_words)
+                    # instruction_selection: 2 x
+                    # tcgen05.ld.sync.aligned.32x32b.x16.b32
+                    for token in range(16):
+                        rcp(gate_rcp, gate_exp[token], approx=True, ftz=True)
+                        mul(dk_hat, dk_restore_part[token],
+                            gate_last * gate_rcp)
+                        # instruction_selection: rcp.approx.ftz.f32 +
+                        # mul.rn.f32; extent: token
+                        add(dk_regs[token], dk_regs[token], dk_hat)
+                        raw_k = unpack_bf16(raw_k_words, token)
+                        if L2NORM:
+                            mul(raw_k, raw_k,
+                                copy_s2r(norm_f32_byte(
+                                    qk_stage, 1, token)))
+                        fma(dgate_last_kdot_parts[token % 4], raw_k,
+                            dk_hat, dgate_last_kdot_parts[token % 4])
+                    # instruction_selection: cvt.f32.bf16, mul.rn.f32,
+                    # mad.rn.f32; extent: 16 token channels
+                    dk_restore_cursor = advance(dk_restore_cursor)
+
+                wait_edge("dq_acc", dq_cursor.stage, dq_cursor.phase)
+                copy_t2r(cg2_tmem_channel_cell(
+                    tmem_base, tmem_row, warp, 368), dq_part)
+                # instruction_selection:
+                # tcgen05.ld.sync.aligned.32x32b.x16.b32
+                for token in range(16):
+                    mul(dq_regs[token], dq_part[token],
+                        gate_exp[token] * scale)
+                # instruction_selection: mul.rn.f32; extent: 16 tokens
+                dq_cursor = advance(dq_cursor)
+
+                wait_edge("dk_inv_acc", dk_inv_cursor.stage,
+                          dk_inv_cursor.phase)
+                copy_t2r(cg2_tmem_channel_cell(
+                    tmem_base, tmem_row, warp, 400), dk_inv_part)
+                # instruction_selection:
+                # tcgen05.ld.sync.aligned.32x32b.x16.b32
+                for token in range(16):
+                    rcp(gate_rcp, gate_exp[token], approx=True, ftz=True)
+                    add(dk_regs[token], dk_regs[token],
+                        dk_inv_part[token] * gate_rcp)
+                    # instruction_selection: rcp.approx.ftz.f32 + fma/add
+                dk_inv_cursor = advance(dk_inv_cursor)
+
+                wait_edge("dk_decay_acc", dk_decay_cursor.stage,
+                          dk_decay_cursor.phase)
+                copy_t2r(cg2_tmem_channel_cell(
+                    tmem_base, tmem_row, warp, 384), dk_decay_part)
+                # instruction_selection:
+                # tcgen05.ld.sync.aligned.32x32b.x16.b32
+                for token in range(16):
+                    mul(dgate_regs[token], -gate_exp[token],
+                        dk_decay_part[token])
+                    add(dk_regs[token], dk_regs[token], dgate_regs[token])
+                # instruction_selection: neg.f32, mul.rn.f32, add.rn.f32;
+                # extent: 16 tokens
+                dk_decay_cursor = advance(dk_decay_cursor)
+                wait_tmem_load()
+                # instruction_selection: tcgen05.wait::ld.sync.aligned
+                arrive_edge("dqk_acc_done", 0)
+
+                copy_t2r(cg2_tmem_channel_cell(
+                    tmem_base, tmem_row, warp,
+                    448 + qk_stage * 8), raw_q_words)
+                copy_t2r(cg2_tmem_channel_cell(
+                    tmem_base, tmem_row, warp,
+                    480 + qk_stage * 8), raw_k_words)
+                # instruction_selection: 2 x
+                # tcgen05.ld.sync.aligned.32x32b.x8.b32
+                for token in range(16):
+                    raw_q = unpack_bf16(raw_q_words, token)
+                    raw_k = unpack_bf16(raw_k_words, token)
+                    if L2NORM:
+                        mul(raw_q, raw_q,
+                            copy_s2r(norm_f32_byte(qk_stage, 0, token)))
+                        mul(raw_k, raw_k,
+                            copy_s2r(norm_f32_byte(qk_stage, 1, token)))
+                    fma(dgate_regs[token], raw_q, dq_regs[token],
+                        raw_k * (2.0 * dgate_regs[token] - dk_regs[token]))
+                    # instruction_selection: cvt.f32.bf16, fma.rn.f32,
+                    # sub.rn.f32; extent: each token
+                add(dgate_regs[15], dgate_regs[15],
+                    sum(dgate_last_kdot_parts))
+
+                if L2NORM:
+                    # Q projection, kept distinct from K to preserve both
+                    # TMEM column and norm-offset immediates.
+                    for half in range(2):
+                        copy_t2r(cg2_tmem_channel_cell(
+                            tmem_base, tmem_row, warp,
+                            448 + qk_stage * 8 + half * 4), q_half_words)
+                        for pair in range(4):
+                            token = half * 8 + pair * 2
+                            q_pair = unpack_bf16x2(q_half_words[pair])
+                            mul(q_dot[token], dq_regs[token], q_pair.lo)
+                            mul(q_dot[token + 1], dq_regs[token + 1], q_pair.hi)
+                            mul(q_dot[token], q_dot[token],
+                                copy_s2r(norm_f32_byte(qk_stage, 0, token)))
+                            mul(q_dot[token + 1], q_dot[token + 1],
+                                copy_s2r(norm_f32_byte(
+                                    qk_stage, 0, token + 1)))
+                    # instruction_selection: 2 x tcgen05.ld.sync.aligned.
+                    # 32x32b.x4.b32, cvt.f32.bf16, mul.rn.f32x2;
+                    # extent: 16 Q tokens
+                    for step in (1,2,4,8,16):
+                        for token_pair in range(8):
+                            shuffle_xor(q_other.lo,
+                                        q_dot[2 * token_pair], step)
+                            shuffle_xor(q_other.hi,
+                                        q_dot[2 * token_pair + 1], step)
+                            add_packed_f32x2(q_dot[2 * token_pair:
+                                                   2 * token_pair + 2],
+                                             q_other)
+                    # instruction_selection: shfl.sync.bfly.b32 steps
+                    # 1,2,4,8,16 plus add.rn.f32x2 for all token pairs
+                    if lane == 0:
+                        for token in range(16):
+                            copy_r2s(q_dot[token], reduction1_f32_byte(
+                                cg2_warp, token))
+                    barrier(2, 128)
+                    for half in range(2):
+                        copy_t2r(cg2_tmem_channel_cell(
+                            tmem_base, tmem_row, warp,
+                            448 + qk_stage * 8 + half * 4), q_half_words)
+                        for pair in range(4):
+                            token = half * 8 + pair * 2
+                            sum(q_dot_all.lo, [copy_s2r(
+                                reduction1_f32_byte(w, token))
+                                for w in range(4)])
+                            sum(q_dot_all.hi, [copy_s2r(
+                                reduction1_f32_byte(w, token + 1))
+                                for w in range(4)])
+                            q_pair = unpack_bf16x2(q_half_words[pair])
+                            q_norm_lo = copy_s2r(norm_f32_byte(
+                                qk_stage, 0, token))
+                            q_norm_hi = copy_s2r(norm_f32_byte(
+                                qk_stage, 0, token + 1))
+                            mul(q_unit.lo, q_pair.lo, q_norm_lo)
+                            mul(q_unit.hi, q_pair.hi, q_norm_hi)
+                            mul(dq_regs[token],
+                                dq_regs[token] - q_unit.lo * q_dot_all.lo,
+                                q_norm_lo)
+                            mul(dq_regs[token + 1],
+                                dq_regs[token + 1]
+                                - q_unit.hi * q_dot_all.hi, q_norm_hi)
+                    # instruction_selection: 2 x tcgen05.ld .x4,
+                    # ld.shared.f32, add/mul/sub.rn.f32x2; extent: Q projection
+                    barrier(2, 128)
+
+                    # K projection is the same fixed instruction sequence at
+                    # the distinct K-raw columns and K-norm offset.
+                    for half in range(2):
+                        copy_t2r(cg2_tmem_channel_cell(
+                            tmem_base, tmem_row, warp,
+                            480 + qk_stage * 8 + half * 4), k_half_words)
+                        for pair in range(4):
+                            token = half * 8 + pair * 2
+                            k_pair = unpack_bf16x2(k_half_words[pair])
+                            mul(k_dot[token], dk_regs[token], k_pair.lo)
+                            mul(k_dot[token + 1], dk_regs[token + 1], k_pair.hi)
+                            mul(k_dot[token], k_dot[token],
+                                copy_s2r(norm_f32_byte(qk_stage, 1, token)))
+                            mul(k_dot[token + 1], k_dot[token + 1],
+                                copy_s2r(norm_f32_byte(
+                                    qk_stage, 1, token + 1)))
+                    # instruction_selection: 2 x tcgen05.ld.sync.aligned.
+                    # 32x32b.x4.b32, cvt.f32.bf16, mul.rn.f32x2;
+                    # extent: 16 K tokens
+                    for step in (1,2,4,8,16):
+                        for token_pair in range(8):
+                            shuffle_xor(k_other.lo,
+                                        k_dot[2 * token_pair], step)
+                            shuffle_xor(k_other.hi,
+                                        k_dot[2 * token_pair + 1], step)
+                            add_packed_f32x2(k_dot[2 * token_pair:
+                                                   2 * token_pair + 2],
+                                             k_other)
+                    if lane == 0:
+                        for token in range(16):
+                            copy_r2s(k_dot[token], reduction1_f32_byte(
+                                cg2_warp, token))
+                    barrier(2, 128)
+                    for half in range(2):
+                        copy_t2r(cg2_tmem_channel_cell(
+                            tmem_base, tmem_row, warp,
+                            480 + qk_stage * 8 + half * 4), k_half_words)
+                        for pair in range(4):
+                            token = half * 8 + pair * 2
+                            sum(k_dot_all.lo, [copy_s2r(
+                                reduction1_f32_byte(w, token))
+                                for w in range(4)])
+                            sum(k_dot_all.hi, [copy_s2r(
+                                reduction1_f32_byte(w, token + 1))
+                                for w in range(4)])
+                            k_pair = unpack_bf16x2(k_half_words[pair])
+                            k_norm_lo = copy_s2r(norm_f32_byte(
+                                qk_stage, 1, token))
+                            k_norm_hi = copy_s2r(norm_f32_byte(
+                                qk_stage, 1, token + 1))
+                            mul(k_unit.lo, k_pair.lo, k_norm_lo)
+                            mul(k_unit.hi, k_pair.hi, k_norm_hi)
+                            mul(dk_regs[token],
+                                dk_regs[token] - k_unit.lo * k_dot_all.lo,
+                                k_norm_lo)
+                            mul(dk_regs[token + 1],
+                                dk_regs[token + 1]
+                                - k_unit.hi * k_dot_all.hi, k_norm_hi)
+                    # instruction_selection: 2 x tcgen05.ld .x4,
+                    # ld.shared.f32, add/mul/sub.rn.f32x2; extent: K projection
+                    barrier(2, 128)
+
+                wait_tmem_load()
+                # instruction_selection: tcgen05.wait::ld.sync.aligned
+                arrive_edge("qk_raw_done", qk_stage)
+
+                wait_edge("dq_store_done", 0, dq_output_cursor.phase)
+                wait_edge("dk_store_done", 0, dk_output_cursor.phase)
+                for token in range(16):
+                    cast(dq_bf16, dq_regs[token])
+                    cast(dk_bf16, dk_regs[token])
+                    # instruction_selection: cvt.rn.bf16.f32 for dQ and dK;
+                    # extent: one scalar per token and key-channel thread
+                    copy_r2s(dq_bf16, dq_output_bf16_byte(token, channel))
+                    copy_r2s(dk_bf16, dk_output_bf16_byte(token, channel))
+                    # instruction_selection: st.shared.u16; vectorized as
+                    # st.shared.v4.b32 across each eight-channel group
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("dq_store_ready", 0)
+                arrive_edge("dk_store_ready", 0)
+                dq_output_cursor = advance(dq_output_cursor)
+                dk_output_cursor = advance(dk_output_cursor)
+
+                if has_dstate and chunk >= FIRST_STATE_CHUNK:
+                    add(dgate_regs[15], dgate_regs[15],
+                        gate_last * dgate_last_value)
+                suffix = 0.0
+                for reverse_token in range(16):
+                    token = 15 - reverse_token
+                    add(suffix, suffix, dgate_regs[token])
+                    assign(dgate_regs[token], suffix)
+                # Strict sequential register suffix; no shuffle and no
+                # SAFE_GATE derivative is applied in this role.  Instruction
+                # selection is 16 ordered add.rn.f32 operations.
+                wait_edge("dgate_store_done", 0,
+                          dgate_output_cursor.phase)
+                for token in range(16):
+                    copy_r2s(dgate_regs[token],
+                             dgate_output_f32_byte(token, channel))
+                    # instruction_selection: st.shared.f32; vectorized as
+                    # st.shared.v4.b32 for each four-channel group
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("dgate_store_ready", 0)
+                dgate_output_cursor = advance(dgate_output_cursor)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+        arrive_edge("tmem_done", 0)
+
+    elif 4 <= warp <= 7:
+        # --------------------------------------------------------------
+        # CG1, source lines 2109..2544; anchor PTX 8330..end
+        # --------------------------------------------------------------
+        set_register_budget("increase", 168)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 168; extent: warpgroup
+        barrier(3,416)
+        # instruction_selection: barrier.sync 3, 416; extent: TMEM users
+        cg1_warp = warp - 4
+        token_row_coord = (lane // 16) * 8 + (lane & 7)
+        value_col_offset = ((lane // 8) & 1) * 8
+        value_dim = cg1_warp * 32 + lane
+        value_dim_base = cg1_warp * 32
+        cg1_linear_thread = cg1_warp * 32 + lane
+        tile = cta
+        sched = consumer_cursor(stages=8, phase=0)
+        raw_cursor = consumer_cursor(stages=2, phase=0)
+        state_k_cursor = consumer_cursor(stages=1, phase=0)
+        u_acc_cursor = consumer_cursor(stages=1, phase=0)
+        du_acc_cursor = consumer_cursor(stages=1, phase=0)
+        dy_acc_cursor = consumer_cursor(stages=1, phase=0)
+        dstate_acc_cursor = consumer_cursor(stages=1, phase=0)
+        dstate_reuse_cursor = consumer_cursor(stages=1, phase=1)
+        dbeta_m_cursor = consumer_cursor(stages=1, phase=0)
+        dv_reuse_cursor = consumer_cursor(stages=2, phase=1)
+        chunk_serial_base = 0
+        while tile < total_tiles:
+            item = decode_work(tile)
+            num_compute_chunks = item.cend - item.wstart
+            if USE_DSTATE_IN and num_compute_chunks > 0:
+                wait_edge("dstate_smem_done", 0, dstate_reuse_cursor.phase)
+                wait_edge("dstate_smem_cg2_done", 0,
+                          dstate_reuse_cursor.phase)
+                seed_true = item.cend == item.num_chunks
+                for key in range(128):
+                    copy_g2r(d_final_state[
+                        item.batch, item.head, value_dim, key],
+                        seed_regs[key])
+                # instruction_selection: ld.global.L1::no_allocate.v4.b32;
+                # extent: 32x128 stripe
+                select(dstate_regs, seed_true, seed_regs, 0.0)
+                for key_sub16 in range(8):
+                    copy_r2t(dstate_regs[key_sub16],
+                             cg1_dstate_tmem_cell(
+                                 tmem_base, tmem_row, warp,
+                                 key_sub16 * 16), dtype="f32")
+                    cast(dstate_bf16_words,
+                         dstate_regs[key_sub16])
+                    copy_r2t(dstate_bf16_words,
+                             cg1_dstate_tmem_cell(
+                                 tmem_base, tmem_row, warp,
+                                 128 + key_sub16 * 8), dtype="bf16")
+                # instruction_selection: 8 x tcgen05.st.sync.aligned.
+                # 32x32b.x16.b32 FP32 plus 8 x .x8.b32 packed BF16
+                wait_tmem_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive_edge("dstate_input", 0)
+                for key_sub16 in range(8):
+                    copy_t2r(cg1_dstate_tmem_cell(
+                        tmem_base, tmem_row, warp,
+                        128 + key_sub16 * 8), dstate_bf16_words)
+                    for half8 in range(2):
+                        copy_r2s(dstate_bf16_words[half8],
+                                 dstate_direct_bf16_byte(
+                                     value_dim,
+                                     key_sub16 * 16 + half8 * 8))
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
+                # plus st.shared.v4.b32; extent: all 128 keys for one value row
+                # Re-read the published TMEM input; do not repack registers.
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("dstate_smem", 0)
+                dstate_reuse_cursor = advance(dstate_reuse_cursor)
+
+            for chunk in reverse_range(item.cend - 1, item.wstart - 1):
+                serial = chunk_serial_base + item.cend - 1 - chunk
+                local_rev = item.cend - 1 - chunk
+                raw_stage = serial % 2
+                beta_stage_id = serial % 4
+                dv_stage_id = serial % 2
+                raw_phase = (serial // 2) & 1
+                beta_phase = (serial // 4) & 1
+                has_state = chunk >= FIRST_STATE_CHUNK
+                has_dstate = local_rev > 0 or USE_DSTATE_IN
+                wait_edge("v_ready", raw_stage, raw_phase)
+                copy_s2r(v_raw_bf16_byte(
+                    raw_stage, token_row_coord,
+                    value_dim_base + value_col_offset), v_regs.lo)
+                copy_s2r(v_raw_bf16_byte(
+                    raw_stage, token_row_coord,
+                    value_dim_base + 16 + value_col_offset), v_regs.hi)
+                # instruction_selection: 2 x
+                # ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16; extent:
+                # exact COL-layout lane bases for the two value halves
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("v_done", raw_stage)
+                wait_edge("beta_ready", beta_stage_id, beta_phase)
+                for half in range(2):
+                    token0 = ((half * 4 + (lane & 3)) ^ 4) * 2
+                    copy_s2r(beta_f32_byte(beta_stage_id, token0),
+                             beta_regs[half].lo)
+                    copy_s2r(beta_f32_byte(beta_stage_id, token0 + 1),
+                             beta_regs[half].hi)
+                # instruction_selection: four ld.shared.f32; extent: exact
+                # lane-permuted beta pairs
+                cast(beta_bf16x2, beta_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: token pairs
+                if has_state:
+                    wait_edge("state_k_acc", state_k_cursor.stage,
+                              state_k_cursor.phase)
+                    copy_t2r(cg1_projection_tmem_cell(
+                        tmem_base, tmem_row, warp, 0, 320),
+                        state_k_regs.lo)
+                    copy_t2r(cg1_projection_tmem_cell(
+                        tmem_base, tmem_row, warp, 1, 320),
+                        state_k_regs.hi)
+                    # instruction_selection: 2 x
+                    # tcgen05.ld.sync.aligned.16x256b.x2.b32
+                    cast(state_k_bf16x2, state_k_regs)
+                    # instruction_selection: cvt.rn.bf16x2.f32
+                    sub_bf16x2(diff_bf16x2, v_bf16x2, state_k_bf16x2)
+                    # instruction_selection: sub.bf16x2
+                    state_k_cursor = advance(state_k_cursor)
+                else:
+                    assign(diff_bf16x2, v_bf16x2)
+                mul_bf16x2(y_bf16x2, beta_bf16x2, diff_bf16x2)
+                # instruction_selection: mul.bf16x2; extent: packed token pairs
+                copy_r2t(y_bf16x2.lo,
+                         cg1_tmem_cell_lo(tmem_base, tmem_row, 432))
+                copy_r2t(y_bf16x2.hi,
+                         cg1_tmem_cell_hi(tmem_base, tmem_row, 432))
+                # instruction_selection: 2 x
+                # tcgen05.st.sync.aligned.16x128b.x4.b32
+                wait_tmem_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive_edge("y_input", 0)
+
+                wait_edge("du_acc", du_acc_cursor.stage, du_acc_cursor.phase)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 0, 352), du_regs.lo)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 1, 352), du_regs.hi)
+                # instruction_selection: 2 x
+                # tcgen05.ld.sync.aligned.16x256b.x2.b32
+                cast(du_bf16, du_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: packed fragment
+                copy_r2t(du_bf16.lo,
+                         cg1_tmem_cell_lo(tmem_base, tmem_row, 440))
+                copy_r2t(du_bf16.hi,
+                         cg1_tmem_cell_hi(tmem_base, tmem_row, 440))
+                # instruction_selection: 2 x
+                # tcgen05.st.sync.aligned.16x128b.x4.b32
+                wait_tmem_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive_edge("du_input", 0)
+                du_acc_cursor = advance(du_acc_cursor)
+
+                wait_edge("u_acc", u_acc_cursor.stage, u_acc_cursor.phase)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 0, 336), u_regs.lo)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 1, 336), u_regs.hi)
+                # instruction_selection: 2 x
+                # tcgen05.ld.sync.aligned.16x256b.x2.b32
+                cast(u_bf16, u_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: packed fragment
+                copy_r2s(u_bf16.lo, raw_bf16_byte(
+                    U_BASE, 0, token_row_coord,
+                    value_dim_base + value_col_offset))
+                copy_r2s(u_bf16.hi, raw_bf16_byte(
+                    U_BASE, 0, token_row_coord,
+                    value_dim_base + 16 + value_col_offset))
+                # instruction_selection: 2 x stmatrix.sync.aligned.
+                # m8n8.x4.trans.shared.b16; extent: exact lane bases
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("u_smem", 0)
+                u_acc_cursor = advance(u_acc_cursor)
+
+                wait_edge("dy_acc", dy_acc_cursor.stage, dy_acc_cursor.phase)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 0, 320), dy_regs.lo)
+                copy_t2r(cg1_projection_tmem_cell(
+                    tmem_base, tmem_row, warp, 1, 320), dy_regs.hi)
+                # instruction_selection: 2 x
+                # tcgen05.ld.sync.aligned.16x256b.x2.b32
+                cast(dy_bf16, dy_regs)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: packed fragment
+                copy_r2s(dy_bf16.lo, raw_bf16_byte(
+                    DY_BASE, 0, token_row_coord,
+                    value_dim_base + value_col_offset))
+                copy_r2s(dy_bf16.hi, raw_bf16_byte(
+                    DY_BASE, 0, token_row_coord,
+                    value_dim_base + 16 + value_col_offset))
+                # instruction_selection: 2 x stmatrix.sync.aligned.
+                # m8n8.x4.trans.shared.b16; extent: exact lane bases
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("dy_smem", 0)
+                dy_acc_cursor = advance(dy_acc_cursor)
+                beta_c0 = copy_s2r(beta_f32_byte(
+                    beta_stage_id, (lane % 4) * 2))
+                beta_c1 = copy_s2r(beta_f32_byte(
+                    beta_stage_id, (lane % 4) * 2 + 1))
+                beta_c8 = copy_s2r(beta_f32_byte(
+                    beta_stage_id, (lane % 4) * 2 + 8))
+                beta_c9 = copy_s2r(beta_f32_byte(
+                    beta_stage_id, (lane % 4) * 2 + 9))
+                # instruction_selection: four ld.shared.f32; extent: exact
+                # beta scalars latched before beta_done
+                beta_self = 0.0
+                if BETA_SIGMOID and cg1_linear_thread < 16:
+                    beta_self = copy_s2r(
+                        beta_f32_byte(beta_stage_id, cg1_linear_thread))
+                arrive_edge("beta_done", beta_stage_id)
+                # 128 CG1 arrivals join the super warp's 32 arrivals.
+
+                for pair in range(4):
+                    beta_lo = select(pair * 2 >= 4, beta_c8, beta_c0)
+                    beta_hi = select(pair * 2 >= 4, beta_c9, beta_c1)
+                    fmul2(beta_dy.lo[pair],
+                          dy_regs.lo[2 * pair], dy_regs.lo[2 * pair + 1],
+                          beta_lo, beta_hi)
+                    fmul2(beta_dy.hi[pair],
+                          dy_regs.hi[2 * pair], dy_regs.hi[2 * pair + 1],
+                          beta_lo, beta_hi)
+                    sub(neg_beta_dy.lo[pair], 0.0, beta_dy.lo[pair])
+                    sub(neg_beta_dy.hi[pair], 0.0, beta_dy.hi[pair])
+                # sDv/GEMM13 consume the same values.  Instruction selection:
+                # mul.rn.f32x2 and neg.f32; extent: both value halves
+                cast(neg_beta_dy_bf16, neg_beta_dy)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: fragment
+                copy_r2t(neg_beta_dy_bf16.lo,
+                         cg1_tmem_cell_lo(tmem_base, tmem_row, 432))
+                copy_r2t(neg_beta_dy_bf16.hi,
+                         cg1_tmem_cell_hi(tmem_base, tmem_row, 432))
+                # instruction_selection: 2 x
+                # tcgen05.st.sync.aligned.16x128b.x4.b32
+                wait_tmem_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive_edge("neg_beta_dy_input", 0)
+
+                # dBeta value term is accumulated before waiting for the dV
+                # output stage, exactly preserving source issue order.
+                fill(dbeta_value_parts[0:4], 0.0)
+                for pair in range(4):
+                    unpack_bf16x2(diff0_lo, diff0_hi,
+                                  diff_bf16x2.lo[pair])
+                    unpack_bf16x2(diff1_lo, diff1_hi,
+                                  diff_bf16x2.hi[pair])
+                    token_lo = 2 * (pair // 2)
+                    token_hi = token_lo + 1
+                    ffma2(tmp_lo, tmp_hi,
+                          dy_regs.lo[2 * pair],
+                          dy_regs.lo[2 * pair + 1],
+                          diff0_lo, diff0_hi,
+                          dbeta_value_parts[token_lo],
+                          dbeta_value_parts[token_hi])
+                    ffma2(dbeta_value_parts[token_lo],
+                          dbeta_value_parts[token_hi],
+                          dy_regs.hi[2 * pair],
+                          dy_regs.hi[2 * pair + 1],
+                          diff1_lo, diff1_hi, tmp_lo, tmp_hi)
+                # instruction_selection: eight ordered paired mad.rn.f32
+                # (FFMA2), first low then high value half for each pair
+
+                # dV is exactly beta*dY; it is both the global output and the
+                # SMEM B operand for logical GEMM 13.
+                wait_edge("dv_store_done", dv_stage_id,
+                          dv_reuse_cursor.phase)
+                cast(dv_bf16, beta_dy)
+                # instruction_selection: cvt.rn.bf16x2.f32; extent: packed fragment
+                copy_r2s(dv_bf16.lo, dv_output_bf16_byte(
+                    dv_stage_id, token_row_coord,
+                    value_dim_base + value_col_offset))
+                copy_r2s(dv_bf16.hi, dv_output_bf16_byte(
+                    dv_stage_id, token_row_coord,
+                    value_dim_base + 16 + value_col_offset))
+                # instruction_selection: 2 x stmatrix.sync.aligned.
+                # m8n8.x4.trans.shared.b16; extent: exact dV lane bases
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                arrive_edge("dv_store_ready", dv_stage_id)
+                dv_reuse_cursor = advance(dv_reuse_cursor)
+
+                # dBeta is reduced across the four warps.
+                barrier(4, 128)  # dbeta sync 1: all value terms complete
+                wait_edge("dbeta_matrix", dbeta_m_cursor.stage,
+                          dbeta_m_cursor.phase)
+                for step in (4,8,16):
+                    shuffle_xor(dbeta_other, dbeta_value_parts, step)
+                    add(dbeta_value_parts, dbeta_value_parts, dbeta_other)
+                # instruction_selection: shfl.sync.bfly.b32 + add.rn.f32;
+                # extent: steps 4,8,16 for all four token accumulators
+                if lane < 4:
+                    for part in range(4):
+                        token = (lane % 4) * 2 + (part % 2)
+                        token += 8 * (part // 2)
+                        copy_r2s(dbeta_value_parts[part],
+                                 reduction0_f32_byte(cg1_warp, token))
+                    # instruction_selection: four st.shared.f32 from each
+                    # lane 0..3 in every CG1 warp
+                barrier(4, 128)  # dbeta sync 2: shared partials visible
+                if cg1_linear_thread < 16:
+                    sum(dbeta_value, [copy_s2r(reduction0_f32_byte(
+                        producer_warp, cg1_linear_thread))
+                        for producer_warp in range(4)])
+                    add(dbeta_out, dbeta_value,
+                        copy_s2r(beta_matrix_f32_byte(
+                            cg1_linear_thread)))
+                    # instruction_selection: four ld.shared.f32 reductions,
+                    # one dBeta-M ld.shared.f32, add.rn.f32 tree
+                    if BETA_SIGMOID:
+                        mul(dbeta_out, dbeta_out,
+                            beta_self - beta_self * beta_self)
+                        # instruction_selection: fma.rn.f32/mul.rn.f32;
+                        # extent: sigmoid derivative on one output token
+                    if (token_valid(item, chunk, cg1_linear_thread)
+                            and chunk < item.wend):
+                        if BETA_SIGMOID:
+                            cast(dbeta_bf16, dbeta_out)
+                            # instruction_selection: cvt.rn.bf16.f32
+                            copy_r2g(dbeta_bf16,
+                                     dbeta[global_token(
+                                               item, chunk,
+                                               cg1_linear_thread),
+                                           item.head])
+                            # instruction_selection: st.global.b16
+                        else:
+                            copy_r2g(dbeta_out,
+                                     dbeta[global_token(
+                                               item, chunk,
+                                               cg1_linear_thread),
+                                           item.head])
+                            # instruction_selection: st.global.b32
+                barrier(4, 128)  # dbeta sync 3: reduction SMEM reusable
+                dbeta_m_cursor = advance(dbeta_m_cursor)
+
+                wait_edge("dstate_acc", dstate_acc_cursor.stage,
+                          dstate_acc_cursor.phase)
+                if local_rev + 1 < num_compute_chunks:
+                    wait_edge("dstate_smem_done", 0,
+                              dstate_reuse_cursor.phase)
+                    wait_edge("dstate_smem_cg2_done", 0,
+                              dstate_reuse_cursor.phase)
+                    for key_sub32 in range(4):
+                        copy_t2r(cg1_dstate_tmem_cell(
+                            tmem_base, tmem_row, warp,
+                            key_sub32 * 32), dstate_regs, dtype="f32")
+                        cast(dstate_bf16_words, dstate_regs)
+                        copy_r2t(dstate_bf16_words,
+                                 cg1_dstate_tmem_cell(
+                                     tmem_base, tmem_row, warp,
+                                     128 + key_sub32 * 16),
+                                 dtype="bf16")
+                    # instruction_selection: four tcgen05.ld .x32 FP32,
+                    # BF16 pack, then four tcgen05.st .x16
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned
+                    arrive_edge("dstate_input", 0)
+                    for key_sub32 in range(4):
+                        copy_t2r(cg1_dstate_tmem_cell(
+                            tmem_base, tmem_row, warp,
+                            128 + key_sub32 * 16), dstate_bf16_words)
+                        for half8 in range(4):
+                            copy_r2s(dstate_bf16_words[half8],
+                                     dstate_direct_bf16_byte(
+                                         value_dim,
+                                         key_sub32 * 32 + half8 * 8))
+                    # instruction_selection: four tcgen05.ld .x16 and
+                    # st.shared.v4.b32; extent: 128 key elements
+                    fence("async_shared_cta")
+                    # instruction_selection: fence.proxy.async.shared::cta; extent: warpgroup
+                    arrive_edge("dstate_smem", 0)
+                    dstate_reuse_cursor = advance(dstate_reuse_cursor)
+                dstate_acc_cursor = advance(dstate_acc_cursor)
+                raw_cursor = advance(raw_cursor)
+
+            if WRITE_DSTATE0:
+                if num_compute_chunks > 0 and item.wstart == 0:
+                    for key_sub32 in range(4):
+                        copy_t2r(cg1_dstate_tmem_cell(
+                            tmem_base, tmem_row, warp, key_sub32 * 32),
+                            dstate0_regs[key_sub32], dtype="f32")
+                    for key in range(128):
+                        copy_r2g(dstate0_regs[key], d_initial_state[
+                            item.batch, item.head, value_dim, key])
+                    # instruction_selection: tcgen05.ld.sync.aligned.
+                    # 32x32b.x32.b32 then st.global.v4.b32; extent: 128 keys
+                elif num_compute_chunks == 0:
+                    for key in range(128):
+                        if USE_DSTATE_IN:
+                            copy_g2g(d_final_state[
+                                item.batch, item.head, value_dim, key],
+                                d_initial_state[
+                                    item.batch, item.head, value_dim, key])
+                        else:
+                            copy_r2g(0.0, d_initial_state[
+                                item.batch, item.head, value_dim, key])
+                    # instruction_selection: ld.global/st.global.v4.b32 or
+                    # st.global.v4.b32 zero; extent: 128 keys
+                # When num_compute_chunks>0 and wstart!=0, this split item does
+                # not own dInitial and intentionally performs no store.
+            arrive_edge("dstate0_stored", 0)
+            chunk_serial_base += item.cend - item.wstart
+            tile, sched = scheduler_consume_at_tile_exit(sched, tile)
+        arrive_edge("tmem_done", 0)
+```
+
+## Logical tcgen05 GEMMs
+
+Every row is one primitive `gemm` occurrence above.  A row may emit a fixed
+loop of the same `tcgen05.mma.cta_group::1.kind::f16` family; publication is a
+separate `tcgen05.commit` operation.
+
+| # | FP32 TMEM destination | A operand | B operand | MxNxK | runtime issues | accumulate |
+| ---: | --- | --- | --- | --- | ---: | --- |
+| 1 | state-K col 320 | state SMEM direct | K-decay SMEM transpose | 128x16x128 | 8 | no |
+| 2 | dQ col 368 | state-input TMEM transpose | dO SMEM transpose | 128x16x128 | 8 | no |
+| 3 | dU col 352 | dState-input TMEM transpose | K-restore SMEM lead16 | 128x16x128 | 8 | no |
+| 4 | dState col 0 | dState-input TMEM transpose | state-scale diagonal SMEM | 128x128x128 | 8 | no |
+| 5 | dU col 352 | dO SMEM transpose | A SMEM lead16 | 128x16x16 | 1 | yes |
+| 6 | dState col 0 | dO SMEM transpose | Q-decay SMEM lead16 | 128x128x16 | 1 | yes |
+| 7 | U col 336 | Y-input TMEM transpose | T-inverse SMEM lead16 | 128x16x16 | 1 | no |
+| 8 | dY/state-K col 320 | dU-input TMEM transpose | T-inverse SMEM transpose | 128x16x16 | 1 | no |
+| 9 | dK-restore col 416 | dState SMEM alternate transpose | U SMEM lead16 transpose | 128x16x128 | 8 | no |
+| 10 | dState col 0 | negative-beta-dY TMEM transpose | K-decay SMEM lead16 | 128x128x16 | 1 | yes |
+| 11 | dK-inverse col 400 | Q-decay SMEM transpose | dA SMEM lead16 | 128x16x16 | 1 | no |
+| 12 | dQ col 368 | K-inverse SMEM A-major | dA SMEM | 128x16x16 | 1 | yes |
+| 13 | dK-decay col 384 | state-input TMEM transpose | beta-dY (`sDv`) SMEM lead16 | 128x16x128 | 8 | no |
+| 14 | dK-inverse col 400 | K-decay SMEM transpose | negative-dM SMEM lead16 | 128x16x16 | 1 | yes |
+| 15 | dK-decay col 384 | K-inverse SMEM A-major | dM SMEM | 128x16x16 | 1 | yes |
+
+The runtime issue vector is exactly `8,8,8,8,1,1,1,1,8,1,1,1,8,1,1`.
+The debug anchor contains 59 static `tcgen05.mma` instruction lines: the 57
+runtime issues plus the mutually-exclusive duplicate static predicate sites
+for rows 12 and 15.  The delayed publication list has exactly 17 mbarrier
+arrivals (2+2+1+2+2+1+2+1+3); no other logical row commits.
+
+## Source/PTX/sketch correspondence
+
+`basic-main` and `basic-prologue` below name the two PTX files in
+`source_export/basic_debug_001`; all other labels name the sole main or
+prologue PTX in the stated independent export directory.  Thus every PTX
+range has one unambiguous file even though generated filenames contain the
+full specialization.
+
+| Source action | Source line(s) | Exact PTX evidence | Sketch line(s) |
+| --- | ---: | ---: | ---: |
+| order generation/scratch sorting | 2920..3054; `split_k.py` 574..712 | order tables below | 143..263 |
+| sequence descriptor arrays 0..8 | 2865..2900; `thd.py` 50..99 | basic-prologue 140..end, nine repeated bodies | 264..289 |
+| checkpoint prefix descriptor array 9 | 2901..2918; `thd.py` 50..99 | basic-prologue final repeated body | 290..311 |
+| main ABI and exact rank-1 arena offsets | 3198..3271 | basic-main 35..101 | 321..372 |
+| raw/state/output byte mappings | 3272..3298 and role-local address expressions | basic-main address arithmetic in each role range | 373..501 |
+| seven raw shared-descriptor encodings | 3299..3395 | descriptor immediates at tcgen sites 2019..3257 | 502..712 |
+| TMEM row/column and register lane coordinates | 638..661, 913..1217, 1700..1740, 2119..2150, 2568..2580 | basic-main 650..8329 role-local TMEM/ldmatrix/stmatrix operands | 537..712 |
+| initialize all 115 words | 187..268, 3396..3486, `barrier.py` 183 | basic-main 102..266 | 715..796 |
+| mbarrier-init fence / CTA sync | 3487..3488 | basic-main 285,287 | 797..800 |
+| scheduler publish/consume | 267..297, `split_k.py` 524..572 | dynamic-main rows below | 845..876; publish 916; consume 1141,1378,1600,1939,2307,2716 |
+| TMA descriptor acquire + Q/K/Gate/dO/V | 1521..1682 | basic-main 291..613 | 903..974 |
+| checkpoint TMA | 1683..1696 | basic-main 614..629 | 976..990 |
+| super KK register GEMM | 689..719 | basic-main 752..930 | 1012..1028 |
+| beta-strict L and three inverse rounds | 720..799 | basic-main 931..1502 | 1030..1078 |
+| dM, strict +/- tiles, dBeta-M | 800..871 | basic-main 1503..1855 | 1080..1139 |
+| TMEM allocation/lifetime barrier | 903..905 | basic-main 1886..1891 | 1149..1154 |
+| tcgen GEMM 1 | 1251..1266 | basic-main 2019..2159 | 1185..1199 |
+| tcgen GEMM 2 | 1267..1286 | basic-main 2218..2315 | 1201..1216 |
+| tcgen GEMM 3 | 1287..1304 | basic-main 2359..2450 | 1218..1230 |
+| tcgen GEMM 4 | 1305..1323 | basic-main 2472..2577 | 1231..1241 |
+| tcgen GEMMs 5/6 | 1324..1345 | basic-main 2610,2637 | 1243..1260 |
+| tcgen GEMMs 7/8 | 1346..1385 | basic-main 2671,2698 | 1262..1280 |
+| tcgen GEMM 9 | 1386..1402 | basic-main 2747..2929 | 1282..1296 |
+| tcgen GEMMs 10/11 | 1403..1431 | basic-main 2967,3004 | 1298..1314 |
+| tcgen GEMM 12, two static sites | 1432..1452 | basic-main 3028,3044 | 1316..1330 |
+| tcgen GEMM 13 + state-input release | 1453..1471 | basic-main 3084..3181 | 1332..1346 |
+| tcgen GEMMs 14/15 | 1472..1505 | basic-main 3221,3243,3257 | 1348..1372 |
+| dState0 gate and TMEM teardown | 1506..1519 | basic-main 3298..3302 | 1374..1387 |
+| epilogue A register GEMM/mask/store | 333..484 | basic-main 3495..3650 | 1423..1456 |
+| epilogue dA register GEMM/mask/store | 485..536 | basic-main 3747..3899 | 1458..1496 |
+| one-behind/tail output TMA ladder | 537..620 | basic-main 4139..4245 | 1498..1598 |
+| CG0 beta, gate, raw Q/K | 1782..1922 | basic-main 4498..5163 | 1651..1779 |
+| CG0 L2 and four rounded operands | 1923..2072 | basic-main 5164..5871 plus l2 rows below | 1781..1904 |
+| CG0 unchanged state publication | 2073..2107 | basic-main 5902..6257 | 1906..1937 |
+| CG2 state-dot and four drains | 2609..2736 | basic-main 6425..8002 | 1977..2133 |
+| CG2 L2 Q/K projections | 2737..2776 | l2norm-main rows below | 2135..2260 |
+| CG2 dQ/dK/dGate staging | 2777..2823 | basic-main 8003..8295 | 2266..2305 |
+| CG1 dFinal seed/Y/dU/U/dY | 2165..2374 | state-main/basic-main rows below | 2339..2510 |
+| CG1 beta-dY/dV/dBeta | 2375..2474 | basic-main 9077..9437; beta rows below | 2511..2647 |
+| CG1 next-dState/dInitial | 2475..2544 | state-main rows below | 2649..2717 |
+
+### Independent accepted-branch rows
+
+| Frozen profile | Source branch | Exact independent-export PTX rows | Sketch line(s) |
+| --- | ---: | ---: | ---: |
+| `tail` | input TMA zero-fill 1643..1696; beta/gate scalar predicates 1782..1847; dBeta scalar predicate 2463..2473; output ownership 537..620 | basic-main 380..629 (unconditional TMA), 4139..4245 (output), 4450..4967 (beta/gate), 9380..9450 (dBeta) | TMA 929..974; output 1498..1598; beta/gate 1648..1699; dBeta 2628..2645 |
+| `grouped` | head ratios at 1625..1628 | grouped-main 322..349 (signed ratio divisions before descriptor addresses 351..366) | 917..918 |
+| `safe_gate` | 1762..1873 | safe_gate-main 4421..4967, `.loc 1 1762..1873` | 1630..1637,1686..1694 |
+| `beta_sigmoid` beta | 1782..1807 | beta_sigmoid-main 4497..4507, `.loc 1 1782..1807` | 1654..1676 |
+| `beta_sigmoid` dBeta | 2462..2473 | beta_sigmoid-main 9419..9463, `.loc 1 2462..2473` | 2623..2645 |
+| `l2norm` forward | 1923..1972 | l2norm-main 5190..5377, `.loc 1 1923..1972` | 1781..1826 |
+| `l2norm` backward | 2737..2776 | l2norm-main 8385..9991, `.loc 1 2737..2776` | 2135..2260 |
+| `state` seed | 2165..2226 | state-main 8375..11044, `.loc 1 2165..2226` | 2339..2382 |
+| `state` recurrence/output | 2475..2543 | state-main 10193..11562, `.loc 1 2475..2543` | 2649..2717 |
+| `dynamic` | 267..297 | dynamic-main 358..376, 1944..1948, 3399..3403, 4439..4443, 6476..6480, 8548..8552, 10460..10464 | 845..876; 916,1141,1378,1600,1939,2307,2716 |
+| `order_scratch` | `split_k.py` 574..712 | order_scratch-prologue 115..1055, `.loc 3 574..712` | 143..263 |
+| `order_generate` | `split_k.py` 574..712 | order_generate-prologue 116..888, `.loc 3 574..712` | 143..263 |
+
+The forward and reverse lookup is exhaustive at action granularity: every
+storage construction, accepted compile-time branch, main role, synchronization
+edge family, and logical tcgen row has exactly one owner above.  In the debug
+anchor, `.file` 1 is the primary KDA source, file 4 barrier helpers, file 5
+split-K scheduling, file 6 TMA helpers, file 7 MMA helpers, and file 8
+pointwise helpers.  Independent prologue exports number their inlined split-K
+file as 3, which is why the two order rows cite `.loc 3` explicitly.
+
+## Static opcode evidence
+
+| Static instruction family | Count | Sketch owner |
+| --- | ---: | --- |
+| `mbarrier.init.shared.b64` | 115 | distributed protocol initialization |
+| `mbarrier.try_wait.parity.acquire...` | 74 | `wait_edge` sites |
+| `mbarrier.arrive.shared.b64` | 45 | thread publication/reuse sites |
+| `mbarrier.arrive.expect_tx.shared.b64` | 6 | TMA transaction starts |
+| `tcgen05.mma...kind::f16` | 59 | warp 13 logical GEMMs |
+| `tcgen05.commit...mbarrier` | 17 | warp 13 publication |
+| `mma.sync...m16n8k16...bf16` | 76 | warps 12 and 15 |
+| rank-3 TMA GMEM->SMEM | 12 | warp 14 raw loads |
+| rank-4 TMA GMEM->SMEM | 2 | warp 14 checkpoint load |
+| rank-3 TMA SMEM->GMEM | 20 | warp 15 store ladder |
+| `tcgen05.alloc/relinquish/dealloc` | 1 each | warp 13 lifecycle |
+
+## TIRx module and validation contract
+
+The implementation must import device language only as
+`import tirx_kernels.kern as K`.  Device code may not use `T`, `Tx`, `I`, any
+`tirx.tile.*` API, a tile primitive, a first-class layout, or rank>1 SMEM.
+The one `u8[196608]` arena and the integer offsets above are part of the frozen
+translation.  `K.smem_pool(base=arena)` may allocate only the 920-byte protocol
+header; all data mappings are raw integer address arithmetic.
+
+`get_kernel` returns the prologue and main launch in order.  `prepare_data` and
+the reference adapter build identical logical inputs but separate output and
+workspace storage.  Correctness covers every accepted capability profile,
+ragged BT tails, head ratios, state gradients, scheduler/order modes, direct
+expanded outputs, and source plus FP64 recurrence references.  Benchmark timing
+contains only the source `run_bwd` prologue+main and the matching two TIRx
+launches; checkpoint/table construction remains outside the timed closure.
+
+The benchmark suite is the only performance authority.  Low-level PTX/SASS or
+profiler evidence may explain a candidate but cannot pass or select it.
+
+## Instruction-selection summary
+
+- Explicit one-dimensional placement plus byte offsets selects dynamic SMEM;
+  integer swizzle bits and leading/stride constants select the same operand
+  descriptor forms as the source without materializing a layout.
+- Rank-3 and rank-4 TensorMap dimensionality, BF16/FP32 box widths, completion
+  barriers, and 128-byte swizzle select the TMA families.
+- Integer TMEM columns, CTA-group 1, BF16 operands, FP32 destinations, and the
+  fixed logical M/N/K loops select the 59 `tcgen05.mma` sites.
+- The exact warp-role chain, register targets, named-barrier counts, stage
+  phases, persistent scheduler, one-behind stores, and teardown determine issue
+  order; none is inferred from opcode counts alone.

--- a/.agents/skills/tirx-codegen-tuning/references/db/elide-tail-predicates-only-when-the-specialization-proves-full-tiles.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/elide-tail-predicates-only-when-the-specialization-proves-full-tiles.md
@@ -1,0 +1,60 @@
+# Elide tail predicates only when the specialization proves full tiles
+
+**Symptoms:** `excess_guard_math`, `branch_in_hot_loop`, `dispatch_specific_deficit`, `instruction_count_gap`
+
+## Symptom
+
+A shape-specialized kernel keeps per-element tail compares and selects even
+when every sequence admitted by that specialization is an exact multiple of
+the processing tile.  The redundant guards sit in the hot loop of one critical
+warp role, while ragged specializations still genuinely need them.
+
+## What to change
+
+Derive a compile-time full-tile fact from the exact specialization inputs and
+split the emitted code.  Keep the guarded fallback intact for every
+specialization that can receive a partial tile.
+
+```python
+full_tiles = all(int(length) % TILE == 0 for length in config["seq_lens"])
+
+if full_tiles:
+    K.assign(value, transformed)
+else:
+    K.assign(value, K.if_then_else(index < runtime_extent, transformed, zero))
+```
+
+## Rationale
+
+A runtime predicate whose result is statically known still costs compare,
+predicate, and select instructions unless the specialization exposes the proof
+to tracing.  Removing that work from a drain-bound warp can shorten the whole
+persistent pipeline even when the guarded reference kernel remains generic.
+
+In the SM100 KDA backward safe-gate path, the full-tile specialization removed
+16 `FSEL` sites and all 15 `ISETP.LE.AND` sites in the final SASS.  On the same
+B200 GPU and the same five-round `bench_suite` protocol, the safe workload
+changed from 1642.624 us TIRx / 1616.763 us reference (ratio 0.984256) to
+1584.229 us TIRx / 1616.954 us reference (ratio 1.020656), a 3.686% TIRx
+latency reduction.  The final unspliced eleven-row suite had minimum ratio
+0.994679.
+
+## Boundary
+
+This is valid only when the compiled artifact is tied to the exact static shape
+fact.  Do not infer full tiles from a benchmark sample if the same artifact may
+later receive different runtime sequence lengths.  Do not delete the ragged
+fallback: the KDA `(17, 33)` safe-gate case was separately checked against both
+the standalone source and the mathematical oracle.
+
+Static instruction reduction alone is not the gate.  A related dead-tail
+unrolling change elsewhere reduced static code but regressed its complete
+matrix; isolate this specialization split and let `bench_suite` decide.
+
+## Verification
+
+Confirm in final SASS that the intended compare/select sites disappear only
+from the full-tile specialization.  Run correctness for both an aligned case
+and a ragged fallback, then run the complete frozen workload matrix.  Record
+raw per-side samples from one unspliced `bench_suite` run and require every row,
+not only the affected one, to pass the project ratio gate.

--- a/.agents/skills/tirx-codegen-tuning/references/db/elide-tail-predicates-only-when-the-specialization-proves-full-tiles.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/elide-tail-predicates-only-when-the-specialization-proves-full-tiles.md
@@ -31,12 +31,11 @@ predicate, and select instructions unless the specialization exposes the proof
 to tracing.  Removing that work from a drain-bound warp can shorten the whole
 persistent pipeline even when the guarded reference kernel remains generic.
 
-In the SM100 KDA backward safe-gate path, the full-tile specialization removed
-16 `FSEL` sites and all 15 `ISETP.LE.AND` sites in the final SASS.  On the same
-B200 GPU and the same five-round `bench_suite` protocol, the safe workload
-changed from 1642.624 us TIRx / 1616.763 us reference (ratio 0.984256) to
-1584.229 us TIRx / 1616.954 us reference (ratio 1.020656), a 3.686% TIRx
-latency reduction.  The final unspliced eleven-row suite had minimum ratio
+In one SM100 persistent backward safe-gate path, the full-tile specialization
+removed 16 `FSEL` sites and all 15 `ISETP.LE.AND` sites in the final SASS.  The
+safe workload changed from 1642.624 us TIRx / 1616.763 us reference (ratio
+0.984256) to 1584.229 us TIRx / 1616.954 us reference (ratio 1.020656), a 3.686%
+TIRx latency reduction.  The complete eleven-row matrix had minimum ratio
 0.994679.
 
 ## Boundary
@@ -44,8 +43,8 @@ latency reduction.  The final unspliced eleven-row suite had minimum ratio
 This is valid only when the compiled artifact is tied to the exact static shape
 fact.  Do not infer full tiles from a benchmark sample if the same artifact may
 later receive different runtime sequence lengths.  Do not delete the ragged
-fallback: the KDA `(17, 33)` safe-gate case was separately checked against both
-the standalone source and the mathematical oracle.
+fallback: the `(17, 33)` safe-gate case was separately checked against both the
+standalone source and the mathematical oracle.
 
 Static instruction reduction alone is not the gate.  A related dead-tail
 unrolling change elsewhere reduced static code but regressed its complete
@@ -55,6 +54,5 @@ matrix; isolate this specialization split and let `bench_suite` decide.
 
 Confirm in final SASS that the intended compare/select sites disappear only
 from the full-tile specialization.  Run correctness for both an aligned case
-and a ragged fallback, then run the complete frozen workload matrix.  Record
-raw per-side samples from one unspliced `bench_suite` run and require every row,
-not only the affected one, to pass the project ratio gate.
+and a ragged fallback, then run the complete frozen workload matrix and require
+every row, not only the affected one, to pass the project ratio gate.

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-mixed-precision-fma-operand-widths-to-the-reference.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-mixed-precision-fma-operand-widths-to-the-reference.md
@@ -1,0 +1,68 @@
+# Match mixed-precision FMA operand widths to the reference
+
+**Symptoms:** `instruction_variant_mismatch`, `instruction_count_gap`, `sass_divergence`, `performance_regression`
+
+## Symptom
+
+A recurrence widens stored 16-bit operands to FP32 and feeds packed FP32 FMA,
+while the reference keeps the operands in their 16-bit register form and uses a
+native mixed-precision FMA with an FP32 accumulator. The port then carries
+extra conversions and packed arithmetic even though both inputs were already
+rounded to the narrower format in memory.
+
+## What to change
+
+Keep the narrow carriers live through the multiply and select the same
+mixed-precision FMA form as the reference instead of widening and pairing the
+operands first.
+
+```python
+# before: widen both halves, then tie two independent results to FP32x2.
+a_lo = _bf16_to_f32(_low_half(a_word))
+a_hi = _bf16_to_f32(_high_half(a_word))
+b_lo = _bf16_to_f32(_low_half(b_word))
+b_hi = _bf16_to_f32(_high_half(b_word))
+next_lo, next_hi = _fma_f32x2(a_lo, a_hi, b_lo, b_hi, accum_lo, accum_hi)
+
+# after: the inputs remain BF16 carriers and each result accumulates in FP32.
+a_lo_bits = K.cast(a_word, "uint16")
+a_hi_bits = K.cast(K.shift_right(a_word, K.uint32(16)), "uint16")
+b_lo_bits = K.cast(b_word, "uint16")
+b_hi_bits = K.cast(K.shift_right(b_word, K.uint32(16)), "uint16")
+next_lo = K.local_scalar("float32")
+next_hi = K.local_scalar("float32")
+K.ptx.fma.rn.f32.bf16(next_lo, a_lo_bits, b_lo_bits, accum_lo)
+K.ptx.fma.rn.f32.bf16(next_hi, a_hi_bits, b_hi_bits, accum_hi)
+```
+
+## Rationale
+
+In one persistent mixed-precision recurrence, paired profiling attributed
+520,192 excess dynamic `FFMA2` executions to the widened path. Selecting the
+reference's BF16-input FMA removed 64 static packed-FMA sites and their
+conversion chains. All ten correctness specializations passed against both the
+source and an independent recurrence oracle.
+
+The four affected ratios moved from 0.9186-0.9286 to 1.0071-1.0590. Across the
+complete matrix, the minimum moved from 0.8981 to 0.9708 and the mean from
+0.9240 to 1.0327; ten of eleven rows finished above parity. The improvement
+tracked the exact arithmetic surplus identified in the profile.
+
+## Boundary
+
+Apply this only when the logical operands have already been rounded to the
+narrow format and the reference PTX uses the mixed-precision instruction. Do
+not downcast live FP32 values merely to reach the instruction. Packed FP32
+arithmetic remains appropriate when the reference operates on FP32 pairs or
+when separating the pair introduces more moves than it removes.
+
+The accumulator and rounding modifiers are part of the contract. Match them
+from reference PTX and confirm that the target architecture certifies the exact
+instruction form.
+
+## Verification
+
+Compare native mixed-precision FMA, packed FP32 FMA, conversion, and move counts
+in final SASS. Check registers and local traffic, run every affected numerical
+branch, and then run the complete performance matrix because a remaining
+specialization-specific deficit can still set the final minimum.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ list.
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
   — MoE grouped GEMM with a dGLU backward epilogue;
   [schedule sketch](.agents/sketch/cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias.md)
+- **Linear attention:**
+  [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
+  — BF16 Kimi Delta Attention backward;
+  [schedule sketch](.agents/sketch/cudnn/sm100_kda_bprop_f16.md)
 
 ### FlashAttention ports
 

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_kda_bprop_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_kda_bprop_f16.yaml
@@ -1,0 +1,15 @@
+# Complete performance-path matrix for the cuDNN Frontend KDA backward port.
+kernel: cudnn_sm100_kda_bprop_f16
+selection_rationale: The selected defaults cover an underfilled small launch, the production L2-normalized path, and a large multi-batch production point; the full matrix additionally covers ragged tails, grouped heads, safe gate, beta sigmoid, state I/O, dynamic scheduling, and both prologue ordering modes.
+configs:
+  - {config: perf_basic_b1_s2048_h16, default: true, selection_role: small}
+  - {config: perf_tail_b2_ragged_h16, default: false}
+  - {config: perf_grouped_b1_s8192_h64_q64_k16_v32, default: false}
+  - {config: perf_l2_b1_s8192_h16, default: true, selection_role: medium}
+  - {config: perf_l2_b4_s8192_h64, default: true, selection_role: large}
+  - {config: perf_safe_b1_s8192_h16, default: false}
+  - {config: perf_beta_b1_s8192_h16, default: false}
+  - {config: perf_state_b1_s8192_h16, default: false}
+  - {config: perf_dynamic_b4_s2048_h64, default: false}
+  - {config: perf_order_scratch_b4_s2048_h64, default: false}
+  - {config: perf_order_generate_b4_s2048_h64, default: false}

--- a/tirx_kernels/cudnn/linear_attention/__init__.py
+++ b/tirx_kernels/cudnn/linear_attention/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""cuDNN Frontend linear-attention kernels."""

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -1917,24 +1917,43 @@ def _make_main(
                             gate_prefix[row],
                             arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, row, channel)]),
                         )
-                        with K.If(token_base + row >= sequence_length), K.Then():
-                            K.assign(gate_prefix[row], K.float32(0.0))
-                        if safe_gate:
-                            with K.If(token_base + row < sequence_length), K.Then():
-                                gate_sigmoid = (
-                                    _tanh_approx(safe_a * (gate_prefix[row] + safe_bias) * 0.5)
-                                    * 0.5
-                                    + 0.5
-                                )
-                                K.assign(
-                                    gate_prefix[row], K.float32(-7.213475204444817) * gate_sigmoid
-                                )
-                        else:
+                    if safe_gate:
+                        with K.unroll(8) as row_pair:
+                            row0 = row_pair * 2
+                            row1 = row0 + 1
+                            gate0 = (
+                                _tanh_approx(safe_a * (gate_prefix[row0] + safe_bias) * 0.5) * 0.5
+                                + 0.5
+                            )
+                            gate1 = (
+                                _tanh_approx(safe_a * (gate_prefix[row1] + safe_bias) * 0.5) * 0.5
+                                + 0.5
+                            )
+                            K.assign(
+                                gate_prefix[row0],
+                                K.if_then_else(
+                                    token_base + row0 < sequence_length,
+                                    K.float32(-7.213475204444817) * gate0,
+                                    K.float32(0.0),
+                                ),
+                            )
+                            K.assign(
+                                gate_prefix[row1],
+                                K.if_then_else(
+                                    token_base + row1 < sequence_length,
+                                    K.float32(-7.213475204444817) * gate1,
+                                    K.float32(0.0),
+                                ),
+                            )
+                    else:
+                        with K.unroll(16) as row:
                             with K.If(token_base + row < sequence_length), K.Then():
                                 K.assign(
                                     gate_prefix[row],
                                     gate_prefix[row] * K.float32(1.4426950408889634),
                                 )
+                            with K.If(token_base + row >= sequence_length), K.Then():
+                                K.assign(gate_prefix[row], K.float32(0.0))
                     prefix = K.local_scalar("float32", init=K.float32(0.0))
                     with K.unroll(8) as row_pair:
                         row0 = row_pair * 2

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -40,8 +40,56 @@ CONFIGS = [
     },
 ]
 
-# The final performance-gate matrix is frozen only after the correctness gate.
-BENCH_CONFIGS = []
+# The performance matrix spans every accepted specialization and three
+# production-scale points while keeping checkpoint construction outside timing.
+BENCH_CONFIGS = [
+    {"label": "perf_basic_b1_s2048_h16", "seq_lens": (2048,), "heads": 16},
+    {"label": "perf_tail_b2_ragged_h16", "seq_lens": (2047, 4093), "heads": 16},
+    {
+        "label": "perf_grouped_b1_s8192_h64_q64_k16_v32",
+        "seq_lens": (8192,),
+        "heads": 64,
+        "q_heads": 64,
+        "k_heads": 16,
+        "v_heads": 32,
+    },
+    {"label": "perf_l2_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "l2norm": True},
+    {
+        "label": "perf_l2_b4_s8192_h64",
+        "seq_lens": (8192, 8192, 8192, 8192),
+        "heads": 64,
+        "l2norm": True,
+    },
+    {"label": "perf_safe_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "safe_gate": True},
+    {"label": "perf_beta_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "beta_sigmoid": True},
+    {
+        "label": "perf_state_b1_s8192_h16",
+        "seq_lens": (8192,),
+        "heads": 16,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {
+        "label": "perf_dynamic_b4_s2048_h64",
+        "seq_lens": (2048, 2048, 2048, 2048),
+        "heads": 64,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "perf_order_scratch_b4_s2048_h64",
+        "seq_lens": (2048, 2048, 2048, 2048),
+        "heads": 64,
+        "run_order": True,
+    },
+    {
+        "label": "perf_order_generate_b4_s2048_h64",
+        "seq_lens": (2048, 2048, 2048, 2048),
+        "heads": 64,
+        "run_order": True,
+        "order_generate": True,
+    },
+]
 
 
 _BT = 16

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -4018,7 +4018,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch()
         torch.cuda.synchronize()
         _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
-        references = {"cudnn_frontend": source_launch}
+        references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},
         references=references,

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -244,11 +244,11 @@ def _barrier_ptr(arena, byte_offset, stage=0):
 def _wait_barrier(arena, byte_offset, stage, phase):
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(ready == K.uint32(0)):
+        barrier_address = K.cuda.cvta_generic_to_shared(arena.ptr_to([0])) + K.cast(
+            byte_offset + stage * 8, "uint32"
+        )
         K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
-            ready,
-            _barrier_ptr(arena, byte_offset, stage),
-            K.cast(phase, "uint32"),
-            K.uint32(_TRY_WAIT_TICKS),
+            ready, barrier_address, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
         )
 
 

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -1,0 +1,4001 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell BF16 Kimi Delta Attention backward kernel.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_bwd`` entry).
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {"name": "cudnn_sm100_kda_bprop_f16", "category": "cudnn", "compute_capability": 10}
+
+CONFIGS = [
+    {"label": "basic", "seq_lens": (64,), "heads": 1},
+    {"label": "tail", "seq_lens": (17, 33), "heads": 2},
+    {"label": "grouped", "seq_lens": (64,), "heads": 4, "q_heads": 4, "k_heads": 1, "v_heads": 2},
+    {"label": "l2norm", "seq_lens": (128,), "heads": 2, "l2norm": True},
+    {"label": "safe_gate", "seq_lens": (64,), "heads": 2, "safe_gate": True},
+    {"label": "beta_sigmoid", "seq_lens": (128,), "heads": 2, "beta_sigmoid": True},
+    {
+        "label": "state",
+        "seq_lens": (32, 48),
+        "heads": 2,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {"label": "dynamic", "seq_lens": (32, 48), "heads": 2, "dynamic_scheduler": True},
+    {"label": "order_scratch", "seq_lens": (32, 48), "heads": 2, "run_order": True},
+    {
+        "label": "order_generate",
+        "seq_lens": (32, 48),
+        "heads": 2,
+        "run_order": True,
+        "order_generate": True,
+    },
+]
+
+# The final performance-gate matrix is frozen only after the correctness gate.
+BENCH_CONFIGS = []
+
+
+_BT = 16
+_DK = 128
+_DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 10
+_MAIN_SMEM_BYTES = 196_608
+_TRY_WAIT_TICKS = 10_000_000
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+
+# (ready byte, done byte, stages, ready arrivals, done arrivals, init warp).
+# This is the frozen 115-word protocol table; None denotes a one-way edge.
+_PROTOCOL = (
+    (0, 16, 2, 1, 128, 14),
+    (32, 48, 2, 1, 128, 14),
+    (64, 80, 2, 1, 256, 14),
+    (96, 112, 2, 1, 32, 14),
+    (128, 144, 2, 1, 128, 14),
+    (160, 168, 1, 1, 1, 14),
+    (176, None, 1, 128, None, 14),
+    (184, 216, 4, 32, 160, 14),
+    (248, None, 1, 1, None, 13),
+    (256, None, 1, 1, None, 13),
+    (264, None, 1, 1, None, 13),
+    (272, None, 1, 1, None, 13),
+    (280, None, 1, 1, None, 13),
+    (288, None, 1, 1, None, 13),
+    (296, None, 1, 1, None, 13),
+    (304, None, 1, 1, None, 13),
+    (312, None, 1, 128, None, 13),
+    (320, 352, 4, 128, 128, 12),
+    (384, 400, 2, 128, 1, 14),
+    (416, None, 2, 128, None, 14),
+    (432, None, 1, 128, None, 13),
+    (440, None, 1, 128, None, 13),
+    (448, None, 1, 128, None, 13),
+    (456, None, 2, 128, None, 12),
+    (472, None, 2, 128, None, 12),
+    (488, None, 2, 1, None, 12),
+    (504, 520, 2, 32, 1, 12),
+    (536, 552, 2, 32, 1, 12),
+    (568, 584, 2, 32, 1, 12),
+    (600, 616, 2, 32, 1, 12),
+    (632, None, 1, 128, None, 13),
+    (640, None, 1, 128, None, 13),
+    (648, None, 1, 32, None, 13),
+    (656, None, 1, 1, None, 13),
+    (664, None, 1, 128, None, 13),
+    (672, 680, 1, 128, 1, 13),
+    (688, None, 1, 128, None, 13),
+    (696, 704, 1, 128, 32, 15),
+    (712, 720, 1, 128, 32, 15),
+    (728, 744, 2, 128, 32, 15),
+    (760, 768, 1, 128, 32, 15),
+    (776, None, 1, 128, None, 13),
+    (784, None, 1, 256, None, 13),
+    (792, 856, 8, 1, 15, 15),
+)
+
+# The single rank-1 arena follows the frozen source allocation order.
+_SMEM_BARRIERS = 0
+_SMEM_TMEM_MAILBOX = 920
+_SMEM_SCHED = 928
+_SMEM_BETA = 960
+_SMEM_NORM = 1216
+_SMEM_RED0 = 1728
+_SMEM_RED1 = 1984
+_SMEM_BETA_M = 2240
+_SMEM_STATE = 3072
+_SMEM_DSTATE = 35_840
+_SMEM_K_DECAY = 68_608
+_SMEM_K_INV = 76_800
+_SMEM_K_RESTORE = 84_992
+_SMEM_Q_DECAY = 93_184
+_SMEM_DIAG = 101_376
+_SMEM_INTERMEDIATE = 109_568
+_SMEM_DO = 114_688
+_SMEM_DV = 122_880
+_SMEM_Q = 131_072
+_SMEM_K = 139_264
+_SMEM_V = 147_456
+_SMEM_GATE = 155_648
+_SMEM_DY = 172_032
+_SMEM_U = 176_128
+_SMEM_DQ = 180_224
+_SMEM_DK = 184_320
+_SMEM_DGATE = 188_416
+
+_TMEM_DSTATE = 0
+_TMEM_DSTATE_INPUT = 128
+_TMEM_STATE_INPUT = 192
+_TMEM_STATE_K_DY = 320
+_TMEM_U = 336
+_TMEM_DU = 352
+_TMEM_DQ = 368
+_TMEM_DK_DECAY = 384
+_TMEM_DK_INV = 400
+_TMEM_DK_RESTORE = 416
+_TMEM_Y_NEG_BETA_DY = 432
+_TMEM_DU_INPUT = 440
+_TMEM_Q_RAW = 448
+_TMEM_K_RAW = 480
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _copy_tensormap(src_map, dst):
+    """Copy one 128-byte TensorMap image using the source's vector traffic."""
+    payload = K.alloc_local((4,), "uint64")
+    src = K.reinterpret("uint64", src_map.ptr_to([0]))
+    target = K.reinterpret("uint64", dst)
+    for group in range(4):
+        offset = K.uint64(group * 32)
+        K.ptx.ld.global_.v4.b64(
+            payload[0], payload[1], payload[2], payload[3], K.reinterpret("handle", src + offset)
+        )
+        K.ptx.st.global_.v4.b64(
+            K.reinterpret("handle", target + offset), payload[0], payload[1], payload[2], payload[3]
+        )
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + stage * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready,
+            _barrier_ptr(arena, byte_offset, stage),
+            K.cast(phase, "uint32"),
+            K.uint32(_TRY_WAIT_TICKS),
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage), K.uint32(1))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=K.cuda.elect_sync()
+    )
+
+
+def _load_work_item(work_items, tile):
+    row = K.alloc_local((8,), "int32")
+    base = K.cast(tile, "int64") * K.int64(8)
+    K.ptx.ld.global_.v4.b32(row[0], row[1], row[2], row[3], work_items.ptr_to([base]))
+    K.ptx.ld.global_.v4.b32(row[4], row[5], row[6], row[7], work_items.ptr_to([base + K.int64(4)]))
+    return row
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _mma_m16n16k16(acc, a, b):
+    K.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[0],
+        b[1],
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+    )
+    K.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[2],
+        b[3],
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+    )
+
+
+def _pack_bf16_pair(lo, hi):
+    packed = K.local_scalar("uint32")
+    K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _movmatrix_b16(value):
+    transposed = K.local_scalar("uint32")
+    K.ptx["movmatrix.sync.aligned.m8n8.trans.b16"](transposed, value)
+    return transposed
+
+
+def _unpack_bf16_pair(packed, lo, hi):
+    K.ptx.cvt.f32.bf16(lo, K.cast(packed, "uint16"))
+    K.ptx.cvt.f32.bf16(hi, K.cast(K.shift_right(packed, K.uint32(16)), "uint16"))
+
+
+def _shuffle_xor_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(delta),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _fadd2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _fmul2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _fsub2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.sub.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _ffma2(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.fma.rn.f32x2(
+        packed,
+        K.cuda.make_float2(a_lo, a_hi),
+        K.cuda.make_float2(b_lo, b_hi),
+        K.cuda.make_float2(c_lo, c_hi),
+    )
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _tcgen_mma_ss(
+    dst,
+    a_desc,
+    b_desc,
+    idesc,
+    *,
+    m,
+    n,
+    k_extent,
+    a_transpose=False,
+    b_transpose=False,
+    accumulate=False,
+):
+    def swizzle_bytes(inner_bytes):
+        if inner_bytes % 128 == 0:
+            return 128
+        if inner_bytes % 64 == 0:
+            return 64
+        return 32
+
+    swizzle_a = swizzle_bytes((m if a_transpose else k_extent) * 2)
+    swizzle_b = swizzle_bytes((n if b_transpose else k_extent) * 2)
+    intra_a = 16 * swizzle_a if a_transpose else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_a = k_extent * swizzle_a if a_transpose else swizzle_a * m
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_a = k_extent // 16 if a_transpose else (swizzle_a // 2) // 16
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    leader = K.cuda.elect_sync()
+    for step in range(k_extent // 16):
+        inc_a = (intra_a * (step % steps_a) + subtile_a * (step // steps_a)) >> 4
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+            K.cast(dst, "uint32"),
+            a_desc + K.uint64(inc_a),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            0,
+            0,
+            0,
+            0,
+            K.ptx.pred(accumulate if step == 0 else 1),
+            pred=leader,
+        )
+
+
+def _tcgen_mma_ts(dst, tmem_a, b_desc, idesc, *, n, k_extent, b_transpose=False, accumulate=False):
+    inner_bytes = (n if b_transpose else k_extent) * 2
+    swizzle_b = 128 if inner_bytes % 128 == 0 else 64 if inner_bytes % 64 == 0 else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    leader = K.cuda.elect_sync()
+    for step in range(k_extent // 16):
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            0,
+            0,
+            0,
+            0,
+            K.ptx.pred(accumulate if step == 0 else 1),
+            pred=leader,
+        )
+
+
+def _exp2_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _rcp_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(result, value)
+    return result
+
+
+def _rsqrt_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.rsqrt.approx.ftz.f32(result, value)
+    return result
+
+
+def _opaque_f32_zero():
+    value = K.local_scalar("float32")
+    K.ptx.mov.b32(value, K.uint32(0))
+    return value
+
+
+def _tanh_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _raw_smem_descriptor(arena, base_byte, leading_bytes, stride_bytes, layout_code):
+    shared_address = K.cuda.cvta_generic_to_shared(arena.ptr_to([base_byte]))
+    address = K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    value = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(value, K.shift_left(K.uint64(layout_code & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column, elem_bytes):
+    elements = 128 // elem_bytes
+    return K.bitwise_xor(column, (row % 8) * (16 // elem_bytes)) % elements
+
+
+def _raw_bf16_byte(base, stage, token, channel):
+    segment = channel // 64
+    within = channel - segment * 64
+    element = segment * 1024 + token * 64 + _swizzle_xor_128b(token, within, 2)
+    return base + stage * 4096 + element * 2
+
+
+def _raw_f32_byte(base, stage, token, channel):
+    segment = channel // 32
+    within = channel - segment * 32
+    element = segment * 512 + token * 32 + _swizzle_xor_128b(token, within, 4)
+    return base + stage * 8192 + element * 4
+
+
+def _tmem_cell(base, row, row_delta, column):
+    return base + column + K.shift_left(row + row_delta, K.int32(16))
+
+
+def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out):
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_q: K.gptr[K.i64],
+        base_k: K.gptr[K.i64],
+        base_v: K.gptr[K.i64],
+        base_gate: K.gptr[K.i64],
+        base_do: K.gptr[K.i64],
+        base_dq: K.gptr[K.i64],
+        base_dk: K.gptr[K.i64],
+        base_dv: K.gptr[K.i64],
+        base_dgate: K.gptr[K.i64],
+        base_checkpoint: K.gptr[K.i64],
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[K.i32],
+        q: K.gptr[K.u8],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        gate: K.gptr[K.u8],
+        do: K.gptr[K.u8],
+        dq: K.gptr[K.u8],
+        dk: K.gptr[K.u8],
+        dv: K.gptr[K.u8],
+        dgate: K.gptr[K.u8],
+        checkpoints: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        n_batch: K.i32,
+        q_row_stride_bytes: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        gate_row_stride_bytes: K.i32,
+        do_row_stride_bytes: K.i32,
+        dq_row_stride_bytes: K.i32,
+        dk_row_stride_bytes: K.i32,
+        dv_row_stride_bytes: K.i32,
+        dgate_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        thread = K.thread_id()
+        warp = K.warp_id()
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+
+            # The ordering launch owns both consumers' four scheduler words.
+            # Their extent is fixed by the frozen two-ring source ABI.
+            with K.If(thread == 0), K.Then():
+                sched_index = K.local_scalar("int32", init=K.int32(0))
+                with K.While(sched_index < 4):
+                    K.ptx.st.global_.s32(scheduler.ptr_to([sched_index]), K.int32(0))
+                    K.assign(sched_index, sched_index + 1)
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    sequence_begin = K.local_scalar("int32")
+                    sequence_end = K.local_scalar("int32")
+                    K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                    K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                    num_chunks = (sequence_end - sequence_begin + _BT - 1) // _BT
+                    values = (
+                        batch,
+                        head,
+                        K.int32(0),
+                        num_chunks,
+                        K.int32(0),
+                        num_chunks,
+                        sequence_begin,
+                        sequence_end,
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]),
+                        values[0],
+                        values[1],
+                        values[2],
+                        values[3],
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]),
+                        values[4],
+                        values[5],
+                        values[6],
+                        values[7],
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+
+                # Four entries per thread fill the fixed 4096-item capacity.
+                # Padding carries INT_MIN so the descending bitonic network
+                # leaves it behind every real work item.
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = K.local_scalar("int32")
+                                end = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(begin, cu_seqlens.ptr_to([batch]))
+                                K.ptx.ld.global_.s32(end, cu_seqlens.ptr_to([batch + 1]))
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                atomic_old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](
+                    atomic_old, order_arena.ptr_to([32_768]), local_min
+                )
+                K.ptx["atom.shared::cta.max.s32"](
+                    atomic_old, order_arena.ptr_to([32_772]), local_max
+                )
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network_size = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network_size <= padded_count):
+                        distance = K.local_scalar("int32", init=network_size // K.int32(2))
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending_half = ((item // network_size) % K.int32(2)) == 0
+                                    swap = K.Or(
+                                        K.And(ascending_half, key_i < key_j),
+                                        K.And(K.Not(ascending_half), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network_size, network_size * 2)
+
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+        maps = (base_q, base_k, base_v, base_gate, base_do, base_dq, base_dk, base_dv, base_dgate)
+        bases = (q, k, v, gate, do, dq, dk, dv, dgate)
+        strides = (
+            q_row_stride_bytes,
+            k_row_stride_bytes,
+            v_row_stride_bytes,
+            gate_row_stride_bytes,
+            do_row_stride_bytes,
+            dq_row_stride_bytes,
+            dk_row_stride_bytes,
+            dv_row_stride_bytes,
+            dgate_row_stride_bytes,
+        )
+        for array_index in range(9):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    with K.serial(n_batch) as batch:
+                        sequence_begin = K.local_scalar("int32")
+                        sequence_end = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                        K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                        sequence_length = sequence_end - sequence_begin
+                        slot = descriptor_workspace.ptr_to(
+                            [(array_index * n_batch + batch) * _TENSOR_MAP_WORDS]
+                        )
+                        _copy_tensormap(maps[array_index], slot)
+                        _replace_tensormap_address(
+                            slot,
+                            bases[array_index].ptr_to(
+                                [K.cast(sequence_begin, "int64") * strides[array_index]]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, sequence_length)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+        with K.If(warp == 9), K.Then():
+            with K.If(_elected()), K.Then():
+                checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                with K.serial(n_batch) as batch:
+                    sequence_begin = K.local_scalar("int32")
+                    sequence_end = K.local_scalar("int32")
+                    K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                    K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                    sequence_length = sequence_end - sequence_begin
+                    checkpoint_count = K.local_scalar("int32", init=K.int32(0))
+                    with K.If(sequence_length > 0), K.Then():
+                        K.assign(checkpoint_count, (sequence_length - 1) // checkpoint_every_n + 1)
+                    slot = descriptor_workspace.ptr_to([(9 * n_batch + batch) * _TENSOR_MAP_WORDS])
+                    _copy_tensormap(base_checkpoint, slot)
+                    _replace_tensormap_address(
+                        slot,
+                        checkpoints.ptr_to(
+                            [K.cast(checkpoint_prefix, "int64") * checkpoint_row_stride_bytes]
+                        ),
+                    )
+                    _replace_tensormap_dim(slot, 2, checkpoint_count)
+                    K.assign(checkpoint_prefix, checkpoint_prefix + checkpoint_count)
+                K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+# KERNEL_SKETCH_START
+def _make_main(
+    *,
+    num_sms,
+    beta_sigmoid,
+    use_dstate_in,
+    use_dstate0,
+    use_initial_state,
+    safe_gate,
+    dynamic_scheduler,
+    l2norm,
+    n_heads_out,
+    q_ratio,
+    k_ratio,
+    v_ratio,
+):
+    beta_dtype = K.bf16 if beta_sigmoid else K.f32
+
+    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        beta: K.gptr[beta_dtype],
+        cu_seqlens: K.gptr[K.i32],
+        dgate: K.gptr[K.f32],
+        dbeta: K.gptr[beta_dtype],
+        d_initial_state: K.gptr[K.f32],
+        d_final_state: K.gptr[K.f32],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        scale: K.f32,
+    ):
+        arena = K.alloc_buffer((_MAIN_SMEM_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        # The pool owns only the fixed pipeline/barrier header over the arena;
+        # all data storage below is addressed by integer byte offsets.
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        # Every physical protocol word has one elected initialization owner.
+        for ready_off, done_off, stages, ready_count, done_count, owner in _PROTOCOL:
+            with K.If(warp == owner), K.Then():
+                with K.If(_elected()), K.Then():
+                    for stage in range(stages):
+                        K.ptx.mbarrier.init.shared.b64(
+                            _barrier_ptr(arena, ready_off, stage), K.uint32(ready_count)
+                        )
+                        if done_off is not None:
+                            K.ptx.mbarrier.init.shared.b64(
+                                _barrier_ptr(arena, done_off, stage), K.uint32(done_count)
+                            )
+        # The two diagonal stages are born zero and later receive only their
+        # diagonal entries from CG0.
+        with K.unroll(8) as diagonal_pass:
+            element = thread + diagonal_pass * 512
+            K.ptx.st.shared.b16(arena.ptr_to([_SMEM_DIAG + element * 2]), K.uint16(0))
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 4), regs=144)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=168)
+        cg2 = roles.role("cg2", warps=range(8, 12), regs=144)
+        super_mma = roles.role("super_mma", warps=[12], regs=56)
+        tcgen = roles.role("tcgen", warps=[13], regs=56)
+        tma = roles.role("tma", warps=[14], regs=56)
+        epilogue = roles.role("epilogue", warps=[15], regs=56)
+        with tma:
+            tile = K.local_scalar("int32", init=K.cta_id())
+            raw = K.PipelineState(2, phase=1)
+            state_cursor = K.PipelineState(1, phase=1)
+            sched_producer = K.PipelineState(8, phase=1)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+
+                next_tile = K.local_scalar("int32", init=tile + num_sms)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 856, sched_producer.stage, sched_producer.phase)
+                    with K.If(_elected()), K.Then():
+                        ticket = K.local_scalar("uint32")
+                        K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                        K.ptx.st.shared.u32(
+                            arena.ptr_to([_SMEM_SCHED + K.cast(sched_producer.stage, "int32") * 4]),
+                            K.uint32(num_sms) + ticket,
+                        )
+                    K.cuda.warp_sync()
+                    K.ptx.ld.shared.s32(
+                        next_tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_producer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 792, sched_producer.stage)
+                    sched_producer.advance()
+
+                head_q = head if q_ratio == 1 else head // q_ratio
+                head_k = head if k_ratio == 1 else head // k_ratio
+                head_v = head if v_ratio == 1 else head // v_ratio
+                desc_q = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_k = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                desc_v = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                desc_gate = _descriptor_slot(descriptor_workspace, n_desc, 3, batch)
+                desc_do = _descriptor_slot(descriptor_workspace, n_desc, 4, batch)
+                desc_state = _descriptor_slot(descriptor_workspace, n_desc, 9, batch)
+                with K.If(_elected()), K.Then():
+                    for desc in (desc_q, desc_k, desc_v, desc_gate, desc_do, desc_state):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
+
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * _BT
+                    raw_stage = raw.stage
+                    raw_phase = raw.phase
+                    with K.If(_elected()), K.Then():
+                        _wait_barrier(arena, 16, raw_stage, raw_phase)
+                        _expect_tx(arena, 0, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_Q + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_q,
+                                K.int32(d_coord),
+                                K.cast(head_q, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, 0, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, 48, raw_stage, raw_phase)
+                        _expect_tx(arena, 32, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_K + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_k,
+                                K.int32(d_coord),
+                                K.cast(head_k, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, 32, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, 80, raw_stage, raw_phase)
+                        _expect_tx(arena, 64, raw_stage, 8192)
+                        for d_coord in (0, 32, 64, 96):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_GATE + K.cast(raw_stage, "int32") * 8192 + d_coord * 64]
+                                ),
+                                desc_gate,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, 64, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, 112, raw_stage, raw_phase)
+                        _expect_tx(arena, 96, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_DO + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_do,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, 96, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, 144, raw_stage, raw_phase)
+                        _expect_tx(arena, 128, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_V + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_v,
+                                K.int32(d_coord),
+                                K.cast(head_v, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, 128, raw_stage),
+                                K.uint64(0),
+                            )
+
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        with K.If(_elected()), K.Then():
+                            _wait_barrier(arena, 176, state_cursor.stage, state_cursor.phase)
+                            _wait_barrier(arena, 168, state_cursor.stage, state_cursor.phase)
+                            _expect_tx(arena, 160, state_cursor.stage, 32768)
+                            for value_coord in (0, 64):
+                                K.ptx[_TMA_G2S_4D](
+                                    arena.ptr_to([_SMEM_STATE + value_coord * 256]),
+                                    desc_state,
+                                    K.int32(value_coord),
+                                    K.int32(0),
+                                    K.cast(chunk, "int32"),
+                                    K.cast(head, "int32"),
+                                    _barrier_ptr(arena, 160, state_cursor.stage),
+                                    K.uint64(0),
+                                )
+                        state_cursor.advance()
+                    raw.advance()
+                K.assign(tile, next_tile)
+        with super_mma:
+            tile = K.local_scalar("int32", init=K.cta_id())
+            chunk_serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            dy_smem_consumer = K.PipelineState(1, phase=0)
+            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_linear = store_row * 16 + store_col
+            store_swizzled = K.bitwise_xor(
+                store_linear,
+                K.shift_left(
+                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                    K.uint32(3),
+                ),
+            )
+            row_lo = lane // 4
+            row_hi = row_lo + 8
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                num_chunks = item[5] - item[2]
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = chunk_serial_base + reverse_index
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    beta_stage = serial % 4
+                    _wait_barrier(arena, 520, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, 456, decay_stage, (serial // 2) & 1)
+
+                    kk = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(kk[accum_index], K.float32(0.0))
+                    with K.unroll(8) as key_block:
+                        a = K.alloc_local((4,), "uint32")
+                        b = K.alloc_local((4,), "uint32")
+                        a_channel = key_block * 16 + lhs_col
+                        b_channel = key_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a[0],
+                            a[1],
+                            a[2],
+                            a[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_DECAY, decay_stage, lhs_row, a_channel)]
+                            ),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b[0],
+                            b[1],
+                            b[2],
+                            b[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, rhs_row, b_channel)]
+                            ),
+                        )
+                        _mma_m16n16k16(kk, a, b)
+
+                    _wait_barrier(arena, 184, beta_stage, (serial // 4) & 1)
+                    beta_lo = K.local_scalar("float32")
+                    beta_hi = K.local_scalar("float32")
+                    K.ptx.ld.shared.f32(
+                        beta_lo, arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + row_lo) * 4])
+                    )
+                    K.ptx.ld.shared.f32(
+                        beta_hi, arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + row_hi) * 4])
+                    )
+                    _arrive_barrier(arena, 216, beta_stage)
+
+                    strict = K.alloc_local((8,), "float32")
+                    l_word = K.alloc_local((4,), "uint32")
+                    rounded = K.alloc_local((8,), "float32")
+                    tinv = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        lower = K.if_then_else(row_coord > col_coord, kk[accum_index], 0.0)
+                        beta_value = beta_lo if accum_index % 4 < 2 else beta_hi
+                        K.assign(strict[accum_index], lower * beta_value)
+                    for pair in range(4):
+                        K.assign(
+                            l_word[pair], _pack_bf16_pair(strict[pair * 2], strict[pair * 2 + 1])
+                        )
+                        _unpack_bf16_pair(l_word[pair], rounded[pair * 2], rounded[pair * 2 + 1])
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        K.assign(
+                            tinv[accum_index],
+                            K.if_then_else(row_coord == col_coord, 1.0, 0.0) - rounded[accum_index],
+                        )
+
+                    l_power = K.alloc_local((4,), "uint32")
+                    l_power_t = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(l_power[pair], l_word[pair])
+                        K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+                    for _ in range(3):
+                        square = K.alloc_local((8,), "float32")
+                        for accum_index in range(8):
+                            K.assign(square[accum_index], K.float32(0.0))
+                        _mma_m16n16k16(square, l_power, l_power_t)
+                        for pair in range(4):
+                            K.assign(
+                                l_power[pair],
+                                _pack_bf16_pair(square[pair * 2], square[pair * 2 + 1]),
+                            )
+                            K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+                        tinv_word = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            K.assign(
+                                tinv_word[pair], _pack_bf16_pair(tinv[pair * 2], tinv[pair * 2 + 1])
+                            )
+                        update = K.alloc_local((8,), "float32")
+                        for accum_index in range(8):
+                            K.assign(update[accum_index], K.float32(0.0))
+                        _mma_m16n16k16(update, tinv_word, l_power_t)
+                        for pair in range(4):
+                            old_lo = K.local_scalar("float32")
+                            old_hi = K.local_scalar("float32")
+                            _unpack_bf16_pair(tinv_word[pair], old_lo, old_hi)
+                            next_lo, next_hi = _fadd2(
+                                old_lo, old_hi, update[pair * 2], update[pair * 2 + 1]
+                            )
+                            K.assign(tinv[pair * 2], next_lo)
+                            K.assign(tinv[pair * 2 + 1], next_hi)
+
+                    tinv_out = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(
+                            tinv_out[pair], _pack_bf16_pair(tinv[pair * 2], tinv[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 512 + store_swizzled * 2]
+                        ),
+                        tinv_out[0],
+                        tinv_out[1],
+                        tinv_out[2],
+                        tinv_out[3],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 504, inter_stage)
+
+                    _wait_barrier(arena, 616, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, 640, dy_smem_consumer.stage, dy_smem_consumer.phase)
+                    dy_smem_consumer.advance()
+                    dm = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(dm[accum_index], K.float32(0.0))
+                    with K.unroll(8) as value_block:
+                        a = K.alloc_local((4,), "uint32")
+                        b = K.alloc_local((4,), "uint32")
+                        a_channel = value_block * 16 + lhs_col
+                        b_channel = value_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a[0],
+                            a[1],
+                            a[2],
+                            a[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DY, 0, lhs_row, a_channel)]),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b[0],
+                            b[1],
+                            b[2],
+                            b[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_U, 0, rhs_row, b_channel)]),
+                        )
+                        _mma_m16n16k16(dm, a, b)
+
+                    dm_word = K.alloc_local((4,), "uint32")
+                    ndm_word = K.alloc_local((4,), "uint32")
+                    bsum_lo = K.local_scalar("float32", init=K.float32(0.0))
+                    bsum_hi = K.local_scalar("float32", init=K.float32(0.0))
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        beta_value = beta_lo if accum_index % 4 < 2 else beta_hi
+                        K.assign(
+                            strict[accum_index],
+                            K.if_then_else(
+                                row_coord > col_coord, dm[accum_index] * beta_value, 0.0
+                            ),
+                        )
+                        contribution = K.if_then_else(
+                            row_coord > col_coord, dm[accum_index] * kk[accum_index], 0.0
+                        )
+                        if accum_index % 4 < 2:
+                            K.assign(bsum_lo, bsum_lo + contribution)
+                        else:
+                            K.assign(bsum_hi, bsum_hi + contribution)
+                    for pair in range(4):
+                        K.assign(
+                            dm_word[pair], _pack_bf16_pair(strict[pair * 2], strict[pair * 2 + 1])
+                        )
+                        K.assign(
+                            ndm_word[pair],
+                            _pack_bf16_pair(-strict[pair * 2], -strict[pair * 2 + 1]),
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 1536 + store_swizzled * 2]
+                        ),
+                        dm_word[0],
+                        dm_word[1],
+                        dm_word[2],
+                        dm_word[3],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 2048 + store_swizzled * 2]
+                        ),
+                        ndm_word[0],
+                        ndm_word[1],
+                        ndm_word[2],
+                        ndm_word[3],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 600, inter_stage)
+
+                    K.assign(bsum_lo, bsum_lo + _shuffle_xor_f32(bsum_lo, 1))
+                    K.assign(bsum_lo, bsum_lo + _shuffle_xor_f32(bsum_lo, 2))
+                    K.assign(bsum_hi, bsum_hi + _shuffle_xor_f32(bsum_hi, 1))
+                    K.assign(bsum_hi, bsum_hi + _shuffle_xor_f32(bsum_hi, 2))
+                    with K.If(lane % 4 == 0), K.Then():
+                        K.ptx.st.shared.f32(arena.ptr_to([_SMEM_BETA_M + row_lo * 4]), -bsum_lo)
+                        K.ptx.st.shared.f32(arena.ptr_to([_SMEM_BETA_M + row_hi * 4]), -bsum_hi)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 648)
+
+                K.assign(chunk_serial_base, chunk_serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with tcgen:
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([_SMEM_TMEM_MAILBOX]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_consumer = K.PipelineState(1, phase=0)
+            dqk_done_consumer = K.PipelineState(1, phase=1)
+            dstate_input_consumer = K.PipelineState(1, phase=0)
+            y_consumer = K.PipelineState(1, phase=0)
+            du_consumer = K.PipelineState(1, phase=0)
+            neg_beta_dy_consumer = K.PipelineState(1, phase=0)
+            u_smem_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_consumer = K.PipelineState(1, phase=0)
+            dstate0_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                cend = item[5]
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    decay_phase = (serial // 2) & 1
+                    inter_phase = (serial // 2) & 1
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+
+                    state_direct = _raw_smem_descriptor(arena, _SMEM_STATE, 16, 1024, 2)
+                    state_alt = _raw_smem_descriptor(arena, _SMEM_STATE, 16384, 1024, 2)
+                    dstate_alt = _raw_smem_descriptor(arena, _SMEM_DSTATE, 16384, 1024, 2)
+                    k_decay_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_DECAY + decay_stage * 4096, 16, 1024, 2
+                    )
+                    k_decay_trans = _raw_smem_descriptor(
+                        arena, _SMEM_K_DECAY + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    k_inverse_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_INV + decay_stage * 4096, 16, 1024, 2
+                    )
+                    k_inverse_amajor = _raw_smem_descriptor(
+                        arena, _SMEM_K_INV + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    k_restore_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_RESTORE + decay_stage * 4096, 16, 1024, 2
+                    )
+                    q_decay_trans = _raw_smem_descriptor(
+                        arena, _SMEM_Q_DECAY + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    do_lead = _raw_smem_descriptor(arena, _SMEM_DO + raw_stage * 4096, 16, 1024, 2)
+                    do_amajor = _raw_smem_descriptor(
+                        arena, _SMEM_DO + raw_stage * 4096, 2048, 1024, 2
+                    )
+                    dv_lead = _raw_smem_descriptor(
+                        arena, _SMEM_DV + (serial % 2) * 4096, 16, 1024, 2
+                    )
+                    u_lead = _raw_smem_descriptor(arena, _SMEM_U, 16, 1024, 2)
+                    inter_a = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560, 16, 256, 6
+                    )
+                    inter_tinv = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 512, 16, 256, 6
+                    )
+                    inter_da = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 1024, 16, 256, 6
+                    )
+                    inter_dm = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 1536, 16, 256, 6
+                    )
+                    inter_ndm = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 2048, 16, 256, 6
+                    )
+
+                    _wait_barrier(arena, 456, decay_stage, decay_phase)
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, 160, state_consumer.stage, state_consumer.phase)
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_STATE_K_DY,
+                            state_direct,
+                            k_decay_lead,
+                            134481040,
+                            m=128,
+                            n=16,
+                            k_extent=128,
+                        )
+                        _tcgen_commit(arena, 248)
+                        _tcgen_commit(arena, 168, state_consumer.stage)
+                        state_consumer.advance()
+
+                    _wait_barrier(arena, 312, dqk_done_consumer.stage, dqk_done_consumer.phase)
+                    dqk_done_consumer.advance()
+                    _wait_barrier(arena, 384, serial % 2, (serial // 2) & 1)
+                    _wait_barrier(arena, 96, raw_stage, (serial // 2) & 1)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DQ,
+                            tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
+                            do_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+
+                    _wait_barrier(arena, 472, decay_stage, decay_phase)
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena, 664, dstate_input_consumer.stage, dstate_input_consumer.phase
+                        )
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DU,
+                            tmem_base + _TMEM_DSTATE_INPUT,
+                            k_restore_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+                        for key_block in range(8):
+                            diagonal = _raw_smem_descriptor(
+                                arena, _SMEM_DIAG + decay_stage * 4096 + key_block * 512, 16, 256, 6
+                            )
+                            _tcgen_mma_ts(
+                                tmem_base + _TMEM_DSTATE + key_block * 16,
+                                tmem_base + _TMEM_DSTATE_INPUT + key_block * 8,
+                                diagonal,
+                                134481040,
+                                n=16,
+                                k_extent=16,
+                            )
+                        dstate_input_consumer.advance()
+
+                    _wait_barrier(arena, 536, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DU,
+                        do_amajor,
+                        inter_a,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=has_dstate,
+                    )
+                    _tcgen_commit(arena, 256)
+                    _tcgen_commit(arena, 552, inter_stage)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DSTATE,
+                        do_amajor,
+                        q_decay_trans,
+                        136414352,
+                        m=128,
+                        n=128,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=has_dstate,
+                    )
+
+                    _wait_barrier(arena, 504, inter_stage, inter_phase)
+                    _wait_barrier(arena, 432, y_consumer.stage, y_consumer.phase)
+                    y_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_U,
+                        tmem_base + _TMEM_Y_NEG_BETA_DY,
+                        inter_tinv,
+                        134481040,
+                        n=16,
+                        k_extent=16,
+                    )
+                    _tcgen_commit(arena, 264)
+
+                    _wait_barrier(arena, 440, du_consumer.stage, du_consumer.phase)
+                    du_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_STATE_K_DY,
+                        tmem_base + _TMEM_DU_INPUT,
+                        inter_tinv,
+                        134546576,
+                        n=16,
+                        k_extent=16,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, 272)
+                    _tcgen_commit(arena, 520, inter_stage)
+
+                    _wait_barrier(arena, 632, u_smem_consumer.stage, u_smem_consumer.phase)
+                    u_smem_consumer.advance()
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena, 672, dstate_smem_consumer.stage, dstate_smem_consumer.phase
+                        )
+                        dstate_smem_consumer.advance()
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_RESTORE,
+                            dstate_alt,
+                            u_lead,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=128,
+                            a_transpose=True,
+                        )
+                        _tcgen_commit(arena, 304)
+                        _tcgen_commit(arena, 680)
+
+                    _wait_barrier(
+                        arena, 448, neg_beta_dy_consumer.stage, neg_beta_dy_consumer.phase
+                    )
+                    neg_beta_dy_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_DSTATE,
+                        tmem_base + _TMEM_Y_NEG_BETA_DY,
+                        k_decay_trans,
+                        136381584,
+                        n=128,
+                        k_extent=16,
+                        b_transpose=True,
+                        accumulate=True,
+                    )
+                    _tcgen_commit(arena, 656)
+
+                    _wait_barrier(arena, 568, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DK_INV,
+                        q_decay_trans,
+                        inter_da,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                    )
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DQ,
+                            k_inverse_amajor,
+                            inter_da,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=True,
+                        )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DQ,
+                            k_inverse_amajor,
+                            inter_da,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=False,
+                        )
+                    _tcgen_commit(arena, 280)
+                    _tcgen_commit(arena, 584, inter_stage)
+
+                    _wait_barrier(arena, 728, serial % 2, (serial // 2) & 1)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DK_DECAY,
+                            tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
+                            dv_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+                    _tcgen_commit(arena, 400, serial % 2)
+
+                    _wait_barrier(arena, 600, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DK_INV,
+                        k_decay_trans,
+                        inter_ndm,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=True,
+                    )
+                    _tcgen_commit(arena, 296)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_DECAY,
+                            k_inverse_amajor,
+                            inter_dm,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=True,
+                        )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_DECAY,
+                            k_inverse_amajor,
+                            inter_dm,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=False,
+                        )
+                    _tcgen_commit(arena, 288)
+                    _tcgen_commit(arena, 616, inter_stage)
+                    _tcgen_commit(arena, 488, decay_stage)
+
+                _wait_barrier(arena, 776, dstate0_consumer.stage, dstate0_consumer.phase)
+                dstate0_consumer.advance()
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _wait_barrier(arena, 784, 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+        with epilogue:
+            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_linear = store_row * 16 + store_col
+            store_swizzled = K.bitwise_xor(
+                store_linear,
+                K.shift_left(
+                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                    K.uint32(3),
+                ),
+            )
+            row_lo = lane // 4
+            row_hi = row_lo + 8
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            u_consumer = K.PipelineState(1, phase=0)
+            dq_store = K.PipelineState(1, phase=0)
+            dk_store = K.PipelineState(1, phase=0)
+            dgate_store = K.PipelineState(1, phase=0)
+            dv_store = K.PipelineState(2, phase=0)
+
+            def store_pending(pend_token, pend_writes, head, desc_dq, desc_dk, desc_dv, desc_dgate):
+                _wait_barrier(arena, 696, dq_store.stage, dq_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dq,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DQ + d_coord * 32]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, 712, dk_store.stage, dk_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dk,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DK + d_coord * 32]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, 760, dgate_store.stage, dgate_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 32, 64, 96):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dgate,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DGATE + d_coord * 64]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, 728, dv_store.stage, dv_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dv,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to(
+                                [_SMEM_DV + K.cast(dv_store.stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                K.ptx.cp.async_.bulk.wait_group.read(3)
+                _arrive_barrier(arena, 704, dq_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(2)
+                _arrive_barrier(arena, 720, dk_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(1)
+                _arrive_barrier(arena, 768, dgate_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(0)
+                _arrive_barrier(arena, 744, dv_store.stage)
+                dq_store.advance()
+                dk_store.advance()
+                dgate_store.advance()
+                dv_store.advance()
+
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                num_chunks = cend - wstart
+                desc_dq = _descriptor_slot(descriptor_workspace, n_desc, 5, batch)
+                desc_dk = _descriptor_slot(descriptor_workspace, n_desc, 6, batch)
+                desc_dv = _descriptor_slot(descriptor_workspace, n_desc, 7, batch)
+                desc_dgate = _descriptor_slot(descriptor_workspace, n_desc, 8, batch)
+                with K.If(_elected()), K.Then():
+                    for desc in (desc_dq, desc_dk, desc_dv, desc_dgate):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
+                pending_token = K.local_scalar("int32", init=K.int32(0))
+                pending_writes = K.local_scalar("bool", init=K.bool(False))
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * 16
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+
+                    _wait_barrier(arena, 552, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, 472, decay_stage, (serial // 2) & 1)
+                    a_acc = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(a_acc[accum_index], K.float32(0.0))
+                    with K.unroll(8) as key_block:
+                        a_frag = K.alloc_local((4,), "uint32")
+                        b_frag = K.alloc_local((4,), "uint32")
+                        a_channel = key_block * 16 + lhs_col
+                        b_channel = key_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a_frag[0],
+                            a_frag[1],
+                            a_frag[2],
+                            a_frag[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q_DECAY, decay_stage, lhs_row, a_channel)]
+                            ),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b_frag[0],
+                            b_frag[1],
+                            b_frag[2],
+                            b_frag[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, rhs_row, b_channel)]
+                            ),
+                        )
+                        _mma_m16n16k16(a_acc, a_frag, b_frag)
+                    a_words = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        row_coord = row_hi if pair * 2 % 4 >= 2 else row_lo
+                        for parity in range(2):
+                            accum_index = pair * 2 + parity
+                            row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                            col_coord = (accum_index // 4) * 8 + 2 * (lane % 4) + (accum_index & 1)
+                            K.assign(
+                                a_acc[accum_index],
+                                K.if_then_else(row_coord >= col_coord, a_acc[accum_index], 0.0),
+                            )
+                        K.assign(
+                            a_words[pair], _pack_bf16_pair(a_acc[pair * 2], a_acc[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + store_swizzled * 2]
+                        ),
+                        *[a_words[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 536, inter_stage)
+
+                    _wait_barrier(arena, 632, u_consumer.stage, u_consumer.phase)
+                    u_consumer.advance()
+                    da_acc = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(da_acc[accum_index], K.float32(0.0))
+                    with K.unroll(8) as value_block:
+                        a_frag = K.alloc_local((4,), "uint32")
+                        b_frag = K.alloc_local((4,), "uint32")
+                        a_channel = value_block * 16 + lhs_col
+                        b_channel = value_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a_frag[0],
+                            a_frag[1],
+                            a_frag[2],
+                            a_frag[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DO, raw_stage, lhs_row, a_channel)]),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b_frag[0],
+                            b_frag[1],
+                            b_frag[2],
+                            b_frag[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_U, 0, rhs_row, b_channel)]),
+                        )
+                        _mma_m16n16k16(da_acc, a_frag, b_frag)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 112, raw_stage)
+                    _wait_barrier(arena, 584, inter_stage, (serial // 2 + 1) & 1)
+                    da_words = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        for parity in range(2):
+                            accum_index = pair * 2 + parity
+                            row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                            col_coord = (accum_index // 4) * 8 + 2 * (lane % 4) + (accum_index & 1)
+                            K.assign(
+                                da_acc[accum_index],
+                                K.if_then_else(row_coord >= col_coord, da_acc[accum_index], 0.0),
+                            )
+                        K.assign(
+                            da_words[pair], _pack_bf16_pair(da_acc[pair * 2], da_acc[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 1024 + store_swizzled * 2]
+                        ),
+                        *[da_words[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 568, inter_stage)
+
+                    with K.If(reverse_index > 0), K.Then():
+                        store_pending(
+                            pending_token,
+                            pending_writes,
+                            head,
+                            desc_dq,
+                            desc_dk,
+                            desc_dv,
+                            desc_dgate,
+                        )
+                    K.assign(pending_token, token)
+                    K.assign(pending_writes, chunk < wend)
+
+                with K.If(num_chunks > 0), K.Then():
+                    store_pending(
+                        pending_token, pending_writes, head, desc_dq, desc_dk, desc_dv, desc_dgate
+                    )
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with cg0:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            warp_in_group = K.warp_id_in_role()
+            channel = warp_in_group * 32 + lane
+            value_channel = (warp % 4) * 32 + lane
+            tmem_row = (tmem_base >> 16) + (warp % 4) * 32
+            tmem_col = tmem_base & 0xFFFF
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                num_chunks = cend - wstart
+                safe_a = K.local_scalar("float32", init=K.float32(1.0))
+                safe_bias = K.local_scalar("float32", init=K.float32(0.0))
+                if safe_gate:
+                    with K.If(num_chunks > 0), K.Then():
+                        a_value = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(a_value, a_log.ptr_to([head]))
+                        K.assign(safe_a, _exp2_approx(a_value * K.float32(1.4426950408889634)))
+                        K.ptx.ld.global_.f32(
+                            safe_bias, dt_bias.ptr_to([K.cast(head, "int64") * 128 + channel])
+                        )
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    token_base = chunk * 16
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+
+                    with K.If(warp_in_group == 0), K.Then():
+                        beta_stage = serial % 4
+                        _wait_barrier(arena, 216, beta_stage, (serial // 4 + 1) & 1)
+                        with K.If(lane < 16), K.Then():
+                            beta_value = K.local_scalar("float32", init=K.float32(0.0))
+                            with K.If(token_base + lane < sequence_length), K.Then():
+                                beta_index = (
+                                    K.cast(bos + token_base + lane, "int64") * n_heads_out + head
+                                )
+                                if beta_sigmoid:
+                                    beta_bits = K.local_scalar("uint16")
+                                    K.ptx.ld.global_.b16(beta_bits, beta.ptr_to([beta_index]))
+                                    K.ptx.cvt.f32.bf16(beta_value, beta_bits)
+                                    K.assign(beta_value, _tanh_approx(beta_value * 0.5) * 0.5 + 0.5)
+                                    # The source rounds sigmoid(beta) through BF16.
+                                    beta_round = K.cast(beta_value, "bfloat16")
+                                    K.assign(beta_value, K.cast(beta_round, "float32"))
+                                else:
+                                    K.ptx.ld.global_.f32(beta_value, beta.ptr_to([beta_index]))
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + lane) * 4]),
+                                beta_value,
+                            )
+                        _arrive_barrier(arena, 184, beta_stage)
+
+                    _wait_barrier(arena, 64, raw_stage, (serial // 2) & 1)
+                    _wait_barrier(arena, 0, raw_stage, (serial // 2) & 1)
+                    _wait_barrier(arena, 32, raw_stage, (serial // 2) & 1)
+
+                    gate_prefix = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as row:
+                        K.ptx.ld.shared.f32(
+                            gate_prefix[row],
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, row, channel)]),
+                        )
+                        with K.If(token_base + row >= sequence_length), K.Then():
+                            K.assign(gate_prefix[row], K.float32(0.0))
+                        if safe_gate:
+                            with K.If(token_base + row < sequence_length), K.Then():
+                                gate_sigmoid = (
+                                    _tanh_approx(safe_a * (gate_prefix[row] + safe_bias) * 0.5)
+                                    * 0.5
+                                    + 0.5
+                                )
+                                K.assign(
+                                    gate_prefix[row], K.float32(-7.213475204444817) * gate_sigmoid
+                                )
+                        else:
+                            with K.If(token_base + row < sequence_length), K.Then():
+                                K.assign(
+                                    gate_prefix[row],
+                                    gate_prefix[row] * K.float32(1.4426950408889634),
+                                )
+                    prefix = K.local_scalar("float32", init=K.float32(0.0))
+                    with K.unroll(8) as row_pair:
+                        row0 = row_pair * 2
+                        row1 = row0 + 1
+                        prefix0, pair_sum = _fadd2(
+                            prefix, gate_prefix[row0], gate_prefix[row0], gate_prefix[row1]
+                        )
+                        prefix1 = prefix + pair_sum
+                        K.assign(gate_prefix[row0], prefix0)
+                        K.assign(gate_prefix[row1], prefix1)
+                        K.assign(prefix, prefix1)
+                    with K.unroll(16) as row:
+                        K.assign(gate_prefix[row], _exp2_approx(gate_prefix[row]))
+
+                    _wait_barrier(arena, 488, decay_stage, (serial // 2 + 1) & 1)
+                    with K.unroll(16) as row:
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, row, channel)]),
+                            gate_prefix[row],
+                        )
+                    diagonal_block = channel // 16
+                    diagonal_coord = channel % 16
+                    diagonal_linear = diagonal_block * 256 + diagonal_coord * 16 + diagonal_coord
+                    diagonal_swizzled = K.bitwise_xor(
+                        diagonal_linear,
+                        K.shift_left(
+                            K.bitwise_and(K.shift_right(diagonal_linear, K.uint32(6)), K.uint32(1)),
+                            K.uint32(3),
+                        ),
+                    )
+                    K.ptx.st.shared.b16(
+                        arena.ptr_to([_SMEM_DIAG + decay_stage * 4096 + diagonal_swizzled * 2]),
+                        K.reinterpret("uint16", K.cast(gate_prefix[15], "bfloat16")),
+                    )
+
+                    qk_stage = serial % 4
+                    _wait_barrier(arena, 352, qk_stage, (serial // 4 + 1) & 1)
+                    q_words = K.alloc_local((8,), "uint32")
+                    k_words = K.alloc_local((8,), "uint32")
+                    raw_segment = channel // 64
+                    raw_channel = channel % 64
+                    with K.unroll(8) as pair:
+                        q_lo_bits = K.local_scalar("uint16")
+                        q_hi_bits = K.local_scalar("uint16")
+                        k_lo_bits = K.local_scalar("uint16")
+                        k_hi_bits = K.local_scalar("uint16")
+                        K.ptx.ld.shared.b16(
+                            q_lo_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2, channel)]),
+                        )
+                        K.ptx.ld.shared.b16(
+                            q_hi_bits,
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2 + 1, channel)]
+                            ),
+                        )
+                        K.ptx.ld.shared.b16(
+                            k_lo_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2, channel)]),
+                        )
+                        K.ptx.ld.shared.b16(
+                            k_hi_bits,
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2 + 1, channel)]
+                            ),
+                        )
+                        K.assign(
+                            q_words[pair],
+                            K.bitwise_or(
+                                K.cast(q_lo_bits, "uint32"),
+                                K.shift_left(K.cast(q_hi_bits, "uint32"), K.uint32(16)),
+                            ),
+                        )
+                        K.assign(
+                            k_words[pair],
+                            K.bitwise_or(
+                                K.cast(k_lo_bits, "uint32"),
+                                K.shift_left(K.cast(k_hi_bits, "uint32"), K.uint32(16)),
+                            ),
+                        )
+                    q_tmem = (
+                        tmem_col + _TMEM_Q_RAW + qk_stage * 8 + K.shift_left(tmem_row, K.int32(16))
+                    )
+                    k_tmem = (
+                        tmem_col + _TMEM_K_RAW + qk_stage * 8 + K.shift_left(tmem_row, K.int32(16))
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                        K.cast(q_tmem, "uint32"), *[q_words[i] for i in range(8)]
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                        K.cast(k_tmem, "uint32"), *[k_words[i] for i in range(8)]
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, 320, qk_stage)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+
+                    row_group_start = warp_in_group * 4
+                    row_in_group = lane // 8
+                    lane_in_group = lane % 8
+                    decay_row = row_group_start + row_in_group
+                    raw_q = K.alloc_local((16,), "float32")
+                    raw_k = K.alloc_local((16,), "float32")
+                    qk0_lo = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk0_hi = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk1_lo = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk1_hi = K.local_scalar("float32", init=_opaque_f32_zero())
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        with K.unroll(8) as dim_offset:
+                            q_bits = K.local_scalar("uint16")
+                            k_bits = K.local_scalar("uint16")
+                            K.ptx.ld.shared.b16(
+                                q_bits,
+                                arena.ptr_to(
+                                    [
+                                        _raw_bf16_byte(
+                                            _SMEM_Q, raw_stage, decay_row, dim_base + dim_offset
+                                        )
+                                    ]
+                                ),
+                            )
+                            K.ptx.ld.shared.b16(
+                                k_bits,
+                                arena.ptr_to(
+                                    [
+                                        _raw_bf16_byte(
+                                            _SMEM_K, raw_stage, decay_row, dim_base + dim_offset
+                                        )
+                                    ]
+                                ),
+                            )
+                            K.ptx.cvt.f32.bf16(raw_q[half * 8 + dim_offset], q_bits)
+                            K.ptx.cvt.f32.bf16(raw_k[half * 8 + dim_offset], k_bits)
+                            if l2norm:
+                                if dim_offset % 2 == 0:
+                                    next_q, next_k = _ffma2(
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        qk0_lo,
+                                        qk0_hi,
+                                    )
+                                    K.assign(qk0_lo, next_q)
+                                    K.assign(qk0_hi, next_k)
+                                else:
+                                    next_q, next_k = _ffma2(
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        qk1_lo,
+                                        qk1_hi,
+                                    )
+                                    K.assign(qk1_lo, next_q)
+                                    K.assign(qk1_hi, next_k)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 16, raw_stage)
+                    _arrive_barrier(arena, 48, raw_stage)
+
+                    q_inv_norm = K.local_scalar("float32", init=K.float32(1.0))
+                    k_inv_norm = K.local_scalar("float32", init=K.float32(1.0))
+                    if l2norm:
+                        q_sum = K.local_scalar("float32", init=qk0_lo + qk1_lo)
+                        k_sum = K.local_scalar("float32", init=qk0_hi + qk1_hi)
+                        for delta in (4, 2, 1):
+                            K.assign(q_sum, q_sum + _shuffle_xor_f32(q_sum, delta))
+                            K.assign(k_sum, k_sum + _shuffle_xor_f32(k_sum, delta))
+                        K.assign(q_inv_norm, _rsqrt_approx(K.max(q_sum, 1.0e-24)))
+                        K.assign(k_inv_norm, _rsqrt_approx(K.max(k_sum, 1.0e-24)))
+                        with K.If(lane_in_group == 0), K.Then():
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + decay_row) * 4]),
+                                q_inv_norm,
+                            )
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + decay_row) * 4]),
+                                k_inv_norm,
+                            )
+                    q_scale = q_inv_norm * scale
+
+                    exp_g = K.alloc_local((16,), "float32")
+                    exp_last = K.alloc_local((16,), "float32")
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        with K.unroll(8) as dim_offset:
+                            K.ptx.ld.shared.f32(
+                                exp_g[half * 8 + dim_offset],
+                                arena.ptr_to(
+                                    [
+                                        _raw_f32_byte(
+                                            _SMEM_GATE, raw_stage, decay_row, dim_base + dim_offset
+                                        )
+                                    ]
+                                ),
+                            )
+                            K.ptx.ld.shared.f32(
+                                exp_last[half * 8 + dim_offset],
+                                arena.ptr_to(
+                                    [
+                                        _raw_f32_byte(
+                                            _SMEM_GATE, raw_stage, 15, dim_base + dim_offset
+                                        )
+                                    ]
+                                ),
+                            )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 80, raw_stage)
+
+                    k_inverse_words = K.alloc_local((8,), "uint32")
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        decay_words = K.alloc_local((4,), "uint32")
+                        with K.unroll(4) as pair:
+                            reg = half * 8 + pair * 2
+                            k0, k1 = _fmul2(raw_k[reg], raw_k[reg + 1], k_inv_norm, k_inv_norm)
+                            k_pair = _pack_bf16_pair(k0, k1)
+                            exp_pair = _pack_bf16_pair(exp_g[reg], exp_g[reg + 1])
+                            inverse_pair = _pack_bf16_pair(
+                                _rcp_approx(exp_g[reg]), _rcp_approx(exp_g[reg + 1])
+                            )
+                            K.ptx.mul.bf16x2(decay_words[pair], k_pair, exp_pair)
+                            K.ptx.mul.bf16x2(k_inverse_words[half * 4 + pair], k_pair, inverse_pair)
+                        operand_byte = _raw_bf16_byte(
+                            _SMEM_K_DECAY, decay_stage, decay_row, dim_base
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([operand_byte]),
+                            decay_words[0],
+                            decay_words[1],
+                            decay_words[2],
+                            decay_words[3],
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, decay_row, dim_base)]
+                            ),
+                            k_inverse_words[half * 4],
+                            k_inverse_words[half * 4 + 1],
+                            k_inverse_words[half * 4 + 2],
+                            k_inverse_words[half * 4 + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 456, decay_stage)
+
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        q_decay_words = K.alloc_local((4,), "uint32")
+                        restore_words = K.alloc_local((4,), "uint32")
+                        with K.unroll(4) as pair:
+                            reg = half * 8 + pair * 2
+                            q0, q1 = _fmul2(raw_q[reg], raw_q[reg + 1], q_scale, q_scale)
+                            q_pair = _pack_bf16_pair(q0, q1)
+                            exp_pair = _pack_bf16_pair(exp_g[reg], exp_g[reg + 1])
+                            K.ptx.mul.bf16x2(q_decay_words[pair], q_pair, exp_pair)
+                            last_pair = _pack_bf16_pair(exp_last[reg], exp_last[reg + 1])
+                            K.ptx.mul.bf16x2(
+                                restore_words[pair], k_inverse_words[half * 4 + pair], last_pair
+                            )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q_DECAY, decay_stage, decay_row, dim_base)]
+                            ),
+                            q_decay_words[0],
+                            q_decay_words[1],
+                            q_decay_words[2],
+                            q_decay_words[3],
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_RESTORE, decay_stage, decay_row, dim_base)]
+                            ),
+                            restore_words[0],
+                            restore_words[1],
+                            restore_words[2],
+                            restore_words[3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 472, decay_stage)
+
+                    _wait_barrier(arena, 400, serial % 2, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, 416, serial % 2, (serial // 2 + 1) & 1)
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, 160, state_consumer.stage, state_consumer.phase)
+                        with K.unroll(2) as value_segment:
+                            with K.unroll(8) as value_group:
+                                state_words = K.alloc_local((4,), "uint32")
+                                with K.unroll(4) as pair:
+                                    lo_bits = K.local_scalar("uint16")
+                                    hi_bits = K.local_scalar("uint16")
+                                    key_lo = value_segment * 64 + value_group * 8 + pair * 2
+                                    key_hi = key_lo + 1
+                                    K.ptx.ld.shared.b16(
+                                        lo_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_STATE
+                                                + (
+                                                    (value_channel // 64) * 8192
+                                                    + key_lo * 64
+                                                    + _swizzle_xor_128b(
+                                                        key_lo, value_channel % 64, 2
+                                                    )
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.b16(
+                                        hi_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_STATE
+                                                + (
+                                                    (value_channel // 64) * 8192
+                                                    + key_hi * 64
+                                                    + _swizzle_xor_128b(
+                                                        key_hi, value_channel % 64, 2
+                                                    )
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.assign(
+                                        state_words[pair],
+                                        K.bitwise_or(
+                                            K.cast(lo_bits, "uint32"),
+                                            K.shift_left(K.cast(hi_bits, "uint32"), K.uint32(16)),
+                                        ),
+                                    )
+                                state_tmem = (
+                                    tmem_col
+                                    + _TMEM_STATE_INPUT
+                                    + (serial % 2) * 64
+                                    + value_segment * 32
+                                    + value_group * 4
+                                    + K.shift_left(tmem_row, K.int32(16))
+                                )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x4.b32"](
+                                    K.cast(state_tmem, "uint32"),
+                                    state_words[0],
+                                    state_words[1],
+                                    state_words[2],
+                                    state_words[3],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, 176, state_consumer.stage)
+                        state_consumer.advance()
+                    _arrive_barrier(arena, 384, serial % 2)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with cg2:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_alloc_row = tmem_base >> 16
+            warp_in_group = K.warp_id_in_role()
+            subpartition = warp % 4
+            channel = subpartition * 32 + lane
+            tmem_row = tmem_alloc_row + subpartition * 32
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            dq_consumer = K.PipelineState(1, phase=0)
+            dk_decay_consumer = K.PipelineState(1, phase=0)
+            dk_inverse_consumer = K.PipelineState(1, phase=0)
+            dk_restore_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+
+                    _wait_barrier(arena, 456, decay_stage, (serial // 2) & 1)
+                    gate_decay = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as token:
+                        K.ptx.ld.shared.f32(
+                            gate_decay[token],
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, token, channel)]),
+                        )
+                    gate_last = gate_decay[15]
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 80, raw_stage)
+
+                    qk_stage = serial % 4
+                    qraw_col = tmem_col + _TMEM_Q_RAW + qk_stage * 8
+                    kraw_col = tmem_col + _TMEM_K_RAW + qk_stage * 8
+                    _wait_barrier(arena, 320, qk_stage, (serial // 4) & 1)
+
+                    dgate_last = K.local_scalar("float32", init=K.float32(0.0))
+                    _wait_barrier(arena, 384, serial % 2, (serial // 2) & 1)
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena, 672, dstate_smem_consumer.stage, dstate_smem_consumer.phase
+                        )
+                        dstate_smem_consumer.advance()
+                        with K.unroll(2) as value_plane:
+                            with K.unroll(2) as row_half:
+                                state_words = K.alloc_local((16,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                                    *[state_words[i] for i in range(16)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TMEM_STATE_INPUT
+                                        + (serial % 2) * 64
+                                        + value_plane * 32
+                                        + row_half * 16
+                                        + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                K.ptx.tcgen05.wait__ld.sync.aligned()
+                                hacc = K.alloc_local((8,), "float32")
+                                for accum_slot in range(8):
+                                    K.assign(hacc[accum_slot], _opaque_f32_zero())
+                                with K.unroll(16) as pair:
+                                    state_lo = K.local_scalar("float32")
+                                    state_hi = K.local_scalar("float32")
+                                    _unpack_bf16_pair(state_words[pair], state_lo, state_hi)
+                                    value0 = value_plane * 64 + row_half * 32 + pair * 2
+                                    h0_bits = K.local_scalar("uint16")
+                                    h1_bits = K.local_scalar("uint16")
+                                    K.ptx.ld.shared.b16(
+                                        h0_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_DSTATE
+                                                + (
+                                                    (channel // 64) * 8192
+                                                    + value0 * 64
+                                                    + _swizzle_xor_128b(value0, channel % 64, 2)
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.b16(
+                                        h1_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_DSTATE
+                                                + (
+                                                    (channel // 64) * 8192
+                                                    + (value0 + 1) * 64
+                                                    + _swizzle_xor_128b(value0 + 1, channel % 64, 2)
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    h0 = K.local_scalar("float32")
+                                    h1 = K.local_scalar("float32")
+                                    K.ptx.cvt.f32.bf16(h0, h0_bits)
+                                    K.ptx.cvt.f32.bf16(h1, h1_bits)
+                                    accum_lo = (2 * pair) % 8
+                                    accum_hi = (2 * pair + 1) % 8
+                                    next_lo, next_hi = _ffma2(
+                                        h0, h1, state_lo, state_hi, hacc[accum_lo], hacc[accum_hi]
+                                    )
+                                    K.assign(hacc[accum_lo], next_lo)
+                                    K.assign(hacc[accum_hi], next_hi)
+                                pa0, pb0 = _fadd2(hacc[0], hacc[2], hacc[4], hacc[6])
+                                pa1, pb1 = _fadd2(hacc[1], hacc[3], hacc[5], hacc[7])
+                                part_a, part_b = _fadd2(pa0, pb0, pa1, pb1)
+                                K.assign(dgate_last, dgate_last + part_a + part_b)
+                        _arrive_barrier(arena, 688)
+                    _arrive_barrier(arena, 416, serial % 2)
+
+                    dq_values = K.alloc_local((16,), "float32")
+                    dk_values = K.alloc_local((16,), "float32")
+                    dgate_values = K.alloc_local((16,), "float32")
+                    last_dot = K.alloc_local((4,), "float32")
+                    for slot in range(4):
+                        K.assign(last_dot[slot], K.float32(0.0))
+                    for token in range(16):
+                        K.assign(dk_values[token], K.float32(0.0))
+
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena, 304, dk_restore_consumer.stage, dk_restore_consumer.phase
+                        )
+                        dk_restore_consumer.advance()
+                        restore = K.alloc_local((16,), "float32")
+                        kraw = K.alloc_local((8,), "uint32")
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                            *[restore[i] for i in range(16)],
+                            K.cast(
+                                tmem_col + _TMEM_DK_RESTORE + K.shift_left(tmem_row, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                            *[kraw[i] for i in range(8)],
+                            K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        with K.unroll(16) as token:
+                            K.assign(
+                                dk_values[token],
+                                gate_last * _rcp_approx(gate_decay[token]) * restore[token],
+                            )
+                            k_lo = K.local_scalar("float32")
+                            k_hi = K.local_scalar("float32")
+                            _unpack_bf16_pair(kraw[token // 2], k_lo, k_hi)
+                            k_value = K.local_scalar("float32")
+                            K.assign(k_value, K.if_then_else(token % 2 == 0, k_lo, k_hi))
+                            if l2norm:
+                                k_norm = K.local_scalar("float32")
+                                K.ptx.ld.shared.f32(
+                                    k_norm,
+                                    arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + token) * 4]),
+                                )
+                                K.assign(k_value, k_value * k_norm)
+                            K.assign(
+                                last_dot[token % 4],
+                                last_dot[token % 4] + k_value * dk_values[token],
+                            )
+
+                    _wait_barrier(arena, 280, dq_consumer.stage, dq_consumer.phase)
+                    dq_consumer.advance()
+                    dq_acc = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[dq_acc[i] for i in range(16)],
+                        K.cast(tmem_col + _TMEM_DQ + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    with K.unroll(8) as pair:
+                        token = pair * 2
+                        scaled_lo, scaled_hi = _fmul2(
+                            gate_decay[token], gate_decay[token + 1], scale, scale
+                        )
+                        dq_lo, dq_hi = _fmul2(
+                            scaled_lo, scaled_hi, dq_acc[token], dq_acc[token + 1]
+                        )
+                        K.assign(dq_values[token], dq_lo)
+                        K.assign(dq_values[token + 1], dq_hi)
+
+                    _wait_barrier(arena, 296, dk_inverse_consumer.stage, dk_inverse_consumer.phase)
+                    dk_inverse_consumer.advance()
+                    inverse = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[inverse[i] for i in range(16)],
+                        K.cast(
+                            tmem_col + _TMEM_DK_INV + K.shift_left(tmem_row, K.int32(16)), "uint32"
+                        ),
+                    )
+                    with K.unroll(16) as token:
+                        K.assign(
+                            dk_values[token],
+                            dk_values[token] + inverse[token] * _rcp_approx(gate_decay[token]),
+                        )
+
+                    _wait_barrier(arena, 288, dk_decay_consumer.stage, dk_decay_consumer.phase)
+                    dk_decay_consumer.advance()
+                    decay = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[decay[i] for i in range(16)],
+                        K.cast(
+                            tmem_col + _TMEM_DK_DECAY + K.shift_left(tmem_row, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    with K.unroll(16) as token:
+                        K.assign(dgate_values[token], -gate_decay[token] * decay[token])
+                        K.assign(dk_values[token], dk_values[token] + dgate_values[token])
+                    _arrive_barrier(arena, 312)
+
+                    qraw = K.alloc_local((8,), "uint32")
+                    kraw = K.alloc_local((8,), "uint32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                        *[qraw[i] for i in range(8)],
+                        K.cast(qraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                        *[kraw[i] for i in range(8)],
+                        K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    with K.unroll(16) as token:
+                        q_lo = K.local_scalar("float32")
+                        q_hi = K.local_scalar("float32")
+                        k_lo = K.local_scalar("float32")
+                        k_hi = K.local_scalar("float32")
+                        _unpack_bf16_pair(qraw[token // 2], q_lo, q_hi)
+                        _unpack_bf16_pair(kraw[token // 2], k_lo, k_hi)
+                        q_value = K.local_scalar("float32")
+                        k_value = K.local_scalar("float32")
+                        K.assign(q_value, K.if_then_else(token % 2 == 0, q_lo, q_hi))
+                        K.assign(k_value, K.if_then_else(token % 2 == 0, k_lo, k_hi))
+                        if l2norm:
+                            q_norm = K.local_scalar("float32")
+                            k_norm = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                q_norm, arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + token) * 4])
+                            )
+                            K.ptx.ld.shared.f32(
+                                k_norm,
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + token) * 4]),
+                            )
+                            K.assign(q_value, q_value * q_norm)
+                            K.assign(k_value, k_value * k_norm)
+                        K.assign(
+                            dgate_values[token],
+                            q_value * dq_values[token]
+                            + k_value * (K.float32(2.0) * dgate_values[token] - dk_values[token]),
+                        )
+                    K.assign(
+                        dgate_values[15],
+                        dgate_values[15] + last_dot[0] + last_dot[1] + last_dot[2] + last_dot[3],
+                    )
+
+                    if l2norm:
+                        for grad, raw_column, norm_offset in (
+                            (dq_values, qraw_col, 0),
+                            (dk_values, kraw_col, 16),
+                        ):
+                            dots = K.alloc_local((16,), "float32")
+                            for half in range(2):
+                                half_words = K.alloc_local((4,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](
+                                    *[half_words[i] for i in range(4)],
+                                    K.cast(
+                                        raw_column + half * 4 + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                for pair in range(4):
+                                    token = half * 8 + pair * 2
+                                    raw_lo = K.local_scalar("float32")
+                                    raw_hi = K.local_scalar("float32")
+                                    _unpack_bf16_pair(half_words[pair], raw_lo, raw_hi)
+                                    norm_lo = K.local_scalar("float32")
+                                    norm_hi = K.local_scalar("float32")
+                                    K.ptx.ld.shared.f32(
+                                        norm_lo,
+                                        arena.ptr_to(
+                                            [_SMEM_NORM + (qk_stage * 32 + norm_offset + token) * 4]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.f32(
+                                        norm_hi,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_NORM
+                                                + (qk_stage * 32 + norm_offset + token + 1) * 4
+                                            ]
+                                        ),
+                                    )
+                                    product_lo, product_hi = _fmul2(
+                                        grad[token], grad[token + 1], raw_lo, raw_hi
+                                    )
+                                    product_lo, product_hi = _fmul2(
+                                        product_lo, product_hi, norm_lo, norm_hi
+                                    )
+                                    K.assign(dots[token], product_lo)
+                                    K.assign(dots[token + 1], product_hi)
+                            for delta in (1, 2, 4, 8, 16):
+                                for pair in range(8):
+                                    token = pair * 2
+                                    other_lo = _shuffle_xor_f32(dots[token], delta)
+                                    other_hi = _shuffle_xor_f32(dots[token + 1], delta)
+                                    sum_lo, sum_hi = _fadd2(
+                                        dots[token], dots[token + 1], other_lo, other_hi
+                                    )
+                                    K.assign(dots[token], sum_lo)
+                                    K.assign(dots[token + 1], sum_hi)
+                            with K.If(lane == 0), K.Then():
+                                for token in range(16):
+                                    K.ptx.st.shared.f32(
+                                        arena.ptr_to(
+                                            [_SMEM_RED1 + (subpartition * 16 + token) * 4]
+                                        ),
+                                        dots[token],
+                                    )
+                            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                            for half in range(2):
+                                half_words = K.alloc_local((4,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](
+                                    *[half_words[i] for i in range(4)],
+                                    K.cast(
+                                        raw_column + half * 4 + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                for pair in range(4):
+                                    token = half * 8 + pair * 2
+                                    partials = K.alloc_local((8,), "float32")
+                                    for reduction_warp in range(4):
+                                        K.ptx.ld.shared.f32(
+                                            partials[reduction_warp * 2],
+                                            arena.ptr_to(
+                                                [_SMEM_RED1 + (reduction_warp * 16 + token) * 4]
+                                            ),
+                                        )
+                                        K.ptx.ld.shared.f32(
+                                            partials[reduction_warp * 2 + 1],
+                                            arena.ptr_to(
+                                                [_SMEM_RED1 + (reduction_warp * 16 + token + 1) * 4]
+                                            ),
+                                        )
+                                    dot_lo, dot_hi = _fadd2(
+                                        partials[0], partials[1], partials[2], partials[3]
+                                    )
+                                    dot_lo, dot_hi = _fadd2(
+                                        dot_lo, dot_hi, partials[4], partials[5]
+                                    )
+                                    dot_lo, dot_hi = _fadd2(
+                                        dot_lo, dot_hi, partials[6], partials[7]
+                                    )
+                                    raw_lo = K.local_scalar("float32")
+                                    raw_hi = K.local_scalar("float32")
+                                    _unpack_bf16_pair(half_words[pair], raw_lo, raw_hi)
+                                    norm_lo = K.local_scalar("float32")
+                                    norm_hi = K.local_scalar("float32")
+                                    K.ptx.ld.shared.f32(
+                                        norm_lo,
+                                        arena.ptr_to(
+                                            [_SMEM_NORM + (qk_stage * 32 + norm_offset + token) * 4]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.f32(
+                                        norm_hi,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_NORM
+                                                + (qk_stage * 32 + norm_offset + token + 1) * 4
+                                            ]
+                                        ),
+                                    )
+                                    unit_lo, unit_hi = _fmul2(raw_lo, raw_hi, norm_lo, norm_hi)
+                                    correction_lo, correction_hi = _fmul2(
+                                        unit_lo, unit_hi, dot_lo, dot_hi
+                                    )
+                                    residual_lo, residual_hi = _fsub2(
+                                        grad[token], grad[token + 1], correction_lo, correction_hi
+                                    )
+                                    result_lo, result_hi = _fmul2(
+                                        residual_lo, residual_hi, norm_lo, norm_hi
+                                    )
+                                    K.assign(grad[token], result_lo)
+                                    K.assign(grad[token + 1], result_hi)
+                            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    _arrive_barrier(arena, 352, qk_stage)
+                    _wait_barrier(arena, 704, 0, (serial + 1) & 1)
+                    _wait_barrier(arena, 720, 0, (serial + 1) & 1)
+                    with K.unroll(16) as token:
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DQ, 0, token, channel)]),
+                            K.reinterpret("uint16", K.cast(dq_values[token], "bfloat16")),
+                        )
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DK, 0, token, channel)]),
+                            K.reinterpret("uint16", K.cast(dk_values[token], "bfloat16")),
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 696)
+                    _arrive_barrier(arena, 712)
+
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(K.And(has_dstate, chunk >= first_state_chunk)), K.Then():
+                        K.assign(dgate_values[15], dgate_values[15] + gate_last * dgate_last)
+                    suffix = K.local_scalar("float32", init=K.float32(0.0))
+                    for reverse_token in range(16):
+                        token = 15 - reverse_token
+                        K.assign(suffix, suffix + dgate_values[token])
+                        K.assign(dgate_values[token], suffix)
+                    _wait_barrier(arena, 768, 0, (serial + 1) & 1)
+                    with K.unroll(16) as token:
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_raw_f32_byte(_SMEM_DGATE, 0, token, channel)]),
+                            dgate_values[token],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 760)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _arrive_barrier(arena, 784)
+        with cg1:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_alloc_row = tmem_base >> 16
+            warp_in_group = K.warp_id_in_role()
+            subpartition = warp % 4
+            value_dim = subpartition * 32 + lane
+            value_base = subpartition * 32
+            token_row = (lane // 16) * 8 + (lane & 7)
+            value_col_offset = ((lane // 8) & 1) * 8
+            group_thread = warp_in_group * 32 + lane
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_k_consumer = K.PipelineState(1, phase=0)
+            du_consumer = K.PipelineState(1, phase=0)
+            u_consumer = K.PipelineState(1, phase=0)
+            dy_consumer = K.PipelineState(1, phase=0)
+            dstate_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_done = K.PipelineState(1, phase=1)
+            dbeta_m_consumer = K.PipelineState(1, phase=0)
+            dv_done_consumer = K.PipelineState(2, phase=1)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                sequence_chunks = (sequence_length + 15) // 16
+                num_chunks = cend - wstart
+                dstate_index_base = (
+                    (K.cast(batch, "int64") * n_heads_out + head) * 128 + value_dim
+                ) * 128
+
+                if use_dstate_in:
+                    with K.If(num_chunks > 0), K.Then():
+                        _wait_barrier(arena, 680, dstate_smem_done.stage, dstate_smem_done.phase)
+                        _wait_barrier(arena, 688, dstate_smem_done.stage, dstate_smem_done.phase)
+                        dstate_smem_done.advance()
+                        seed_enabled = cend == sequence_chunks
+                        seed_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(8) as key_subtile:
+                            seed = K.alloc_local((16,), "float32")
+                            seed_pack = K.alloc_local((8,), "uint32")
+                            with K.unroll(16) as key_offset:
+                                K.ptx.ld.global_.f32(
+                                    seed[key_offset],
+                                    d_final_state.ptr_to(
+                                        [dstate_index_base + key_subtile * 16 + key_offset]
+                                    ),
+                                )
+                                with K.If(K.Not(seed_enabled)), K.Then():
+                                    K.assign(seed[key_offset], K.float32(0.0))
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 16
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[seed[i] for i in range(16)],
+                            )
+                            for pair in range(8):
+                                K.assign(
+                                    seed_pack[pair],
+                                    _pack_bf16_pair(seed[pair * 2], seed[pair * 2 + 1]),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 8
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[seed_pack[i] for i in range(8)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, 664)
+                        with K.unroll(8) as key_subtile:
+                            seed_words = K.alloc_local((8,), "uint32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                                *[seed_words[i] for i in range(8)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 8
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            with K.unroll(2) as half:
+                                key_base = key_subtile * 16 + half * 8
+                                K.ptx.st.shared.v4.b32(
+                                    arena.ptr_to(
+                                        [
+                                            _SMEM_DSTATE
+                                            + (
+                                                (key_base // 64) * 8192
+                                                + value_dim * 64
+                                                + _swizzle_xor_128b(value_dim, key_base % 64, 2)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    seed_words[half * 4],
+                                    seed_words[half * 4 + 1],
+                                    seed_words[half * 4 + 2],
+                                    seed_words[half * 4 + 3],
+                                )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, 672)
+
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    beta_stage = serial % 4
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+                    row_lo = tmem_alloc_row
+                    row_hi = tmem_alloc_row + 16
+                    projection_row0 = tmem_alloc_row + value_base
+                    projection_row1 = projection_row0 + 16
+
+                    _wait_barrier(arena, 128, raw_stage, (serial // 2) & 1)
+                    raw_v0 = K.alloc_local((4,), "uint32")
+                    raw_v1 = K.alloc_local((4,), "uint32")
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_v0[0],
+                        raw_v0[1],
+                        raw_v0[2],
+                        raw_v0[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_V, raw_stage, token_row, value_base + value_col_offset
+                                )
+                            ]
+                        ),
+                    )
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_v1[0],
+                        raw_v1[1],
+                        raw_v1[2],
+                        raw_v1[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_V,
+                                    raw_stage,
+                                    token_row,
+                                    value_base + 16 + value_col_offset,
+                                )
+                            ]
+                        ),
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 144, raw_stage)
+
+                    _wait_barrier(arena, 184, beta_stage, (serial // 4) & 1)
+                    beta_pairs = K.alloc_local((2,), "uint32")
+                    for half in range(2):
+                        token0 = ((half * 4 + (lane & 3)) ^ 4) * 2
+                        beta0 = K.local_scalar("float32")
+                        beta1 = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            beta0, arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + token0) * 4])
+                        )
+                        K.ptx.ld.shared.f32(
+                            beta1, arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + token0 + 1) * 4])
+                        )
+                        K.assign(beta_pairs[half], _pack_bf16_pair(beta0, beta1))
+
+                    difference0 = K.alloc_local((4,), "uint32")
+                    difference1 = K.alloc_local((4,), "uint32")
+                    y_pack0 = K.alloc_local((4,), "uint32")
+                    y_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        raw_matrix = (1 - reg // 2) * 2 + (reg & 1)
+                        K.assign(difference0[reg ^ 2], raw_v0[raw_matrix])
+                        K.assign(difference1[reg ^ 2], raw_v1[raw_matrix])
+                        K.ptx.mul.bf16x2(y_pack0[reg ^ 2], beta_pairs[reg // 2], raw_v0[raw_matrix])
+                        K.ptx.mul.bf16x2(y_pack1[reg ^ 2], beta_pairs[reg // 2], raw_v1[raw_matrix])
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, 248, state_k_consumer.stage, state_k_consumer.phase)
+                        state_k_consumer.advance()
+                        state0 = K.alloc_local((8,), "float32")
+                        state1 = K.alloc_local((8,), "float32")
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                            *[state0[i] for i in range(8)],
+                            K.cast(
+                                tmem_col
+                                + _TMEM_STATE_K_DY
+                                + K.shift_left(projection_row0, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                            *[state1[i] for i in range(8)],
+                            K.cast(
+                                tmem_col
+                                + _TMEM_STATE_K_DY
+                                + K.shift_left(projection_row1, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        for reg in range(4):
+                            raw_matrix = (1 - reg // 2) * 2 + (reg & 1)
+                            frag_pair = (reg ^ 2) * 2
+                            state_pair0 = _pack_bf16_pair(state0[frag_pair], state0[frag_pair + 1])
+                            state_pair1 = _pack_bf16_pair(state1[frag_pair], state1[frag_pair + 1])
+                            K.ptx.sub.bf16x2(difference0[reg ^ 2], raw_v0[raw_matrix], state_pair0)
+                            K.ptx.sub.bf16x2(difference1[reg ^ 2], raw_v1[raw_matrix], state_pair1)
+                            K.ptx.mul.bf16x2(
+                                y_pack0[reg ^ 2], beta_pairs[reg // 2], difference0[reg ^ 2]
+                            )
+                            K.ptx.mul.bf16x2(
+                                y_pack1[reg ^ 2], beta_pairs[reg // 2], difference1[reg ^ 2]
+                            )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_BETA_DY + K.shift_left(row_lo, K.int32(16)),
+                            "uint32",
+                        ),
+                        *[y_pack0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_BETA_DY + K.shift_left(row_hi, K.int32(16)),
+                            "uint32",
+                        ),
+                        *[y_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, 432)
+
+                    _wait_barrier(arena, 256, du_consumer.stage, du_consumer.phase)
+                    du_consumer.advance()
+                    du0 = K.alloc_local((8,), "float32")
+                    du1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[du0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_DU + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[du1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_DU + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    du_pack0 = K.alloc_local((4,), "uint32")
+                    du_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(du_pack0[reg], _pack_bf16_pair(du0[2 * reg], du0[2 * reg + 1]))
+                        K.assign(du_pack1[reg], _pack_bf16_pair(du1[2 * reg], du1[2 * reg + 1]))
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_DU_INPUT + K.shift_left(row_lo, K.int32(16)), "uint32"
+                        ),
+                        *[du_pack0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_DU_INPUT + K.shift_left(row_hi, K.int32(16)), "uint32"
+                        ),
+                        *[du_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, 440)
+
+                    _wait_barrier(arena, 264, u_consumer.stage, u_consumer.phase)
+                    u_consumer.advance()
+                    u0 = K.alloc_local((8,), "float32")
+                    u1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[u0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_U + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[u1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_U + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    u_pack0 = K.alloc_local((4,), "uint32")
+                    u_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(u_pack0[reg], _pack_bf16_pair(u0[2 * reg], u0[2 * reg + 1]))
+                        K.assign(u_pack1[reg], _pack_bf16_pair(u1[2 * reg], u1[2 * reg + 1]))
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to(
+                            [_raw_bf16_byte(_SMEM_U, 0, token_row, value_base + value_col_offset)]
+                        ),
+                        *[u_pack0[i] for i in range(4)],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_U, 0, token_row, value_base + 16 + value_col_offset
+                                )
+                            ]
+                        ),
+                        *[u_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 632)
+
+                    _wait_barrier(arena, 272, dy_consumer.stage, dy_consumer.phase)
+                    dy_consumer.advance()
+                    dy0 = K.alloc_local((8,), "float32")
+                    dy1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[dy0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col
+                            + _TMEM_STATE_K_DY
+                            + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[dy1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col
+                            + _TMEM_STATE_K_DY
+                            + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    dy_pack0 = K.alloc_local((4,), "uint32")
+                    dy_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(dy_pack0[reg], _pack_bf16_pair(dy0[2 * reg], dy0[2 * reg + 1]))
+                        K.assign(dy_pack1[reg], _pack_bf16_pair(dy1[2 * reg], dy1[2 * reg + 1]))
+                    dy_addr0 = _raw_bf16_byte(_SMEM_DY, 0, token_row, value_base + value_col_offset)
+                    dy_addr1 = _raw_bf16_byte(
+                        _SMEM_DY, 0, token_row, value_base + 16 + value_col_offset
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([dy_addr0]), *[dy_pack0[i] for i in range(4)]
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([dy_addr1]), *[dy_pack1[i] for i in range(4)]
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 640)
+
+                    beta_values = K.alloc_local((4,), "float32")
+                    for beta_slot, token_slot in enumerate((0, 1, 8, 9)):
+                        K.ptx.ld.shared.f32(
+                            beta_values[beta_slot],
+                            arena.ptr_to(
+                                [_SMEM_BETA + (beta_stage * 16 + (lane % 4) * 2 + token_slot) * 4]
+                            ),
+                        )
+                    beta_self = K.local_scalar("float32", init=K.float32(0.0))
+                    if beta_sigmoid:
+                        with K.If(group_thread < 16), K.Then():
+                            K.ptx.ld.shared.f32(
+                                beta_self,
+                                arena.ptr_to([_SMEM_BETA + (beta_stage * 16 + group_thread) * 4]),
+                            )
+                    _arrive_barrier(arena, 216, beta_stage)
+
+                    beta_dy0 = K.alloc_local((8,), "float32")
+                    beta_dy1 = K.alloc_local((8,), "float32")
+                    with K.unroll(4) as pair:
+                        beta_lo = K.if_then_else(pair >= 2, beta_values[2], beta_values[0])
+                        beta_hi = K.if_then_else(pair >= 2, beta_values[3], beta_values[1])
+                        product_lo, product_hi = _fmul2(
+                            dy0[pair * 2], dy0[pair * 2 + 1], beta_lo, beta_hi
+                        )
+                        K.assign(beta_dy0[pair * 2], product_lo)
+                        K.assign(beta_dy0[pair * 2 + 1], product_hi)
+                        product_lo, product_hi = _fmul2(
+                            dy1[pair * 2], dy1[pair * 2 + 1], beta_lo, beta_hi
+                        )
+                        K.assign(beta_dy1[pair * 2], product_lo)
+                        K.assign(beta_dy1[pair * 2 + 1], product_hi)
+                    neg0 = K.alloc_local((4,), "uint32")
+                    neg1 = K.alloc_local((4,), "uint32")
+                    dv_pack0 = K.alloc_local((4,), "uint32")
+                    dv_pack1 = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(
+                            neg0[pair],
+                            _pack_bf16_pair(-beta_dy0[pair * 2], -beta_dy0[pair * 2 + 1]),
+                        )
+                        K.assign(
+                            neg1[pair],
+                            _pack_bf16_pair(-beta_dy1[pair * 2], -beta_dy1[pair * 2 + 1]),
+                        )
+                        K.assign(
+                            dv_pack0[pair],
+                            _pack_bf16_pair(beta_dy0[pair * 2], beta_dy0[pair * 2 + 1]),
+                        )
+                        K.assign(
+                            dv_pack1[pair],
+                            _pack_bf16_pair(beta_dy1[pair * 2], beta_dy1[pair * 2 + 1]),
+                        )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_BETA_DY + K.shift_left(row_lo, K.int32(16)),
+                            "uint32",
+                        ),
+                        *[neg0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_BETA_DY + K.shift_left(row_hi, K.int32(16)),
+                            "uint32",
+                        ),
+                        *[neg1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, 448)
+
+                    token_sums = K.alloc_local((4,), "float32")
+                    for token_sum in range(4):
+                        K.assign(token_sums[token_sum], K.float32(0.0))
+                    for pair in range(4):
+                        diff0_lo = K.local_scalar("float32")
+                        diff0_hi = K.local_scalar("float32")
+                        diff1_lo = K.local_scalar("float32")
+                        diff1_hi = K.local_scalar("float32")
+                        _unpack_bf16_pair(difference0[pair], diff0_lo, diff0_hi)
+                        _unpack_bf16_pair(difference1[pair], diff1_lo, diff1_hi)
+                        sum_lo = 2 * (pair // 2)
+                        sum_hi = sum_lo + 1
+                        accum_lo, accum_hi = _ffma2(
+                            dy0[2 * pair],
+                            dy0[2 * pair + 1],
+                            diff0_lo,
+                            diff0_hi,
+                            token_sums[sum_lo],
+                            token_sums[sum_hi],
+                        )
+                        accum_lo, accum_hi = _ffma2(
+                            dy1[2 * pair], dy1[2 * pair + 1], diff1_lo, diff1_hi, accum_lo, accum_hi
+                        )
+                        K.assign(token_sums[sum_lo], accum_lo)
+                        K.assign(token_sums[sum_hi], accum_hi)
+
+                    dv_stage = serial % 2
+                    _wait_barrier(arena, 744, dv_done_consumer.stage, dv_done_consumer.phase)
+                    dv_done_consumer.advance()
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([_SMEM_DV + dv_stage * 4096 + (dy_addr0 - _SMEM_DY)]),
+                        *[dv_pack0[i] for i in range(4)],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([_SMEM_DV + dv_stage * 4096 + (dy_addr1 - _SMEM_DY)]),
+                        *[dv_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, 728, dv_stage)
+
+                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+                    _wait_barrier(arena, 648, dbeta_m_consumer.stage, dbeta_m_consumer.phase)
+                    dbeta_m_consumer.advance()
+                    for delta in (4, 8, 16):
+                        for slot in range(4):
+                            K.assign(
+                                token_sums[slot],
+                                token_sums[slot] + _shuffle_xor_f32(token_sums[slot], delta),
+                            )
+                    with K.If(lane < 4), K.Then():
+                        for slot in range(4):
+                            reduction_token = (lane % 4) * 2 + (slot % 2) + 8 * (slot // 2)
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to(
+                                    [_SMEM_RED0 + (warp_in_group * 16 + reduction_token) * 4]
+                                ),
+                                token_sums[slot],
+                            )
+                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+                    with K.If(group_thread < 16), K.Then():
+                        dbeta_value = K.local_scalar("float32", init=K.float32(0.0))
+                        for reduction_warp in range(4):
+                            partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                partial,
+                                arena.ptr_to(
+                                    [_SMEM_RED0 + (reduction_warp * 16 + group_thread) * 4]
+                                ),
+                            )
+                            K.assign(dbeta_value, dbeta_value + partial)
+                        beta_m = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(beta_m, arena.ptr_to([_SMEM_BETA_M + group_thread * 4]))
+                        K.assign(dbeta_value, dbeta_value + beta_m)
+                        if beta_sigmoid:
+                            K.assign(dbeta_value, dbeta_value * (beta_self - beta_self * beta_self))
+                        token_index = chunk * 16 + group_thread
+                        with K.If(K.And(token_index < sequence_length, chunk < wend)), K.Then():
+                            output_index = K.cast(bos + token_index, "int64") * n_heads_out + head
+                            if beta_sigmoid:
+                                K.ptx.st.global_.b16(
+                                    dbeta.ptr_to([output_index]),
+                                    K.reinterpret("uint16", K.cast(dbeta_value, "bfloat16")),
+                                )
+                            else:
+                                K.ptx.st.global_.f32(dbeta.ptr_to([output_index]), dbeta_value)
+                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+
+                    _wait_barrier(arena, 656, dstate_consumer.stage, dstate_consumer.phase)
+                    dstate_consumer.advance()
+                    with K.If(reverse_index + 1 < num_chunks), K.Then():
+                        _wait_barrier(arena, 680, dstate_smem_done.stage, dstate_smem_done.phase)
+                        _wait_barrier(arena, 688, dstate_smem_done.stage, dstate_smem_done.phase)
+                        dstate_smem_done.advance()
+                        dstate_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(4) as key_subtile:
+                            dstate_values = K.alloc_local((32,), "float32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                *[dstate_values[i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 32
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            dstate_words = K.alloc_local((16,), "uint32")
+                            for pair in range(16):
+                                K.assign(
+                                    dstate_words[pair],
+                                    _pack_bf16_pair(
+                                        dstate_values[pair * 2], dstate_values[pair * 2 + 1]
+                                    ),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 16
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[dstate_words[i] for i in range(16)],
+                            )
+                            with K.unroll(4) as half:
+                                key_base = key_subtile * 32 + half * 8
+                                K.ptx.st.shared.v4.b32(
+                                    arena.ptr_to(
+                                        [
+                                            _SMEM_DSTATE
+                                            + (
+                                                (key_base // 64) * 8192
+                                                + value_dim * 64
+                                                + _swizzle_xor_128b(value_dim, key_base % 64, 2)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    dstate_words[half * 4],
+                                    dstate_words[half * 4 + 1],
+                                    dstate_words[half * 4 + 2],
+                                    dstate_words[half * 4 + 3],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, 664)
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, 672)
+
+                if use_dstate0:
+                    with K.If(K.And(num_chunks > 0, wstart == 0)), K.Then():
+                        dstate_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(4) as key_subtile:
+                            dstate_values = K.alloc_local((32,), "float32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                *[dstate_values[i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 32
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            for key_offset in range(32):
+                                K.ptx.st.global_.f32(
+                                    d_initial_state.ptr_to(
+                                        [dstate_index_base + key_subtile * 32 + key_offset]
+                                    ),
+                                    dstate_values[key_offset],
+                                )
+                    with K.If(num_chunks == 0), K.Then():
+                        with K.unroll(128) as key:
+                            passthrough = K.local_scalar("float32", init=K.float32(0.0))
+                            if use_dstate_in:
+                                K.ptx.ld.global_.f32(
+                                    passthrough, d_final_state.ptr_to([dstate_index_base + key])
+                                )
+                            K.ptx.st.global_.f32(
+                                d_initial_state.ptr_to([dstate_index_base + key]), passthrough
+                            )
+                _arrive_barrier(arena, 776)
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, 792, sched_consumer.stage, sched_consumer.phase)
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, 856, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _arrive_barrier(arena, 784)
+
+    return main
+
+
+def _normalized_config(config):
+    config = {key: value for key, value in config.items() if key != "label"}
+    config.setdefault("seq_lens", (64,))
+    config.setdefault("heads", 1)
+    config.setdefault("q_heads", config["heads"])
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("num_sms", 148)
+    config.setdefault("scale", 1.0 / (_DK**0.5))
+    for key in (
+        "l2norm",
+        "safe_gate",
+        "beta_sigmoid",
+        "use_initial_state",
+        "use_dstate_in",
+        "use_dstate0",
+        "dynamic_scheduler",
+        "run_order",
+        "order_generate",
+    ):
+        config.setdefault(key, False)
+    heads = int(config["heads"])
+    for name in ("q_heads", "k_heads", "v_heads"):
+        if heads % int(config[name]) != 0:
+            raise ValueError(f"{name}={config[name]} must divide heads={heads}")
+    return config
+
+
+def get_kernel(**config):
+    config = _normalized_config(config)
+    num_sms = int(config.get("num_sms", 148))
+    prologue = _make_prologue(
+        run_order=bool(config.get("run_order", False)),
+        order_generate=bool(config.get("order_generate", False)),
+        dynamic_scheduler=bool(config.get("dynamic_scheduler", False)),
+        n_heads_out=int(config.get("n_heads_out", config.get("heads", 1))),
+    )
+    main = _make_main(
+        num_sms=num_sms,
+        beta_sigmoid=bool(config.get("beta_sigmoid", False)),
+        use_dstate_in=bool(config.get("use_dstate_in", False)),
+        use_dstate0=bool(config.get("use_dstate0", False)),
+        use_initial_state=bool(config.get("use_initial_state", False)),
+        safe_gate=bool(config.get("safe_gate", False)),
+        dynamic_scheduler=bool(config.get("dynamic_scheduler", False)),
+        l2norm=bool(config.get("l2norm", False)),
+        n_heads_out=int(config.get("n_heads_out", config.get("heads", 1))),
+        q_ratio=int(config.get("q_ratio", config["heads"] // config["q_heads"])),
+        k_ratio=int(config.get("k_ratio", config["heads"] // config["k_heads"])),
+        v_ratio=int(config.get("v_ratio", config["heads"] // config["v_heads"])),
+    )
+    return [prologue.func, main.func]
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8 != 0:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment != 0:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _make_work_items(torch, seq_lens, heads):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return torch.tensor(rows, dtype=torch.int32, device="cuda")
+
+
+def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias):
+    q_effective = q
+    k_effective = k
+    if l2norm:
+        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
+        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
+    gate_effective = gate
+    if safe_gate:
+        gate_effective = -5.0 * torch.sigmoid(
+            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
+        )
+    beta_effective = beta.sigmoid() if beta_sigmoid else beta
+    return q_effective, k_effective, gate_effective, beta_effective
+
+
+def _forward_and_checkpoints(
+    torch, q, k, v, gate, beta, cu_seqlens, *, scale, initial_state, checkpoint_dtype
+):
+    from itertools import pairwise
+
+    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
+    batch_count = len(bounds) - 1
+    heads = gate.shape[1]
+    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
+    checkpoints = torch.zeros(
+        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
+    )
+    outputs = []
+    final_states = []
+    for batch, (begin, end) in enumerate(pairwise(bounds)):
+        if initial_state is None:
+            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
+        else:
+            state = initial_state[batch].transpose(-1, -2)
+        checkpoint_base = begin // _BT + batch
+        for local_token, token in enumerate(range(begin, end)):
+            if local_token % _BT == 0:
+                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
+                    checkpoint_dtype
+                )
+            state = gate[token].exp()[..., None] * state
+            residual = v[token] - torch.einsum("hd,hdv->hv", k[token], state)
+            state = state + beta[token, :, None, None] * torch.einsum(
+                "hd,hv->hdv", k[token], residual
+            )
+            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
+        final_states.append(state.transpose(-1, -2))
+    output = torch.stack(outputs)
+    return output, torch.stack(final_states), checkpoints
+
+
+def _new_outputs(torch, config, total_tokens):
+    heads = config["heads"]
+    beta_dtype = torch.bfloat16 if config["beta_sigmoid"] else torch.float32
+    result = {
+        "dq": torch.zeros(total_tokens, heads, _DK, dtype=torch.bfloat16, device="cuda"),
+        "dk": torch.zeros(total_tokens, heads, _DK, dtype=torch.bfloat16, device="cuda"),
+        "dv": torch.zeros(total_tokens, heads, _DV, dtype=torch.bfloat16, device="cuda"),
+        "dgate": torch.zeros(total_tokens, heads, _DK, dtype=torch.float32, device="cuda"),
+        "dbeta": torch.zeros(total_tokens, heads, dtype=beta_dtype, device="cuda"),
+    }
+    if config["use_dstate0"]:
+        result["d_initial_state"] = torch.zeros(
+            len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda"
+        )
+    return result
+
+
+def _prepare_work_tables(torch, config):
+    base = _make_work_items(torch, config["seq_lens"], config["heads"])
+
+    def one_side():
+        if config["run_order"]:
+            work_items = torch.empty_like(base)
+            staging = None if config["order_generate"] else base.clone()
+            sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+        else:
+            work_items = base.clone()
+            staging = None
+            sched_all = None
+        return {
+            "work_items": work_items,
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": staging,
+            "sched_all": sched_all,
+            "sched_ctr": (
+                torch.zeros(2, dtype=torch.int32, device="cuda")
+                if config["dynamic_scheduler"]
+                else None
+            ),
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _prepare_data(config, *, with_oracle):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260823)
+    total_tokens = sum(config["seq_lens"])
+    heads = config["heads"]
+    q_heads = config["q_heads"]
+    k_heads = config["k_heads"]
+    v_heads = config["v_heads"]
+    q = (0.2 * torch.randn(total_tokens, q_heads, _DK, device="cuda")).to(torch.bfloat16)
+    k = (0.2 * torch.randn(total_tokens, k_heads, _DK, device="cuda")).to(torch.bfloat16)
+    v = (0.2 * torch.randn(total_tokens, v_heads, _DV, device="cuda")).to(torch.bfloat16)
+    gate = torch.empty(total_tokens, heads, _DK, dtype=torch.float32, device="cuda").uniform_(
+        -1.5, -0.5
+    )
+    if config["safe_gate"]:
+        gate = 0.2 * torch.randn_like(gate)
+    beta_dtype = torch.bfloat16 if config["beta_sigmoid"] else torch.float32
+    beta = (0.3 * torch.randn(total_tokens, heads, device="cuda")).to(beta_dtype)
+    if not config["beta_sigmoid"]:
+        beta = beta.sigmoid()
+    do = (0.2 * torch.randn(total_tokens, heads, _DV, device="cuda")).to(torch.bfloat16)
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(config["seq_lens"]).cumsum(0).tolist()], dtype=torch.int32, device="cuda"
+    )
+    a_log = (
+        0.1 * torch.randn(heads, dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(heads, _DK, dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        0.01
+        * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float64, device="cuda")
+        if config["use_initial_state"]
+        else None
+    )
+    if initial_state is not None and with_oracle:
+        initial_state.requires_grad_(True)
+    d_final_state = (
+        0.02
+        * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        if config["use_dstate_in"]
+        else None
+    )
+
+    oracle = None
+    if with_oracle:
+        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
+        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
+        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
+        gate_ref = gate.double().detach().requires_grad_(True)
+        beta_ref = beta.double().detach().requires_grad_(True)
+        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
+            torch,
+            q_ref,
+            k_ref,
+            gate_ref,
+            beta_ref,
+            l2norm=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            beta_sigmoid=config["beta_sigmoid"],
+            a_log=a_log.double() if a_log is not None else None,
+            dt_bias=dt_bias.double() if dt_bias is not None else None,
+        )
+        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
+            torch,
+            q_effective,
+            k_effective,
+            v_ref,
+            gate_effective,
+            beta_effective,
+            cu_seqlens,
+            scale=config["scale"],
+            initial_state=initial_state,
+            checkpoint_dtype=torch.bfloat16,
+        )
+        loss = (output_ref * do.double()).sum()
+        if d_final_state is not None:
+            loss = loss + (final_ref * d_final_state.double()).sum()
+        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref]
+        if config["safe_gate"]:
+            grad_inputs.append(gate_effective)
+        if initial_state is not None:
+            grad_inputs.append(initial_state)
+        grads = torch.autograd.grad(loss, grad_inputs)
+        oracle = {
+            "dq": grads[0],
+            "dk": grads[1],
+            "dv": grads[2],
+            "dgate": grads[5] if config["safe_gate"] else grads[3],
+            "dbeta": grads[4],
+        }
+        if initial_state is not None:
+            oracle["d_initial_state"] = grads[-1]
+        checkpoints = checkpoints.detach()
+    else:
+        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+        checkpoints = (
+            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        ).to(torch.bfloat16)
+
+    workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+    return {
+        "config": config,
+        "q": q,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "do": do,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "checkpoints": checkpoints,
+        "d_final_state": d_final_state,
+        "tirx": _new_outputs(torch, config, total_tokens),
+        "source": _new_outputs(torch, config, total_tokens),
+        "work": _prepare_work_tables(torch, config),
+        "oracle": oracle,
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "_workspace_owners": (tirx_owner, source_owner),
+    }
+
+
+def prepare_data(**config):
+    """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
+    return _prepare_data(config, with_oracle=True)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype.is_floating_point and tensor.element_size() == 2:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif tensor.dtype.is_floating_point and tensor.element_size() == 4:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return (
+        torch.tensor([int(word) for word in tensor_map.opaque], dtype=torch.uint64)
+        .view(torch.int64)
+        .to(device=tensor.device)
+    )
+
+
+def _base_tensor_maps(data):
+    config = data["config"]
+    total_tokens = data["q"].shape[0]
+
+    def headed(tensor, channels, heads, box_channels):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (box_channels, 1, _BT),
+        )
+
+    output = data["tirx"]
+    maps = [
+        headed(data["q"], _DK, config["q_heads"], 64),
+        headed(data["k"], _DK, config["k_heads"], 64),
+        headed(data["v"], _DV, config["v_heads"], 64),
+        headed(data["gate"], _DK, config["heads"], 32),
+        headed(data["do"], _DV, config["heads"], 64),
+        headed(output["dq"], _DK, config["heads"], 64),
+        headed(output["dk"], _DK, config["heads"], 64),
+        headed(output["dv"], _DV, config["heads"], 64),
+        headed(output["dgate"], _DK, config["heads"], 32),
+    ]
+    checkpoints = data["checkpoints"]
+    maps.append(
+        _encode_tiled_map(
+            checkpoints,
+            (_DV, _DK, checkpoints.shape[0], config["heads"]),
+            (
+                checkpoints.stride(2) * checkpoints.element_size(),
+                checkpoints.stride(0) * checkpoints.element_size(),
+                checkpoints.stride(1) * checkpoints.element_size(),
+            ),
+            (64, _DK, 1, 1),
+        )
+    )
+    return maps
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data)
+    work = data["work"]["tirx"]
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_a_log = torch.zeros(config["heads"], dtype=torch.float32, device="cuda")
+    dummy_dt_bias = torch.zeros(config["heads"], _DK, dtype=torch.float32, device="cuda")
+    dummy_dstate_in = torch.zeros(1, dtype=torch.float32, device="cuda")
+    dummy_dstate_out = torch.zeros(1, dtype=torch.float32, device="cuda")
+    output = data["tirx"]
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *maps,
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["q"].view(torch.uint8).reshape(-1),
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            data["gate"].view(torch.uint8).reshape(-1),
+            data["do"].view(torch.uint8).reshape(-1),
+            output["dq"].view(torch.uint8).reshape(-1),
+            output["dk"].view(torch.uint8).reshape(-1),
+            output["dv"].view(torch.uint8).reshape(-1),
+            output["dgate"].view(torch.uint8).reshape(-1),
+            data["checkpoints"].view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["sched_all"] if work["sched_all"] is not None else dummy_i32,
+            len(config["seq_lens"]),
+            data["q"].stride(0) * data["q"].element_size(),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            data["gate"].stride(0) * data["gate"].element_size(),
+            data["do"].stride(0) * data["do"].element_size(),
+            output["dq"].stride(0) * output["dq"].element_size(),
+            output["dk"].stride(0) * output["dk"].element_size(),
+            output["dv"].stride(0) * output["dv"].element_size(),
+            output["dgate"].stride(0) * output["dgate"].element_size(),
+            data["checkpoints"].stride(0) * data["checkpoints"].element_size(),
+            _BT,
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["a_log"] if data["a_log"] is not None else dummy_a_log,
+            (
+                data["dt_bias"].reshape(-1)
+                if data["dt_bias"] is not None
+                else dummy_dt_bias.reshape(-1)
+            ),
+            data["beta"].reshape(-1),
+            data["cu_seqlens"],
+            output["dgate"].reshape(-1),
+            output["dbeta"].reshape(-1),
+            output.get("d_initial_state", dummy_dstate_out).reshape(-1),
+            (
+                data["d_final_state"].reshape(-1)
+                if data["d_final_state"] is not None
+                else dummy_dstate_in
+            ),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["sched_ctr"] if work["sched_ctr"] is not None else dummy_i32,
+            config["scale"],
+        )
+
+    launch._keep_alive = (
+        maps,
+        dummy_i32,
+        dummy_a_log,
+        dummy_dt_bias,
+        dummy_dstate_in,
+        dummy_dstate_out,
+    )
+    return launch
+
+
+_REFERENCE_SOURCE = None
+
+
+def _load_reference_source():
+    global _REFERENCE_SOURCE
+    if _REFERENCE_SOURCE is not None:
+        return _REFERENCE_SOURCE
+    import importlib
+    import os
+    import sys
+
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    python_root = os.path.join(root, "python")
+    if python_root not in sys.path:
+        sys.path.append(python_root)
+    import cudnn
+
+    cudnn_root = os.path.join(python_root, "cudnn")
+    if cudnn_root not in cudnn.__path__:
+        cudnn.__path__.append(cudnn_root)
+    _REFERENCE_SOURCE = importlib.import_module("cudnn.linear_attention.frost.kernel.kda_bprop_f16")
+    return _REFERENCE_SOURCE
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_kda_bwd_sm100(
+            data["q"],
+            data["k"],
+            data["v"],
+            data["gate"],
+            data["beta"],
+            data["do"],
+            data["checkpoints"],
+            output["dq"],
+            output["dk"],
+            output["dv"],
+            output["dgate"],
+            output["dbeta"],
+            data["cu_seqlens"],
+            config["scale"],
+            use_initial_state=config["use_initial_state"],
+            d_initial_state=output.get("d_initial_state"),
+            d_final_state=data["d_final_state"],
+            use_qk_l2norm_in_kernel=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            gate_lower_bound=-5.0,
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=config["beta_sigmoid"],
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["sched_ctr"],
+            sched_all=work["sched_all"],
+            work_item_scratch=work["staging"],
+            order_in_prologue=config["run_order"],
+            tensormap_workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    return launch
+
+
+def _rms_ratio(torch, actual, expected):
+    actual = actual.detach().double()
+    expected = expected.detach().double()
+    denominator = expected.square().mean().sqrt().clamp_min(1e-12)
+    return float(((actual - expected).square().mean().sqrt() / denominator).item())
+
+
+def _validate_outputs(data, *, sources, with_oracle):
+    import math
+
+    import torch
+
+    config = data["config"]
+    limits = {
+        "dq": 0.10,
+        "dk": 0.10,
+        "dv": 0.10,
+        "dgate": 0.30,
+        "dbeta": 0.10,
+        "d_initial_state": 0.10,
+    }
+    failures = {}
+    if with_oracle:
+        if data["oracle"] is None:
+            raise AssertionError("oracle validation requested without oracle data")
+        for source_name in sources:
+            for output_name, expected in data["oracle"].items():
+                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
+                if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                    failures[f"{source_name}.{output_name}"] = ratio
+    if "tirx" in sources and "source" in sources:
+        for output_name in data["tirx"]:
+            ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
+            if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                failures[f"tirx_vs_source.{output_name}"] = ratio
+    if failures:
+        raise AssertionError(f"KDA backward validation failed for {config}: {failures}")
+
+
+def run_test(**config):
+    """Compare both kernels with the standalone FP64 recurrence oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _normalized_config(config)
+    data = _prepare_data(kernel_config, with_oracle=True)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
+    return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
+
+
+def prepare_bench(**config):
+    """Compile the two TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _normalized_config(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then let bench_suite time the exact two-launch paths."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config, with_oracle=False)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    with_source = external_references_enabled()
+    references = None
+    if with_source:
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        references = {"cudnn_frontend": source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -2377,9 +2377,10 @@ def _make_main(
                                 for accum_slot in range(8):
                                     K.assign(hacc[accum_slot], _opaque_f32_zero())
                                 with K.unroll(16) as pair:
-                                    state_lo = K.local_scalar("float32")
-                                    state_hi = K.local_scalar("float32")
-                                    _unpack_bf16_pair(state_words[pair], state_lo, state_hi)
+                                    state_lo = K.cast(state_words[pair], "uint16")
+                                    state_hi = K.cast(
+                                        K.shift_right(state_words[pair], K.uint32(16)), "uint16"
+                                    )
                                     value0 = value_plane * 64 + row_half * 32 + pair * 2
                                     h0_bits = K.local_scalar("uint16")
                                     h1_bits = K.local_scalar("uint16")
@@ -2411,14 +2412,15 @@ def _make_main(
                                             ]
                                         ),
                                     )
-                                    h0 = K.local_scalar("float32")
-                                    h1 = K.local_scalar("float32")
-                                    K.ptx.cvt.f32.bf16(h0, h0_bits)
-                                    K.ptx.cvt.f32.bf16(h1, h1_bits)
                                     accum_lo = (2 * pair) % 8
                                     accum_hi = (2 * pair + 1) % 8
-                                    next_lo, next_hi = _ffma2(
-                                        h0, h1, state_lo, state_hi, hacc[accum_lo], hacc[accum_hi]
+                                    next_lo = K.local_scalar("float32")
+                                    next_hi = K.local_scalar("float32")
+                                    K.ptx.fma.rn.f32.bf16(
+                                        next_lo, h0_bits, state_lo, hacc[accum_lo]
+                                    )
+                                    K.ptx.fma.rn.f32.bf16(
+                                        next_hi, h1_bits, state_hi, hacc[accum_hi]
                                     )
                                     K.assign(hacc[accum_lo], next_lo)
                                     K.assign(hacc[accum_hi], next_hi)

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -518,7 +518,6 @@ def _tmem_cell(base, row, row_delta, column):
 
 
 def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out):
-
     @K.kernel(warps=32, arch="sm_100a", grid=1)
     def prologue(
         base_q: K.gptr[K.i64],
@@ -1931,12 +1930,8 @@ def _make_main(
                                 + 0.5
                             )
                             if full_tiles:
-                                K.assign(
-                                    gate_prefix[row0], K.float32(-7.213475204444817) * gate0
-                                )
-                                K.assign(
-                                    gate_prefix[row1], K.float32(-7.213475204444817) * gate1
-                                )
+                                K.assign(gate_prefix[row0], K.float32(-7.213475204444817) * gate0)
+                                K.assign(gate_prefix[row1], K.float32(-7.213475204444817) * gate1)
                             else:
                                 K.assign(
                                     gate_prefix[row0],

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -2043,29 +2043,28 @@ def _make_main(
                     qk1_hi = K.local_scalar("float32", init=_opaque_f32_zero())
                     with K.unroll(2) as half:
                         dim_base = half * 64 + lane_in_group * 8
+                        q_fragment = K.alloc_local((4,), "uint32")
+                        k_fragment = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            q_fragment[0],
+                            q_fragment[1],
+                            q_fragment[2],
+                            q_fragment[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_Q, raw_stage, decay_row, dim_base)]),
+                        )
+                        K.ptx.ld.shared.v4.b32(
+                            k_fragment[0],
+                            k_fragment[1],
+                            k_fragment[2],
+                            k_fragment[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_K, raw_stage, decay_row, dim_base)]),
+                        )
                         with K.unroll(8) as dim_offset:
-                            q_bits = K.local_scalar("uint16")
-                            k_bits = K.local_scalar("uint16")
-                            K.ptx.ld.shared.b16(
-                                q_bits,
-                                arena.ptr_to(
-                                    [
-                                        _raw_bf16_byte(
-                                            _SMEM_Q, raw_stage, decay_row, dim_base + dim_offset
-                                        )
-                                    ]
-                                ),
-                            )
-                            K.ptx.ld.shared.b16(
-                                k_bits,
-                                arena.ptr_to(
-                                    [
-                                        _raw_bf16_byte(
-                                            _SMEM_K, raw_stage, decay_row, dim_base + dim_offset
-                                        )
-                                    ]
-                                ),
-                            )
+                            shift = K.cast((dim_offset % 2) * 16, "uint32")
+                            q_word = K.shift_right(q_fragment[dim_offset // 2], shift)
+                            k_word = K.shift_right(k_fragment[dim_offset // 2], shift)
+                            q_bits = K.cast(q_word, "uint16")
+                            k_bits = K.cast(k_word, "uint16")
                             K.ptx.cvt.f32.bf16(raw_q[half * 8 + dim_offset], q_bits)
                             K.ptx.cvt.f32.bf16(raw_k[half * 8 + dim_offset], k_bits)
                             if l2norm:
@@ -2120,25 +2119,28 @@ def _make_main(
                     exp_last = K.alloc_local((16,), "float32")
                     with K.unroll(2) as half:
                         dim_base = half * 64 + lane_in_group * 8
-                        with K.unroll(8) as dim_offset:
-                            K.ptx.ld.shared.f32(
-                                exp_g[half * 8 + dim_offset],
+                        with K.unroll(2) as group:
+                            fragment_base = half * 8 + group * 4
+                            K.ptx.ld.shared.v4.f32(
+                                exp_g[fragment_base],
+                                exp_g[fragment_base + 1],
+                                exp_g[fragment_base + 2],
+                                exp_g[fragment_base + 3],
                                 arena.ptr_to(
                                     [
                                         _raw_f32_byte(
-                                            _SMEM_GATE, raw_stage, decay_row, dim_base + dim_offset
+                                            _SMEM_GATE, raw_stage, decay_row, dim_base + group * 4
                                         )
                                     ]
                                 ),
                             )
-                            K.ptx.ld.shared.f32(
-                                exp_last[half * 8 + dim_offset],
+                            K.ptx.ld.shared.v4.f32(
+                                exp_last[fragment_base],
+                                exp_last[fragment_base + 1],
+                                exp_last[fragment_base + 2],
+                                exp_last[fragment_base + 3],
                                 arena.ptr_to(
-                                    [
-                                        _raw_f32_byte(
-                                            _SMEM_GATE, raw_stage, 15, dim_base + dim_offset
-                                        )
-                                    ]
+                                    [_raw_f32_byte(_SMEM_GATE, raw_stage, 15, dim_base + group * 4)]
                                 ),
                             )
                     K.ptx.fence.proxy.async_.shared__cta()

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -801,6 +801,7 @@ def _make_main(
     use_dstate0,
     use_initial_state,
     safe_gate,
+    full_tiles,
     dynamic_scheduler,
     l2norm,
     n_heads_out,
@@ -1929,22 +1930,30 @@ def _make_main(
                                 _tanh_approx(safe_a * (gate_prefix[row1] + safe_bias) * 0.5) * 0.5
                                 + 0.5
                             )
-                            K.assign(
-                                gate_prefix[row0],
-                                K.if_then_else(
-                                    token_base + row0 < sequence_length,
-                                    K.float32(-7.213475204444817) * gate0,
-                                    K.float32(0.0),
-                                ),
-                            )
-                            K.assign(
-                                gate_prefix[row1],
-                                K.if_then_else(
-                                    token_base + row1 < sequence_length,
-                                    K.float32(-7.213475204444817) * gate1,
-                                    K.float32(0.0),
-                                ),
-                            )
+                            if full_tiles:
+                                K.assign(
+                                    gate_prefix[row0], K.float32(-7.213475204444817) * gate0
+                                )
+                                K.assign(
+                                    gate_prefix[row1], K.float32(-7.213475204444817) * gate1
+                                )
+                            else:
+                                K.assign(
+                                    gate_prefix[row0],
+                                    K.if_then_else(
+                                        token_base + row0 < sequence_length,
+                                        K.float32(-7.213475204444817) * gate0,
+                                        K.float32(0.0),
+                                    ),
+                                )
+                                K.assign(
+                                    gate_prefix[row1],
+                                    K.if_then_else(
+                                        token_base + row1 < sequence_length,
+                                        K.float32(-7.213475204444817) * gate1,
+                                        K.float32(0.0),
+                                    ),
+                                )
                     else:
                         with K.unroll(16) as row:
                             with K.If(token_base + row < sequence_length), K.Then():
@@ -3457,6 +3466,7 @@ def get_kernel(**config):
         use_dstate0=bool(config.get("use_dstate0", False)),
         use_initial_state=bool(config.get("use_initial_state", False)),
         safe_gate=bool(config.get("safe_gate", False)),
+        full_tiles=all(int(length) % _BT == 0 for length in config["seq_lens"]),
         dynamic_scheduler=bool(config.get("dynamic_scheduler", False)),
         l2norm=bool(config.get("l2norm", False)),
         n_heads_out=int(config.get("n_heads_out", config.get("heads", 1))),


### PR DESCRIPTION
## Summary

- port cuDNN Frontend KDA BF16 backward from commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5` using only `tirx_kernels.kern`
- preserve the two-launch prologue/main pipeline, persistent scheduler, TMA/TMEM dataflow, optional L2 normalization, safe gate, beta sigmoid, state I/O, and ordering modes
- add registry metadata, correctness/oracle adapters, the complete benchmark matrix, README integration, and the frozen schedule sketch
- specialize provably full-tile safe-gate paths while retaining the ragged fallback
- document the measured mixed-precision FMA and full-tile tail-predicate mechanisms in the codegen tuning database

Depends on apache/tvm#20171 for `movmatrix.sync.aligned.m8n8.trans.b16` lowering.

## Correctness

- all 10 `CONFIGS` pass against both the standalone cuDNN Frontend source kernel and the independent FP64 recurrence oracle
- the additional ragged safe-gate fallback `(17, 33)` also passes source and oracle validation
- all 21 unique specializations and 42 prologue/main entries pass the low-level IR, K-only, no-layout, and no-tile checks
- all 11 `prepare_bench` configurations pass the CUDA-uninitialized CPU preparation gate

## Performance

The final fresh, unspliced `bench_suite` run used references, five rounds per side, and all 11 frozen workloads. Every row passes the strict `mean(cudnn_frontend) / mean(tirx) > 0.99` gate.

- minimum ratio: `0.9946788847`
- mean ratio: `1.0341577318`
- safe-gate ratio: `1.0206563834`

## Testing

- `python -m pytest -q tests/test_bench_suite_run.py tests/test_low_level_ir.py`
- `python tests/lint/check_license_headers.py`
- `pre-commit run --files <changed files>`
- full `CONFIGS` source/oracle validation
- full 11-row `bench_suite` validation with five raw samples per implementation