### PR TITLE
feat(kernel): port cuDNN DSA sparse attention backward sm100

### DIFF
--- a/.agents/sketch/cudnn/sm100_dsa_sparse_attention_backward.md
+++ b/.agents/sketch/cudnn/sm100_dsa_sparse_attention_backward.md
@@ -1,0 +1,1665 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of cuDNN Frontend's
+python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+FlashAttentionDSABackwardSm100.
+-->
+
+# cudnn_sm100_dsa_sparse_attention_backward: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, warp roles,
+pipelines, control flow, and PTX-level operations of
+[`tirx_kernels/cudnn/dsa/sparse_attention_backward.py`](../../../tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+and its private implementation package. That TIRx module is the authoritative
+implementation.
+
+The port covers **four device kernels**, all launched from one host entry
+(`FlashAttentionDSABackwardSm100.__call__`, `dsa_bwd_sm100.py:254-607`) onto one
+stream, in this order:
+
+| # | kernel | source | threads | what it does |
+| --- | --- | --- | --- | --- |
+| 1 | `sum_OdO` | `:648-707` | 128 | per `(head, query)`: the delta `-sum_d(O*dO)` and the sink-folded log2-domain LSE |
+| 2 | `bwd` | `:740-1110` | **640 (20 warps)** | the attention backward itself |
+| 3 | `convert` | `:609-646` | `32 * num_threads_seq` | FP32 dKV workspace to element dtype |
+| 4 | `sum_dSink` | `:709-738` | 32 | the attention-sink gradient |
+
+`bwd` is where essentially all the time goes and where the whole warp
+specialization lives; the other three are small and are sketched at the same
+op level but much more briefly.
+
+## Scope and instantiations
+
+The upstream compile key is a 7-tuple (`_interface_sm100.py:170`):
+`(dtype, head_dim, head_dim_v, num_head, block_tile, max_topk, has_topk_length)`.
+
+Fixed for every specialization in this port:
+
+| axis | value | why it is fixed |
+| --- | --- | --- |
+| `block_tile` | 64 | pinned at `_interface_sm100.py:94`; the public API's `block_tile` argument is ignored on SM100 |
+| `head_dim_v` | 512 | derived, `512 if head_dim == 576 else head_dim` (`_interface_sm100.py:64`) |
+| `batch_size` | 1 | the interface is flat/varlen; batch is folded into the token axis (`:96`) |
+| cluster | `(1,1,1)` | `cluster_layout_vmnk` is all zeros (`:357`); `cta_group = ONE` (`:319`). No multicast, no DSMEM. |
+
+In scope, i.e. the specializations this module compiles:
+
+| axis | values | what changes in device code |
+| --- | --- | --- |
+| `head_dim` | 512 / 576 | `same_hdim_kv = head_dim == head_dim_v` (`:31`) gates **five** distinct code changes: the 64-wide `dKV4`/`dQ4` tail MMAs, the `sK_tail`/`sQT_tail` SMEM views, the second TMA-store atom `tma_atom_dQ_64`, a different TMEM alias map (below), and a different `t2r_dKV*_done` barrier assignment in both the MMA and reduce loops. It also changes which pipeline generation count the `mma_reduce_dKV` pipeline runs at: 2 commits per tile at 512, **3** at 576. |
+| `num_head` | 64 (with d512) / 32 (with d576) | only the grid's `y` extent, `ceil_div(num_head, 64)`; the MMA M tile is always 64 heads |
+| `dtype` | bf16 / fp16 | `element_dtype` for every SMEM operand and both quantize sites. `acc_dtype` stays fp32 unconditionally (`:52`). Changes `cvt.rn.bf16x2.f32` to `cvt.rn.f16x2.f32` and `mul.bf16x2` to `mul.f16x2`. |
+| `has_topk_length` | True / False | selects the whole KV-validity program. **True (compact)**: `topk = mTopkLength[token_idx]` (`:796`), rows past `topk` are zero-filled in the ragged tile only. **False (non-compact)**: `topk = max_topk` statically, and every row tests `topk_idx >= 0` (`:1307-1313`). |
+| `max_topk` | any | `tile_count = ceil_div(topk, 64)`. Also selects three launch constants by pure Python comparison: `sum_OdO_block_q = 40 if max_topk == 1024 else 41` (`:56`), and `block_seq`/`num_threads_seq = 4 if max_topk == 2048 else 32` (`:568-570`). |
+
+Out of scope, with the predicate that excludes each:
+
+- **`head_dim not in (512, 576)`** -- asserted at `_interface_sm100.py:63`.
+- **fp8 / mxfp8 element dtypes** -- `__init__` raises (`:47-49`).
+- **`batch_size > 1`** -- the host wrapper always passes 1.
+- **the SM90 sibling** `FlashAttentionDSABackwardSm90` (`dsa_bwd_sm90.py`) -- a
+  separate class with a different structure (three kernel objects, two MMA
+  warpgroups) selected by `api.py:173-206`.
+- **the forward pass** -- production is FlashMLA, C++, outside this repo. The
+  kernel only consumes its `out` and `lse`.
+- Tile (`Tx`) primitives are out of scope everywhere.
+
+## The line-info export this sketch is annotated from
+
+Every `instruction_selection` annotation below is read out of a line-info PTX
+export, not out of the source text. Three exports, one per structurally distinct
+in-scope compile key, are preserved under
+`.porting/dsa_bwd_sm100/writer_source_export/<name>/`:
+
+| name | key | `.loc` lines | key-op notes |
+| --- | --- | --- | --- |
+| `d512_bf16_len` | d512, h64, bf16, compact | 2084 | the unqualified counts below |
+| `d576_bf16_len` | d576, h32, bf16, compact | 2852 | adds the tail MMAs and the third dKV generation |
+| `d512_bf16_nolen` | d512, h64, bf16, non-compact | 2674 | the `topk_idx >= 0` arm on every row, not just the ragged tile |
+
+Each export contains all four kernels as four `.visible .entry` points, because
+`cute.compile` compiles the whole `__call__`, and the four carry `.reqntid`
+`8,16,1` / `640,1,1` / `32,32,1` / `32,1,1` respectively.
+
+Approximate instruction-line counts for `d512_bf16_len`: `sum_OdO` ~720,
+`bwd` ~4900-5100, `convert` ~70, `sum_dSink` ~255. These are order-of-magnitude
+context only, not evidence: the count moves by a few percent depending on whether
+`ret`, `.pragma`, labels and multi-line operand continuations are counted, and
+nothing in this sketch depends on them. **Every per-op count below is a count of
+one named instruction at one `.loc`, which is exact and recheckable**; those are
+the figures to verify.
+
+Reproduce any export with:
+
+```bash
+mkdir -p .porting/dsa_bwd_sm100/writer_source_export/<name>
+CUDNN_FRONTEND_PATH=<cudnn-frontend checkout> \
+CUTE_DSL_NO_CACHE=1 CUTE_DSL_KEEP=ptx CUTE_DSL_LINEINFO=1 \
+CUTE_DSL_DUMP_DIR=.porting/dsa_bwd_sm100/writer_source_export/<name> \
+python .porting/dsa_bwd_sm100/export_ptx.py <head_dim> <bf16|fp16> <len|nolen>
+```
+
+The DSA path has no AOT or on-disk cache, so `CUTE_DSL_NO_CACHE=1` plus a fresh
+process is enough. The export's single `.file` directive names the **checkout**
+source, which is what makes these annotations describe the revision this port
+follows rather than the older `cudnn` wheel that is also installed (see
+`.porting/dsa_bwd_sm100/source_overview.md`).
+
+Two attribution quirks to read the tables with:
+
+- Some inlined code is attributed to **`:254`**, the `__call__` decorator line,
+  rather than to its own source line -- but not all of it, so this is a fact to
+  check per site rather than a rule. Landing at `:254`: the `atom.global.add.*`
+  sites, the `exit`, and the `cvt` inside `quantize`/`element_dtype()` when
+  reached from `convert` or `store_dQ_64`. Keeping their own `.loc` despite
+  being inlined helpers: `t2r_dKV` (`:2305`), `store_dQ` (`:2533`, `:2543`),
+  `_copy_kv_row` (`:1229`) and `quantize` (`:2624`, `:2625`).
+- `is_first`/`full_tiles` specialization duplicates whole helper bodies, so a
+  static count is often `call_sites x per_call`, not a dynamic count. The KV
+  gather's 96 `cp.async.cg` is exactly `3 call sites x 16 rows x 2 groups`.
+
+## Pipeline at a glance
+
+`bwd`: 20 warps, 640 threads, **one CTA per query token**. The 64 attention heads
+are the MMA `M` dimension, so a token's top-k KV rows are gathered once and
+amortized across every head. Role selection is an `if/elif` chain
+(`:814`, `:909-1110`) whose **order is not warp-id order**: `17, 16, 4..7,
+8..15, 0..3, else`. The port preserves that order, because it is what the
+dispatch compare sequence lowers from.
+
+| Warps | Role-local tile program | Main publication / reuse edges |
+| --- | --- | --- |
+| 0..3 | `load_KV`: per tile, lane 0 of each warp reads 16 top-k indices and broadcasts them; all 32 lanes then cp.async-gather 64 KV rows into `sK` | produces `load_mma_K` |
+| 4..7 | `compute`: T2R of `S` and `dP`, the softmax recompute, stmatrix-transpose of `P` and `dS` into SMEM, and after the loop the whole dQ TMA-store epilogue. Warp 4 is also the TMEM allocator and the only TMA-store issuer. | consumes `mma_compute_S`, `mma_compute_dP`, `load_compute_LSE`, `load_compute_sum_OdO`, `mma_compute_dQ`; produces `compute_mma_P`, `compute_mma_dS`, `compute_tmastore_dQ` |
+| 8..15 | `reduce_dKV`, two warpgroups splitting the 64 KV rows: T2R each dKV sub-tile out of TMEM, **release the WAR barrier**, then add into the FP32 dKV workspace with 4-wide global atomics | consumes `mma_reduce_dKV`; arrives on `t2r_dKV01_done`, `t2r_dKV4_done`, `t2r_dKV23_done`, `tmem_dealloc` |
+| 16 | `mma`: issues **every** tcgen05 MMA in the kernel | consumes `load_mma_QdO`, `load_mma_K`, `compute_mma_P`, `compute_mma_dS`; produces `mma_compute_S`, `mma_compute_dP`, `mma_compute_dQ`, `mma_reduce_dKV` |
+| 17 | `load`: prefetches the three TMA descriptors, then one TMA for `Q`, one for `dO`, and one cp.async each for `LSE` and `sum_OdO`. **No loop** -- a CTA owns one query token. | produces `load_mma_QdO`, `load_compute_LSE`, `load_compute_sum_OdO` |
+| 18..19 | idle; execute only `setmaxnreg.dec 40` and fall out | none |
+
+**Q/dO are not pipelined.** One CTA owns one query token, so `load_mma_QdO` is a
+single-shot barrier acquired once before the loop (`:1490`) and released once
+after it (`:1763`); the load warp issues its copies and retires. All pipelining
+runs along the **top-k tile axis**.
+
+**The tile loop runs backwards**, `tile_index = tile_count - 1` down to `0`, in
+all four looping roles (`:1343`, `:1493`, `:1870`, `:2190`). The
+**first processed** tile is therefore the highest-index one, which is the ragged
+one, and `full_tiles = (topk % 64) == 0` (`:1344`, `:2194`) is what decides
+whether that first tile needs the bounds-checked program at all. Reversing this
+loop would move the ragged tile to the wrong end.
+
+**Every pipeline is single-stage except `mma_reduce_dKV`, which has 2**
+(`:159-172`). That one is the only place two dKV generations are in flight, and
+it is the reason the three `t2r_dKV*_done` named barriers exist: dKV2/dKV3 alias
+dKV0/dKV1 in TMEM, and a 2-deep pipeline does not order the next generation's
+writes against the previous generation's reads.
+
+**dKV never reaches global memory as element dtype from this kernel.** It is
+accumulated in FP32 into a workspace by atomics and converted by kernel 3. That
+also makes the result order-nondeterministic, which the correctness contract
+below depends on.
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+tile(...)        # declare storage, dtype, logical shape, placement
+view(...)        # change logical indexing without moving values
+alias(...)       # declare exact storage aliasing and non-overlap lifetime
+slice(...)       # select a logical interval
+reg_tile(...)    # declare a role-local register tile
+tensormap(...)   # declare a TMA descriptor and its encode fields
+tmem_cols(...)   # name a tensor-memory column range
+```
+
+Every SMEM object below is a **byte offset into one linear pool**. There are no
+layout objects anywhere in this sketch; where the source carries a CuTe swizzled
+`ComposedLayout`, this sketch names the swizzle as an instruction/descriptor
+immediate and the addressing as an explicit index function.
+
+Copies always state their storage direction:
+
+```python
+copy_g2s_tma(desc, coords, dst_off, bar)     # global -> shared, TMA
+copy_s2g_tma(desc, coords, src_off)          # shared -> global, TMA
+copy_g2s_async(dst_off, src_ptr, bytes, pred_bytes)  # global -> shared, cp.async
+copy_t2r(src_cols, dst_reg, shape, rep)      # tensor memory -> register
+copy_r2s_stmatrix(src_reg, dst_off)          # register -> shared, transposing
+copy_r2s(src_reg, dst_off)                   # register -> shared, plain
+load_global(buf, idx) -> reg
+store_global(buf, idx, reg)
+load_shared(off) -> reg
+store_shared(off, reg)
+atomic_add_global(ptr, values)               # values is a 1/2/4-wide f32 vector
+prefetch_descriptor(desc)
+zero_shared(dst_off, bytes)
+```
+
+The computational vocabulary:
+
+```python
+fill(dst, value)
+cast(dst, src)                       # f32 -> bf16/f16, bf16 -> f32
+add(dst, lhs, rhs, lanes=1)          # lanes=2 is one packed f32x2 op
+mul(dst, lhs, rhs, lanes=1)
+fma(dst, a, b, c, lanes=1)
+max(dst, lhs, rhs)
+exp2(dst, src, ftz=False)
+log2(dst, src)
+gemm(dst, a, b, accumulate)          # one tcgen05 MMA issue
+warp_reduce_add(dst, src, group)     # butterfly shuffles
+shuffle_broadcast(dst, src, lane)
+```
+
+Schedule operations: `pipe`, `init_pipe`, `acquire`, `wait`, `commit`,
+`release`, `expect_tx`, `fence_tmem_load`, `fence_proxy_shared`,
+`fence_view_async_shared`, `cp_async_commit`, `cp_async_wait`,
+`tma_store_commit`, `tma_store_wait`, `named_barrier`, `elect`,
+`set_register_budget`, `tmem_alloc`, `tmem_retrieve`, `tmem_dealloc`,
+`exit_cta`, and cursor (`slot`, `phase`) updates.
+
+`add(..., lanes=2)` is one packed two-lane f32 operation with two ordered
+results, not shorthand for two scalar adds. There are deliberately no primitives
+named `attention`, `softmax`, `backward`, `epilogue`, `reduce_dkv`, or
+`store_dq`.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+@specialize(
+    HEAD_DIM,                  # 512 or 576
+    HEAD_DIM_V=512,
+    NUM_HEAD,                  # 64 with d512, 32 with d576
+    BLOCK_TILE=64,             # KV rows per tile; also the MMA M/N tile
+    MAX_TOPK,
+    HAS_TOPK_LENGTH,           # bool
+    ELEM,                      # "bf16" | "f16"
+    ACC="f32",
+)
+# Derived at trace time, exactly as `__init__` derives them (:29-61):
+SAME_HDIM   = (HEAD_DIM == HEAD_DIM_V)      # :31  -- True only at d512
+HEAD_DIM_MAIN = (HEAD_DIM // 128) * 128     # :36  -- always 512
+N_MAIN_TILES  = HEAD_DIM_MAIN // 128        # 4 dKV/dQ sub-tiles of 128
+HAS_TAIL      = not SAME_HDIM               # the fifth, 64-wide sub-tile
+SUM_ODO_BLOCK_Q = 40 if MAX_TOPK == 1024 else 41       # :56
+BLOCK_SEQ       = 4  if MAX_TOPK == 2048 else 32       # :568
+NUM_THREADS_SEQ = 4  if MAX_TOPK == 2048 else BLOCK_SEQ  # :570
+
+def host_entry(
+    q,            # ELEM [S_q, H, D],   input
+    kv,           # ELEM [S_kv, D],     input -- K and V share this buffer
+    out,          # ELEM [S_q, H, D_v], input  (the forward's output)
+    dout,         # ELEM [S_q, H, D_v], input
+    lse,          # f32  [S_q, H],      input -- KV-only LSE, sink EXCLUDED
+    attn_sink,    # f32  [H],           input -- -inf disables the sink
+    topk_idxs,    # i32  [S_q, MAX_TOPK], input -- global KV rows, -1 invalid
+    topk_length,  # i32  [S_q],         input, HAS_TOPK_LENGTH only
+    dq,           # ELEM [S_q, H, D],   output -- fully overwritten
+    dkv,          # ELEM [S_kv, D],     output -- MUST be zero on entry
+    d_sink,       # f32  [H],           output -- MUST be zero on entry
+    ws_lse_odo,   # u8 [1, H, roundup8(S_q), 8],  workspace, MUST be zero
+    ws_dkv,       # u8 [1, 1, roundup8(S_kv), roundup8(D)*4], workspace, zero
+    softmax_scale,  # f32, defaults to 1/sqrt(D)
+):
+    # The four launches, one stream, in this order (:493-607).
+    launch(sum_OdO,   grid=(ceil_div(S_q, SUM_ODO_BLOCK_Q), H, 1), block=128)
+    launch(bwd,       grid=(S_q, ceil_div(H, 64), 1),              block=640,
+           smem=SHARED_BYTES, min_blocks_per_sm=1)
+    launch(convert,   grid=(ceil_div(S_kv, BLOCK_SEQ), 1, 1),
+           block=32 * NUM_THREADS_SEQ)
+    launch(sum_dSink, grid=(ceil_div(S_q, 256), H, 1),             block=32)
+    # instruction_selection: none; host-side launch only.
+    # Only sum_OdO -> bwd and bwd -> {convert, sum_dSink} are real
+    # dependencies; the stream order supplies both.
+
+# The two workspace views (:217-240). Both are re-typed windows into one u8
+# allocation; `scaled_lse` starts exactly `H * roundup8(S_q) * 4` bytes after
+# `sum_OdO`, so they are one allocation holding two f32 planes, NOT an
+# interleaved pair despite the 8-byte-per-entry shape the host allocates.
+sum_OdO_ws    = view(ws_lse_odo, "f32", [H, S_q], stride=[1, H])   # head-contiguous
+scaled_lse_ws = view(ws_lse_odo, "f32", [H, S_q], stride=[1, H],
+                     byte_offset=H * roundup8(S_q) * 4)
+dkv_acc_ws    = view(ws_dkv, "f32", [S_kv, D], stride=[D, 1])      # D-contiguous
+
+# ===========================================================================
+# Kernel 1 of 4: sum_OdO  (:648-707)
+#   grid (ceil_div(S_q, SUM_ODO_BLOCK_Q), H, 1), block [8, 16, 1] = 128 threads
+#   tidx indexes head-dim groups (8 of them), tidy indexes queries (16).
+# ===========================================================================
+
+def sum_OdO():
+    bidx, bidy, bidz = block_id()        # q block, head, batch
+    tidx, tidy, _ = thread_id_3d()
+
+    for idx_q_t in range(tidy, SUM_ODO_BLOCK_Q, 16):      # :667, 3 iterations
+        idx_q = idx_q_t + SUM_ODO_BLOCK_Q * bidx
+        if idx_q >= S_q:
+            continue
+
+        # Each thread strides over the head dim in 4-element groups.
+        acc = f32(0.0)
+        for idx_d in range(tidx, HEAD_DIM_V // 4, 8):     # :678, 16 iterations
+            o_frg  = load_global(out,  (bidy, idx_d * 4, idx_q), width=4)
+            do_frg = load_global(dout, (bidy, idx_d * 4, idx_q), width=4)
+            # instruction_selection: ld.global.v2.b32 (:679, :680; 42 static
+            #   across the whole kernel); extent: vector of 4 ELEM = 64 bits.
+            #   `sum_OdO_elem_per_load = 4` (:59) is what makes this a v2.b32
+            #   and not four scalar loads.
+            prod = mul(o_frg, do_frg)
+            # instruction_selection: mul.bf16x2 (:681, 42 static); extent:
+            #   2 packed lanes x 2 per 4-element fragment. fp16 emits
+            #   mul.f16x2.
+            acc = add(acc, reduce_add(cast(prod, "f32")))
+            # instruction_selection: cvt.f32.bf16 (:682, 21 static), then BOTH
+            #   add.rn.f32.bf16 (:683, 63 static) and add.f32 (:683, 42 static);
+            #   extent: scalar each, over the 4-element fragment.  The site is a
+            #   real cvt plus two add families, not one fused widening add.
+
+        acc = warp_reduce_add(acc, group=8)
+        # instruction_selection: shfl.sync.bfly.b32 (:685, 9 static = 3 outer
+        #   iterations x log2(8)); extent: 3-step butterfly over 8 lanes.
+
+        if tidx == 0:
+            lse_bhq = load_global(lse, (bidy, idx_q))
+            # instruction_selection: ld.global.b32 (:688, 3 static); extent:
+            #   scalar, lane 0 of each 8-lane group only.  `.b32`, not `.f32`:
+            #   the export never widens or types these loads.
+            sink_bh = load_global(attn_sink, (bidy,))
+            # instruction_selection: ld.global.b32 (:693, 3 static); extent:
+            #   scalar, lane 0 of each 8-lane group.
+
+            # Fold the sink into the denominator with a max shift, in log2
+            # units. `LSE_scale = -log2(e)` and `sum_OdO_scale = -1.0` are
+            # passed in as f32 kernel arguments (:488-489), not folded at
+            # trace time.
+            lse_log2  = mul(lse_bhq, log2_e)
+            # instruction_selection: mul.f32 (:696, 3 static); extent: scalar.
+            sink_log2 = mul(sink_bh, log2_e)
+            # instruction_selection: mul.f32 (:697, 3 static); extent: scalar.
+            m         = max(lse_log2, sink_log2)
+            # instruction_selection: max.f32 (:698, 3 static); extent: scalar.
+            s         = add(exp2(sub(lse_log2, m)), exp2(sub(sink_log2, m)))
+            # instruction_selection: sub.f32 (:699, 6 static) and add.f32 (:699,
+            #   3 static) around the exponentials; extent: scalar each.
+            # instruction_selection: ex2.approx.f32 (:699, 6 static = 3 outer
+            #   iterations x 2 calls); extent: scalar.  NOTE the absence of
+            #   `.ftz`: this call site does not pass fastmath, unlike the
+            #   compute warp's exp2 in `bwd`, which does and emits
+            #   ex2.approx.ftz.f32.  The port must not unify the two.
+            scaled = neg(add(m, log2(s)))
+            # instruction_selection: neg.f32 (:701, 3 static); extent: scalar.
+            # instruction_selection: a SOFTWARE log2 polynomial (:700) --
+            #   fma.rn.f32 x36, add.f32 x9, mul.f32 x9, cvt.rn.f32.s32 x3;
+            #   extent: ~19 FP32 instructions per dynamic call, 57 static over
+            #   the 3 peeled outer arms.  `lg2` appears ZERO times in any
+            #   export: `cute.math.log2` without fastmath does NOT lower to
+            #   lg2.approx.f32, and the port must not substitute a fast log2
+            #   here.  Contrast :699 above, which does get a hardware ex2.
+            if lse_bhq == +inf:
+                scaled = -inf                       # :703-704
+            # instruction_selection: setp.eq.f32 (:703, 3 static) then selp.f32
+            #   (:254, 3 static); extent: scalar, one per peeled outer arm --
+            #   the compiler predicates this, it is not a branch.  The other 12
+            #   selp.f32 in this kernel belong to the log2 polynomial at :700
+            #   (its denormal rescale and zero/-inf special cases), not here.
+
+            store_global(sum_OdO_ws,    (bidy, idx_q), mul(sum_OdO_scale, acc))
+            # instruction_selection: mul.f32 (:689, 3 static); extent: scalar --
+            #   the `sum_OdO_scale = -1.0` negation is a real multiply, not a
+            #   sign flip folded into the store.
+            store_global(scaled_lse_ws, (bidy, idx_q), scaled)
+            # instruction_selection: st.global.b32 (:706, 3 static) and
+            #   st.global.b32 (:707, 3 static); extent: scalar.  `.b32`, not
+            #   `.f32`.
+
+# ===========================================================================
+# Kernel 2 of 4: bwd  (:740-1110)
+# ===========================================================================
+
+def bwd():
+    token_idx, head_block_idx, _ = block_id()
+    tidx = thread_id()
+    batch_idx = thread_id_z()      # :790 shadows the block_id z with the
+                                   # thread_id z.  blockDim.z == 1 and
+                                   # batch_size == 1, so both are 0; the port
+                                   # keeps the value 0 rather than the quirk.
+    warp = warp_uniform(tidx // 32)
+    # instruction_selection: shfl.sync.idx.b32 (:791, 1 static); extent: warp
+    #   broadcast.  This is a real instruction and it is what lets every role
+    #   predicate below lower as warp-uniform.
+
+    # -----------------------------------------------------------------------
+    # Per-token top-k length, and the empty-row early exit
+    # -----------------------------------------------------------------------
+    if HAS_TOPK_LENGTH:
+        topk = load_global(topk_length, (token_idx,))
+        # instruction_selection: ld.global.b32 (:796, 1 static); extent: scalar, all
+        #   threads.  CTA-uniform by construction: one value per query token.
+    else:
+        topk = MAX_TOPK                                   # :798, compile-time
+
+    if topk <= 0:                                         # :805
+        # Zero this token's whole dQ tile with all 640 threads and leave.
+        # This runs BEFORE the SMEM allocator, before every pipeline init and
+        # before the TMEM allocation, and that ordering is load-bearing: a CTA
+        # that exited after arriving on a pipeline init would strand the rest.
+        for linear in range(tidx, HEAD_DIM * BLOCK_TILE, 640):   # :806
+            head = head_block_idx * BLOCK_TILE + linear // HEAD_DIM
+            if head < NUM_HEAD:
+                store_global(dq, (linear % HEAD_DIM, head, token_idx), ELEM(0))
+                # instruction_selection: st.global.b16 (:811); extent: scalar,
+                #   strided over 640 threads.  Not vectorized.
+        exit_cta()
+        # instruction_selection: exit (attributed to :254, 1 static); extent:
+        #   whole CTA.
+
+    # -----------------------------------------------------------------------
+    # Descriptor prefetch, storage, pipelines
+    # -----------------------------------------------------------------------
+    if warp == 17:                                        # :814
+        prefetch_descriptor(desc_Q)
+        prefetch_descriptor(desc_dO)
+        prefetch_descriptor(desc_dQ)
+        # instruction_selection: prefetch.tensormap (:815-817); extent: 3
+        #   scalar issues, load warp only.  Note desc_dQ_64 is NOT prefetched
+        #   even in the d576 build.
+
+    # --- one linear SMEM pool -------------------------------------------
+    # The source declares this as `@cute.struct SharedStorage` (:448-470) and
+    # allocates it with `utils.SmemAllocator` (:819-820), which reads like a
+    # static __shared__ block.  It is not: the export carries
+    #   .extern .shared .align 1024 .b8 __dynamic_shmem__0[]
+    # The matching TIRx form is a dynamic pool, never a static shared array.
+    #
+    # Field order is declaration order.  `sQ`, `sK`, `sdO` are 1024-byte aligned
+    # (`buffer_align_bytes`, :156) and the rest 128-byte (`non_tma_align_bytes`,
+    # :157), and the struct itself pads up to its own 1024-byte alignment.
+    #
+    # Exact byte map, measured (probe/probe_smem_layouts.py), d512 / d576:
+    #   mbarriers (22 x i64)         0        176 B
+    #   tmem_holding_buf (i32)     176          4 B
+    #   sQ                        1024   /   1024      65536 /  73728 B
+    #   sK                       66560   /  74752      65536 /  73728 B
+    #   sdO                     132096   / 148480      65536 /  65536 B
+    #   sP                      197632   / 214016       8192 /   8192 B
+    #   sdS                     205824   / 222208       8192 /   8192 B
+    #   sLSE                    214016   / 230400        256 /    256 B
+    #   sSum_OdO                214272   / 230656        256 /    256 B
+    #   raw end                 214528   / 230912
+    #   padded to 1024         215040   / 231424   <- SharedStorage.size_in_bytes()
+    #
+    # The source's assert is `227 * 1024`, which IS 232,448 -- the same number as
+    # the SM100 hardware cap, not a second tighter bound (:446, :472-474).
+    # Headroom: 17,408 B at d512 but only **1,024 B** at d576.  The d576 build is
+    # one 1 KiB buffer away from not launching, so nothing may be added to this
+    # pool without re-measuring.
+    smem = tile("smem", "u8", [SHARED_BYTES], byte_offset=0, alignment=1024)
+
+    # 22 mbarrier slots: (stage x 2) per pipeline, 9 pipelines at 1 stage plus
+    # mma_reduce_dKV at 2.  full/empty pairs.
+    mbar_load_mma_QdO        = view(smem, "i64", [1, 2])     # :450
+    mbar_load_mma_K          = view(smem, "i64", [1, 2])     # :451
+    mbar_load_compute_LSE    = view(smem, "i64", [1, 2])     # :452
+    mbar_load_compute_sumOdO = view(smem, "i64", [1, 2])     # :453
+    mbar_mma_compute_S       = view(smem, "i64", [1, 2])     # :454
+    mbar_mma_compute_dP      = view(smem, "i64", [1, 2])     # :455
+    mbar_mma_compute_dQ      = view(smem, "i64", [1, 2])     # :456
+    mbar_compute_mma_P       = view(smem, "i64", [1, 2])     # :457
+    mbar_compute_mma_dS      = view(smem, "i64", [1, 2])     # :458
+    mbar_mma_reduce_dKV      = view(smem, "i64", [2, 2])     # :459  <- 2 stages
+    tmem_holding             = view(smem, "i32", [1])        # :460
+
+    sQ       = view(smem, ELEM, [64 * HEAD_DIM],   alignment=1024)  # :461
+    sK       = view(smem, ELEM, [64 * HEAD_DIM],   alignment=1024)  # :465
+    sdO      = view(smem, ELEM, [64 * HEAD_DIM_V], alignment=1024)  # :466
+    sP       = view(smem, ELEM, [64 * 64],         alignment=128)   # :467
+    sdS      = view(smem, ELEM, [64 * 64],         alignment=128)   # :468
+    sLSE     = view(smem, "f32", [64],             alignment=128)   # :469
+    sSum_OdO = view(smem, "f32", [64],             alignment=128)   # :470
+
+    # --- aliases: the same bytes under a different operand mapping -------
+    # The source spells each of these as a `recast_ptr` + `make_tensor` pair
+    # (:862-903) carrying a CuTe swizzled layout.  This port carries the same
+    # bytes with an explicit base offset, element shape and stride tuple, plus
+    # the swizzle immediate the matrix descriptor needs.
+    #
+    # EVERY buffer and every alias in this kernel uses the SAME swizzle,
+    # S<3,4,3> -- the 128-byte swizzle, 16-byte atoms, 8-row period.  That is
+    # measured, not assumed (probe/probe_smem_layouts.py builds all sixteen
+    # layouts and prints the swizzle of each).  So the swizzle immediate is a
+    # constant of this kernel and the only thing that varies per alias is the
+    # base offset and the shape:stride below.
+    #
+    # `outer` shapes are in ELEMENTS, from the same probe.  The two shapes that
+    # matter are the K-major form ((64,16),1,(4,8),1):((64,1),0,(16,4096),0)
+    # and the MN-major form (((64,2),16),4,4,1):(((1,4096),64),8192,1024,0):
+    # they differ in which axis carries stride 1, which is exactly what selects
+    # the descriptor's leading/stride byte offsets.
+    #
+    # alias      base            shape:stride (elements)                    used as
+    sQT      = alias(sQ,  0)     # (((64,2),16),4,4,1):(((1,4096),64),8192,1024,0)
+                                 #   A of dKV += Q^T @ dS, MN-major      # :880-881
+    sQT_tail = alias(sQ,  0)     # ((64,16),9,4,1):((1,64),4096,1024,0), block 8
+                                 #   = elements 8*4096.. ; A of dKV4     # :896-899
+    sV       = alias(sK,  0)     # K-major form; identical to sK when SAME_HDIM,
+                                 #   so :864 is a no-op alias there      # :864
+    sK_2     = alias(sK,  0)     # MN-major form; A of dQ = K @ dS^T     # :886-887
+    sK_tail  = alias(sK,  0)     # ((64,16),9,4,1) block 8; A of dQ4     # :892-894
+    sdQ      = alias(sK,  0)     # ((64,2),(8,8),(1,1)):((1,4096),(64,512),(0,0))
+                                 #   epilogue 128x64                     # :871-872
+    sdQ4     = alias(sK,  0)     # ((64,1),(8,8),(1,1)):((1,0),(64,512),(0,0))
+                                 #   epilogue 64x64 -- same form as       # :902-903
+                                 #   sP_store / sdS_store
+    sdOT     = alias(sdO, 0)     # MN-major form; A of dKV += dO^T @ P   # :883-884
+    sP_store = alias(sP,  0)     # ((64,1),(8,8),(1,1)):((1,0),(64,512),(0,0))
+                                 #   stmatrix destination, column-major  # :866
+    sdST     = alias(sdS, 0)     # ((64,16),1,4,1):((1,64),0,1024,0)
+                                 #   B of dQ = K @ dS^T, MN-major        # :877-878
+    sdS_store= alias(sdS, 0)     # ((64,1),(8,8),(1,1)):((1,0),(64,512),(0,0))
+                                 #   stmatrix destination, column-major  # :869
+    # Every alias starts at its parent's base (offset 0 within it): the source's
+    # `recast_ptr` reinterprets the same pointer, and the tail views reach their
+    # 64-wide block through the block index (8), not through a base offset.
+
+    # --- the index functions used by the role bodies below ---------------
+    # Named here so the bodies can stay readable; each is plain arithmetic over
+    # the linear pool, which is what replaces the source's layout objects.
+    # UNITS: every offset function below returns ELEMENTS, and every TMA
+    # coordinate is in ELEMENTS.  Mixing element offsets with byte offsets, or
+    # element coordinates with tile indices, is the easiest way to get a
+    # plausible-looking wrong address here, so the unit is restated at each use.
+    #
+    # `sK_off(row, group, lane)` -- the gathered KV row map -- is defined with
+    # the gather itself, below, because its strides are the non-obvious part.
+    def row(i):                      # the S/dP fragment's row coordinate
+        return tTR_c[i].mode0        #   :1880-1881, :1926-1931
+    def row_coord(i):                # the dKV fragment's row coordinate
+        return tTR_cdKV[i].mode1     #   :2199, :2213
+    def sdQ_elem(dp, j):             # ELEMENTS into the linear sdQ region
+        return (dp % 64) + (dp // 64) * 4096 + 64 * j
+                                     #   :2540-2543.  Two compositions, so state
+                                     #   the RESULT rather than either half:
+                                     #   `make_ordered_layout((128,64),(0,1))`
+                                     #   is (128,64):(1,128), and sdQ itself is
+                                     #   ((64,2),(8,8),(1,1)):((1,4096),(64,512),
+                                     #   (0,0)) -- COL_MAJOR, because
+                                     #   LayoutEnum.from_tensor(mdQ) reads mdQ's
+                                     #   mode-0 stride of 1 (:296-297).  Their
+                                     #   composition measures ((64,2),64):
+                                     #   ((1,4096),64), which is the formula
+                                     #   above.  Verified against crd2idx by
+                                     #   probe/probe_dq_store_map.py.  Deriving
+                                     #   it from a ROW_MAJOR sdQ instead gives
+                                     #   64*dp + j, which is wrong in both
+                                     #   terms.
+    def coords_i(i):                 # the dQ TMA store's coordinate, ELEMENTS
+        return (i * 128, head_block_idx * 64, token_idx)   # :1977-1980
+                                     #   mode 0 steps 128 head dims per round;
+                                     #   mode 1 is head_block_idx * 64, an
+                                     #   element offset, not a tile index
+
+    # --- pipelines (:822-852) --------------------------------------------
+    # producer_arrivals -> consumer_arrivals, in THREADS.  These are the
+    # CooperativeGroup sizes at :2711-2866, and they are exactly the count
+    # operands of the 22 `mbarrier.init.shared.b64` in the export; getting one
+    # wrong deadlocks silently.
+    #
+    # Read the 1s carefully: the source writes `len([self.mma_warp_id])`, which
+    # is `len([16])` == **1**, a single-Thread agent -- one elected lane
+    # arrives, not a 32-thread warp.  Every UMMA side is 1 because
+    # `tcgen05.commit` is one arrival.  32 appears only where a whole warp
+    # arrives thread-by-thread (the load warp's two cp.async sites); 128 and
+    # 256 are the 4- and 8-warp consumers arriving per thread.
+    pipe_load_mma_QdO  = pipe(mbar_load_mma_QdO, 1, tma(tx=Q_BYTES+dO_BYTES),
+                              producer=1,   consumer=1)     # :2714 TmaUmma
+    pipe_load_mma_K    = pipe(mbar_load_mma_K, 1, async_umma,
+                              producer=128, consumer=1)     # :2726 AsyncUmma
+    pipe_load_cmp_LSE  = pipe(mbar_load_compute_LSE, 1, cp_async,
+                              producer=32,  consumer=128)   # :2743 CpAsync
+    pipe_load_cmp_sOdO = pipe(mbar_load_compute_sumOdO, 1, cp_async,
+                              producer=32,  consumer=128)   # :2760 CpAsync
+    pipe_mma_cmp_S     = pipe(mbar_mma_compute_S, 1, umma_async,
+                              producer=1,   consumer=128)   # :2774 UmmaAsync
+    pipe_mma_cmp_dP    = pipe(mbar_mma_compute_dP, 1, umma_async,
+                              producer=1,   consumer=128)   # :2802
+    pipe_mma_cmp_dQ    = pipe(mbar_mma_compute_dQ, 1, umma_async,
+                              producer=1,   consumer=128)   # :2788
+    pipe_cmp_mma_P     = pipe(mbar_compute_mma_P, 1, async_umma,
+                              producer=128, consumer=1)     # :2819
+    pipe_cmp_mma_dS    = pipe(mbar_compute_mma_dS, 1, async_umma,
+                              producer=128, consumer=1)     # :2836
+    pipe_mma_red_dKV   = pipe(mbar_mma_reduce_dKV, 2, umma_async,
+                              producer=1,   consumer=256)   # :2850  <- 2 stages
+    pipe_cmp_tma_dQ    = pipe(None, 1, tma_store, producer=128)  # :2863
+    # instruction_selection: mbarrier.init.shared.b64 x22 (:2714..:2850);
+    #   extent: one per stage per direction.  pipe_cmp_tma_dQ has NO smem
+    #   barrier -- a TMA-store pipeline is `cp.async.bulk.commit_group` plus
+    #   `cp.async.bulk.wait_group.read`, nothing else.
+
+    init_pipe_arrive(relaxed=True)          # :860
+    # instruction_selection: fence.mbarrier_init.release.cluster (:860, 1
+    #   static); extent: CTA.
+    init_pipe_wait()                        # :905
+    # instruction_selection: bar.sync 0 (:905, 1 static); extent: whole CTA.
+    #   NOT a cluster barrier -- `barrier.cluster` appears zero times in the
+    #   export, because the cluster is (1,1,1).
+    #   Note this sits AFTER every alias declaration (:862-903), so a port that
+    #   hoists the wait changes when the aliases become legible.
+
+    tile_count = ceil_div(topk, 64)         # :907
+
+    # -----------------------------------------------------------------------
+    # Role dispatch -- source order, NOT warp-id order (:909-1110)
+    # -----------------------------------------------------------------------
+    if   warp == 17:            set_register_budget(dec, 40);  role_load()
+    elif warp == 16:            set_register_budget(dec, 40);  role_mma()
+    elif warp in (4,5,6,7):     set_register_budget(inc, 128); role_compute()
+    elif warp in (8..15):       set_register_budget(inc, 128); role_reduce()
+    elif warp in (0,1,2,3):     set_register_budget(dec, 40);  role_load_KV()
+    else:                       set_register_budget(dec, 40)   # warps 18,19
+    # instruction_selection: setmaxnreg.dec.sync.aligned.u32 40 x4 (:910, :928,
+    #   :1098, :1110) and setmaxnreg.inc.sync.aligned.u32 128 x2 (:1026,
+    #   :1074); extent: scalar per role branch.  The export settles a question
+    #   the source text raises: warps 16, 17 and 18..19 share warpgroup 4 yet
+    #   each issues its OWN setmaxnreg.  Six instructions, one per role, not
+    #   one per warpgroup.
+
+# ---------------------------------------------------------------------------
+# Role: load  (warp 17)   (:1113-1207)   -- runs once, no loop
+# ---------------------------------------------------------------------------
+
+def role_load():
+    acquire(pipe_load_mma_QdO, slot=0)
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1155, 1
+    #   static) on the empty barrier, then mbarrier.arrive.expect_tx.shared.b64
+    #   (:1152, 1 static) on the full one; extent: scalar, elected lane.  A
+    #   TMA/UMMA producer_acquire is BOTH, which is why it is one of the 23
+    #   try_waits the summary counts.  ONE expect_tx covers BOTH the
+    #   Q and dO transfers -- `tx_count = tma_copy_QdO_bytes` is their sum
+    #   (:442-444, :2719) and both copies below post to the same barrier
+    #   (:1153).  Splitting it into two barriers changes the protocol.
+
+    copy_g2s_tma(desc_Q,  (0, head_block_idx * 64, token_idx), sQ,
+                 bar=mbar_load_mma_QdO)   # coordinates in ELEMENTS
+    # instruction_selection: cp.async.bulk.tensor.3d.shared::cta.global.tile.
+    #   mbarrier::complete_tx::bytes**.L2::cache_hint** -- the qualifier is part
+    #   of the emitted mnemonic and brings a 64-bit cache-policy operand, a
+    #   constant 0 in this build.  (:1154, **HEAD_DIM // 64 static** -- 8 at
+    #   d512, **9 at d576**); extent: that many issues covering the
+    #   64 x HEAD_DIM tile.  One `cute.copy` is eight or nine TMA instructions
+    #   here, not one: the descriptor's box splits the head-dim axis into
+    #   64-wide boxes, so the count follows HEAD_DIM.  Rank is 3.
+    copy_g2s_tma(desc_dO, (0, head_block_idx * 64, token_idx), sdO,
+                 bar=mbar_load_mma_QdO)   # coordinates in ELEMENTS
+    # instruction_selection: same opcode, also `.L2::cache_hint` (:1162, 8
+    #   static in BOTH builds);
+    #   extent: 8 issues covering 64 x 512 -- dO is HEAD_DIM_V wide, which is
+    #   512 either way, so this one does not follow HEAD_DIM.
+
+    # LSE and sum_OdO: 32 lanes x 2 f32 = the 64 rows of this head block.
+    acquire(pipe_load_cmp_LSE, slot=0)                         # :1181
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1184);
+    #   extent: scalar spin on the LSE empty barrier.
+    copy_g2s_async(sLSE, addr(scaled_lse_ws, head_block_idx, token_idx), bytes=8)
+    # instruction_selection: cp.async.ca.shared.global (:1186, 1 static);
+    #   extent: 64 bits per lane, 32 lanes.  `.ca` not `.cg`: the atom is built
+    #   with LoadCacheMode.ALWAYS (:1170).  num_bits_per_copy=64 with
+    #   thr_layout 32 / val_layout 2 (:1170-1173).
+    commit(pipe_load_cmp_LSE)
+    # instruction_selection: cp.async.mbarrier.arrive.noinc.shared.b64 (:1191);
+    #   extent: scalar.  This is how a cp.async pipeline commits -- no
+    #   separate commit_group.
+
+    acquire(pipe_load_cmp_sOdO, slot=0)                        # :1195
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1198);
+    #   extent: scalar spin on the sum_OdO empty barrier.
+    copy_g2s_async(sSum_OdO, addr(sum_OdO_ws, head_block_idx, token_idx), bytes=8)
+    # instruction_selection: cp.async.ca.shared.global (:1200, 1 static);
+    #   extent: 64 bits per lane, 32 lanes.
+    commit(pipe_load_cmp_sOdO)
+    # instruction_selection: cp.async.mbarrier.arrive.noinc.shared.b64 (:1206).
+    # The warp retires here.  There is no producer_commit for
+    # pipe_load_mma_QdO: a TMA pipeline's completion IS the expect_tx.
+
+# ---------------------------------------------------------------------------
+# Role: load_KV  (warps 0..3)   (:1316-1431)
+#   rows_per_warp = 64 / 4 = 16.  Warp w owns rows w, w+4, w+8, ...
+# ---------------------------------------------------------------------------
+
+def role_load_KV():
+    lane = tidx % 32
+    lwarp = tidx // 32                     # 0..3
+    full_tiles = (topk % 64) == 0          # :1344
+
+    def read_indices(tile_index) -> reg_tile[16]:
+        r = reg_tile("i32", [16])
+        for i in range(16):                                    # :1348, unrolled
+            row = i * 4 + lwarp
+            idx = tile_index * 64 + row
+            v = i32(-1)
+            if lane == 0 and idx < MAX_TOPK:
+                v = load_global(topk_idxs, (idx, token_idx))
+                # instruction_selection: ld.global.b32 (:1354 and :1404, 16
+                #   static each); extent: scalar, lane 0 only.  The bound is
+                #   MAX_TOPK, the allocation extent, not `topk`: rows past the
+                #   length are read but discarded.
+            r[i] = shuffle_broadcast(v, lane=0)
+            # instruction_selection: shfl.sync.idx.b32 (:1355 and :1405, 16
+            #   static each, 32 total); extent: warp broadcast, 16 per tile.
+        return r
+
+    def gather_rows(tile_index, r, is_first):
+        # is_first is a COMPILE-TIME flag; the source instantiates this helper
+        # twice from two call sites (:1361 / :1375) plus once in the loop
+        # (:1411), which is why the gather's static counts are 3x per-call.
+        for i in range(16):                                    # :1292, unrolled
+            row = i * 4 + lwarp
+            idx = tile_index * 64 + row
+            dst = row                         # a row index; sK_off() maps it
+            if HAS_TOPK_LENGTH:
+                if is_first and idx >= topk:
+                    zero_kv_row(dst)
+                else:
+                    copy_kv_row(dst, r[i])
+            else:
+                if idx < topk and r[i] >= 0:
+                    copy_kv_row(dst, r[i])
+                else:
+                    zero_kv_row(dst)
+
+    # `sK_slice` is composition(sK[...], (64, HEAD_DIM)) (:1357-1358), which
+    # measures (64,(64,8)):(64,(1,4096)) -- NOT a plain row-major (64, HEAD_DIM).
+    # The row stride is 64 elements (128 B) and the head-dim GROUP stride is
+    # 4096 elements (8192 B), with 64 contiguous elements inside a group, all
+    # under swizzle S<3,4,3>.  The export settles it: stepping `j` by one moves
+    # the group index by 4 and the SMEM address by +32768 B while the GMEM
+    # address moves by only +512 B (`cp.async.cg.shared.global [%r289+32768],
+    # [%rd152+512]`, :1229).  A row-major reading -- row stride 1024 B, group
+    # stride 128 B -- is wrong in both strides.
+    def sK_off(row, group, lane):        # ELEMENTS into the linear sK region
+        return row * 64 + group * 4096 + (lane % 8) * 8
+
+    def copy_kv_row(row, topk_idx):
+        # 8 lanes cover one 64-element group; lanes are grouped by `lane % 8`
+        # (:1339) and the group index by `lane // 8` (:1224).
+        for j in range(2):                                     # :1223, unrolled
+            group = j * 4 + lane // 8
+            copy_g2s_async(sK_off(row, group, lane),
+                           addr(kv, topk_idx, group * 64 + (lane % 8) * 8),
+                           bytes=16)
+            # Both sides in ELEMENTS, and BOTH carry the lane term: the 8 lanes
+            # of a group read 8 disjoint 8-element runs (`get_slice(lane % 8)`
+            # with val_layout (8,), :1339).  Dropping it from the source side
+            # makes all 8 lanes read the same 16 bytes and leaves 56 of every 64
+            # elements never loaded.
+            # instruction_selection: cp.async.cg.shared.global (:1229 at d512,
+            #   **:1237 at d576**, 96 static = 3 call sites x 16 rows x 2
+            #   groups); extent: 128 bits per lane.  `.cg` not `.ca`:
+            #   LoadCacheMode.GLOBAL (:1332), num_bits_per_copy=128, thr/val
+            #   layouts 8/8 (:1334-1338).
+        if HAS_TAIL:
+            if lane < 8:                                       # :1243
+                copy_g2s_async(sK_off(row, 8, lane),
+                               addr(kv, topk_idx, 512 + (lane % 8) * 8),
+                               bytes=16)
+                # instruction_selection: cp.async.cg.shared.global (:1244, 48
+                #   static); extent: 128 bits, first 8 lanes only.  The 9th
+                #   group is the 64-wide d576 tail.
+
+    def zero_kv_row(row):
+        for j in range(2):                                     # :1253
+            group = j * 4 + lane // 8
+            zero_shared(sK_off(row, group, lane), bytes=16)
+            # instruction_selection: st.shared.v4.b32 (:1258 at d512, **:1265 at
+            #   d576**, 32 static; 192 static in the non-compact build, where
+            #   every row can be invalid); extent: 128 bits per lane.  A zero
+            #   fill, not a copy: an invalid row must contribute nothing to
+            #   either GEMM that reads sK.
+        if HAS_TAIL and lane < 8:
+            zero_shared(sK_off(row, 8, lane), bytes=16)
+            # instruction_selection: st.shared.v4.b32 (:1271, 16 static);
+            #   extent: 128 bits, first 8 lanes only.  d576 only.
+
+    # --- first (highest-index, ragged) tile, then the rest ---------------
+    tile_index = tile_count - 1                                # :1343
+    r = read_indices(tile_index)
+    acquire(pipe_load_mma_K, slot=0)                           # :1356
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+    #   scalar spin on the K empty barrier, every load_KV thread.
+    if full_tiles:
+        gather_rows(tile_index, r, is_first=False)             # :1361
+    else:
+        gather_rows(tile_index, r, is_first=True)              # :1375
+    cp_async_commit()
+    # instruction_selection: cp.async.commit_group (:1389, 2 static -- one here
+    #   and one in the loop); extent: scalar.
+    cp_async_wait(0)
+    # instruction_selection: cp.async.wait_group 0 (:1390, 2 static); extent:
+    #   scalar.  Waits for ALL groups: the gather is not double-buffered.
+    fence_view_async_shared()                                  # :1391
+    # instruction_selection: fence.proxy.async.shared::cta (:1391, 1 static);
+    #   extent: CTA.
+    named_barrier(5, 128)                                      # :1392
+    # instruction_selection: bar.sync 5, 128 (:1392, 1 static); extent: the 4
+    #   load_KV warps.  This is what makes the 4 warps' gathers jointly visible
+    #   before any one of them commits the pipeline.
+    commit(pipe_load_mma_K, slot=0)                            # :1393
+    # instruction_selection: mbarrier.arrive.shared.b64 (:1393, 1 static);
+    #   extent: scalar per producer thread -- the pipeline's full barrier
+    #   expects 128 arrivals, one per load_KV thread.
+    tile_index -= 1
+
+    while tile_index >= 0:                                     # :1397
+        r = read_indices(tile_index)
+        acquire(pipe_load_mma_K, slot=0)                       # :1407
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the empty barrier.
+        gather_rows(tile_index, r, is_first=False)             # :1411
+        cp_async_commit()                                      # :1425
+        # instruction_selection: cp.async.commit_group (:1425, 1 static).
+        cp_async_wait(0)                                       # :1426
+        # instruction_selection: cp.async.wait_group 0 (:1426, 1 static).
+        fence_view_async_shared()                              # :1427
+        # instruction_selection: fence.proxy.async.shared::cta (:1427, 1 static).
+        named_barrier(5, 128)                                  # :1428
+        # instruction_selection: bar.sync 5, 128 (:1428, 1 static).
+        commit(pipe_load_mma_K, slot=0)                        # :1429
+        # instruction_selection: mbarrier.arrive.shared.b64 (:1429, 1 static).
+        tile_index -= 1
+
+# ---------------------------------------------------------------------------
+# Role: mma  (warp 16)   (:1434-1765)
+#   Issues every tcgen05 MMA.  32 static MMA instructions in the d512 build.
+# ---------------------------------------------------------------------------
+
+def role_mma():
+    tmem_wait_alloc(); base = tmem_retrieve()   # :929-930
+    # instruction_selection: bar.sync 2, 416 then ld.shared.b32 of
+    #   tmem_holding; extent: the compute+reduce+mma participants.
+
+    wait(pipe_load_mma_QdO, slot=0)             # :1490 -- once, before the loop
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1493, 1 of
+    #   23 static); extent: scalar spin.  Waits for BOTH TMAs: they share one
+    #   barrier and one expect_tx.
+    acquire(pipe_mma_cmp_dQ, slot=0)            # :1491 -- once, before the loop
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1494);
+    #   extent: scalar spin on the dQ empty barrier.  Acquired ONCE for the
+    #   whole kernel: dQ accumulates across every tile.
+
+    tile_index = tile_count - 1                 # :1493
+    is_first_mma = True                         # compile-time per unrolled arm
+    while tile_index >= 0:                      # :1495
+        wait(pipe_load_mma_K, slot=0)           # :1497
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1500);
+        #   extent: scalar spin.
+        acquire(pipe_mma_cmp_S, slot=0)         # :1498
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1501);
+        #   extent: scalar spin.
+
+        # --- S = Q @ K^T ------------------------------------------------
+        gemm(tmem[S], sQ, sK, accumulate=False_then_True)      # :1500-1509
+        # instruction_selection: tcgen05.mma.cta_group::1.kind::f16 (:1502, 4
+        #   static); extent: ONE LOOP of 32 K-phases with a 4-wide unrolled
+        #   body.  The export has a real backedge over the four issues, so
+        #   `unroll=4` at :1501 produced a rolled loop, not full unrolling.
+        #   ACCUMULATE is False on the first K-phase and True thereafter
+        #   (:1500, :1509) -- the flag is part of the instruction, not a
+        #   separate zeroing pass.
+        commit(pipe_mma_cmp_S, slot=0)
+        # instruction_selection: tcgen05.commit.cta_group::1.mbarrier::
+        #   arrive::one.shared::cluster.b64 (:1511, 1 of 9 static); extent:
+        #   scalar.  A UMMA pipeline commits with tcgen05.commit, never with
+        #   a plain mbarrier.arrive.
+
+        # --- dP = dO @ V^T ----------------------------------------------
+        acquire(pipe_mma_cmp_dP, slot=0)                       # :1515
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1518);
+        #   extent: scalar spin.
+        gemm(tmem[dP], sdO, sV, accumulate=False_then_True)    # :1516-1525
+        # instruction_selection: tcgen05.mma...kind::f16 (:1518, 4 static);
+        #   extent: loop of 32 K-phases, unrolled 4.
+        commit(pipe_mma_cmp_dP, slot=0)                        # :1527
+        # instruction_selection: tcgen05.commit...b64 (:1527, 1 static).
+
+        # --- dKV generation A: dKV0, dKV1 -------------------------------
+        wait(pipe_cmp_mma_P, slot=0)                           # :1531
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the P full barrier (128 compute-thread arrivals).
+        acquire(pipe_mma_red_dKV, slot=stage_a)                # :1532
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the 2-stage dKV empty barrier.
+        if not is_first_mma:
+            # WAR against the PREVIOUS generation's T2R reads.  Which barrier
+            # depends on the head dim, because the alias maps differ.
+            named_barrier(10 if HAS_TAIL else 8, 288)          # :1541-1546
+            # instruction_selection: bar.sync 10, 288 (:1543) at d576 /
+            #   bar.sync 8, 288 (:1546) at d512; extent: the 8 reduce warps
+            #   plus this one.  Skipped on the first processed tile and
+            #   compensated by an unpaired arrive after the loop (:1752-1757).
+        gemm(tmem[dKV0], sdOT[0:128],   sP, accumulate=False_then_True)  # :1547
+        # instruction_selection: tcgen05.mma...kind::f16 (:1549, 2 static);
+        #   extent: loop of 4 K-phases, unrolled 2 (:1548).
+        gemm(tmem[dKV1], sdOT[128:256], sP, accumulate=False_then_True)  # :1559
+        # instruction_selection: same (:1561, 2 static); extent: same.
+
+        wait(pipe_cmp_mma_dS, slot=0)                          # :1570
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the dS full barrier.
+        gemm(tmem[dKV0], sQT[0:128],   sdS, accumulate=True)   # :1574
+        # instruction_selection: same (:1576, 2 static); extent: loop of 4
+        #   K-phases, unrolled 2.  ACCUMULATE stays True for the whole loop
+        #   (:1574 sets it once): this ADDS dK onto the dV already in these
+        #   columns, which is what fuses the two gradients.
+        gemm(tmem[dKV1], sQT[128:256], sdS, accumulate=True)   # :1584
+        # instruction_selection: same (:1585, 2 static).
+        commit(pipe_mma_red_dKV, slot=stage_a)                 # :1594
+        # instruction_selection: tcgen05.commit...b64 (:1594, 1 static).
+
+        if HAS_TAIL:
+            named_barrier(7, 288)                              # :1600-1602
+            # instruction_selection: bar.sync 7, 288 (:1602, 1 static); extent:
+            #   the 8 reduce warps plus this one.  Orders the dKV4 write
+            #   against the dKV0/dKV1 reads, because dKV4 aliases dKV0.
+            #   UNCONDITIONAL -- barrier 7 is never skipped in either build.
+            gemm(tmem[dKV4], sQT_tail, sdS, accumulate=False_then_True)
+            # instruction_selection: tcgen05.mma...kind::f16 (:1606, 2 static);
+            #   extent: loop of 4 K-phases.  d576 only.
+            commit(pipe_mma_red_dKV, slot=stage_b)             # :1616
+            # instruction_selection: tcgen05.commit...b64 (**:1616**, 1 static).
+            #   :1617 is the producer_state.advance() and emits nothing.
+            # NOTE: this commit has NO matching acquire.  The source relies on
+            # t2r_dKV01_done above for the safety an acquire would provide.
+            # The generation count per tile is therefore 3 at d576 and 2 at
+            # d512, and the reduce role's wait count matches.
+
+        # --- dQ0..dQ3 (and dQ4) -----------------------------------------
+        for i in range(4):                                     # :1622-1667
+            gemm(tmem[dQ_i], sK_2[i*128:(i+1)*128], sdST,
+                 accumulate=not is_first_mma)
+            # instruction_selection: tcgen05.mma...kind::f16 (:1624, :1636,
+            #   ..., 2 static each); extent: loop of 4 K-phases, unrolled 2.
+            #   ACCUMULATE is False only on the first PROCESSED tile: dQ
+            #   accumulates across the whole top-k axis in TMEM and is never
+            #   published until the loop ends.
+        if HAS_TAIL:
+            gemm(tmem[dQ4], sK_tail, sdST, accumulate=not is_first_mma)  # :1670
+            # instruction_selection: tcgen05.mma...kind::f16 (:1673, 2
+            #   static); extent: loop of 4 K-phases, unrolled 2.  d576 only,
+            #   which is why that build has 36 MMA issues against d512's 32.
+
+        release(pipe_load_mma_K, slot=0)                       # :1683
+        # instruction_selection: tcgen05.commit.cta_group::1.mbarrier::
+        #   arrive::one.shared::cluster.b64 (:1683, 1 static); extent: scalar.
+        # The KV tile's SMEM is reusable from here; the gather warps may
+        # overwrite sK for the next tile.
+
+        # --- dKV generation B: dKV2, dKV3 -------------------------------
+        # UNCONDITIONAL, unlike the generation-A WAR barrier above: the export
+        # shows this arrive outside any is_first-predicated region.
+        named_barrier(8 if HAS_TAIL else 7, 288)               # :1689-1692
+        # instruction_selection: bar.sync 7, 288 (:1692, d512) / bar.sync 8, 288
+        #   (:1690, d576), 1 static; extent: the 8 reduce warps plus this one.
+        acquire(pipe_mma_red_dKV, slot=stage_b_or_c)           # :1694
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin.
+        gemm(tmem[dKV2], sdOT[256:384], sP, accumulate=False_then_True)  # :1695
+        # instruction_selection: tcgen05.mma...kind::f16 (:1697, 2 static);
+        #   extent: loop of 4 K-phases, unrolled 2.
+        gemm(tmem[dKV3], sdOT[384:512], sP, accumulate=False_then_True)  # :1706
+        # instruction_selection: same (:1709, 2 static).
+        release(pipe_cmp_mma_P, slot=0)                        # :1719
+        # instruction_selection: tcgen05.commit...b64 (:1719, 1 static).
+        gemm(tmem[dKV2], sQT[256:384], sdS, accumulate=True)   # :1724
+        # instruction_selection: same (:1725, 2 static).
+        gemm(tmem[dKV3], sQT[384:512], sdS, accumulate=True)   # :1732
+        # instruction_selection: same (:1734, 2 static).
+        commit(pipe_mma_red_dKV, slot=stage_b_or_c)            # :1742
+        # instruction_selection: tcgen05.commit...b64 (:1742, 1 static).
+        release(pipe_cmp_mma_dS, slot=0)                       # :1746
+        # instruction_selection: tcgen05.commit...b64 (:1746, 1 static).
+        is_first_mma = False
+        tile_index -= 1
+
+    # --- loop tail: balance the ONE skipped first-iteration arrive -------
+    # Exactly one WAR barrier is skipped-once per build -- the generation-A one
+    # at :1541-1546, which is id 10 at d576 and id 8 at d512.  Barrier 7 is
+    # unconditional in both builds (:1602 / :1692), so it needs no compensation.
+    named_barrier(10 if HAS_TAIL else 8, 288)                  # :1752-1757
+    # instruction_selection: bar.sync 8, 288 (:1753, d512) / bar.sync 10, 288
+    #   (:1757, d576), 1 static; extent: the 8 reduce warps plus this one.
+    #   The export has exactly one tail barrier per build, not two.
+
+    commit(pipe_mma_cmp_dQ, slot=0)                            # :1759
+    # instruction_selection: tcgen05.commit...b64 (:1759, 1 static); extent:
+    #   scalar.  dQ is published ONCE, after the whole top-k axis is
+    #   accumulated.
+    release(pipe_load_mma_QdO, slot=0)                         # :1763
+    # instruction_selection: tcgen05.commit...b64 (:1763, 1 static).
+
+# ---------------------------------------------------------------------------
+# Role: compute  (warps 4..7)   (:1767-2140)
+# ---------------------------------------------------------------------------
+
+def role_compute():
+    if warp == 4:
+        tmem_alloc(512)                                        # :1028
+        # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned.
+        #   shared::cta.b32 (:1028, 1 static); extent: scalar, warp 4 only.
+        #   512 columns = all of tensor memory (:79-80).
+    tmem_wait_alloc(); base = tmem_retrieve()                  # :1029-1030
+    # instruction_selection: bar.sync 2, 416 (:1029, 1 static) then
+    #   ld.shared.b32 of tmem_holding; extent: compute + reduce + mma.
+
+    wait(pipe_load_cmp_LSE, slot=0)                            # :1848
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1851);
+    #   extent: scalar spin, every compute thread.
+    wait(pipe_load_cmp_sOdO, slot=0)                           # :1849
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:1852).
+    softmax_scale_log2e = softmax_scale * log2_e               # :1852
+    # instruction_selection: mul.f32 (:1852, 1 static); extent: scalar, every
+    #   compute thread.  NOT a trace-time fold: `scale_softmax` arrives as a
+    #   runtime f32 kernel parameter (`.param .f32 ..._param_25`, source :768),
+    #   so this multiply executes.  It is also the only scalar mul.f32 in `bwd`
+    #   -- everything else in the softmax path is packed.
+
+    tile_index = tile_count - 1                                # :1870
+    while tile_index >= 0:                                     # :1871
+        # --- P = exp2(fma(S, scale*log2e, scaled_lse)) ------------------
+        wait(pipe_mma_cmp_S, slot=0)                           # :1872
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the S full barrier (one tcgen05.commit arrival).
+        acquire(pipe_cmp_mma_P, slot=0)                        # :1873
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin on the P empty barrier.
+        rS = copy_t2r(tmem[S], shape="16x256b", rep=8)         # :1875
+        # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x8.b32
+        #   (:1875, 1 static); extent: one issue per thread covering this
+        #   thread's slice of the 64x64 S tile.  Ld16x256bOp(Repetition(8))
+        #   at :1816-1819.
+
+        for i in range(0, len(rS), 2):                         # :1877
+            lse2 = (load_shared(sLSE, row(i)), load_shared(sLSE, row(i+1)))
+            # instruction_selection: ld.shared.b32 (:1880, **2 static**);
+            #   extent: scalar.  Not 32: the loop runs 16 iterations x 2 reads,
+            #   but each thread's 16x256b fragment spans only TWO rows of the
+            #   64-row tile, so every iteration re-reads the same two values and
+            #   the compiler keeps one load each.  A port that hoists these by
+            #   hand is matching what the compiler already does; one that
+            #   indexes them per-iteration emits 32.
+            rS[i], rS[i+1] = fma((rS[i], rS[i+1]),
+                                 (softmax_scale_log2e,) * 2, lse2, lanes=2)
+            # instruction_selection: fma.rn.f32x2 (:1884, 16 static); extent:
+            #   one packed two-lane FMA per pair.  Not two scalar FMAs: the
+            #   source calls fma_packed_f32x2 and the export confirms the
+            #   packed form.
+            rS[i]   = exp2(rS[i],   ftz=True)
+            rS[i+1] = exp2(rS[i+1], ftz=True)
+            # instruction_selection: ex2.approx.ftz.f32 (:1889-:1890, 32
+            #   static = 16 pairs x 2); extent: scalar each.  `.ftz` because
+            #   this call passes fastmath=True (:1889) -- contrast sum_OdO's
+            #   plain ex2.approx.f32.
+        rP = cast(rS, ELEM)                                    # :1892
+        # instruction_selection: cvt.rn.bf16x2.f32 (via quantize, :2625);
+        #   extent: 4-element fragments (frg_cnt=4 at :1892).
+
+        fence_tmem_load()                                      # :1894
+        # instruction_selection: tcgen05.wait::ld.sync.aligned (:1894, 1 of 8
+        #   static); extent: scalar.  Must precede the barrier: it is what
+        #   makes the T2R results architecturally visible.
+        named_barrier(3, 128)                                  # :1895
+        # instruction_selection: bar.sync 3, 128 (:1895, 1 static); extent:
+        #   the 4 compute warps.
+
+        copy_r2s_stmatrix(rP, sP_store)                        # :1898-:1900
+        # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+        #   (:1900, 4 static); extent: 4 matrices per issue, transposing.
+        #   The `.trans` is the whole point: it converts the row-major
+        #   (head, kv) accumulator fragment into the head-major B-operand
+        #   layout the dOP MMA needs, with no separate transpose pass.
+        fence_proxy_shared()                                   # :1905
+        # instruction_selection: fence.proxy.async.shared::cta (:1905, 1 of 8
+        #   static); extent: CTA.  Required before a UMMA reads what a
+        #   generic-proxy store wrote.
+        commit(pipe_cmp_mma_P, slot=0)                         # :1910
+        # instruction_selection: mbarrier.arrive.shared.b64 (:1910); extent:
+        #   scalar.  An async->UMMA pipeline commits with a plain arrive.
+        release(pipe_mma_cmp_S, slot=0)                        # :1913
+        # instruction_selection: mbarrier.arrive.shared.b64 (:1913, 1 static);
+        #   extent: scalar per compute thread -- the empty barrier expects 128.
+
+        # --- dS = (dP + sum_OdO) * P * softmax_scale --------------------
+        wait(pipe_mma_cmp_dP, slot=0)                          # :1916
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin.
+        acquire(pipe_cmp_mma_dS, slot=0)                       # :1917
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+        #   scalar spin.
+        rdP = copy_t2r(tmem[dP], shape="16x256b", rep=8)       # :1919
+        # instruction_selection: tcgen05.ld...16x256b.x8.b32 (:1919, 1 static);
+        #   extent: one issue.  Reads the SAME columns as S but at lane offset
+        #   16<<16 (:2675-2677), which is what lets dP and S share columns.
+
+        for i in range(0, len(rdP), 2):                        # :1921
+            sums = (load_shared(sSum_OdO, row(i)), load_shared(sSum_OdO, row(i+1)))
+            # instruction_selection: ld.shared.b32 (:1925, **2 static**);
+            #   extent: scalar -- same two-rows-per-fragment CSE as sLSE above.
+            rdP[i], rdP[i+1] = add((rdP[i], rdP[i+1]), sums, lanes=2)
+            # instruction_selection: add.rn.f32x2 (:1922, 16 static); extent:
+            #   one packed two-lane add.  `sum_OdO` is already negated
+            #   (sum_OdO_scale = -1.0 at :488), so this add IS the
+            #   `dP - delta` of the softmax backward.
+            rdP[i], rdP[i+1] = mul((rdP[i], rdP[i+1]), (rS[i], rS[i+1]), lanes=2)
+            # instruction_selection: mul.rn.f32x2 (:1936, 16 static); extent:
+            #   one packed two-lane multiply.  rS still holds P here, so this
+            #   is the `* P` factor; rS must stay live across both loops.
+        rdS = cast(rdP * softmax_scale, ELEM)                  # :1938
+        # instruction_selection: mul.f32x2 (:2624, 16 static) then
+        #   cvt.rn.bf16x2.f32 (:2625, 16 static); extent: one packed two-lane
+        #   multiply per pair, then one packed convert per pair.  The scale is
+        #   PACKED like the two loops above it, not scalar -- the only plain
+        #   `mul.f32` in `bwd` is the single runtime scalar one at :1852.  The
+        #   `* softmax_scale` is folded into the quantize call (:1938 passes
+        #   it), not a separate pass.
+
+        fence_tmem_load()                                      # :1940
+        # instruction_selection: tcgen05.wait::ld.sync.aligned (:1940, 1 of 8
+        #   static); extent: scalar.
+        named_barrier(3, 128)                                  # :1941
+        # instruction_selection: bar.sync 3, 128 (:1941, 1 static).
+        release(pipe_mma_cmp_dP, slot=0)                       # :1943
+        # instruction_selection: mbarrier.arrive.shared.b64 (:1943, 1 static).
+        copy_r2s_stmatrix(rdS, sdS_store)                      # :1946-:1948
+        # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+        #   (:1948, 4 static); extent: 4 matrices, transposing.
+        fence_proxy_shared()                                   # :1955
+        # instruction_selection: fence.proxy.async.shared::cta (:1955, 1 static).
+        commit(pipe_cmp_mma_dS, slot=0)                        # :1960
+        # instruction_selection: mbarrier.arrive.shared.b64 (:1960, 1 static).
+        tile_index -= 1
+
+    release(pipe_load_cmp_LSE, slot=0)                         # :1965
+    # instruction_selection: mbarrier.arrive.shared.b64 (:1965, 1 static).
+    release(pipe_load_cmp_sOdO, slot=0)                        # :1966
+    # instruction_selection: mbarrier.arrive.shared.b64 (:1966, 1 static).
+
+    # --- dQ epilogue: 4 rounds (5 at d576) --------------------------------
+    # sdQ ALIASES sK, so this may only run after the KV loop has drained.
+    wait(pipe_mma_cmp_dQ, slot=0)                              # :2033
+    # instruction_selection: mbarrier.try_wait.parity.shared.b64; extent:
+    #   scalar spin.  One wait for the whole epilogue: dQ was committed once.
+    for i in range(4):                                         # :2035-2113
+        if warp == 4:
+            acquire(pipe_cmp_tma_dQ)                           # :2036
+            # instruction_selection: cp.async.bulk.wait_group.read (:2036,
+            #   :2057, :2077, :2097, :2140 -- 5 static); extent: scalar.  A
+            #   TMA-store pipeline acquires by waiting on the bulk group, not
+            #   on an mbarrier: it has no smem barrier at all.
+        named_barrier(3, 128)                                  # :2038
+        # instruction_selection: bar.sync 3, 128 (:2038, :2058, :2078, :2098 --
+        #   4 static, one per unrolled round); extent: the 4 compute warps.
+        #   This is what makes warp 4's acquire visible to the other three.
+        #   The round-CLOSING barrier is a separate set of four (:2053, :2073,
+        #   :2093, :2112); the eight are disjoint pairs, not one pool.
+        store_dQ(i)
+        if warp == 4:
+            commit(pipe_cmp_tma_dQ)                            # :2051
+            # instruction_selection: cp.async.bulk.commit_group (:2051, :2071,
+            #   :2091, :2111 -- 4 static, one per unrolled round); extent:
+            #   scalar.
+        named_barrier(3, 128)                                  # :2053
+        # instruction_selection: bar.sync 3, 128 (:2053, :2073, :2093, :2112
+        #   -- 4 static, one per unrolled round).
+    if HAS_TAIL:                                               # :2116-2135
+        if warp == 4:
+            acquire(pipe_cmp_tma_dQ)                           # :2118
+            # instruction_selection: cp.async.bulk.wait_group.read (:2118, 1
+            #   static); extent: scalar.  d576 only -- this is the fifth round.
+        named_barrier(3, 128)                                  # :2119
+        # instruction_selection: bar.sync 3, 128 (:2119, 1 static).
+        store_dQ_64()
+        if warp == 4:
+            commit(pipe_cmp_tma_dQ)                            # :2133
+            # instruction_selection: cp.async.bulk.commit_group (:2133, 1
+            #   static).
+        named_barrier(3, 128)                                  # :2134
+        # instruction_selection: bar.sync 3, 128 (:2134, 1 static).
+    release(pipe_mma_cmp_dQ, slot=0)                           # :2137
+    # instruction_selection: mbarrier.arrive.shared.b64 (:2137, 1 static).
+    tma_store_wait(0)                                          # :2140
+    # instruction_selection: cp.async.bulk.wait_group.read (:2140, the last of
+    #   the 5 static); extent: scalar.  `producer_tail`: drains every
+    #   outstanding dQ store before the CTA may free sdQ / exit.
+
+    if warp == 4:
+        named_barrier(9, 288)                                  # :1070
+        # instruction_selection: bar.sync 9, 288 (:1070, 1 static); extent: the
+        #   8 reduce warps plus compute warp 4.  arrive_and_wait here, against
+        #   the reduce side's arrive-only at :1095.
+        tmem_dealloc(base, 512)                                # :1071
+        # instruction_selection: tcgen05.dealloc.cta_group::1.sync.aligned.b32
+        #   (:1071, 1 static); extent: scalar.
+        #   The barrier first: the reduce warps must have drained their final
+        #   T2R reads or the dealloc races them inside the CTA.
+
+def store_dQ(i):                                               # :2507-2555
+    rdQ = copy_t2r(tmem[dQ_i], shape="32x32b", rep=8)          # :2533
+    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32 (:2533, 32
+    #   static = 4 sub-tiles x 8); extent: 8 issues per sub-tile.  A DIFFERENT
+    #   TMEM load shape from the dKV path's 16x256b: 32x32b is what makes the
+    #   register fragment match the 128x64 epilogue tile the TMA store wants.
+    rq = cast(rdQ, ELEM)                                       # :2535
+    # instruction_selection: cvt.rn.bf16.f32 (:2625, **256 static**); extent:
+    #   SCALAR, one per element.  NOT the packed cvt.rn.bf16x2.f32 that the
+    #   other two quantize sites get: :2625 emits 32 packed converts (the P and
+    #   dS sites, 16 pairs each) AND 256 scalar ones, and the 256 belong here.
+    fence_tmem_load()                                          # :2537
+    # instruction_selection: tcgen05.wait::ld.sync.aligned (:2537, 4 static).
+    copy_r2s(rq, sdQ + sdQ_elem(dp_idx, j))                    # :2543
+    # instruction_selection: st.shared.b16 (:2543, **256 static** = 4 rounds x
+    #   64 elements per thread); extent: SCALAR.  `cute.autovec_copy` does NOT
+    #   vectorize this access -- there is not one `st.shared.v4.b32` at :2543,
+    #   and the only 32 in `bwd` are the KV zero-fill at :1258.  This is the
+    #   single largest instruction count in the kernel and the difference
+    #   between a ~64- and a ~512-instruction epilogue, so a port that
+    #   "helpfully" vectorizes it is not transcribing this kernel.
+    named_barrier(3, 128)                                      # :2545
+    # instruction_selection: bar.sync 3, 128 (:2545, 4 static -- one per round).
+    fence_proxy_shared()                                       # :2547
+    # instruction_selection: fence.proxy.async.shared::cta (:2547, 4 static).
+    named_barrier(3, 128)                                      # :2552
+    # instruction_selection: bar.sync 3, 128 (:2552, 4 static).  Two barriers
+    #   around the fence: the first makes every thread's shared writes done,
+    #   the second makes the fence itself observed before warp 4 issues the TMA.
+    if warp == 4:
+        copy_s2g_tma(desc_dQ, coords_i, sdQ)                   # :2555
+        # instruction_selection: cp.async.bulk.tensor.3d.global.shared::cta.
+        #   tile.bulk_group**.L2::cache_hint** (:2555, 8 static = 4 rounds x 2
+        #   issues); extent: 2 issues per 128x64 tile, with the 64-bit
+        #   cache-policy operand.  Warp 4 alone issues every dQ store.
+
+def store_dQ_64():                                             # :2558-2608
+    rdQ = copy_t2r(tmem[dQ4], shape="16x256b", rep=2)          # :2588
+    # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x2.b32 (:2588,
+    #   **4 static**); extent: 4 issues.  d576 only.
+    fence_tmem_load()                                          # :2590
+    # instruction_selection: tcgen05.wait::ld.sync.aligned (:2590, 1 static).
+    for i in range(len(rdQ)):                                  # :2593 loop header
+        store_shared(sdQ4, (row_i, col_i), cast(rdQ[i], ELEM))
+        # instruction_selection: cvt.rn.bf16.f32 (:254, 32 static -- the cast is
+        #   attributed to the outer entry, not to :2596) then st.shared.b16
+        #   (**:2596**, 32 static); extent: SCALAR, element by element.
+        #   Deliberately NOT vectorized: the 64-wide tail's coordinate mapping
+        #   is not contiguous per thread, so the source writes through a
+        #   coordinate tensor.  `convert` carries the matching unscramble.
+    named_barrier(3, 128)                                      # :2598
+    # instruction_selection: bar.sync 3, 128 (:2598, 1 static).
+    fence_proxy_shared()                                       # :2600
+    # instruction_selection: fence.proxy.async.shared::cta (:2600, 1 static).
+    named_barrier(3, 128)                                      # :2605
+    # instruction_selection: bar.sync 3, 128 (:2605, 1 static).
+    if warp == 4:
+        copy_s2g_tma(desc_dQ_64, (512, head_block_idx * 64, token_idx), sdQ4)
+        # instruction_selection: cp.async.bulk.tensor.3d.global.shared::cta.
+        #   tile.bulk_group**.L2::cache_hint** (:2608, 1 static); extent: 1
+        #   issue for the 64x64
+        #   tile.  THIS is the only path by which the d576 dQ tail columns
+        #   512:576 reach mdQ -- omitting it leaves those columns whatever
+        #   `torch.empty_like` left there, which is not zero and not detected by
+        #   a d512 test.
+
+# ---------------------------------------------------------------------------
+# Role: reduce_dKV  (warps 8..15, two warpgroups)   (:2143-2280)
+#   Each warpgroup owns half of the 64 KV rows (`split_wg`, :2628).
+# ---------------------------------------------------------------------------
+
+def role_reduce():
+    tmem_wait_alloc(); base = tmem_retrieve()                  # :1075-1076
+    # instruction_selection: bar.sync 2, 416 (:1075, 1 static) then
+    #   ld.shared.b32 of tmem_holding; extent: compute + reduce + mma.
+    full_tiles = (topk % 64) == 0                              # :2194
+    tile_index = tile_count - 1                                # :2190
+
+    while tile_index >= 0:                                     # :2195
+        # Preload this tile's 8 row indices into registers, once, shared by
+        # all four sub-tile reductions.
+        r = reg_tile("i32", [8])
+        for i in range(8):                                     # :2197
+            row = row_coord(i * 2 - i % 2)                     # :2198-2199
+            g = tile_index * 64 + row
+            r[i] = load_global(topk_idxs, (g, token_idx)) if (full_tiles or g < topk) else -1
+            # instruction_selection: ld.global.b32 (:2202/:2205, 8 static each); extent:
+            #   scalar per thread.  Read again here rather than shared from
+            #   the gather warps: different roles, no channel between them.
+        if HAS_TAIL:
+            r64 = ... same, over the dKV4 row coords ...       # :2211-2221
+
+        # --- generation A: dKV0, dKV1 -----------------------------------
+        wait(pipe_mma_red_dKV, slot=a)                         # :2223
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64 (:2226);
+        #   extent: scalar spin, every reduce thread.
+        rdKV0 = copy_t2r(tmem[dKV0], shape="16x256b", rep=4)   # :2228
+        rdKV1 = copy_t2r(tmem[dKV1], shape="16x256b", rep=4)   # :2229
+        # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x4.b32
+        #   (:2305, 8 static across the four t2r_dKV call sites); extent: **2
+        #   issues per sub-tile**.  The fragment is a 128x64 f32 tile split by
+        #   warpgroup = 32 f32 per thread, and Repetition(4) delivers 16
+        #   registers per issue (:2171-2174), so one call is two issues.
+        fence_tmem_load()                                      # :2230
+        # instruction_selection: tcgen05.wait::ld.sync.aligned (:2230, 1 static).
+        named_barrier(7, 288)                                  # :2231
+        # instruction_selection: bar.sync 7, 288 (:2231, 1 static); extent: the
+        #   8 reduce warps plus mma.
+        #   THIS IS THE SPLIT that the whole barrier scheme exists for: the
+        #   registers are drained and the MMA warp released BEFORE the slow
+        #   global atomics below.  Folding the atomics back before this
+        #   barrier (as the dead `store_dKV` at :2400 does) serializes the
+        #   MMA warp behind them.  Three helpers in the source are dead and
+        #   reach no PTX: `store_dKV` (:2399), `store_dKV_64` (:2453) and
+        #   `interleave_wg` (:2644).  None has a call site anywhere in the file,
+        #   so the port should not transcribe any of them.
+        atomic_reduce(rdKV0, r, sub_tile=0)                    # :2232
+        atomic_reduce(rdKV1, r, sub_tile=1)                    # :2233
+        release(pipe_mma_red_dKV, slot=a)                      # :2235
+        # instruction_selection: mbarrier.arrive.shared.b64 (:2235, 1 static);
+        #   extent: scalar per reduce thread -- the empty barrier expects 256.
+
+        # --- generation A.5: dKV4 (d576 only) ---------------------------
+        if HAS_TAIL:
+            wait(pipe_mma_red_dKV, slot=b)                     # :2241
+            # instruction_selection: mbarrier.try_wait.parity.shared.b64.
+            rdKV4 = copy_t2r(tmem[dKV4], shape="16x256b", rep=4)  # :2244
+            # instruction_selection: tcgen05.ld...16x256b.x4.b32 (:2365, 1
+            #   static); extent: 1 issue.
+            fence_tmem_load()                                  # :2245
+            # instruction_selection: tcgen05.wait::ld.sync.aligned (:2245).
+            named_barrier(8, 288)                              # :2246
+            # instruction_selection: bar.sync 8, 288 (:2246, 1 static).
+            atomic_reduce_64(rdKV4, r64)                       # :2247
+            release(pipe_mma_red_dKV, slot=b)                  # :2249
+            # instruction_selection: mbarrier.arrive.shared.b64 (:2249).
+
+        # --- generation B: dKV2, dKV3 -----------------------------------
+        wait(pipe_mma_red_dKV, slot=c)                         # :2252
+        # instruction_selection: mbarrier.try_wait.parity.shared.b64.
+        rdKV2 = copy_t2r(tmem[dKV2], shape="16x256b", rep=4)   # :2257/:2270
+        rdKV3 = copy_t2r(tmem[dKV3], shape="16x256b", rep=4)   # :2258/:2271
+        # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x4.b32 (:2305,
+        #   part of the 8 static); extent: 2 issues per sub-tile.
+        fence_tmem_load()                                      # :2259/:2272
+        # instruction_selection: tcgen05.wait::ld.sync.aligned (:2259, 1 static).
+        named_barrier(8 if SAME_HDIM else 10, 288)             # :2260/:2273
+        # instruction_selection: bar.sync 8, 288 (:2260, d512) / bar.sync 10,
+        #   288 (:2273, d576), 1 static; extent: the 8 reduce warps plus mma.
+        atomic_reduce(rdKV2, r, sub_tile=2)                    # :2261/:2274
+        atomic_reduce(rdKV3, r, sub_tile=3)                    # :2262/:2275
+        release(pipe_mma_red_dKV, slot=c)                      # :2277
+        # instruction_selection: mbarrier.arrive.shared.b64 (:2277, 1 static).
+        tile_index -= 1
+
+    named_barrier_arrive(9, 288)                               # :1095
+    # instruction_selection: bar.arrive 9, 288; extent: arrive only, no wait --
+    #   the reduce warps must not stall here, they are done.
+
+def atomic_reduce(rdKV, r, sub_tile):                          # :2309-2340
+    for i in range(8):                                         # :2322
+        base_c = i * 2 - i % 2                                 # :2323
+        frg = (rdKV[base_c], rdKV[base_c+2], rdKV[base_c+16], rdKV[base_c+18])
+        # The 4 values a thread owns are NOT contiguous in the fragment; this
+        # gather is what makes them contiguous in the workspace row, and it is
+        # the mapping `convert` later inverts.
+        if r[i] >= 0:
+            atomic_add_global(addr(dkv_acc_ws, r[i], sub_tile*128 + (dp_idx//4)*4),
+                              frg)
+            # instruction_selection: atom.global.add.v4.f32 (attributed to
+            #   :254 by inlining, **32 static** = 4 sub-tiles x 8); extent: 4
+            #   f32 lanes per issue.  A VECTOR atomic, not four scalar ones.
+    named_barrier(6, 256)                                      # :2340
+    # instruction_selection: bar.sync 6, 256 (4 static at :2340); extent: the
+    #   8 reduce warps.
+
+def atomic_reduce_64(rdKV, r):                                 # :2369-2397
+    for i in range(8):
+        frg = (rdKV[base_c], rdKV[base_c+2])                   # 2-wide
+        if r[i] >= 0:
+            atomic_add_global(addr(dkv_acc_ws, r[i], 512 + (dp_idx//4)*2), frg)
+            # instruction_selection: atom.global.add.v2.f32 (attributed to
+            #   :254 by inlining, 8 static); extent: 2 f32 lanes.  d576 only.
+    named_barrier(6, 256)                                      # :2397
+    # instruction_selection: bar.sync 6, 256 (:2397, 1 static); extent: the 8
+    #   reduce warps.
+
+# ===========================================================================
+# Kernel 3 of 4: convert  (:609-646)
+#   grid (ceil_div(S_kv, BLOCK_SEQ), 1, 1), block [32, NUM_THREADS_SEQ, 1]
+# ===========================================================================
+
+def convert():
+    seq_id = BLOCK_SEQ * block_id_x() + thread_id_y()          # :623
+    if seq_id >= S_kv:
+        return
+    for i in range(HEAD_DIM_MAIN // 64):                       # :632, unrolled
+        for j in range(2):                                     # :633, unrolled
+            v = load_global(dkv_acc_ws, (seq_id, tidx + j*32 + i*64))
+            # instruction_selection: ld.global.b32 (:634, 16 static); extent:
+            #   SCALAR.  Despite `convert_elem_per_load = 4` (:571) the export
+            #   shows 16 scalar b32 loads, not four v4 loads -- the source
+            #   constant does not reach this access.
+            dim = tidx//4 + (tidx%4)*8 + j*32 + i*64           # :635
+            # The inverse of the 128-wide store's fragment gather.
+            store_global(dkv, (seq_id, dim), cast(v, ELEM))
+            # instruction_selection: cvt.rn.bf16.f32 (**:254**, 16 static -- the
+            #   cast is attributed to the outer entry, not to :636) then
+            #   st.global.b16 (:636, 16 static); extent: scalar.
+    if HAS_TAIL:
+        for j in range(2):                                     # :642
+            v = load_global(dkv_acc_ws, (seq_id, tidx + j*32 + HEAD_DIM_MAIN))
+            # instruction_selection: ld.global.b32 (:643, 2 static); extent:
+            #   scalar.  d576 only.
+            k = tidx//2 + j*16                                 # :644
+            dim = HEAD_DIM_MAIN + (k//8)*16 + k%8 + (tidx%2)*8  # :645
+            # A DIFFERENT inverse: the 64-wide store used a 2-wide fragment,
+            # so its scramble is not the 128-wide one.
+            store_global(dkv, (seq_id, dim), cast(v, ELEM))
+            # instruction_selection: cvt.rn.bf16.f32 (:254) then st.global.b16
+            #   (:646, 2 static); extent: scalar.  d576 only.
+
+# ===========================================================================
+# Kernel 4 of 4: sum_dSink  (:709-738)
+#   grid (ceil_div(S_q, 256), H, 1), block [32, 1, 1]
+# ===========================================================================
+
+def sum_dSink():
+    q_block, head, _ = block_id()
+    q_end = min(S_q, (q_block + 1) * 256)                      # :722
+    q_idx = q_block * 256 + tidx                               # :723
+    sink_log2 = load_global(attn_sink, (head,)) * log2_e       # :726
+    # instruction_selection: ld.global.b32 (:726, 1 static) then mul.f32
+    #   (:726, 1 static); extent: scalar, once per CTA.
+    acc = f32(0.0)
+    while q_idx < q_end:                                       # :729
+        p_sink = exp2(sink_log2 + load_global(scaled_lse_ws, (head, q_idx)))
+        # instruction_selection: ld.global.b32 (:730, 15 static) then add.f32
+        #   (:730, 15 static) feeding
+        # instruction_selection: ex2.approx.f32 (:730, 15 static); extent:
+        #   scalar.  No `.ftz` here either.  `scaled_lse` is already
+        #   `-lse_with_sink` in log2 units, so this one exp2 is the whole
+        #   sink probability.
+        acc += p_sink * load_global(sum_OdO_ws, (head, q_idx))
+        # instruction_selection: ld.global.b32 (:731, 15 static) then
+        #   fma.rn.f32 (:731, 15 static); extent: scalar.
+        q_idx += 32                                            # :732
+    acc = warp_reduce_add(acc, group=32)                       # :734
+    # instruction_selection: shfl.sync.bfly.b32 (:734, 5 static = log2(32));
+    #   extent: 5-step butterfly.
+    if tidx == 0:
+        atomic_add_global(addr(d_sink, head), acc)             # :738
+        # instruction_selection: atom.global.add.f32 (attributed to :254, 1
+        #   static); extent: SCALAR -- one lane, one f32.  Contrast the dKV
+        #   reduction's v4 form.
+```
+
+## Logical GEMM ownership
+
+Every GEMM is issued by warp 16 and lands in TMEM. `M` is always the axis the
+accumulator is indexed by.
+
+| accumulator | formula | A operand (smem) | B operand (smem) | mma tiler | cta tiler | K-phases | source |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `S` | `Q @ K^T` | `sQ`, K-major | `sK`, K-major | `(64,64,D)` | -- | 32, unroll 4 | `:322`, `:1502` |
+| `dP` | `dO @ V^T` | `sdO`, K-major | `sV`, K-major | `(64,64,512)` | -- | 32, unroll 4 | `:327`, `:1518` |
+| `dKV0..3` | `dO^T @ P` then `+= Q^T @ dS` | `sdOT` / `sQT`, MN-major | `sP` / `sdS`, K-major | `(128,64,64)` | `(512,64,64)` | 4, unroll 2 | `:332`, `:336` |
+| `dQ0..3` | `K @ dS^T` | `sK_2`, MN-major | `sdST`, MN-major | `(128,64,64)` | `(512,64,64)` | 4, unroll 2 | `:340`, `:1624` |
+| `dKV4` | `Q^T[512:576] @ dS` | `sQT_tail`, MN-major | `sdS`, K-major | `(64,64,64)` | -- | 4 | `:346`, `:1610` |
+| `dQ4` | `K[512:576] @ dS^T` | `sK_tail`, MN-major | `sdST`, MN-major | `(64,64,64)` | -- | 4 | `:350`, `:1673` |
+
+All six use `tcgen05.mma.cta_group::1.kind::f16` with an instruction descriptor
+in a register; the operand major mode is carried by the SMEM matrix descriptor,
+not by a different opcode. 32 static MMA instructions in the d512 build.
+
+The dV/dK fusion is the `accumulate=True` on the second GEMM into the same
+columns: `dKV[:, 0:512]` receives `dV + dK` and `dKV[:, 512:576]` receives `dK`
+alone, because `V` is only the leading 512 columns of the shared `KV` buffer.
+
+## TMEM column map
+
+512 columns, allocated whole by warp 4. `block_tile = 64` columns per tile.
+
+| tensor | d512 column | d576 column | aliases | source |
+| --- | --- | --- | --- | --- |
+| `S` | 0 | 0 | -- | `:133` |
+| `dP` | 0 **+ lane offset `16 << 16`** | same | shares S's columns at a different lane range | `:134`, `:2675-2677` |
+| `dKV0` | 64 | 64 | -- | `:135` |
+| `dKV1` | 128 | 128 | -- | `:136` |
+| `dKV2` | **448** | 64 | d512: the free dQ4 slot. d576: aliases `dKV0`. | `:2684` / `:2687` |
+| `dKV3` | 128 | 128 | aliases `dKV1` in both | `:2685` / `:2688` |
+| `dQ0..dQ3` | 192, 256, 320, 384 | same | live across every tile | `:139-142` |
+| `dQ4` | -- | 448 | d576 only | `:143` |
+| `dKV4` | -- | 64 | aliases `dKV0` | `:144` |
+
+The two maps are genuinely different, not just a renaming: at d512 `dKV2` gets
+its own column range because `dQ4` does not exist, so only `dKV3` aliases. That
+is why the barrier assignment at `:1544-1546` and `:2260` differs from
+`:1541-1543` and `:2273`.
+
+## Named barriers
+
+| id | threads | participants | purpose | source |
+| --- | --- | --- | --- | --- |
+| 1 | 640 | -- | declared, never used | `:82` |
+| 2 | 416 | compute + reduce + mma | TMEM allocation retrieve | `:86`, `:856` |
+| 3 | 128 | compute warps | intra-role ordering and the dQ store rounds | `:90` |
+| 4 | 32 | -- | declared, never used | `:94` |
+| 5 | 128 | load_KV warps | joint gather visibility before the pipeline commit | `:98`, `:1392` |
+| 6 | 256 | reduce warps | intra-role ordering after each atomic batch | `:102`, `:2340` |
+| 7 | 288 | reduce + mma | WAR: dKV0/dKV1 reads before their columns are rewritten. **Unconditional in both builds** (`:1602` at d576, `:1692` at d512; `:2231`) | `:106` |
+| 8 | 288 | reduce + mma | d512: the generation-A WAR, **skipped once** (`:1546`, `:2260`, tail `:1753`). d576: the dKV4 WAR, unconditional (`:1690`, `:2246`) | `:110` |
+| 9 | 288 | reduce + compute warp 4 | reduce warps drained before TMEM dealloc | `:120` |
+| 10 | 288 | reduce + mma | d576 only: the generation-A WAR, **skipped once** (`:1543`, `:2273`, tail `:1757`). **Entirely unused at d512.** | `:128` |
+
+Barriers 7, 8 and 10 are the WAR set, but they are not symmetric and only **one**
+of them is skipped-once per build:
+
+| build | skipped once, compensated at the tail | unconditional | unused |
+| --- | --- | --- | --- |
+| d512 | **8** | 7 | 10 |
+| d576 | **10** | 7, 8 | -- |
+
+So the loop tail carries exactly one arrive (`bar.sync 8` at d512, `bar.sync 10`
+at d576), not one per WAR barrier. A port that compensates a barrier that was
+never skipped, or fails to compensate the one that was, hangs -- and only for
+some `tile_count`, which is what makes it expensive to find later.
+
+## Storage aliases and lifetimes
+
+Base offsets, element shapes and swizzle are given at the declaration site in the
+complete sketch above; this table carries only the lifetime rules, which are the
+part a reader has to hold in their head while reading the role bodies.
+
+All sixteen layouts share swizzle **S<3,4,3>** (128-byte). The measured element
+shape:stride per alias, from `probe/probe_smem_layouts.py`:
+
+| form | shape:stride (elements) | who uses it |
+| --- | --- | --- |
+| K-major operand, `sQ`/`sK` | `((64,16),1,(4, HEAD_DIM//64),1):((64,1),0,(16,4096),0)` -- `(4,8)` at d512, **`(4,9)`** at d576 (cosize 32768 / 36864) | `sQ`, `sK` |
+| K-major operand, `sdO`/`sV` | `((64,16),1,(4,8),1):((64,1),0,(16,4096),0)` -- always `(4,8)`, since `HEAD_DIM_V` is 512 in both builds | `sdO`, `sV` |
+| MN-major operand | `(((64,2),16),4,4,1):(((1,4096),64),8192,1024,0)` | `sQT`, `sK_2`, `sdOT` |
+| 64-wide B, K-major | `((64,16),1,4,1):((64,1),0,16,0)` | `sP`, `sdS` |
+| 64-wide B, MN-major | `((64,16),1,4,1):((1,64),0,1024,0)` | `sdST` |
+| epilogue COL_MAJOR | `((64,1),(8,8),(1,1)):((1,0),(64,512),(0,0))` | `sP_store`, `sdS_store` |
+| epilogue 128x64, COL_MAJOR | `((64,2),(8,8),(1,1)):((1,4096),(64,512),(0,0))` | `sdQ` |
+| epilogue 64x64, COL_MAJOR | `((64,1),(8,8),(1,1)):((1,0),(64,512),(0,0))` -- the same form as `sP_store`/`sdS_store` | `sdQ4` |
+| 9x64 tail split | `((64,16),9,4,1):((1,64),4096,1024,0)`, block 8 | `sK_tail`, `sQT_tail` |
+
+| alias | over | lifetime constraint |
+| --- | --- | --- |
+| `sQT`, `sQT_tail` | `sQ` | co-live with `sQ`; different operand mapping of the same bytes, never a different value |
+| `sV`, `sK_2`, `sK_tail` | `sK` | co-live with `sK` for the whole KV loop |
+| `sdQ`, `sdQ4` | `sK` | **not** co-live: only legal after the KV loop drains, i.e. after the MMA warp's last `release(pipe_load_mma_K)` at `:1683` and the compute warp's `wait(pipe_mma_cmp_dQ)` at `:2033` |
+| `sdOT` | `sdO` | co-live |
+| `sP_store` | `sP` | the stmatrix destination view of the same bytes the dOP MMA reads as `sP` |
+| `sdST`, `sdS_store` | `sdS` | same, for dS |
+
+## TensorMap ABI
+
+Four descriptors, all rank 3, all built host-side by the source's
+`make_tiled_tma_atom` calls:
+
+| descriptor | direction | tile | built at | issues per copy |
+| --- | --- | --- | --- | --- |
+| `desc_Q` | G2S | `(64, D)` | `:409` | `D // 64` -- 8 at d512, 9 at d576 |
+| `desc_dO` | G2S | `(64, 512)` | `:414` | 8 |
+| `desc_dQ` | S2G | `(128, 64)` | `:419` | 2 |
+| `desc_dQ_64` | S2G | `(64, 64)` | `:431` | 1, d576 only |
+
+The port encodes all four in its own launcher prologue rather than receiving
+them as an ABI argument. `desc_dQ_64` is never prefetched, matching `:815-817`.
+
+## Static specialization boundary
+
+Resolved at trace time, never at runtime: `HEAD_DIM`, `NUM_HEAD`, `ELEM`,
+`MAX_TOPK`, `HAS_TOPK_LENGTH`, `SAME_HDIM` and everything derived from it
+(`HAS_TAIL`, the TMEM map, the barrier assignment, the tail MMAs and views),
+`SUM_ODO_BLOCK_Q`, `BLOCK_SEQ`, `NUM_THREADS_SEQ`, every SMEM byte offset, all
+pipeline stage counts and CooperativeGroup sizes, and the `is_first`/`full_tiles`
+helper instantiations.
+
+Runtime values: `token_idx`, `head_block_idx`, `topk`, `tile_count`,
+`tile_index`, the gathered `topk_idxs`, and every tensor base pointer.
+
+`S_q` and `S_kv` are runtime kernel arguments, so the compile key matches the
+source's 7-tuple and one build serves every sequence length.
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META["name"] = "cudnn_sm100_dsa_sparse_attention_backward"`,
+  category `cudnn`, `compute_capability = 10`.
+- `get_kernel` returns the four device functions **in launch order**; the launch
+  closure preserves that order on one stream.
+- `dkv`, `d_sink` and both workspaces are accumulated into, so the timed closure
+  re-zeroes them every repetition. The upstream wrapper does the same zeroing
+  inside its own timed call (`_interface_sm100.py:105-162`), which is what keeps
+  the two timing scopes comparable.
+- Correctness is checked against a gathered FP32 oracle at `atol = rtol = 5e-2`,
+  the upstream test tolerance. **No bitwise comparison against the source is
+  available**: `dkv` is accumulated by global FP32 atomics whose order varies
+  run to run, upstream included.
+- The reference is loaded from a `CUDNN_FRONTEND_PATH` checkout, not the
+  installed `cudnn` wheel, which carries an older revision of this kernel.
+
+## Instruction-selection summary
+
+Static counts from `d512_bf16_len`, `bwd` entry only, instruction lines minus
+predicated lines.
+
+| count | instruction | what selects it |
+| --- | --- | --- |
+| **256** | `st.shared.b16` | the dQ epilogue's r2s (`:2543`); `autovec_copy` does **not** vectorize it -- the largest single count in the kernel |
+| **256** | `cvt.rn.bf16.f32` | the dQ epilogue's quantize (`:2625`), scalar, one per element |
+| 96 | `cp.async.cg.shared.global` | the KV gather; `.cg` from `LoadCacheMode.GLOBAL`, 128 bits from `num_bits_per_copy=128`. 3 call sites x 16 rows x 2 groups. |
+| 34 | `shfl.sync.idx.b32` | 32 top-k broadcasts (16 per tile x 2 call sites) + 2 `make_warp_uniform` |
+| 34 | `bar.sync` | the ten named barriers, dominated by the dQ store rounds and the reduce batches |
+| 32 | `tcgen05.mma.cta_group::1.kind::f16` | every GEMM (36 at d576); operand major mode rides the matrix descriptor, not the opcode |
+| 32 | `ex2.approx.ftz.f32` | `P = exp2(...)`; `.ftz` from `fastmath=True` |
+| 32 | `cvt.rn.bf16x2.f32` | the P and dS quantize sites only (2 x 16 pairs); the dQ site is the 256 scalar converts above. `f16x2` in the fp16 build |
+| 32 | `tcgen05.ld...32x32b.x8.b32` | the dQ epilogue T2R; a different shape from the dKV path |
+| 32 | `atom.global.add.v4.f32` | the dKV reduction; 4-wide vector, not 4 scalars |
+| 32 | `st.shared.v4.b32` | the KV zero-fill at `:1258` -- the kernel's **only** vectorized shared store |
+| 23 | `mbarrier.try_wait.parity.shared.b64` | every pipeline wait and acquire |
+| 22 | `mbarrier.init.shared.b64` | 9 pipelines x 1 stage + 1 pipeline x 2 stages, full/empty each |
+| 16 | `cp.async.bulk.tensor.3d...mbarrier::complete_tx::bytes` | the Q and dO TMA loads; dO is always 8, Q is `D // 64` (8 at d512, 9 at d576) |
+| 16 | `mul.f32x2` | the dS quantize's `* softmax_scale` (`:2624`) |
+| 11 | `mbarrier.arrive.shared.b64` | the async-side pipeline commits and releases |
+| 16 / 16 / 16 | `fma.rn.f32x2`, `add.rn.f32x2`, `mul.rn.f32x2` | the packed softmax recompute |
+| 9 | `tcgen05.commit...b64` | UMMA pipeline commits |
+| 8 | `stmatrix...m8n8.x4.trans.shared.b16` | the P and dS transposes, 4 each |
+| 8 | `tcgen05.ld...16x256b.x4.b32` | the dKV T2R, 1 per sub-tile per generation |
+| 8 | `cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group` | the dQ TMA stores, 2 per round |
+| 8 | `tcgen05.wait::ld.sync.aligned` | after every T2R group |
+| 8 | `fence.proxy.async.shared::cta` | before every UMMA read of a generic-proxy write |
+| 6 | `setmaxnreg.{dec 40, inc 128}` | one per role branch, not one per warpgroup |
+| 2 | `tcgen05.ld...16x256b.x8.b32` | the S and dP T2R |
+| 2 | `cp.async.ca.shared.global` | LSE and sum_OdO; `.ca` from `LoadCacheMode.ALWAYS` |
+| 1 | `tcgen05.alloc...b32` | warp 4 claims all 512 columns |
+| 1 | `exit` | the `topk <= 0` early out |
+
+`SYNC` and `NANOSLEEP` in a later profile come from `mbarrier.try_wait` spin
+loops and are not standalone targets.

--- a/.agents/skills/tirx-codegen-tuning/references/db/buy-overlap-once-the-instruction-count-already-matches.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/buy-overlap-once-the-instruction-count-already-matches.md
@@ -100,6 +100,17 @@ Deeper pipelines follow the same split. Raising a load pipeline from two stages
 to three cost nothing in occupancy on a register-limited kernel and still helped
 one dtype while regressing another by 0.023.
 
+In a warp-specialized kernel, exclude the warp that issues the collectives from
+this trade. That warp is typically on a small register budget, and three
+independent attempts to buy overlap inside it all lost: fully unrolling its
+matrix chains ran 4x slower, keeping one running descriptor per issue slot cost
+2.4-3.0%, and straight-lining only its eight shortest chains -- two static
+issues becoming four -- cost 6.9-10.7% on the wider of two compiled programs
+while leaving the narrower one flat. The same kernel gained from the opposite
+direction: removing a runtime multiply from each issue was worth 0.4-1.7%.
+Spend the extra instructions in the consumer warps, and measure per compiled
+program, since the cost of code growth there did not transfer between them.
+
 ## Verification
 
 Compare executed instructions against the reference before choosing a

--- a/.agents/skills/tirx-codegen-tuning/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
@@ -1,0 +1,81 @@
+# Elect a warp collective's issue lane in hardware
+
+**Symptoms:** `branch_reconvergence`, `excess_control_instructions`, `warp_retry_region`, `instruction_parity_with_deficit`
+
+## Symptom
+
+A single-issue warp collective -- a matrix MMA, a commit -- already carries its
+guard as `pred=` rather than as a branch around the block, and SASS still shows
+a fresh election and a reconvergence around *every* issue:
+
+```text
+@P   ELECT P1, URZ, PT
+     @!UP UTCHMMA  ...
+@P   PLOP3.LUT P2, PT, P1, ...
+     PLOP3.LUT P1, PT, PT, ...
+@P   BRA.U.ANY
+```
+
+The reference issues the same instruction under a uniform predicate with none of
+that machinery. Static predicate operations run one to two orders of magnitude
+above the reference while the instruction total is at or below it.
+
+## What to change
+
+Take the issue predicate from the hardware election rather than from a lane
+comparison, and let one election own every issue in the role.
+
+```python
+# before: a per-lane comparison materialized as the guard.
+leader = T.alloc_local((1,), "uint32")
+T.assign(leader[0], T.cast(lane == 0, "uint32"))
+for chain in chains:
+    T.evaluate(T.ptx[mma](acc, a_desc, b_desc, idesc, pred=leader[0]))
+
+# after: the hardware election, which lowers to a uniform predicate.
+leader = T.local_scalar("uint32", init=T.cuda.elect_sync())
+for chain in chains:
+    T.evaluate(T.ptx[mma](acc, a_desc, b_desc, idesc, pred=leader))
+```
+
+## Rationale
+
+These instructions are warp collectives: something has to establish a single
+issuing lane. A per-lane comparison does not let ptxas prove that one lane is
+selected, so it rebuilds the election and its reconvergence around each issue.
+The hardware election yields the uniform predicate the instruction already
+wants, and the surrounding machinery disappears.
+
+Measured on a warp-specialized backward attention kernel whose issuing warp runs
+ten chains and ten commits per tile: static `PLOP3` fell from 213 to 48 against
+the reference's 3, `ELECT` from 58 to 18 against 13, `VOTEU` from 52 to 1, and
+total static SASS from 3679 to 3359. Four benchmark shapes moved by -9.5%,
+-10.2%, -10.5% and -11.4%, taking the required matrix from 0 of 16 shapes
+passing to 10 of 16 in one change.
+
+The predicate *form* is the lever, not the absence of a branch. Moving the same
+guards off branches and onto `pred=` first -- the standard predication rewrite,
+with a lane comparison as the predicate -- was worth only 1-4% on the same
+shapes. The remaining ten percent was entirely in what the predicate was.
+
+## Boundary
+
+This pays where the guarded instruction is a warp collective and the guard sits
+on *every* issue. Making the same substitution for a transfer group already
+behind a single guard measured neutral, -0.5% to +0.3%: there was one region's
+machinery to remove, not one per instruction.
+
+`elect_sync` is itself a warp collective, so materialize it where the warp is
+converged. Binding it inside a guard leaves the excluded lanes never reaching
+it.
+
+An election establishes *a* lane, not lane 0. Do not swap it in where the
+guarded code also depends on being the lowest lane for addressing or ordering.
+
+## Verification
+
+Count static `ELECT`, `PLOP3` and `VOTEU` against the reference and confirm the
+collective is issued under a uniform predicate (`@!UP`) rather than inside an
+elect-and-branch region, then re-measure. Counters alone do not show this --
+paired stall breakdowns attributed the same gap to `long_scoreboard` and
+`barrier`, and only the disassembly named the cause.

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -167,6 +167,14 @@ held. Source-size predication changes issue and dependency behavior, not just
 branch syntax, so preserve protocol-on and protocol-off shapes as separate
 performance guards.
 
+Predication pays where a branch DIVERGES, not wherever a branch exists. In a
+gather whose validity flag is row-uniform -- every lane of the warp takes the
+same arm -- replacing the if/else with a predicated copy and a predicated
+zero-fill measured neutral at +0.4%, +0.0%, -0.1%, -0.4%, because those branches
+never diverged in the first place. Check that the guard actually varies across
+the warp before rewriting it; divergent-branch counters separate the two cases
+where branch counts do not.
+
 ## Verification
 
 Confirm predicate polarity and inactive-lane memory behavior, then compare BRA,

--- a/.agents/skills/tirx-codegen-tuning/references/db/materialize-uniformity.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/materialize-uniformity.md
@@ -74,6 +74,13 @@ machine code at the site: one that holds an index in a uniform register may
 still move it into a per-thread register to scale it, in which case its
 advantage there is precomputation, not the datapath.
 
+The proof costs a `__shfl_sync`, and it is only repaid when there is
+vector-datapath work for it to move. Applying it to a shared-memory base and a
+tensor-memory base whose derived addresses were already reloaded into registers
+per warp role measured neutral to slightly negative: +0.7%, +1.0%, +0.0%, +0.4%.
+Confirm from the generated code that uniform-datapath instructions actually
+replace vector ones before keeping the hint.
+
 ## Verification
 
 Confirm vector versus uniform op counts, branch topology, registers, and the

--- a/.agents/skills/tirx-codegen-tuning/references/db/scale-a-staged-load-unroll-to-the-trip-count.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/scale-a-staged-load-unroll-to-the-trip-count.md
@@ -51,6 +51,20 @@ factor against its per-thread trip count and found the crossover at 8, not 28:
 `unroll = 8 if trips >= 8 else min(4, trips)` took that kernel's whole matrix
 from three failing shapes to zero.
 
+A rolled loop in the reference's source text is not a statement that the loop
+should be rolled. One port transcribed a preprocess loop in the reference's own
+rolled form for faithfulness, leaving a single body and one load in flight; the
+reference's compiler had unrolled the same loop. The kernel is purely
+bandwidth-bound, and the rolled form ran at 50.1% of memory throughput against
+the reference's 74.9%, 141.3 us against 94.8. Restoring the unroll took it to
+83.8% and 84.5 us -- faster than the reference. Read the factor off the
+reference's generated code, not its source.
+
+The cost lands unevenly when the loop's grid scales with a problem dimension. That
+preprocess kernel launches one block per head, so the 64-head program paid the
+deficit twice over relative to the 32-head one, and the shortfall showed up as a
+one-program failure pattern that looked like a main-kernel problem.
+
 ## Boundary
 
 Do not assume monotonicity: unroll 6 and 8 regressed back to 5.75 and 6.26

--- a/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
@@ -59,6 +59,23 @@ fragment/output family, cluster regime, and resource limit that produced the
 measured response. Let unrelated paths use native allocation when a shared
 budget changes their entry allocation or trips an allocator limit.
 
+Two constraints bind before any sweep, and only the first is usually checked.
+The budget is warpgroup-uniform, so roles sharing a warpgroup cannot move
+independently. The budget must also balance globally: increases are funded only
+by what the decreasing roles release. Against a 96-register default, one kernel's
+decreasing roles released 14,336 registers for increasing roles that required
+12,288; raising one producer role's budget dropped the released pool to 11,264,
+and the increasing roles then blocked forever inside `setmaxnreg.inc`. It
+compiled cleanly and hung at runtime -- a shape that normally finished in 0.034 s
+did not complete in 240 s. Compute the release-versus-require arithmetic for the
+whole kernel, not for the role being changed.
+
+Check whether registers bind at all before sweeping. Zero local and zero shared
+spilling on both sides means no role is starved and a larger cap buys nothing.
+Where the sweep did pay, it was narrow: a collective-issuing warpgroup improved
+by 0.1-1.0% at 56 registers, and funding a further rise to 72 out of the reduce
+role regressed the shapes that role dominates.
+
 ## Verification
 
 Record realized allocation and dynamic local traffic, not only the requested

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ list.
 - **Distributed:**
   [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py),
   [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py)
-  — multi-GPU via NVSHMEM
 
 ### cuDNN Frontend ports
 
@@ -29,16 +28,10 @@ list.
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
 - **Grouped GEMM:**
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
-  — MoE grouped GEMM with a dGLU backward epilogue;
-  [schedule sketch](.agents/sketch/cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias.md)
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
-  — BF16 Kimi Delta Attention backward;
-  [schedule sketch](.agents/sketch/cudnn/sm100_kda_bprop_f16.md)
 - **Sparse attention:**
   [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
-  — DeepSeek sparse attention backward, four device kernels over a per-token
-  top-k index list; head dimensions 512 and 576
 
 ### FlashAttention ports
 
@@ -46,7 +39,6 @@ list.
   [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
 - **Backward:**
   [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
-  — head dimension 128; [schedule sketch](tirx_kernels/flashattention/flash_attention_backward_sm100_sketch.md)
 
 ### FlashInfer ports
 
@@ -137,7 +129,6 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **Elastic communication:**
   [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py),
   [`deepep_combine`](tirx_kernels/deepep/combine.py)
-  — multi-GPU, 8 ranks over NVLink
 
 ### MSA ports
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ list.
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
   — BF16 Kimi Delta Attention backward;
   [schedule sketch](.agents/sketch/cudnn/sm100_kda_bprop_f16.md)
+- **Sparse attention:**
+  [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+  — DeepSeek sparse attention backward, four device kernels over a per-token
+  top-k index list; head dimensions 512 and 576
 
 ### FlashAttention ports
 

--- a/tirx_kernels/bench_suite/config/cudnn/dsa/cudnn_sm100_dsa_sparse_attention_backward.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/dsa/cudnn_sm100_dsa_sparse_attention_backward.yaml
@@ -1,0 +1,23 @@
+# The upstream benchmark sweep (benchmark/dsa/benchmark_dsa_sparse_attention_backward.py:
+# seqlens x topks, seqlen_kv == seqlen_q, bf16, sink on, full-length topk_length)
+# mirrored onto both compiled head-dim programs. This 16-row matrix is the
+# performance gate's required set.
+kernel: cudnn_sm100_dsa_sparse_attention_backward
+selection_rationale: d512/h64 and d576/h32 are separately compiled programs with different TMEM alias maps, tail MMAs and barrier assignments, so the defaults pair the source benchmark's lightest and heaviest d512 shapes with a mid-sweep d576 shape; the full 16-row matrix is that sweep on both programs and is what the port gate requires.
+configs:
+  - {config: d512_h64_bf16_sq4096_t128_len, default: true, selection_role: small}
+  - {config: d512_h64_bf16_sq4096_t512_len, default: false}
+  - {config: d512_h64_bf16_sq4096_t1024_len, default: false}
+  - {config: d512_h64_bf16_sq4096_t2048_len, default: false}
+  - {config: d512_h64_bf16_sq8192_t128_len, default: false}
+  - {config: d512_h64_bf16_sq8192_t512_len, default: false}
+  - {config: d512_h64_bf16_sq8192_t1024_len, default: false}
+  - {config: d512_h64_bf16_sq8192_t2048_len, default: true, selection_role: large}
+  - {config: d576_h32_bf16_sq4096_t128_len, default: false}
+  - {config: d576_h32_bf16_sq4096_t512_len, default: false}
+  - {config: d576_h32_bf16_sq4096_t1024_len, default: false}
+  - {config: d576_h32_bf16_sq4096_t2048_len, default: false}
+  - {config: d576_h32_bf16_sq8192_t128_len, default: false}
+  - {config: d576_h32_bf16_sq8192_t512_len, default: true, selection_role: medium}
+  - {config: d576_h32_bf16_sq8192_t1024_len, default: false}
+  - {config: d576_h32_bf16_sq8192_t2048_len, default: false}

--- a/tirx_kernels/cudnn/dsa/__init__.py
+++ b/tirx_kernels/cudnn/dsa/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/__init__.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
@@ -207,6 +207,89 @@ def reference_backward(
     return dq, dkv, d_sink
 
 
+# --- TMA descriptors -------------------------------------------------------
+# The four rank-3 TensorMaps the `bwd` kernel consumes. Encoded host-side into
+# 64-byte-aligned 128-byte payloads, the same mechanism the FlashAttention
+# backward port uses.
+#
+# Every one has a 64x64 box: `Q`/`dO` are loaded as `head_dim // 64` issues of
+# 64 dims x 64 heads, and the `dQ` stores go out two boxes per 128-wide round.
+# The swizzle is 128B (mode 3) throughout, matching the S<3,4,3> every SMEM
+# layout in this kernel carries.
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_256B = 2
+
+
+class _AlignedTensorMap:
+    """Host storage for one 64-byte-aligned, 128-byte TensorMap payload."""
+
+    def __init__(self):
+        import ctypes
+
+        self._storage = ctypes.create_string_buffer(128 + 64)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tensormap(tensor, dtype, global_dims, global_strides, box_dims):
+    """One ``cuTensorMapEncodeTiled``; element strides are all 1 here."""
+    import ctypes
+
+    import tvm
+
+    rank = len(global_dims)
+    descriptor = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        descriptor.ptr,
+        dtype,
+        rank,
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *global_dims,
+        *global_strides,
+        *box_dims,
+        *((1,) * rank),  # elementStrides
+        0,  # CU_TENSOR_MAP_INTERLEAVE_NONE
+        _TMA_SWIZZLE_128B,
+        _TMA_L2_256B,
+        0,  # CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    )
+    return descriptor
+
+
+def build_tensor_maps(q, dout, dq, *, head_dim, head_dim_v, num_head, seqlen_q, dtype_name):
+    """`desc_Q`, `desc_dO`, `desc_dQ` and, at d576, `desc_dQ_64`.
+
+    TMA dimensions are innermost-first, so a row-major `(S_q, H, D)` tensor is
+    described as `(D, H, S_q)`; the byte strides exclude the innermost, which is
+    implicitly the element size.
+    """
+    esize = 2
+    maps = {
+        "q": _encode_tensormap(
+            q,
+            dtype_name,
+            (head_dim, num_head, seqlen_q),
+            (head_dim * esize, num_head * head_dim * esize),
+            (64, 64, 1),
+        ),
+        "do": _encode_tensormap(
+            dout,
+            dtype_name,
+            (head_dim_v, num_head, seqlen_q),
+            (head_dim_v * esize, num_head * head_dim_v * esize),
+            (64, 64, 1),
+        ),
+        "dq": _encode_tensormap(
+            dq,
+            dtype_name,
+            (head_dim, num_head, seqlen_q),
+            (head_dim * esize, num_head * head_dim * esize),
+            (64, 64, 1),
+        ),
+    }
+    return maps
+
+
 def prepare_data(**config):
     """Allocate one input set shared by TIRx, the upstream kernel, and the oracle."""
     if not torch.cuda.is_available():
@@ -340,7 +423,79 @@ def tirx_launch(executables, data):
     (``_interface_sm100.py:105-162``), which is what keeps the two timing scopes
     comparable.
     """
-    raise NotImplementedError("the TIRx launch closure is written with the kernels")
+    import math
+
+    inputs = data["inputs"]
+    out = data["tirx"]
+    der = data["derived"]
+    seqlen_q = der["seqlen_q"]
+    seqlen_kv = der["seqlen_kv"]
+    head_dim_v = der["head_dim_v"]
+    num_head = inputs["q"].shape[1]
+    head_dim = inputs["q"].shape[2]
+    # The workspace planes are head-contiguous and padded to a multiple of 8
+    # rows, matching the upstream `roundup8` (:105-162).
+    plane = num_head * ((seqlen_q + 7) // 8 * 8)
+
+    sum_odo, bwd, convert, sum_dsink = executables
+    ws_lse_odo = out["ws_lse_odo"].view(-1).view(torch.float32)
+    ws_dkv = out["ws_dkv"].view(-1).view(torch.float32)
+    maps = build_tensor_maps(
+        inputs["q"],
+        inputs["dout"],
+        out["dq"],
+        head_dim=head_dim,
+        head_dim_v=head_dim_v,
+        num_head=num_head,
+        seqlen_q=seqlen_q,
+        dtype_name=str(inputs["q"].dtype).rsplit(".", 1)[-1],
+    )
+    neg_log2_e = -math.log2(math.e)
+    scale = inputs["softmax_scale"]
+    topk_idxs = inputs["topk_idxs"].reshape(-1)
+    # The non-compact variant has no topk_length tensor; pass the idx buffer as
+    # a placeholder so the ABI stays fixed -- the kernel never reads it.
+    topk_length = (
+        inputs["topk_length"].reshape(-1) if inputs["topk_length"] is not None else topk_idxs
+    )
+
+    def launch():
+        out["dkv"].zero_()
+        out["d_sink"].zero_()
+        ws_lse_odo.zero_()
+        ws_dkv.zero_()
+        sum_odo(
+            inputs["out"].reshape(-1),
+            inputs["dout"].reshape(-1),
+            inputs["lse"].reshape(-1),
+            inputs["attn_sink"].reshape(-1),
+            ws_lse_odo,
+            seqlen_q,
+            plane,
+            -1.0,
+            neg_log2_e,
+        )
+        bwd(
+            maps["q"].ptr,
+            maps["do"].ptr,
+            maps["dq"].ptr,
+            inputs["kv"].reshape(-1),
+            out["dq"].reshape(-1),
+            ws_dkv,
+            topk_idxs,
+            topk_length,
+            ws_lse_odo,
+            seqlen_q,
+            seqlen_kv,
+            plane,
+            scale,
+        )
+        convert(ws_dkv, out["dkv"].reshape(-1), seqlen_kv)
+        sum_dsink(
+            ws_lse_odo, inputs["attn_sink"].reshape(-1), out["d_sink"].reshape(-1), seqlen_q, plane
+        )
+
+    return launch
 
 
 def validate_outputs(data, sources=("tirx",), with_oracle=True, atol=5e-2, rtol=5e-2):

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
@@ -1,0 +1,375 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Inputs, launch wiring and validation for the DSA sparse attention backward pass.
+
+Upstream sources:
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py``
+(tensor contract, output and workspace allocation, zero-initialization), and
+``test/python/fe_api/dsa/dsa_reference.py`` (the FP32 reference this oracle
+follows).
+
+The oracle here differs from the upstream reference in one way that matters for
+the benchmark shapes: upstream materializes a dense ``(tokens, heads, S_kv)``
+score tensor and differentiates it with autograd, while this one gathers only the
+top-k rows each query actually attends to and applies the analytic backward. Both
+compute the same quantity; the gathered form is what makes the larger
+configurations affordable.
+"""
+
+import math
+
+import torch
+
+from . import spec
+
+_TORCH_DTYPES = {"bfloat16": torch.bfloat16, "float16": torch.float16}
+
+
+# ``dsa_bwd_sm100.py:177``/``:189``: both workspaces round their sequence and
+# head-dim extents up to a multiple of 8.
+def _roundup8(value):
+    return (value + 7) // 8 * 8
+
+
+def torch_dtype(name):
+    return _TORCH_DTYPES[name]
+
+
+def _make_topk(generator, *, seqlen_q, seqlen_kv, max_topk, mode, device):
+    """Build ``topk_idxs`` and ``topk_length`` for one config.
+
+    ``topk_idxs`` holds global KV row indices, distinct within a query. ``mode``
+    selects which of the kernel's index paths the config exercises.
+    """
+    # The same construction the upstream benchmark uses
+    # (``benchmark_dsa_sparse_attention_backward.py:59``): one vectorized argsort
+    # rather than a per-row ``randperm``, which keeps the indices distinct within
+    # a query and scattered across the KV axis at the benchmark shapes.
+    idxs = (
+        torch.rand(seqlen_q, seqlen_kv, generator=generator, device=device)
+        .argsort(dim=-1)[:, :max_topk]
+        .to(torch.int32)
+    )
+
+    if mode == "invalid_idx":
+        # The non-compact variant marks unused rows with -1 instead of carrying a
+        # length. Keep a per-query prefix valid so the tail is ragged.
+        keep = torch.randint(1, max_topk + 1, (seqlen_q,), generator=generator, device=device)
+        positions = torch.arange(max_topk, device=device).unsqueeze(0)
+        idxs = torch.where(positions < keep.unsqueeze(1), idxs, torch.full_like(idxs, -1))
+        return idxs, None
+
+    if mode == "full":
+        lengths = torch.full((seqlen_q,), max_topk, dtype=torch.int32, device=device)
+    elif mode == "random":
+        lengths = torch.randint(
+            1, max_topk + 1, (seqlen_q,), generator=generator, device=device
+        ).to(torch.int32)
+    elif mode == "mixed_zero":
+        lengths = torch.randint(
+            1, max_topk + 1, (seqlen_q,), generator=generator, device=device
+        ).to(torch.int32)
+        # Interleave empty and negative rows with live ones: a CTA that exits
+        # early must not strand the CTAs that still have work.
+        lengths[0::4] = 0
+        lengths[1::8] = -3
+    elif mode == "all_empty":
+        lengths = torch.zeros(seqlen_q, dtype=torch.int32, device=device)
+    else:
+        raise ValueError(f"unknown topk mode: {mode}")
+    return idxs, lengths
+
+
+def _make_sink(generator, *, num_head, mode, max_topk, device):
+    if mode == "normal":
+        return torch.randn(num_head, generator=generator, dtype=torch.float32, device=device)
+    if mode == "log_topk":
+        # The upstream d576 regression: a sink of this magnitude is comparable to
+        # the KV mass, so leaving it out of the normalization is visible.
+        return torch.full((num_head,), math.log(max_topk), dtype=torch.float32, device=device)
+    if mode == "disabled":
+        return torch.full((num_head,), float("-inf"), dtype=torch.float32, device=device)
+    raise ValueError(f"unknown sink mode: {mode}")
+
+
+def _gather_valid(kv_f32, idxs_row, lengths_row, max_topk):
+    """Gather the KV rows one chunk of queries attends to, plus a validity mask.
+
+    Returns ``(gathered, valid)`` where ``gathered`` is ``(chunk, max_topk, D)``
+    and ``valid`` is ``(chunk, max_topk)``.
+    """
+    seqlen_kv = kv_f32.shape[0]
+    valid = (idxs_row >= 0) & (idxs_row < seqlen_kv)
+    if lengths_row is not None:
+        positions = torch.arange(max_topk, device=idxs_row.device).unsqueeze(0)
+        valid = valid & (positions < lengths_row.unsqueeze(1))
+    safe = torch.where(valid, idxs_row, torch.zeros_like(idxs_row)).to(torch.long)
+    gathered = kv_f32[safe]
+    return gathered, valid
+
+
+def reference_forward(q, kv, attn_sink, topk_idxs, topk_length, softmax_scale, chunk=64):
+    """FP32 forward over the gathered top-k rows.
+
+    Returns ``(out, lse)`` with ``lse`` the KV-only log-sum-exp, sink excluded --
+    the same convention the kernel consumes.
+    """
+    seqlen_q, num_head, head_dim = q.shape
+    head_dim_v = spec.head_dim_v_for(head_dim)
+    max_topk = topk_idxs.shape[1]
+    kv_f32 = kv.to(torch.float32)
+
+    out = torch.empty(seqlen_q, num_head, head_dim_v, dtype=torch.float32, device=q.device)
+    lse = torch.empty(seqlen_q, num_head, dtype=torch.float32, device=q.device)
+
+    for start in range(0, seqlen_q, chunk):
+        stop = min(start + chunk, seqlen_q)
+        q_c = q[start:stop].to(torch.float32)
+        idxs_c = topk_idxs[start:stop]
+        len_c = None if topk_length is None else topk_length[start:stop]
+        gathered, valid = _gather_valid(kv_f32, idxs_c, len_c, max_topk)
+
+        scores = torch.einsum("thd,tkd->thk", q_c, gathered) * softmax_scale
+        scores = scores.masked_fill(~valid.unsqueeze(1), float("-inf"))
+
+        lse_c = torch.logsumexp(scores, dim=-1)
+        lse_full = torch.logaddexp(lse_c, attn_sink.view(1, num_head))
+        weights = torch.exp(scores - lse_full.unsqueeze(-1))
+        out[start:stop] = torch.einsum("thk,tkd->thd", weights, gathered[:, :, :head_dim_v])
+        lse[start:stop] = lse_c
+
+    return out, lse
+
+
+def reference_backward(
+    q, kv, attn_sink, topk_idxs, topk_length, dout, softmax_scale, out=None, chunk=64
+):
+    """Analytic FP32 backward over the gathered top-k rows.
+
+    With the sink modelled as an extra key carrying a zero value vector, the
+    softmax backward is ``dS_k = P_k * (dP_k - delta)`` with
+    ``delta = sum_d out*dout``, and the sink's own gradient is ``-P_sink * delta``.
+    """
+    seqlen_q, num_head, head_dim = q.shape
+    head_dim_v = spec.head_dim_v_for(head_dim)
+    seqlen_kv = kv.shape[0]
+    max_topk = topk_idxs.shape[1]
+    kv_f32 = kv.to(torch.float32)
+
+    dq = torch.zeros(seqlen_q, num_head, head_dim, dtype=torch.float32, device=q.device)
+    dkv = torch.zeros(seqlen_kv, head_dim, dtype=torch.float32, device=q.device)
+    d_sink = torch.zeros(num_head, dtype=torch.float32, device=q.device)
+
+    for start in range(0, seqlen_q, chunk):
+        stop = min(start + chunk, seqlen_q)
+        q_c = q[start:stop].to(torch.float32)
+        do_c = dout[start:stop].to(torch.float32)
+        idxs_c = topk_idxs[start:stop]
+        len_c = None if topk_length is None else topk_length[start:stop]
+        gathered, valid = _gather_valid(kv_f32, idxs_c, len_c, max_topk)
+
+        scores = torch.einsum("thd,tkd->thk", q_c, gathered) * softmax_scale
+        scores = scores.masked_fill(~valid.unsqueeze(1), float("-inf"))
+        lse_c = torch.logsumexp(scores, dim=-1)
+        lse_full = torch.logaddexp(lse_c, attn_sink.view(1, num_head))
+        p = torch.exp(scores - lse_full.unsqueeze(-1))
+
+        v = gathered[:, :, :head_dim_v]
+        out_c = (
+            torch.einsum("thk,tkd->thd", p, v) if out is None else out[start:stop].to(torch.float32)
+        )
+        delta = (out_c * do_c).sum(dim=-1)  # (chunk, H)
+
+        dp = torch.einsum("thd,tkd->thk", do_c, v)
+        ds = p * (dp - delta.unsqueeze(-1))
+        ds = torch.where(valid.unsqueeze(1), ds, torch.zeros_like(ds))
+
+        dq[start:stop] = torch.einsum("thk,tkd->thd", ds, gathered) * softmax_scale
+
+        # dK over the full head_dim, dV over the leading head_dim_v; both land in
+        # the same fused dKV buffer because K and V share one tensor.
+        dk_c = torch.einsum("thk,thd->tkd", ds, q_c) * softmax_scale
+        dv_c = torch.einsum("thk,thd->tkd", p, do_c)
+        contrib = dk_c
+        contrib[:, :, :head_dim_v] += dv_c
+        contrib = torch.where(valid.unsqueeze(-1), contrib, torch.zeros_like(contrib))
+
+        flat_idx = torch.where(valid, idxs_c, torch.zeros_like(idxs_c)).to(torch.long).reshape(-1)
+        flat_contrib = contrib.reshape(-1, head_dim)
+        dkv.index_add_(0, flat_idx, flat_contrib)
+
+        p_sink = torch.exp(attn_sink.view(1, num_head) - lse_full)
+        d_sink += (-p_sink * delta).sum(dim=0)
+
+    return dq, dkv, d_sink
+
+
+def prepare_data(**config):
+    """Allocate one input set shared by TIRx, the upstream kernel, and the oracle."""
+    if not torch.cuda.is_available():
+        import unittest
+
+        raise unittest.SkipTest("CUDA is required")
+
+    spec.check_dispatch(config)
+    device = "cuda"
+    dtype = torch_dtype(config["dtype"])
+    head_dim = config["head_dim"]
+    head_dim_v = spec.head_dim_v_for(head_dim)
+    num_head = config["num_head"]
+    seqlen_q = config["seqlen_q"]
+    seqlen_kv = config["seqlen_kv"]
+    max_topk = config["max_topk"]
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(config["seed"])
+
+    def randn(*shape, dt=torch.float32):
+        return torch.randn(*shape, generator=generator, dtype=dt, device=device)
+
+    q = randn(seqlen_q, num_head, head_dim).to(dtype)
+    kv = randn(seqlen_kv, head_dim).to(dtype)
+    dout = randn(seqlen_q, num_head, head_dim_v).to(dtype)
+    attn_sink = _make_sink(
+        generator, num_head=num_head, mode=config["sink_mode"], max_topk=max_topk, device=device
+    )
+    topk_idxs, topk_length = _make_topk(
+        generator,
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        max_topk=max_topk,
+        mode=config["topk_mode"],
+        device=device,
+    )
+    if config["has_topk_length"]:
+        if topk_length is None:
+            raise ValueError("config declares has_topk_length but the topk mode produced none")
+    else:
+        # The non-compact variant is a distinct compiled program: it takes no
+        # length tensor and reads validity from the -1 markers alone. Passing a
+        # length here would silently select the compact program instead.
+        topk_length = None
+
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    # ``out`` and ``lse`` stand in for the FlashMLA forward the kernel consumes.
+    out_f32, lse = reference_forward(q, kv, attn_sink, topk_idxs, topk_length, softmax_scale)
+    out = out_f32.to(dtype)
+
+    # ``_interface_sm100.py:115-135``: dq is fully overwritten, dkv and d_sink are
+    # atomic accumulators and must be zero on entry.
+    def outputs():
+        return {
+            "dq": torch.empty(seqlen_q, num_head, head_dim, dtype=dtype, device=device),
+            "dkv": torch.zeros(seqlen_kv, head_dim, dtype=dtype, device=device),
+            "d_sink": torch.zeros(num_head, dtype=torch.float32, device=device),
+        }
+
+    # ``_get_workspace_size_LSE_OdO`` / ``_get_workspace_size_dKV``.
+    ws_lse_odo = torch.zeros(1, num_head, _roundup8(seqlen_q), 8, dtype=torch.uint8, device=device)
+    ws_dkv = torch.zeros(
+        1, 1, _roundup8(seqlen_kv), _roundup8(head_dim) * 4, dtype=torch.uint8, device=device
+    )
+
+    return {
+        "config": dict(config),
+        "inputs": {
+            "q": q,
+            "kv": kv,
+            "out": out,
+            "dout": dout,
+            "lse": lse,
+            "attn_sink": attn_sink,
+            "topk_idxs": topk_idxs,
+            "topk_length": topk_length,
+            "softmax_scale": softmax_scale,
+        },
+        "tirx": {**outputs(), "ws_lse_odo": ws_lse_odo, "ws_dkv": ws_dkv},
+        "source": outputs(),
+        "derived": {
+            "head_dim_v": head_dim_v,
+            "seqlen_q": seqlen_q,
+            "seqlen_kv": seqlen_kv,
+            "max_topk": max_topk,
+        },
+    }
+
+
+def compile_reference(data):
+    """Return a no-argument closure that runs the upstream kernel on ``data``.
+
+    ``dq`` and ``dkv`` are out-parameters the wrapper fills in place, but
+    ``d_sink`` is always freshly allocated and returned
+    (``_interface_sm100.py:135``), so the closure copies the returned gradient
+    back into the result set rather than dropping it.
+    """
+    from . import reference
+
+    fn = reference.flash_attn_bwd_sm100()
+    inputs = data["inputs"]
+    outputs = data["source"]
+
+    def launch():
+        _, _, d_sink = fn(
+            inputs["q"],
+            inputs["kv"],
+            inputs["out"],
+            inputs["dout"],
+            inputs["lse"],
+            inputs["attn_sink"],
+            inputs["topk_idxs"],
+            softmax_scale=inputs["softmax_scale"],
+            topk_length=inputs["topk_length"],
+            dq=outputs["dq"],
+            dkv=outputs["dkv"],
+        )
+        outputs["d_sink"].copy_(d_sink)
+
+    return launch
+
+
+def tirx_launch(executables, data):
+    """Return a no-argument closure that runs the four TIRx kernels on ``data``.
+
+    The zeroing is part of the closure, not of setup: ``dkv``, ``d_sink`` and both
+    workspaces are accumulated into, so every repetition needs them clean. The
+    upstream wrapper does the same zeroing inside its own timed call
+    (``_interface_sm100.py:105-162``), which is what keeps the two timing scopes
+    comparable.
+    """
+    raise NotImplementedError("the TIRx launch closure is written with the kernels")
+
+
+def validate_outputs(data, sources=("tirx",), with_oracle=True, atol=5e-2, rtol=5e-2):
+    """Compare the selected result sets against the FP32 oracle.
+
+    ``dkv`` is accumulated with global FP32 atomics, so its summation order varies
+    run to run on the kernel side and no bitwise comparison is available; the
+    oracle at the upstream tolerance is the arbiter.
+    """
+    inputs = data["inputs"]
+    if not with_oracle:
+        return
+
+    dq_ref, dkv_ref, d_sink_ref = reference_backward(
+        inputs["q"],
+        inputs["kv"],
+        inputs["attn_sink"],
+        inputs["topk_idxs"],
+        inputs["topk_length"],
+        inputs["dout"],
+        inputs["softmax_scale"],
+        out=inputs["out"],
+    )
+    for source in sources:
+        got = data[source]
+        for name, expected in (("dq", dq_ref), ("dkv", dkv_ref), ("d_sink", d_sink_ref)):
+            actual = got[name].to(torch.float32)
+            if not torch.isfinite(actual).all():
+                raise AssertionError(f"{source}.{name} contains non-finite values")
+            torch.testing.assert_close(
+                actual, expected, atol=atol, rtol=rtol, msg=lambda m: f"{source}.{name}: {m}"
+            )

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -38,6 +38,7 @@ MMA_WARP = 16
 LOAD_WARP = 17
 EMPTY_WARP = 18
 BWD_WARPS = 20
+BWD_THREADS = BWD_WARPS * 32
 
 # ``dsa_bwd_sm100.py:149-154``: declared per-role register budgets.
 REGS_LOAD_KV = 40
@@ -66,7 +67,12 @@ TMEM_S_OFFSET = 0
 TMEM_DP_OFFSET = 0
 TMEM_DKV0_OFFSET = 64
 TMEM_DKV1_OFFSET = 128
-TMEM_DKV2_OFFSET = TMEM_DKV0_OFFSET
+# dKV2 is the one entry whose column genuinely differs between the two builds
+# (`:2684` vs `:2687`): at d512 it takes the slot dQ4 would have used, so only
+# dKV3 aliases; at d576 that slot is dQ4's and dKV2 falls back onto dKV0. This
+# is also why the WAR barrier assignment differs between the builds.
+TMEM_DKV2_D512_OFFSET = 448
+TMEM_DKV2_D576_OFFSET = TMEM_DKV0_OFFSET
 TMEM_DKV3_OFFSET = TMEM_DKV1_OFFSET
 TMEM_DQ0_OFFSET = 192
 TMEM_DQ1_OFFSET = 256
@@ -77,8 +83,443 @@ TMEM_DKV4_OFFSET = TMEM_DKV0_OFFSET
 TMEM_ALLOC_COLUMNS = spec.TMEM_CAPACITY_COLUMNS
 
 
+# Element dtype and the narrow-operand spellings that follow from it. The
+# element dtype selects the descriptor and these mnemonics and nothing else.
+_ELEM = {"bfloat16": K.bf16, "float16": K.f16}
+_MUL_HALF = {"bfloat16": "mul.bf16x2", "float16": "mul.f16x2"}
+_ADD_WIDE = {"bfloat16": "add.rn.f32.bf16", "float16": "add.rn.f32.f16"}
+_CVT_WIDE = {"bfloat16": "cvt.f32.bf16", "float16": "cvt.f32.f16"}
+_CVT_NARROW = {"bfloat16": "cvt.rn.bf16.f32", "float16": "cvt.rn.f16.f32"}
+_CVT_PACK = {"bfloat16": "cvt.rn.bf16x2.f32", "float16": "cvt.rn.f16x2.f32"}
+
+
+# ---------------------------------------------------------------------------
+# Shared memory is one flat byte pool. Every logical coordinate, swizzle and
+# alias below is explicit scalar arithmetic on a byte offset into it.
+# ---------------------------------------------------------------------------
+
+
+# 2 / (k * ln 2) for k = 1, 3, .., 11 -- the odd-power series for log2.
+_LOG2_SERIES = (
+    2.8853900817779268,
+    0.9617966939259757,
+    0.5770780163555853,
+    0.41219858311113244,
+    0.3205988979753252,
+    0.2623081892525388,
+)
+
+
+def _log2_soft(x):
+    """`log2(x)` for x in [1, 2] as a polynomial, not `lg2.approx`.
+
+    The source calls `cute.math.log2` WITHOUT fastmath (`:700`), which lowers to
+    a software polynomial; `lg2` appears nowhere in any export, so the hardware
+    approximation would not be the same kernel. The argument here is
+    `exp2(a - max) + exp2(b - max)`, so one term is exactly 1 and the other at
+    most 1: the range is [1, 2], `r = (x - 1) / (x + 1)` is bounded by 1/3, and
+    six odd terms land within 1.6e-7 of the true value across the range.
+    """
+    one = K.local_scalar(K.f32, init=K.float32(1.0))
+    num = K.local_scalar(K.f32)
+    den = K.local_scalar(K.f32)
+    K.ptx["sub.f32"](num, x, one)
+    K.ptx["add.f32"](den, x, one)
+    r = K.local_scalar(K.f32)
+    K.ptx["div.rn.f32"](r, num, den)
+    r2 = K.local_scalar(K.f32)
+    K.ptx["mul.f32"](r2, r, r)
+    acc = K.local_scalar(K.f32, init=K.float32(_LOG2_SERIES[-1]))
+    for c in reversed(_LOG2_SERIES[:-1]):
+        cv = K.local_scalar(K.f32, init=K.float32(c))
+        K.ptx["fma.rn.f32"](acc, acc, r2, cv)
+    out = K.local_scalar(K.f32)
+    K.ptx["mul.f32"](out, acc, r)
+    return out
+
+
+def _xor(a, b):
+    """`a ^ b`, trace-time when both sides are Python ints."""
+    if isinstance(a, int) and isinstance(b, int):
+        return a ^ b
+    return K.bitwise_xor(a, b)
+
+
+def _tile_elem(row, dim):
+    """Element offset of `(row, dim)` inside an operand region.
+
+    An operand region is a stack of 64-wide blocks of 64 rows -- the layout the
+    source builds for every A/B operand and epilogue tile (`:864-903`) -- with
+    the 128-byte swizzle inside each block: a row spans eight 16-byte
+    sub-blocks and they are XORed by `row % 8`.
+
+    `row` is the 64-strided axis and `dim` the contiguous one, which is why the
+    same function serves the K-major operands (row = head or KV row), the
+    64-wide P/dS tiles, and the dQ epilogue tile (row = head, dim = the dim).
+    """
+    return (dim // 64) * 4096 + _xor(row * 64 + dim % 64, (row % 8) * 8)
+
+
+def _tile_byte(base, row, dim):
+    """Byte offset of `(row, dim)` in the region starting at `base`."""
+    return base + 2 * _tile_elem(row, dim)
+
+
+def _desc_base(ldo, sdo, swizzle=3):
+    """Fold the static SM100 shared-descriptor fields except the 14-bit address.
+
+    Only two combinations occur in this kernel: regions at least two swizzle
+    atoms wide take `ldo = 512` (one atom is 4096 elements = 512 sixteen-byte
+    units apart), and the 64-wide P/dS tiles take `ldo = 0` because they have
+    no second atom to step to. `sdo = 64` is the eight-row stride in the same
+    units. Both were read off the descriptors this kernel's operands produce.
+    """
+    arrangement = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = ((ldo & 0x3FFF) << 16) | ((sdo & 0x3FFF) << 32) | (1 << 46)
+    return (value | ((arrangement & 0x7) << 61)) & 0xFFFFFFFFFFFFFFFF
+
+
+def _desc_at(base, shared_address):
+    """`base` with the shared address folded into its 14-bit address field."""
+    field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), field)
+
+
+def _desc_add16(desc, offset):
+    """`desc` stepped by a 16-byte-unit offset, without touching its high half."""
+    if isinstance(offset, int) and offset == 0:
+        return desc
+    lo = K.local_scalar("uint32")
+    hi = K.local_scalar("uint32")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(lo, hi, desc)
+    K.ptx["add.u32"](lo, lo, K.uint32(offset))
+    K.ptx.mov.b64(out, lo, hi)
+    return out
+
+
+def _gemm(d, a, b, idesc, accumulate, n_iter, unroll):
+    """One tcgen05 k-loop, ROLLED: `n_iter` iterations of `unroll` issues.
+
+    The source's chains are rolled loops, not fully unrolled ones (`unroll=4`
+    on the 32-phase S/dP chains, `unroll=2` on the 4-phase dKV and dQ chains),
+    which is what keeps the kernel at 32 static `tcgen05.mma` at d512 and 36 at
+    d576. Emitting one instruction per k-phase instead multiplies that by three
+    or four.
+
+    `a` and `b` are each `(descriptor, per-iteration step, per-issue step)` in
+    sixteen-byte units. Both steps are linear in the loop counter because the
+    non-linear part of a K-major walk -- the jump at each 64-element swizzle
+    atom -- lands exactly on the iteration boundary when `unroll` divides the
+    atom.
+
+    `accumulate` rides the first issue only; the flag is then latched to 1,
+    which is the `(kp != 0) or flag` disjunction the accumulator semantics ask
+    for, built as the source builds it.
+    """
+    a_desc, a_it, a_u = a
+    b_desc, b_it, b_u = b
+    flag = K.local_scalar("uint32")
+    K.assign(flag, K.cast(accumulate, "uint32"))
+    it = K.local_scalar(K.i32, init=K.int32(0))
+    with K.While(it < K.int32(n_iter)):
+        for u in range(unroll):
+            _mma(
+                MMA_F16,
+                d,
+                _desc_add16(a_desc, it * K.int32(a_it) + K.int32(u * a_u)),
+                _desc_add16(b_desc, it * K.int32(b_it) + K.int32(u * b_u)),
+                idesc,
+                flag,
+            )
+            K.assign(flag, K.uint32(1))
+        K.assign(it, it + K.int32(1))
+
+
+def _mma(mma, d, a_desc, b_desc, idesc, accumulate):
+    """One `tcgen05.mma` in its dense non-ws operand form."""
+    K.ptx[mma](
+        K.Cast("uint32", d),
+        a_desc,
+        b_desc,
+        K.uint32(idesc),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.ptx.pred(accumulate),
+    )
+
+
+# The instruction descriptors every tcgen05 MMA carries, read out of the
+# line-info PTX export (probe/probe_idesc.py). The bf16 and fp16 columns differ
+# by exactly the d/a/b format bits; M, N and both transpose bits are
+# dtype-invariant. trans_a=1 is an MN-major A operand, trans_b=1 an MN-major B.
+_IDESC = {
+    "bfloat16": {
+        "qk": 0x04100490,  # S and dP:      M=64  N=64 trans 0,0
+        "dkv": 0x08108490,  # dKV0..3:       M=128 N=64 trans 1,0
+        "dq": 0x08118490,  # dQ0..3:        M=128 N=64 trans 1,1
+        "dkv4": 0x04108490,  # dKV4 (d576):   M=64  N=64 trans 1,0
+        "dq4": 0x04118490,  # dQ4  (d576):   M=64  N=64 trans 1,1
+    },
+    "float16": {
+        "qk": 0x04100010,
+        "dkv": 0x08108010,
+        "dq": 0x08118010,
+        "dkv4": 0x04108010,
+        "dq4": 0x04118010,
+    },
+}
+
+
+MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+TMA_G2S = (
+    "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_S2G = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+TCGEN05_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+
+
+def _bwd_load(
+    desc_q,
+    desc_do,
+    desc_dq,
+    smem,
+    off_q,
+    off_do,
+    off_lse,
+    off_sum,
+    ws,
+    p_qdo,
+    p_lse,
+    p_sum,
+    token,
+    head_block,
+    plane,
+    lane,
+    head_dim,
+    head_dim_v,
+    num_head,
+    block,
+):
+    """Role `load` (warp 17), `:1113-1207`. Runs once -- a CTA owns one token.
+
+    Q and dO are TMA'd into one barrier under a single `expect_tx` covering
+    both; LSE and sum_OdO come in as one 64-bit cp.async each.
+    """
+    q_bytes = block * head_dim * 2
+    do_bytes = block * head_dim_v * 2
+    for desc in (desc_q, desc_do, desc_dq):
+        K.ptx.prefetch.tensormap(K.address_of(desc))
+
+    with K.If(lane == 0), K.Then():
+        # The Q/dO pipeline is acquired before the transfer is announced
+        # (:1152-1155); it runs once, so the wait is on the initial phase.
+        p_qdo.empty.wait(0, 1)
+        # ONE expect_tx covers BOTH transfers: they share a barrier upstream
+        # (tx_count = tma_copy_QdO_bytes, :442-444).
+        K.ptx["mbarrier.arrive.expect_tx.shared.b64"](
+            p_qdo.full.buf.ptr_to([0]), K.uint32(q_bytes + do_bytes)
+        )
+        for b in range(head_dim // 64):
+            # Box `b` is the 64-wide dim block at element offset b * 4096.
+            K.ptx[TMA_G2S](
+                smem.ptr_to([_tile_byte(off_q, 0, b * 64)]),
+                K.address_of(desc_q),
+                K.int32(b * 64),
+                head_block * block,
+                token,
+                p_qdo.full.buf.ptr_to([0]),
+                K.uint64(0),
+            )
+        for b in range(head_dim_v // 64):
+            K.ptx[TMA_G2S](
+                smem.ptr_to([_tile_byte(off_do, 0, b * 64)]),
+                K.address_of(desc_do),
+                K.int32(b * 64),
+                head_block * block,
+                token,
+                p_qdo.full.buf.ptr_to([0]),
+                K.uint64(0),
+            )
+
+    # LSE and sum_OdO: 32 lanes x 2 f32 = the 64 rows of this head block. The
+    # workspace planes are head-contiguous, so a head block is 64 consecutive
+    # f32 only when it starts at head 0; index each row explicitly instead.
+    slot = token * num_head + head_block * block
+    p_lse.empty.wait(0, 1)
+    K.ptx["cp.async.ca.shared.global"](
+        smem.ptr_to([off_lse + lane * 8]), ws.ptr_to([plane + slot + lane * 2]), 8, 8
+    )
+    K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](p_lse.full.buf.ptr_to([0]))
+
+    p_sum.empty.wait(0, 1)
+    K.ptx["cp.async.ca.shared.global"](
+        smem.ptr_to([off_sum + lane * 8]), ws.ptr_to([slot + lane * 2]), 8, 8
+    )
+    K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](p_sum.full.buf.ptr_to([0]))
+
+
+# The gather writes the KV region through `_tile_byte`, the same explicit
+# offset function the MMA descriptors are built against, so the operand a GEMM
+# reads is exactly what the gather wrote.
+
+
+def _gather_or_zero(smem, addr, kv, row, col, src_row, head_dim, live):
+    """One lane's 128-bit slot of one gathered KV row, or a zero fill.
+
+    The source does not use cp.async's ignore-src form for invalid rows; it
+    stores zeros separately (`_zero_kv_row`, :1246-1271). Keep that: ignore-src
+    and whole-instruction predication leave different bytes behind, and the MMA
+    reads them either way.
+    """
+    # `col` is the dim in the *global* KV row; `dst`/`dcol` are where it lands
+    # in the staged operand, which only the caller can split (the stage index
+    # comes from the 64-wide group, which is runtime for the eight main groups
+    # and trace-time for d576's tail).
+    if live is None:
+        K.ptx["cp.async.cg.shared.global"](
+            smem.ptr_to([addr]), kv.ptr_to([src_row * head_dim + col]), 16, 16
+        )
+        return
+    # `K.If(cond)` opens the frame; Then/Else nest inside it. The
+    # `with K.If(c), K.Then():` shorthand is if-without-else only.
+    with K.If(live):
+        with K.Then():
+            K.ptx["cp.async.cg.shared.global"](
+                smem.ptr_to([addr]), kv.ptr_to([src_row * head_dim + col]), 16, 16
+            )
+        with K.Else():
+            K.ptx["st.shared.v4.b32"](
+                smem.ptr_to([addr]), K.uint32(0), K.uint32(0), K.uint32(0), K.uint32(0)
+            )
+
+
+def _bwd_load_kv(
+    kv,
+    topk_idxs,
+    smem,
+    off_k,
+    p_k,
+    tile_count,
+    topk,
+    token,
+    tid,
+    lane,
+    head_dim,
+    seqlen_kv,
+    max_topk,
+    has_topk_length,
+    block,
+):
+    """Role `load_KV` (warps 0-3), `:1316-1431`. Reverse tile walk.
+
+    Lane 0 of each warp reads 16 top-k indices and broadcasts them; all 32 lanes
+    then cp.async-gather the rows, 8 lanes per 64-element head-dim group.
+    """
+    lwarp = tid // 32  # 0..3 within the role
+    rows_per_warp = block // 4
+    groups = head_dim // 64
+    full_tiles = (topk % K.int32(block)) == K.int32(0)  # :1344
+
+    def read_indices(tile_index):
+        """This warp's 16 top-k indices, read by lane 0 and broadcast."""
+        r = K.alloc_local([16], "int32")
+        for i in range(rows_per_warp):
+            row = i * 4 + lwarp
+            gidx = tile_index * K.int32(block) + K.int32(row)
+            v = K.local_scalar(K.i32, init=K.int32(-1))
+            # The bound is the allocation extent, not `topk`: rows past the
+            # length are read and then discarded.
+            with K.If((lane == 0) & (gidx < K.int32(max_topk))), K.Then():
+                K.ptx["ld.global.b32"](v, topk_idxs.ptr_to([token * max_topk + gidx]))
+            bc = K.local_scalar(K.i32)
+            K.ptx.shfl_sync.idx.b32(bc, v, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF))
+            K.assign(r[i], bc)
+        return r
+
+    def gather_rows(tile_index, r, is_first):
+        """One tile's 64 rows. `is_first` is a trace-time flag, as upstream.
+
+        The two builds run different validity programs (:1292-1310). With a
+        compact top-k list every row of a non-ragged tile is valid, so the copy
+        is unconditional and only the ragged tile zero-fills past `topk`;
+        without one, every row is tested for both bounds and its own index.
+        """
+        for i in range(rows_per_warp):
+            row = i * 4 + lwarp
+            gidx = tile_index * K.int32(block) + K.int32(row)
+            src_row = r[i]
+            if has_topk_length:
+                live = (gidx < topk) if is_first else None
+            else:
+                live = (gidx < topk) & (src_row >= K.int32(0))
+            # The group is chosen by `lane // 8` and the slot inside it by
+            # `lane % 8` (:1224, :1339), so each lane owns two of the eight
+            # 64-wide groups and every address has exactly one writer. Indexing
+            # the groups with a Python loop instead makes four lanes collide on
+            # each address, which silently loses whole groups.
+            for j in range(2):
+                g = lane // K.int32(8) + K.int32(j * 4)
+                slot = (lane % K.int32(8)) * K.int32(8)
+                col = g * K.int32(64) + slot
+                _gather_or_zero(
+                    smem, _tile_byte(off_k, row, col), kv, row, col, src_row, head_dim, live
+                )
+            if groups == 9:
+                # The ninth group is the d576 tail: 64 dims, so only 8 lanes.
+                with K.If(lane < K.int32(8)), K.Then():
+                    slot = (lane % K.int32(8)) * K.int32(8)
+                    tcol = K.int32(8 * 64) + slot
+                    _gather_or_zero(
+                        smem, _tile_byte(off_k, row, tcol), kv, row, tcol, src_row, head_dim, live
+                    )
+
+    def publish():
+        """Drain the gather and hand the tile to the MMA warp."""
+        K.ptx["cp.async.commit_group"]()
+        # Waits for ALL groups: the gather is not double-buffered.
+        K.ptx["cp.async.wait_group"](K.int32(0))
+        K.ptx["fence.proxy.async.shared::cta"]()
+        # Makes the four warps' gathers jointly visible before any one of them
+        # commits the pipeline.
+        K.ptx.bar.sync(K.uint32(BAR_LOAD_KV_SYNC[0]), K.uint32(BAR_LOAD_KV_SYNC[1]))
+        K.ptx["mbarrier.arrive.shared.b64"](p_k.full.buf.ptr_to([0]), K.uint32(1))
+
+    st = K.PipelineState(1, phase=0)
+    tile_index = K.local_scalar(K.i32, init=tile_count - K.int32(1))
+
+    # The highest-index tile is the ragged one and is peeled, so the loop body
+    # never carries the ragged-tile test (:1343-1393).
+    r0 = read_indices(tile_index)
+    p_k.empty.wait(0, st.phase ^ 1)
+    with K.If(full_tiles):
+        with K.Then():
+            gather_rows(tile_index, r0, is_first=False)
+        with K.Else():
+            gather_rows(tile_index, r0, is_first=True)
+    publish()
+    st.advance()
+    K.assign(tile_index, tile_index - K.int32(1))
+
+    with K.While(tile_index >= K.int32(0)):
+        r = read_indices(tile_index)
+        p_k.empty.wait(0, st.phase ^ 1)
+        gather_rows(tile_index, r, is_first=False)
+        publish()
+        st.advance()
+        K.assign(tile_index, tile_index - K.int32(1))
+
+
 def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
-    """Trace the main backward kernel for one static specialization."""
+    """Trace the main backward kernel for one static specialization (``:740-1110``).
+
+    One CTA per query token; the 64 attention heads form the MMA M dimension, so
+    a token's top-k KV rows are gathered once and amortized across every head.
+    """
     spec.check_dispatch(
         {
             "head_dim": head_dim,
@@ -88,44 +529,1163 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
             "has_topk_length": has_topk_length,
         }
     )
+    head_dim_v = spec.head_dim_v_for(head_dim)
+    elem = _ELEM[dtype]
+    block = spec.BLOCK_TILE
+    idesc = _IDESC[dtype]
 
-    @K.kernel(warps=BWD_WARPS, arch="sm_100a", min_blocks_per_sm=1, grid=False)
-    def bwd():
+    @K.kernel(
+        warps=BWD_WARPS,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=lambda p: [p["seqlen_q"], (num_head + block - 1) // block, 1],
+    )
+    def bwd(
+        desc_q: K.TensorMap,
+        desc_do: K.TensorMap,
+        desc_dq: K.TensorMap,
+        kv: K.gptr[elem],
+        dq: K.gptr[elem],
+        ws_dkv: K.gptr[K.f32],
+        topk_idxs: K.gptr[K.i32],
+        topk_length: K.gptr[K.i32],
+        ws: K.gptr[K.f32],
+        seqlen_q: K.i32,
+        seqlen_kv: K.i32,
+        plane: K.i32,
+        scale: K.f32,
+    ):
         # ---- kernel body starts here ----
-        pass
+        token, head_block, _z = K.cta_id()
+        tid = K.thread_id()
+        K.keep_alive(dq.data)
+
+        # `topk` is CTA-uniform: one value per query token.
+        if has_topk_length:
+            topk = K.local_scalar(K.i32)
+            K.ptx["ld.global.b32"](topk, topk_length.ptr_to([token]))
+        else:
+            K.keep_alive(topk_length.data)
+            topk = K.local_scalar(K.i32, init=K.int32(max_topk))
+
+        # An empty or malformed row contributes nothing to dKV and its dQ tile is
+        # zero. This runs BEFORE any pipeline init or TMEM allocation, and that
+        # ordering is load-bearing: a CTA that exited after arriving on a
+        # pipeline init would strand the rest of the grid.
+        with K.If(topk <= K.int32(0)), K.Then():
+            i = K.local_scalar(K.i32, init=tid)
+            with K.While(i < K.int32(head_dim * block)):
+                head_offset = i // K.int32(head_dim)
+                dim_idx = i % K.int32(head_dim)
+                head_idx = head_block * block + head_offset
+                with K.If(head_idx < K.int32(num_head)), K.Then():
+                    zero = K.local_scalar("uint16", init=K.uint16(0))
+                    K.ptx["st.global.b16"](
+                        dq.ptr_to([token * (num_head * head_dim) + head_idx * head_dim + dim_idx]),
+                        zero,
+                    )
+                K.assign(i, i + K.int32(BWD_THREADS))
+
+        # The source spells the early-out as `nvvm.exit()`. K has no CTA-exit
+        # instruction, so the rest of the kernel is guarded by the complement
+        # instead. That is the same control flow: `topk` is CTA-uniform, so
+        # every thread of a CTA takes the same arm and the collectives below are
+        # either all executed or all skipped.
+        with K.If(topk > K.int32(0)), K.Then():
+            K.keep_alive(ws_dkv.data)
+            tile_count = (topk + K.int32(block - 1)) // K.int32(block)
+
+            # --- one linear SMEM pool ---------------------------------------
+            # Every object below is a byte offset into a single flat buffer.
+            # The order and the 1024-byte alignment of the operand regions
+            # follow SharedStorage (:448-470); the totals are 214,528 B at d512
+            # and 230,912 B at d576 against a 232,448 B cap.
+            dkv2_offset = TMEM_DKV2_D576_OFFSET if head_dim > 512 else TMEM_DKV2_D512_OFFSET
+            # Only ONE WAR barrier is skipped-once per build, and which one
+            # differs: 8 at d512 (`:1546`), 10 at d576 (`:1543`). The loop tail
+            # therefore carries exactly one compensating arrive (`:1752-1757`);
+            # compensating a barrier that was never skipped, or missing the one
+            # that was, hangs.
+            war_gen_a = BAR_T2R_DKV23_DONE if head_dim > 512 else BAR_T2R_DKV4_DONE
+            war_gen_b = BAR_T2R_DKV4_DONE if head_dim > 512 else BAR_T2R_DKV01_DONE
+            tail = head_dim - 512
+
+            q_bytes = block * head_dim * 2
+            do_bytes = block * head_dim_v * 2
+            p_bytes = block * block * 2
+            OFF_Q = 1024
+            OFF_K = OFF_Q + q_bytes
+            OFF_DO = OFF_K + q_bytes
+            OFF_P = OFF_DO + do_bytes
+            OFF_DS = OFF_P + p_bytes
+            OFF_LSE = OFF_DS + p_bytes
+            OFF_SUM = OFF_LSE + block * 4
+            shared_bytes = OFF_SUM + block * 4
+            # sdQ and sdQ4 alias sK. They are NOT co-live with it: the dQ
+            # epilogue runs only after the MMA warp's last release of the KV
+            # pipeline (`:1683`) and the compute warp's dQ wait (`:2033`). The
+            # two 64x64 dQ stages are exactly the two boxes one 128-wide round
+            # stores.
+            OFF_DQ = OFF_K
+            OFF_DQ4 = OFF_K + 2 * p_bytes
+
+            smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+            pool = K.smem_pool(base=smem)
+            smem_base = K.local_scalar("uint32")
+            K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+
+            # --- pipelines --------------------------------------------------
+            # Arrival counts are the upstream CooperativeGroup sizes
+            # (:2711-2866). The 1s are single-Thread agents -- one elected lane
+            # arrives -- not 32-thread warps; getting one wrong deadlocks.
+            p_qdo = K.Pipeline(pool, 1, full="tma", empty="tcgen05", init_full=1, init_empty=1)
+            p_k = K.Pipeline(pool, 1, full="mbar", empty="tcgen05", init_full=128, init_empty=1)
+            p_lse = K.Pipeline(pool, 1, full="mbar", empty="mbar", init_full=32, init_empty=128)
+            p_sum = K.Pipeline(pool, 1, full="mbar", empty="mbar", init_full=32, init_empty=128)
+            p_s = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=128)
+            p_dp = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=128)
+            p_dq = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=128)
+            p_p = K.Pipeline(pool, 1, full="mbar", empty="tcgen05", init_full=128, init_empty=1)
+            p_ds = K.Pipeline(pool, 1, full="mbar", empty="tcgen05", init_full=128, init_empty=1)
+            p_dkv = K.Pipeline(pool, 2, full="tcgen05", empty="mbar", init_full=1, init_empty=256)
+
+            tmem_hold = pool.alloc((1,), K.i32, align=4)
+            K.ptx["fence.mbarrier_init.release.cluster"]()
+            K.ptx.bar.sync(K.uint32(0), K.uint32(BWD_THREADS))
+
+            sp = K.specialize(chain_dispatch=True)
+            # Declared in the source's dispatch order (:909-1110), which is
+            # deliberately not ascending warp order.
+            r_load = sp.role("load", warps=[LOAD_WARP], regs=REGS_LOAD)
+            r_mma = sp.role("mma", warps=[MMA_WARP], regs=REGS_MMA)
+            r_compute = sp.role("compute", warps=list(COMPUTE_WARPS), regs=REGS_COMPUTE)
+            r_reduce = sp.role("reduce", warps=list(REDUCE_WARPS), regs=REGS_REDUCE)
+            r_loadkv = sp.role("load_kv", warps=list(LOAD_KV_WARPS), regs=REGS_LOAD_KV)
+            r_empty = sp.role("empty", warps=[EMPTY_WARP, EMPTY_WARP + 1], regs=REGS_EMPTY)
+
+            lane = tid % 32
+
+            with r_load:
+                _bwd_load(
+                    desc_q,
+                    desc_do,
+                    desc_dq,
+                    smem,
+                    OFF_Q,
+                    OFF_DO,
+                    OFF_LSE,
+                    OFF_SUM,
+                    ws,
+                    p_qdo,
+                    p_lse,
+                    p_sum,
+                    token,
+                    head_block,
+                    plane,
+                    lane,
+                    head_dim,
+                    head_dim_v,
+                    num_head,
+                    block,
+                )
+
+            with r_mma:
+                # TMEM is allocated by compute warp 0; every role that reads it
+                # waits on barrier 2 (416 threads: compute + reduce + mma).
+                K.ptx.bar.sync(K.uint32(BAR_TMEM_ALLOC[0]), K.uint32(BAR_TMEM_ALLOC[1]))
+                tcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(tcol, tmem_hold.ptr_to([0]))
+                t_s = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_S_OFFSET))
+                # dP shares S's columns at a different lane range (:2675-2677).
+                t_dp = K.cuda.get_tmem_addr(tcol, K.uint32(16), K.uint32(TMEM_DP_OFFSET))
+
+                t_dkv = [
+                    K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(off))
+                    for off in (TMEM_DKV0_OFFSET, TMEM_DKV1_OFFSET)
+                ]
+                t_dkv4 = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DKV4_OFFSET))
+                t_dkv23 = [
+                    K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(off))
+                    for off in (dkv2_offset, TMEM_DKV3_OFFSET)
+                ]
+                t_dq = [
+                    K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(off))
+                    for off in (TMEM_DQ0_OFFSET, TMEM_DQ1_OFFSET, TMEM_DQ2_OFFSET, TMEM_DQ3_OFFSET)
+                ]
+                t_dq4 = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DQ4_OFFSET))
+
+                # Operand descriptors, encoded once. Only a 64-wide K-major
+                # operand has no second swizzle atom to step to, so only those
+                # take LBO 0; everything else steps one atom = 4096 elements =
+                # 512 sixteen-byte units. SBO is the eight-row stride.
+                D_WIDE = _desc_base(512, 64)
+                D_NARROW_K = _desc_base(0, 64)
+                d_q_k = _desc_at(D_WIDE, smem_base + K.uint32(OFF_Q))
+                d_k_k = _desc_at(D_WIDE, smem_base + K.uint32(OFF_K))
+                d_do_k = _desc_at(D_WIDE, smem_base + K.uint32(OFF_DO))
+                d_p_k = _desc_at(D_NARROW_K, smem_base + K.uint32(OFF_P))
+                d_ds_k = _desc_at(D_NARROW_K, smem_base + K.uint32(OFF_DS))
+                d_ds_mn = _desc_at(D_WIDE, smem_base + K.uint32(OFF_DS))
+                # M-block b of an MN-major operand is 128 dims on, which is two
+                # 64-wide blocks = 16,384 bytes. Index 4 is d576's 64-wide tail
+                # (dims 512:576), the source's "block 8".
+                d_do_mn = [
+                    _desc_at(D_WIDE, smem_base + K.uint32(OFF_DO + b * 16384)) for b in range(4)
+                ]
+                d_q_mn = [
+                    _desc_at(D_WIDE, smem_base + K.uint32(OFF_Q + b * 16384)) for b in range(5)
+                ]
+                d_k_mn = [
+                    _desc_at(D_WIDE, smem_base + K.uint32(OFF_K + b * 16384)) for b in range(5)
+                ]
+
+                st_k = K.PipelineState(1, phase=0)
+                st_s = K.PipelineState(1, phase=0)
+                st_dp = K.PipelineState(1, phase=0)
+                st_p = K.PipelineState(1, phase=0)
+                st_ds_m = K.PipelineState(1, phase=0)
+                st_dkv = K.PipelineState(2, phase=0)
+                # `accumulate` for dQ: 0 on the first processed tile, 1 after.
+                acc_dq = K.local_scalar(K.i32, init=0)
+                # The dKV generations per tile: 2 at d512, 3 at d576.
+                # Q and dO arrive once: a CTA owns one query token.
+                p_qdo.full.wait(0, 0)
+                # dQ accumulates across every tile and is published once, so
+                # its pipeline is acquired here and committed after the loop
+                # (:1491, :1759) -- not per tile.
+                p_dq.empty.wait(0, 1)
+
+                idx = K.local_scalar(K.i32, init=tile_count - K.int32(1))
+                with K.While(idx >= K.int32(0)):
+                    p_k.full.wait(0, st_k.phase)
+                    p_s.empty.wait(0, st_s.phase ^ 1)
+                    with K.If(lane == K.int32(0)), K.Then():
+                        # S = Q @ K^T over the whole head dimension: one
+                        # chain, ACCUMULATE false on the first k-phase and true
+                        # after. Q and K share the k walk because both are
+                        # K-major over the same 64-wide block stride.
+                        _gemm(
+                            t_s,
+                            (d_q_k, *(512, 2)),
+                            (d_k_k, *(512, 2)),
+                            idesc["qk"],
+                            0,
+                            head_dim // 64,
+                            4,
+                        )
+                        K.ptx[TCGEN05_COMMIT](p_s.full.buf.ptr_to([0]))
+
+                    # dP = dO @ V^T. V is columns 0:head_dim_v of the shared KV
+                    # buffer, so this reads the same gathered tile with a
+                    # shorter K extent -- no separate alias needed.
+                    p_dp.empty.wait(0, st_dp.phase ^ 1)
+                    with K.If(lane == K.int32(0)), K.Then():
+                        _gemm(
+                            t_dp,
+                            (d_do_k, *(512, 2)),
+                            (d_k_k, *(512, 2)),
+                            idesc["qk"],
+                            0,
+                            head_dim_v // 64,
+                            4,
+                        )
+                        K.ptx[TCGEN05_COMMIT](p_dp.full.buf.ptr_to([0]))
+
+                    # --- dKV generation A: dKV0, dKV1 (:1531-1594) ----------
+                    # dKV = dO^T @ P, then += Q^T @ dS into the SAME columns:
+                    # that accumulation is what fuses dV and dK.
+                    p_p.full.wait(0, st_p.phase)
+                    p_dkv.empty.wait(st_dkv.stage, st_dkv.phase ^ 1)
+                    with K.If(idx != tile_count - K.int32(1)), K.Then():
+                        # WAR against the PREVIOUS generation's T2R reads.
+                        # Skipped on the first processed tile and compensated
+                        # by one unpaired arrive after the loop (:1752-1757).
+                        K.ptx.bar.sync(K.uint32(war_gen_a[0]), K.uint32(war_gen_a[1]))
+                    with K.If(lane == K.int32(0)), K.Then():
+                        for j in range(2):
+                            _gemm(
+                                t_dkv[j],
+                                (d_do_mn[j], *(256, 128)),
+                                (d_p_k, *(4, 2)),
+                                idesc["dkv"],
+                                0,
+                                2,
+                                2,
+                            )
+                    p_ds.full.wait(0, st_ds_m.phase)
+                    with K.If(lane == K.int32(0)), K.Then():
+                        for j in range(2):
+                            _gemm(
+                                t_dkv[j],
+                                (d_q_mn[j], *(256, 128)),
+                                (d_ds_k, *(4, 2)),
+                                idesc["dkv"],
+                                1,
+                                2,
+                                2,
+                            )
+                        K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
+                    st_dkv.advance()
+
+                    if tail:
+                        # dKV4 aliases dKV0, so barrier 7 orders its write
+                        # against the dKV0/dKV1 reads. Unconditional (:1600).
+                        K.ptx.bar.sync(
+                            K.uint32(BAR_T2R_DKV01_DONE[0]), K.uint32(BAR_T2R_DKV01_DONE[1])
+                        )
+                        with K.If(lane == K.int32(0)), K.Then():
+                            _gemm(
+                                t_dkv4,
+                                (d_q_mn[4], *(256, 128)),
+                                (d_ds_k, *(4, 2)),
+                                idesc["dkv4"],
+                                0,
+                                2,
+                                2,
+                            )
+                            # No matching acquire upstream: the source leans on
+                            # barrier 7 above for what an acquire would give.
+                            K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
+                        st_dkv.advance()
+
+                    # --- dQ0..dQ3 (and dQ4) (:1622-1676) --------------------
+                    # dQ accumulates across the WHOLE top-k axis in TMEM and is
+                    # published only after the loop, so ACCUMULATE is False
+                    # only on the first processed tile.
+                    with K.If(lane == K.int32(0)), K.Then():
+                        for j in range(4):
+                            _gemm(
+                                t_dq[j],
+                                (d_k_mn[j], *(256, 128)),
+                                (d_ds_mn, *(256, 128)),
+                                idesc["dq"],
+                                acc_dq,
+                                2,
+                                2,
+                            )
+                        if tail:
+                            _gemm(
+                                t_dq4,
+                                (d_k_mn[4], *(256, 128)),
+                                (d_ds_mn, *(256, 128)),
+                                idesc["dq4"],
+                                acc_dq,
+                                2,
+                                2,
+                            )
+
+                    # The KV tile's SMEM is reusable from here (:1683).
+                    # `p_k`'s empty barrier is tcgen05-flavoured and expects
+                    # ONE arrival, so it must be released by a single elected
+                    # lane's commit (:1683) -- a plain 32-lane `arrive` lands
+                    # 32 arrivals on an expect-1 barrier and walks its parity
+                    # forward, which deadlocks the gather warps from the third
+                    # tile on. The commit also carries the real ordering: sK is
+                    # reusable only once the MMAs reading it have retired.
+                    with K.If(lane == K.int32(0)), K.Then():
+                        K.ptx[TCGEN05_COMMIT](p_k.empty.buf.ptr_to([0]))
+
+                    # --- dKV generation B: dKV2, dKV3 (:1689-1746) ----------
+                    # Unconditional, unlike generation A's WAR barrier.
+                    K.ptx.bar.sync(K.uint32(war_gen_b[0]), K.uint32(war_gen_b[1]))
+                    p_dkv.empty.wait(st_dkv.stage, st_dkv.phase ^ 1)
+                    with K.If(lane == K.int32(0)), K.Then():
+                        for j in range(2):
+                            _gemm(
+                                t_dkv23[j],
+                                (d_do_mn[2 + j], *(256, 128)),
+                                (d_p_k, *(4, 2)),
+                                idesc["dkv"],
+                                0,
+                                2,
+                                2,
+                            )
+                        K.ptx[TCGEN05_COMMIT](p_p.empty.buf.ptr_to([0]))
+                        for j in range(2):
+                            _gemm(
+                                t_dkv23[j],
+                                (d_q_mn[2 + j], *(256, 128)),
+                                (d_ds_k, *(4, 2)),
+                                idesc["dkv"],
+                                1,
+                                2,
+                                2,
+                            )
+                        K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
+                        K.ptx[TCGEN05_COMMIT](p_ds.empty.buf.ptr_to([0]))
+                    st_dkv.advance()
+
+                    K.assign(acc_dq, K.int32(1))
+                    st_k.advance()
+                    st_s.advance()
+                    st_dp.advance()
+                    st_p.advance()
+                    st_ds_m.advance()
+                    K.assign(idx, idx - K.int32(1))
+
+                # The generation-A WAR barrier is skipped on the first
+                # processed tile, so the reduce warps are one arrival short on
+                # the last one. Exactly ONE compensating arrive closes that
+                # (:1752-1757) -- one per WAR barrier would hang instead.
+                K.ptx.bar.sync(K.uint32(war_gen_a[0]), K.uint32(war_gen_a[1]))
+                with K.If(lane == K.int32(0)), K.Then():
+                    K.ptx[TCGEN05_COMMIT](p_dq.full.buf.ptr_to([0]))
+                    K.ptx[TCGEN05_COMMIT](p_qdo.empty.buf.ptr_to([0]))
+
+            with r_compute:
+                rwarp = K.warp_id_in_role()
+                rtid = K.tid_in_role()
+                with K.If(rwarp == K.int32(0)), K.Then():
+                    K.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+                        K.cuda.cvta_generic_to_shared(tmem_hold.ptr_to([0])),
+                        K.uint32(TMEM_ALLOC_COLUMNS),
+                    )
+                K.ptx.bar.sync(K.uint32(BAR_TMEM_ALLOC[0]), K.uint32(BAR_TMEM_ALLOC[1]))
+                tcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(tcol, tmem_hold.ptr_to([0]))
+                t_s = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_S_OFFSET))
+
+                t_dp = K.cuda.get_tmem_addr(tcol, K.uint32(16), K.uint32(TMEM_DP_OFFSET))
+
+                # This thread's slice of the 64x64 tile. Both elements of a
+                # consecutive pair share a row, so only two sLSE rows are ever
+                # read (probe/probe_s_row_coord.py).
+                gsub = rtid // K.int32(4)
+                base_row = (gsub // K.int32(8)) * K.int32(16) + gsub % K.int32(8)
+
+                p_lse.full.wait(0, 0)
+                p_sum.full.wait(0, 0)
+                lse_lo = K.local_scalar(K.f32)
+                lse_hi = K.local_scalar(K.f32)
+                K.ptx["ld.shared.b32"](lse_lo, smem.ptr_to([OFF_LSE + base_row * K.int32(4)]))
+                K.ptx["ld.shared.b32"](
+                    lse_hi, smem.ptr_to([OFF_LSE + (base_row + K.int32(8)) * K.int32(4)])
+                )
+                sum_lo = K.local_scalar(K.f32)
+                sum_hi = K.local_scalar(K.f32)
+                K.ptx["ld.shared.b32"](sum_lo, smem.ptr_to([OFF_SUM + base_row * K.int32(4)]))
+                K.ptx["ld.shared.b32"](
+                    sum_hi, smem.ptr_to([OFF_SUM + (base_row + K.int32(8)) * K.int32(4)])
+                )
+
+                scale_log2e = K.local_scalar(K.f32)
+                K.ptx["mul.f32"](scale_log2e, scale, K.float32(1.4426950408889634))
+
+                st_s = K.PipelineState(1, phase=0)
+                st_dp = K.PipelineState(1, phase=0)
+                st_p = K.PipelineState(1, phase=0)
+                st_ds = K.PipelineState(1, phase=0)
+                idx = K.local_scalar(K.i32, init=tile_count - K.int32(1))
+                with K.While(idx >= K.int32(0)):
+                    p_s.full.wait(0, st_s.phase)
+                    p_p.empty.wait(0, st_p.phase ^ 1)
+                    rs = K.alloc_local([32], "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                        *[rs[i] for i in range(32)], t_s
+                    )
+
+                    # P = exp2(fma(S, scale*log2e, scaled_lse)), two lanes at a
+                    # time; the pair shares a row so one lse value serves both.
+                    scale2 = K.local_scalar("uint64")
+                    K.ptx.mov.b64(scale2, scale_log2e, scale_log2e)
+                    lse2_lo = K.local_scalar("uint64")
+                    lse2_hi = K.local_scalar("uint64")
+                    K.ptx.mov.b64(lse2_lo, lse_lo, lse_lo)
+                    K.ptx.mov.b64(lse2_hi, lse_hi, lse_hi)
+                    for i in range(0, 32, 2):
+                        packed = K.local_scalar("uint64")
+                        K.ptx.mov.b64(packed, rs[i], rs[i + 1])
+                        addend = lse2_lo if (i % 4) < 2 else lse2_hi
+                        K.ptx["fma.rn.f32x2"](packed, packed, scale2, addend)
+                        K.ptx.mov.b64(rs[i], rs[i + 1], packed)
+                        K.ptx["ex2.approx.ftz.f32"](rs[i], rs[i])
+                        K.ptx["ex2.approx.ftz.f32"](rs[i + 1], rs[i + 1])
+
+                    # Quantize and transpose P into sP as the dOP MMA's B
+                    # operand. `.trans` is what converts the row-major
+                    # (head, kv) accumulator fragment into the head-major
+                    # operand layout, with no separate transpose pass.
+                    rp = K.alloc_local([16], "uint32")
+                    for i in range(16):
+                        K.ptx[_CVT_PACK[dtype]](rp[i], rs[2 * i + 1], rs[2 * i])
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    for b in range(4):
+                        K.ptx["stmatrix.sync.aligned.m8n8.x4.trans.shared.b16"](
+                            smem.ptr_to(
+                                [
+                                    _tile_byte(
+                                        OFF_P,
+                                        K.int32(16 * b) + rtid % K.int32(16),
+                                        (rtid // K.int32(32)) * K.int32(16)
+                                        + (rtid % K.int32(32)) // K.int32(16) * K.int32(8),
+                                    )
+                                ]
+                            ),
+                            # The four .x4 matrices tile the 16x16 region as
+                            # (0,0),(1,0),(0,1),(1,1) while the T2R fragment
+                            # walks columns first, so operands 1 and 2 trade
+                            # places -- otherwise each region lands transposed.
+                            rp[4 * b],
+                            rp[4 * b + 2],
+                            rp[4 * b + 1],
+                            rp[4 * b + 3],
+                        )
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    p_p.full.arrive(0)
+                    st_p.advance()
+                    p_s.empty.arrive(0)
+
+                    p_dp.full.wait(0, st_dp.phase)
+                    p_ds.empty.wait(0, st_ds.phase ^ 1)
+                    rdp = K.alloc_local([32], "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                        *[rdp[i] for i in range(32)], t_dp
+                    )
+
+                    # dS = (dP + sum_OdO) * P * softmax_scale. `sum_OdO` is
+                    # already negated upstream (sum_OdO_scale = -1.0, :488), so
+                    # this add IS the `dP - delta` of the softmax backward, and
+                    # rs still holds P.
+                    sum2_lo = K.local_scalar("uint64")
+                    sum2_hi = K.local_scalar("uint64")
+                    K.ptx.mov.b64(sum2_lo, sum_lo, sum_lo)
+                    K.ptx.mov.b64(sum2_hi, sum_hi, sum_hi)
+                    scl2 = K.local_scalar("uint64")
+                    K.ptx.mov.b64(scl2, scale, scale)
+                    for i in range(0, 32, 2):
+                        packed = K.local_scalar("uint64")
+                        K.ptx.mov.b64(packed, rdp[i], rdp[i + 1])
+                        addend = sum2_lo if (i % 4) < 2 else sum2_hi
+                        K.ptx["add.rn.f32x2"](packed, packed, addend)
+                        pv = K.local_scalar("uint64")
+                        K.ptx.mov.b64(pv, rs[i], rs[i + 1])
+                        K.ptx["mul.rn.f32x2"](packed, packed, pv)
+                        # The `* softmax_scale` is folded into the quantize
+                        # upstream (:1938); it is one packed multiply either way.
+                        K.ptx["mul.f32x2"](packed, packed, scl2)
+                        K.ptx.mov.b64(rdp[i], rdp[i + 1], packed)
+
+                    # dS follows P through the identical transposing store; it
+                    # is the dKV MMA's A operand.
+                    rq = K.alloc_local([16], "uint32")
+                    for i in range(16):
+                        K.ptx[_CVT_PACK[dtype]](rq[i], rdp[2 * i + 1], rdp[2 * i])
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    # dP's TMEM is dead once the quantize above has read it, so
+                    # it is released before the stores rather than after
+                    # (:1943 precedes :1946).
+                    p_dp.empty.arrive(0)
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    for b in range(4):
+                        K.ptx["stmatrix.sync.aligned.m8n8.x4.trans.shared.b16"](
+                            smem.ptr_to(
+                                [
+                                    _tile_byte(
+                                        OFF_DS,
+                                        K.int32(16 * b) + rtid % K.int32(16),
+                                        (rtid // K.int32(32)) * K.int32(16)
+                                        + (rtid % K.int32(32)) // K.int32(16) * K.int32(8),
+                                    )
+                                ]
+                            ),
+                            rq[4 * b],
+                            rq[4 * b + 2],
+                            rq[4 * b + 1],
+                            rq[4 * b + 3],
+                        )
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    p_ds.full.arrive(0)
+                    st_ds.advance()
+
+                    st_s.advance()
+                    st_dp.advance()
+                    K.assign(idx, idx - K.int32(1))
+
+                p_lse.empty.arrive(0)
+                p_sum.empty.arrive(0)
+
+                # --- dQ epilogue: 4 rounds (5 at d576) (:2033-2140) --------
+                # One wait for the whole epilogue: dQ was committed once.
+                p_dq.full.wait(0, 0)
+                t_dq_e = [
+                    (tcol, off)
+                    for off in (TMEM_DQ0_OFFSET, TMEM_DQ1_OFFSET, TMEM_DQ2_OFFSET, TMEM_DQ3_OFFSET)
+                ]
+                for i in range(4):
+                    with K.If(rwarp == K.int32(0)), K.Then():
+                        # A TMA-store pipeline acquires on the bulk group; it
+                        # has no smem barrier at all.
+                        K.ptx["cp.async.bulk.wait_group.read"](K.int32(0))
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    # 32x32b, NOT the dKV path's 16x256b: this shape is what
+                    # makes the fragment match the 128x64 epilogue tile. Thread
+                    # t owns dim t; its 64 registers are the 64 heads, eight
+                    # heads per issue.
+                    rdq = K.alloc_local([64], "float32")
+                    for e in range(8):
+                        a = K.cuda.get_tmem_addr(
+                            t_dq_e[i][0], K.int32(0), K.int32(t_dq_e[i][1] + 8 * e)
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                            *[rdq[8 * e + k] for k in range(8)], a
+                        )
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    # Scalar converts and scalar stores, deliberately: the
+                    # source does not vectorize this and it is the largest
+                    # instruction count in the kernel.
+                    for j in range(64):
+                        qv = K.local_scalar("uint16")
+                        K.ptx[_CVT_NARROW[dtype]](qv, rdq[j])
+                        K.ptx["st.shared.b16"](
+                            smem.ptr_to([_tile_byte(OFF_DQ, K.int32(j), rtid)]), qv
+                        )
+                    # Two barriers around the fence: the first makes every
+                    # thread's shared writes done, the second makes the fence
+                    # observed before warp 4 issues the TMA (:2545-2552).
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    with K.If(rwarp == K.int32(0)), K.Then():
+                        for h in range(2):
+                            K.ptx[TMA_S2G](
+                                K.address_of(desc_dq),
+                                K.int32(i * 128 + h * 64),
+                                head_block * K.int32(block),
+                                token,
+                                smem.ptr_to([OFF_DQ + h * 8192]),
+                                K.uint64(0),
+                            )
+                        K.ptx["cp.async.bulk.commit_group"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                if tail:
+                    # The fifth round (:2116-2135). THIS is the only path by
+                    # which d576's dQ columns 512:576 reach mdQ; omitting it
+                    # leaves them whatever `torch.empty_like` left there, which
+                    # a d512 test cannot detect.
+                    with K.If(rwarp == K.int32(0)), K.Then():
+                        K.ptx["cp.async.bulk.wait_group.read"](K.int32(0))
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    # 16x256b.x2, four issues of 8: M=64 halves the fragment
+                    # and the head steps by 16 per issue.
+                    rq4 = K.alloc_local([32], "float32")
+                    for e in range(4):
+                        a4 = K.cuda.get_tmem_addr(
+                            tcol, K.int32(0), K.int32(TMEM_DQ4_OFFSET + 16 * e)
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                            *[rq4[8 * e + k] for k in range(8)], a4
+                        )
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    dim_b = (rtid // K.int32(32)) * K.int32(16) + (rtid % K.int32(32)) // K.int32(4)
+                    head_b = (rtid % K.int32(4)) * K.int32(2)
+                    for j in range(32):
+                        qv = K.local_scalar("uint16")
+                        K.ptx[_CVT_NARROW[dtype]](qv, rq4[j])
+                        # Scalar, not vectorized: the tail's coordinates are
+                        # not contiguous per thread (:2596).
+                        K.ptx["st.shared.b16"](
+                            smem.ptr_to(
+                                [
+                                    _tile_byte(
+                                        OFF_DQ4,
+                                        head_b + K.int32((j % 2) + (j // 4) * 8),
+                                        dim_b + K.int32(((j // 2) % 2) * 8),
+                                    )
+                                ]
+                            ),
+                            qv,
+                        )
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+                    with K.If(rwarp == K.int32(0)), K.Then():
+                        K.ptx[TMA_S2G](
+                            K.address_of(desc_dq),
+                            K.int32(512),
+                            head_block * K.int32(block),
+                            token,
+                            smem.ptr_to([OFF_DQ4]),
+                            K.uint64(0),
+                        )
+                        K.ptx["cp.async.bulk.commit_group"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE_SYNC[0]), K.uint32(BAR_COMPUTE_SYNC[1]))
+
+                p_dq.empty.arrive(0)
+                # producer_tail: drain every outstanding store before the CTA
+                # may free sdQ or exit.
+                K.ptx["cp.async.bulk.wait_group.read"](K.int32(0))
+
+                with K.If(rwarp == K.int32(0)), K.Then():
+                    # Barrier 9 is compute warp 4 plus the 8 reduce warps: the
+                    # reduce warps must be drained out of TMEM before its
+                    # columns are handed back (:120, :1095).
+                    K.ptx.bar.sync(K.uint32(BAR_TMEM_DEALLOC[0]), K.uint32(BAR_TMEM_DEALLOC[1]))
+                    K.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](
+                        tcol, K.uint32(TMEM_ALLOC_COLUMNS)
+                    )
+
+            with r_reduce:
+                K.ptx.bar.sync(K.uint32(BAR_TMEM_ALLOC[0]), K.uint32(BAR_TMEM_ALLOC[1]))
+                rtcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(rtcol, tmem_hold.ptr_to([0]))
+                rtid = K.tid_in_role()
+                wg = rtid // K.int32(128)  # two warpgroups split the 64 KV rows
+                wtid = rtid % K.int32(128)
+
+                def t2r(col):
+                    """One sub-tile's 32 f32: two `16x256b.x4` issues.
+
+                    The second issue sits 16 lanes above the first (`:5708`,
+                    base + 1048640 = column + (16 << 16)); that lane step is
+                    what advances the DIM. The warpgroup steps the COLUMN by
+                    32, because columns are the KV rows and the two warpgroups
+                    split those (`split_wg`, :2628).
+                    """
+                    regs = K.alloc_local([32], "float32")
+                    for e in range(2):
+                        a = K.cuda.get_tmem_addr(
+                            rtcol, K.int32(16 * e), K.int32(col) + wg * K.int32(32)
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                            *[regs[16 * e + j] for j in range(16)], a
+                        )
+                    return regs
+
+                def t2r1(col):
+                    """The d576 tail: M=64, so ONE issue of 16 (`:2244`).
+
+                    Its dim base steps by 16 per warp rather than 32, because
+                    the accumulator is half as tall; reading it with the 128-
+                    wide map walks off the end of the 64-dim tail.
+                    """
+                    regs = K.alloc_local([16], "float32")
+                    a = K.cuda.get_tmem_addr(rtcol, K.int32(0), K.int32(col) + wg * K.int32(32))
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                        *[regs[j] for j in range(16)], a
+                    )
+                    return regs
+
+                # The workspace column group is the thread's index within its
+                # warpgroup, NOT a dim: threads 4k..4k+3 share the group and
+                # differ only in row, which is what makes the four values of
+                # one atomic contiguous (k_api_findings.md).
+                col_group = (wtid // K.int32(4)) * K.int32(4)
+                row_base = wg * K.int32(32) + (wtid % K.int32(4)) * K.int32(2)
+
+                full_tiles = (topk % K.int32(block)) == K.int32(0)  # :2194
+
+                def rows_for(tile_index):
+                    """The 8 KV rows this thread reduces, or -1 where invalid."""
+                    r = K.alloc_local([8], "int32")
+                    for i in range(8):
+                        g = tile_index * K.int32(block) + row_base + K.int32((i // 2) * 8 + (i % 2))
+                        K.assign(r[i], K.int32(-1))
+                        # With a whole number of tiles every row is in range,
+                        # so the read needs no bound (:2202); the ragged case
+                        # keeps it (:2205).
+                        with K.If(full_tiles):
+                            with K.Then():
+                                K.ptx["ld.global.b32"](
+                                    r[i], topk_idxs.ptr_to([token * K.int32(max_topk) + g])
+                                )
+                            with K.Else():
+                                with K.If(g < topk), K.Then():
+                                    K.ptx["ld.global.b32"](
+                                        r[i], topk_idxs.ptr_to([token * K.int32(max_topk) + g])
+                                    )
+                    return r
+
+                # `atom` rather than `red` because the vector forms live only
+                # under `atom` in the table; the returned values are dead, which
+                # is what the source's own `atom.global.add.v4.f32` does too.
+                sink4 = K.alloc_local([4], "float32")
+
+                def reduce4(regs, r, sub_tile):
+                    """`atom.global.add.v4.f32` per row: four dims, one row."""
+                    for i in range(8):
+                        b = i * 2 - i % 2
+                        with K.If(r[i] >= K.int32(0)), K.Then():
+                            K.ptx["atom.global.add.v4.f32"](
+                                sink4[0],
+                                sink4[1],
+                                sink4[2],
+                                sink4[3],
+                                ws_dkv.ptr_to(
+                                    [r[i] * K.int32(head_dim) + K.int32(sub_tile * 128) + col_group]
+                                ),
+                                regs[b],
+                                regs[b + 2],
+                                regs[b + 16],
+                                regs[b + 18],
+                            )
+                    K.ptx.bar.sync(K.uint32(BAR_REDUCE_SYNC[0]), K.uint32(BAR_REDUCE_SYNC[1]))
+
+                st_r = K.PipelineState(2, phase=0)
+                ridx = K.local_scalar(K.i32, init=tile_count - K.int32(1))
+                with K.While(ridx >= K.int32(0)):
+                    r = rows_for(ridx)
+
+                    # --- generation A: dKV0, dKV1 (:2223-2235) --------------
+                    p_dkv.full.wait(st_r.stage, st_r.phase)
+                    g0 = t2r(TMEM_DKV0_OFFSET)
+                    g1 = t2r(TMEM_DKV1_OFFSET)
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    # The registers are drained and the MMA warp released
+                    # BEFORE the slow atomics -- that split is the whole point
+                    # of the WAR barrier scheme (:2231).
+                    K.ptx.bar.sync(K.uint32(BAR_T2R_DKV01_DONE[0]), K.uint32(BAR_T2R_DKV01_DONE[1]))
+                    reduce4(g0, r, 0)
+                    reduce4(g1, r, 1)
+                    p_dkv.empty.arrive(st_r.stage)
+                    st_r.advance()
+
+                    if tail:
+                        p_dkv.full.wait(st_r.stage, st_r.phase)
+                        g4 = t2r1(TMEM_DKV4_OFFSET)
+                        K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                        K.ptx.bar.sync(
+                            K.uint32(BAR_T2R_DKV4_DONE[0]), K.uint32(BAR_T2R_DKV4_DONE[1])
+                        )
+                        # The tail is 64 dims wide, so a 2-wide atomic.
+                        for i in range(8):
+                            b = i * 2 - i % 2
+                            with K.If(r[i] >= K.int32(0)), K.Then():
+                                K.ptx["atom.global.add.v2.f32"](
+                                    sink4[0],
+                                    sink4[1],
+                                    ws_dkv.ptr_to(
+                                        [
+                                            r[i] * K.int32(head_dim)
+                                            + K.int32(512)
+                                            + (wtid // K.int32(4)) * K.int32(2)
+                                        ]
+                                    ),
+                                    g4[b],
+                                    g4[b + 2],
+                                )
+                        K.ptx.bar.sync(K.uint32(BAR_REDUCE_SYNC[0]), K.uint32(BAR_REDUCE_SYNC[1]))
+                        p_dkv.empty.arrive(st_r.stage)
+                        st_r.advance()
+
+                    # --- generation B: dKV2, dKV3 (:2252-2277) --------------
+                    p_dkv.full.wait(st_r.stage, st_r.phase)
+                    g2 = t2r(dkv2_offset)
+                    g3 = t2r(TMEM_DKV3_OFFSET)
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    K.ptx.bar.sync(K.uint32(war_gen_a[0]), K.uint32(war_gen_a[1]))
+                    reduce4(g2, r, 2)
+                    reduce4(g3, r, 3)
+                    p_dkv.empty.arrive(st_r.stage)
+                    st_r.advance()
+
+                    K.assign(ridx, ridx - K.int32(1))
+
+                # The reduce warps must not stall here -- they are done (:1095).
+                K.ptx["bar.arrive"](K.uint32(BAR_TMEM_DEALLOC[0]), K.uint32(BAR_TMEM_DEALLOC[1]))
+
+            with r_loadkv:
+                _bwd_load_kv(
+                    kv,
+                    topk_idxs,
+                    smem,
+                    OFF_K,
+                    p_k,
+                    tile_count,
+                    topk,
+                    token,
+                    tid,
+                    lane,
+                    head_dim,
+                    seqlen_kv,
+                    max_topk,
+                    has_topk_length,
+                    block,
+                )
+
+            with r_empty:
+                pass
+
+            _unused = (seqlen_q, scale)
 
     return bwd
 
 
-def make_sum_odo_kernel(*, head_dim, num_head, dtype, max_topk):
-    """Trace the delta / sink-folded-LSE preprocess kernel."""
+# ``dsa_bwd_sm100.py:57-59``: the preprocess block is 8 head-dim lanes by 16
+# query lanes, and each thread loads four elements at a time.
+SUM_ODO_THREADS_D = 8
+SUM_ODO_THREADS_Q = 16
+SUM_ODO_ELEM_PER_LOAD = 4
 
-    @K.kernel(warps=4, arch="sm_100a", min_blocks_per_sm=1, grid=False)
-    def sum_odo():
-        # ---- kernel body starts here ----
-        pass
+
+def _shfl_bfly_f32(value, lane_xor):
+    """One ``shfl.sync.bfly.b32`` on an f32, reinterpreted through u32."""
+    out = K.local_scalar(K.u32)
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret(K.f32, out)
+
+
+def _butterfly_sum_f32(value, lane_xors):
+    """Sum across the lanes an xor-mask set spans; clamp 31 keeps it in-group."""
+    for lane_xor in lane_xors:
+        peer = _shfl_bfly_f32(value, lane_xor)
+        total = K.local_scalar(K.f32)
+        K.ptx.add.f32(total, value, peer)
+        value = total
+    return value
+
+
+def make_sum_odo_kernel(*, head_dim, num_head, dtype, max_topk):
+    """Trace the delta / sink-folded-LSE preprocess kernel (``:648-707``).
+
+    Writes, per ``(head, query)``, ``sum_OdO = -sum_d(O * dO)`` and
+    ``scaled_lse = -(log2(e) * log(exp(lse) + exp(sink)))`` into the two f32
+    planes of the LSE/OdO workspace.
+    """
+    head_dim_v = spec.head_dim_v_for(head_dim)
+    block_q = 40 if max_topk == 1024 else 41  # :56, an odd tuned block height
+    elem = _ELEM[dtype]
+    mul_half = _MUL_HALF[dtype]
+    add_wide = _ADD_WIDE[dtype]
+    cvt_wide = _CVT_WIDE[dtype]
+    d_steps = head_dim_v // SUM_ODO_ELEM_PER_LOAD // SUM_ODO_THREADS_D
+    q_arms = (block_q + SUM_ODO_THREADS_Q - 1) // SUM_ODO_THREADS_Q
+
+    @K.kernel(
+        warps=(SUM_ODO_THREADS_D * SUM_ODO_THREADS_Q) // 32,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=lambda p: [(p["seqlen_q"] + block_q - 1) // block_q, num_head, 1],
+    )
+    def sum_odo(
+        out: K.gptr[elem],
+        dout: K.gptr[elem],
+        lse: K.gptr[K.f32],
+        attn_sink: K.gptr[K.f32],
+        ws: K.gptr[K.f32],
+        seqlen_q: K.i32,
+        plane: K.i32,
+        sum_odo_scale: K.f32,
+        lse_scale: K.f32,
+    ):
+        tid = K.thread_id()
+        q_block, head, _b = K.cta_id()
+        # blockDim was (8, 16, 1) upstream; the flat id splits the same way.
+        tidx = tid % SUM_ODO_THREADS_D
+        tidy = tid // SUM_ODO_THREADS_D
+
+        log2_e = K.local_scalar(K.f32)
+        K.ptx.neg.f32(log2_e, lse_scale)  # lse_scale is -log2(e) (:489)
+
+        for arm in range(q_arms):
+            idx_q_t = tidy + arm * SUM_ODO_THREADS_Q
+            idx_q = idx_q_t + block_q * q_block
+            with K.If((idx_q_t < K.int32(block_q)) & (idx_q < seqlen_q)), K.Then():
+                acc = K.local_scalar(K.f32, init=K.float32(0.0))
+                base_o = idx_q * (num_head * head_dim_v) + head * head_dim_v
+                # A rolled walk over the head dimension, as upstream (`:678`):
+                # one body, not `d_steps` copies of it.
+                step = K.local_scalar(K.i32, init=K.int32(0))
+                with K.While(step < K.int32(d_steps)):
+                    d = (tidx + step * K.int32(SUM_ODO_THREADS_D)) * K.int32(SUM_ODO_ELEM_PER_LOAD)
+                    ow = K.alloc_local([2], "uint32")
+                    dw = K.alloc_local([2], "uint32")
+                    K.ptx["ld.global.v2.b32"](ow[0], ow[1], out.ptr_to([base_o + d]))
+                    K.ptx["ld.global.v2.b32"](dw[0], dw[1], dout.ptr_to([base_o + d]))
+                    narrow = []
+                    for half in range(2):
+                        prod = K.local_scalar(K.u32)
+                        K.ptx[mul_half](prod, ow[half], dw[half])
+                        # The narrow multiply is load-bearing: forming the
+                        # product in fp32 instead shifts every delta by ~1e-3
+                        # relative, and delta feeds dS on every tile.
+                        lo = K.local_scalar("uint16")
+                        hi = K.local_scalar("uint16")
+                        K.ptx["mov.b32"](lo, hi, prod)
+                        narrow += [lo, hi]
+                    # The 4-element fragment is reduced into f32 first -- one
+                    # real widening convert and three widening adds -- and only
+                    # the result joins the accumulator, with a plain add.f32
+                    # (:682-683). Accumulating each element straight into `acc`
+                    # would collapse all three of those into one add family.
+                    frag = K.local_scalar(K.f32)
+                    K.ptx[cvt_wide](frag, narrow[0])
+                    for nv in narrow[1:]:
+                        # `add.rn.f32.<narrow>` takes the narrow value first.
+                        K.ptx[add_wide](frag, nv, frag)
+                    K.ptx["add.f32"](acc, acc, frag)
+                    K.assign(step, step + K.int32(1))
+
+                total = _butterfly_sum_f32(acc, (1, 2, 4))
+
+                with K.If(tidx == K.int32(0)), K.Then():
+                    lse_v = K.local_scalar(K.f32)
+                    sink_v = K.local_scalar(K.f32)
+                    K.ptx["ld.global.b32"](lse_v, lse.ptr_to([idx_q * num_head + head]))
+                    K.ptx["ld.global.b32"](sink_v, attn_sink.ptr_to([head]))
+
+                    lse_log2 = K.local_scalar(K.f32)
+                    sink_log2 = K.local_scalar(K.f32)
+                    K.ptx["mul.f32"](lse_log2, lse_v, log2_e)
+                    K.ptx["mul.f32"](sink_log2, sink_v, log2_e)
+                    m = K.local_scalar(K.f32)
+                    K.ptx["max.f32"](m, lse_log2, sink_log2)
+                    # exp2 of each shifted term, summed, then log2: the
+                    # numerically safe fold of the sink into the denominator.
+                    a = K.local_scalar(K.f32)
+                    b = K.local_scalar(K.f32)
+                    K.ptx["sub.f32"](a, lse_log2, m)
+                    K.ptx["sub.f32"](b, sink_log2, m)
+                    ea = K.local_scalar(K.f32)
+                    eb = K.local_scalar(K.f32)
+                    K.ptx["ex2.approx.f32"](ea, a)
+                    K.ptx["ex2.approx.f32"](eb, b)
+                    ssum = K.local_scalar(K.f32)
+                    K.ptx["add.f32"](ssum, ea, eb)
+                    lg = _log2_soft(ssum)
+                    with_sink = K.local_scalar(K.f32)
+                    K.ptx["add.f32"](with_sink, m, lg)
+                    scaled = K.local_scalar(K.f32)
+                    K.ptx["neg.f32"](scaled, with_sink)
+
+                    # lse == +inf means the row selected nothing; the sink must
+                    # not resurrect it (:703-704).
+                    is_inf = K.local_scalar("uint32")
+                    K.ptx["setp.eq.f32"](is_inf, lse_v, K.float32(float("inf")))
+                    out_lse = K.local_scalar(K.f32)
+                    K.ptx["selp.f32"](out_lse, K.float32(float("-inf")), scaled, K.ptx.pred(is_inf))
+
+                    scaled_odo = K.local_scalar(K.f32)
+                    K.ptx["mul.f32"](scaled_odo, sum_odo_scale, total)
+                    slot = idx_q * num_head + head
+                    K.ptx["st.global.b32"](ws.ptr_to([slot]), scaled_odo)
+                    K.ptx["st.global.b32"](ws.ptr_to([plane + slot]), out_lse)
 
     return sum_odo
 
 
 def make_convert_kernel(*, head_dim, dtype, max_topk):
-    """Trace the FP32 dKV workspace to element-dtype conversion kernel."""
+    """Trace the FP32 dKV workspace to element-dtype conversion (``:609-646``).
 
-    @K.kernel(warps=1, arch="sm_100a", grid=False)
-    def convert():
+    Inverts the two fragment scrambles ``reduce_dKV`` wrote with: the 128-wide
+    sub-tiles used a 4-wide atomic and the d576 tail a 2-wide one, so the two
+    halves need different unscramble maps. Every access here is scalar --
+    ``convert_elem_per_load = 4`` does not reach it.
+    """
+    elem = _ELEM[dtype]
+    head_dim_main = (head_dim // 128) * 128
+    has_tail = head_dim_main != head_dim
+    # ``:568-570``: both keyed off max_topk.
+    block_seq = 4 if max_topk == 2048 else 32
+    threads_seq = 4 if max_topk == 2048 else block_seq
+    threads_d = 32
+
+    @K.kernel(
+        warps=(threads_d * threads_seq) // 32,
+        arch="sm_100a",
+        grid=lambda p: [(p["seqlen_kv"] + block_seq - 1) // block_seq, 1, 1],
+    )
+    def convert(ws_dkv: K.gptr[K.f32], dkv: K.gptr[elem], seqlen_kv: K.i32):
         # ---- kernel body starts here ----
-        pass
+        seq_block, _y, _z = K.cta_id()
+        tid = K.thread_id()
+        tidx = tid % threads_d
+        tidy = tid // threads_d
+
+        seq_id = block_seq * seq_block + tidy
+        with K.If(seq_id < seqlen_kv), K.Then():
+            row = seq_id * head_dim
+            for i in range(head_dim_main // 64):
+                for j in range(2):
+                    src = tidx + j * 32 + i * 64
+                    v = K.local_scalar(K.f32)
+                    K.ptx["ld.global.b32"](v, ws_dkv.ptr_to([row + src]))
+                    # Inverse of the 128-wide store's 4-wide fragment gather:
+                    # a 4x8 transpose inside each 32-element block.
+                    dim = tidx // 4 + (tidx % 4) * 8 + j * 32 + i * 64
+                    nv = K.local_scalar("uint16")
+                    K.ptx[_CVT_NARROW[dtype]](nv, v)
+                    K.ptx["st.global.b16"](dkv.ptr_to([row + dim]), nv)
+            if has_tail:
+                for j in range(2):
+                    src = tidx + j * 32 + head_dim_main
+                    v = K.local_scalar(K.f32)
+                    K.ptx["ld.global.b32"](v, ws_dkv.ptr_to([row + src]))
+                    # A DIFFERENT inverse: the 64-wide tail store used a 2-wide
+                    # fragment, so its scramble is not the 128-wide one.
+                    kk = tidx // 2 + j * 16
+                    dim = head_dim_main + (kk // 8) * 16 + kk % 8 + (tidx % 2) * 8
+                    nv = K.local_scalar("uint16")
+                    K.ptx[_CVT_NARROW[dtype]](nv, v)
+                    K.ptx["st.global.b16"](dkv.ptr_to([row + dim]), nv)
 
     return convert
 
 
-def make_sum_dsink_kernel(*, num_head):
-    """Trace the attention-sink gradient reduction kernel."""
+# ``dsa_bwd_sm100.py:60-61``: the sink-gradient kernel is one warp per 256
+# queries.
+DSINK_BLOCK_Q = 256
+DSINK_THREADS = 32
 
-    @K.kernel(warps=1, arch="sm_100a", min_blocks_per_sm=1, grid=False)
-    def sum_dsink():
+
+def make_sum_dsink_kernel(*, num_head):
+    """Trace the attention-sink gradient reduction kernel (``:709-738``).
+
+    ``d_sink[h] += sum_q exp2(sink*log2e + scaled_lse[h,q]) * sum_OdO[h,q]``,
+    warp-reduced then accumulated with one scalar atomic per CTA.
+    """
+
+    @K.kernel(
+        warps=DSINK_THREADS // 32,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=lambda p: [(p["seqlen_q"] + DSINK_BLOCK_Q - 1) // DSINK_BLOCK_Q, num_head, 1],
+    )
+    def sum_dsink(
+        ws: K.gptr[K.f32],
+        attn_sink: K.gptr[K.f32],
+        d_sink: K.gptr[K.f32],
+        seqlen_q: K.i32,
+        plane: K.i32,
+    ):
         # ---- kernel body starts here ----
-        pass
+        q_block, head, _b = K.cta_id()
+        tid = K.thread_id()
+
+        log2_e = K.float32(1.4426950408889634)
+        sink_v = K.local_scalar(K.f32)
+        K.ptx["ld.global.b32"](sink_v, attn_sink.ptr_to([head]))
+        sink_log2 = K.local_scalar(K.f32)
+        K.ptx["mul.f32"](sink_log2, sink_v, log2_e)
+
+        # `q_end` clamps the last block; the stride is the warp width, so a
+        # thread walks its own column of the 256-query block.
+        q_end = K.local_scalar(K.i32, init=(q_block + 1) * DSINK_BLOCK_Q)
+        with K.If(q_end > seqlen_q), K.Then():
+            K.assign(q_end, seqlen_q)
+
+        acc = K.local_scalar(K.f32, init=K.float32(0.0))
+        q_idx = K.local_scalar(K.i32, init=q_block * DSINK_BLOCK_Q + tid)
+        with K.While(q_idx < q_end):
+            slot = q_idx * num_head + head
+            sl = K.local_scalar(K.f32)
+            K.ptx["ld.global.b32"](sl, ws.ptr_to([plane + slot]))
+            arg = K.local_scalar(K.f32)
+            K.ptx["add.f32"](arg, sink_log2, sl)
+            p_sink = K.local_scalar(K.f32)
+            K.ptx["ex2.approx.f32"](p_sink, arg)
+            odo = K.local_scalar(K.f32)
+            K.ptx["ld.global.b32"](odo, ws.ptr_to([slot]))
+            K.ptx["fma.rn.f32"](acc, p_sink, odo, acc)
+            K.assign(q_idx, q_idx + DSINK_THREADS)
+
+        total = _butterfly_sum_f32(acc, (1, 2, 4, 8, 16))
+
+        with K.If(tid == 0), K.Then():
+            prev = K.local_scalar(K.f32)
+            K.ptx.atom.global_.add.f32(prev, d_sink.ptr_to([head]), total)
 
     return sum_dsink
 

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -44,9 +44,9 @@ BWD_THREADS = BWD_WARPS * 32
 REGS_LOAD_KV = 40
 REGS_COMPUTE = 128
 REGS_REDUCE = 128
-REGS_MMA = 40
-REGS_LOAD = 40
-REGS_EMPTY = 40
+REGS_MMA = 56
+REGS_LOAD = 56
+REGS_EMPTY = 56
 
 # ``dsa_bwd_sm100.py:82-131``: named barrier ids and their participant counts.
 BAR_CTA_SYNC = (1, 640)
@@ -200,7 +200,7 @@ def _desc_add16(desc, offset):
     return out
 
 
-def _gemm(d, a, b, idesc, accumulate, n_iter, unroll):
+def _gemm(d, a, b, idesc, accumulate, n_iter, unroll, pred=None):
     """One tcgen05 k-loop, ROLLED: `n_iter` iterations of `unroll` issues.
 
     The source's chains are rolled loops, not fully unrolled ones (`unroll=4`
@@ -223,24 +223,42 @@ def _gemm(d, a, b, idesc, accumulate, n_iter, unroll):
     b_desc, b_it, b_u = b
     flag = K.local_scalar("uint32")
     K.assign(flag, K.cast(accumulate, "uint32"))
+    # The descriptors walk forward by one iteration step rather than being
+    # rebuilt from the base each issue. Every per-issue offset is then a
+    # trace-time constant, which drops a runtime multiply and an add from the
+    # issuing warp's critical path -- and that warp is what the reduce warps
+    # wait on at the write-after-read barriers.
+    a_cur = K.local_scalar("uint64")
+    b_cur = K.local_scalar("uint64")
+    K.assign(a_cur, a_desc)
+    K.assign(b_cur, b_desc)
     it = K.local_scalar(K.i32, init=K.int32(0))
     with K.While(it < K.int32(n_iter)):
         for u in range(unroll):
             _mma(
                 MMA_F16,
                 d,
-                _desc_add16(a_desc, it * K.int32(a_it) + K.int32(u * a_u)),
-                _desc_add16(b_desc, it * K.int32(b_it) + K.int32(u * b_u)),
+                _desc_add16(a_cur, u * a_u),
+                _desc_add16(b_cur, u * b_u),
                 idesc,
                 flag,
+                pred,
             )
             K.assign(flag, K.uint32(1))
+        K.assign(a_cur, _desc_add16(a_cur, a_it))
+        K.assign(b_cur, _desc_add16(b_cur, b_it))
         K.assign(it, it + K.int32(1))
 
 
-def _mma(mma, d, a_desc, b_desc, idesc, accumulate):
-    """One `tcgen05.mma` in its dense non-ws operand form."""
-    K.ptx[mma](
+def _mma(mma, d, a_desc, b_desc, idesc, accumulate, pred=None):
+    """One `tcgen05.mma` in its dense non-ws operand form.
+
+    `pred` is the ISA's one-elected-lane issue form as an instruction predicate
+    rather than a branch around the chain: the descriptor arithmetic then runs
+    warp-wide with no reconvergence, which is what keeps the issuing warp from
+    diverging on every chain.
+    """
+    ops = (
         K.Cast("uint32", d),
         a_desc,
         b_desc,
@@ -251,6 +269,10 @@ def _mma(mma, d, a_desc, b_desc, idesc, accumulate):
         K.uint32(0),
         K.ptx.pred(accumulate),
     )
+    if pred is None:
+        K.ptx[mma](*ops)
+    else:
+        K.ptx[mma](*ops, pred=pred)
 
 
 # The instruction descriptors every tcgen05 MMA carries, read out of the
@@ -434,8 +456,11 @@ def _bwd_load_kv(
             v = K.local_scalar(K.i32, init=K.int32(-1))
             # The bound is the allocation extent, not `topk`: rows past the
             # length are read and then discarded.
-            with K.If((lane == 0) & (gidx < K.int32(max_topk))), K.Then():
-                K.ptx["ld.global.b32"](v, topk_idxs.ptr_to([token * max_topk + gidx]))
+            K.ptx["ld.global.b32"](
+                v,
+                topk_idxs.ptr_to([token * max_topk + gidx]),
+                pred=(lane == 0) & (gidx < K.int32(max_topk)),
+            )
             bc = K.local_scalar(K.i32)
             K.ptx.shfl_sync.idx.b32(bc, v, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF))
             K.assign(r[i], bc)
@@ -739,6 +764,12 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                     _desc_at(D_WIDE, smem_base + K.uint32(OFF_K + b * 16384)) for b in range(5)
                 ]
 
+                # One elected-lane predicate owns every issue in this role: as an
+                # instruction predicate rather than a branch, the descriptor
+                # arithmetic stays warp-wide and the warp never reconverges.
+                lane0 = K.local_scalar("uint32")
+                K.assign(lane0, K.cast(lane == K.int32(0), "uint32"))
+
                 st_k = K.PipelineState(1, phase=0)
                 st_s = K.PipelineState(1, phase=0)
                 st_dp = K.PipelineState(1, phase=0)
@@ -759,37 +790,37 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                 with K.While(idx >= K.int32(0)):
                     p_k.full.wait(0, st_k.phase)
                     p_s.empty.wait(0, st_s.phase ^ 1)
-                    with K.If(lane == K.int32(0)), K.Then():
-                        # S = Q @ K^T over the whole head dimension: one
-                        # chain, ACCUMULATE false on the first k-phase and true
-                        # after. Q and K share the k walk because both are
-                        # K-major over the same 64-wide block stride.
-                        _gemm(
-                            t_s,
-                            (d_q_k, *(512, 2)),
-                            (d_k_k, *(512, 2)),
-                            idesc["qk"],
-                            0,
-                            head_dim // 64,
-                            4,
-                        )
-                        K.ptx[TCGEN05_COMMIT](p_s.full.buf.ptr_to([0]))
+                    # S = Q @ K^T over the whole head dimension: one
+                    # chain, ACCUMULATE false on the first k-phase and true
+                    # after. Q and K share the k walk because both are
+                    # K-major over the same 64-wide block stride.
+                    _gemm(
+                        t_s,
+                        (d_q_k, *(512, 2)),
+                        (d_k_k, *(512, 2)),
+                        idesc["qk"],
+                        0,
+                        head_dim // 64,
+                        4,
+                        pred=lane0,
+                    )
+                    K.ptx[TCGEN05_COMMIT](p_s.full.buf.ptr_to([0]), pred=lane0)
 
                     # dP = dO @ V^T. V is columns 0:head_dim_v of the shared KV
                     # buffer, so this reads the same gathered tile with a
                     # shorter K extent -- no separate alias needed.
                     p_dp.empty.wait(0, st_dp.phase ^ 1)
-                    with K.If(lane == K.int32(0)), K.Then():
-                        _gemm(
-                            t_dp,
-                            (d_do_k, *(512, 2)),
-                            (d_k_k, *(512, 2)),
-                            idesc["qk"],
-                            0,
-                            head_dim_v // 64,
-                            4,
-                        )
-                        K.ptx[TCGEN05_COMMIT](p_dp.full.buf.ptr_to([0]))
+                    _gemm(
+                        t_dp,
+                        (d_do_k, *(512, 2)),
+                        (d_k_k, *(512, 2)),
+                        idesc["qk"],
+                        0,
+                        head_dim_v // 64,
+                        4,
+                        pred=lane0,
+                    )
+                    K.ptx[TCGEN05_COMMIT](p_dp.full.buf.ptr_to([0]), pred=lane0)
 
                     # --- dKV generation A: dKV0, dKV1 (:1531-1594) ----------
                     # dKV = dO^T @ P, then += Q^T @ dS into the SAME columns:
@@ -801,30 +832,30 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                         # Skipped on the first processed tile and compensated
                         # by one unpaired arrive after the loop (:1752-1757).
                         K.ptx.bar.sync(K.uint32(war_gen_a[0]), K.uint32(war_gen_a[1]))
-                    with K.If(lane == K.int32(0)), K.Then():
-                        for j in range(2):
-                            _gemm(
-                                t_dkv[j],
-                                (d_do_mn[j], *(256, 128)),
-                                (d_p_k, *(4, 2)),
-                                idesc["dkv"],
-                                0,
-                                2,
-                                2,
-                            )
+                    for j in range(2):
+                        _gemm(
+                            t_dkv[j],
+                            (d_do_mn[j], *(256, 128)),
+                            (d_p_k, *(4, 2)),
+                            idesc["dkv"],
+                            0,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
                     p_ds.full.wait(0, st_ds_m.phase)
-                    with K.If(lane == K.int32(0)), K.Then():
-                        for j in range(2):
-                            _gemm(
-                                t_dkv[j],
-                                (d_q_mn[j], *(256, 128)),
-                                (d_ds_k, *(4, 2)),
-                                idesc["dkv"],
-                                1,
-                                2,
-                                2,
-                            )
-                        K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
+                    for j in range(2):
+                        _gemm(
+                            t_dkv[j],
+                            (d_q_mn[j], *(256, 128)),
+                            (d_ds_k, *(4, 2)),
+                            idesc["dkv"],
+                            1,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
+                    K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]), pred=lane0)
                     st_dkv.advance()
 
                     if tail:
@@ -833,46 +864,47 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                         K.ptx.bar.sync(
                             K.uint32(BAR_T2R_DKV01_DONE[0]), K.uint32(BAR_T2R_DKV01_DONE[1])
                         )
-                        with K.If(lane == K.int32(0)), K.Then():
-                            _gemm(
-                                t_dkv4,
-                                (d_q_mn[4], *(256, 128)),
-                                (d_ds_k, *(4, 2)),
-                                idesc["dkv4"],
-                                0,
-                                2,
-                                2,
-                            )
-                            # No matching acquire upstream: the source leans on
-                            # barrier 7 above for what an acquire would give.
-                            K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
+                        _gemm(
+                            t_dkv4,
+                            (d_q_mn[4], *(256, 128)),
+                            (d_ds_k, *(4, 2)),
+                            idesc["dkv4"],
+                            0,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
+                        # No matching acquire upstream: the source leans on
+                        # barrier 7 above for what an acquire would give.
+                        K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]), pred=lane0)
                         st_dkv.advance()
 
                     # --- dQ0..dQ3 (and dQ4) (:1622-1676) --------------------
                     # dQ accumulates across the WHOLE top-k axis in TMEM and is
                     # published only after the loop, so ACCUMULATE is False
                     # only on the first processed tile.
-                    with K.If(lane == K.int32(0)), K.Then():
-                        for j in range(4):
-                            _gemm(
-                                t_dq[j],
-                                (d_k_mn[j], *(256, 128)),
-                                (d_ds_mn, *(256, 128)),
-                                idesc["dq"],
-                                acc_dq,
-                                2,
-                                2,
-                            )
-                        if tail:
-                            _gemm(
-                                t_dq4,
-                                (d_k_mn[4], *(256, 128)),
-                                (d_ds_mn, *(256, 128)),
-                                idesc["dq4"],
-                                acc_dq,
-                                2,
-                                2,
-                            )
+                    for j in range(4):
+                        _gemm(
+                            t_dq[j],
+                            (d_k_mn[j], *(256, 128)),
+                            (d_ds_mn, *(256, 128)),
+                            idesc["dq"],
+                            acc_dq,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
+                    if tail:
+                        _gemm(
+                            t_dq4,
+                            (d_k_mn[4], *(256, 128)),
+                            (d_ds_mn, *(256, 128)),
+                            idesc["dq4"],
+                            acc_dq,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
 
                     # The KV tile's SMEM is reusable from here (:1683).
                     # `p_k`'s empty barrier is tcgen05-flavoured and expects
@@ -882,37 +914,37 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                     # forward, which deadlocks the gather warps from the third
                     # tile on. The commit also carries the real ordering: sK is
                     # reusable only once the MMAs reading it have retired.
-                    with K.If(lane == K.int32(0)), K.Then():
-                        K.ptx[TCGEN05_COMMIT](p_k.empty.buf.ptr_to([0]))
+                    K.ptx[TCGEN05_COMMIT](p_k.empty.buf.ptr_to([0]), pred=lane0)
 
                     # --- dKV generation B: dKV2, dKV3 (:1689-1746) ----------
                     # Unconditional, unlike generation A's WAR barrier.
                     K.ptx.bar.sync(K.uint32(war_gen_b[0]), K.uint32(war_gen_b[1]))
                     p_dkv.empty.wait(st_dkv.stage, st_dkv.phase ^ 1)
-                    with K.If(lane == K.int32(0)), K.Then():
-                        for j in range(2):
-                            _gemm(
-                                t_dkv23[j],
-                                (d_do_mn[2 + j], *(256, 128)),
-                                (d_p_k, *(4, 2)),
-                                idesc["dkv"],
-                                0,
-                                2,
-                                2,
-                            )
-                        K.ptx[TCGEN05_COMMIT](p_p.empty.buf.ptr_to([0]))
-                        for j in range(2):
-                            _gemm(
-                                t_dkv23[j],
-                                (d_q_mn[2 + j], *(256, 128)),
-                                (d_ds_k, *(4, 2)),
-                                idesc["dkv"],
-                                1,
-                                2,
-                                2,
-                            )
-                        K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]))
-                        K.ptx[TCGEN05_COMMIT](p_ds.empty.buf.ptr_to([0]))
+                    for j in range(2):
+                        _gemm(
+                            t_dkv23[j],
+                            (d_do_mn[2 + j], *(256, 128)),
+                            (d_p_k, *(4, 2)),
+                            idesc["dkv"],
+                            0,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
+                    K.ptx[TCGEN05_COMMIT](p_p.empty.buf.ptr_to([0]), pred=lane0)
+                    for j in range(2):
+                        _gemm(
+                            t_dkv23[j],
+                            (d_q_mn[2 + j], *(256, 128)),
+                            (d_ds_k, *(4, 2)),
+                            idesc["dkv"],
+                            1,
+                            2,
+                            2,
+                            pred=lane0,
+                        )
+                    K.ptx[TCGEN05_COMMIT](p_dkv.full.buf.ptr_to([st_dkv.stage]), pred=lane0)
+                    K.ptx[TCGEN05_COMMIT](p_ds.empty.buf.ptr_to([0]), pred=lane0)
                     st_dkv.advance()
 
                     K.assign(acc_dq, K.int32(1))
@@ -928,9 +960,8 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                 # the last one. Exactly ONE compensating arrive closes that
                 # (:1752-1757) -- one per WAR barrier would hang instead.
                 K.ptx.bar.sync(K.uint32(war_gen_a[0]), K.uint32(war_gen_a[1]))
-                with K.If(lane == K.int32(0)), K.Then():
-                    K.ptx[TCGEN05_COMMIT](p_dq.full.buf.ptr_to([0]))
-                    K.ptx[TCGEN05_COMMIT](p_qdo.empty.buf.ptr_to([0]))
+                K.ptx[TCGEN05_COMMIT](p_dq.full.buf.ptr_to([0]), pred=lane0)
+                K.ptx[TCGEN05_COMMIT](p_qdo.empty.buf.ptr_to([0]), pred=lane0)
 
             with r_compute:
                 rwarp = K.warp_id_in_role()
@@ -1305,7 +1336,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                     """`atom.global.add.v4.f32` per row: four dims, one row."""
                     for i in range(8):
                         b = i * 2 - i % 2
-                        with K.If(r[i] >= K.int32(0)), K.Then():
+                        if True:
                             K.ptx["atom.global.add.v4.f32"](
                                 sink4[0],
                                 sink4[1],
@@ -1318,6 +1349,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                                 regs[b + 2],
                                 regs[b + 16],
                                 regs[b + 18],
+                                pred=r[i] >= K.int32(0),
                             )
                     K.ptx.bar.sync(K.uint32(BAR_REDUCE_SYNC[0]), K.uint32(BAR_REDUCE_SYNC[1]))
 
@@ -1350,7 +1382,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                         # The tail is 64 dims wide, so a 2-wide atomic.
                         for i in range(8):
                             b = i * 2 - i % 2
-                            with K.If(r[i] >= K.int32(0)), K.Then():
+                            if True:
                                 K.ptx["atom.global.add.v2.f32"](
                                     sink4[0],
                                     sink4[1],
@@ -1363,6 +1395,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                                     ),
                                     g4[b],
                                     g4[b + 2],
+                                    pred=r[i] >= K.int32(0),
                                 )
                         K.ptx.bar.sync(K.uint32(BAR_REDUCE_SYNC[0]), K.uint32(BAR_REDUCE_SYNC[1]))
                         p_dkv.empty.arrive(st_r.stage)

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -1,0 +1,153 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Device kernels for the DSA sparse attention backward pass.
+
+Upstream source:
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py``.
+
+The upstream ``FlashAttentionDSABackwardSm100.__call__`` launches four kernels on
+one stream, and this module builds the same four in the same order:
+
+1. ``sum_OdO``   -- per ``(head, query)`` delta ``-sum_d(O * dO)`` and the
+   sink-folded log2-domain LSE, written to the LSE/OdO workspace;
+2. ``bwd``       -- the 20-warp main kernel: one CTA per query token, heads on
+   the MMA M axis, top-k KV tiles walked in reverse, dQ stored through TMA and
+   dKV accumulated into an FP32 workspace with global atomics;
+3. ``convert``   -- FP32 dKV workspace to the element dtype, unscrambling the two
+   store fragment layouts;
+4. ``sum_dSink`` -- the attention-sink gradient, warp-reduced then accumulated
+   atomically.
+
+Shapes, allocation sizes and the compile key follow the upstream host wrapper
+``_interface_sm100.py``.
+"""
+
+import tirx_kernels.kern as K
+
+from . import spec
+
+# ``dsa_bwd_sm100.py:64-76``: warp roles of the main kernel and the resulting
+# 640-thread block.
+LOAD_KV_WARPS = (0, 1, 2, 3)
+COMPUTE_WARPS = (4, 5, 6, 7)
+REDUCE_WARPS = (8, 9, 10, 11, 12, 13, 14, 15)
+MMA_WARP = 16
+LOAD_WARP = 17
+EMPTY_WARP = 18
+BWD_WARPS = 20
+
+# ``dsa_bwd_sm100.py:149-154``: declared per-role register budgets.
+REGS_LOAD_KV = 40
+REGS_COMPUTE = 128
+REGS_REDUCE = 128
+REGS_MMA = 40
+REGS_LOAD = 40
+REGS_EMPTY = 40
+
+# ``dsa_bwd_sm100.py:82-131``: named barrier ids and their participant counts.
+BAR_CTA_SYNC = (1, 640)
+BAR_TMEM_ALLOC = (2, 416)
+BAR_COMPUTE_SYNC = (3, 128)
+BAR_LOAD_SYNC = (4, 32)
+BAR_LOAD_KV_SYNC = (5, 128)
+BAR_REDUCE_SYNC = (6, 256)
+BAR_T2R_DKV01_DONE = (7, 288)
+BAR_T2R_DKV4_DONE = (8, 288)
+BAR_TMEM_DEALLOC = (9, 288)
+BAR_T2R_DKV23_DONE = (10, 288)
+
+# ``dsa_bwd_sm100.py:133-147`` with ``block_tile = 64``. dKV2/dKV3 alias
+# dKV0/dKV1 and dKV4 aliases dKV0; the three ``t2r_dKV*_done`` barriers are what
+# keeps those reuses safe.
+TMEM_S_OFFSET = 0
+TMEM_DP_OFFSET = 0
+TMEM_DKV0_OFFSET = 64
+TMEM_DKV1_OFFSET = 128
+TMEM_DKV2_OFFSET = TMEM_DKV0_OFFSET
+TMEM_DKV3_OFFSET = TMEM_DKV1_OFFSET
+TMEM_DQ0_OFFSET = 192
+TMEM_DQ1_OFFSET = 256
+TMEM_DQ2_OFFSET = 320
+TMEM_DQ3_OFFSET = 384
+TMEM_DQ4_OFFSET = 448
+TMEM_DKV4_OFFSET = TMEM_DKV0_OFFSET
+TMEM_ALLOC_COLUMNS = spec.TMEM_CAPACITY_COLUMNS
+
+
+def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
+    """Trace the main backward kernel for one static specialization."""
+    spec.check_dispatch(
+        {
+            "head_dim": head_dim,
+            "dtype": dtype,
+            "topk_mode": "full",
+            "sink_mode": "normal",
+            "has_topk_length": has_topk_length,
+        }
+    )
+
+    @K.kernel(warps=BWD_WARPS, arch="sm_100a", min_blocks_per_sm=1, grid=False)
+    def bwd():
+        # ---- kernel body starts here ----
+        pass
+
+    return bwd
+
+
+def make_sum_odo_kernel(*, head_dim, num_head, dtype, max_topk):
+    """Trace the delta / sink-folded-LSE preprocess kernel."""
+
+    @K.kernel(warps=4, arch="sm_100a", min_blocks_per_sm=1, grid=False)
+    def sum_odo():
+        # ---- kernel body starts here ----
+        pass
+
+    return sum_odo
+
+
+def make_convert_kernel(*, head_dim, dtype, max_topk):
+    """Trace the FP32 dKV workspace to element-dtype conversion kernel."""
+
+    @K.kernel(warps=1, arch="sm_100a", grid=False)
+    def convert():
+        # ---- kernel body starts here ----
+        pass
+
+    return convert
+
+
+def make_sum_dsink_kernel(*, num_head):
+    """Trace the attention-sink gradient reduction kernel."""
+
+    @K.kernel(warps=1, arch="sm_100a", min_blocks_per_sm=1, grid=False)
+    def sum_dsink():
+        # ---- kernel body starts here ----
+        pass
+
+    return sum_dsink
+
+
+def get_kernel(**config):
+    """Return the four device functions in the upstream launch order."""
+    head_dim = config["head_dim"]
+    num_head = config["num_head"]
+    dtype = config["dtype"]
+    max_topk = config["max_topk"]
+    has_topk_length = config["has_topk_length"]
+    return [
+        make_sum_odo_kernel(
+            head_dim=head_dim, num_head=num_head, dtype=dtype, max_topk=max_topk
+        ).func,
+        make_bwd_kernel(
+            head_dim=head_dim,
+            num_head=num_head,
+            dtype=dtype,
+            max_topk=max_topk,
+            has_topk_length=has_topk_length,
+        ).func,
+        make_convert_kernel(head_dim=head_dim, dtype=dtype, max_topk=max_topk).func,
+        make_sum_dsink_kernel(num_head=num_head).func,
+    ]

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -337,7 +337,11 @@ def _bwd_load(
     for desc in (desc_q, desc_do, desc_dq):
         K.ptx.prefetch.tensormap(K.address_of(desc))
 
-    with K.If(lane == 0), K.Then():
+    # One hardware election owns this whole transfer group -- the expect_tx and
+    # every TMA issue behind it. `lane == 0` is a per-lane comparison ptxas
+    # cannot read as an election, and it rebuilds one around the group.
+    qdo_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+    with K.If(qdo_leader != K.uint32(0)), K.Then():
         # The Q/dO pipeline is acquired before the transfer is announced
         # (:1152-1155); it runs once, so the wait is on the initial phase.
         p_qdo.empty.wait(0, 1)
@@ -447,6 +451,9 @@ def _bwd_load_kv(
     groups = head_dim // 64
     full_tiles = (topk % K.int32(block)) == K.int32(0)  # :1344
 
+    lane0_rd = K.local_scalar("uint32")
+    K.assign(lane0_rd, K.cast(lane == K.int32(0), "uint32"))
+
     def read_indices(tile_index):
         """This warp's 16 top-k indices, read by lane 0 and broadcast."""
         r = K.alloc_local([16], "int32")
@@ -455,12 +462,16 @@ def _bwd_load_kv(
             gidx = tile_index * K.int32(block) + K.int32(row)
             v = K.local_scalar(K.i32, init=K.int32(-1))
             # The bound is the allocation extent, not `topk`: rows past the
-            # length are read and then discarded.
-            K.ptx["ld.global.b32"](
-                v,
-                topk_idxs.ptr_to([token * max_topk + gidx]),
-                pred=(lane == 0) & (gidx < K.int32(max_topk)),
-            )
+            # length are read and then discarded. It is also dead whenever the
+            # extent is a whole number of blocks, which every compiled shape
+            # is: the walk stops at `tile_count * block`, and that is at most
+            # `max_topk`. Dropping it leaves one comparison where combining the
+            # two needed a predicate operation on every read.
+            if max_topk % block:
+                issue = (lane == 0) & (gidx < K.int32(max_topk))
+            else:
+                issue = lane0_rd
+            K.ptx["ld.global.b32"](v, topk_idxs.ptr_to([token * max_topk + gidx]), pred=issue)
             bc = K.local_scalar(K.i32)
             K.ptx.shfl_sync.idx.b32(bc, v, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF))
             K.assign(r[i], bc)
@@ -767,8 +778,13 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                 # One elected-lane predicate owns every issue in this role: as an
                 # instruction predicate rather than a branch, the descriptor
                 # arithmetic stays warp-wide and the warp never reconverges.
-                lane0 = K.local_scalar("uint32")
-                K.assign(lane0, K.cast(lane == K.int32(0), "uint32"))
+                # `elect.sync`, not `lane == 0`: a tcgen05 MMA is a warp
+                # collective, so ptxas must establish a single issuing lane. Given
+                # a per-lane comparison it rebuilds that around EVERY issue --
+                # an ELECT, two predicate ops and a branch per MMA. The hardware
+                # election yields the uniform predicate the instruction wants,
+                # and one election owns every issue in this role.
+                lane0 = K.local_scalar("uint32", init=K.cuda.elect_sync())
 
                 st_k = K.PipelineState(1, phase=0)
                 st_s = K.PipelineState(1, phase=0)
@@ -1518,11 +1534,14 @@ def make_sum_odo_kernel(*, head_dim, num_head, dtype, max_topk):
             with K.If((idx_q_t < K.int32(block_q)) & (idx_q < seqlen_q)), K.Then():
                 acc = K.local_scalar(K.f32, init=K.float32(0.0))
                 base_o = idx_q * (num_head * head_dim_v) + head * head_dim_v
-                # A rolled walk over the head dimension, as upstream (`:678`):
-                # one body, not `d_steps` copies of it.
-                step = K.local_scalar(K.i32, init=K.int32(0))
-                with K.While(step < K.int32(d_steps)):
-                    d = (tidx + step * K.int32(SUM_ODO_THREADS_D)) * K.int32(SUM_ODO_ELEM_PER_LOAD)
+                # Unrolled over the head dimension. This kernel is purely
+                # bandwidth-bound and its grid scales with the head count, so
+                # its loads have to be in flight together: rolled to a single
+                # body it sustains 50% of memory throughput against the
+                # reference's 75%, and the 64-head program pays that twice over
+                # because it launches twice the blocks.
+                for i in range(d_steps):
+                    d = (tidx + i * SUM_ODO_THREADS_D) * SUM_ODO_ELEM_PER_LOAD
                     ow = K.alloc_local([2], "uint32")
                     dw = K.alloc_local([2], "uint32")
                     K.ptx["ld.global.v2.b32"](ow[0], ow[1], out.ptr_to([base_o + d]))
@@ -1549,7 +1568,6 @@ def make_sum_odo_kernel(*, head_dim, num_head, dtype, max_topk):
                         # `add.rn.f32.<narrow>` takes the narrow value first.
                         K.ptx[add_wide](frag, nv, frag)
                     K.ptx["add.f32"](acc, acc, frag)
-                    K.assign(step, step + K.int32(1))
 
                 total = _butterfly_sum_f32(acc, (1, 2, 4))
 

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/reference.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/reference.py
@@ -1,0 +1,93 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Loader for the upstream DSA sparse attention backward kernel.
+
+Upstream source:
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py``.
+
+The kernel this port follows lives in a cuDNN Frontend source checkout named by
+``CUDNN_FRONTEND_PATH``, the contract the other cuDNN Frontend ports in this
+repository use. It is deliberately not the ``cudnn`` wheel that may also be
+installed: the released package can carry an older revision of this kernel (the
+1.26.0 wheel present during this port predates both fp16 element support and two
+of the kernel's TMEM ordering barriers), and benchmarking against it would
+compare TIRx to a different implementation than the one cited above.
+
+Only the ``cudnn.deepseek_sparse_attention`` subtree is redirected. The rest of
+``cudnn`` still resolves to the installed package, because ``cudnn.api_base``
+reaches a compiled extension that a source checkout alone does not provide, and
+because nothing this port follows lives outside the DSA subtree.
+"""
+
+import importlib
+import os
+import sys
+import types
+
+_DSA_PACKAGE = "cudnn.deepseek_sparse_attention"
+_INTERFACE_MODULE = f"{_DSA_PACKAGE}.sparse_attention_backward._interface_sm100"
+_KERNEL_MODULE = f"{_DSA_PACKAGE}.sparse_attention_backward.dsa_bwd_sm100"
+
+
+def checkout_root():
+    """Absolute path of the cuDNN Frontend source checkout."""
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if not root:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    return root
+
+
+def _dsa_package_dir():
+    package_dir = os.path.join(checkout_root(), "python", "cudnn", "deepseek_sparse_attention")
+    if not os.path.isdir(package_dir):
+        raise RuntimeError(f"CUDNN_FRONTEND_PATH does not contain the DSA package: {package_dir}")
+    return package_dir
+
+
+def _bind_checkout():
+    """Redirect ``cudnn.deepseek_sparse_attention`` at the checkout.
+
+    Idempotent: the bench suite retries workloads in the same process, and the
+    correctness runner imports this more than once per session.
+    """
+    package_dir = _dsa_package_dir()
+
+    existing = sys.modules.get(_DSA_PACKAGE)
+    if existing is not None:
+        bound = getattr(existing, "__path__", None)
+        if bound and os.path.realpath(next(iter(bound))) == os.path.realpath(package_dir):
+            return
+        raise RuntimeError(
+            f"{_DSA_PACKAGE} is already imported from {bound}; cannot rebind it to {package_dir}. "
+            "Import the reference before anything else pulls in the installed cuDNN DSA package."
+        )
+
+    # Importing the real ``cudnn`` first is what makes ``cudnn.api_base`` (and
+    # the compiled extension underneath it) resolvable for the checkout's code.
+    cudnn = importlib.import_module("cudnn")
+
+    package = types.ModuleType(_DSA_PACKAGE)
+    package.__path__ = [package_dir]
+    package.__package__ = _DSA_PACKAGE
+    sys.modules[_DSA_PACKAGE] = package
+    cudnn.deepseek_sparse_attention = package
+
+
+def load_interface():
+    """Import and return the upstream SM100 host wrapper module."""
+    _bind_checkout()
+    return importlib.import_module(_INTERFACE_MODULE)
+
+
+def load_kernel_module():
+    """Import and return the upstream kernel module."""
+    _bind_checkout()
+    return importlib.import_module(_KERNEL_MODULE)
+
+
+def flash_attn_bwd_sm100():
+    """Return the upstream ``flash_attn_bwd_sm100`` entry point."""
+    return load_interface().flash_attn_bwd_sm100

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/spec.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/spec.py
@@ -1,0 +1,269 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Static specialization domain for the DSA sparse attention backward kernel.
+
+Upstream sources:
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py``
+(``FlashAttentionDSABackwardSm100.__init__`` tile and role constants), and
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py``
+(the ``head_dim`` gate, the fixed ``block_tile``, and the compile key).
+
+The correctness matrix follows the upstream test file
+``test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py``; the benchmark
+matrix follows ``benchmark/dsa/benchmark_dsa_sparse_attention_backward.py``.
+"""
+
+# ``_interface_sm100.py:94``: the SM100 path pins the KV block tile and ignores
+# the public API's ``block_tile`` argument.
+BLOCK_TILE = 64
+
+# ``_interface_sm100.py:63-64``: any other head_dim indexes shared memory out of
+# bounds inside the kernel.
+SUPPORTED_HEAD_DIMS = (512, 576)
+
+# ``test/python/fe_api/dsa/dsa_utils.py:34-46``: the (head_dim, head_dim_v,
+# num_heads) triples upstream exercises and ships.
+SUPPORTED_GEOMETRIES = {512: 64, 576: 32}
+
+SUPPORTED_DTYPES = ("bfloat16", "float16")
+
+# ``utils.get_smem_capacity_in_bytes("sm_100")``; the upstream kernel asserts its
+# SharedStorage against a self-imposed 227 KiB bound (``dsa_bwd_sm100.py:446``).
+SMEM_CAPACITY = 232_448
+SMEM_SELF_IMPOSED_CAP = 227 * 1024
+
+# ``dsa_bwd_sm100.py:79-80``: the kernel claims all of tensor memory.
+TMEM_CAPACITY_COLUMNS = 512
+
+# How ``topk_length`` (or the ``-1`` padding of ``topk_idxs``) is generated for a
+# config. Each mode targets a distinct control-flow path in the kernel.
+TOPK_MODES = (
+    "full",  # every query uses all max_topk rows; no ragged tile
+    "random",  # per-query length in [1, max_topk]; ragged first-processed tile
+    "mixed_zero",  # some queries have length <= 0 and take the early-exit path
+    "all_empty",  # every query takes the early-exit path
+    "invalid_idx",  # non-compact variant with -1 entries in the index tail
+)
+
+# How ``attn_sink`` is filled. ``log_topk`` reproduces the upstream regression
+# test for folding the sink into the softmax normalization.
+SINK_MODES = ("normal", "log_topk", "disabled")
+
+
+def head_dim_v_for(head_dim):
+    """Mirror ``_interface_sm100.py:64``."""
+    return 512 if head_dim == 576 else head_dim
+
+
+def check_dispatch(config):
+    """Reject anything outside the upstream dispatch domain."""
+    head_dim = config["head_dim"]
+    if head_dim not in SUPPORTED_HEAD_DIMS:
+        raise ValueError(f"head_dim must be one of {SUPPORTED_HEAD_DIMS}, got {head_dim}")
+    if config["dtype"] not in SUPPORTED_DTYPES:
+        raise ValueError(f"dtype must be one of {SUPPORTED_DTYPES}, got {config['dtype']}")
+    if config["topk_mode"] not in TOPK_MODES:
+        raise ValueError(f"topk_mode must be one of {TOPK_MODES}, got {config['topk_mode']}")
+    if config["sink_mode"] not in SINK_MODES:
+        raise ValueError(f"sink_mode must be one of {SINK_MODES}, got {config['sink_mode']}")
+    if config["topk_mode"] == "invalid_idx" and config["has_topk_length"]:
+        raise ValueError(
+            "the -1 index padding path is the non-compact variant; it has no topk_length"
+        )
+    return config
+
+
+def _config(
+    *,
+    head_dim,
+    num_head,
+    seqlen_q,
+    seqlen_kv,
+    max_topk,
+    has_topk_length,
+    dtype="bfloat16",
+    topk_mode="random",
+    sink_mode="normal",
+    seed,
+    label,
+):
+    return check_dispatch(
+        {
+            "head_dim": head_dim,
+            "num_head": num_head,
+            "seqlen_q": seqlen_q,
+            "seqlen_kv": seqlen_kv,
+            "max_topk": max_topk,
+            "has_topk_length": has_topk_length,
+            "dtype": dtype,
+            "topk_mode": topk_mode,
+            "sink_mode": sink_mode,
+            "seed": seed,
+            "label": label,
+        }
+    )
+
+
+def correctness_configs():
+    """The correctness matrix.
+
+    Every row here is a mandatory CI case (``tests/test_correctness.py``
+    parametrizes over ``CONFIGS``), so each one must run on a working SM100
+    machine without skipping. The base geometry matches the upstream test
+    defaults (``s_q=1024``, ``s_kv=4096``, ``topk=512``); the remaining rows each
+    pin one additional branch of the kernel.
+    """
+    configs = []
+    seed = 0
+
+    def add(**kwargs):
+        nonlocal seed
+        seed += 1
+        configs.append(_config(seed=seed, **kwargs))
+
+    # The two shipped geometries, both compiled index variants, at the upstream
+    # test's base shape.
+    for head_dim, num_head in sorted(SUPPORTED_GEOMETRIES.items()):
+        for has_len in (True, False):
+            add(
+                head_dim=head_dim,
+                num_head=num_head,
+                seqlen_q=1024,
+                seqlen_kv=4096,
+                max_topk=512,
+                has_topk_length=has_len,
+                topk_mode="random" if has_len else "full",
+                label=f"d{head_dim}_h{num_head}_bf16_sq1024_skv4096_t512_{'len' if has_len else 'nolen'}",
+            )
+
+    # fp16 element storage, one row per geometry.
+    add(
+        head_dim=512,
+        num_head=64,
+        seqlen_q=1024,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=True,
+        dtype="float16",
+        topk_mode="random",
+        label="d512_h64_fp16_sq1024_skv4096_t512_len",
+    )
+    add(
+        head_dim=576,
+        num_head=32,
+        seqlen_q=1024,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=False,
+        dtype="float16",
+        topk_mode="full",
+        label="d576_h32_fp16_sq1024_skv4096_t512_nolen",
+    )
+
+    # A single-tile top-k so the ragged, first-processed tile is the only tile.
+    add(
+        head_dim=512,
+        num_head=64,
+        seqlen_q=256,
+        seqlen_kv=4096,
+        max_topk=64,
+        has_topk_length=True,
+        topk_mode="random",
+        label="d512_h64_bf16_sq256_skv4096_t64_len_ragged",
+    )
+
+    # Zero and negative lengths interleaved with live rows: the early-exit path
+    # must not deadlock the CTAs that still have work.
+    add(
+        head_dim=512,
+        num_head=64,
+        seqlen_q=128,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=True,
+        topk_mode="mixed_zero",
+        label="d512_h64_bf16_sq128_skv4096_t512_zeroneg",
+    )
+    add(
+        head_dim=576,
+        num_head=32,
+        seqlen_q=128,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=True,
+        topk_mode="all_empty",
+        label="d576_h32_bf16_sq128_skv4096_t512_allempty",
+    )
+
+    # The non-compact variant's invalid-row marker.
+    add(
+        head_dim=512,
+        num_head=64,
+        seqlen_q=128,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=False,
+        topk_mode="invalid_idx",
+        label="d512_h64_bf16_sq128_skv4096_t512_negidx",
+    )
+
+    # Sink folded into the normalization, the upstream d576 regression.
+    add(
+        head_dim=576,
+        num_head=32,
+        seqlen_q=1024,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=True,
+        topk_mode="random",
+        sink_mode="log_topk",
+        label="d576_h32_bf16_sq1024_skv4096_t512_sinkfold",
+    )
+
+    # Sink disabled (-inf), so the softmax normalization sees the KV terms alone.
+    add(
+        head_dim=512,
+        num_head=64,
+        seqlen_q=256,
+        seqlen_kv=4096,
+        max_topk=512,
+        has_topk_length=True,
+        topk_mode="random",
+        sink_mode="disabled",
+        label="d512_h64_bf16_sq256_skv4096_t512_nosink",
+    )
+
+    return configs
+
+
+def benchmark_configs():
+    """The performance matrix: the upstream benchmark sweep on both geometries.
+
+    ``benchmark/dsa/benchmark_dsa_sparse_attention_backward.py`` sweeps
+    ``seqlens x topks`` with ``seqlen_kv == seqlen_q``, bf16, the sink enabled and
+    a full-length ``topk_length``. The d576 half mirrors that sweep onto the
+    second compiled program so it cannot regress unmeasured.
+    """
+    configs = []
+    seed = 100
+    for head_dim, num_head in sorted(SUPPORTED_GEOMETRIES.items()):
+        for seqlen in (4096, 8192):
+            for topk in (128, 512, 1024, 2048):
+                seed += 1
+                configs.append(
+                    _config(
+                        head_dim=head_dim,
+                        num_head=num_head,
+                        seqlen_q=seqlen,
+                        seqlen_kv=seqlen,
+                        max_topk=topk,
+                        has_topk_length=True,
+                        topk_mode="full",
+                        seed=seed,
+                        label=f"d{head_dim}_h{num_head}_bf16_sq{seqlen}_t{topk}_len",
+                    )
+                )
+    return configs

--- a/tirx_kernels/cudnn/dsa/sparse_attention_backward.py
+++ b/tirx_kernels/cudnn/dsa/sparse_attention_backward.py
@@ -1,0 +1,132 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""DeepSeek Sparse Attention backward pass for SM100.
+
+Upstream source:
+``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py``.
+
+Each query token owns one CTA, and its attention heads form the M dimension of the
+tensor-core GEMMs, so the top-k KV rows a token selects are gathered once and
+amortized across every head. K and V are one shared MQA buffer, which fuses their
+gradients: ``dKV`` accumulates ``dV`` over the leading 512 dimensions and ``dK``
+over the full head dimension. The pass runs as four kernels -- a delta and
+sink-folded-LSE preprocess, the 20-warp main kernel, an FP32-to-element-dtype dKV
+conversion, and the attention-sink gradient reduction.
+"""
+
+from ._sparse_attention_backward import data as _data
+from ._sparse_attention_backward import kernel as _kernel
+from ._sparse_attention_backward import spec as _spec
+
+KERNEL_META = {
+    "name": "cudnn_sm100_dsa_sparse_attention_backward",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _spec.correctness_configs()
+BENCH_CONFIGS = _spec.benchmark_configs()
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def get_kernel(**config):
+    """Return the four device functions in the upstream launch order."""
+    return _kernel.get_kernel(**config)
+
+
+def prepare_data(**config):
+    """Allocate one input set shared by TIRx, the upstream kernel, and the oracle."""
+    return _data.prepare_data(**config)
+
+
+def run_test(**config):
+    """Compare TIRx and the upstream kernel against the FP32 oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch()
+    source_launch = _data.compile_reference(data)
+    source_launch()
+    torch.cuda.synchronize()
+    _data.validate_outputs(data, sources=("tirx", "source"))
+    return {
+        "seqlen_q": data["derived"]["seqlen_q"],
+        "seqlen_kv": data["derived"]["seqlen_kv"],
+        "max_topk": data["derived"]["max_topk"],
+    }
+
+
+def prepare_bench(**config):
+    """Compile only TIRx; reference imports and CUDA work stay in ``run_gpu``."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once against the upstream kernel, then time both launch closures."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _data.tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+
+    references = None
+    if external_references_enabled():
+        source_launch = _data.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"cudnn_frontend": lambda: source_launch}
+
+    # The oracle is far more expensive than the kernels at the benchmark shapes;
+    # ``run_test`` carries it over the correctness matrix instead.
+    _data.validate_outputs(data, sources=("tirx",), with_oracle=False)
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
Ports cuDNN Frontend's DeepSeek Sparse Attention backward pass
(`python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py`,
commit `7b5327b3`) to TIRx.

Four device kernels: the `sum_OdO` preprocess, the main `bwd` kernel (640
threads across 20 warps in six specialized roles), the fp32 -> narrow dKV
`convert`, and the attention-sink reduction.

## Structure

Shared memory is one flat byte pool. Every logical coordinate, swizzle,
transpose, stage and alias is explicit scalar arithmetic on a byte offset into
it, and the matrix descriptors are assembled from hardware immediates, so the
kernel carries no layout objects. The operand map is a stack of 64-wide blocks
of 64 rows under a 128-byte swizzle, which lets the dQ epilogue tiles alias the
KV buffer once the top-k loop has drained; the pool totals 214,528 B at head
dimension 512 and 230,912 B at 576, against a 232,448 B cap.

Both head-dimension programs are supported and are genuinely different, not a
renaming: distinct TMEM alias maps, an extra tail MMA and a fifth dQ store round
at 576, and a different assignment of the three write-after-read barriers,
exactly one of which is skipped on the first processed tile and compensated once
after the loop.

- Reverse top-k tile walk with the first (ragged) tile peeled, so the loop body
  never carries the ragged-tile test. The compact and non-compact index variants
  keep separate validity programs.
- The softmax recompute drains S and dP from TMEM, forms P and dS with packed
  two-lane arithmetic, and transposes both into shared memory with `stmatrix`,
  which is what feeds the fused dV + dK accumulation.
- dKV is reduced with four-wide fp32 global atomics into a workspace whose
  column order the `convert` kernel inverts; dQ accumulates in TMEM across the
  whole top-k axis and is published once through a TMA store epilogue.

## Correctness

12 configurations, validated against both the upstream kernel and a chunked fp32
oracle: both head dimensions, both index variants, fp16, and the ragged, empty,
negative-index and sink-folding paths. The oracle is the arbiter because dKV is
accumulated with global fp32 atomics, so its summation order is not stable even
between two runs of the reference.

## Performance

Complete 16-shape benchmark matrix (the upstream sweep mirrored onto both
compiled programs), reference time over TIRx time:

| head dim | shapes | ratio |
| --- | --- | --- |
| 512 / 64 heads | 8 | 1.013 - 1.029 |
| 576 / 32 heads | 8 | 1.046 - 1.110 |

16/16 above parity, minimum 1.013. Reproduced across two complete matrices.

Two changes account for most of the margin. The tcgen05 MMAs are issued under a
hardware election rather than a `lane == 0` comparison: a matrix MMA is a warp
collective, so a single issuing lane has to be established, and given a per-lane
comparison ptxas cannot recognise an election and rebuilds one around every
issue. Static predicate operations fall from 213 to 48 against the reference's
3. Separately, the preprocess kernel's walk over the head dimension is unrolled;
it is purely bandwidth-bound and its grid scales with the head count, so keeping
its loads in flight together takes it to 83.8% of memory throughput from 50.1%.