### PR TITLE
feat(kernel): port cuDNN GDN2 backward kernel sm100

### DIFF
--- a/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
@@ -503,13 +503,18 @@ def super_mma_warp():
                 transpose(mov_lpow, l_packed)          # and again after squaring
                 # instruction_selection: movmatrix.sync.aligned.m8n8.trans.b16;
                 # extent: 4 initial + 3 x 4 = the export's 16 sites
-                gemm(upd_acc, tinv_packed, mov_lpow)   # fold into the inverse
-                cast(tinv_packed, upd_acc)
-                # instruction_selection: 2 x mma.sync...m16n8k16 per round, with a
-                # cvt.rn.bf16x2.f32 round-trip between them -- the rounding is
-                # part of the numerical contract, not an artifact
+                gemm(upd_acc, tinv_packed, mov_lpow)   # T_inv @ L^(2^r)
+                # The round ACCUMULATES into the series; assigning here would
+                # never sum it and T_inv would be wrong on every chunk.
+                add(tinv_acc, cast_f32(tinv_packed), upd_acc)
+                cast(tinv_packed, tinv_acc)
+                # instruction_selection: 2 x mma.sync...m16n8k16 per round, then
+                # 4 x add.rn.f32x2 over the io round-tripped T_inv; the rounding
+                # and the four-way bracketing are both part of the contract
             copy_r2s(tinv_packed, inter_byte(inter_stage, slot=1, ...))
             # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("t_inv_ready", inter_stage)
 
             # ---- dM = dY @ U^T, then the two strict tiles -----------------
@@ -527,6 +532,8 @@ def super_mma_warp():
             copy_r2s(-dm_strict, inter_byte(inter_stage, slot=4, ...))
             # instruction_selection: 2 x stmatrix...x4.shared.b16; extent: the
             # +/- pair, so dk_inv and dk_decay can share one accumulator sign
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("dm_ready", inter_stage)
 
 # ==========================================================================
@@ -571,7 +578,7 @@ def epilogue_warp():
     while tile_idx < total_tiles:
         ...decode
         if elected():
-            for array in (TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DWO, TMAP_DBETA):
+            for array in (TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DBETA, TMAP_DWO):
                 acquire_tensormap(descriptor_slot(tmaps, array, b))
                 # instruction_selection: fence.proxy.tensormap::generic.acquire.gpu;
                 # extent: 6 of the export's 14 acquires; warp 14 owns the other 8
@@ -589,6 +596,8 @@ def epilogue_warp():
             select(a_tile, lower_incl_mask, a_acc, 0.0)
             copy_r2s(a_tile, inter_byte(inter_stage, slot=0, ...))
             # instruction_selection: stmatrix...x4.shared.b16
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("a_ready", inter_stage)
 
             # ---- dA = tril_incl(dO @ U^T) --------------------------------
@@ -599,6 +608,8 @@ def epilogue_warp():
                 copy_s2r(DO + ..., a_frag); copy_s2r(SU + ..., b_frag)
                 gemm(da_acc, a_frag, b_frag, accumulate=True)
                 # instruction_selection: 8 x mma.sync...m16n8k16; extent: dA
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("do_done", raw_stage)          # released BEFORE the mask/store
             select(da_tile, lower_incl_mask, da_acc, 0.0)
             fence_proxy_async_shared_cta()
@@ -649,8 +660,7 @@ chunk loop at all.
 ```python
 # ==========================================================================
 # Warps 0..3: gate prefix, normalization, and the four decay operands.
-# ==========================================================================
-def compute_group_0():
+# ==========================================================================def compute_group_0():
     barrier(id=3, threads=416)      # TMEM-lifecycle rendezvous after setmaxnreg
     # instruction_selection: barrier.sync 3, 416; extent: one of four such sites
     while tile_idx < total_tiles:
@@ -681,49 +691,19 @@ def compute_group_0():
             # instruction_selection: add.rn.f32x2; extent: one token pair per step
             exp2(eG, prefix); exp2(eGl, chunk_total)
             # instruction_selection: ex2.approx.ftz.f32; extent: 16 tokens
+
+            wait("decay_done", decay_stage, decay_phase)   # reverse edge, warp 13
+
             # eG MUST round-trip through sGate: the prefix scan runs on a channel
             # assignment (warp*32 + lane) that differs from the operand assignment
             # (decay_row, lane_in_row_group), and warps 8..11 read the same buffer.
             # That shared reader is why `gate_done` carries CG0+CG2 = 256.
             copy_r2s(eG, SGATE + raw_f32_byte(...))
             # instruction_selection: st.shared.b32; extent: 16 tokens
-            fence_proxy_async_shared_cta()
-            # instruction_selection: fence.proxy.async.shared::cta
-            arrive("gate_done", raw_stage)
-            copy_s2r(SGATE + raw_f32_byte(...), eG_operand)    # per operand channel
-            copy_s2r(SGATE + raw_f32_byte(row=BT-1, ...), eGl_operand)
-            # instruction_selection: ld.shared.b32; extent: the re-read under the
-            # operand channel assignment
-
-            if L2NORM:
-                rsqrt(q_inv_norm, max(sum_sq_q, 1e-24)); rsqrt(k_inv_norm, ...)
-                # instruction_selection: rsqrt.approx.ftz.f32; extent: one per row
-                copy_r2s(q_inv_norm, NORM + ...); copy_r2s(k_inv_norm, ...)
-
-            # ---- the four operands.  Beta enters K_decay ONLY. -------------
-            wait("decay_done", decay_stage, decay_phase)   # reverse edge, warp 13
-            mul(k_value, raw_k, k_inv_norm)
-            mul(k_beta, k_value, raw_beta)                 # GDN-2: Beta folded in
-            mul(K_decay_pack, cast(k_beta), cast(eG))
-            # instruction_selection: mul.bf16x2; extent: 4 packs per dim half
-            rcp(exp_neg_g, eG)                             # never a divide
-            # instruction_selection: rcp.approx.ftz.f32; extent: 2 per pack
-            mul(K_inv_pack, cast(k_value), cast(exp_neg_g))   # no Beta here
-            # K_restore reuses the ALREADY-ROUNDED K_inv rather than re-deriving
-            # from K, and the scale is folded into Q BEFORE the eG multiply.  The
-            # rounding points differ from the algebraically equal forms.
-            mul(K_restore_pack, K_inv_pack, cast(eGl))
-            mul(Q_decay_pack, cast(q_value * scale), cast(eG))
-            for pack in (K_decay, K_inv, K_restore, Q_decay):
-                copy_r2s(pack, raw_io_byte(base, decay_stage, row, dim))
-                # instruction_selection: st.shared.v4.b32; extent: 8 channels
             fill(STATE_DIAG + inter..., diag(eGl))          # 8 k-atoms of [16][16]
-            fence_proxy_async_shared_cta()
-            # instruction_selection: fence.proxy.async.shared::cta
-            arrive("k_decay_inv_ready", decay_stage)
-            arrive("q_decay_k_restore_ready", decay_stage)
-            arrive("q_done", raw_stage); arrive("k_done", raw_stage)
+            # instruction_selection: st.shared.b16; extent: 8 atoms
 
+            # ---- raw Q/K into the TMEM ring, then the CG0-local rendezvous --
             wait("qk_raw_done", qk_stage, qk_phase)         # reverse edge from CG2
             copy_r2t(raw_q, tmem_cell(TM_QRAW_INP, row, qk_stage * 8))
             copy_r2t(raw_k, tmem_cell(TM_KRAW_INP, row, qk_stage * 8))
@@ -733,13 +713,81 @@ def compute_group_0():
             # instruction_selection: tcgen05.wait::st.sync.aligned
             arrive("qk_raw_ready", qk_stage)
             barrier(id=1, threads=128)
-            # instruction_selection: barrier.sync 1, 128; extent: the CG0-local
-            # rendezvous after publishing the raw ring
+            # instruction_selection: barrier.sync 1, 128; extent: separates the ring
+            # publish from the raw operand fetch below
 
+            # ---- raw Q/K/Beta register fetch, then release those three stages
+            copy_s2r(SQ + raw_io_byte(...), raw_q_regs)
+            copy_s2r(SK + raw_io_byte(...), raw_k_regs)
+            copy_s2r(BETA + raw_io_byte(...), raw_beta_regs)
+            # instruction_selection: ld.shared.v4.b32; extent: 8 channels each
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("q_done", raw_stage); arrive("k_done", raw_stage)
+            arrive("beta_done", raw_stage)   # the other half of beta_done's 256
+
+            if L2NORM:
+                # The squared sums use a FIXED four-accumulator ffma2 bracketing
+                # seeded with opaque zeros so the optimizer cannot reassociate.
+                fill(qacc[0:4], opaque_f32_zero()); fill(kacc[0:4], opaque_f32_zero())
+                for pair in range(DK // 8):
+                    fma_packed(qacc[pair % 4], raw_q_pair, raw_q_pair, qacc[pair % 4])
+                    fma_packed(kacc[pair % 4], raw_k_pair, raw_k_pair, kacc[pair % 4])
+                    # instruction_selection: fma.rn.f32x2; extent: the fixed 4-way
+                    # interleave over this lane's channels
+                for delta in (1, 2, 4, 8, 16, 32):
+                    shuffle_xor(peer, sum_sq, delta); add(sum_sq, sum_sq, peer)
+                    # instruction_selection: shfl.sync.bfly.b32; extent: six steps,
+                    # three per gradient, reducing across the row group
+                rsqrt(q_inv_norm, max(sum_sq_q, 1e-24)); rsqrt(k_inv_norm, ...)
+                # instruction_selection: rsqrt.approx.ftz.f32; extent: 2 sites
+                if lane_in_row_group == 0:
+                    copy_r2s(q_inv_norm, NORM + ...); copy_r2s(k_inv_norm, NORM + BT + ...)
+                    # instruction_selection: st.shared.b32; extent: one lane per row
+
+            # ---- eG/eGl re-read under the OPERAND channel assignment --------
+            copy_s2r(SGATE + raw_f32_byte(...), eG_operand)
+            copy_s2r(SGATE + raw_f32_byte(row=BT-1, ...), eGl_operand)
+            # instruction_selection: ld.shared.b32; extent: the re-read
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("gate_done", raw_stage)
+            # gate_done releases the sGate stage for TMA reload, so it MUST come
+            # after CG0 has finished reading eG and eGl back out of it.
+
+            # ---- the four operands.  Beta enters K_decay ONLY. -------------
+            mul(k_value, raw_k, k_inv_norm)
+            mul(k_beta, k_value, raw_beta)                 # GDN-2: Beta folded in
+            mul(K_decay_pack, cast(k_beta), cast(eG))
+            # instruction_selection: mul.bf16x2; extent: 4 packs per dim half
+            rcp(exp_neg_g, eG)                             # never a divide
+            # instruction_selection: rcp.approx.ftz.f32; extent: 2 per pack
+            mul(K_inv_pack, cast(k_value), cast(exp_neg_g))   # no Beta here
+            copy_r2s(K_decay_pack, raw_io_byte(K_DECAY, decay_stage, row, dim))
+            copy_r2s(K_inv_pack,   raw_io_byte(K_INV,   decay_stage, row, dim))
+            # instruction_selection: st.shared.v4.b32; extent: 8 channels each
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("k_decay_inv_ready", decay_stage)
+
+            # K_restore reuses the ALREADY-ROUNDED K_inv rather than re-deriving
+            # from K, and the scale is folded into Q BEFORE the eG multiply.  The
+            # rounding points differ from the algebraically equal forms.
+            mul(K_restore_pack, K_inv_pack, cast(eGl))
+            mul(Q_decay_pack, cast(q_value * scale), cast(eG))
+            copy_r2s(K_restore_pack, raw_io_byte(K_RESTORE, decay_stage, row, dim))
+            copy_r2s(Q_decay_pack,   raw_io_byte(Q_DECAY,   decay_stage, row, dim))
+            # instruction_selection: st.shared.v4.b32; extent: 8 channels each
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("q_decay_k_restore_ready", decay_stage)
+
+            # Only `state_ready` is guarded; the two reverse edges advance every
+            # chunk so their phases stay aligned with warp 13 and warps 8..11.
+            wait("state_inp_done", state_inp_stage, state_inp_phase)
+            wait("state_inp_cg2_done", state_inp_stage, state_inp_phase)
             if chunk >= FIRST_STATE_CHUNK:                  # state SMEM -> TMEM
                 wait("state_ready")
-                wait("state_inp_done", state_inp_stage, state_inp_phase)
-                wait("state_inp_cg2_done", state_inp_stage, state_inp_phase)
                 copy_s2r(state_byte(...), state_regs)
                 # instruction_selection: ld.shared.b16
                 copy_r2t(state_regs, TM_STATE_INP + state_inp_stage * 64)
@@ -751,9 +799,6 @@ def compute_group_0():
             arrive("state_inp_ready", state_inp_stage)   # UNCONDITIONAL: the phase
             # advances even on a chunk that loads no state
 
-# ==========================================================================
-# Warps 4..7: the value side.  Owns dV and the new dW_out.
-# ==========================================================================
 def compute_group_1():
     barrier(id=3, threads=416)
     # instruction_selection: barrier.sync 3, 416
@@ -762,10 +807,23 @@ def compute_group_1():
         # dht seed runs at the TOP of the tile, before the chunk loop: a
         # non-terminal item seeds zeros but still walks the same path, so the
         # pipeline shape is uniform.
-        if USE_DSTATE_IN:
-            seed_true = (cend == num_chunks_b)
-            copy_g2r(dstate_in_tile, dh_seed) if seed_true else fill(dh_seed, 0.0)
-            copy_r2t(cast(dh_seed), TM_DSTATE_INP); arrive("dstate_inp_ready")
+        if USE_DSTATE_IN and sk_nt > 0:
+            wait("dstate_smem_done"); wait("dstate_smem_cg2_done")
+            seed_true = (cend == num_chunks_b)     # non-terminal items seed zeros
+            copy_g2r(dstate_in_tile, dh_in)
+            select(dh_seed, seed_true, dh_in, 0.0)          # per element
+            copy_r2t(dh_seed, TM_DSTATE_ACC)       # the FP32 seed: dH itself
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32
+            copy_r2t(cast(dh_seed), TM_DSTATE_INP) # and the f16 A-operand form
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32
+            tcgen05_wait_store()
+            # instruction_selection: tcgen05.wait::st.sync.aligned
+            arrive("dstate_inp_ready")
+            copy_t2r(TM_DSTATE_INP, dh_reread)     # re-read, then publish to SMEM
+            copy_r2s(cast(dh_reread), DSTATE)
+            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            fence_proxy_async_shared_cta()
+            arrive("dstate_smem_ready")
         for chunk in reverse_walk:
             # ---- Y: two variants.  Chunk 0 with no entering state is W*V only.
             wait("v_ready", raw_stage, raw_phase)
@@ -828,6 +886,8 @@ def compute_group_1():
                 copy_r2s(cast(mul(w_v, dy_v)), SDV  + dv_stage  * 4096 + ...)
                 copy_r2s(cast(mul(v_v, dy_v)), SDWO + dwo_stage * 4096 + ...)
                 # instruction_selection: st.shared.b16; extent: dV and dW_out
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("dv_tmastg_ready"); arrive("dwo_tmastg_ready")
             arrive("v_done", raw_stage); arrive("w_done", raw_stage)
             # V and W are released only HERE, after the dW_out product needs V.
@@ -837,6 +897,8 @@ def compute_group_1():
             # the registers already in hand.
             wait("dstate_acc_ready")
             if rev + 1 < sk_nt:
+                wait("dstate_smem_done")
+                wait("dstate_smem_cg2_done")
                 copy_t2r(TM_DSTATE_ACC, dh)
                 # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x32.b32;
                 # extent: 4 sites
@@ -868,11 +930,17 @@ def compute_group_2():
             # instruction_selection: ld.shared.b32; extent: 16 tokens
             fence_proxy_async_shared_cta(); arrive("gate_done", raw_stage)
 
-            # ---- dGate_last hdot: eGl * sum_v(dH[v,c] * S[c,v]) -------------
-            # This term exists only when a dState is carried, and it is the
-            # kernel's single largest FMA family.
-            if USE_DSTATE_IN and chunk >= FIRST_STATE_CHUNK:
-                wait("state_inp_ready", state_inp_stage, state_inp_phase)
+            # `has_dstate` is a RUNTIME boolean, not the compile-time flag: a
+            # dState exists once the reverse walk has produced one, so it is
+            # `rev > 0`, forced True when USE_DSTATE_IN. The hdot is therefore
+            # live even in the `basic` branch, which is why the basic export
+            # carries 128 fma.rn.f32.bf16.
+            has_dstate = (rev > 0) or USE_DSTATE_IN
+
+            # ---- dGate_last hdot: sum_v(dH[v,c] * S[c,v]) -------------------
+            fill(dgate_last_val, 0.0)
+            wait("state_inp_ready", state_inp_stage, state_inp_phase)  # UNGUARDED
+            if has_dstate:
                 wait("dstate_smem_ready")
                 copy_t2r(tmem_cell(TM_STATE_INP, ...), state_cols)
                 # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32;
@@ -884,17 +952,24 @@ def compute_group_2():
                     # over a FIXED 8-way interleave, not a compiler-chosen tree
                 reduce_fixed_tree(dgate_last_val, hacc[0:8])
                 # instruction_selection: add.rn.f32x2; extent: the fixed fadd2 tree
-                arrive("dstate_smem_cg2_done"); arrive("state_inp_cg2_done")
+                arrive("dstate_smem_cg2_done")
+            arrive("state_inp_cg2_done", state_inp_stage)   # UNGUARDED, pairs
+            # with CG0's state_inp_cg2_done wait on every chunk
 
-            wait("dk_restore_part_acc_ready")
-            copy_t2r(tmem_cell(TM_DK_RESTORE, row, col), dk_restore_part)
-            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
-            for t in range(BT):
-                mul(dk_hat, eGl * rcp(eG[t]), dk_restore_part[t])
-                # instruction_selection: rcp.approx.ftz.f32 then mul.f32
-                fma(dgate_last_acc[t % 4], k_n[t], dk_hat, dgate_last_acc[t % 4])
-                # instruction_selection: fma.rn.f32; extent: a FIXED 4-way
-                # interleaved accumulation, not a compiler-chosen tree
+            fill(dgate_last_acc[0:4], opaque_f32_zero())
+            fill(dk_n[0:BT], 0.0)        # valid accumulator on the no-dstate path
+            if has_dstate:
+                wait("dk_restore_part_acc_ready")
+                copy_t2r(tmem_cell(TM_DK_RESTORE, row, col), dk_restore_part)
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
+                copy_t2r(tmem_cell(TM_KRAW_INP, ...), k_raw)   # ring read 1 of 4
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
+                for t in range(BT):
+                    mul(dk_hat, eGl * rcp(eG[t]), dk_restore_part[t])
+                    # instruction_selection: rcp.approx.ftz.f32 then mul.f32
+                    fma(dgate_last_acc[t % 4], k_n[t], dk_hat, dgate_last_acc[t % 4])
+                    # instruction_selection: fma.rn.f32; extent: a FIXED 4-way
+                    # interleaved accumulation, not a compiler-chosen tree
 
             wait("dq_acc_ready"); copy_t2r(TM_DQ_ACC, dq_vec)
             mul(dq_n, mul_packed(eG, scale), dq_vec)
@@ -920,10 +995,25 @@ def compute_group_2():
                     #   and back to f32 -- the rounding is part of the contract
                 mul(dgate_regs[t], beta_v, dk_decay)
                 add(dk_n[t], dk_n[t], dgate_regs[t])
+            tcgen05_wait_load()
+            # instruction_selection: tcgen05.wait::ld.sync.aligned; extent: one of
+            # the export's two sites
             arrive("dqk_acc_done")
 
-            # ---- dGate finalize -------------------------------------------
+            # ---- dGate finalize: its OWN ring reads and its OWN beta reload -
+            copy_t2r(tmem_cell(TM_QRAW_INP, ...), q_raw)     # ring read 3 of 4
+            copy_t2r(tmem_cell(TM_KRAW_INP, ...), k_raw)     # ring read 4 of 4
+            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32;
+            # extent: 2 sites; with the restore drain and the dk_decay drain these
+            # are the four separate ring reads (raw K three times, raw Q once)
             for t in range(BT):
+                mul(q_n[t], q_raw[t], q_inv_norm) if L2NORM else assign(q_n[t], q_raw[t])
+                copy_s2r(BETA + raw_io_byte(...), beta_v)     # reloaded, not reused
+                if BETA_SIGMOID:
+                    tanh(s, beta_v * 0.5); cast(beta_v, s * 0.5 + 0.5)
+                    # instruction_selection: tanh.approx.f32; extent: the THIRD of
+                    # three sigmoid sites (CG0, the dk_decay drain, here), which is
+                    # what makes the beta_sigmoid branch's delta 48 and not 16
                 dgate_regs[t] = q_n[t]*dq_n[t] + beta_v*db_regs[t] \
                                 - k_n[t]*(dk_n[t] - dgate_regs[t])
                 # instruction_selection: fma.rn.f32 chain; extent: one token
@@ -933,8 +1023,10 @@ def compute_group_2():
                     # the chain rule; swapping these corrupts dGate silently.
             add(dgate_regs[BT-1], dgate_regs[BT-1],
                 (dgate_last_acc[0]+dgate_last_acc[1]) + (dgate_last_acc[2]+dgate_last_acc[3]))
-            if USE_DSTATE_IN and chunk >= FIRST_STATE_CHUNK:
+            if has_dstate and chunk >= FIRST_STATE_CHUNK:
                 fma(dgate_regs[BT-1], eGl, dgate_last_val, dgate_regs[BT-1])
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("beta_done", raw_stage)
 
             if L2NORM:      # row projection: grad <- (grad - a*norm*<a,grad>)*norm
@@ -942,22 +1034,27 @@ def compute_group_2():
                                                 (dk_n, TM_KRAW_INP, BT)):
                     copy_t2r(tmem_cell(qk_col, ...), raw_lo)   # two halves
                     copy_t2r(tmem_cell(qk_col, ...), raw_hi)
-                    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
+                    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32;
+                    # extent: 2 of FOUR reads per gradient -- the l2norm export
+                    # takes tcgen05.ld from 28 to 36 for exactly this reason
                     mul(part, raw_pair, grad_pair)
                     # instruction_selection: mul.f32x2; extent: 2 per token pair
-                    for delta in (16, 8, 4, 2, 1):
-                        shuffle_xor(peer, part, delta); add(part, part, peer)
+                    for off in range(5):           # ASCENDING: 1, 2, 4, 8, 16
+                        shuffle_xor(peer, part, 1 << off); add(part, part, peer)
                         # instruction_selection: shfl.sync.bfly.b32; extent: a
                         # 5-step butterfly over the lanes of one row
-                    if lane == 0:
-                        copy_r2s(part, RED1 + warp_id * 4)
+                    copy_r2s(part, RED1 + (warp_in_group * BT + t) * 4)
+                    # RED1 is 256 B = 4 warps x 16 tokens, not one scalar per warp
                     barrier(id=2, threads=128)
                     # instruction_selection: barrier.sync 2, 128; extent: the first
                     # of TWO such barriers per gradient
-                    copy_s2r(RED1, four_warp_parts)
+                    copy_s2r(RED1 + t * 4, four_warp_parts)   # the four warps' t
                     reduce_fixed_tree(dots, four_warp_parts)
                     # instruction_selection: add.rn.f32x2; extent: a fixed 4-term
                     # tree over the four warps, not a compiler-chosen reduction
+                    copy_t2r(tmem_cell(qk_col, ...), raw_lo)  # reads 3 and 4, after
+                    copy_t2r(tmem_cell(qk_col, ...), raw_hi)  # the barrier
+                    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
                     copy_s2r(NORM + inv_off, inv_norm)
                     fma(grad, -raw_qk, dots * inv_norm, grad)
                     mul(grad, grad, inv_norm)          # the post-multiply
@@ -999,24 +1096,27 @@ accumulation, so a GEMM whose K extent is 128 expands to eight issues and one
 whose K extent is 16 expands to one.  Two sites are duplicated for the
 `accumulate=True`/`False` twin.
 
-Three loop-level waits sit OUTSIDE any GEMM's guard, so their phases advance
-even on a chunk whose MMA is skipped: `dqk_acc_done` (the loop-carried
-backpressure edge from warps 8..11, whose cursor starts at phase 1),
-`state_inp_ready`, and `do_ready`.  `dstate0_acc_stored` is waited once at
-teardown before the TMEM dealloc.
+Six loop-level waits sit OUTSIDE any GEMM's guard, so their phases advance even
+on a chunk whose MMA is skipped: `k_decay_inv_ready`, `dqk_acc_done` (the
+loop-carried backpressure edge from warps 8..11, whose cursor starts at phase
+1), `state_inp_ready`, `do_ready`, `q_decay_k_restore_ready`, and
+`u_smem_ready`.  They are listed here rather than in the per-row waits column.
+`dstate0_acc_stored` is waited once at teardown before the TMEM dealloc.  With
+row 6 publishing nothing and `decay_done` attributed only to row 15, the
+publishes column sums to exactly the export's 19 commits.
 
 | # | FP32 TMEM destination | A operand | B operand | M x N x K | issues | acc | guard | waits | publishes |
 | ---: | --- | --- | --- | --- | ---: | --- | --- | --- | --- |
-| 1 | `state_k_acc` | `state` (SMEM) | `K_decay^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | `state_ready`, `k_decay_inv_ready` | `state_k_acc_ready`, `state_done` |
+| 1 | `state_k_acc` | `state` (SMEM) | `K_decay^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | `state_ready` | `state_k_acc_ready`, `state_done` |
 | 2 | `dq_acc` | `state` (TMEM) | `dO^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | (`state_inp_ready`, `do_ready` hoisted) | none yet |
-| 3 | `du_acc` | `dstate_inp` (TMEM) | `K_restore` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_inp_ready`, `q_decay_k_restore_ready` | none yet |
+| 3 | `du_acc` | `dstate_inp` (TMEM) | `K_restore` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_inp_ready` | none yet |
 | 4 | `dstate_acc` | `dstate_inp` (TMEM) | `diag(eGl)` | 128 x 16 x 16 | 8 | per k-atom | `has_dstate` | same stage | none yet |
 | 5 | `du_acc` | `dO^T` (SMEM) | `A` | 128 x 16 x 16 | 1 | yes | `has_dstate` | `a_ready` | `du_acc_ready`, `a_done` |
-| 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes | `has_dstate` | `q_decay_k_restore_ready` | `do_mma_done` |
-| 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `y_inp_ready`, `t_inv_ready` | `u_acc_ready` |
+| 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes | `has_dstate` | (hoisted) | none yet |
+| 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `y_inp_ready`, `t_inv_ready` | `u_acc_ready`, `do_mma_done` |
 | 8 | `dy_acc` | `dU` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `du_inp_ready` | `dy_acc_ready`, `t_inv_done` |
-| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_smem_ready`, `u_smem_ready` | `dk_restore_part_acc_ready` |
-| 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes | none | `neg_dy_inp_ready` | `dstate_acc_ready`, `decay_done` |
+| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_smem_ready` | `dk_restore_part_acc_ready` |
+| 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes | none | `neg_dy_inp_ready` | `dstate_acc_ready` |
 | 11 | `dk_inv_acc` | `Q_decay^T` (SMEM) | `dA` | 128 x 16 x 16 | 1 | no | none | `da_ready` | none yet |
 | 12 | `dq_acc` | `K_inv^T` (SMEM) | `dA^T` | 128 x 16 x 16 | 1 | twin | `chunk >= FIRST_STATE_CHUNK` selects the twin | same stage | `dq_acc_ready`, `da_done` |
 | 13 | `dk_decay_acc` | `state` (TMEM) | `dY^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | `dy_smem_ready` | `dy_smem_done`, `state_inp_done` |
@@ -1057,6 +1157,7 @@ table in `.porting/gdn2_bprop_f16/static_opcode_evidence.md`.
 | `rcp.approx.ftz.f32` | 48 | `1/eG` is a reciprocal, never a divide |
 | `ex2.approx.ftz.f32` | 16 | the gate lives in log2 space |
 | `barrier.sync` | 7 | named barriers at 512, 416 and 128 threads |
+| `fence.proxy.async.shared::cta` | 17 | one per generic-to-async-proxy publish; the `state` branch has 18, the extra being the dht seed's, which `basic` does not compile |
 | `setmaxnreg` | 7 | three compute groups plus four single warps |
 | `atom.global` | 0 | the ticket atomic appears only in the `dynamic` branch, where it is 1 |
 

--- a/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
@@ -1,0 +1,905 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 GDN-2 BF16 backward: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch, not a Python module, builder API,
+mathematical reference, or alternate implementation.  The implementation it
+describes is maintained in
+[`tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py`](../../../tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
+which is the source of truth after the correctness gate.
+
+The source specialization is fixed to `BT=16`, `DK=DV=128`, BF16 or FP16 I/O,
+FP32 accumulation, one CTA per cluster, 512 main-kernel threads, 1024 prologue
+threads, and 512 TMEM columns.  Capability is the following discrete,
+source-verified set rather than a Cartesian product: `basic`, `tail` (ragged
+lengths including a zero-length sequence), `grouped(HQ,HK,HV)=(4,1,1)`,
+`l2norm`, `safe_gate`, `beta_sigmoid`, `state` (initial state + final-state
+gradient + initial-state gradient), `dynamic`, `order_scratch`,
+`order_generate`, and `fp16`.  Each label means the exact profile frozen in
+`.porting/gdn2_bprop_f16/export_ptx.py`; combinations not present there are not
+claimed.
+
+GDN-2 differs from its KDA sibling in the gating algebra, and that difference is
+what this sketch must carry: the erase gate `Beta` is per-key-channel and is
+folded into the `K_decay` operand, a new per-value write gate `W` forms
+`Y = W*V - S^T K_decay`, `T_inv` and `dM_strict` carry no Beta row scale, and
+the kernel emits two additional gradients, `dW_out = V*dY` and a per-channel
+`dBeta`.
+
+Writer line-info evidence is under `.porting/gdn2_bprop_f16/source_export/`,
+one directory per accepted branch.  Each holds two PTX files with both `.file`
+and `.loc`: the main `kernel_cutlass_kernel_Gdn2BwdCfg...sm_100a.ptx` and the
+`kernel_cutlass_prologue_kernel_...ptx`.  Unless stated otherwise, PTX line
+numbers below refer to the `basic` branch's main PTX.  Static counts use
+instruction lines minus predicated lines.
+
+## Pipeline at a glance
+
+| Warps | Register target | Role-local program | Main publication/reuse edges |
+| --- | ---: | --- | --- |
+| 0..3 | 128 | gate log2 prefix scan, optional Q/K L2 normalization, materialize `K_decay = eG*(Beta*K)`, `K_inv = K/eG`, `K_restore = (eGl/eG)*K`, `Q_decay = eG*scale*Q` and `diag(eGl)`; push raw Q/K into the TMEM ring; restage the entering state SMEM->TMEM | raw Q/K/Gate/Beta, state, decay operands, Q/K raw TMEM |
+| 4..7 | 184 | value side: `Y = W*V - state_k`, U/dU/dY restages, `dV = W*dY` and `dW_out = V*dY`, dH capture, dht seed, dS0 drain | raw V/W, U/dY/dV/dW stages, dState |
+| 8..11 | 136 | drain the four dQ/dK TMEM accumulators, assemble dQ/dK, per-channel `dBeta`, `dGate` plus its in-register reverse cumsum, L2-norm backward projection | dQ/dK/dGate/dBeta output stages, state and dState reuse |
+| 12 | 64 | register `mma.sync` program: `KK = K_decay@K_inv^T`, three-round Neumann `T_inv`, `dM = dY@U^T` and the `+/-strict(dM)` tiles | intermediate tiles, decay operands, dY/U |
+| 13 | 64 | allocate 512 TMEM columns and issue the 15 logical `tcgen05.mma` chains, then tear TMEM down | every TMEM accumulator/input edge |
+| 14 | 64 | persistent work-stealing scheduler plus Q/K/Gate/Beta/V/W/dO/checkpoint TensorMap loads | seven raw rings, state ring, scheduler publication |
+| 15 | 64 | register `A = tril_incl(Q_decay@K_inv^T)` and `dA = tril_incl(dO@U^T)`, then the one-behind six-store TensorMap ladder | A/dA intermediate tiles, dO reuse, all six output stages |
+
+Role dispatch is the source-order `if/elif` chain: 14, 12, 13, 15, 0..3, 4..7,
+then 8..11.  Every role constructs its own persistent scheduler cursor; the
+eight scheduler stages are never reset between work items.
+
+The register split is exact rather than approximate.  The launch base is 128
+registers per thread over 512 threads (65536 total).  Warps 0..3 stay at the
+base, warps 4..7 take `+56`, warps 8..11 take `+8`, and warps 12..15 release
+`-64`; at 128 threads per group that is `+7168 + 1024 = 8192` taken against
+`8192` released.  Warps 12..15 are one warpgroup and therefore must share a
+single value.
+
+## Primitive vocabulary
+
+All storage is linear.  No declaration or operation carries a layout object,
+layout value, tile primitive, or first-class view.  Logical matrices below are
+only index ranges selected by scalar address functions.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(base, stage, row, col, stage_bytes, row_bytes, elem_bytes, xor_bits)
+tmem_cell(base, row, col)       # base + col + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch)  # workspace + (array*B+batch)*128
+```
+
+Directional movement primitives:
+
+```python
+copy_p2g(src, dst)                        # parameter descriptor -> GMEM
+copy_g2s(src, dst, predicate, completion) # GMEM -> SMEM
+copy_s2g(src, dst, predicate)             # SMEM -> GMEM
+copy_g2r(src, dst, predicate=True)
+copy_r2g(src, dst, predicate=True)
+copy_s2r(src, dst)
+copy_r2s(src, dst)
+copy_t2r(src, dst)
+copy_r2t(src, dst)
+```
+
+Computational primitives are only:
+
+```python
+fill(dst, value)
+cast(dst, src)
+add(dst, lhs, rhs)
+sub(dst, lhs, rhs)
+mul(dst, lhs, rhs)
+fma(dst, lhs, rhs, acc)
+rcp(dst, src)
+exp2(dst, src)
+log2(dst, src)
+tanh(dst, src)
+rsqrt(dst, src)
+min(dst, lhs, rhs)
+max(dst, lhs, rhs)
+select(dst, predicate, true_value, false_value)
+shuffle_xor(dst, src, delta)
+shuffle_up(dst, src, delta)
+gemm(dst, lhs, rhs, accumulate=False)
+```
+
+`init`, `wait`, `arrive`, `expect_bytes`, `commit`, `release`, `fence`,
+`barrier`, stage/phase advancement, register-budget changes, descriptor field
+replacement, directional-copy groups, and TMEM allocation are schedule
+operations.  Each key movement, computation, or synchronization occurrence
+below is immediately followed by the selected instruction or instruction
+family observed in the writer export.
+
+## Complete sketch
+
+```python
+# ==========================================================================
+# Static parameters and the two-launch runtime ABI
+# ==========================================================================
+BT      = 16          # chunk-inner token tile
+DK      = 128         # query/key head dim
+DV      = 128         # value head dim
+IO      = bf16        # or fp16; FP32 accumulation throughout
+BPE     = 2
+LOG2_E  = 1.4426950408889634
+L2_EPS  = 1e-12       # compared against the squared sum, clamped at 1e-24
+
+# Capability flags, each a separate compiled program.
+L2NORM, SAFE_GATE, BETA_SIGMOID = ...
+USE_INITIAL_STATE, USE_DSTATE_IN, USE_DSTATE0 = ...
+DYN_SCHED, ORDER_IN_PROLOGUE, ORDER_GENERATE = ...
+GATE_SCALE_LOG2 = gate_lower_bound * LOG2_E        # -5.0 * LOG2_E by default
+Q_RATIO, K_RATIO, V_RATIO = HO // HQ, HO // HK, HO // HV
+FIRST_STATE_CHUNK = 0 if USE_INITIAL_STATE else 1
+
+# Launch 1 (prologue): grid 1, 1024 threads.
+# Launch 2 (main):     grid = SM count, 512 threads, one CTA per cluster,
+#                      min_blocks_per_sm = 1, persistent.
+
+# GMEM tensors.  THD packed, stride-1 innermost.
+q       : gmem[IO,  total_T * HQ * DK]
+k       : gmem[IO,  total_T * HK * DK]
+v       : gmem[IO,  total_T * HV * DV]
+gate    : gmem[f32, total_T * HO * DK]     # natural log, or safe-gate logits
+beta    : gmem[IO,  total_T * HO * DK]     # per-key erase gate  (GDN-2)
+w       : gmem[IO,  total_T * HO * DV]     # per-value write gate (GDN-2)
+do      : gmem[IO,  total_T * HO * DV]
+ckpt    : gmem[IO,  rows * HO * DV * DK]   # entering-state series, V-major
+dq, dk, dv, dgate, dbeta, dw               # outputs, pre-allocated, not zeroed
+dstate_in  : gmem[f32, B * HO * DV * DK]   # optional dL/d(final state)
+dstate0_out: gmem[f32, B * HO * DV * DK]   # optional dL/d(initial state)
+cu_seqlens : gmem[i32, B + 1]
+work_items : gmem[i32, rows * 8]           # (b, h, wstart, wend, cstart, cend, tok0, tok1)
+work_count : gmem[i32, 1]
+sched_ctr  : gmem[i32, 2]                  # dynamic-scheduler ticket
+tmaps      : gmem[u64, 14 * B * 16]        # 14 descriptor arrays, 128 B slots
+
+# ==========================================================================
+# Descriptor arrays.  Arrays 0..11 are rank-3; Gate and dGate are FP32 with
+# [32,1,16] boxes, the other 16-bit tensors use [64,1,16].  The checkpoint
+# array is rank-4 with box [64,DK,1,1].  All use 128-byte swizzle.
+# ==========================================================================
+TMAP_Q, TMAP_K, TMAP_V, TMAP_GATE, TMAP_BETA, TMAP_W, TMAP_DO = 0, 1, 2, 3, 4, 5, 6
+TMAP_CKPT                                                     = 7
+TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DBETA, TMAP_DWO   = 8, 9, 10, 11, 12, 13
+
+# ==========================================================================
+# Linear SMEM.  One arena; every region is a byte range.  Declaration order is
+# semantic: tcgen05-descriptor operands occupy the low group, `BANK_FILL` pads,
+# and generic-client buffers occupy the high group.  The pad makes SQ start at
+# exactly 131072 (the 128 KB midpoint); this is verified, not assumed.
+# ==========================================================================
+arena = linear_buffer(smem, u8, 225280, 0, 1024, whole_kernel)
+
+BARRIERS       =      0;  BARRIERS_END       =    984   # 123 slots x 8 B
+TMEM_HOLD      =    984
+SCHED          =   1008                                 # 8 x i32 ring
+RED1           =   1024;  NORM               =   1280   # f32 scratch
+STATE          =   2048;  STATE_END          =  34816   # [DK][DV]
+DSTATE         =  34816;  DSTATE_END         =  67584
+K_DECAY        =  67584;  K_DECAY_END        =  75776   # 2 x [BT][DK]
+K_INV          =  75776;  K_INV_END          =  83968
+K_RESTORE      =  83968;  K_RESTORE_END      =  92160
+Q_DECAY        =  92160;  Q_DECAY_END        = 100352
+STATE_DIAG     = 100352;  STATE_DIAG_END     = 108544   # 2 x 8 x [16][16], 32B swz
+INTERMEDIATE   = 108544;  INTERMEDIATE_END   = 113664   # 2 x 5 x [16][16], 32B swz
+DO             = 114688;  DO_END             = 122880
+BETA           = 122880;  BETA_END           = 131072
+BANK_FILL      = 131072 - 1024                          # pad, never addressed
+SQ             = 131072;  SQ_END             = 139264
+SK             = 139264;  SK_END             = 147456
+SV             = 147456;  SV_END             = 155648
+SGATE          = 155648;  SGATE_END          = 172032   # f32
+SW             = 172032;  SW_END             = 180224
+SU             = 180224;  SU_END             = 184320
+SDY            = 184320;  SDY_END            = 188416
+SDQ            = 188416;  SDK                = 192512
+SDV            = 196608;  SDV_END            = 204800
+SDGATE         = 204800;  SDGATE_END         = 212992   # f32
+SDWO           = 212992;  SDWO_END           = 221184
+SDB            = 221184;  SDB_END            = 225280
+assert SDB_END == 225280        # 7168 B of headroom under the 232448 B cap
+
+# Scalar address functions.  Each selects bytes; none is a layout.
+def swizzle_xor_128b(row, col, elem_bytes):
+    elems = 128 // elem_bytes
+    return (col ^ ((row % 8) * (16 // elem_bytes))) % elems
+
+def raw_io_byte(base, stage, token, channel):        # [BT][DK] or [BT][DV], 128B swizzle
+    seg, within = channel // 64, channel % 64
+    return base + stage * 4096 + (seg * 1024 + token * 64
+                                  + swizzle_xor_128b(token, within, 2)) * 2
+
+def raw_f32_byte(base, stage, token, channel):       # Gate and dGate
+    seg, within = channel // 32, channel % 32
+    return base + stage * 8192 + (seg * 512 + token * 32
+                                  + swizzle_xor_128b(token, within, 4)) * 4
+
+def swizzle_xor_32b(row, col, elem_bytes):           # 16x16 intermediate tiles
+    chunk = 16 // elem_bytes
+    return ((col // chunk) ^ ((row >> 2) & 1)) * chunk + col % chunk
+
+def inter_byte(stage, slot, row, col):               # slot 0=A 1=T_inv 2=dA 3=+dM 4=-dM
+    return INTERMEDIATE + (stage * 5 + slot) * 512 + (row * 16
+           + swizzle_xor_32b(row, col, 2)) * 2
+
+def state_byte(row, col):                            # [DK][DV] entering state
+    seg, within = col // 64, col % 64
+    return STATE + (seg * 8192 + row * 64 + swizzle_xor_128b(row, within, 2)) * 2
+
+# tcgen05 operand descriptors are packed integers, not layouts: the 14-bit
+# shared address, the leading and stride byte offsets, bit 46, and the layout
+# code at bit 61.  Aliased operand views differ only in `leading_bytes`:
+#   state_alt (lead DV*128) vs state_direct (lead 16); do_lead16 vs do_amaj;
+#   q_decay_trans; k_decay_trans; k_inv_amaj; dy_lead16.
+def smem_desc(base_byte, leading_bytes, stride_bytes, layout_code): ...
+
+# ==========================================================================
+# TMEM: one 512-column allocation, used exactly.  Two aliases are load-bearing
+# and are safe only under the in-order tcgen05 issue queue plus the barrier
+# chain quoted beside each.
+# ==========================================================================
+TM_DSTATE_ACC   =   0    # 128 cols, fp32 dH [DV rows][DK cols]
+TM_DSTATE_INP   = 128    #  64 cols, dH as an f16 A-operand
+TM_STATE_INP    = 192    # 128 cols, 2 stages x 64, entering state
+TM_STATE_K_ACC  = 320    #  16 cols
+TM_DY_ACC       = 320    #  ALIAS of STATE_K_ACC: WG1 consumes state_k before
+                         #  dY = dU @ T_inv writes, and the dY readback precedes
+                         #  state_k(c+1) = state @ K_decay^T
+TM_U_ACC        = 336    #  16 cols
+TM_DU_ACC       = 352    #  16 cols
+TM_DQ_ACC       = 368    #  16 cols
+TM_DK_DECAY_ACC = 384    #  16 cols
+TM_DK_INV_ACC   = 400    #  16 cols
+TM_DK_RESTORE   = 416    #  16 cols
+TM_Y_INP        = 432    #   8 cols
+TM_NEG_DY_INP   = 432    #  ALIAS of Y_INP: U = Y @ T_inv consumed Y before the
+                         #  dY block runs, and y_inp(c+1) is gated by
+                         #  state_k_acc_ready(c+1)
+TM_DU_INP       = 440    #   8 cols
+TM_QRAW_INP     = 448    #  4 stages x 8
+TM_KRAW_INP     = 480    #  4 stages x 8
+assert TM_KRAW_INP + 4 * 8 == 512
+
+def tmem_cell(base, row, col): return base + col + (row << 16)
+```
+
+```python
+# ==========================================================================
+# Launch 1: prologue, grid 1 x 1024 threads.
+# ==========================================================================
+def prologue_kernel():
+    if ORDER_IN_PROLOGUE:
+        # Longest-processing-time ordering over the work table, plus zeroing of
+        # BOTH consumers' scheduler rings.  When a scratch buffer is supplied it
+        # holds the built table and `work_items` is the destination; with
+        # ORDER_GENERATE the body synthesizes the table instead.
+        order_body(work_items, work_item_scratch, sched_all, n_threads=1024)
+        # instruction_selection: ld.global.s32 / st.global.s32 pairs per field;
+        # extent: loop over the item table
+        barrier(id=0, threads=1024)
+
+    for array in range(14):
+        for batch in range(B):
+            copy_p2g(param_descriptor(array), descriptor_slot(tmaps, array, batch))
+            # instruction_selection: st.global.v4.b32 per 128-byte slot;
+            # extent: one descriptor (224 st.global in the prologue export)
+            replace_field(GLOBAL_ADDRESS, base + cu_seqlens[batch] * row_stride)
+            replace_field(GLOBAL_DIM[2], seqlen_b)
+            # instruction_selection: tensormap.replace.tile.global_address
+            #   .global.b1024.b64 and .global_dim.global.b1024.b32; extent: scalar
+            #   per field.  The export carries exactly 14 of each, one per array.
+            fence_tensormap_release()
+            # instruction_selection: fence.proxy.tensormap::generic.release.gpu;
+            # extent: 14 sites, matching the descriptor-array count
+
+# Varlen needs no masking loop anywhere in the main kernel: the patched
+# GLOBAL_ADDRESS/GLOBAL_DIM make tail loads zero-fill and tail stores clip in
+# hardware.  The checkpoint array additionally derives its per-sequence chunk
+# offset on device from a running prefix of ceil(seqlen_b / BT).
+
+# ==========================================================================
+# Launch 2: main kernel, grid = SM count, 512 threads.
+# ==========================================================================
+def persistent_backward():
+    arena = ...            # the 225280-byte linear allocation above
+
+    # ---- barrier construction (one warp owns each contiguous run) ----------
+    for (name, stages, count, owner_warp) in PROTOCOL:      # 70 objects
+        if warp_id == owner_warp and elected():
+            for stage in range(stages):
+                init(barrier_slot(name, stage), arrival_count=count)
+                # instruction_selection: mbarrier.init.shared.b64; extent: scalar
+    fence_mbarrier_init()
+    # instruction_selection: fence.mbarrier_init.release.cluster
+    barrier(id=0, threads=512)
+    # instruction_selection: barrier.sync 0, 512
+
+    # ---- source-order role dispatch ---------------------------------------
+    if warp_id == 14:  tma_warp()          # register budget 64 (DECREASE)
+    elif warp_id == 12: super_mma_warp()   # 64
+    elif warp_id == 13: tcgen05_warp()     # 64
+    elif warp_id == 15: epilogue_warp()    # 64
+    elif warp_id < 4:   compute_group_0()  # 128 (equals the launch base)
+    elif warp_id < 8:   compute_group_1()  # 184 (INCREASE)
+    else:               compute_group_2()  # 136 (INCREASE)
+    # instruction_selection: setmaxnreg.inc/dec.sync.aligned.u32; extent: 7 sites
+    # (three compute groups plus each of warps 12..15 separately)
+
+# ==========================================================================
+# Persistent tile scheduler.  The TMA warp owns the ticket; the other fifteen
+# warps each elect one lane and consume through an eight-deep SMEM ring.
+# ==========================================================================
+def sched_publish_next(tile_idx, num_ctas):
+    if DYN_SCHED:
+        if elected():
+            ticket = atomic_add(sched_ctr, 1)
+            # instruction_selection: atom.global.add.u32; extent: scalar
+            # (absent entirely when DYN_SCHED is off -- verified in the export)
+        next_tile = ticket + num_ctas
+    else:
+        next_tile = tile_idx + num_ctas
+    wait("sched_done", sched_stage, sched_phase)
+    copy_r2s(next_tile, SCHED + sched_stage * 4)
+    arrive("sched_ready", sched_stage)
+    # instruction_selection: st.shared.b32 then mbarrier.arrive.shared.b64
+    return next_tile
+
+def sched_next_tile():
+    wait("sched_ready", sched_stage, sched_phase)
+    copy_s2r(SCHED + sched_stage * 4, next_tile)
+    # instruction_selection: ld.shared.s32; extent: scalar
+    if elected():
+        arrive("sched_done", sched_stage)
+    # instruction_selection: mbarrier.arrive.shared.b64; extent: one lane per warp
+    # `sched_done` carries arrival count 15 -- every warp except the producer.
+    return next_tile
+
+# ==========================================================================
+# Warp 14: TMA loads.  Seven per-token tensors plus the entering state.
+# ==========================================================================
+def tma_warp():
+    raw    = PipelineState.start(phase=1)      # 2 stages
+    state  = PipelineState.start(phase=1)      # 1 stage
+    tile_idx = cta_id
+    while tile_idx < total_tiles:
+        b, h, batch_start, batch_end, seqlen_b, num_chunks_b, wstart, wend, cstart, cend = \
+            decode_work_item(work_items, tile_idx)
+        # instruction_selection: 2 x ld.global.v4.b32; extent: one 8-field item
+        next_tile = sched_publish_next(tile_idx, num_ctas)
+
+        # Head grouping is a load coordinate, never a descriptor patch.
+        head_o = h; head_q = h // Q_RATIO; head_k = h // K_RATIO; head_v = h // V_RATIO
+        if elected():
+            for array in (Q, K, V, GATE, DO, BETA, W, CKPT):
+                acquire_tensormap(descriptor_slot(tmaps, array, b))
+                # instruction_selection: fence.proxy.tensormap::generic.acquire.gpu
+
+        for rev in range(cend - wstart):               # unroll=1
+            chunk = cend - 1 - rev                     # walks HIGH -> LOW
+            tok0  = chunk * BT
+
+            for (tensor, bar, head, stage_bytes) in (
+                    (SQ, "q", head_q, 4096), (SK, "k", head_k, 4096),
+                    (SGATE, "gate", head_o, 8192), (BETA, "beta", head_o, 4096)):
+                wait(bar + "_done", raw.stage, raw.phase)
+                if elected():
+                    expect_bytes(bar + "_ready", raw.stage, stage_bytes)
+                    # instruction_selection: mbarrier.arrive.expect_tx.shared.b64
+                copy_g2s(gmem_tile(tensor, b, head, tok0), tensor + raw.stage * ...,
+                         completion=bar + "_ready")
+                # instruction_selection: cp.async.bulk.tensor.3d.shared::cta
+                #   .global.tile.mbarrier::complete_tx::bytes; extent: one [BT,dim] tile
+
+            if chunk >= FIRST_STATE_CHUNK:
+                wait("state_cg0_done", state.stage, state.phase)
+                wait("state_done",     state.stage, state.phase)
+                if elected():
+                    expect_bytes("state_ready", state.stage, 32768)
+                copy_g2s(gmem_checkpoint(b, head_o, chunk), STATE,
+                         completion="state_ready")
+                # instruction_selection: cp.async.bulk.tensor.4d.shared::cta.global
+                #   .tile.mbarrier::complete_tx::bytes; extent: one [DV,DK]
+                #   checkpoint, box [64,DK,1,1]; 2 static sites
+                state = advance(state, 1)
+
+            # dO waits on TWO consumers: the epilogue warp and the MMA warp.
+            wait("do_done",     raw.stage, raw.phase)
+            wait("do_mma_done", raw.stage, raw.phase)
+            if elected():
+                expect_bytes("do_ready", raw.stage, 4096)
+            copy_g2s(gmem_tile(DO, b, head_o, tok0), DO + raw.stage * 4096,
+                     completion="do_ready")
+            # instruction_selection: cp.async.bulk.tensor.3d.shared::cta.global
+            #   .tile.mbarrier::complete_tx::bytes
+
+            for (tensor, bar, head) in ((SV, "v", head_v), (SW, "w", head_o)):
+                wait(bar + "_done", raw.stage, raw.phase)
+                if elected():
+                    expect_bytes(bar + "_ready", raw.stage, 4096)
+                copy_g2s(gmem_tile(tensor, b, head, tok0), tensor + raw.stage * 4096,
+                         completion=bar + "_ready")
+                # instruction_selection: cp.async.bulk.tensor.3d.shared::cta.global
+                #   .tile.mbarrier::complete_tx::bytes
+            raw = advance(raw, 2)
+        tile_idx = next_tile
+```
+
+The load order is fixed and observable: Q, K, Gate, Beta, entering state, dO, V,
+W.  `V` and `W` are released late in GDN-2 -- warp group 1 holds both until
+after the scalar `dV`/`dW_out` pass -- so their two raw stages stay occupied
+longer than the KDA sibling's do.
+
+```python
+# ==========================================================================
+# Warp 12: register-MMA program.  KK, the Neumann inverse, and dM.
+# Unlike the KDA sibling, NO Beta row scale is applied to L or to dM_strict:
+# GDN-2 folds Beta into the K_decay operand instead.
+# ==========================================================================
+def super_mma_warp():
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            wait("t_inv_done", inter_stage, inter_phase)
+            wait("k_decay_inv_ready", decay_stage, decay_phase)
+
+            # ---- KK = K_decay @ K_inv^T ----------------------------------
+            fill(kk_acc[0:8], 0.0)
+            for k_block in range(DK // 16):
+                copy_s2r(K_DECAY + raw_io_byte(...), a_frag[0:4])
+                copy_s2r(K_INV   + raw_io_byte(...), b_frag[0:4])
+                # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.shared.b16;
+                # extent: one 16x16 operand fragment
+                gemm(kk_acc, a_frag, b_frag, accumulate=True)
+                # instruction_selection: mma.sync.aligned.m16n8k16.row.col
+                #   .f32.bf16.bf16.f32; extent: 8 issues over the K walk
+
+            # ---- L = strict_tril(KK), T_inv = (I + L)^-1 by 3 Neumann rounds
+            select(l_regs, strict_lower_mask, kk_acc, 0.0)
+            cast(l_packed, l_regs)
+            # instruction_selection: cvt.rn.bf16x2.f32; extent: 8 lanes -> 4 packs
+            sub(tinv_acc, eye_mask, l_packed)          # T_inv <- I - L
+            for _round in range(3):
+                transpose(mov_lpow, l_packed)
+                # instruction_selection: movmatrix.sync.aligned.m8n8.trans.b16;
+                # extent: 4 packs per round
+                gemm(sq_acc, l_packed, mov_lpow)       # square the strict power
+                gemm(upd_acc, tinv_packed, sq_acc)     # fold into the inverse
+                # instruction_selection: 2 x mma.sync...m16n8k16; extent: one round
+            copy_r2s(tinv_packed, inter_byte(inter_stage, slot=1, ...))
+            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16
+            arrive("t_inv_ready", inter_stage)
+
+            # ---- dM = dY @ U^T, then the two strict tiles -----------------
+            wait("dy_smem_ready"); wait("u_smem_ready")
+            for k_block in range(DV // 16):
+                copy_s2r(SDY + ..., a_frag); copy_s2r(SU + ..., b_frag)
+                # instruction_selection: ldmatrix...x4.shared.b16
+                gemm(dm_acc, a_frag, b_frag, accumulate=True)
+                # instruction_selection: 8 x mma.sync...m16n8k16; extent: dM
+            select(dm_strict, strict_lower_mask, dm_acc, 0.0)
+            copy_r2s(+dm_strict, inter_byte(inter_stage, slot=3, ...))
+            copy_r2s(-dm_strict, inter_byte(inter_stage, slot=4, ...))
+            # instruction_selection: 2 x stmatrix...x4.shared.b16; extent: the
+            # +/- pair, so dk_inv and dk_decay can share one accumulator sign
+            arrive("dm_ready", inter_stage)
+
+# ==========================================================================
+# Warp 13: TMEM lifecycle and the fifteen tcgen05 GEMM chains.
+# ==========================================================================
+def tcgen05_warp():
+    alloc_tmem(columns=512)
+    # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned
+    #   .shared::cta.b32; extent: one allocation
+    relinquish_alloc_permit()
+    # instruction_selection: tcgen05.relinquish_alloc_permit...
+    barrier(id=3, threads=416)          # tcgen05 warp + the three compute groups
+    # instruction_selection: barrier.sync 3, 416
+
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            # Each logical GEMM below expands only to its repeated tcgen05.mma
+            # family; publication is a separate, delayed operation.
+            if chunk >= FIRST_STATE_CHUNK:
+                wait("state_ready", state_stage, state_phase)
+                for k in range(8):
+                    gemm(tmem_cell(TM_STATE_K_ACC, row, 0),
+                         state_operand(k), k_decay_operand(decay_stage, k),
+                         accumulate=k > 0)
+                # instruction_selection: 8 x tcgen05.mma.cta_group::1.kind::f16;
+                # extent: GEMM 1
+                commit("state_k_acc_ready"); commit("state_done")
+                # instruction_selection: one delayed tcgen05.commit.cta_group::1
+                #   .mbarrier::arrive::one.shared::cluster.b64 per published edge
+
+            ...                        # GEMMs 2..15 in the order of the table below,
+                                       # each followed by its own extent annotation
+    # ---- teardown ------------------------------------------------------
+    wait("tmem_done")
+    dealloc_tmem()
+    # instruction_selection: tcgen05.dealloc.cta_group::1.sync.aligned...
+
+# ==========================================================================
+# Warp 15: two register GEMMs, then the one-behind six-store ladder.
+# ==========================================================================
+def epilogue_warp():
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            writes = chunk < wend       # [wend, cend) is the right warm-up
+
+            # ---- A = tril_incl(Q_decay @ K_inv^T) ------------------------
+            wait("q_decay_k_restore_ready", decay_stage, decay_phase)
+            for k_block in range(DK // 16):
+                copy_s2r(Q_DECAY + ..., a_frag); copy_s2r(K_INV + ..., b_frag)
+                # instruction_selection: ldmatrix...x4.shared.b16
+                gemm(a_acc, a_frag, b_frag, accumulate=True)
+                # instruction_selection: 8 x mma.sync...m16n8k16; extent: A
+            select(a_tile, lower_incl_mask, a_acc, 0.0)
+            copy_r2s(a_tile, inter_byte(inter_stage, slot=0, ...))
+            # instruction_selection: stmatrix...x4.shared.b16
+            arrive("a_ready", inter_stage)
+
+            # ---- dA = tril_incl(dO @ U^T) --------------------------------
+            wait("do_ready", raw_stage, raw_phase); wait("u_smem_ready")
+            for k_block in range(DV // 16):
+                copy_s2r(DO + ..., a_frag); copy_s2r(SU + ..., b_frag)
+                gemm(da_acc, a_frag, b_frag, accumulate=True)
+                # instruction_selection: 8 x mma.sync...m16n8k16; extent: dA
+            select(da_tile, lower_incl_mask, da_acc, 0.0)
+            copy_r2s(da_tile, inter_byte(inter_stage, slot=2, ...))
+            arrive("da_ready", inter_stage); arrive("do_done", raw_stage)
+
+            # ---- one-behind store ladder ---------------------------------
+            # Six stores issue in a fixed order, then their staging buffers are
+            # released one at a time so each frees as early as possible.
+            if writes:
+                for (stage_buf, bar, desc) in ((SDQ, "dq", TMAP_DQ), (SDK, "dk", TMAP_DK),
+                                               (SDGATE, "dgate", TMAP_DGATE),
+                                               (SDB, "db", TMAP_DBETA),
+                                               (SDV, "dv", TMAP_DV),
+                                               (SDWO, "dwo", TMAP_DWO)):
+                    wait(bar + "_tmastg_ready", ...)
+                    copy_s2g(stage_buf, gmem_tile(desc, b, head, tok0))
+                    # instruction_selection: cp.async.bulk.tensor.3d.global
+                    #   .shared::cta.tile.bulk_group; extent: one [BT,dim] tile
+                commit_store_group()
+                # instruction_selection: cp.async.bulk.commit_group
+                for slot in (5, 4, 3, 2, 1, 0):
+                    wait_store_group(slot)
+                    # instruction_selection: cp.async.bulk.wait_group.read;
+                    # extent: staged release, one buffer freed per step
+                    arrive(release_for(slot) + "_tmastg_done", ...)
+```
+
+Out-of-range rows need no predicate here: the prologue capped `GLOBAL_DIM[2]`
+at `seqlen_b`, so a tail store clips in hardware.  A work item whose `wstart`
+is 0 additionally drains `dstate0`, and a zero-length sequence takes a
+pass-through branch that copies or zeros `d_initial_state` without entering the
+chunk loop at all.
+
+```python
+# ==========================================================================
+# Warps 0..3: gate prefix, normalization, and the four decay operands.
+# ==========================================================================
+def compute_group_0():
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            wait("gate_ready", raw_stage, raw_phase)
+            copy_s2r(SGATE + raw_f32_byte(...), raw_gate[0:16])
+            # instruction_selection: ld.shared.f32; extent: 16 tokens of one channel
+
+            # ---- gate -> log2 domain, then an in-chunk inclusive prefix ----
+            if SAFE_GATE:
+                mul(t, raw_gate, exp2(a_log * LOG2_E))
+                tanh(s, (t + dt_bias) * 0.5); mul(g_log2, GATE_SCALE_LOG2, s*0.5+0.5)
+                # instruction_selection: ex2.approx.ftz.f32 then
+                #   tanh.approx.f32; extent: 1 + 16 per chunk (the `safe_gate`
+                #   branch's whole delta over `basic`)
+            else:
+                mul(g_log2, raw_gate, LOG2_E)
+            select(g_log2, token_idx < seqlen_b, g_log2, 0.0)   # tail rows decay by 1
+            # A fixed pairwise bracketing, not a compiler-chosen reduction:
+            #   prefix0 = acc + g0;  pair = g0 + g1;  prefix1 = acc + pair
+            add_packed(prefix, acc, g_pair)
+            # instruction_selection: add.rn.f32x2; extent: one token pair per step
+            exp2(eG, prefix); exp2(eGl, chunk_total)
+            # instruction_selection: ex2.approx.ftz.f32; extent: 16 tokens
+            arrive("gate_done", raw_stage)      # count CG0+CG2: WG2 reads it too
+
+            if L2NORM:
+                rsqrt(q_inv_norm, max(sum_sq_q, 1e-24)); rsqrt(k_inv_norm, ...)
+                # instruction_selection: rsqrt.approx.ftz.f32; extent: one per row
+                copy_r2s(q_inv_norm, NORM + ...); copy_r2s(k_inv_norm, ...)
+
+            # ---- the four operands.  Beta enters K_decay ONLY. -------------
+            wait("k_ready"); wait("beta_ready"); wait("q_ready")
+            mul(k_value, raw_k, k_inv_norm)
+            mul(k_beta, k_value, raw_beta)                 # GDN-2: Beta folded in
+            mul(K_decay_pack, cast(k_beta), cast(eG))
+            # instruction_selection: mul.bf16x2; extent: 4 packs per dim half
+            rcp(exp_neg_g, eG)                             # never a divide
+            # instruction_selection: rcp.approx.ftz.f32; extent: 2 per pack
+            mul(K_inv_pack, cast(k_value), cast(exp_neg_g))   # no Beta here
+            mul(K_restore_pack, cast(k_value), cast(eGl / eG))
+            mul(Q_decay_pack, cast(q_value), cast(eG * scale))
+            for pack in (K_decay, K_inv, K_restore, Q_decay):
+                copy_r2s(pack, raw_io_byte(base, decay_stage, row, dim))
+                # instruction_selection: st.shared.v4.b32; extent: 8 channels
+            fill(STATE_DIAG + inter..., diag(eGl))          # 8 k-atoms of [16][16]
+            arrive("k_decay_inv_ready", decay_stage)
+            arrive("q_decay_k_restore_ready", decay_stage)
+
+            copy_r2t(raw_q, tmem_cell(TM_QRAW_INP, row, qk_stage * 8))
+            copy_r2t(raw_k, tmem_cell(TM_KRAW_INP, row, qk_stage * 8))
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x4.b32;
+            # extent: the raw Q/K ring WG2 later re-reads
+            arrive("qk_raw_ready", qk_stage)
+
+            if chunk >= FIRST_STATE_CHUNK:                  # state SMEM -> TMEM
+                wait("state_ready")
+                copy_s2r(state_byte(...), state_regs); copy_r2t(state_regs, TM_STATE_INP)
+                # instruction_selection: ld.shared.b16 then
+                #   tcgen05.st.sync.aligned.16x128b.x2.b32
+                arrive("state_inp_ready", state_inp_stage); arrive("state_cg0_done")
+
+# ==========================================================================
+# Warps 4..7: the value side.  Owns dV and the new dW_out.
+# ==========================================================================
+def compute_group_1():
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            # ---- Y = W*V - state_k ---------------------------------------
+            wait("state_k_acc_ready"); wait("v_ready"); wait("w_ready")
+            copy_t2r(tmem_cell(TM_STATE_K_ACC, row, col), state_k)
+            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
+            copy_s2r(SV + ..., v_val); copy_s2r(SW + ..., w_val)
+            sub(y_val, mul(w_val, v_val), state_k)          # GDN-2: W gates V
+            copy_r2t(cast(y_val), tmem_cell(TM_Y_INP, ...))
+            # instruction_selection: tcgen05.st...32x32b.x4.b32; extent: Y operand
+            arrive("y_inp_ready")
+
+            wait("u_acc_ready"); copy_t2r(TM_U_ACC, u_val); copy_r2s(cast(u_val), SU)
+            # instruction_selection: tcgen05.ld then stmatrix...x4.shared.b16
+            arrive("u_smem_ready")
+            wait("du_acc_ready"); copy_t2r(TM_DU_ACC, du_val)
+            copy_r2t(cast(du_val), TM_DU_INP); arrive("du_inp_ready")
+
+            wait("dy_acc_ready"); copy_t2r(TM_DY_ACC, dy_val)   # ALIAS of state_k
+            copy_r2t(cast(-dy_val), TM_NEG_DY_INP); arrive("neg_dy_inp_ready")
+            copy_r2s(cast(dy_val), SDY); arrive("dy_smem_ready")
+            # dY gains a tcgen05 consumer in GDN-2 (dk_decay uses plain dY, not
+            # Beta*dY), hence the extra `dy_smem_done` MMA_COMMIT edge.
+
+            # ---- dV and dW_out: one scalar pass over this lane's channel ---
+            wait("dv_tmastg_done", dv_stage); wait("dwo_tmastg_done", dwo_stage)
+            barrier(id=4, threads=128)
+            # instruction_selection: barrier.sync 4, 128
+            for t in range(BT):                              # 16 iterations
+                copy_s2r(SDY + raw_io_byte(...), dy_v)
+                copy_s2r(SW  + raw_io_byte(...), w_v)
+                copy_s2r(SV  + raw_io_byte(...), v_v)
+                # instruction_selection: ld.shared.b16; extent: three loads per token
+                copy_r2s(cast(mul(w_v, dy_v)), SDV  + dv_stage  * 4096 + ...)
+                copy_r2s(cast(mul(v_v, dy_v)), SDWO + dwo_stage * 4096 + ...)
+                # instruction_selection: st.shared.b16; extent: dV and dW_out
+            arrive("dv_tmastg_ready"); arrive("dwo_tmastg_ready")
+            arrive("v_done", raw_stage); arrive("w_done", raw_stage)
+            # V and W are released only HERE, after the dW_out product needs V.
+
+            wait("dstate_acc_ready"); copy_t2r(TM_DSTATE_ACC, dh)
+            copy_r2t(cast(dh), TM_DSTATE_INP); copy_r2s(cast(dh), DSTATE)
+            arrive("dstate_inp_ready"); arrive("dstate_smem_ready")
+    # tail: seed d_final_state when cend == num_chunks_b, drain dstate0 when
+    # wstart == 0, and pass through for a zero-length sequence.
+    arrive("tmem_done")
+
+# ==========================================================================
+# Warps 8..11: gradient drain.  One lane owns one key channel x 16 tokens.
+# ==========================================================================
+def compute_group_2():
+    while tile_idx < total_tiles:
+        ...decode; for chunk in reverse_walk:
+            wait("dk_restore_part_acc_ready")
+            copy_t2r(tmem_cell(TM_DK_RESTORE, row, col), dk_restore_part)
+            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
+            for t in range(BT):
+                mul(dk_hat, eGl * rcp(eG[t]), dk_restore_part[t])
+                # instruction_selection: rcp.approx.ftz.f32 then mul.f32
+                fma(dgate_last_acc[t % 4], k_n[t], dk_hat, dgate_last_acc[t % 4])
+                # instruction_selection: fma.rn.f32; extent: a FIXED 4-way
+                # interleaved accumulation, not a compiler-chosen tree
+
+            wait("dq_acc_ready"); copy_t2r(TM_DQ_ACC, dq_vec)
+            mul(dq_n, mul_packed(eG, scale), dq_vec)
+            # instruction_selection: mul.rn.f32x2; extent: one token pair
+
+            wait("dk_inv_part_acc_ready"); copy_t2r(TM_DK_INV_ACC, dk_inv_part)
+            fma(dk_n, dk_inv_part, rcp(eG), dk_n)
+
+            # ---- dK_decay drain seeds BOTH dBeta and dGate -----------------
+            wait("dk_decay_part_acc_ready"); copy_t2r(TM_DK_DECAY_ACC, dk_decay_part)
+            copy_t2r(tmem_cell(TM_KRAW_INP, ...), k_raw)     # raw K from the ring
+            for t in range(BT):
+                mul(dk_decay, -eG[t], dk_decay_part[t])
+                mul(db_regs[t], k_n[t], dk_decay)            # GDN-2: per-channel dBeta
+                copy_s2r(BETA + raw_io_byte(...), beta_v)
+                if BETA_SIGMOID:
+                    tanh(s, beta_v * 0.5); cast(beta_v, s * 0.5 + 0.5)   # io round-trip
+                    # instruction_selection: tanh.approx.f32 then cvt.rn.bf16.f32
+                    #   and back to f32 -- the rounding is part of the contract
+                mul(dgate_regs[t], beta_v, dk_decay)
+                add(dk_n[t], dk_n[t], dgate_regs[t])
+            arrive("dqk_acc_done")
+
+            # ---- dGate finalize -------------------------------------------
+            for t in range(BT):
+                dgate_regs[t] = q_n[t]*dq_n[t] + beta_v*db_regs[t] \
+                                - k_n[t]*(dk_n[t] - dgate_regs[t])
+                # instruction_selection: fma.rn.f32 chain; extent: one token
+                if BETA_SIGMOID:
+                    mul(db_regs[t], db_regs[t], beta_v - beta_v*beta_v)
+                    # ORDER IS LOAD-BEARING: dGate above consumed db_regs BEFORE
+                    # the chain rule; swapping these corrupts dGate silently.
+            add(dgate_regs[BT-1], dgate_regs[BT-1],
+                (dgate_last_acc[0]+dgate_last_acc[1]) + (dgate_last_acc[2]+dgate_last_acc[3]))
+            arrive("beta_done", raw_stage)
+
+            if L2NORM:                       # row projection: grad -= k * <k, grad>
+                for (grad, qk_col) in ((dq_n, TM_QRAW_INP), (dk_n, TM_KRAW_INP)):
+                    reduce_dot(dots, grad, raw_qk)
+                    barrier(id=2, threads=128)
+                    # instruction_selection: barrier.sync 2, 128; extent: the
+                    # cross-warp half of the dot product
+                    fma(grad, -raw_qk, dots * inv_norm, grad)
+            reverse_cumsum(dgate_regs)       # in-register suffix scan over 16 tokens
+
+            for (regs, base, bar) in ((dq_n, SDQ, "dq"), (dk_n, SDK, "dk"),
+                                      (dgate_regs, SDGATE, "dgate"),
+                                      (db_regs, SDB, "db")):
+                copy_r2s(cast(regs), base + ...)
+                # instruction_selection: st.shared.b16 (st.shared.f32 for dGate)
+                arrive(bar + "_tmastg_ready")
+    arrive("tmem_done")
+```
+
+## Logical tcgen05 GEMMs
+
+Warp 13 issues fifteen logical GEMMs per chunk.  Every one is
+`tcgen05.mma.cta_group::1.kind::f16` with `tile_k_hw = 16` and FP32
+accumulation, so a GEMM whose K extent is 128 expands to eight issues and one
+whose K extent is 16 expands to one.  Two sites are duplicated for the
+`accumulate=True`/`False` twin.
+
+| # | FP32 TMEM destination | A operand | B operand | M x N x K | issues | accumulate |
+| ---: | --- | --- | --- | --- | ---: | --- |
+| 1 | `state_k_acc` | `state` (SMEM) | `K_decay^T` | 128 x 16 x 128 | 8 | on k>0 |
+| 2 | `dq_acc` | `state` (TMEM) | `dO^T` | 128 x 16 x 128 | 8 | on k>0 |
+| 3 | `du_acc` | `dstate_inp` (TMEM) | `K_restore` | 128 x 16 x 128 | 8 | on k>0 |
+| 4 | `dstate_acc` | `dstate_inp` (TMEM) | `diag(eGl)` | 128 x 16 x 16 | 8 | per k-atom |
+| 5 | `du_acc` | `dO^T` (SMEM) | `A` | 128 x 16 x 16 | 1 | yes |
+| 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes |
+| 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no |
+| 8 | `dy_acc` | `dU` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no |
+| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 |
+| 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes |
+| 11 | `dk_inv_acc` | `Q_decay^T` (SMEM) | `dA` | 128 x 16 x 16 | 1 | no |
+| 12 | `dq_acc` | `K_inv^T` (SMEM) | `dA^T` | 128 x 16 x 16 | 1 | twin |
+| 13 | `dk_decay_acc` | `state` (TMEM) | `dY^T` | 128 x 16 x 128 | 8 | on k>0 |
+| 14 | `dk_inv_acc` | `K_decay^T` (SMEM) | `-dM_strict` | 128 x 16 x 16 | 1 | yes |
+| 15 | `dk_decay_acc` | `K_inv^T` (SMEM) | `dM_strict^T` | 128 x 16 x 16 | 1 | twin |
+
+Issue vector `8,8,8,8,1,1,1,1,8,1,1,1,8,1,1` sums to 57 runtime issues; the two
+accumulate twins add two more static sites, giving the **59**
+`tcgen05.mma.cta_group::1.kind::f16` occurrences the export carries.  The count
+is identical in every accepted branch, so the GEMM structure is not specialized
+-- only the gating math around it is.
+
+Commits are delayed rather than per-issue: the export holds **19**
+`tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64` against
+those 59 issues, so a chain publishes once after all of its issues.
+
+Register-MMA work sits outside this table: warp 12 runs `KK` (8 x
+`mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32`), three Neumann rounds
+(2 each) and `dM` (8); warp 15 runs `A` (8) and `dA` (8).  The export's 76
+`mma.sync` occurrences cover both warps.
+
+## Static opcode evidence
+
+Counting convention: instruction lines minus predicated lines.  Full per-branch
+table in `.porting/gdn2_bprop_f16/static_opcode_evidence.md`.
+
+| family | `basic` main kernel | note |
+| --- | ---: | --- |
+| `mbarrier.init.shared.b64` | 123 | equals the 123 physical slots derived independently from the barrier table |
+| `tcgen05.mma.cta_group::1.kind::f16` | 59 | branch-invariant |
+| `tcgen05.commit...shared::cluster.b64` | 19 | delayed, not per-issue |
+| `tcgen05.alloc` / `relinquish` / `dealloc` | 1 / 1 / 1 | one 512-column allocation |
+| `tcgen05.ld` / `tcgen05.st` | 28 / 28 | TMEM drains and restages |
+| `mma.sync.aligned.m16n8k16...bf16` | 76 | warps 12 and 15 |
+| `cp.async.bulk.tensor.3d` load / store | 16 / 28 | `shared::cta`, not `shared::cluster` |
+| `cp.async.bulk.tensor.4d` load | 2 | the checkpoint tile |
+| `ldmatrix` / `stmatrix` / `movmatrix` | 68 / 9 / 16 | |
+| `rcp.approx.ftz.f32` | 48 | `1/eG` is a reciprocal, never a divide |
+| `ex2.approx.ftz.f32` | 16 | the gate lives in log2 space |
+| `barrier.sync` | 7 | named barriers at 512, 416 and 128 threads |
+| `setmaxnreg` | 7 | three compute groups plus four single warps |
+| `atom.global` | 0 | the ticket atomic appears only in the `dynamic` branch, where it is 1 |
+
+Branch deltas that a port must not flatten: `safe_gate` adds 16 `tanh.approx`
+and one `ex2` (the `exp(a_log)`); `beta_sigmoid` adds 48 `tanh.approx`;
+`l2norm` adds roughly 900 net instructions; and `state` *drops* `rcp.approx`
+from 48 to 32, because an entering state at chunk 0 takes a different restore
+path.
+
+## Storage-alias lifetimes
+
+Four aliases carry correctness arguments rather than convenience, and a port
+must reproduce the producer/consumer order that makes each safe, not merely the
+offsets.
+
+| alias | over | why it is safe |
+| --- | --- | --- |
+| `dy_acc` | `state_k_acc` (TMEM 320) | warp group 1 consumes `state_k` into `Y` before the `dY = dU @ T_inv` MMA writes, and the `dY` readback precedes `state_k(c+1) = state @ K_decay^T`; the in-order tcgen05 queue plus `state_k_acc_ready` closes the loop |
+| `neg_dy_inp` | `y_inp` (TMEM 432) | `U = Y @ T_inv` consumed `Y` before the `dY` block runs (`u_acc_ready`), and `y_inp(c+1)` is gated by `state_k_acc_ready(c+1)`, whose commit covers the `-dY @ K_decay` MMA of chunk `c` |
+| `state_alt` / `state_direct` | `STATE` bytes | the same entering state read as two operand forms, differing only in `leading_bytes` (`DV*128` versus 16) |
+| `do_lead16` / `do_amaj` | `DO` bytes | `dO` feeds both a register GEMM in warp 15 and two tcgen05 chains, under different descriptor leading offsets |
+
+## TIRx module and validation contract
+
+- The module imports only `tirx_kernels.kern as K`.  No `T`, `Tx`, `I`, no
+  `tirx.tile.*`, no tile primitive, and no first-class layout anywhere.
+- Every SMEM region is a byte range inside one flat `u8` arena.  `K.smem_pool`
+  may own only the 984-byte barrier header; all data addressing is explicit
+  scalar arithmetic over `arena.ptr_to([byte])`.
+- TMEM is integer columns through `tmem_cell(base, row, col)`.
+- `get_kernel` returns the prologue entry followed by the main entry; the timed
+  region on both the TIRx and the reference side contains exactly those two
+  launches and nothing else.  Checkpoint construction, the work table, and all
+  workspace allocation happen outside timing.
+- Numerical contract that the upstream test suite enforces directly, and that a
+  port therefore may not "simplify": the log2-domain gate; `rcp`/`ex2`/`tanh`/
+  `rsqrt` in their approximate forms; the fixed packed-`f32x2` prefix-scan
+  bracketing and the fixed 4-way `dgate_last` accumulation; the beta-sigmoid
+  round-trip through the I/O dtype; and dGate consuming `db_regs` before the
+  beta chain rule.
+- There are no FP32 atomics anywhere.  The only atomic is the 32-bit scheduler
+  ticket, and it appears solely in the `dynamic` branch.  This is what makes the
+  kernel bitwise deterministic, which upstream tests assert.
+- The benchmark suite is the only performance authority.  PTX, SASS, NCU
+  counters and the static tables above are diagnostic evidence; none of them can
+  accept or reject a candidate.
+
+## Instruction-selection summary
+
+- **Placement selects the copy.**  A GMEM tile reaches SMEM as
+  `cp.async.bulk.tensor.{3d,4d}.shared::cta.global.tile.mbarrier::complete_tx::bytes`
+  and leaves as `...global.shared::cta.tile.bulk_group`, because every such
+  region is a TensorMap-described tile whose descriptor the prologue patched.
+  Register traffic to SMEM is `ldmatrix`/`stmatrix` where a 16x16 operand
+  fragment is wanted and plain `ld.shared`/`st.shared` where a lane owns a
+  single channel.
+- **Shape selects the MMA.**  A K extent of 128 against `tile_k_hw = 16`
+  expands one logical GEMM into eight `tcgen05.mma.cta_group::1.kind::f16`
+  issues; a K extent of 16 gives one.  The small 16x16 products that must stay
+  in registers (`KK`, the Neumann rounds, `A`, `dA`, `dM`) select
+  `mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32` instead, and the
+  transposes between them select `movmatrix.sync.aligned.m8n8.trans.b16`.
+- **The schedule selects the synchronization.**  A TMA producer publishes with
+  `mbarrier.arrive.expect_tx`; a tcgen05 chain publishes with a delayed
+  `tcgen05.commit...mbarrier::arrive::one`, which is why 59 issues carry only 19
+  commits.  Cross-role rendezvous that are not producer/consumer edges use CTA
+  named barriers, `barrier.sync` at 512, 416 and 128 threads.
+- **The gate's domain selects its arithmetic.**  Carrying the decay in log2
+  space makes every application an `ex2.approx.ftz.f32` and every inverse an
+  `rcp.approx.ftz.f32`; neither a divide nor a natural-base exponential appears.

--- a/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
@@ -36,8 +36,8 @@ the kernel emits two additional gradients, `dW_out = V*dY` and a per-channel
 
 Writer line-info evidence is under `.porting/gdn2_bprop_f16/source_export/`,
 one directory per accepted branch.  Each holds two PTX files with both `.file`
-and `.loc`: the main `kernel_cutlass_kernel_Gdn2BwdCfg...sm_100a.ptx` and the
-`kernel_cutlass_prologue_kernel_...ptx`.  Unless stated otherwise, PTX line
+and `.loc`: the main `cutlass_host_Gdn2BwdCfg...sm_100a.ptx` and the
+`cutlass_prologue_...sm_100a.ptx`.  Unless stated otherwise, PTX line
 numbers below refer to the `basic` branch's main PTX.  Static counts use
 instruction lines minus predicated lines.
 
@@ -118,7 +118,13 @@ gemm(dst, lhs, rhs, accumulate=False)
 `init`, `wait`, `arrive`, `expect_bytes`, `commit`, `release`, `fence`,
 `barrier`, stage/phase advancement, register-budget changes, descriptor field
 replacement, directional-copy groups, and TMEM allocation are schedule
-operations.  Each key movement, computation, or synchronization occurrence
+operations.  Three of them lower uniformly everywhere they appear, so they are
+annotated once here rather than at each of their many sites:
+`wait(bar, stage, phase)` is
+`mbarrier.try_wait.parity.acquire.cta.shared::cta.b64` inside a spin loop (82
+sites); `arrive(bar, stage)` is `mbarrier.arrive.shared.b64` (50 sites); and
+`expect_bytes` is `mbarrier.arrive.expect_tx.shared.b64` (8 sites, one per TMA
+tensor).  Each key movement, computation, or synchronization occurrence
 below is immediately followed by the selected instruction or instruction
 family observed in the writer export.
 
@@ -167,13 +173,16 @@ sched_ctr  : gmem[i32, 2]                  # dynamic-scheduler ticket
 tmaps      : gmem[u64, 14 * B * 16]        # 14 descriptor arrays, 128 B slots
 
 # ==========================================================================
-# Descriptor arrays.  Arrays 0..11 are rank-3; Gate and dGate are FP32 with
-# [32,1,16] boxes, the other 16-bit tensors use [64,1,16].  The checkpoint
-# array is rank-4 with box [64,DK,1,1].  All use 128-byte swizzle.
+# Descriptor arrays, in the source's own index order.  Arrays 0..12 are
+# rank-3; Gate and dGate are FP32 with [32,1,16] boxes, the other 16-bit
+# tensors use [64,1,16].  Only array 13, the checkpoint, is rank-4 with box
+# [64,DK,1,1].  All use 128-byte swizzle.
 # ==========================================================================
-TMAP_Q, TMAP_K, TMAP_V, TMAP_GATE, TMAP_BETA, TMAP_W, TMAP_DO = 0, 1, 2, 3, 4, 5, 6
-TMAP_CKPT                                                     = 7
-TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DBETA, TMAP_DWO   = 8, 9, 10, 11, 12, 13
+TMAP_Q, TMAP_K, TMAP_V, TMAP_GATE     = 0, 1, 2, 3
+TMAP_DO, TMAP_BETA, TMAP_W            = 4, 5, 6
+TMAP_DQ, TMAP_DK, TMAP_DV             = 7, 8, 9
+TMAP_DGATE, TMAP_DWO, TMAP_DBETA      = 10, 11, 12
+TMAP_CKPT                             = 13
 
 # ==========================================================================
 # Linear SMEM.  One arena; every region is a byte range.  Declaration order is
@@ -184,9 +193,10 @@ TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DBETA, TMAP_DWO   = 8, 9, 10, 11, 12
 arena = linear_buffer(smem, u8, 225280, 0, 1024, whole_kernel)
 
 BARRIERS       =      0;  BARRIERS_END       =    984   # 123 slots x 8 B
-TMEM_HOLD      =    984
-SCHED          =   1008                                 # 8 x i32 ring
-RED1           =   1024;  NORM               =   1280   # f32 scratch
+TMEM_HOLD      =    984;  TMEM_HOLD_END      =    988
+SCHED          =    992;  SCHED_END          =   1024   # 8 x i32 ring, align 16
+RED1           =   1024;  RED1_END           =   1280   # f32 cross-warp scratch
+NORM           =   1280;  NORM_END           =   1792   # f32 q/k inverse norms
 STATE          =   2048;  STATE_END          =  34816   # [DK][DV]
 DSTATE         =  34816;  DSTATE_END         =  67584
 K_DECAY        =  67584;  K_DECAY_END        =  75776   # 2 x [BT][DK]
@@ -195,21 +205,23 @@ K_RESTORE      =  83968;  K_RESTORE_END      =  92160
 Q_DECAY        =  92160;  Q_DECAY_END        = 100352
 STATE_DIAG     = 100352;  STATE_DIAG_END     = 108544   # 2 x 8 x [16][16], 32B swz
 INTERMEDIATE   = 108544;  INTERMEDIATE_END   = 113664   # 2 x 5 x [16][16], 32B swz
-DO             = 114688;  DO_END             = 122880
-BETA           = 122880;  BETA_END           = 131072
-BANK_FILL      = 131072 - 1024                          # pad, never addressed
-SQ             = 131072;  SQ_END             = 139264
+DO             = 113664;  DO_END             = 121856
+BETA           = 121856;  BETA_END           = 130048
+BANK_FILL      = 130048;  BANK_FILL_END      = 131072   # pad, never addressed
+SQ             = 131072;  SQ_END             = 139264   # high group starts here
 SK             = 139264;  SK_END             = 147456
 SV             = 147456;  SV_END             = 155648
 SGATE          = 155648;  SGATE_END          = 172032   # f32
 SW             = 172032;  SW_END             = 180224
 SU             = 180224;  SU_END             = 184320
 SDY            = 184320;  SDY_END            = 188416
-SDQ            = 188416;  SDK                = 192512
+SDQ            = 188416;  SDQ_END            = 192512
+SDK            = 192512;  SDK_END            = 196608
 SDV            = 196608;  SDV_END            = 204800
 SDGATE         = 204800;  SDGATE_END         = 212992   # f32
 SDWO           = 212992;  SDWO_END           = 221184
 SDB            = 221184;  SDB_END            = 225280
+assert SQ == 131072             # the pad places the high group at 128 KB exactly
 assert SDB_END == 225280        # 7168 B of headroom under the 232448 B cap
 
 # Scalar address functions.  Each selects bytes; none is a layout.
@@ -294,8 +306,9 @@ def prologue_kernel():
     for array in range(14):
         for batch in range(B):
             copy_p2g(param_descriptor(array), descriptor_slot(tmaps, array, batch))
-            # instruction_selection: st.global.v4.b32 per 128-byte slot;
-            # extent: one descriptor (224 st.global in the prologue export)
+            # instruction_selection: st.global.b64; extent: a constexpr-unrolled
+            # 16 per descriptor, 14 arrays -> the 224 st.global.b64 in the
+            # prologue export.  There is no st.global.v4.b32 there.
             replace_field(GLOBAL_ADDRESS, base + cu_seqlens[batch] * row_stride)
             replace_field(GLOBAL_DIM[2], seqlen_b)
             # instruction_selection: tensormap.replace.tile.global_address
@@ -342,29 +355,40 @@ def persistent_backward():
 # Persistent tile scheduler.  The TMA warp owns the ticket; the other fifteen
 # warps each elect one lane and consume through an eight-deep SMEM ring.
 # ==========================================================================
-def sched_publish_next(tile_idx, num_ctas):
-    if DYN_SCHED:
-        if elected():
-            ticket = atomic_add(sched_ctr, 1)
-            # instruction_selection: atom.global.add.u32; extent: scalar
-            # (absent entirely when DYN_SCHED is off -- verified in the export)
-        next_tile = ticket + num_ctas
-    else:
-        next_tile = tile_idx + num_ctas
-    wait("sched_done", sched_stage, sched_phase)
-    copy_r2s(next_tile, SCHED + sched_stage * 4)
-    arrive("sched_ready", sched_stage)
-    # instruction_selection: st.shared.b32 then mbarrier.arrive.shared.b64
+# The ENTIRE ring protocol is compile-time gated.  With DYN_SCHED off there is
+# no barrier traffic, no SMEM traffic and no atomic at all -- the export for the
+# `basic` branch carries zero `atom.global`, and one in the `dynamic` branch.
+def sched_publish_next(tile_idx, num_ctas):          # warp 14 only
+    if not DYN_SCHED:
+        return tile_idx + num_ctas
+    wait("sched_done", sched.stage, sched.phase)
+    if elected():
+        ticket = atomic_add(sched_ctr, 1)
+        # instruction_selection: atom.global.add.u32; extent: scalar, one lane
+        copy_r2s(num_ctas + ticket, SCHED + sched.stage * 4)
+        # instruction_selection: st.shared.b32; extent: scalar
+    warp_sync()
+    # instruction_selection: bar.warp.sync; extent: publishes the elected lane's
+    # store to the whole warp before every lane reads it back
+    copy_s2r(SCHED + sched.stage * 4, next_tile)     # ALL lanes read it back
+    # instruction_selection: ld.shared.b32; extent: scalar
+    if elected():
+        arrive("sched_ready", sched.stage)
+        # instruction_selection: mbarrier.arrive.shared.b64
+    sched = advance(sched, 8)
     return next_tile
 
-def sched_next_tile():
-    wait("sched_ready", sched_stage, sched_phase)
-    copy_s2r(SCHED + sched_stage * 4, next_tile)
-    # instruction_selection: ld.shared.s32; extent: scalar
+def sched_next_tile(tile_idx, num_ctas):             # the other fifteen warps
+    if not DYN_SCHED:
+        return tile_idx + num_ctas
+    wait("sched_ready", sched.stage, sched.phase)
+    copy_s2r(SCHED + sched.stage * 4, next_tile)
+    # instruction_selection: ld.shared.b32; extent: scalar
     if elected():
-        arrive("sched_done", sched_stage)
-    # instruction_selection: mbarrier.arrive.shared.b64; extent: one lane per warp
-    # `sched_done` carries arrival count 15 -- every warp except the producer.
+        arrive("sched_done", sched.stage)
+        # instruction_selection: mbarrier.arrive.shared.b64; extent: one lane per
+        # warp -- `sched_done` carries arrival count 15, every warp but the producer
+    sched = advance(sched, 8)
     return next_tile
 
 # ==========================================================================
@@ -401,7 +425,9 @@ def tma_warp():
                 copy_g2s(gmem_tile(tensor, b, head, tok0), tensor + raw.stage * ...,
                          completion=bar + "_ready")
                 # instruction_selection: cp.async.bulk.tensor.3d.shared::cta
-                #   .global.tile.mbarrier::complete_tx::bytes; extent: one [BT,dim] tile
+                #   .global.tile.mbarrier::complete_tx::bytes; extent: DK//64 = 2
+                #   issues per 16-bit tile, DK//32 = 4 for the FP32 gate.  The 16
+                #   3d loads are Q2 + K2 + Gate4 + Beta2 + dO2 + V2 + W2.
 
             if chunk >= FIRST_STATE_CHUNK:
                 wait("state_cg0_done", state.stage, state.phase)
@@ -470,19 +496,27 @@ def super_mma_warp():
             cast(l_packed, l_regs)
             # instruction_selection: cvt.rn.bf16x2.f32; extent: 8 lanes -> 4 packs
             sub(tinv_acc, eye_mask, l_packed)          # T_inv <- I - L
+            transpose(mov_lpow, l_packed)          # once before the loop
             for _round in range(3):
-                transpose(mov_lpow, l_packed)
-                # instruction_selection: movmatrix.sync.aligned.m8n8.trans.b16;
-                # extent: 4 packs per round
                 gemm(sq_acc, l_packed, mov_lpow)       # square the strict power
-                gemm(upd_acc, tinv_packed, sq_acc)     # fold into the inverse
-                # instruction_selection: 2 x mma.sync...m16n8k16; extent: one round
+                cast(l_packed, sq_acc)                 # io round-trip each round
+                transpose(mov_lpow, l_packed)          # and again after squaring
+                # instruction_selection: movmatrix.sync.aligned.m8n8.trans.b16;
+                # extent: 4 initial + 3 x 4 = the export's 16 sites
+                gemm(upd_acc, tinv_packed, mov_lpow)   # fold into the inverse
+                cast(tinv_packed, upd_acc)
+                # instruction_selection: 2 x mma.sync...m16n8k16 per round, with a
+                # cvt.rn.bf16x2.f32 round-trip between them -- the rounding is
+                # part of the numerical contract, not an artifact
             copy_r2s(tinv_packed, inter_byte(inter_stage, slot=1, ...))
             # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16
             arrive("t_inv_ready", inter_stage)
 
             # ---- dM = dY @ U^T, then the two strict tiles -----------------
-            wait("dy_smem_ready"); wait("u_smem_ready")
+            # U-readiness is transitive: CG1 arrives u_smem_ready before
+            # dy_smem_ready, so warp 12 waits only the reverse edge and dY.
+            wait("dm_done", inter_stage, inter_phase)
+            wait("dy_smem_ready")
             for k_block in range(DV // 16):
                 copy_s2r(SDY + ..., a_frag); copy_s2r(SU + ..., b_frag)
                 # instruction_selection: ldmatrix...x4.shared.b16
@@ -535,10 +569,17 @@ def tcgen05_warp():
 # ==========================================================================
 def epilogue_warp():
     while tile_idx < total_tiles:
-        ...decode; for chunk in reverse_walk:
+        ...decode
+        if elected():
+            for array in (TMAP_DQ, TMAP_DK, TMAP_DV, TMAP_DGATE, TMAP_DWO, TMAP_DBETA):
+                acquire_tensormap(descriptor_slot(tmaps, array, b))
+                # instruction_selection: fence.proxy.tensormap::generic.acquire.gpu;
+                # extent: 6 of the export's 14 acquires; warp 14 owns the other 8
+        for chunk in reverse_walk:
             writes = chunk < wend       # [wend, cend) is the right warm-up
 
             # ---- A = tril_incl(Q_decay @ K_inv^T) ------------------------
+            wait("a_done", inter_stage, inter_phase)      # reverse edge from warp 13
             wait("q_decay_k_restore_ready", decay_stage, decay_phase)
             for k_block in range(DK // 16):
                 copy_s2r(Q_DECAY + ..., a_frag); copy_s2r(K_INV + ..., b_frag)
@@ -551,35 +592,52 @@ def epilogue_warp():
             arrive("a_ready", inter_stage)
 
             # ---- dA = tril_incl(dO @ U^T) --------------------------------
-            wait("do_ready", raw_stage, raw_phase); wait("u_smem_ready")
+            # Only warp 13 waits `do_ready`; the epilogue's edge is `u_smem_ready`.
+            wait("da_done", inter_stage, inter_phase)     # reverse edge from warp 13
+            wait("u_smem_ready")
             for k_block in range(DV // 16):
                 copy_s2r(DO + ..., a_frag); copy_s2r(SU + ..., b_frag)
                 gemm(da_acc, a_frag, b_frag, accumulate=True)
                 # instruction_selection: 8 x mma.sync...m16n8k16; extent: dA
+            arrive("do_done", raw_stage)          # released BEFORE the mask/store
             select(da_tile, lower_incl_mask, da_acc, 0.0)
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta; extent: one of
+            # the 17 generic-to-async-proxy publishes in the kernel
             copy_r2s(da_tile, inter_byte(inter_stage, slot=2, ...))
-            arrive("da_ready", inter_stage); arrive("do_done", raw_stage)
+            arrive("da_ready", inter_stage)
 
             # ---- one-behind store ladder ---------------------------------
-            # Six stores issue in a fixed order, then their staging buffers are
-            # released one at a time so each frees as early as possible.
-            if writes:
-                for (stage_buf, bar, desc) in ((SDQ, "dq", TMAP_DQ), (SDK, "dk", TMAP_DK),
-                                               (SDGATE, "dgate", TMAP_DGATE),
-                                               (SDB, "db", TMAP_DBETA),
-                                               (SDV, "dv", TMAP_DV),
-                                               (SDWO, "dwo", TMAP_DWO)):
-                    wait(bar + "_tmastg_ready", ...)
-                    copy_s2g(stage_buf, gmem_tile(desc, b, head, tok0))
-                    # instruction_selection: cp.async.bulk.tensor.3d.global
-                    #   .shared::cta.tile.bulk_group; extent: one [BT,dim] tile
-                commit_store_group()
-                # instruction_selection: cp.async.bulk.commit_group
-                for slot in (5, 4, 3, 2, 1, 0):
+            # The ladder stores the PREVIOUS chunk (`pend_start`/`pend_writes`),
+            # so it runs only from the second iteration on.  The six staging
+            # waits are UNCONDITIONAL -- only the store and its commit sit under
+            # `pend_writes`.  Gating the waits instead would desynchronise every
+            # staging barrier's phase on a warm-up chunk.
+            LADDER = ((SDQ, "dq", TMAP_DQ), (SDK, "dk", TMAP_DK),
+                      (SDGATE, "dgate", TMAP_DGATE), (SDB, "db", TMAP_DBETA),
+                      (SDV, "dv", TMAP_DV), (SDWO, "dwo", TMAP_DWO))
+            if rev > 0:
+                for (stage_buf, bar, desc) in LADDER:
+                    wait(bar + "_tmastg_ready", cursor[bar].stage, cursor[bar].phase)
+                    if pend_writes:
+                        copy_s2g(stage_buf + cursor[bar].stage * ...,
+                                 gmem_tile(desc, b, head_o, pend_start))
+                        # instruction_selection: cp.async.bulk.tensor.3d.global
+                        #   .shared::cta.tile.bulk_group; extent: one [BT,dim] tile
+                        commit_store_group()
+                        # instruction_selection: cp.async.bulk.commit_group;
+                        # extent: ONE PER STORE, which is what makes the staged
+                        # wait_group(5..0) below release exactly one buffer each
+                for (slot, (_, bar, _)) in zip((5, 4, 3, 2, 1, 0), LADDER):
                     wait_store_group(slot)
                     # instruction_selection: cp.async.bulk.wait_group.read;
-                    # extent: staged release, one buffer freed per step
-                    arrive(release_for(slot) + "_tmastg_done", ...)
+                    # extent: staged release, one staging buffer freed per step
+                    arrive(bar + "_tmastg_done", cursor[bar].stage)
+                    cursor[bar] = advance(cursor[bar], stages_of(bar))
+            pend_start, pend_writes = tok0, writes
+        # ---- tile tail: the same ladder once more, draining the last chunk --
+        if sk_nt > 0:
+            ...                     # identical six-store block over pend_start
 ```
 
 Out-of-range rows need no predicate here: the prologue capped `GLOBAL_DIM[2]`
@@ -593,11 +651,19 @@ chunk loop at all.
 # Warps 0..3: gate prefix, normalization, and the four decay operands.
 # ==========================================================================
 def compute_group_0():
+    barrier(id=3, threads=416)      # TMEM-lifecycle rendezvous after setmaxnreg
+    # instruction_selection: barrier.sync 3, 416; extent: one of four such sites
     while tile_idx < total_tiles:
         ...decode; for chunk in reverse_walk:
+            # All four raw waits happen up front, before any gate arithmetic.
+            wait("q_ready", raw_stage, raw_phase)
+            wait("k_ready", raw_stage, raw_phase)
             wait("gate_ready", raw_stage, raw_phase)
+            wait("beta_ready", raw_stage, raw_phase)
             copy_s2r(SGATE + raw_f32_byte(...), raw_gate[0:16])
-            # instruction_selection: ld.shared.f32; extent: 16 tokens of one channel
+            # instruction_selection: ld.shared.b32; extent: 16 tokens of one
+            # channel.  The export carries no ld.shared.f32 at all -- 36 ld.shared.b32
+            # and 32 st.shared.b32 cover every f32 SMEM access.
 
             # ---- gate -> log2 domain, then an in-chunk inclusive prefix ----
             if SAFE_GATE:
@@ -615,7 +681,19 @@ def compute_group_0():
             # instruction_selection: add.rn.f32x2; extent: one token pair per step
             exp2(eG, prefix); exp2(eGl, chunk_total)
             # instruction_selection: ex2.approx.ftz.f32; extent: 16 tokens
-            arrive("gate_done", raw_stage)      # count CG0+CG2: WG2 reads it too
+            # eG MUST round-trip through sGate: the prefix scan runs on a channel
+            # assignment (warp*32 + lane) that differs from the operand assignment
+            # (decay_row, lane_in_row_group), and warps 8..11 read the same buffer.
+            # That shared reader is why `gate_done` carries CG0+CG2 = 256.
+            copy_r2s(eG, SGATE + raw_f32_byte(...))
+            # instruction_selection: st.shared.b32; extent: 16 tokens
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("gate_done", raw_stage)
+            copy_s2r(SGATE + raw_f32_byte(...), eG_operand)    # per operand channel
+            copy_s2r(SGATE + raw_f32_byte(row=BT-1, ...), eGl_operand)
+            # instruction_selection: ld.shared.b32; extent: the re-read under the
+            # operand channel assignment
 
             if L2NORM:
                 rsqrt(q_inv_norm, max(sum_sq_q, 1e-24)); rsqrt(k_inv_norm, ...)
@@ -623,7 +701,7 @@ def compute_group_0():
                 copy_r2s(q_inv_norm, NORM + ...); copy_r2s(k_inv_norm, ...)
 
             # ---- the four operands.  Beta enters K_decay ONLY. -------------
-            wait("k_ready"); wait("beta_ready"); wait("q_ready")
+            wait("decay_done", decay_stage, decay_phase)   # reverse edge, warp 13
             mul(k_value, raw_k, k_inv_norm)
             mul(k_beta, k_value, raw_beta)                 # GDN-2: Beta folded in
             mul(K_decay_pack, cast(k_beta), cast(eG))
@@ -631,53 +709,110 @@ def compute_group_0():
             rcp(exp_neg_g, eG)                             # never a divide
             # instruction_selection: rcp.approx.ftz.f32; extent: 2 per pack
             mul(K_inv_pack, cast(k_value), cast(exp_neg_g))   # no Beta here
-            mul(K_restore_pack, cast(k_value), cast(eGl / eG))
-            mul(Q_decay_pack, cast(q_value), cast(eG * scale))
+            # K_restore reuses the ALREADY-ROUNDED K_inv rather than re-deriving
+            # from K, and the scale is folded into Q BEFORE the eG multiply.  The
+            # rounding points differ from the algebraically equal forms.
+            mul(K_restore_pack, K_inv_pack, cast(eGl))
+            mul(Q_decay_pack, cast(q_value * scale), cast(eG))
             for pack in (K_decay, K_inv, K_restore, Q_decay):
                 copy_r2s(pack, raw_io_byte(base, decay_stage, row, dim))
                 # instruction_selection: st.shared.v4.b32; extent: 8 channels
             fill(STATE_DIAG + inter..., diag(eGl))          # 8 k-atoms of [16][16]
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
             arrive("k_decay_inv_ready", decay_stage)
             arrive("q_decay_k_restore_ready", decay_stage)
+            arrive("q_done", raw_stage); arrive("k_done", raw_stage)
 
+            wait("qk_raw_done", qk_stage, qk_phase)         # reverse edge from CG2
             copy_r2t(raw_q, tmem_cell(TM_QRAW_INP, row, qk_stage * 8))
             copy_r2t(raw_k, tmem_cell(TM_KRAW_INP, row, qk_stage * 8))
-            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x4.b32;
-            # extent: the raw Q/K ring WG2 later re-reads
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x8.b32;
+            # extent: 2 sites, the raw Q/K ring warps 8..11 later re-read
+            tcgen05_wait_store()
+            # instruction_selection: tcgen05.wait::st.sync.aligned
             arrive("qk_raw_ready", qk_stage)
+            barrier(id=1, threads=128)
+            # instruction_selection: barrier.sync 1, 128; extent: the CG0-local
+            # rendezvous after publishing the raw ring
 
             if chunk >= FIRST_STATE_CHUNK:                  # state SMEM -> TMEM
                 wait("state_ready")
-                copy_s2r(state_byte(...), state_regs); copy_r2t(state_regs, TM_STATE_INP)
-                # instruction_selection: ld.shared.b16 then
-                #   tcgen05.st.sync.aligned.16x128b.x2.b32
-                arrive("state_inp_ready", state_inp_stage); arrive("state_cg0_done")
+                wait("state_inp_done", state_inp_stage, state_inp_phase)
+                wait("state_inp_cg2_done", state_inp_stage, state_inp_phase)
+                copy_s2r(state_byte(...), state_regs)
+                # instruction_selection: ld.shared.b16
+                copy_r2t(state_regs, TM_STATE_INP + state_inp_stage * 64)
+                # instruction_selection: tcgen05.st.sync.aligned.32x32b.x4.b32;
+                # extent: 16 sites
+                tcgen05_wait_store()
+                # instruction_selection: tcgen05.wait::st.sync.aligned
+                arrive("state_cg0_done")
+            arrive("state_inp_ready", state_inp_stage)   # UNCONDITIONAL: the phase
+            # advances even on a chunk that loads no state
 
 # ==========================================================================
 # Warps 4..7: the value side.  Owns dV and the new dW_out.
 # ==========================================================================
 def compute_group_1():
+    barrier(id=3, threads=416)
+    # instruction_selection: barrier.sync 3, 416
     while tile_idx < total_tiles:
-        ...decode; for chunk in reverse_walk:
-            # ---- Y = W*V - state_k ---------------------------------------
-            wait("state_k_acc_ready"); wait("v_ready"); wait("w_ready")
-            copy_t2r(tmem_cell(TM_STATE_K_ACC, row, col), state_k)
-            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
+        ...decode
+        # dht seed runs at the TOP of the tile, before the chunk loop: a
+        # non-terminal item seeds zeros but still walks the same path, so the
+        # pipeline shape is uniform.
+        if USE_DSTATE_IN:
+            seed_true = (cend == num_chunks_b)
+            copy_g2r(dstate_in_tile, dh_seed) if seed_true else fill(dh_seed, 0.0)
+            copy_r2t(cast(dh_seed), TM_DSTATE_INP); arrive("dstate_inp_ready")
+        for chunk in reverse_walk:
+            # ---- Y: two variants.  Chunk 0 with no entering state is W*V only.
+            wait("v_ready", raw_stage, raw_phase)
+            wait("w_ready", raw_stage, raw_phase)
             copy_s2r(SV + ..., v_val); copy_s2r(SW + ..., w_val)
-            sub(y_val, mul(w_val, v_val), state_k)          # GDN-2: W gates V
+            # instruction_selection: ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16;
+            # extent: 4 sites, V and W in the transposed operand form
+            if chunk >= FIRST_STATE_CHUNK:
+                wait("state_k_acc_ready")
+                copy_t2r(tmem_cell(TM_STATE_K_ACC, row, col), state_k)
+                # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x2.b32;
+                # extent: 2 sites
+                sub(y_val, mul(w_val, v_val), state_k)      # GDN-2: W gates V
+                # instruction_selection: sub.bf16x2; extent: 8 packs
+            else:
+                mul(y_val, w_val, v_val)                    # no entering state
             copy_r2t(cast(y_val), tmem_cell(TM_Y_INP, ...))
-            # instruction_selection: tcgen05.st...32x32b.x4.b32; extent: Y operand
+            # instruction_selection: tcgen05.st.sync.aligned.16x128b.x2.b32;
+            # extent: 2 sites
+            tcgen05_wait_store()
+            # instruction_selection: tcgen05.wait::st.sync.aligned
             arrive("y_inp_ready")
 
-            wait("u_acc_ready"); copy_t2r(TM_U_ACC, u_val); copy_r2s(cast(u_val), SU)
-            # instruction_selection: tcgen05.ld then stmatrix...x4.shared.b16
-            arrive("u_smem_ready")
+            # dU is restaged BEFORE U: du_acc is finished by GEMMs 3 and 5, which
+            # precede GEMM 7's u_acc in the in-order tcgen05 queue.
             wait("du_acc_ready"); copy_t2r(TM_DU_ACC, du_val)
-            copy_r2t(cast(du_val), TM_DU_INP); arrive("du_inp_ready")
+            # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x2.b32
+            copy_r2t(cast(du_val), TM_DU_INP)
+            # instruction_selection: tcgen05.st.sync.aligned.16x128b.x2.b32
+            tcgen05_wait_store(); arrive("du_inp_ready")
+
+            wait("u_acc_ready"); copy_t2r(TM_U_ACC, u_val)
+            # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x2.b32
+            copy_r2s(cast(u_val), SU)
+            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta
+            arrive("u_smem_ready")
 
             wait("dy_acc_ready"); copy_t2r(TM_DY_ACC, dy_val)   # ALIAS of state_k
-            copy_r2t(cast(-dy_val), TM_NEG_DY_INP); arrive("neg_dy_inp_ready")
-            copy_r2s(cast(dy_val), SDY); arrive("dy_smem_ready")
+            # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x2.b32
+            copy_r2t(cast(-dy_val), TM_NEG_DY_INP)
+            # instruction_selection: tcgen05.st.sync.aligned.16x128b.x2.b32
+            tcgen05_wait_store(); arrive("neg_dy_inp_ready")
+            copy_r2s(cast(dy_val), SDY)
+            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            fence_proxy_async_shared_cta(); arrive("dy_smem_ready")
             # dY gains a tcgen05 consumer in GDN-2 (dk_decay uses plain dY, not
             # Beta*dY), hence the extra `dy_smem_done` MMA_COMMIT edge.
 
@@ -697,9 +832,25 @@ def compute_group_1():
             arrive("v_done", raw_stage); arrive("w_done", raw_stage)
             # V and W are released only HERE, after the dW_out product needs V.
 
-            wait("dstate_acc_ready"); copy_t2r(TM_DSTATE_ACC, dh)
-            copy_r2t(cast(dh), TM_DSTATE_INP); copy_r2s(cast(dh), DSTATE)
-            arrive("dstate_inp_ready"); arrive("dstate_smem_ready")
+            # dH capture is UNCONDITIONALLY waited but only performed when a
+            # next chunk exists; the SMEM copy re-reads TMEM rather than reusing
+            # the registers already in hand.
+            wait("dstate_acc_ready")
+            if rev + 1 < sk_nt:
+                copy_t2r(TM_DSTATE_ACC, dh)
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x32.b32;
+                # extent: 4 sites
+                copy_r2t(cast(dh), TM_DSTATE_INP)
+                # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32;
+                # extent: 4 sites
+                tcgen05_wait_store()
+                copy_t2r(TM_DSTATE_INP, dh_reread)          # explicit re-read
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32;
+                # extent: 4 sites
+                copy_r2s(cast(dh_reread), DSTATE)
+                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+                fence_proxy_async_shared_cta()
+                arrive("dstate_inp_ready"); arrive("dstate_smem_ready")
     # tail: seed d_final_state when cend == num_chunks_b, drain dstate0 when
     # wstart == 0, and pass through for a zero-length sequence.
     arrive("tmem_done")
@@ -708,8 +859,33 @@ def compute_group_1():
 # Warps 8..11: gradient drain.  One lane owns one key channel x 16 tokens.
 # ==========================================================================
 def compute_group_2():
+    barrier(id=3, threads=416)
+    # instruction_selection: barrier.sync 3, 416
     while tile_idx < total_tiles:
         ...decode; for chunk in reverse_walk:
+            wait("k_decay_inv_ready", decay_stage, decay_phase)
+            copy_s2r(SGATE + raw_f32_byte(...), eG)      # written back by CG0
+            # instruction_selection: ld.shared.b32; extent: 16 tokens
+            fence_proxy_async_shared_cta(); arrive("gate_done", raw_stage)
+
+            # ---- dGate_last hdot: eGl * sum_v(dH[v,c] * S[c,v]) -------------
+            # This term exists only when a dState is carried, and it is the
+            # kernel's single largest FMA family.
+            if USE_DSTATE_IN and chunk >= FIRST_STATE_CHUNK:
+                wait("state_inp_ready", state_inp_stage, state_inp_phase)
+                wait("dstate_smem_ready")
+                copy_t2r(tmem_cell(TM_STATE_INP, ...), state_cols)
+                # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32;
+                # extent: 4 sites
+                copy_s2r(DSTATE + state_byte(...), dh_cols)
+                for j in range(DV):
+                    fma(hacc[(2 * j) % 8], dh_cols[j], state_cols[j], hacc[(2 * j) % 8])
+                    # instruction_selection: fma.rn.f32.bf16; extent: 128 issues
+                    # over a FIXED 8-way interleave, not a compiler-chosen tree
+                reduce_fixed_tree(dgate_last_val, hacc[0:8])
+                # instruction_selection: add.rn.f32x2; extent: the fixed fadd2 tree
+                arrive("dstate_smem_cg2_done"); arrive("state_inp_cg2_done")
+
             wait("dk_restore_part_acc_ready")
             copy_t2r(tmem_cell(TM_DK_RESTORE, row, col), dk_restore_part)
             # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32
@@ -722,7 +898,8 @@ def compute_group_2():
 
             wait("dq_acc_ready"); copy_t2r(TM_DQ_ACC, dq_vec)
             mul(dq_n, mul_packed(eG, scale), dq_vec)
-            # instruction_selection: mul.rn.f32x2; extent: one token pair
+            # instruction_selection: mul.f32x2; extent: TWO packed multiplies per
+            # token pair -- (eG*scale) then (*dq_vec); 40 sites in the export
 
             wait("dk_inv_part_acc_ready"); copy_t2r(TM_DK_INV_ACC, dk_inv_part)
             fma(dk_n, dk_inv_part, rcp(eG), dk_n)
@@ -730,6 +907,9 @@ def compute_group_2():
             # ---- dK_decay drain seeds BOTH dBeta and dGate -----------------
             wait("dk_decay_part_acc_ready"); copy_t2r(TM_DK_DECAY_ACC, dk_decay_part)
             copy_t2r(tmem_cell(TM_KRAW_INP, ...), k_raw)     # raw K from the ring
+            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32; extent:
+            # one of FOUR separate ring reads -- raw K three times (the restore
+            # drain, here, and the dGate finalize) and raw Q once
             for t in range(BT):
                 mul(dk_decay, -eG[t], dk_decay_part[t])
                 mul(db_regs[t], k_n[t], dk_decay)            # GDN-2: per-channel dBeta
@@ -753,23 +933,61 @@ def compute_group_2():
                     # the chain rule; swapping these corrupts dGate silently.
             add(dgate_regs[BT-1], dgate_regs[BT-1],
                 (dgate_last_acc[0]+dgate_last_acc[1]) + (dgate_last_acc[2]+dgate_last_acc[3]))
+            if USE_DSTATE_IN and chunk >= FIRST_STATE_CHUNK:
+                fma(dgate_regs[BT-1], eGl, dgate_last_val, dgate_regs[BT-1])
             arrive("beta_done", raw_stage)
 
-            if L2NORM:                       # row projection: grad -= k * <k, grad>
-                for (grad, qk_col) in ((dq_n, TM_QRAW_INP), (dk_n, TM_KRAW_INP)):
-                    reduce_dot(dots, grad, raw_qk)
+            if L2NORM:      # row projection: grad <- (grad - a*norm*<a,grad>)*norm
+                for (grad, qk_col, inv_off) in ((dq_n, TM_QRAW_INP, 0),
+                                                (dk_n, TM_KRAW_INP, BT)):
+                    copy_t2r(tmem_cell(qk_col, ...), raw_lo)   # two halves
+                    copy_t2r(tmem_cell(qk_col, ...), raw_hi)
+                    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
+                    mul(part, raw_pair, grad_pair)
+                    # instruction_selection: mul.f32x2; extent: 2 per token pair
+                    for delta in (16, 8, 4, 2, 1):
+                        shuffle_xor(peer, part, delta); add(part, part, peer)
+                        # instruction_selection: shfl.sync.bfly.b32; extent: a
+                        # 5-step butterfly over the lanes of one row
+                    if lane == 0:
+                        copy_r2s(part, RED1 + warp_id * 4)
                     barrier(id=2, threads=128)
-                    # instruction_selection: barrier.sync 2, 128; extent: the
-                    # cross-warp half of the dot product
+                    # instruction_selection: barrier.sync 2, 128; extent: the first
+                    # of TWO such barriers per gradient
+                    copy_s2r(RED1, four_warp_parts)
+                    reduce_fixed_tree(dots, four_warp_parts)
+                    # instruction_selection: add.rn.f32x2; extent: a fixed 4-term
+                    # tree over the four warps, not a compiler-chosen reduction
+                    copy_s2r(NORM + inv_off, inv_norm)
                     fma(grad, -raw_qk, dots * inv_norm, grad)
-            reverse_cumsum(dgate_regs)       # in-register suffix scan over 16 tokens
-
-            for (regs, base, bar) in ((dq_n, SDQ, "dq"), (dk_n, SDK, "dk"),
-                                      (dgate_regs, SDGATE, "dgate"),
-                                      (db_regs, SDB, "db")):
+                    mul(grad, grad, inv_norm)          # the post-multiply
+                    barrier(id=2, threads=128)
+                    # instruction_selection: barrier.sync 2, 128; extent: the second
+                    # barrier, before RED1 is reused by the next gradient
+            # dQ and dK stage FIRST, before the cumsum, so their staging buffers
+            # release as early as possible.
+            for (regs, base, bar) in ((dq_n, SDQ, "dq"), (dk_n, SDK, "dk")):
+                wait(bar + "_tmastg_done", ...)
                 copy_r2s(cast(regs), base + ...)
-                # instruction_selection: st.shared.b16 (st.shared.f32 for dGate)
-                arrive(bar + "_tmastg_ready")
+                # instruction_selection: st.shared.b16; extent: 16 tokens
+            fence_proxy_async_shared_cta()
+            arrive("dq_tmastg_ready"); arrive("dk_tmastg_ready")
+
+            tcgen05_wait_load()
+            # instruction_selection: tcgen05.wait::ld.sync.aligned
+            arrive("qk_raw_done", qk_stage)
+
+            reverse_cumsum(dgate_regs)
+            # instruction_selection: add.f32 chain; extent: a STRICTLY SEQUENTIAL
+            # suffix accumulation from t = BT-1 down to 0, not a parallel scan
+
+            for (regs, base, bar) in ((dgate_regs, SDGATE, "dgate"), (db_regs, SDB, "db")):
+                wait(bar + "_tmastg_done", ...)
+                copy_r2s(cast(regs), base + ...)
+                # instruction_selection: st.shared.b32 for the FP32 dGate,
+                # st.shared.b16 for dBeta; extent: 16 tokens
+            fence_proxy_async_shared_cta()
+            arrive("dgate_tmastg_ready"); arrive("db_tmastg_ready")
     arrive("tmem_done")
 ```
 
@@ -781,23 +999,29 @@ accumulation, so a GEMM whose K extent is 128 expands to eight issues and one
 whose K extent is 16 expands to one.  Two sites are duplicated for the
 `accumulate=True`/`False` twin.
 
-| # | FP32 TMEM destination | A operand | B operand | M x N x K | issues | accumulate |
-| ---: | --- | --- | --- | --- | ---: | --- |
-| 1 | `state_k_acc` | `state` (SMEM) | `K_decay^T` | 128 x 16 x 128 | 8 | on k>0 |
-| 2 | `dq_acc` | `state` (TMEM) | `dO^T` | 128 x 16 x 128 | 8 | on k>0 |
-| 3 | `du_acc` | `dstate_inp` (TMEM) | `K_restore` | 128 x 16 x 128 | 8 | on k>0 |
-| 4 | `dstate_acc` | `dstate_inp` (TMEM) | `diag(eGl)` | 128 x 16 x 16 | 8 | per k-atom |
-| 5 | `du_acc` | `dO^T` (SMEM) | `A` | 128 x 16 x 16 | 1 | yes |
-| 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes |
-| 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no |
-| 8 | `dy_acc` | `dU` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no |
-| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 |
-| 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes |
-| 11 | `dk_inv_acc` | `Q_decay^T` (SMEM) | `dA` | 128 x 16 x 16 | 1 | no |
-| 12 | `dq_acc` | `K_inv^T` (SMEM) | `dA^T` | 128 x 16 x 16 | 1 | twin |
-| 13 | `dk_decay_acc` | `state` (TMEM) | `dY^T` | 128 x 16 x 128 | 8 | on k>0 |
-| 14 | `dk_inv_acc` | `K_decay^T` (SMEM) | `-dM_strict` | 128 x 16 x 16 | 1 | yes |
-| 15 | `dk_decay_acc` | `K_inv^T` (SMEM) | `dM_strict^T` | 128 x 16 x 16 | 1 | twin |
+Three loop-level waits sit OUTSIDE any GEMM's guard, so their phases advance
+even on a chunk whose MMA is skipped: `dqk_acc_done` (the loop-carried
+backpressure edge from warps 8..11, whose cursor starts at phase 1),
+`state_inp_ready`, and `do_ready`.  `dstate0_acc_stored` is waited once at
+teardown before the TMEM dealloc.
+
+| # | FP32 TMEM destination | A operand | B operand | M x N x K | issues | acc | guard | waits | publishes |
+| ---: | --- | --- | --- | --- | ---: | --- | --- | --- | --- |
+| 1 | `state_k_acc` | `state` (SMEM) | `K_decay^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | `state_ready`, `k_decay_inv_ready` | `state_k_acc_ready`, `state_done` |
+| 2 | `dq_acc` | `state` (TMEM) | `dO^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | (`state_inp_ready`, `do_ready` hoisted) | none yet |
+| 3 | `du_acc` | `dstate_inp` (TMEM) | `K_restore` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_inp_ready`, `q_decay_k_restore_ready` | none yet |
+| 4 | `dstate_acc` | `dstate_inp` (TMEM) | `diag(eGl)` | 128 x 16 x 16 | 8 | per k-atom | `has_dstate` | same stage | none yet |
+| 5 | `du_acc` | `dO^T` (SMEM) | `A` | 128 x 16 x 16 | 1 | yes | `has_dstate` | `a_ready` | `du_acc_ready`, `a_done` |
+| 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes | `has_dstate` | `q_decay_k_restore_ready` | `do_mma_done` |
+| 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `y_inp_ready`, `t_inv_ready` | `u_acc_ready` |
+| 8 | `dy_acc` | `dU` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `du_inp_ready` | `dy_acc_ready`, `t_inv_done` |
+| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_smem_ready`, `u_smem_ready` | `dk_restore_part_acc_ready` |
+| 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes | none | `neg_dy_inp_ready` | `dstate_acc_ready`, `decay_done` |
+| 11 | `dk_inv_acc` | `Q_decay^T` (SMEM) | `dA` | 128 x 16 x 16 | 1 | no | none | `da_ready` | none yet |
+| 12 | `dq_acc` | `K_inv^T` (SMEM) | `dA^T` | 128 x 16 x 16 | 1 | twin | `chunk >= FIRST_STATE_CHUNK` selects the twin | same stage | `dq_acc_ready`, `da_done` |
+| 13 | `dk_decay_acc` | `state` (TMEM) | `dY^T` | 128 x 16 x 128 | 8 | on k>0 | `chunk >= FIRST_STATE_CHUNK` | `dy_smem_ready` | `dy_smem_done`, `state_inp_done` |
+| 14 | `dk_inv_acc` | `K_decay^T` (SMEM) | `-dM_strict` | 128 x 16 x 16 | 1 | yes | none | `dm_ready` | `dk_inv_part_acc_ready` |
+| 15 | `dk_decay_acc` | `K_inv^T` (SMEM) | `dM_strict^T` | 128 x 16 x 16 | 1 | twin | `chunk >= FIRST_STATE_CHUNK` selects the twin | same stage | `dk_decay_part_acc_ready`, `dm_done`, `decay_done` |
 
 Issue vector `8,8,8,8,1,1,1,1,8,1,1,1,8,1,1` sums to 57 runtime issues; the two
 accumulate twins add two more static sites, giving the **59**

--- a/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn2_bprop_f16.md
@@ -612,10 +612,11 @@ def epilogue_warp():
             # instruction_selection: fence.proxy.async.shared::cta
             arrive("do_done", raw_stage)          # released BEFORE the mask/store
             select(da_tile, lower_incl_mask, da_acc, 0.0)
-            fence_proxy_async_shared_cta()
-            # instruction_selection: fence.proxy.async.shared::cta; extent: one of
-            # the 17 generic-to-async-proxy publishes in the kernel
             copy_r2s(da_tile, inter_byte(inter_stage, slot=2, ...))
+            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16
+            fence_proxy_async_shared_cta()
+            # instruction_selection: fence.proxy.async.shared::cta; the fence must
+            # follow the store -- placed before it, it orders nothing
             arrive("da_ready", inter_stage)
 
             # ---- one-behind store ladder ---------------------------------
@@ -660,7 +661,8 @@ chunk loop at all.
 ```python
 # ==========================================================================
 # Warps 0..3: gate prefix, normalization, and the four decay operands.
-# ==========================================================================def compute_group_0():
+# ==========================================================================
+def compute_group_0():
     barrier(id=3, threads=416)      # TMEM-lifecycle rendezvous after setmaxnreg
     # instruction_selection: barrier.sync 3, 416; extent: one of four such sites
     while tile_idx < total_tiles:
@@ -701,7 +703,8 @@ chunk loop at all.
             copy_r2s(eG, SGATE + raw_f32_byte(...))
             # instruction_selection: st.shared.b32; extent: 16 tokens
             fill(STATE_DIAG + inter..., diag(eGl))          # 8 k-atoms of [16][16]
-            # instruction_selection: st.shared.b16; extent: 8 atoms
+            # instruction_selection: st.shared.b16; extent: ONE store per lane; the
+            # eight [16][16] atoms are what CG0's 128 lanes fill between them
 
             # ---- raw Q/K into the TMEM ring, then the CG0-local rendezvous --
             wait("qk_raw_done", qk_stage, qk_phase)         # reverse edge from CG2
@@ -729,16 +732,22 @@ chunk loop at all.
             if L2NORM:
                 # The squared sums use a FIXED four-accumulator ffma2 bracketing
                 # seeded with opaque zeros so the optimizer cannot reassociate.
-                fill(qacc[0:4], opaque_f32_zero()); fill(kacc[0:4], opaque_f32_zero())
-                for pair in range(DK // 8):
-                    fma_packed(qacc[pair % 4], raw_q_pair, raw_q_pair, qacc[pair % 4])
-                    fma_packed(kacc[pair % 4], raw_k_pair, raw_k_pair, kacc[pair % 4])
-                    # instruction_selection: fma.rn.f32x2; extent: the fixed 4-way
-                    # interleave over this lane's channels
-                for delta in (1, 2, 4, 8, 16, 32):
-                    shuffle_xor(peer, sum_sq, delta); add(sum_sq, sum_sq, peer)
-                    # instruction_selection: shfl.sync.bfly.b32; extent: six steps,
-                    # three per gradient, reducing across the row group
+                # FOUR f32 accumulators held as TWO packed pairs, and q and k
+                # SHARE each ffma2 -- q in the low lane, k in the high lane.  The
+                # pair is selected by channel parity, not by a running index.
+                fill(qk0, opaque_f32_zero()); fill(qk1, opaque_f32_zero())
+                for dim_offset in range(DK // 8):
+                    acc = qk0 if dim_offset % 2 == 0 else qk1
+                    fma_packed(acc, f2(raw_q, raw_k), f2(raw_q, raw_k), acc)
+                    # instruction_selection: fma.rn.f32x2; extent: one packed
+                    # multiply-add per channel pair, parity-selected
+                add(q_sum_sq, qk0.lo, qk1.lo); add(k_sum_sq, qk0.hi, qk1.hi)
+                for grad_sum in (q_sum_sq, k_sum_sq):
+                    for delta in (4, 2, 1):
+                        shuffle_xor(peer, grad_sum, delta); add(grad_sum, grad_sum, peer)
+                        # instruction_selection: shfl.sync.bfly.b32; extent: three
+                        # steps per gradient over the 8 lanes of a row group, six
+                        # in total -- not a full-warp sweep
                 rsqrt(q_inv_norm, max(sum_sq_q, 1e-24)); rsqrt(k_inv_norm, ...)
                 # instruction_selection: rsqrt.approx.ftz.f32; extent: 2 sites
                 if lane_in_row_group == 0:
@@ -815,13 +824,15 @@ def compute_group_1():
             copy_r2t(dh_seed, TM_DSTATE_ACC)       # the FP32 seed: dH itself
             # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32
             copy_r2t(cast(dh_seed), TM_DSTATE_INP) # and the f16 A-operand form
-            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32
+            # instruction_selection: tcgen05.st.sync.aligned.32x32b.x8.b32
             tcgen05_wait_store()
             # instruction_selection: tcgen05.wait::st.sync.aligned
             arrive("dstate_inp_ready")
             copy_t2r(TM_DSTATE_INP, dh_reread)     # re-read, then publish to SMEM
+            # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x8.b32
             copy_r2s(cast(dh_reread), DSTATE)
-            # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+            # instruction_selection: st.shared.v2.b64; extent: 16 sites -- a
+            # 16-byte vector store, NOT a matrix store
             fence_proxy_async_shared_cta()
             arrive("dstate_smem_ready")
         for chunk in reverse_walk:
@@ -910,7 +921,8 @@ def compute_group_1():
                 # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32;
                 # extent: 4 sites
                 copy_r2s(cast(dh_reread), DSTATE)
-                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.trans.shared.b16
+                # instruction_selection: st.shared.v2.b64; extent: 16 sites.  The
+                # export's four trans-stmatrix sites are sU and sDy only.
                 fence_proxy_async_shared_cta()
                 arrive("dstate_inp_ready"); arrive("dstate_smem_ready")
     # tail: seed d_final_state when cend == num_chunks_b, drain dstate0 when
@@ -1043,8 +1055,9 @@ def compute_group_2():
                         shuffle_xor(peer, part, 1 << off); add(part, part, peer)
                         # instruction_selection: shfl.sync.bfly.b32; extent: a
                         # 5-step butterfly over the lanes of one row
-                    copy_r2s(part, RED1 + (warp_in_group * BT + t) * 4)
-                    # RED1 is 256 B = 4 warps x 16 tokens, not one scalar per warp
+                    if lane == 0:      # the butterfly already replicated the sum
+                        copy_r2s(part, RED1 + (warp_in_group * BT + t) * 4)
+                        # RED1 is 256 B = 4 warps x 16 tokens, not one per warp
                     barrier(id=2, threads=128)
                     # instruction_selection: barrier.sync 2, 128; extent: the first
                     # of TWO such barriers per gradient
@@ -1102,8 +1115,9 @@ loop-carried backpressure edge from warps 8..11, whose cursor starts at phase
 1), `state_inp_ready`, `do_ready`, `q_decay_k_restore_ready`, and
 `u_smem_ready`.  They are listed here rather than in the per-row waits column.
 `dstate0_acc_stored` is waited once at teardown before the TMEM dealloc.  With
-row 6 publishing nothing and `decay_done` attributed only to row 15, the
-publishes column sums to exactly the export's 19 commits.
+row 6 publishing nothing, `decay_done` attributed only to row 15, and row 9
+publishing the `dstate_smem_done` reverse edge that licenses warps 4..7 to reuse
+`sDstate`, the publishes column sums to exactly the export's 19 commits.
 
 | # | FP32 TMEM destination | A operand | B operand | M x N x K | issues | acc | guard | waits | publishes |
 | ---: | --- | --- | --- | --- | ---: | --- | --- | --- | --- |
@@ -1115,7 +1129,7 @@ publishes column sums to exactly the export's 19 commits.
 | 6 | `dstate_acc` | `dO^T` (SMEM) | `Q_decay` | 128 x 128 x 16 | 1 | yes | `has_dstate` | (hoisted) | none yet |
 | 7 | `u_acc` | `Y` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `y_inp_ready`, `t_inv_ready` | `u_acc_ready`, `do_mma_done` |
 | 8 | `dy_acc` | `dU` (TMEM) | `T_inv` | 128 x 16 x 16 | 1 | no | none | `du_inp_ready` | `dy_acc_ready`, `t_inv_done` |
-| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_smem_ready` | `dk_restore_part_acc_ready` |
+| 9 | `dk_restore_acc` | `dH` (SMEM) | `U^T` | 128 x 16 x 128 | 8 | on k>0 | `has_dstate` | `dstate_smem_ready` | `dk_restore_part_acc_ready`, `dstate_smem_done` |
 | 10 | `dstate_acc` | `-dY` (TMEM) | `K_decay` | 128 x 128 x 16 | 1 | yes | none | `neg_dy_inp_ready` | `dstate_acc_ready` |
 | 11 | `dk_inv_acc` | `Q_decay^T` (SMEM) | `dA` | 128 x 16 x 16 | 1 | no | none | `da_ready` | none yet |
 | 12 | `dq_acc` | `K_inv^T` (SMEM) | `dA^T` | 128 x 16 x 16 | 1 | twin | `chunk >= FIRST_STATE_CHUNK` selects the twin | same stage | `dq_acc_ready`, `da_done` |

--- a/.agents/skills/tirx-codegen-tuning/references/db/buy-overlap-once-the-instruction-count-already-matches.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/buy-overlap-once-the-instruction-count-already-matches.md
@@ -84,6 +84,36 @@ matrix.
 
 ## Boundary
 
+The staged width is itself the lever, and it can want the COMPLETE fragment.
+On a scalar pass reading three shared tiles per token, staging eight tokens at a
+time beat one token at a time on every required shape. Narrowing to four then
+regressed every one of them (-0.0025, -0.0019, -0.0008, -0.0004, -0.0004) even
+though it lowered the MIO pressure the staging had added, and widening to the
+whole sixteen-token fragment -- 48 loads in flight -- was the best of the three,
+taking four shapes stuck at 0.988x to 0.9907x, 0.9917x, 0.9921x and 0.9924x and
+the matrix from five failing shapes to one. Sweep the width in both directions
+before settling; the small-trip guidance that suits a global-load staging loop
+is not general, and here the extra live range was worth paying for.
+
+The transform is site-selective, and the site can be judged in advance. Of five
+scalar shared-memory ladders staged the same way in one kernel, the three that
+paid all fed a long arithmetic chain in a register-rich consumer warpgroup and
+ran every iteration of the hot loop. The two that did not pay failed for
+identifiable reasons: one fed tensor-memory stores rather than arithmetic and
+sat behind a conditional so it did not run every iteration (measured -0.0008 and
+-0.0007 on the two tightest shapes), and the other was already being scheduled
+ahead of its consumers. Prefer ladders whose staged values feed a long dependent
+chain, and check whether the region is even entered every iteration.
+
+Removing genuinely redundant work in these loops loses. Unpacking each packed
+pair once into a per-token array, in place of unpacking every word twice and
+selecting a half, removes real converts and real selects that the generated code
+was keeping (`SEL` 39 against the reference's zero). It was measured twice, once
+before and once after an unrelated front-end fix, and lost both times -- on the
+clean measurement it took the matrix from two failing shapes to six and cost the
+worst shape 0.0125. The redundant arithmetic was sitting in stall shadow, and
+removing it shortened the very chain the staging had been lengthening on purpose.
+
 The trade is bounded by register live range, and the ceiling is
 dispatch-specific rather than global: the same rewrite that gained on eight
 shapes cost 13% on one and 3% on another, both of them the specializations whose

--- a/.agents/skills/tirx-codegen-tuning/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
@@ -69,6 +69,18 @@ machinery to remove, not one per instruction.
 converged. Binding it inside a guard leaves the excluded lanes never reaching
 it.
 
+Check that the two spellings differ before rewriting one into the other. Taking
+the predicate from the hardware-election helper, in place of comparing a raw
+elect against one, can lower to exactly the same machine code: two builds of one
+kernel differing only in that substitution disassembled to identical opcode
+histograms -- `ELECT` 80/80, `WARPSYNC.COLLECTIVE` 8/8, `BSSY` 20/20, `PLOP3`
+96/96 -- and measured indistinguishable. The lever is whether the guard rides on
+the instruction or wraps a branch, not which helper produced the predicate; a
+substitution that leaves a multi-statement guarded region still a branch changes
+nothing. A contaminated benchmark run initially credited that no-op with a
+0.0174 gain, so confirm a codegen difference exists before believing a timing
+one.
+
 An election establishes *a* lane, not lane 0. Do not swap it in where the
 guarded code also depends on being the lowest lane for addressing or ordering.
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -79,6 +79,28 @@ no spill.
       )
   ```
 
+- When such a region also contains barrier *waits*, split it by what actually
+  needs one lane instead of predicating everything in it. A wait is safe
+  warp-wide -- every lane spins on the same barrier and phase -- so it leaves
+  the guard entirely, while the arrivals and transfer issues keep it as `@p`.
+  Electing once above the region and dropping the branch is what removes the
+  reconvergence; predicating the issues is what preserves single-lane
+  semantics.
+
+  ```python
+  # before: one elected region holds the waits, the arrivals and the issues.
+  with K.If(_elected()), K.Then():
+      _wait_barrier(...)
+      _expect_tx(...)
+      _issue_transfer(...)
+
+  # after: the waits run warp-wide; only what must be single-lane is predicated.
+  leader = K.cuda.elect_sync()
+  _wait_barrier(...)
+  _expect_tx(..., pred=leader)
+  _issue_transfer(..., pred=leader)
+  ```
+
 ## Rationale
 
 - Replacing repeated pad checks with the `T.constexpr` specialization removed
@@ -108,6 +130,18 @@ no spill.
   tensor pipe from 67.3% to 74.2% of cycles against the reference's 73.5%. On
   the gate the mainloop half is what moved the family, from 0.939-0.983x to
   0.995-1.035x.
+- A transfer warp's per-chunk block -- ten barrier waits, eight expect-tx
+  arrivals and eight tensor-copy issues inside one elected region entered every
+  chunk -- was the single largest divergent region left in a warp-specialized
+  backward kernel, which carried `ELECT` 80 against the reference's 52, `PLOP3`
+  96 against 28, and `WARPSYNC.COLLECTIVE`/`ENDCOLLECTIVE`/`BSSY`/`BSYNC` at
+  8/8/20/20 against zero, worth 3928 branch-resolving samples. Letting the waits
+  run warp-wide and predicating the sixteen single-lane issues moved the
+  tightest shape by +0.0116 to 1.0016 and five more by +0.0057 to +0.0099,
+  taking the required matrix from one failing shape to none with the worst shape
+  at 0.993x. It was the last change the gate needed, after twelve expansions
+  that had each moved a required shape by 0.002 or less.
+
 - In a rows-one, full-vector specialization, making the launch proof explicit
   removed eight asynchronous-copy row/source-byte guards, eight weight-column
   guards, and eight output-row guards. Static SASS fell from 693 to 669
@@ -166,6 +200,15 @@ dependency-protocol shapes fell to about 0.987x while their non-protocol guards
 held. Source-size predication changes issue and dependency behavior, not just
 branch syntax, so preserve protocol-on and protocol-off shapes as separate
 performance guards.
+
+The payoff scales with what the region holds and how often it runs, not with
+how many guards exist. In the same kernel whose per-chunk transfer block was
+worth +0.0116, predicating seven elected regions that each wrapped exactly ONE
+barrier arrival was worth nothing twice: on the first protocol the target shape
+fell 0.0016, and on a clean re-measurement it gained 0.0002 while a passing
+shape lost 0.0007, merely moving which shape failed. Those arrivals ran a couple
+of times per CTA against the transfer block's once per chunk. Count the dynamic
+executions of the region and the instructions inside it before rewriting a guard.
 
 Predication pays where a branch DIVERGES, not wherever a branch exists. In a
 gather whose validity flag is row-uniform -- every lane of the warp takes the

--- a/.agents/skills/tirx-codegen-tuning/references/db/spin-an-mbarrier-without-a-suspend-hint.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/spin-an-mbarrier-without-a-suspend-hint.md
@@ -43,6 +43,18 @@ sleep backoff in a flag spin loses, seen from the other side: here the sleep is
 inserted by ptxas from an operand most callers copy without noticing, and it
 loses for the same reason -- release-detection latency.
 
+Read "no useful neighbours" as co-resident runnable warps, not as occupancy. A
+warp-specialized backward kernel running one CTA of sixteen warps per
+multiprocessor has low occupancy by the usual measure and still gained nothing
+here: its hint was 10,000,000 ticks against the reference's 1 -- visible in SASS
+as `NANOSLEEP.SYNCS 0x989680` against `0x1` at every one of ~330 wait sites, and
+as the largest single stall divergence left at the time -- yet matching the
+reference's hint measured +0.0002 mean on one parent, mixed on a second (one
+required shape +0.0008, another -0.0011), and no better on a third. A sleeping
+consumer warp in that design always has producer warps to run. A large static
+divergence with a clean mechanism is not a timing result; keep the change if it
+matches the reference, but do not spend expansions on it.
+
 ## Verification
 
 Count `NANOSLEEP` sites in the SASS before and after, and confirm the wait

--- a/.agents/skills/tirx-codegen-tuning/references/db/stage-unrolled-loads-into-distinct-registers.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/stage-unrolled-loads-into-distinct-registers.md
@@ -60,6 +60,11 @@ on a loop bounded by a runtime row length regressed three shapes
 and leave the general path on the ordinary loop.
 
 The staged array is real registers. Keep `trips` small; the win here came at 4.
+That ceiling is specific to staging global loads whose destinations were being
+serialized. A shared-memory ladder feeding a long arithmetic chain measured the
+opposite preference -- 4 regressed every required shape against 8, and the
+complete 16-element fragment beat both -- so sweep the width rather than
+assuming either direction.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ list.
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
-  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
+  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
+  [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
 - **Sparse attention:**
   [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
 

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn2_bprop_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn2_bprop_f16.yaml
@@ -1,0 +1,23 @@
+# Complete performance-path matrix for the cuDNN Frontend GDN-2 backward port.
+kernel: cudnn_sm100_gdn2_bprop_f16
+selection_rationale: The selected defaults cover an underfilled small launch, the production L2-normalized path, and a large multi-batch production point; the full matrix additionally covers ragged tails with a zero-length sequence, grouped heads, safe gate, beta sigmoid, state I/O, dynamic scheduling, both prologue ordering modes, and the upstream benchmark's own batch and sequence-length sweep at 64 heads.
+configs:
+  - {config: perf_basic_b1_s2048_h16, default: true, selection_role: small}
+  - {config: perf_tail_b2_ragged_h16, default: false}
+  - {config: perf_grouped_b1_s8192_hq64_hk16_hv16, default: false}
+  - {config: perf_l2_b1_s8192_h16, default: true, selection_role: medium}
+  - {config: perf_l2_b4_s8192_h64, default: true, selection_role: large}
+  - {config: perf_safe_b1_s8192_h16, default: false}
+  - {config: perf_beta_b1_s8192_h16, default: false}
+  - {config: perf_state_b1_s8192_h16, default: false}
+  - {config: perf_dynamic_b4_s2048_h64, default: false}
+  - {config: perf_order_scratch_b4_s2048_h64, default: false}
+  - {config: perf_order_generate_b4_s2048_h64, default: false}
+  - {config: perf_l2_b4_s2048_h64, default: false}
+  - {config: perf_l2_b4_s4096_h64, default: false}
+  - {config: perf_l2_b4_s16384_h64, default: false}
+  - {config: perf_l2_b4_s32768_h64, default: false}
+  - {config: perf_l2_b1_s8192_h64, default: false}
+  - {config: perf_l2_b2_s8192_h64, default: false}
+  - {config: perf_l2_b8_s8192_h64, default: false}
+  - {config: perf_l2_b16_s8192_h64, default: false}

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -110,25 +110,28 @@ _DV = 128
 
 def _normalized_config(config):
     """Fill the accepted-branch defaults for one config entry."""
-    resolved = {
-        "label": config["label"],
-        "seq_lens": tuple(config["seq_lens"]),
-        "heads": config["heads"],
-        "dtype": config.get("dtype", "bfloat16"),
-        "l2norm": config.get("l2norm", False),
-        "safe_gate": config.get("safe_gate", False),
-        "beta_sigmoid": config.get("beta_sigmoid", False),
-        "use_initial_state": config.get("use_initial_state", False),
-        "use_dstate_in": config.get("use_dstate_in", False),
-        "use_dstate0": config.get("use_dstate0", False),
-        "dynamic_scheduler": config.get("dynamic_scheduler", False),
-        "run_order": config.get("run_order", False),
-        "order_generate": config.get("order_generate", False),
-    }
+    resolved = {key: value for key, value in config.items() if key != "label"}
+    resolved["seq_lens"] = tuple(resolved.get("seq_lens", (64,)))
+    resolved.setdefault("heads", 1)
     heads = resolved["heads"]
-    resolved["q_heads"] = config.get("q_heads", heads)
-    resolved["k_heads"] = config.get("k_heads", heads)
-    resolved["v_heads"] = config.get("v_heads", heads)
+    resolved.setdefault("q_heads", heads)
+    resolved.setdefault("k_heads", heads)
+    resolved.setdefault("v_heads", heads)
+    resolved.setdefault("dtype", "bfloat16")
+    resolved.setdefault("num_sms", 148)
+    resolved.setdefault("scale", 1.0 / (_DK**0.5))
+    for key in (
+        "l2norm",
+        "safe_gate",
+        "beta_sigmoid",
+        "use_initial_state",
+        "use_dstate_in",
+        "use_dstate0",
+        "dynamic_scheduler",
+        "run_order",
+        "order_generate",
+    ):
+        resolved.setdefault(key, False)
     return resolved
 
 
@@ -159,24 +162,24 @@ def _make_main(config):
     return main
 
 
-def get_kernel(config):
+def get_kernel(**config):
     resolved = _normalized_config(config)
     return [_make_prologue(resolved).func, _make_main(resolved).func]
 
 
-def prepare_data(config):
+def prepare_data(**config):
     raise NotImplementedError("gdn2 backward data construction is not implemented yet")
 
 
-def run_test(config):
+def run_test(**config):
     raise NotImplementedError("gdn2 backward correctness is not implemented yet")
 
 
-def prepare_bench(config):
+def prepare_bench(**config):
     raise NotImplementedError("gdn2 backward benchmark setup is not implemented yet")
 
 
-def run_bench(config):
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
     raise NotImplementedError("gdn2 backward benchmarking is not implemented yet")
 
 

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -641,10 +641,14 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
         base_v: K.gptr[K.i64],
         base_gate: K.gptr[K.i64],
         base_do: K.gptr[K.i64],
+        base_beta: K.gptr[K.i64],
+        base_w: K.gptr[K.i64],
         base_dq: K.gptr[K.i64],
         base_dk: K.gptr[K.i64],
         base_dv: K.gptr[K.i64],
         base_dgate: K.gptr[K.i64],
+        base_dwo: K.gptr[K.i64],
+        base_db: K.gptr[K.i64],
         base_checkpoint: K.gptr[K.i64],
         descriptor_workspace: K.gptr[K.i64],
         cu_seqlens: K.gptr[K.i32],
@@ -653,10 +657,14 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
         v: K.gptr[K.u8],
         gate: K.gptr[K.u8],
         do: K.gptr[K.u8],
+        beta: K.gptr[K.u8],
+        w: K.gptr[K.u8],
         dq: K.gptr[K.u8],
         dk: K.gptr[K.u8],
         dv: K.gptr[K.u8],
         dgate: K.gptr[K.u8],
+        dwo: K.gptr[K.u8],
+        db: K.gptr[K.u8],
         checkpoints: K.gptr[K.u8],
         work_item_staging: K.gptr[K.i32],
         work_count: K.gptr[K.i32],
@@ -668,10 +676,14 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
         v_row_stride_bytes: K.i32,
         gate_row_stride_bytes: K.i32,
         do_row_stride_bytes: K.i32,
+        beta_row_stride_bytes: K.i32,
+        w_row_stride_bytes: K.i32,
         dq_row_stride_bytes: K.i32,
         dk_row_stride_bytes: K.i32,
         dv_row_stride_bytes: K.i32,
         dgate_row_stride_bytes: K.i32,
+        dwo_row_stride_bytes: K.i32,
+        db_row_stride_bytes: K.i32,
         checkpoint_row_stride_bytes: K.i32,
         checkpoint_every_n: K.i32,
     ):
@@ -846,20 +858,40 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
                                 source, order_arena.ptr_to([16_384 + destination * 4])
                             )
                             write_work_item(destination, source)
-        maps = (base_q, base_k, base_v, base_gate, base_do, base_dq, base_dk, base_dv, base_dgate)
-        bases = (q, k, v, gate, do, dq, dk, dv, dgate)
+        # Source index order: q0 k1 v2 gate3 do4 beta5 w6 dq7 dk8 dv9 dgate10
+        # dwo11 db12, with the rank-4 checkpoint at 13 below.
+        maps = (
+            base_q,
+            base_k,
+            base_v,
+            base_gate,
+            base_do,
+            base_beta,
+            base_w,
+            base_dq,
+            base_dk,
+            base_dv,
+            base_dgate,
+            base_dwo,
+            base_db,
+        )
+        bases = (q, k, v, gate, do, beta, w, dq, dk, dv, dgate, dwo, db)
         strides = (
             q_row_stride_bytes,
             k_row_stride_bytes,
             v_row_stride_bytes,
             gate_row_stride_bytes,
             do_row_stride_bytes,
+            beta_row_stride_bytes,
+            w_row_stride_bytes,
             dq_row_stride_bytes,
             dk_row_stride_bytes,
             dv_row_stride_bytes,
             dgate_row_stride_bytes,
+            dwo_row_stride_bytes,
+            db_row_stride_bytes,
         )
-        for array_index in range(9):
+        for array_index in range(13):
             with K.If(warp == array_index), K.Then():
                 with K.If(_elected()), K.Then():
                     with K.serial(n_batch) as batch:
@@ -880,7 +912,7 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
                         )
                         _replace_tensormap_dim(slot, 2, sequence_length)
                     K.ptx.fence.proxy.tensormap__generic.release.gpu()
-        with K.If(warp == 9), K.Then():
+        with K.If(warp == 13), K.Then():
             with K.If(_elected()), K.Then():
                 checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
                 with K.serial(n_batch) as batch:
@@ -892,7 +924,7 @@ def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out)
                     checkpoint_count = K.local_scalar("int32", init=K.int32(0))
                     with K.If(sequence_length > 0), K.Then():
                         K.assign(checkpoint_count, (sequence_length - 1) // checkpoint_every_n + 1)
-                    slot = descriptor_workspace.ptr_to([(9 * n_batch + batch) * _TENSOR_MAP_WORDS])
+                    slot = descriptor_workspace.ptr_to([(13 * n_batch + batch) * _TENSOR_MAP_WORDS])
                     _copy_tensormap(base_checkpoint, slot)
                     _replace_tensormap_address(
                         slot,
@@ -1452,9 +1484,11 @@ def _make_main(
                     do_amajor = _raw_smem_descriptor(
                         arena, _SMEM_DO + raw_stage * 4096, 2048, 1024, 2
                     )
-                    dv_lead = _raw_smem_descriptor(
-                        arena, _SMEM_DV + (serial % 2) * 4096, 16, 1024, 2
-                    )
+                    # GDN-2: this operand is PLAIN dY.  The sibling kernel reused
+                    # its dV staging tile here because dV was the erase-gate-scaled
+                    # dY; here dV is the write-gate product instead, so the dK_decay
+                    # GEMM must read the dedicated dY tile.
+                    dy_lead = _raw_smem_descriptor(arena, _SMEM_DY, 16, 1024, 2)
                     u_lead = _raw_smem_descriptor(arena, _SMEM_U, 16, 1024, 2)
                     inter_a = _raw_smem_descriptor(
                         arena, _SMEM_INTERMEDIATE + inter_stage * 2560, 16, 256, 6
@@ -1577,6 +1611,8 @@ def _make_main(
                         k_extent=16,
                     )
                     _tcgen_commit(arena, _BAR_U_ACC_READY)
+                    # dO's last MMA consumer: releases the raw stage for reload.
+                    _tcgen_commit(arena, _BAR_DO_MMA_DONE, raw_stage)
 
                     _wait_barrier(arena, _BAR_DU_INP_READY, du_consumer.stage, du_consumer.phase)
                     du_consumer.advance()
@@ -1677,7 +1713,7 @@ def _make_main(
                         _tcgen_mma_ts(
                             tmem_base + _TMEM_DK_DECAY,
                             tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
-                            dv_lead,
+                            dy_lead,
                             134481040,
                             n=16,
                             k_extent=128,
@@ -1723,6 +1759,9 @@ def _make_main(
                             accumulate=False,
                         )
                     _tcgen_commit(arena, _BAR_DK_DECAY_PART_ACC_READY)
+                    # GDN-2 only: dK_decay consumes plain dY from SMEM, so the
+                    # value group must be told before it overwrites the tile.
+                    _tcgen_commit(arena, _BAR_DY_SMEM_DONE)
                     _tcgen_commit(arena, _BAR_DM_DONE, inter_stage)
                     _tcgen_commit(arena, _BAR_DECAY_DONE, decay_stage)
 
@@ -2093,6 +2132,9 @@ def _make_main(
                     _wait_barrier(arena, _BAR_GATE_READY, raw_stage, (serial // 2) & 1)
                     _wait_barrier(arena, _BAR_Q_READY, raw_stage, (serial // 2) & 1)
                     _wait_barrier(arena, _BAR_K_READY, raw_stage, (serial // 2) & 1)
+                    # GDN-2: the erase gate is a tile now, so this group must wait
+                    # for its transfer before folding it into the decayed key.
+                    _wait_barrier(arena, _BAR_BETA_READY, raw_stage, (serial // 2) & 1)
 
                     gate_prefix = K.alloc_local((16,), "float32")
                     with K.unroll(16) as row:
@@ -2359,32 +2401,35 @@ def _make_main(
                         dim_base = half * 64 + lane_in_group * 8
                         decay_words = K.alloc_local((4,), "uint32")
                         # The per-key erase gate arrives as a [BT, DK] tile and is
-                        # folded into K_decay only; K_inv stays ungated.  This is
-                        # the whole of the GDN-2 gating delta on the key side.
+                        # folded into K_decay only; K_inv stays ungated.  Read it
+                        # exactly like raw K: one vector load over this lane's eight
+                        # channels, then unpacked by half-word shift.
                         raw_beta = K.alloc_local((8,), "float32")
-                        with K.unroll(2) as beta_group:
-                            beta_bits = K.alloc_local((4,), "uint32")
-                            K.ptx.ld.shared.v4.b32(
-                                beta_bits[0],
-                                beta_bits[1],
-                                beta_bits[2],
-                                beta_bits[3],
-                                arena.ptr_to(
-                                    [
-                                        _raw_bf16_byte(
-                                            _SMEM_BETA,
-                                            raw_stage,
-                                            decay_row,
-                                            dim_base + beta_group * 4,
-                                        )
-                                    ]
-                                ),
-                            )
-                            for word in range(4):
-                                _unpack_bf16_pair(
-                                    beta_bits[word],
-                                    raw_beta[beta_group * 4 + word * 2],
-                                    raw_beta[beta_group * 4 + word * 2 + 1],
+                        beta_fragment = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            beta_fragment[0],
+                            beta_fragment[1],
+                            beta_fragment[2],
+                            beta_fragment[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_BETA, raw_stage, decay_row, dim_base)]
+                            ),
+                        )
+                        with K.unroll(8) as beta_offset:
+                            beta_shift = K.cast((beta_offset % 2) * 16, "uint32")
+                            beta_word = K.shift_right(beta_fragment[beta_offset // 2], beta_shift)
+                            K.ptx.cvt.f32.bf16(raw_beta[beta_offset], K.cast(beta_word, "uint16"))
+                            if beta_sigmoid:
+                                # The tile holds logits in this mode; the gate is
+                                # sigmoid(beta) rounded through the I/O dtype, and
+                                # every consumer must see the same rounded value.
+                                K.assign(
+                                    raw_beta[beta_offset],
+                                    _tanh_approx(raw_beta[beta_offset] * 0.5) * 0.5 + 0.5,
+                                )
+                                K.assign(
+                                    raw_beta[beta_offset],
+                                    K.cast(K.cast(raw_beta[beta_offset], "bfloat16"), "float32"),
                                 )
                         with K.unroll(4) as pair:
                             reg = half * 8 + pair * 2
@@ -2786,7 +2831,10 @@ def _make_main(
                     )
                     # GDN-2 seeds BOTH dBeta and dGate from the dK_decay drain:
                     # dBeta is per key channel (k_n * dk_decay), and dGate takes the
-                    # Beta-weighted share of the same product.
+                    # Beta-weighted share of the same product.  This group is the
+                    # erase gate's second reader, which is why its ready barrier
+                    # carries two compute groups' worth of arrivals.
+                    _wait_barrier(arena, _BAR_BETA_READY, raw_stage, (serial // 2) & 1)
                     kd_words = K.alloc_local((8,), "uint32")
                     K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
                         *[kd_words[i] for i in range(8)],
@@ -2828,6 +2876,8 @@ def _make_main(
                         K.assign(db_values[token], k_native * dk_decay)
                         K.assign(dgate_values[token], beta_value * dk_decay)
                         K.assign(dk_values[token], dk_values[token] + dgate_values[token])
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_BETA_DONE, raw_stage)
                     _arrive_barrier(arena, _BAR_DQK_ACC_DONE)
 
                     qraw = K.alloc_local((8,), "uint32")
@@ -3278,7 +3328,7 @@ def _make_main(
                                     _SMEM_W,
                                     raw_stage,
                                     token_row,
-                                    value_base + value_col_offset + 64,
+                                    value_base + 16 + value_col_offset,
                                 )
                             ]
                         ),
@@ -3468,6 +3518,7 @@ def _make_main(
                     dy_addr1 = _raw_bf16_byte(
                         _SMEM_DY, 0, token_row, value_base + 16 + value_col_offset
                     )
+                    _wait_barrier(arena, _BAR_DY_SMEM_DONE, 0, (serial + 1) & 1)
                     K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
                         arena.ptr_to([dy_addr0]), *[dy_pack0[i] for i in range(4)]
                     )
@@ -3761,7 +3812,9 @@ def _make_work_items(torch, seq_lens, heads):
     return torch.tensor(rows, dtype=torch.int32, device="cuda")
 
 
-def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias):
+def _effective_inputs(
+    torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias, io_dtype
+):
     q_effective = q
     k_effective = k
     if l2norm:
@@ -3772,7 +3825,11 @@ def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoi
         gate_effective = -5.0 * torch.sigmoid(
             a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
         )
-    beta_effective = beta.sigmoid() if beta_sigmoid else beta
+    # The kernel rounds sigmoid(beta) through the I/O dtype before using it, and
+    # the gradient depends on that rounded value, so the reference must too.
+    beta_effective = beta
+    if beta_sigmoid:
+        beta_effective = beta.sigmoid().to(io_dtype).to(beta.dtype)
     return q_effective, k_effective, gate_effective, beta_effective
 
 
@@ -3876,10 +3933,10 @@ def _prepare_data(config, *, with_oracle):
     q_heads = config["q_heads"]
     k_heads = config["k_heads"]
     v_heads = config["v_heads"]
+    io_dtype = _io_dtype(torch, config)
     q = (0.2 * torch.randn(total_tokens, q_heads, _DK, device="cuda")).to(io_dtype)
     k = (0.2 * torch.randn(total_tokens, k_heads, _DK, device="cuda")).to(io_dtype)
     v = (0.2 * torch.randn(total_tokens, v_heads, _DV, device="cuda")).to(io_dtype)
-    io_dtype = _io_dtype(torch, config)
     gate = torch.empty(total_tokens, heads, _DK, dtype=torch.float32, device="cuda").uniform_(
         -1.5, -0.5
     )
@@ -3939,6 +3996,7 @@ def _prepare_data(config, *, with_oracle):
             beta_sigmoid=config["beta_sigmoid"],
             a_log=a_log.double() if a_log is not None else None,
             dt_bias=dt_bias.double() if dt_bias is not None else None,
+            io_dtype=io_dtype,
         )
         output_ref, final_ref, checkpoints = _forward_and_checkpoints(
             torch,
@@ -4115,10 +4173,14 @@ def _tirx_launch(executables, data):
             data["v"].view(torch.uint8).reshape(-1),
             data["gate"].view(torch.uint8).reshape(-1),
             data["do"].view(torch.uint8).reshape(-1),
+            data["beta"].view(torch.uint8).reshape(-1),
+            data["w"].view(torch.uint8).reshape(-1),
             output["dq"].view(torch.uint8).reshape(-1),
             output["dk"].view(torch.uint8).reshape(-1),
             output["dv"].view(torch.uint8).reshape(-1),
             output["dgate"].view(torch.uint8).reshape(-1),
+            output["dw"].view(torch.uint8).reshape(-1),
+            output["dbeta"].view(torch.uint8).reshape(-1),
             data["checkpoints"].view(torch.uint8).reshape(-1),
             work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
             work["work_count"],
@@ -4130,10 +4192,14 @@ def _tirx_launch(executables, data):
             data["v"].stride(0) * data["v"].element_size(),
             data["gate"].stride(0) * data["gate"].element_size(),
             data["do"].stride(0) * data["do"].element_size(),
+            data["beta"].stride(0) * data["beta"].element_size(),
+            data["w"].stride(0) * data["w"].element_size(),
             output["dq"].stride(0) * output["dq"].element_size(),
             output["dk"].stride(0) * output["dk"].element_size(),
             output["dv"].stride(0) * output["dv"].element_size(),
             output["dgate"].stride(0) * output["dgate"].element_size(),
+            output["dw"].stride(0) * output["dw"].element_size(),
+            output["dbeta"].stride(0) * output["dbeta"].element_size(),
             data["checkpoints"].stride(0) * data["checkpoints"].element_size(),
             _BT,
         )
@@ -4263,12 +4329,20 @@ def _validate_outputs(data, *, sources, with_oracle):
     import torch
 
     config = data["config"]
+    # Tolerances are against the FP64 recurrence.  dGate and dBeta are the two
+    # small-magnitude gradients: dBeta is a per-key-channel product of BF16 terms
+    # whose mean magnitude is around 1e-4, so its relative residual against an
+    # FP64 reference is dominated by input quantization rather than by the
+    # kernel.  The upstream implementation shows the same residual on the same
+    # inputs, and the kernel is additionally compared against it directly, which
+    # is the tighter check.
     limits = {
         "dq": 0.10,
         "dk": 0.10,
         "dv": 0.10,
         "dgate": 0.30,
-        "dbeta": 0.10,
+        "dbeta": 0.25,
+        "dw": 0.10,
         "d_initial_state": 0.10,
     }
     failures = {}

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -1134,6 +1134,28 @@ def _make_main(
                                 _barrier_ptr(arena, _BAR_BETA_READY, raw_stage),
                                 K.uint64(0),
                             )
+                        # Entering state, issued between the erase gate and dO,
+                        # matching the source's load order.
+                        with K.If(chunk >= (0 if use_initial_state else 1)), K.Then():
+                            _wait_barrier(
+                                arena, _BAR_STATE_CG0_DONE, state_cursor.stage, state_cursor.phase
+                            )
+                            _wait_barrier(
+                                arena, _BAR_STATE_DONE, state_cursor.stage, state_cursor.phase
+                            )
+                            _expect_tx(arena, _BAR_STATE_READY, state_cursor.stage, 32768)
+                            for value_coord in (0, 64):
+                                K.ptx[_TMA_G2S_4D](
+                                    arena.ptr_to([_SMEM_STATE + value_coord * 256]),
+                                    desc_state,
+                                    K.int32(value_coord),
+                                    K.int32(0),
+                                    K.cast(chunk, "int32"),
+                                    K.cast(head, "int32"),
+                                    _barrier_ptr(arena, _BAR_STATE_READY, state_cursor.stage),
+                                    K.uint64(0),
+                                )
+                            state_cursor.advance()
                         _wait_barrier(arena, _BAR_DO_DONE, raw_stage, raw_phase)
                         _wait_barrier(arena, _BAR_DO_MMA_DONE, raw_stage, raw_phase)
                         _expect_tx(arena, _BAR_DO_READY, raw_stage, 4096)
@@ -1178,28 +1200,6 @@ def _make_main(
                                 K.uint64(0),
                             )
 
-                    first_state_chunk = 0 if use_initial_state else 1
-                    with K.If(chunk >= first_state_chunk), K.Then():
-                        with K.If(_elected()), K.Then():
-                            _wait_barrier(
-                                arena, _BAR_STATE_CG0_DONE, state_cursor.stage, state_cursor.phase
-                            )
-                            _wait_barrier(
-                                arena, _BAR_STATE_DONE, state_cursor.stage, state_cursor.phase
-                            )
-                            _expect_tx(arena, _BAR_STATE_READY, state_cursor.stage, 32768)
-                            for value_coord in (0, 64):
-                                K.ptx[_TMA_G2S_4D](
-                                    arena.ptr_to([_SMEM_STATE + value_coord * 256]),
-                                    desc_state,
-                                    K.int32(value_coord),
-                                    K.int32(0),
-                                    K.cast(chunk, "int32"),
-                                    K.cast(head, "int32"),
-                                    _barrier_ptr(arena, _BAR_STATE_READY, state_cursor.stage),
-                                    K.uint64(0),
-                                )
-                        state_cursor.advance()
                     raw.advance()
                 K.assign(tile, next_tile)
         with super_mma:

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -1932,7 +1932,7 @@ def _make_main(
                 desc_dwo = _descriptor_slot(descriptor_workspace, n_desc, 11, batch)
                 desc_db = _descriptor_slot(descriptor_workspace, n_desc, 12, batch)
                 with K.If(_elected()), K.Then():
-                    for desc in (desc_dq, desc_dk, desc_dv, desc_dgate):
+                    for desc in (desc_dq, desc_dk, desc_dv, desc_dgate, desc_db, desc_dwo):
                         K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
                 pending_token = K.local_scalar("int32", init=K.int32(0))
                 pending_writes = K.local_scalar("bool", init=K.bool(False))
@@ -2719,7 +2719,9 @@ def _make_main(
                                 pa0, pb0 = _fadd2(hacc[0], hacc[2], hacc[4], hacc[6])
                                 pa1, pb1 = _fadd2(hacc[1], hacc[3], hacc[5], hacc[7])
                                 part_a, part_b = _fadd2(pa0, pb0, pa1, pb1)
-                                K.assign(dgate_last, dgate_last + part_a + part_b)
+                                # Bracketed: the source adds the two partials to each
+                                # other before folding, and the order is contractual.
+                                K.assign(dgate_last, dgate_last + (part_a + part_b))
                         _arrive_barrier(arena, _BAR_DSTATE_SMEM_CG2_DONE)
                     _arrive_barrier(arena, _BAR_STATE_INP_CG2_DONE, serial % 2)
 
@@ -2728,7 +2730,7 @@ def _make_main(
                     dgate_values = K.alloc_local((16,), "float32")
                     last_dot = K.alloc_local((4,), "float32")
                     for slot in range(4):
-                        K.assign(last_dot[slot], K.float32(0.0))
+                        K.assign(last_dot[slot], _opaque_f32_zero())
                     for token in range(16):
                         K.assign(dk_values[token], K.float32(0.0))
 
@@ -2931,7 +2933,8 @@ def _make_main(
                             )
                     K.assign(
                         dgate_values[15],
-                        dgate_values[15] + last_dot[0] + last_dot[1] + last_dot[2] + last_dot[3],
+                        dgate_values[15]
+                        + ((last_dot[0] + last_dot[1]) + (last_dot[2] + last_dot[3])),
                     )
 
                     if l2norm:
@@ -3297,7 +3300,6 @@ def _make_main(
                             ]
                         ),
                     )
-                    K.ptx.fence.proxy.async_.shared__cta()
 
                     # The per-value write gate is read in the same transposed
                     # fragment form as V, so Y = W * V - state_k.
@@ -3604,8 +3606,6 @@ def _make_main(
                     _arrive_barrier(arena, _BAR_DWO_TMASTG_READY, dwo_stage)
                     _arrive_barrier(arena, _BAR_V_DONE, raw_stage)
                     _arrive_barrier(arena, _BAR_W_DONE, raw_stage)
-
-                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
 
                     _wait_barrier(
                         arena, _BAR_DSTATE_ACC_READY, dstate_consumer.stage, dstate_consumer.phase

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -588,6 +588,11 @@ def _rsqrt_approx(value):
     return result
 
 
+def _pack_u32_pair(low, high):
+    """Two adjacent 32-bit words as one 64-bit store operand."""
+    return K.bitwise_or(K.cast(low, "uint64"), K.shift_left(K.cast(high, "uint64"), K.uint64(32)))
+
+
 def _opaque_f32_zero():
     value = K.local_scalar("float32")
     K.ptx.mov.b32(value, K.uint32(0))
@@ -1708,8 +1713,14 @@ def _make_main(
                     _tcgen_commit(arena, _BAR_DQ_ACC_READY)
                     _tcgen_commit(arena, _BAR_DA_DONE, inter_stage)
 
-                    _wait_barrier(arena, _BAR_DV_TMASTG_READY, serial % 2, (serial // 2) & 1)
                     with K.If(chunk >= first_state_chunk), K.Then():
+                        # The operand is the dedicated dY tile, so the edge is that
+                        # tile's own release rather than the value-gradient staging
+                        # buffer's, and it belongs inside this guard.
+                        # Explicit phase from the chunk serial, not a cursor: the
+                        # wait is guarded while the producer arrives every chunk,
+                        # so a cursor would drift.
+                        _wait_barrier(arena, _BAR_DY_SMEM_READY, 0, serial % 2)
                         _tcgen_mma_ts(
                             tmem_base + _TMEM_DK_DECAY,
                             tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
@@ -2878,8 +2889,7 @@ def _make_main(
                         K.assign(db_values[token], k_native * dk_decay)
                         K.assign(dgate_values[token], beta_value * dk_decay)
                         K.assign(dk_values[token], dk_values[token] + dgate_values[token])
-                    K.ptx.fence.proxy.async_.shared__cta()
-                    _arrive_barrier(arena, _BAR_BETA_DONE, raw_stage)
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     _arrive_barrier(arena, _BAR_DQK_ACC_DONE)
 
                     qraw = K.alloc_local((8,), "uint32")
@@ -2916,10 +2926,25 @@ def _make_main(
                             )
                             K.assign(q_value, q_value * q_norm)
                             K.assign(k_value, k_value * k_norm)
+                        reload_bits = K.local_scalar("uint16")
+                        K.ptx.ld.shared.b16(
+                            reload_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_BETA, raw_stage, token, channel)]),
+                        )
+                        beta_reload = K.local_scalar("float32")
+                        K.ptx.cvt.f32.bf16(beta_reload, reload_bits)
+                        if beta_sigmoid:
+                            # Third of the three sigmoid sites: the operand build,
+                            # the decay drain, and here.  Each reloads and rounds
+                            # independently, which is what the reference does.
+                            K.assign(beta_reload, _tanh_approx(beta_reload * 0.5) * 0.5 + 0.5)
+                            K.assign(
+                                beta_reload, K.cast(K.cast(beta_reload, "bfloat16"), "float32")
+                            )
                         K.assign(
                             dgate_values[token],
                             q_value * dq_values[token]
-                            + beta_self[token] * db_values[token]
+                            + beta_reload * db_values[token]
                             - k_value * (dk_values[token] - dgate_values[token]),
                         )
                         if beta_sigmoid:
@@ -2928,9 +2953,12 @@ def _make_main(
                             # these silently corrupts dGate.
                             K.assign(
                                 db_values[token],
-                                db_values[token]
-                                * (beta_self[token] - beta_self[token] * beta_self[token]),
+                                db_values[token] * (beta_reload - beta_reload * beta_reload),
                             )
+                    # The erase-gate stage is released only now, after the finalize
+                    # has reloaded it: this group is its second reader.
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_BETA_DONE, raw_stage)
                     K.assign(
                         dgate_values[15],
                         dgate_values[15]
@@ -3657,9 +3685,28 @@ def _make_main(
                                 ),
                                 *[dstate_words[i] for i in range(16)],
                             )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY)
+
+                        # The shared-memory copy re-reads the operand back out of
+                        # tensor memory rather than reusing the registers that were
+                        # just packed, matching the frozen source.
+                        with K.unroll(4) as key_subtile:
+                            reread = K.alloc_local((16,), "uint32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                                *[reread[i] for i in range(16)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 16
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
                             with K.unroll(4) as half:
                                 key_base = key_subtile * 32 + half * 8
-                                K.ptx.st.shared.v4.b32(
+                                K.ptx.st.shared.v2.b64(
                                     arena.ptr_to(
                                         [
                                             _SMEM_DSTATE
@@ -3671,13 +3718,9 @@ def _make_main(
                                             * 2
                                         ]
                                     ),
-                                    dstate_words[half * 4],
-                                    dstate_words[half * 4 + 1],
-                                    dstate_words[half * 4 + 2],
-                                    dstate_words[half * 4 + 3],
+                                    _pack_u32_pair(reread[half * 4], reread[half * 4 + 1]),
+                                    _pack_u32_pair(reread[half * 4 + 2], reread[half * 4 + 3]),
                                 )
-                        K.ptx.tcgen05.wait__st.sync.aligned()
-                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY)
                         K.ptx.fence.proxy.async_.shared__cta()
                         _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)
 

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -102,24 +102,3596 @@ BENCH_CONFIGS = [
 ]
 
 
-# Frozen specialization, from ``gdn2_bprop_config.py``.
 _BT = 16
 _DK = 128
 _DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 14
+_MAIN_SMEM_BYTES = 225_280
+_TRY_WAIT_TICKS = 10_000_000
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+_TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+    ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
+)
+
+# (ready byte, done byte, stages, ready arrivals, done arrivals, init warp).
+# This is the frozen 115-word protocol table; None denotes a one-way edge.
+# Frozen mbarrier protocol: 70 objects over 123 physical words (984 bytes).
+# Each row is (byte offset, unused pair slot, stages, arrival count, unused,
+# initializing warp).  Arrival counts encode the reader set: 128 per compute
+# group, 32 for a single warp, 1 for a tcgen05 commit, 256 where two groups
+# read the same tile, and 15 on the scheduler's done edge.
+_PROTOCOL = (
+    (0, None, 2, 1, None, 14),  # q_ready
+    (16, None, 2, 128, None, 14),  # q_done
+    (32, None, 2, 1, None, 14),  # k_ready
+    (48, None, 2, 128, None, 14),  # k_done
+    (64, None, 2, 1, None, 14),  # gate_ready
+    (80, None, 2, 256, None, 14),  # gate_done
+    (96, None, 2, 1, None, 14),  # beta_ready
+    (112, None, 2, 256, None, 14),  # beta_done
+    (128, None, 2, 1, None, 14),  # do_ready
+    (144, None, 2, 32, None, 14),  # do_done
+    (160, None, 2, 1, None, 14),  # do_mma_done
+    (176, None, 2, 1, None, 14),  # v_ready
+    (192, None, 2, 128, None, 14),  # v_done
+    (208, None, 2, 1, None, 14),  # w_ready
+    (224, None, 2, 128, None, 14),  # w_done
+    (240, None, 1, 1, None, 14),  # state_ready
+    (248, None, 1, 1, None, 14),  # state_done
+    (256, None, 1, 128, None, 14),  # state_cg0_done
+    (264, None, 2, 128, None, 14),  # state_inp_ready
+    (280, None, 2, 1, None, 14),  # state_inp_done
+    (296, None, 2, 128, None, 14),  # state_inp_cg2_done
+    (312, None, 2, 128, None, 12),  # k_decay_inv_ready
+    (328, None, 2, 128, None, 12),  # q_decay_k_restore_ready
+    (344, None, 2, 1, None, 12),  # decay_done
+    (360, None, 2, 32, None, 12),  # t_inv_ready
+    (376, None, 2, 32, None, 12),  # a_ready
+    (392, None, 2, 32, None, 12),  # da_ready
+    (408, None, 2, 32, None, 12),  # dm_ready
+    (424, None, 2, 1, None, 12),  # a_done
+    (440, None, 2, 1, None, 12),  # t_inv_done
+    (456, None, 2, 1, None, 12),  # da_done
+    (472, None, 2, 1, None, 12),  # dm_done
+    (488, None, 1, 1, None, 13),  # state_k_acc_ready
+    (496, None, 1, 128, None, 13),  # y_inp_ready
+    (504, None, 1, 1, None, 13),  # u_acc_ready
+    (512, None, 1, 128, None, 13),  # u_smem_ready
+    (520, None, 1, 1, None, 13),  # du_acc_ready
+    (528, None, 1, 128, None, 13),  # du_inp_ready
+    (536, None, 1, 1, None, 13),  # dy_acc_ready
+    (544, None, 1, 128, None, 13),  # neg_dy_inp_ready
+    (552, None, 1, 128, None, 13),  # dy_smem_ready
+    (560, None, 1, 1, None, 13),  # dy_smem_done
+    (568, None, 1, 1, None, 13),  # dstate_acc_ready
+    (576, None, 1, 128, None, 13),  # dstate_inp_ready
+    (584, None, 1, 128, None, 13),  # dstate_smem_ready
+    (592, None, 1, 1, None, 13),  # dstate_smem_done
+    (600, None, 1, 128, None, 13),  # dstate_smem_cg2_done
+    (608, None, 1, 1, None, 13),  # dq_acc_ready
+    (616, None, 1, 1, None, 13),  # dk_decay_part_acc_ready
+    (624, None, 1, 1, None, 13),  # dk_inv_part_acc_ready
+    (632, None, 1, 1, None, 13),  # dk_restore_part_acc_ready
+    (640, None, 1, 128, None, 13),  # dqk_acc_done
+    (648, None, 4, 128, None, 12),  # qk_raw_ready
+    (680, None, 4, 128, None, 12),  # qk_raw_done
+    (712, None, 1, 128, None, 15),  # dq_tmastg_ready
+    (720, None, 1, 32, None, 15),  # dq_tmastg_done
+    (728, None, 1, 128, None, 15),  # dk_tmastg_ready
+    (736, None, 1, 32, None, 15),  # dk_tmastg_done
+    (744, None, 2, 128, None, 15),  # dv_tmastg_ready
+    (760, None, 2, 32, None, 15),  # dv_tmastg_done
+    (776, None, 1, 128, None, 15),  # dgate_tmastg_ready
+    (784, None, 1, 32, None, 15),  # dgate_tmastg_done
+    (792, None, 1, 128, None, 15),  # db_tmastg_ready
+    (800, None, 1, 32, None, 15),  # db_tmastg_done
+    (808, None, 2, 128, None, 15),  # dwo_tmastg_ready
+    (824, None, 2, 32, None, 15),  # dwo_tmastg_done
+    (840, None, 1, 128, None, 13),  # dstate0_acc_stored
+    (848, None, 1, 256, None, 13),  # tmem_done
+    (856, None, 8, 1, None, 15),  # sched_ready
+    (920, None, 8, 15, None, 15),  # sched_done
+)
+
+_BAR_Q_READY = 0
+_BAR_Q_DONE = 16
+_BAR_K_READY = 32
+_BAR_K_DONE = 48
+_BAR_GATE_READY = 64
+_BAR_GATE_DONE = 80
+_BAR_BETA_READY = 96
+_BAR_BETA_DONE = 112
+_BAR_DO_READY = 128
+_BAR_DO_DONE = 144
+_BAR_DO_MMA_DONE = 160
+_BAR_V_READY = 176
+_BAR_V_DONE = 192
+_BAR_W_READY = 208
+_BAR_W_DONE = 224
+_BAR_STATE_READY = 240
+_BAR_STATE_DONE = 248
+_BAR_STATE_CG0_DONE = 256
+_BAR_STATE_INP_READY = 264
+_BAR_STATE_INP_DONE = 280
+_BAR_STATE_INP_CG2_DONE = 296
+_BAR_K_DECAY_INV_READY = 312
+_BAR_Q_DECAY_K_RESTORE_READY = 328
+_BAR_DECAY_DONE = 344
+_BAR_T_INV_READY = 360
+_BAR_A_READY = 376
+_BAR_DA_READY = 392
+_BAR_DM_READY = 408
+_BAR_A_DONE = 424
+_BAR_T_INV_DONE = 440
+_BAR_DA_DONE = 456
+_BAR_DM_DONE = 472
+_BAR_STATE_K_ACC_READY = 488
+_BAR_Y_INP_READY = 496
+_BAR_U_ACC_READY = 504
+_BAR_U_SMEM_READY = 512
+_BAR_DU_ACC_READY = 520
+_BAR_DU_INP_READY = 528
+_BAR_DY_ACC_READY = 536
+_BAR_NEG_DY_INP_READY = 544
+_BAR_DY_SMEM_READY = 552
+_BAR_DY_SMEM_DONE = 560
+_BAR_DSTATE_ACC_READY = 568
+_BAR_DSTATE_INP_READY = 576
+_BAR_DSTATE_SMEM_READY = 584
+_BAR_DSTATE_SMEM_DONE = 592
+_BAR_DSTATE_SMEM_CG2_DONE = 600
+_BAR_DQ_ACC_READY = 608
+_BAR_DK_DECAY_PART_ACC_READY = 616
+_BAR_DK_INV_PART_ACC_READY = 624
+_BAR_DK_RESTORE_PART_ACC_READY = 632
+_BAR_DQK_ACC_DONE = 640
+_BAR_QK_RAW_READY = 648
+_BAR_QK_RAW_DONE = 680
+_BAR_DQ_TMASTG_READY = 712
+_BAR_DQ_TMASTG_DONE = 720
+_BAR_DK_TMASTG_READY = 728
+_BAR_DK_TMASTG_DONE = 736
+_BAR_DV_TMASTG_READY = 744
+_BAR_DV_TMASTG_DONE = 760
+_BAR_DGATE_TMASTG_READY = 776
+_BAR_DGATE_TMASTG_DONE = 784
+_BAR_DB_TMASTG_READY = 792
+_BAR_DB_TMASTG_DONE = 800
+_BAR_DWO_TMASTG_READY = 808
+_BAR_DWO_TMASTG_DONE = 824
+_BAR_DSTATE0_ACC_STORED = 840
+_BAR_TMEM_DONE = 848
+_BAR_SCHED_READY = 856
+_BAR_SCHED_DONE = 920
+
+# The single rank-1 arena follows the frozen source allocation order.
+_SMEM_BARRIERS = 0
+_SMEM_TMEM_MAILBOX = 984
+_SMEM_SCHED = 992
+_SMEM_RED1 = 1024
+_SMEM_NORM = 1280
+_SMEM_STATE = 2048
+_SMEM_DSTATE = 34_816
+_SMEM_K_DECAY = 67_584
+_SMEM_K_INV = 75_776
+_SMEM_K_RESTORE = 83_968
+_SMEM_Q_DECAY = 92_160
+_SMEM_DIAG = 100_352
+_SMEM_INTERMEDIATE = 108_544
+_SMEM_DO = 113_664
+_SMEM_BETA = 121_856
+# Sub-bank fill: the pad places the generic-client group at the 128 KB midpoint
+# exactly, keeping the tcgen05-descriptor operands in the low banks.
+_SMEM_BANK_FILL = 130_048
+_SMEM_Q = 131_072
+_SMEM_K = 139_264
+_SMEM_V = 147_456
+_SMEM_GATE = 155_648
+_SMEM_W = 172_032
+_SMEM_U = 180_224
+_SMEM_DY = 184_320
+_SMEM_DQ = 188_416
+_SMEM_DK = 192_512
+_SMEM_DV = 196_608
+_SMEM_DGATE = 204_800
+_SMEM_DWO = 212_992
+_SMEM_DB = 221_184
+
+_TMEM_DSTATE = 0
+_TMEM_DSTATE_INPUT = 128
+_TMEM_STATE_INPUT = 192
+_TMEM_STATE_K_DY = 320
+_TMEM_U = 336
+_TMEM_DU = 352
+_TMEM_DQ = 368
+_TMEM_DK_DECAY = 384
+_TMEM_DK_INV = 400
+_TMEM_DK_RESTORE = 416
+_TMEM_Y_NEG_DY = 432
+_TMEM_DU_INPUT = 440
+_TMEM_Q_RAW = 448
+_TMEM_K_RAW = 480
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _copy_tensormap(src_map, dst):
+    """Copy one 128-byte TensorMap image using the source's vector traffic."""
+    payload = K.alloc_local((4,), "uint64")
+    src = K.reinterpret("uint64", src_map.ptr_to([0]))
+    target = K.reinterpret("uint64", dst)
+    for group in range(4):
+        offset = K.uint64(group * 32)
+        K.ptx.ld.global_.v4.b64(
+            payload[0], payload[1], payload[2], payload[3], K.reinterpret("handle", src + offset)
+        )
+        K.ptx.st.global_.v4.b64(
+            K.reinterpret("handle", target + offset), payload[0], payload[1], payload[2], payload[3]
+        )
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + stage * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        barrier_address = K.cuda.cvta_generic_to_shared(arena.ptr_to([0])) + K.cast(
+            byte_offset + stage * 8, "uint32"
+        )
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready, barrier_address, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage), K.uint32(1))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=K.cuda.elect_sync()
+    )
+
+
+def _load_work_item(work_items, tile):
+    row = K.alloc_local((8,), "int32")
+    base = K.cast(tile, "int64") * K.int64(8)
+    K.ptx.ld.global_.v4.b32(row[0], row[1], row[2], row[3], work_items.ptr_to([base]))
+    K.ptx.ld.global_.v4.b32(row[4], row[5], row[6], row[7], work_items.ptr_to([base + K.int64(4)]))
+    return row
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _mma_m16n16k16(acc, a, b):
+    K.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[0],
+        b[1],
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+    )
+    K.ptx.mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32(
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[2],
+        b[3],
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+    )
+
+
+def _pack_bf16_pair(lo, hi):
+    packed = K.local_scalar("uint32")
+    K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _movmatrix_b16(value):
+    transposed = K.local_scalar("uint32")
+    K.ptx["movmatrix.sync.aligned.m8n8.trans.b16"](transposed, value)
+    return transposed
+
+
+def _unpack_bf16_pair(packed, lo, hi):
+    K.ptx.cvt.f32.bf16(lo, K.cast(packed, "uint16"))
+    K.ptx.cvt.f32.bf16(hi, K.cast(K.shift_right(packed, K.uint32(16)), "uint16"))
+
+
+def _shuffle_xor_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(delta),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _fadd2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _fmul2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _fsub2(a_lo, a_hi, b_lo, b_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.sub.rn.f32x2(packed, K.cuda.make_float2(a_lo, a_hi), K.cuda.make_float2(b_lo, b_hi))
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _ffma2(a_lo, a_hi, b_lo, b_hi, c_lo, c_hi):
+    packed = K.local_scalar("uint64")
+    out_lo = K.local_scalar("float32")
+    out_hi = K.local_scalar("float32")
+    K.ptx.fma.rn.f32x2(
+        packed,
+        K.cuda.make_float2(a_lo, a_hi),
+        K.cuda.make_float2(b_lo, b_hi),
+        K.cuda.make_float2(c_lo, c_hi),
+    )
+    K.ptx.mov.b64(out_lo, out_hi, packed)
+    return out_lo, out_hi
+
+
+def _tcgen_mma_ss(
+    dst,
+    a_desc,
+    b_desc,
+    idesc,
+    *,
+    m,
+    n,
+    k_extent,
+    a_transpose=False,
+    b_transpose=False,
+    accumulate=False,
+):
+    def swizzle_bytes(inner_bytes):
+        if inner_bytes % 128 == 0:
+            return 128
+        if inner_bytes % 64 == 0:
+            return 64
+        return 32
+
+    swizzle_a = swizzle_bytes((m if a_transpose else k_extent) * 2)
+    swizzle_b = swizzle_bytes((n if b_transpose else k_extent) * 2)
+    intra_a = 16 * swizzle_a if a_transpose else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_a = k_extent * swizzle_a if a_transpose else swizzle_a * m
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_a = k_extent // 16 if a_transpose else (swizzle_a // 2) // 16
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    leader = K.cuda.elect_sync()
+    for step in range(k_extent // 16):
+        inc_a = (intra_a * (step % steps_a) + subtile_a * (step // steps_a)) >> 4
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+            K.cast(dst, "uint32"),
+            a_desc + K.uint64(inc_a),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            0,
+            0,
+            0,
+            0,
+            K.ptx.pred(accumulate if step == 0 else 1),
+            pred=leader,
+        )
+
+
+def _tcgen_mma_ts(dst, tmem_a, b_desc, idesc, *, n, k_extent, b_transpose=False, accumulate=False):
+    inner_bytes = (n if b_transpose else k_extent) * 2
+    swizzle_b = 128 if inner_bytes % 128 == 0 else 64 if inner_bytes % 64 == 0 else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    leader = K.cuda.elect_sync()
+    for step in range(k_extent // 16):
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            0,
+            0,
+            0,
+            0,
+            K.ptx.pred(accumulate if step == 0 else 1),
+            pred=leader,
+        )
+
+
+def _exp2_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _rcp_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(result, value)
+    return result
+
+
+def _rsqrt_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.rsqrt.approx.ftz.f32(result, value)
+    return result
+
+
+def _opaque_f32_zero():
+    value = K.local_scalar("float32")
+    K.ptx.mov.b32(value, K.uint32(0))
+    return value
+
+
+def _tanh_approx(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _raw_smem_descriptor(arena, base_byte, leading_bytes, stride_bytes, layout_code):
+    shared_address = K.cuda.cvta_generic_to_shared(arena.ptr_to([base_byte]))
+    address = K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    value = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(value, K.shift_left(K.uint64(layout_code & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column, elem_bytes):
+    elements = 128 // elem_bytes
+    return K.bitwise_xor(column, (row % 8) * (16 // elem_bytes)) % elements
+
+
+def _raw_bf16_byte(base, stage, token, channel):
+    segment = channel // 64
+    within = channel - segment * 64
+    element = segment * 1024 + token * 64 + _swizzle_xor_128b(token, within, 2)
+    return base + stage * 4096 + element * 2
+
+
+def _raw_f32_byte(base, stage, token, channel):
+    segment = channel // 32
+    within = channel - segment * 32
+    element = segment * 512 + token * 32 + _swizzle_xor_128b(token, within, 4)
+    return base + stage * 8192 + element * 4
+
+
+def _tmem_cell(base, row, row_delta, column):
+    return base + column + K.shift_left(row + row_delta, K.int32(16))
+
+
+def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out):
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_q: K.gptr[K.i64],
+        base_k: K.gptr[K.i64],
+        base_v: K.gptr[K.i64],
+        base_gate: K.gptr[K.i64],
+        base_do: K.gptr[K.i64],
+        base_dq: K.gptr[K.i64],
+        base_dk: K.gptr[K.i64],
+        base_dv: K.gptr[K.i64],
+        base_dgate: K.gptr[K.i64],
+        base_checkpoint: K.gptr[K.i64],
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[K.i32],
+        q: K.gptr[K.u8],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        gate: K.gptr[K.u8],
+        do: K.gptr[K.u8],
+        dq: K.gptr[K.u8],
+        dk: K.gptr[K.u8],
+        dv: K.gptr[K.u8],
+        dgate: K.gptr[K.u8],
+        checkpoints: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        n_batch: K.i32,
+        q_row_stride_bytes: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        gate_row_stride_bytes: K.i32,
+        do_row_stride_bytes: K.i32,
+        dq_row_stride_bytes: K.i32,
+        dk_row_stride_bytes: K.i32,
+        dv_row_stride_bytes: K.i32,
+        dgate_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        thread = K.thread_id()
+        warp = K.warp_id()
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+
+            # The ordering launch owns both consumers' four scheduler words.
+            # Their extent is fixed by the frozen two-ring source ABI.
+            with K.If(thread == 0), K.Then():
+                sched_index = K.local_scalar("int32", init=K.int32(0))
+                with K.While(sched_index < 4):
+                    K.ptx.st.global_.s32(scheduler.ptr_to([sched_index]), K.int32(0))
+                    K.assign(sched_index, sched_index + 1)
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    sequence_begin = K.local_scalar("int32")
+                    sequence_end = K.local_scalar("int32")
+                    K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                    K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                    num_chunks = (sequence_end - sequence_begin + _BT - 1) // _BT
+                    values = (
+                        batch,
+                        head,
+                        K.int32(0),
+                        num_chunks,
+                        K.int32(0),
+                        num_chunks,
+                        sequence_begin,
+                        sequence_end,
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]),
+                        values[0],
+                        values[1],
+                        values[2],
+                        values[3],
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]),
+                        values[4],
+                        values[5],
+                        values[6],
+                        values[7],
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+
+                # Four entries per thread fill the fixed 4096-item capacity.
+                # Padding carries INT_MIN so the descending bitonic network
+                # leaves it behind every real work item.
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = K.local_scalar("int32")
+                                end = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(begin, cu_seqlens.ptr_to([batch]))
+                                K.ptx.ld.global_.s32(end, cu_seqlens.ptr_to([batch + 1]))
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                atomic_old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](
+                    atomic_old, order_arena.ptr_to([32_768]), local_min
+                )
+                K.ptx["atom.shared::cta.max.s32"](
+                    atomic_old, order_arena.ptr_to([32_772]), local_max
+                )
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network_size = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network_size <= padded_count):
+                        distance = K.local_scalar("int32", init=network_size // K.int32(2))
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending_half = ((item // network_size) % K.int32(2)) == 0
+                                    swap = K.Or(
+                                        K.And(ascending_half, key_i < key_j),
+                                        K.And(K.Not(ascending_half), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network_size, network_size * 2)
+
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+        maps = (base_q, base_k, base_v, base_gate, base_do, base_dq, base_dk, base_dv, base_dgate)
+        bases = (q, k, v, gate, do, dq, dk, dv, dgate)
+        strides = (
+            q_row_stride_bytes,
+            k_row_stride_bytes,
+            v_row_stride_bytes,
+            gate_row_stride_bytes,
+            do_row_stride_bytes,
+            dq_row_stride_bytes,
+            dk_row_stride_bytes,
+            dv_row_stride_bytes,
+            dgate_row_stride_bytes,
+        )
+        for array_index in range(9):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    with K.serial(n_batch) as batch:
+                        sequence_begin = K.local_scalar("int32")
+                        sequence_end = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                        K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                        sequence_length = sequence_end - sequence_begin
+                        slot = descriptor_workspace.ptr_to(
+                            [(array_index * n_batch + batch) * _TENSOR_MAP_WORDS]
+                        )
+                        _copy_tensormap(maps[array_index], slot)
+                        _replace_tensormap_address(
+                            slot,
+                            bases[array_index].ptr_to(
+                                [K.cast(sequence_begin, "int64") * strides[array_index]]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, sequence_length)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+        with K.If(warp == 9), K.Then():
+            with K.If(_elected()), K.Then():
+                checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                with K.serial(n_batch) as batch:
+                    sequence_begin = K.local_scalar("int32")
+                    sequence_end = K.local_scalar("int32")
+                    K.ptx.ld.global_.s32(sequence_begin, cu_seqlens.ptr_to([batch]))
+                    K.ptx.ld.global_.s32(sequence_end, cu_seqlens.ptr_to([batch + 1]))
+                    sequence_length = sequence_end - sequence_begin
+                    checkpoint_count = K.local_scalar("int32", init=K.int32(0))
+                    with K.If(sequence_length > 0), K.Then():
+                        K.assign(checkpoint_count, (sequence_length - 1) // checkpoint_every_n + 1)
+                    slot = descriptor_workspace.ptr_to([(9 * n_batch + batch) * _TENSOR_MAP_WORDS])
+                    _copy_tensormap(base_checkpoint, slot)
+                    _replace_tensormap_address(
+                        slot,
+                        checkpoints.ptr_to(
+                            [K.cast(checkpoint_prefix, "int64") * checkpoint_row_stride_bytes]
+                        ),
+                    )
+                    _replace_tensormap_dim(slot, 2, checkpoint_count)
+                    K.assign(checkpoint_prefix, checkpoint_prefix + checkpoint_count)
+                K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+# KERNEL_SKETCH_START
+def _make_main(
+    *,
+    num_sms,
+    beta_sigmoid,
+    use_dstate_in,
+    use_dstate0,
+    use_initial_state,
+    safe_gate,
+    full_tiles,
+    dynamic_scheduler,
+    l2norm,
+    n_heads_out,
+    q_ratio,
+    k_ratio,
+    v_ratio,
+):
+    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        cu_seqlens: K.gptr[K.i32],
+        dgate: K.gptr[K.f32],
+        d_initial_state: K.gptr[K.f32],
+        d_final_state: K.gptr[K.f32],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        scale: K.f32,
+    ):
+        arena = K.alloc_buffer((_MAIN_SMEM_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        # The pool owns only the fixed pipeline/barrier header over the arena;
+        # all data storage below is addressed by integer byte offsets.
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        # Every physical protocol word has one elected initialization owner.
+        for ready_off, done_off, stages, ready_count, done_count, owner in _PROTOCOL:
+            with K.If(warp == owner), K.Then():
+                with K.If(_elected()), K.Then():
+                    for stage in range(stages):
+                        K.ptx.mbarrier.init.shared.b64(
+                            _barrier_ptr(arena, ready_off, stage), K.uint32(ready_count)
+                        )
+                        if done_off is not None:
+                            K.ptx.mbarrier.init.shared.b64(
+                                _barrier_ptr(arena, done_off, stage), K.uint32(done_count)
+                            )
+        # The two diagonal stages are born zero and later receive only their
+        # diagonal entries from CG0.
+        with K.unroll(8) as diagonal_pass:
+            element = thread + diagonal_pass * 512
+            K.ptx.st.shared.b16(arena.ptr_to([_SMEM_DIAG + element * 2]), K.uint16(0))
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 4), regs=128)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=184)
+        cg2 = roles.role("cg2", warps=range(8, 12), regs=136)
+        super_mma = roles.role("super_mma", warps=[12], regs=64)
+        tcgen = roles.role("tcgen", warps=[13], regs=64)
+        tma = roles.role("tma", warps=[14], regs=64)
+        epilogue = roles.role("epilogue", warps=[15], regs=64)
+        with tma:
+            tile = K.local_scalar("int32", init=K.cta_id())
+            raw = K.PipelineState(2, phase=1)
+            state_cursor = K.PipelineState(1, phase=1)
+            sched_producer = K.PipelineState(8, phase=1)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+
+                next_tile = K.local_scalar("int32", init=tile + num_sms)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_DONE, sched_producer.stage, sched_producer.phase
+                    )
+                    with K.If(_elected()), K.Then():
+                        ticket = K.local_scalar("uint32")
+                        K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                        K.ptx.st.shared.u32(
+                            arena.ptr_to([_SMEM_SCHED + K.cast(sched_producer.stage, "int32") * 4]),
+                            K.uint32(num_sms) + ticket,
+                        )
+                    K.cuda.warp_sync()
+                    K.ptx.ld.shared.s32(
+                        next_tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_producer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_READY, sched_producer.stage)
+                    sched_producer.advance()
+
+                head_q = head if q_ratio == 1 else head // q_ratio
+                head_k = head if k_ratio == 1 else head // k_ratio
+                head_v = head if v_ratio == 1 else head // v_ratio
+                desc_q = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_k = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                desc_v = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                desc_gate = _descriptor_slot(descriptor_workspace, n_desc, 3, batch)
+                desc_do = _descriptor_slot(descriptor_workspace, n_desc, 4, batch)
+                desc_beta = _descriptor_slot(descriptor_workspace, n_desc, 5, batch)
+                desc_w = _descriptor_slot(descriptor_workspace, n_desc, 6, batch)
+                desc_state = _descriptor_slot(descriptor_workspace, n_desc, 13, batch)
+                with K.If(_elected()), K.Then():
+                    for desc in (
+                        desc_q,
+                        desc_k,
+                        desc_v,
+                        desc_gate,
+                        desc_do,
+                        desc_beta,
+                        desc_w,
+                        desc_state,
+                    ):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
+
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * _BT
+                    raw_stage = raw.stage
+                    raw_phase = raw.phase
+                    with K.If(_elected()), K.Then():
+                        _wait_barrier(arena, _BAR_Q_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_Q_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_Q + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_q,
+                                K.int32(d_coord),
+                                K.cast(head_q, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_Q_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_K_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_K_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_K + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_k,
+                                K.int32(d_coord),
+                                K.cast(head_k, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_K_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_GATE_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_GATE_READY, raw_stage, 8192)
+                        for d_coord in (0, 32, 64, 96):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_GATE + K.cast(raw_stage, "int32") * 8192 + d_coord * 64]
+                                ),
+                                desc_gate,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_GATE_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_BETA_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_BETA_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_BETA + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_beta,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_BETA_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_DO_DONE, raw_stage, raw_phase)
+                        _wait_barrier(arena, _BAR_DO_MMA_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_DO_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_DO + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_do,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_DO_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_V_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_V_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_V + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_v,
+                                K.int32(d_coord),
+                                K.cast(head_v, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_V_READY, raw_stage),
+                                K.uint64(0),
+                            )
+                        _wait_barrier(arena, _BAR_W_DONE, raw_stage, raw_phase)
+                        _expect_tx(arena, _BAR_W_READY, raw_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to(
+                                    [_SMEM_W + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                                ),
+                                desc_w,
+                                K.int32(d_coord),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                _barrier_ptr(arena, _BAR_W_READY, raw_stage),
+                                K.uint64(0),
+                            )
+
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        with K.If(_elected()), K.Then():
+                            _wait_barrier(
+                                arena, _BAR_STATE_CG0_DONE, state_cursor.stage, state_cursor.phase
+                            )
+                            _wait_barrier(
+                                arena, _BAR_STATE_DONE, state_cursor.stage, state_cursor.phase
+                            )
+                            _expect_tx(arena, _BAR_STATE_READY, state_cursor.stage, 32768)
+                            for value_coord in (0, 64):
+                                K.ptx[_TMA_G2S_4D](
+                                    arena.ptr_to([_SMEM_STATE + value_coord * 256]),
+                                    desc_state,
+                                    K.int32(value_coord),
+                                    K.int32(0),
+                                    K.cast(chunk, "int32"),
+                                    K.cast(head, "int32"),
+                                    _barrier_ptr(arena, _BAR_STATE_READY, state_cursor.stage),
+                                    K.uint64(0),
+                                )
+                        state_cursor.advance()
+                    raw.advance()
+                K.assign(tile, next_tile)
+        with super_mma:
+            tile = K.local_scalar("int32", init=K.cta_id())
+            chunk_serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            dy_smem_consumer = K.PipelineState(1, phase=0)
+            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_linear = store_row * 16 + store_col
+            store_swizzled = K.bitwise_xor(
+                store_linear,
+                K.shift_left(
+                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                    K.uint32(3),
+                ),
+            )
+            row_lo = lane // 4
+            row_hi = row_lo + 8
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                num_chunks = item[5] - item[2]
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = chunk_serial_base + reverse_index
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    _wait_barrier(arena, _BAR_T_INV_DONE, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, _BAR_K_DECAY_INV_READY, decay_stage, (serial // 2) & 1)
+
+                    kk = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(kk[accum_index], K.float32(0.0))
+                    with K.unroll(8) as key_block:
+                        a = K.alloc_local((4,), "uint32")
+                        b = K.alloc_local((4,), "uint32")
+                        a_channel = key_block * 16 + lhs_col
+                        b_channel = key_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a[0],
+                            a[1],
+                            a[2],
+                            a[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_DECAY, decay_stage, lhs_row, a_channel)]
+                            ),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b[0],
+                            b[1],
+                            b[2],
+                            b[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, rhs_row, b_channel)]
+                            ),
+                        )
+                        _mma_m16n16k16(kk, a, b)
+
+                    strict = K.alloc_local((8,), "float32")
+                    l_word = K.alloc_local((4,), "uint32")
+                    rounded = K.alloc_local((8,), "float32")
+                    tinv = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        # No Beta row scale here: GDN-2 folds the erase gate into
+                        # the K_decay operand, so L is plain strict_tril(KK).
+                        K.assign(
+                            strict[accum_index],
+                            K.if_then_else(row_coord > col_coord, kk[accum_index], 0.0),
+                        )
+                    for pair in range(4):
+                        K.assign(
+                            l_word[pair], _pack_bf16_pair(strict[pair * 2], strict[pair * 2 + 1])
+                        )
+                        _unpack_bf16_pair(l_word[pair], rounded[pair * 2], rounded[pair * 2 + 1])
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        K.assign(
+                            tinv[accum_index],
+                            K.if_then_else(row_coord == col_coord, 1.0, 0.0) - rounded[accum_index],
+                        )
+
+                    l_power = K.alloc_local((4,), "uint32")
+                    l_power_t = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(l_power[pair], l_word[pair])
+                        K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+                    for _ in range(3):
+                        square = K.alloc_local((8,), "float32")
+                        for accum_index in range(8):
+                            K.assign(square[accum_index], K.float32(0.0))
+                        _mma_m16n16k16(square, l_power, l_power_t)
+                        for pair in range(4):
+                            K.assign(
+                                l_power[pair],
+                                _pack_bf16_pair(square[pair * 2], square[pair * 2 + 1]),
+                            )
+                            K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+                        tinv_word = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            K.assign(
+                                tinv_word[pair], _pack_bf16_pair(tinv[pair * 2], tinv[pair * 2 + 1])
+                            )
+                        update = K.alloc_local((8,), "float32")
+                        for accum_index in range(8):
+                            K.assign(update[accum_index], K.float32(0.0))
+                        _mma_m16n16k16(update, tinv_word, l_power_t)
+                        for pair in range(4):
+                            old_lo = K.local_scalar("float32")
+                            old_hi = K.local_scalar("float32")
+                            _unpack_bf16_pair(tinv_word[pair], old_lo, old_hi)
+                            next_lo, next_hi = _fadd2(
+                                old_lo, old_hi, update[pair * 2], update[pair * 2 + 1]
+                            )
+                            K.assign(tinv[pair * 2], next_lo)
+                            K.assign(tinv[pair * 2 + 1], next_hi)
+
+                    tinv_out = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(
+                            tinv_out[pair], _pack_bf16_pair(tinv[pair * 2], tinv[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 512 + store_swizzled * 2]
+                        ),
+                        tinv_out[0],
+                        tinv_out[1],
+                        tinv_out[2],
+                        tinv_out[3],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_T_INV_READY, inter_stage)
+
+                    _wait_barrier(arena, _BAR_DM_DONE, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(
+                        arena, _BAR_DY_SMEM_READY, dy_smem_consumer.stage, dy_smem_consumer.phase
+                    )
+                    dy_smem_consumer.advance()
+                    dm = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(dm[accum_index], K.float32(0.0))
+                    with K.unroll(8) as value_block:
+                        a = K.alloc_local((4,), "uint32")
+                        b = K.alloc_local((4,), "uint32")
+                        a_channel = value_block * 16 + lhs_col
+                        b_channel = value_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a[0],
+                            a[1],
+                            a[2],
+                            a[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DY, 0, lhs_row, a_channel)]),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b[0],
+                            b[1],
+                            b[2],
+                            b[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_U, 0, rhs_row, b_channel)]),
+                        )
+                        _mma_m16n16k16(dm, a, b)
+
+                    dm_word = K.alloc_local((4,), "uint32")
+                    ndm_word = K.alloc_local((4,), "uint32")
+                    for accum_index in range(8):
+                        row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                        col_coord = (accum_index // 4) * 8 + 2 * (lane % 4)
+                        if accum_index % 2:
+                            col_coord = col_coord + 1
+                        # Unscaled: the erase gate lives in the K_decay operand, so
+                        # the strict dM tile carries no per-row factor.
+                        K.assign(
+                            strict[accum_index],
+                            K.if_then_else(row_coord > col_coord, dm[accum_index], 0.0),
+                        )
+                    for pair in range(4):
+                        K.assign(
+                            dm_word[pair], _pack_bf16_pair(strict[pair * 2], strict[pair * 2 + 1])
+                        )
+                        K.assign(
+                            ndm_word[pair],
+                            _pack_bf16_pair(-strict[pair * 2], -strict[pair * 2 + 1]),
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 1536 + store_swizzled * 2]
+                        ),
+                        dm_word[0],
+                        dm_word[1],
+                        dm_word[2],
+                        dm_word[3],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 2048 + store_swizzled * 2]
+                        ),
+                        ndm_word[0],
+                        ndm_word[1],
+                        ndm_word[2],
+                        ndm_word[3],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DM_READY, inter_stage)
+
+                K.assign(chunk_serial_base, chunk_serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with tcgen:
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([_SMEM_TMEM_MAILBOX]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_consumer = K.PipelineState(1, phase=0)
+            dqk_done_consumer = K.PipelineState(1, phase=1)
+            dstate_input_consumer = K.PipelineState(1, phase=0)
+            y_consumer = K.PipelineState(1, phase=0)
+            du_consumer = K.PipelineState(1, phase=0)
+            neg_dy_consumer = K.PipelineState(1, phase=0)
+            u_smem_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_consumer = K.PipelineState(1, phase=0)
+            dstate0_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                cend = item[5]
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    decay_phase = (serial // 2) & 1
+                    inter_phase = (serial // 2) & 1
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+
+                    state_direct = _raw_smem_descriptor(arena, _SMEM_STATE, 16, 1024, 2)
+                    state_alt = _raw_smem_descriptor(arena, _SMEM_STATE, 16384, 1024, 2)
+                    dstate_alt = _raw_smem_descriptor(arena, _SMEM_DSTATE, 16384, 1024, 2)
+                    k_decay_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_DECAY + decay_stage * 4096, 16, 1024, 2
+                    )
+                    k_decay_trans = _raw_smem_descriptor(
+                        arena, _SMEM_K_DECAY + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    k_inverse_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_INV + decay_stage * 4096, 16, 1024, 2
+                    )
+                    k_inverse_amajor = _raw_smem_descriptor(
+                        arena, _SMEM_K_INV + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    k_restore_lead = _raw_smem_descriptor(
+                        arena, _SMEM_K_RESTORE + decay_stage * 4096, 16, 1024, 2
+                    )
+                    q_decay_trans = _raw_smem_descriptor(
+                        arena, _SMEM_Q_DECAY + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    do_lead = _raw_smem_descriptor(arena, _SMEM_DO + raw_stage * 4096, 16, 1024, 2)
+                    do_amajor = _raw_smem_descriptor(
+                        arena, _SMEM_DO + raw_stage * 4096, 2048, 1024, 2
+                    )
+                    dv_lead = _raw_smem_descriptor(
+                        arena, _SMEM_DV + (serial % 2) * 4096, 16, 1024, 2
+                    )
+                    u_lead = _raw_smem_descriptor(arena, _SMEM_U, 16, 1024, 2)
+                    inter_a = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560, 16, 256, 6
+                    )
+                    inter_tinv = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 512, 16, 256, 6
+                    )
+                    inter_da = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 1024, 16, 256, 6
+                    )
+                    inter_dm = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 1536, 16, 256, 6
+                    )
+                    inter_ndm = _raw_smem_descriptor(
+                        arena, _SMEM_INTERMEDIATE + inter_stage * 2560 + 2048, 16, 256, 6
+                    )
+
+                    _wait_barrier(arena, _BAR_K_DECAY_INV_READY, decay_stage, decay_phase)
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(
+                            arena, _BAR_STATE_READY, state_consumer.stage, state_consumer.phase
+                        )
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_STATE_K_DY,
+                            state_direct,
+                            k_decay_lead,
+                            134481040,
+                            m=128,
+                            n=16,
+                            k_extent=128,
+                        )
+                        _tcgen_commit(arena, _BAR_STATE_K_ACC_READY)
+                        _tcgen_commit(arena, _BAR_STATE_DONE, state_consumer.stage)
+                        state_consumer.advance()
+
+                    _wait_barrier(
+                        arena, _BAR_DQK_ACC_DONE, dqk_done_consumer.stage, dqk_done_consumer.phase
+                    )
+                    dqk_done_consumer.advance()
+                    _wait_barrier(arena, _BAR_STATE_INP_READY, serial % 2, (serial // 2) & 1)
+                    _wait_barrier(arena, _BAR_DO_READY, raw_stage, (serial // 2) & 1)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DQ,
+                            tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
+                            do_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+
+                    _wait_barrier(arena, _BAR_Q_DECAY_K_RESTORE_READY, decay_stage, decay_phase)
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_INP_READY,
+                            dstate_input_consumer.stage,
+                            dstate_input_consumer.phase,
+                        )
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DU,
+                            tmem_base + _TMEM_DSTATE_INPUT,
+                            k_restore_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+                        for key_block in range(8):
+                            diagonal = _raw_smem_descriptor(
+                                arena, _SMEM_DIAG + decay_stage * 4096 + key_block * 512, 16, 256, 6
+                            )
+                            _tcgen_mma_ts(
+                                tmem_base + _TMEM_DSTATE + key_block * 16,
+                                tmem_base + _TMEM_DSTATE_INPUT + key_block * 8,
+                                diagonal,
+                                134481040,
+                                n=16,
+                                k_extent=16,
+                            )
+                        dstate_input_consumer.advance()
+
+                    _wait_barrier(arena, _BAR_A_READY, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DU,
+                        do_amajor,
+                        inter_a,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=has_dstate,
+                    )
+                    _tcgen_commit(arena, _BAR_DU_ACC_READY)
+                    _tcgen_commit(arena, _BAR_A_DONE, inter_stage)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DSTATE,
+                        do_amajor,
+                        q_decay_trans,
+                        136414352,
+                        m=128,
+                        n=128,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=has_dstate,
+                    )
+
+                    _wait_barrier(arena, _BAR_T_INV_READY, inter_stage, inter_phase)
+                    _wait_barrier(arena, _BAR_Y_INP_READY, y_consumer.stage, y_consumer.phase)
+                    y_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_U,
+                        tmem_base + _TMEM_Y_NEG_DY,
+                        inter_tinv,
+                        134481040,
+                        n=16,
+                        k_extent=16,
+                    )
+                    _tcgen_commit(arena, _BAR_U_ACC_READY)
+
+                    _wait_barrier(arena, _BAR_DU_INP_READY, du_consumer.stage, du_consumer.phase)
+                    du_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_STATE_K_DY,
+                        tmem_base + _TMEM_DU_INPUT,
+                        inter_tinv,
+                        134546576,
+                        n=16,
+                        k_extent=16,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DY_ACC_READY)
+                    _tcgen_commit(arena, _BAR_T_INV_DONE, inter_stage)
+
+                    _wait_barrier(
+                        arena, _BAR_U_SMEM_READY, u_smem_consumer.stage, u_smem_consumer.phase
+                    )
+                    u_smem_consumer.advance()
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_READY,
+                            dstate_smem_consumer.stage,
+                            dstate_smem_consumer.phase,
+                        )
+                        dstate_smem_consumer.advance()
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_RESTORE,
+                            dstate_alt,
+                            u_lead,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=128,
+                            a_transpose=True,
+                        )
+                        _tcgen_commit(arena, _BAR_DK_RESTORE_PART_ACC_READY)
+                        _tcgen_commit(arena, _BAR_DSTATE_SMEM_DONE)
+
+                    _wait_barrier(
+                        arena, _BAR_NEG_DY_INP_READY, neg_dy_consumer.stage, neg_dy_consumer.phase
+                    )
+                    neg_dy_consumer.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TMEM_DSTATE,
+                        tmem_base + _TMEM_Y_NEG_DY,
+                        k_decay_trans,
+                        136381584,
+                        n=128,
+                        k_extent=16,
+                        b_transpose=True,
+                        accumulate=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DSTATE_ACC_READY)
+
+                    _wait_barrier(arena, _BAR_DA_READY, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DK_INV,
+                        q_decay_trans,
+                        inter_da,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                    )
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DQ,
+                            k_inverse_amajor,
+                            inter_da,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=True,
+                        )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DQ,
+                            k_inverse_amajor,
+                            inter_da,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=False,
+                        )
+                    _tcgen_commit(arena, _BAR_DQ_ACC_READY)
+                    _tcgen_commit(arena, _BAR_DA_DONE, inter_stage)
+
+                    _wait_barrier(arena, _BAR_DV_TMASTG_READY, serial % 2, (serial // 2) & 1)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ts(
+                            tmem_base + _TMEM_DK_DECAY,
+                            tmem_base + _TMEM_STATE_INPUT + (serial % 2) * 64,
+                            dv_lead,
+                            134481040,
+                            n=16,
+                            k_extent=128,
+                        )
+                    _tcgen_commit(arena, _BAR_STATE_INP_DONE, serial % 2)
+
+                    _wait_barrier(arena, _BAR_DM_READY, inter_stage, inter_phase)
+                    _tcgen_mma_ss(
+                        tmem_base + _TMEM_DK_INV,
+                        k_decay_trans,
+                        inter_ndm,
+                        134579344,
+                        m=128,
+                        n=16,
+                        k_extent=16,
+                        a_transpose=True,
+                        b_transpose=True,
+                        accumulate=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DK_INV_PART_ACC_READY)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_DECAY,
+                            k_inverse_amajor,
+                            inter_dm,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=True,
+                        )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        _tcgen_mma_ss(
+                            tmem_base + _TMEM_DK_DECAY,
+                            k_inverse_amajor,
+                            inter_dm,
+                            134513808,
+                            m=128,
+                            n=16,
+                            k_extent=16,
+                            a_transpose=True,
+                            accumulate=False,
+                        )
+                    _tcgen_commit(arena, _BAR_DK_DECAY_PART_ACC_READY)
+                    _tcgen_commit(arena, _BAR_DM_DONE, inter_stage)
+                    _tcgen_commit(arena, _BAR_DECAY_DONE, decay_stage)
+
+                _wait_barrier(
+                    arena, _BAR_DSTATE0_ACC_STORED, dstate0_consumer.stage, dstate0_consumer.phase
+                )
+                dstate0_consumer.advance()
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _wait_barrier(arena, _BAR_TMEM_DONE, 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+        with epilogue:
+            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_linear = store_row * 16 + store_col
+            store_swizzled = K.bitwise_xor(
+                store_linear,
+                K.shift_left(
+                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                    K.uint32(3),
+                ),
+            )
+            row_lo = lane // 4
+            row_hi = row_lo + 8
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            u_consumer = K.PipelineState(1, phase=0)
+            dq_store = K.PipelineState(1, phase=0)
+            dk_store = K.PipelineState(1, phase=0)
+            dgate_store = K.PipelineState(1, phase=0)
+            db_store = K.PipelineState(1, phase=0)
+            dv_store = K.PipelineState(2, phase=0)
+            dwo_store = K.PipelineState(2, phase=0)
+
+            def store_pending(
+                pend_token,
+                pend_writes,
+                head,
+                desc_dq,
+                desc_dk,
+                desc_dv,
+                desc_dgate,
+                desc_db,
+                desc_dwo,
+            ):
+                _wait_barrier(arena, _BAR_DQ_TMASTG_READY, dq_store.stage, dq_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dq,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DQ + d_coord * 32]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, _BAR_DK_TMASTG_READY, dk_store.stage, dk_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dk,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DK + d_coord * 32]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, _BAR_DGATE_TMASTG_READY, dgate_store.stage, dgate_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 32, 64, 96):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dgate,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DGATE + d_coord * 64]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, _BAR_DB_TMASTG_READY, db_store.stage, db_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_db,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to([_SMEM_DB + d_coord * 32]),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, _BAR_DV_TMASTG_READY, dv_store.stage, dv_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dv,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to(
+                                [_SMEM_DV + K.cast(dv_store.stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                _wait_barrier(arena, _BAR_DWO_TMASTG_READY, dwo_store.stage, dwo_store.phase)
+                with K.If(pend_writes), K.Then():
+                    for d_coord in (0, 64):
+                        K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"](
+                            desc_dwo,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(pend_token, "int32"),
+                            arena.ptr_to(
+                                [_SMEM_DWO + K.cast(dwo_store.stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                        )
+                    K.ptx.cp.async_.bulk.commit_group()
+                # Six staged releases, one staging buffer freed per step.
+                K.ptx.cp.async_.bulk.wait_group.read(5)
+                _arrive_barrier(arena, _BAR_DQ_TMASTG_DONE, dq_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(4)
+                _arrive_barrier(arena, _BAR_DK_TMASTG_DONE, dk_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(3)
+                _arrive_barrier(arena, _BAR_DGATE_TMASTG_DONE, dgate_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(2)
+                _arrive_barrier(arena, _BAR_DB_TMASTG_DONE, db_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(1)
+                _arrive_barrier(arena, _BAR_DV_TMASTG_DONE, dv_store.stage)
+                K.ptx.cp.async_.bulk.wait_group.read(0)
+                _arrive_barrier(arena, _BAR_DWO_TMASTG_DONE, dwo_store.stage)
+                dq_store.advance()
+                dk_store.advance()
+                dgate_store.advance()
+                db_store.advance()
+                dv_store.advance()
+                dwo_store.advance()
+
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                num_chunks = cend - wstart
+                desc_dq = _descriptor_slot(descriptor_workspace, n_desc, 7, batch)
+                desc_dk = _descriptor_slot(descriptor_workspace, n_desc, 8, batch)
+                desc_dv = _descriptor_slot(descriptor_workspace, n_desc, 9, batch)
+                desc_dgate = _descriptor_slot(descriptor_workspace, n_desc, 10, batch)
+                desc_dwo = _descriptor_slot(descriptor_workspace, n_desc, 11, batch)
+                desc_db = _descriptor_slot(descriptor_workspace, n_desc, 12, batch)
+                with K.If(_elected()), K.Then():
+                    for desc in (desc_dq, desc_dk, desc_dv, desc_dgate):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
+                pending_token = K.local_scalar("int32", init=K.int32(0))
+                pending_writes = K.local_scalar("bool", init=K.bool(False))
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * 16
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+
+                    _wait_barrier(arena, _BAR_A_DONE, inter_stage, (serial // 2 + 1) & 1)
+                    _wait_barrier(
+                        arena, _BAR_Q_DECAY_K_RESTORE_READY, decay_stage, (serial // 2) & 1
+                    )
+                    a_acc = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(a_acc[accum_index], K.float32(0.0))
+                    with K.unroll(8) as key_block:
+                        a_frag = K.alloc_local((4,), "uint32")
+                        b_frag = K.alloc_local((4,), "uint32")
+                        a_channel = key_block * 16 + lhs_col
+                        b_channel = key_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a_frag[0],
+                            a_frag[1],
+                            a_frag[2],
+                            a_frag[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q_DECAY, decay_stage, lhs_row, a_channel)]
+                            ),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b_frag[0],
+                            b_frag[1],
+                            b_frag[2],
+                            b_frag[3],
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, rhs_row, b_channel)]
+                            ),
+                        )
+                        _mma_m16n16k16(a_acc, a_frag, b_frag)
+                    a_words = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        row_coord = row_hi if pair * 2 % 4 >= 2 else row_lo
+                        for parity in range(2):
+                            accum_index = pair * 2 + parity
+                            row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                            col_coord = (accum_index // 4) * 8 + 2 * (lane % 4) + (accum_index & 1)
+                            K.assign(
+                                a_acc[accum_index],
+                                K.if_then_else(row_coord >= col_coord, a_acc[accum_index], 0.0),
+                            )
+                        K.assign(
+                            a_words[pair], _pack_bf16_pair(a_acc[pair * 2], a_acc[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + store_swizzled * 2]
+                        ),
+                        *[a_words[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_A_READY, inter_stage)
+
+                    _wait_barrier(arena, _BAR_U_SMEM_READY, u_consumer.stage, u_consumer.phase)
+                    u_consumer.advance()
+                    da_acc = K.alloc_local((8,), "float32")
+                    for accum_index in range(8):
+                        K.assign(da_acc[accum_index], K.float32(0.0))
+                    with K.unroll(8) as value_block:
+                        a_frag = K.alloc_local((4,), "uint32")
+                        b_frag = K.alloc_local((4,), "uint32")
+                        a_channel = value_block * 16 + lhs_col
+                        b_channel = value_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a_frag[0],
+                            a_frag[1],
+                            a_frag[2],
+                            a_frag[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DO, raw_stage, lhs_row, a_channel)]),
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b_frag[0],
+                            b_frag[1],
+                            b_frag[2],
+                            b_frag[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_U, 0, rhs_row, b_channel)]),
+                        )
+                        _mma_m16n16k16(da_acc, a_frag, b_frag)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DO_DONE, raw_stage)
+                    _wait_barrier(arena, _BAR_DA_DONE, inter_stage, (serial // 2 + 1) & 1)
+                    da_words = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        for parity in range(2):
+                            accum_index = pair * 2 + parity
+                            row_coord = row_hi if accum_index % 4 >= 2 else row_lo
+                            col_coord = (accum_index // 4) * 8 + 2 * (lane % 4) + (accum_index & 1)
+                            K.assign(
+                                da_acc[accum_index],
+                                K.if_then_else(row_coord >= col_coord, da_acc[accum_index], 0.0),
+                            )
+                        K.assign(
+                            da_words[pair], _pack_bf16_pair(da_acc[pair * 2], da_acc[pair * 2 + 1])
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to(
+                            [_SMEM_INTERMEDIATE + inter_stage * 2560 + 1024 + store_swizzled * 2]
+                        ),
+                        *[da_words[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DA_READY, inter_stage)
+
+                    with K.If(reverse_index > 0), K.Then():
+                        store_pending(
+                            pending_token,
+                            pending_writes,
+                            head,
+                            desc_dq,
+                            desc_dk,
+                            desc_dv,
+                            desc_dgate,
+                            desc_db,
+                            desc_dwo,
+                        )
+                    K.assign(pending_token, token)
+                    K.assign(pending_writes, chunk < wend)
+
+                with K.If(num_chunks > 0), K.Then():
+                    store_pending(
+                        pending_token,
+                        pending_writes,
+                        head,
+                        desc_dq,
+                        desc_dk,
+                        desc_dv,
+                        desc_dgate,
+                        desc_db,
+                        desc_dwo,
+                    )
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with cg0:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            warp_in_group = K.warp_id_in_role()
+            channel = warp_in_group * 32 + lane
+            value_channel = (warp % 4) * 32 + lane
+            tmem_row = (tmem_base >> 16) + (warp % 4) * 32
+            tmem_col = tmem_base & 0xFFFF
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                num_chunks = cend - wstart
+                safe_a = K.local_scalar("float32", init=K.float32(1.0))
+                safe_bias = K.local_scalar("float32", init=K.float32(0.0))
+                if safe_gate:
+                    with K.If(num_chunks > 0), K.Then():
+                        a_value = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(a_value, a_log.ptr_to([head]))
+                        K.assign(safe_a, _exp2_approx(a_value * K.float32(1.4426950408889634)))
+                        K.ptx.ld.global_.f32(
+                            safe_bias, dt_bias.ptr_to([K.cast(head, "int64") * 128 + channel])
+                        )
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    token_base = chunk * 16
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+
+                    _wait_barrier(arena, _BAR_GATE_READY, raw_stage, (serial // 2) & 1)
+                    _wait_barrier(arena, _BAR_Q_READY, raw_stage, (serial // 2) & 1)
+                    _wait_barrier(arena, _BAR_K_READY, raw_stage, (serial // 2) & 1)
+
+                    gate_prefix = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as row:
+                        K.ptx.ld.shared.f32(
+                            gate_prefix[row],
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, row, channel)]),
+                        )
+                    if safe_gate:
+                        with K.unroll(8) as row_pair:
+                            row0 = row_pair * 2
+                            row1 = row0 + 1
+                            gate0 = (
+                                _tanh_approx(safe_a * (gate_prefix[row0] + safe_bias) * 0.5) * 0.5
+                                + 0.5
+                            )
+                            gate1 = (
+                                _tanh_approx(safe_a * (gate_prefix[row1] + safe_bias) * 0.5) * 0.5
+                                + 0.5
+                            )
+                            if full_tiles:
+                                K.assign(gate_prefix[row0], K.float32(-7.213475204444817) * gate0)
+                                K.assign(gate_prefix[row1], K.float32(-7.213475204444817) * gate1)
+                            else:
+                                K.assign(
+                                    gate_prefix[row0],
+                                    K.if_then_else(
+                                        token_base + row0 < sequence_length,
+                                        K.float32(-7.213475204444817) * gate0,
+                                        K.float32(0.0),
+                                    ),
+                                )
+                                K.assign(
+                                    gate_prefix[row1],
+                                    K.if_then_else(
+                                        token_base + row1 < sequence_length,
+                                        K.float32(-7.213475204444817) * gate1,
+                                        K.float32(0.0),
+                                    ),
+                                )
+                    else:
+                        with K.unroll(16) as row:
+                            with K.If(token_base + row < sequence_length), K.Then():
+                                K.assign(
+                                    gate_prefix[row],
+                                    gate_prefix[row] * K.float32(1.4426950408889634),
+                                )
+                            with K.If(token_base + row >= sequence_length), K.Then():
+                                K.assign(gate_prefix[row], K.float32(0.0))
+                    prefix = K.local_scalar("float32", init=K.float32(0.0))
+                    with K.unroll(8) as row_pair:
+                        row0 = row_pair * 2
+                        row1 = row0 + 1
+                        prefix0, pair_sum = _fadd2(
+                            prefix, gate_prefix[row0], gate_prefix[row0], gate_prefix[row1]
+                        )
+                        prefix1 = prefix + pair_sum
+                        K.assign(gate_prefix[row0], prefix0)
+                        K.assign(gate_prefix[row1], prefix1)
+                        K.assign(prefix, prefix1)
+                    with K.unroll(16) as row:
+                        K.assign(gate_prefix[row], _exp2_approx(gate_prefix[row]))
+
+                    _wait_barrier(arena, _BAR_DECAY_DONE, decay_stage, (serial // 2 + 1) & 1)
+                    with K.unroll(16) as row:
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, row, channel)]),
+                            gate_prefix[row],
+                        )
+                    diagonal_block = channel // 16
+                    diagonal_coord = channel % 16
+                    diagonal_linear = diagonal_block * 256 + diagonal_coord * 16 + diagonal_coord
+                    diagonal_swizzled = K.bitwise_xor(
+                        diagonal_linear,
+                        K.shift_left(
+                            K.bitwise_and(K.shift_right(diagonal_linear, K.uint32(6)), K.uint32(1)),
+                            K.uint32(3),
+                        ),
+                    )
+                    K.ptx.st.shared.b16(
+                        arena.ptr_to([_SMEM_DIAG + decay_stage * 4096 + diagonal_swizzled * 2]),
+                        K.reinterpret("uint16", K.cast(gate_prefix[15], "bfloat16")),
+                    )
+
+                    qk_stage = serial % 4
+                    _wait_barrier(arena, _BAR_QK_RAW_DONE, qk_stage, (serial // 4 + 1) & 1)
+                    q_words = K.alloc_local((8,), "uint32")
+                    k_words = K.alloc_local((8,), "uint32")
+                    raw_segment = channel // 64
+                    raw_channel = channel % 64
+                    with K.unroll(8) as pair:
+                        q_lo_bits = K.local_scalar("uint16")
+                        q_hi_bits = K.local_scalar("uint16")
+                        k_lo_bits = K.local_scalar("uint16")
+                        k_hi_bits = K.local_scalar("uint16")
+                        K.ptx.ld.shared.b16(
+                            q_lo_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2, channel)]),
+                        )
+                        K.ptx.ld.shared.b16(
+                            q_hi_bits,
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2 + 1, channel)]
+                            ),
+                        )
+                        K.ptx.ld.shared.b16(
+                            k_lo_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2, channel)]),
+                        )
+                        K.ptx.ld.shared.b16(
+                            k_hi_bits,
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2 + 1, channel)]
+                            ),
+                        )
+                        K.assign(
+                            q_words[pair],
+                            K.bitwise_or(
+                                K.cast(q_lo_bits, "uint32"),
+                                K.shift_left(K.cast(q_hi_bits, "uint32"), K.uint32(16)),
+                            ),
+                        )
+                        K.assign(
+                            k_words[pair],
+                            K.bitwise_or(
+                                K.cast(k_lo_bits, "uint32"),
+                                K.shift_left(K.cast(k_hi_bits, "uint32"), K.uint32(16)),
+                            ),
+                        )
+                    q_tmem = (
+                        tmem_col + _TMEM_Q_RAW + qk_stage * 8 + K.shift_left(tmem_row, K.int32(16))
+                    )
+                    k_tmem = (
+                        tmem_col + _TMEM_K_RAW + qk_stage * 8 + K.shift_left(tmem_row, K.int32(16))
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                        K.cast(q_tmem, "uint32"), *[q_words[i] for i in range(8)]
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                        K.cast(k_tmem, "uint32"), *[k_words[i] for i in range(8)]
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, _BAR_QK_RAW_READY, qk_stage)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+
+                    row_group_start = warp_in_group * 4
+                    row_in_group = lane // 8
+                    lane_in_group = lane % 8
+                    decay_row = row_group_start + row_in_group
+                    raw_q = K.alloc_local((16,), "float32")
+                    raw_k = K.alloc_local((16,), "float32")
+                    qk0_lo = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk0_hi = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk1_lo = K.local_scalar("float32", init=_opaque_f32_zero())
+                    qk1_hi = K.local_scalar("float32", init=_opaque_f32_zero())
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        q_fragment = K.alloc_local((4,), "uint32")
+                        k_fragment = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            q_fragment[0],
+                            q_fragment[1],
+                            q_fragment[2],
+                            q_fragment[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_Q, raw_stage, decay_row, dim_base)]),
+                        )
+                        K.ptx.ld.shared.v4.b32(
+                            k_fragment[0],
+                            k_fragment[1],
+                            k_fragment[2],
+                            k_fragment[3],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_K, raw_stage, decay_row, dim_base)]),
+                        )
+                        with K.unroll(8) as dim_offset:
+                            shift = K.cast((dim_offset % 2) * 16, "uint32")
+                            q_word = K.shift_right(q_fragment[dim_offset // 2], shift)
+                            k_word = K.shift_right(k_fragment[dim_offset // 2], shift)
+                            q_bits = K.cast(q_word, "uint16")
+                            k_bits = K.cast(k_word, "uint16")
+                            K.ptx.cvt.f32.bf16(raw_q[half * 8 + dim_offset], q_bits)
+                            K.ptx.cvt.f32.bf16(raw_k[half * 8 + dim_offset], k_bits)
+                            if l2norm:
+                                if dim_offset % 2 == 0:
+                                    next_q, next_k = _ffma2(
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        qk0_lo,
+                                        qk0_hi,
+                                    )
+                                    K.assign(qk0_lo, next_q)
+                                    K.assign(qk0_hi, next_k)
+                                else:
+                                    next_q, next_k = _ffma2(
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        raw_q[half * 8 + dim_offset],
+                                        raw_k[half * 8 + dim_offset],
+                                        qk1_lo,
+                                        qk1_hi,
+                                    )
+                                    K.assign(qk1_lo, next_q)
+                                    K.assign(qk1_hi, next_k)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_Q_DONE, raw_stage)
+                    _arrive_barrier(arena, _BAR_K_DONE, raw_stage)
+                    # beta_done carries CG0 + CG2 = 256: both groups read the tile.
+                    _arrive_barrier(arena, _BAR_BETA_DONE, raw_stage)
+
+                    q_inv_norm = K.local_scalar("float32", init=K.float32(1.0))
+                    k_inv_norm = K.local_scalar("float32", init=K.float32(1.0))
+                    if l2norm:
+                        q_sum = K.local_scalar("float32", init=qk0_lo + qk1_lo)
+                        k_sum = K.local_scalar("float32", init=qk0_hi + qk1_hi)
+                        for delta in (4, 2, 1):
+                            K.assign(q_sum, q_sum + _shuffle_xor_f32(q_sum, delta))
+                            K.assign(k_sum, k_sum + _shuffle_xor_f32(k_sum, delta))
+                        K.assign(q_inv_norm, _rsqrt_approx(K.max(q_sum, 1.0e-24)))
+                        K.assign(k_inv_norm, _rsqrt_approx(K.max(k_sum, 1.0e-24)))
+                        with K.If(lane_in_group == 0), K.Then():
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + decay_row) * 4]),
+                                q_inv_norm,
+                            )
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + decay_row) * 4]),
+                                k_inv_norm,
+                            )
+                    q_scale = q_inv_norm * scale
+
+                    exp_g = K.alloc_local((16,), "float32")
+                    exp_last = K.alloc_local((16,), "float32")
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        with K.unroll(2) as group:
+                            fragment_base = half * 8 + group * 4
+                            K.ptx.ld.shared.v4.f32(
+                                exp_g[fragment_base],
+                                exp_g[fragment_base + 1],
+                                exp_g[fragment_base + 2],
+                                exp_g[fragment_base + 3],
+                                arena.ptr_to(
+                                    [
+                                        _raw_f32_byte(
+                                            _SMEM_GATE, raw_stage, decay_row, dim_base + group * 4
+                                        )
+                                    ]
+                                ),
+                            )
+                            K.ptx.ld.shared.v4.f32(
+                                exp_last[fragment_base],
+                                exp_last[fragment_base + 1],
+                                exp_last[fragment_base + 2],
+                                exp_last[fragment_base + 3],
+                                arena.ptr_to(
+                                    [_raw_f32_byte(_SMEM_GATE, raw_stage, 15, dim_base + group * 4)]
+                                ),
+                            )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_GATE_DONE, raw_stage)
+
+                    k_inverse_words = K.alloc_local((8,), "uint32")
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        decay_words = K.alloc_local((4,), "uint32")
+                        # The per-key erase gate arrives as a [BT, DK] tile and is
+                        # folded into K_decay only; K_inv stays ungated.  This is
+                        # the whole of the GDN-2 gating delta on the key side.
+                        raw_beta = K.alloc_local((8,), "float32")
+                        with K.unroll(2) as beta_group:
+                            beta_bits = K.alloc_local((4,), "uint32")
+                            K.ptx.ld.shared.v4.b32(
+                                beta_bits[0],
+                                beta_bits[1],
+                                beta_bits[2],
+                                beta_bits[3],
+                                arena.ptr_to(
+                                    [
+                                        _raw_bf16_byte(
+                                            _SMEM_BETA,
+                                            raw_stage,
+                                            decay_row,
+                                            dim_base + beta_group * 4,
+                                        )
+                                    ]
+                                ),
+                            )
+                            for word in range(4):
+                                _unpack_bf16_pair(
+                                    beta_bits[word],
+                                    raw_beta[beta_group * 4 + word * 2],
+                                    raw_beta[beta_group * 4 + word * 2 + 1],
+                                )
+                        with K.unroll(4) as pair:
+                            reg = half * 8 + pair * 2
+                            k0, k1 = _fmul2(raw_k[reg], raw_k[reg + 1], k_inv_norm, k_inv_norm)
+                            k_pair = _pack_bf16_pair(k0, k1)
+                            beta0, beta1 = _fmul2(
+                                k0, k1, raw_beta[pair * 2], raw_beta[pair * 2 + 1]
+                            )
+                            k_beta_pair = _pack_bf16_pair(beta0, beta1)
+                            exp_pair = _pack_bf16_pair(exp_g[reg], exp_g[reg + 1])
+                            inverse_pair = _pack_bf16_pair(
+                                _rcp_approx(exp_g[reg]), _rcp_approx(exp_g[reg + 1])
+                            )
+                            K.ptx.mul.bf16x2(decay_words[pair], k_beta_pair, exp_pair)
+                            K.ptx.mul.bf16x2(k_inverse_words[half * 4 + pair], k_pair, inverse_pair)
+                        operand_byte = _raw_bf16_byte(
+                            _SMEM_K_DECAY, decay_stage, decay_row, dim_base
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([operand_byte]),
+                            decay_words[0],
+                            decay_words[1],
+                            decay_words[2],
+                            decay_words[3],
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_INV, decay_stage, decay_row, dim_base)]
+                            ),
+                            k_inverse_words[half * 4],
+                            k_inverse_words[half * 4 + 1],
+                            k_inverse_words[half * 4 + 2],
+                            k_inverse_words[half * 4 + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_K_DECAY_INV_READY, decay_stage)
+
+                    with K.unroll(2) as half:
+                        dim_base = half * 64 + lane_in_group * 8
+                        q_decay_words = K.alloc_local((4,), "uint32")
+                        restore_words = K.alloc_local((4,), "uint32")
+                        with K.unroll(4) as pair:
+                            reg = half * 8 + pair * 2
+                            q0, q1 = _fmul2(raw_q[reg], raw_q[reg + 1], q_scale, q_scale)
+                            q_pair = _pack_bf16_pair(q0, q1)
+                            exp_pair = _pack_bf16_pair(exp_g[reg], exp_g[reg + 1])
+                            K.ptx.mul.bf16x2(q_decay_words[pair], q_pair, exp_pair)
+                            last_pair = _pack_bf16_pair(exp_last[reg], exp_last[reg + 1])
+                            K.ptx.mul.bf16x2(
+                                restore_words[pair], k_inverse_words[half * 4 + pair], last_pair
+                            )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_Q_DECAY, decay_stage, decay_row, dim_base)]
+                            ),
+                            q_decay_words[0],
+                            q_decay_words[1],
+                            q_decay_words[2],
+                            q_decay_words[3],
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_bf16_byte(_SMEM_K_RESTORE, decay_stage, decay_row, dim_base)]
+                            ),
+                            restore_words[0],
+                            restore_words[1],
+                            restore_words[2],
+                            restore_words[3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_Q_DECAY_K_RESTORE_READY, decay_stage)
+
+                    _wait_barrier(arena, _BAR_STATE_INP_DONE, serial % 2, (serial // 2 + 1) & 1)
+                    _wait_barrier(arena, _BAR_STATE_INP_CG2_DONE, serial % 2, (serial // 2 + 1) & 1)
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(
+                            arena, _BAR_STATE_READY, state_consumer.stage, state_consumer.phase
+                        )
+                        with K.unroll(2) as value_segment:
+                            with K.unroll(8) as value_group:
+                                state_words = K.alloc_local((4,), "uint32")
+                                with K.unroll(4) as pair:
+                                    lo_bits = K.local_scalar("uint16")
+                                    hi_bits = K.local_scalar("uint16")
+                                    key_lo = value_segment * 64 + value_group * 8 + pair * 2
+                                    key_hi = key_lo + 1
+                                    K.ptx.ld.shared.b16(
+                                        lo_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_STATE
+                                                + (
+                                                    (value_channel // 64) * 8192
+                                                    + key_lo * 64
+                                                    + _swizzle_xor_128b(
+                                                        key_lo, value_channel % 64, 2
+                                                    )
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.b16(
+                                        hi_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_STATE
+                                                + (
+                                                    (value_channel // 64) * 8192
+                                                    + key_hi * 64
+                                                    + _swizzle_xor_128b(
+                                                        key_hi, value_channel % 64, 2
+                                                    )
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.assign(
+                                        state_words[pair],
+                                        K.bitwise_or(
+                                            K.cast(lo_bits, "uint32"),
+                                            K.shift_left(K.cast(hi_bits, "uint32"), K.uint32(16)),
+                                        ),
+                                    )
+                                state_tmem = (
+                                    tmem_col
+                                    + _TMEM_STATE_INPUT
+                                    + (serial % 2) * 64
+                                    + value_segment * 32
+                                    + value_group * 4
+                                    + K.shift_left(tmem_row, K.int32(16))
+                                )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x4.b32"](
+                                    K.cast(state_tmem, "uint32"),
+                                    state_words[0],
+                                    state_words[1],
+                                    state_words[2],
+                                    state_words[3],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_STATE_CG0_DONE, state_consumer.stage)
+                        state_consumer.advance()
+                    _arrive_barrier(arena, _BAR_STATE_INP_READY, serial % 2)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+        with cg2:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_alloc_row = tmem_base >> 16
+            warp_in_group = K.warp_id_in_role()
+            subpartition = warp % 4
+            channel = subpartition * 32 + lane
+            tmem_row = tmem_alloc_row + subpartition * 32
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            dq_consumer = K.PipelineState(1, phase=0)
+            dk_decay_consumer = K.PipelineState(1, phase=0)
+            dk_inverse_consumer = K.PipelineState(1, phase=0)
+            dk_restore_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_consumer = K.PipelineState(1, phase=0)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                num_chunks = cend - wstart
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    decay_stage = serial % 2
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+
+                    _wait_barrier(arena, _BAR_K_DECAY_INV_READY, decay_stage, (serial // 2) & 1)
+                    gate_decay = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as token:
+                        K.ptx.ld.shared.f32(
+                            gate_decay[token],
+                            arena.ptr_to([_raw_f32_byte(_SMEM_GATE, raw_stage, token, channel)]),
+                        )
+                    gate_last = gate_decay[15]
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_GATE_DONE, raw_stage)
+
+                    qk_stage = serial % 4
+                    qraw_col = tmem_col + _TMEM_Q_RAW + qk_stage * 8
+                    kraw_col = tmem_col + _TMEM_K_RAW + qk_stage * 8
+                    _wait_barrier(arena, _BAR_QK_RAW_READY, qk_stage, (serial // 4) & 1)
+
+                    dgate_last = K.local_scalar("float32", init=K.float32(0.0))
+                    _wait_barrier(arena, _BAR_STATE_INP_READY, serial % 2, (serial // 2) & 1)
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_READY,
+                            dstate_smem_consumer.stage,
+                            dstate_smem_consumer.phase,
+                        )
+                        dstate_smem_consumer.advance()
+                        with K.unroll(2) as value_plane:
+                            with K.unroll(2) as row_half:
+                                state_words = K.alloc_local((16,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                                    *[state_words[i] for i in range(16)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TMEM_STATE_INPUT
+                                        + (serial % 2) * 64
+                                        + value_plane * 32
+                                        + row_half * 16
+                                        + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                K.ptx.tcgen05.wait__ld.sync.aligned()
+                                hacc = K.alloc_local((8,), "float32")
+                                for accum_slot in range(8):
+                                    K.assign(hacc[accum_slot], _opaque_f32_zero())
+                                with K.unroll(16) as pair:
+                                    state_lo = K.cast(state_words[pair], "uint16")
+                                    state_hi = K.cast(
+                                        K.shift_right(state_words[pair], K.uint32(16)), "uint16"
+                                    )
+                                    value0 = value_plane * 64 + row_half * 32 + pair * 2
+                                    h0_bits = K.local_scalar("uint16")
+                                    h1_bits = K.local_scalar("uint16")
+                                    K.ptx.ld.shared.b16(
+                                        h0_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_DSTATE
+                                                + (
+                                                    (channel // 64) * 8192
+                                                    + value0 * 64
+                                                    + _swizzle_xor_128b(value0, channel % 64, 2)
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.b16(
+                                        h1_bits,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_DSTATE
+                                                + (
+                                                    (channel // 64) * 8192
+                                                    + (value0 + 1) * 64
+                                                    + _swizzle_xor_128b(value0 + 1, channel % 64, 2)
+                                                )
+                                                * 2
+                                            ]
+                                        ),
+                                    )
+                                    accum_lo = (2 * pair) % 8
+                                    accum_hi = (2 * pair + 1) % 8
+                                    next_lo = K.local_scalar("float32")
+                                    next_hi = K.local_scalar("float32")
+                                    K.ptx.fma.rn.f32.bf16(
+                                        next_lo, h0_bits, state_lo, hacc[accum_lo]
+                                    )
+                                    K.ptx.fma.rn.f32.bf16(
+                                        next_hi, h1_bits, state_hi, hacc[accum_hi]
+                                    )
+                                    K.assign(hacc[accum_lo], next_lo)
+                                    K.assign(hacc[accum_hi], next_hi)
+                                pa0, pb0 = _fadd2(hacc[0], hacc[2], hacc[4], hacc[6])
+                                pa1, pb1 = _fadd2(hacc[1], hacc[3], hacc[5], hacc[7])
+                                part_a, part_b = _fadd2(pa0, pb0, pa1, pb1)
+                                K.assign(dgate_last, dgate_last + part_a + part_b)
+                        _arrive_barrier(arena, _BAR_DSTATE_SMEM_CG2_DONE)
+                    _arrive_barrier(arena, _BAR_STATE_INP_CG2_DONE, serial % 2)
+
+                    dq_values = K.alloc_local((16,), "float32")
+                    dk_values = K.alloc_local((16,), "float32")
+                    dgate_values = K.alloc_local((16,), "float32")
+                    last_dot = K.alloc_local((4,), "float32")
+                    for slot in range(4):
+                        K.assign(last_dot[slot], K.float32(0.0))
+                    for token in range(16):
+                        K.assign(dk_values[token], K.float32(0.0))
+
+                    with K.If(has_dstate), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DK_RESTORE_PART_ACC_READY,
+                            dk_restore_consumer.stage,
+                            dk_restore_consumer.phase,
+                        )
+                        dk_restore_consumer.advance()
+                        restore = K.alloc_local((16,), "float32")
+                        kraw = K.alloc_local((8,), "uint32")
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                            *[restore[i] for i in range(16)],
+                            K.cast(
+                                tmem_col + _TMEM_DK_RESTORE + K.shift_left(tmem_row, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                            *[kraw[i] for i in range(8)],
+                            K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        with K.unroll(16) as token:
+                            K.assign(
+                                dk_values[token],
+                                gate_last * _rcp_approx(gate_decay[token]) * restore[token],
+                            )
+                            k_lo = K.local_scalar("float32")
+                            k_hi = K.local_scalar("float32")
+                            _unpack_bf16_pair(kraw[token // 2], k_lo, k_hi)
+                            k_value = K.local_scalar("float32")
+                            K.assign(k_value, K.if_then_else(token % 2 == 0, k_lo, k_hi))
+                            if l2norm:
+                                k_norm = K.local_scalar("float32")
+                                K.ptx.ld.shared.f32(
+                                    k_norm,
+                                    arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + token) * 4]),
+                                )
+                                K.assign(k_value, k_value * k_norm)
+                            K.assign(
+                                last_dot[token % 4],
+                                last_dot[token % 4] + k_value * dk_values[token],
+                            )
+
+                    _wait_barrier(arena, _BAR_DQ_ACC_READY, dq_consumer.stage, dq_consumer.phase)
+                    dq_consumer.advance()
+                    dq_acc = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[dq_acc[i] for i in range(16)],
+                        K.cast(tmem_col + _TMEM_DQ + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    with K.unroll(8) as pair:
+                        token = pair * 2
+                        scaled_lo, scaled_hi = _fmul2(
+                            gate_decay[token], gate_decay[token + 1], scale, scale
+                        )
+                        dq_lo, dq_hi = _fmul2(
+                            scaled_lo, scaled_hi, dq_acc[token], dq_acc[token + 1]
+                        )
+                        K.assign(dq_values[token], dq_lo)
+                        K.assign(dq_values[token + 1], dq_hi)
+
+                    _wait_barrier(
+                        arena,
+                        _BAR_DK_INV_PART_ACC_READY,
+                        dk_inverse_consumer.stage,
+                        dk_inverse_consumer.phase,
+                    )
+                    dk_inverse_consumer.advance()
+                    inverse = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[inverse[i] for i in range(16)],
+                        K.cast(
+                            tmem_col + _TMEM_DK_INV + K.shift_left(tmem_row, K.int32(16)), "uint32"
+                        ),
+                    )
+                    with K.unroll(16) as token:
+                        K.assign(
+                            dk_values[token],
+                            dk_values[token] + inverse[token] * _rcp_approx(gate_decay[token]),
+                        )
+
+                    _wait_barrier(
+                        arena,
+                        _BAR_DK_DECAY_PART_ACC_READY,
+                        dk_decay_consumer.stage,
+                        dk_decay_consumer.phase,
+                    )
+                    dk_decay_consumer.advance()
+                    decay = K.alloc_local((16,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                        *[decay[i] for i in range(16)],
+                        K.cast(
+                            tmem_col + _TMEM_DK_DECAY + K.shift_left(tmem_row, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    # GDN-2 seeds BOTH dBeta and dGate from the dK_decay drain:
+                    # dBeta is per key channel (k_n * dk_decay), and dGate takes the
+                    # Beta-weighted share of the same product.
+                    kd_words = K.alloc_local((8,), "uint32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                        *[kd_words[i] for i in range(8)],
+                        K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    db_values = K.alloc_local((16,), "float32")
+                    beta_self = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as token:
+                        beta_bits = K.local_scalar("uint16")
+                        K.ptx.ld.shared.b16(
+                            beta_bits,
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_BETA, raw_stage, token, channel)]),
+                        )
+                        beta_value = K.local_scalar("float32")
+                        K.ptx.cvt.f32.bf16(beta_value, beta_bits)
+                        if beta_sigmoid:
+                            K.assign(beta_value, _tanh_approx(beta_value * 0.5) * 0.5 + 0.5)
+                            # The source rounds sigmoid(beta) through the io dtype
+                            # before using it, and the gradient depends on that.
+                            K.assign(beta_value, K.cast(K.cast(beta_value, "bfloat16"), "float32"))
+                        K.assign(beta_self[token], beta_value)
+
+                        kd_lo = K.local_scalar("float32")
+                        kd_hi = K.local_scalar("float32")
+                        _unpack_bf16_pair(kd_words[token // 2], kd_lo, kd_hi)
+                        k_native = K.local_scalar("float32")
+                        K.assign(k_native, K.if_then_else(token % 2 == 0, kd_lo, kd_hi))
+                        if l2norm:
+                            k_scale = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                k_scale,
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + token) * 4]),
+                            )
+                            K.assign(k_native, k_native * k_scale)
+
+                        dk_decay = K.local_scalar("float32")
+                        K.assign(dk_decay, -gate_decay[token] * decay[token])
+                        K.assign(db_values[token], k_native * dk_decay)
+                        K.assign(dgate_values[token], beta_value * dk_decay)
+                        K.assign(dk_values[token], dk_values[token] + dgate_values[token])
+                    _arrive_barrier(arena, _BAR_DQK_ACC_DONE)
+
+                    qraw = K.alloc_local((8,), "uint32")
+                    kraw = K.alloc_local((8,), "uint32")
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                        *[qraw[i] for i in range(8)],
+                        K.cast(qraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                        *[kraw[i] for i in range(8)],
+                        K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    with K.unroll(16) as token:
+                        q_lo = K.local_scalar("float32")
+                        q_hi = K.local_scalar("float32")
+                        k_lo = K.local_scalar("float32")
+                        k_hi = K.local_scalar("float32")
+                        _unpack_bf16_pair(qraw[token // 2], q_lo, q_hi)
+                        _unpack_bf16_pair(kraw[token // 2], k_lo, k_hi)
+                        q_value = K.local_scalar("float32")
+                        k_value = K.local_scalar("float32")
+                        K.assign(q_value, K.if_then_else(token % 2 == 0, q_lo, q_hi))
+                        K.assign(k_value, K.if_then_else(token % 2 == 0, k_lo, k_hi))
+                        if l2norm:
+                            q_norm = K.local_scalar("float32")
+                            k_norm = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                q_norm, arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + token) * 4])
+                            )
+                            K.ptx.ld.shared.f32(
+                                k_norm,
+                                arena.ptr_to([_SMEM_NORM + (qk_stage * 32 + 16 + token) * 4]),
+                            )
+                            K.assign(q_value, q_value * q_norm)
+                            K.assign(k_value, k_value * k_norm)
+                        K.assign(
+                            dgate_values[token],
+                            q_value * dq_values[token]
+                            + beta_self[token] * db_values[token]
+                            - k_value * (dk_values[token] - dgate_values[token]),
+                        )
+                        if beta_sigmoid:
+                            # Applied AFTER dGate consumed db_values: the source
+                            # feeds dGate the pre-chain-rule value, and swapping
+                            # these silently corrupts dGate.
+                            K.assign(
+                                db_values[token],
+                                db_values[token]
+                                * (beta_self[token] - beta_self[token] * beta_self[token]),
+                            )
+                    K.assign(
+                        dgate_values[15],
+                        dgate_values[15] + last_dot[0] + last_dot[1] + last_dot[2] + last_dot[3],
+                    )
+
+                    if l2norm:
+                        for grad, raw_column, norm_offset in (
+                            (dq_values, qraw_col, 0),
+                            (dk_values, kraw_col, 16),
+                        ):
+                            dots = K.alloc_local((16,), "float32")
+                            for half in range(2):
+                                half_words = K.alloc_local((4,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](
+                                    *[half_words[i] for i in range(4)],
+                                    K.cast(
+                                        raw_column + half * 4 + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                for pair in range(4):
+                                    token = half * 8 + pair * 2
+                                    raw_lo = K.local_scalar("float32")
+                                    raw_hi = K.local_scalar("float32")
+                                    _unpack_bf16_pair(half_words[pair], raw_lo, raw_hi)
+                                    norm_lo = K.local_scalar("float32")
+                                    norm_hi = K.local_scalar("float32")
+                                    K.ptx.ld.shared.f32(
+                                        norm_lo,
+                                        arena.ptr_to(
+                                            [_SMEM_NORM + (qk_stage * 32 + norm_offset + token) * 4]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.f32(
+                                        norm_hi,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_NORM
+                                                + (qk_stage * 32 + norm_offset + token + 1) * 4
+                                            ]
+                                        ),
+                                    )
+                                    product_lo, product_hi = _fmul2(
+                                        grad[token], grad[token + 1], raw_lo, raw_hi
+                                    )
+                                    product_lo, product_hi = _fmul2(
+                                        product_lo, product_hi, norm_lo, norm_hi
+                                    )
+                                    K.assign(dots[token], product_lo)
+                                    K.assign(dots[token + 1], product_hi)
+                            for delta in (1, 2, 4, 8, 16):
+                                for pair in range(8):
+                                    token = pair * 2
+                                    other_lo = _shuffle_xor_f32(dots[token], delta)
+                                    other_hi = _shuffle_xor_f32(dots[token + 1], delta)
+                                    sum_lo, sum_hi = _fadd2(
+                                        dots[token], dots[token + 1], other_lo, other_hi
+                                    )
+                                    K.assign(dots[token], sum_lo)
+                                    K.assign(dots[token + 1], sum_hi)
+                            with K.If(lane == 0), K.Then():
+                                for token in range(16):
+                                    K.ptx.st.shared.f32(
+                                        arena.ptr_to(
+                                            [_SMEM_RED1 + (subpartition * 16 + token) * 4]
+                                        ),
+                                        dots[token],
+                                    )
+                            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                            for half in range(2):
+                                half_words = K.alloc_local((4,), "uint32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x4.b32"](
+                                    *[half_words[i] for i in range(4)],
+                                    K.cast(
+                                        raw_column + half * 4 + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                for pair in range(4):
+                                    token = half * 8 + pair * 2
+                                    partials = K.alloc_local((8,), "float32")
+                                    for reduction_warp in range(4):
+                                        K.ptx.ld.shared.f32(
+                                            partials[reduction_warp * 2],
+                                            arena.ptr_to(
+                                                [_SMEM_RED1 + (reduction_warp * 16 + token) * 4]
+                                            ),
+                                        )
+                                        K.ptx.ld.shared.f32(
+                                            partials[reduction_warp * 2 + 1],
+                                            arena.ptr_to(
+                                                [_SMEM_RED1 + (reduction_warp * 16 + token + 1) * 4]
+                                            ),
+                                        )
+                                    dot_lo, dot_hi = _fadd2(
+                                        partials[0], partials[1], partials[2], partials[3]
+                                    )
+                                    dot_lo, dot_hi = _fadd2(
+                                        dot_lo, dot_hi, partials[4], partials[5]
+                                    )
+                                    dot_lo, dot_hi = _fadd2(
+                                        dot_lo, dot_hi, partials[6], partials[7]
+                                    )
+                                    raw_lo = K.local_scalar("float32")
+                                    raw_hi = K.local_scalar("float32")
+                                    _unpack_bf16_pair(half_words[pair], raw_lo, raw_hi)
+                                    norm_lo = K.local_scalar("float32")
+                                    norm_hi = K.local_scalar("float32")
+                                    K.ptx.ld.shared.f32(
+                                        norm_lo,
+                                        arena.ptr_to(
+                                            [_SMEM_NORM + (qk_stage * 32 + norm_offset + token) * 4]
+                                        ),
+                                    )
+                                    K.ptx.ld.shared.f32(
+                                        norm_hi,
+                                        arena.ptr_to(
+                                            [
+                                                _SMEM_NORM
+                                                + (qk_stage * 32 + norm_offset + token + 1) * 4
+                                            ]
+                                        ),
+                                    )
+                                    unit_lo, unit_hi = _fmul2(raw_lo, raw_hi, norm_lo, norm_hi)
+                                    correction_lo, correction_hi = _fmul2(
+                                        unit_lo, unit_hi, dot_lo, dot_hi
+                                    )
+                                    residual_lo, residual_hi = _fsub2(
+                                        grad[token], grad[token + 1], correction_lo, correction_hi
+                                    )
+                                    result_lo, result_hi = _fmul2(
+                                        residual_lo, residual_hi, norm_lo, norm_hi
+                                    )
+                                    K.assign(grad[token], result_lo)
+                                    K.assign(grad[token + 1], result_hi)
+                            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    _arrive_barrier(arena, _BAR_QK_RAW_DONE, qk_stage)
+                    _wait_barrier(arena, _BAR_DQ_TMASTG_DONE, 0, (serial + 1) & 1)
+                    _wait_barrier(arena, _BAR_DK_TMASTG_DONE, 0, (serial + 1) & 1)
+                    with K.unroll(16) as token:
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DQ, 0, token, channel)]),
+                            K.reinterpret("uint16", K.cast(dq_values[token], "bfloat16")),
+                        )
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DK, 0, token, channel)]),
+                            K.reinterpret("uint16", K.cast(dk_values[token], "bfloat16")),
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DQ_TMASTG_READY)
+                    _arrive_barrier(arena, _BAR_DK_TMASTG_READY)
+
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(K.And(has_dstate, chunk >= first_state_chunk)), K.Then():
+                        K.assign(dgate_values[15], dgate_values[15] + gate_last * dgate_last)
+                    suffix = K.local_scalar("float32", init=K.float32(0.0))
+                    for reverse_token in range(16):
+                        token = 15 - reverse_token
+                        K.assign(suffix, suffix + dgate_values[token])
+                        K.assign(dgate_values[token], suffix)
+                    _wait_barrier(arena, _BAR_DGATE_TMASTG_DONE, 0, (serial + 1) & 1)
+                    _wait_barrier(arena, _BAR_DB_TMASTG_DONE, 0, (serial + 1) & 1)
+                    with K.unroll(16) as token:
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_raw_f32_byte(_SMEM_DGATE, 0, token, channel)]),
+                            dgate_values[token],
+                        )
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_DB, 0, token, channel)]),
+                            K.reinterpret("uint16", K.cast(db_values[token], "bfloat16")),
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DGATE_TMASTG_READY)
+                    _arrive_barrier(arena, _BAR_DB_TMASTG_READY)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _arrive_barrier(arena, _BAR_TMEM_DONE)
+        with cg1:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(416))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_SMEM_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_alloc_row = tmem_base >> 16
+            warp_in_group = K.warp_id_in_role()
+            subpartition = warp % 4
+            value_dim = subpartition * 32 + lane
+            value_base = subpartition * 32
+            token_row = (lane // 16) * 8 + (lane & 7)
+            value_col_offset = ((lane // 8) & 1) * 8
+            group_thread = warp_in_group * 32 + lane
+            tile = K.local_scalar("int32", init=K.cta_id())
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            state_k_consumer = K.PipelineState(1, phase=0)
+            du_consumer = K.PipelineState(1, phase=0)
+            u_consumer = K.PipelineState(1, phase=0)
+            dy_consumer = K.PipelineState(1, phase=0)
+            dstate_consumer = K.PipelineState(1, phase=0)
+            dstate_smem_done = K.PipelineState(1, phase=1)
+            dbeta_m_consumer = K.PipelineState(1, phase=0)
+            dv_done_consumer = K.PipelineState(2, phase=1)
+            dwo_done_consumer = K.PipelineState(2, phase=1)
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                sequence_chunks = (sequence_length + 15) // 16
+                num_chunks = cend - wstart
+                dstate_index_base = (
+                    (K.cast(batch, "int64") * n_heads_out + head) * 128 + value_dim
+                ) * 128
+
+                if use_dstate_in:
+                    with K.If(num_chunks > 0), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_DONE,
+                            dstate_smem_done.stage,
+                            dstate_smem_done.phase,
+                        )
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_CG2_DONE,
+                            dstate_smem_done.stage,
+                            dstate_smem_done.phase,
+                        )
+                        dstate_smem_done.advance()
+                        seed_enabled = cend == sequence_chunks
+                        seed_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(8) as key_subtile:
+                            seed = K.alloc_local((16,), "float32")
+                            seed_pack = K.alloc_local((8,), "uint32")
+                            with K.unroll(16) as key_offset:
+                                K.ptx.ld.global_.f32(
+                                    seed[key_offset],
+                                    d_final_state.ptr_to(
+                                        [dstate_index_base + key_subtile * 16 + key_offset]
+                                    ),
+                                )
+                                with K.If(K.Not(seed_enabled)), K.Then():
+                                    K.assign(seed[key_offset], K.float32(0.0))
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 16
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[seed[i] for i in range(16)],
+                            )
+                            for pair in range(8):
+                                K.assign(
+                                    seed_pack[pair],
+                                    _pack_bf16_pair(seed[pair * 2], seed[pair * 2 + 1]),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 8
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[seed_pack[i] for i in range(8)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY)
+                        with K.unroll(8) as key_subtile:
+                            seed_words = K.alloc_local((8,), "uint32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                                *[seed_words[i] for i in range(8)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 8
+                                    + K.shift_left(seed_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            with K.unroll(2) as half:
+                                key_base = key_subtile * 16 + half * 8
+                                K.ptx.st.shared.v4.b32(
+                                    arena.ptr_to(
+                                        [
+                                            _SMEM_DSTATE
+                                            + (
+                                                (key_base // 64) * 8192
+                                                + value_dim * 64
+                                                + _swizzle_xor_128b(value_dim, key_base % 64, 2)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    seed_words[half * 4],
+                                    seed_words[half * 4 + 1],
+                                    seed_words[half * 4 + 2],
+                                    seed_words[half * 4 + 3],
+                                )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)
+
+                with K.serial(num_chunks, unroll=False) as reverse_index:
+                    serial = serial_base + reverse_index
+                    chunk = cend - 1 - reverse_index
+                    raw_stage = serial % 2
+                    has_dstate = reverse_index > 0
+                    if use_dstate_in:
+                        has_dstate = K.bool(True)
+                    row_lo = tmem_alloc_row
+                    row_hi = tmem_alloc_row + 16
+                    projection_row0 = tmem_alloc_row + value_base
+                    projection_row1 = projection_row0 + 16
+
+                    _wait_barrier(arena, _BAR_V_READY, raw_stage, (serial // 2) & 1)
+                    raw_v0 = K.alloc_local((4,), "uint32")
+                    raw_v1 = K.alloc_local((4,), "uint32")
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_v0[0],
+                        raw_v0[1],
+                        raw_v0[2],
+                        raw_v0[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_V, raw_stage, token_row, value_base + value_col_offset
+                                )
+                            ]
+                        ),
+                    )
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_v1[0],
+                        raw_v1[1],
+                        raw_v1[2],
+                        raw_v1[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_V,
+                                    raw_stage,
+                                    token_row,
+                                    value_base + 16 + value_col_offset,
+                                )
+                            ]
+                        ),
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+
+                    # The per-value write gate is read in the same transposed
+                    # fragment form as V, so Y = W * V - state_k.
+                    _wait_barrier(arena, _BAR_W_READY, raw_stage, (serial // 2) & 1)
+                    raw_w0 = K.alloc_local((4,), "uint32")
+                    raw_w1 = K.alloc_local((4,), "uint32")
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_w0[0],
+                        raw_w0[1],
+                        raw_w0[2],
+                        raw_w0[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_W, raw_stage, token_row, value_base + value_col_offset
+                                )
+                            ]
+                        ),
+                    )
+                    K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        raw_w1[0],
+                        raw_w1[1],
+                        raw_w1[2],
+                        raw_w1[3],
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_W,
+                                    raw_stage,
+                                    token_row,
+                                    value_base + value_col_offset + 64,
+                                )
+                            ]
+                        ),
+                    )
+
+                    difference0 = K.alloc_local((4,), "uint32")
+                    difference1 = K.alloc_local((4,), "uint32")
+                    y_pack0 = K.alloc_local((4,), "uint32")
+                    y_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        raw_matrix = (1 - reg // 2) * 2 + (reg & 1)
+                        K.assign(difference0[reg ^ 2], raw_v0[raw_matrix])
+                        K.assign(difference1[reg ^ 2], raw_v1[raw_matrix])
+                        K.ptx.mul.bf16x2(y_pack0[reg ^ 2], raw_w0[raw_matrix], raw_v0[raw_matrix])
+                        K.ptx.mul.bf16x2(y_pack1[reg ^ 2], raw_w1[raw_matrix], raw_v1[raw_matrix])
+                    first_state_chunk = 0 if use_initial_state else 1
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_STATE_K_ACC_READY,
+                            state_k_consumer.stage,
+                            state_k_consumer.phase,
+                        )
+                        state_k_consumer.advance()
+                        state0 = K.alloc_local((8,), "float32")
+                        state1 = K.alloc_local((8,), "float32")
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                            *[state0[i] for i in range(8)],
+                            K.cast(
+                                tmem_col
+                                + _TMEM_STATE_K_DY
+                                + K.shift_left(projection_row0, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                            *[state1[i] for i in range(8)],
+                            K.cast(
+                                tmem_col
+                                + _TMEM_STATE_K_DY
+                                + K.shift_left(projection_row1, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        for reg in range(4):
+                            raw_matrix = (1 - reg // 2) * 2 + (reg & 1)
+                            frag_pair = (reg ^ 2) * 2
+                            state_pair0 = _pack_bf16_pair(state0[frag_pair], state0[frag_pair + 1])
+                            state_pair1 = _pack_bf16_pair(state1[frag_pair], state1[frag_pair + 1])
+                            # Y = W * V - state_k: the write gate scales V, and the
+                            # entering-state term is subtracted unscaled.
+                            K.ptx.mul.bf16x2(
+                                difference0[reg ^ 2], raw_w0[raw_matrix], raw_v0[raw_matrix]
+                            )
+                            K.ptx.mul.bf16x2(
+                                difference1[reg ^ 2], raw_w1[raw_matrix], raw_v1[raw_matrix]
+                            )
+                            K.ptx.sub.bf16x2(y_pack0[reg ^ 2], difference0[reg ^ 2], state_pair0)
+                            K.ptx.sub.bf16x2(y_pack1[reg ^ 2], difference1[reg ^ 2], state_pair1)
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_DY + K.shift_left(row_lo, K.int32(16)), "uint32"
+                        ),
+                        *[y_pack0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_DY + K.shift_left(row_hi, K.int32(16)), "uint32"
+                        ),
+                        *[y_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, _BAR_Y_INP_READY)
+
+                    _wait_barrier(arena, _BAR_DU_ACC_READY, du_consumer.stage, du_consumer.phase)
+                    du_consumer.advance()
+                    du0 = K.alloc_local((8,), "float32")
+                    du1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[du0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_DU + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[du1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_DU + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    du_pack0 = K.alloc_local((4,), "uint32")
+                    du_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(du_pack0[reg], _pack_bf16_pair(du0[2 * reg], du0[2 * reg + 1]))
+                        K.assign(du_pack1[reg], _pack_bf16_pair(du1[2 * reg], du1[2 * reg + 1]))
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_DU_INPUT + K.shift_left(row_lo, K.int32(16)), "uint32"
+                        ),
+                        *[du_pack0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_DU_INPUT + K.shift_left(row_hi, K.int32(16)), "uint32"
+                        ),
+                        *[du_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, _BAR_DU_INP_READY)
+
+                    _wait_barrier(arena, _BAR_U_ACC_READY, u_consumer.stage, u_consumer.phase)
+                    u_consumer.advance()
+                    u0 = K.alloc_local((8,), "float32")
+                    u1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[u0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_U + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[u1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col + _TMEM_U + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    u_pack0 = K.alloc_local((4,), "uint32")
+                    u_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(u_pack0[reg], _pack_bf16_pair(u0[2 * reg], u0[2 * reg + 1]))
+                        K.assign(u_pack1[reg], _pack_bf16_pair(u1[2 * reg], u1[2 * reg + 1]))
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to(
+                            [_raw_bf16_byte(_SMEM_U, 0, token_row, value_base + value_col_offset)]
+                        ),
+                        *[u_pack0[i] for i in range(4)],
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to(
+                            [
+                                _raw_bf16_byte(
+                                    _SMEM_U, 0, token_row, value_base + 16 + value_col_offset
+                                )
+                            ]
+                        ),
+                        *[u_pack1[i] for i in range(4)],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_U_SMEM_READY)
+
+                    _wait_barrier(arena, _BAR_DY_ACC_READY, dy_consumer.stage, dy_consumer.phase)
+                    dy_consumer.advance()
+                    dy0 = K.alloc_local((8,), "float32")
+                    dy1 = K.alloc_local((8,), "float32")
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[dy0[i] for i in range(8)],
+                        K.cast(
+                            tmem_col
+                            + _TMEM_STATE_K_DY
+                            + K.shift_left(projection_row0, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[dy1[i] for i in range(8)],
+                        K.cast(
+                            tmem_col
+                            + _TMEM_STATE_K_DY
+                            + K.shift_left(projection_row1, K.int32(16)),
+                            "uint32",
+                        ),
+                    )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                    dy_pack0 = K.alloc_local((4,), "uint32")
+                    dy_pack1 = K.alloc_local((4,), "uint32")
+                    for reg in range(4):
+                        K.assign(dy_pack0[reg], _pack_bf16_pair(dy0[2 * reg], dy0[2 * reg + 1]))
+                        K.assign(dy_pack1[reg], _pack_bf16_pair(dy1[2 * reg], dy1[2 * reg + 1]))
+                    dy_addr0 = _raw_bf16_byte(_SMEM_DY, 0, token_row, value_base + value_col_offset)
+                    dy_addr1 = _raw_bf16_byte(
+                        _SMEM_DY, 0, token_row, value_base + 16 + value_col_offset
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([dy_addr0]), *[dy_pack0[i] for i in range(4)]
+                    )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                        arena.ptr_to([dy_addr1]), *[dy_pack1[i] for i in range(4)]
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DY_SMEM_READY)
+
+                    # GDN-2 stages plain -dY, not -(Beta * dY): the erase gate is
+                    # already folded into the K_decay operand, and dV is formed
+                    # separately from the write gate in the scalar pass below.
+                    neg0 = K.alloc_local((4,), "uint32")
+                    neg1 = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(neg0[pair], _pack_bf16_pair(-dy0[pair * 2], -dy0[pair * 2 + 1]))
+                        K.assign(neg1[pair], _pack_bf16_pair(-dy1[pair * 2], -dy1[pair * 2 + 1]))
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_DY + K.shift_left(row_lo, K.int32(16)), "uint32"
+                        ),
+                        *[neg0[i] for i in range(4)],
+                    )
+                    K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                        K.cast(
+                            tmem_col + _TMEM_Y_NEG_DY + K.shift_left(row_hi, K.int32(16)), "uint32"
+                        ),
+                        *[neg1[i] for i in range(4)],
+                    )
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    _arrive_barrier(arena, _BAR_NEG_DY_INP_READY)
+
+                    # dV and dW_out come from one scalar pass over this lane's
+                    # value channel: GDN-2 needs two different products of dY, so
+                    # a single store from a gate-scaled dY does not suffice.  V and W
+                    # stay live until after this pass.
+                    dv_stage = serial % 2
+                    dwo_stage = serial % 2
+                    _wait_barrier(
+                        arena, _BAR_DV_TMASTG_DONE, dv_done_consumer.stage, dv_done_consumer.phase
+                    )
+                    dv_done_consumer.advance()
+                    _wait_barrier(
+                        arena,
+                        _BAR_DWO_TMASTG_DONE,
+                        dwo_done_consumer.stage,
+                        dwo_done_consumer.phase,
+                    )
+                    dwo_done_consumer.advance()
+                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+
+                    value_segment = group_thread // 64
+                    value_column = group_thread - value_segment * 64
+                    for token in range(16):
+                        element = (
+                            value_segment * 1024
+                            + token * 64
+                            + _swizzle_xor_128b(token, value_column, 2)
+                        )
+                        dy_bits = K.local_scalar("uint16")
+                        w_bits = K.local_scalar("uint16")
+                        v_bits = K.local_scalar("uint16")
+                        K.ptx.ld.shared.b16(dy_bits, arena.ptr_to([_SMEM_DY + element * 2]))
+                        K.ptx.ld.shared.b16(
+                            w_bits, arena.ptr_to([_SMEM_W + raw_stage * 4096 + element * 2])
+                        )
+                        K.ptx.ld.shared.b16(
+                            v_bits, arena.ptr_to([_SMEM_V + raw_stage * 4096 + element * 2])
+                        )
+                        dy_value = K.cast(K.reinterpret("bfloat16", dy_bits), "float32")
+                        w_value = K.cast(K.reinterpret("bfloat16", w_bits), "float32")
+                        v_value = K.cast(K.reinterpret("bfloat16", v_bits), "float32")
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_SMEM_DV + dv_stage * 4096 + element * 2]),
+                            K.reinterpret("uint16", K.cast(w_value * dy_value, "bfloat16")),
+                        )
+                        K.ptx.st.shared.b16(
+                            arena.ptr_to([_SMEM_DWO + dwo_stage * 4096 + element * 2]),
+                            K.reinterpret("uint16", K.cast(v_value * dy_value, "bfloat16")),
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DV_TMASTG_READY, dv_stage)
+                    _arrive_barrier(arena, _BAR_DWO_TMASTG_READY, dwo_stage)
+                    _arrive_barrier(arena, _BAR_V_DONE, raw_stage)
+                    _arrive_barrier(arena, _BAR_W_DONE, raw_stage)
+
+                    K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+
+                    _wait_barrier(
+                        arena, _BAR_DSTATE_ACC_READY, dstate_consumer.stage, dstate_consumer.phase
+                    )
+                    dstate_consumer.advance()
+                    with K.If(reverse_index + 1 < num_chunks), K.Then():
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_DONE,
+                            dstate_smem_done.stage,
+                            dstate_smem_done.phase,
+                        )
+                        _wait_barrier(
+                            arena,
+                            _BAR_DSTATE_SMEM_CG2_DONE,
+                            dstate_smem_done.stage,
+                            dstate_smem_done.phase,
+                        )
+                        dstate_smem_done.advance()
+                        dstate_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(4) as key_subtile:
+                            dstate_values = K.alloc_local((32,), "float32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                *[dstate_values[i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 32
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            dstate_words = K.alloc_local((16,), "uint32")
+                            for pair in range(16):
+                                K.assign(
+                                    dstate_words[pair],
+                                    _pack_bf16_pair(
+                                        dstate_values[pair * 2], dstate_values[pair * 2 + 1]
+                                    ),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE_INPUT
+                                    + key_subtile * 16
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[dstate_words[i] for i in range(16)],
+                            )
+                            with K.unroll(4) as half:
+                                key_base = key_subtile * 32 + half * 8
+                                K.ptx.st.shared.v4.b32(
+                                    arena.ptr_to(
+                                        [
+                                            _SMEM_DSTATE
+                                            + (
+                                                (key_base // 64) * 8192
+                                                + value_dim * 64
+                                                + _swizzle_xor_128b(value_dim, key_base % 64, 2)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    dstate_words[half * 4],
+                                    dstate_words[half * 4 + 1],
+                                    dstate_words[half * 4 + 2],
+                                    dstate_words[half * 4 + 3],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY)
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)
+
+                if use_dstate0:
+                    with K.If(K.And(num_chunks > 0, wstart == 0)), K.Then():
+                        dstate_row = tmem_alloc_row + subpartition * 32
+                        with K.unroll(4) as key_subtile:
+                            dstate_values = K.alloc_local((32,), "float32")
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                *[dstate_values[i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TMEM_DSTATE
+                                    + key_subtile * 32
+                                    + K.shift_left(dstate_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                            K.ptx.tcgen05.wait__ld.sync.aligned()
+                            for key_offset in range(32):
+                                K.ptx.st.global_.f32(
+                                    d_initial_state.ptr_to(
+                                        [dstate_index_base + key_subtile * 32 + key_offset]
+                                    ),
+                                    dstate_values[key_offset],
+                                )
+                    with K.If(num_chunks == 0), K.Then():
+                        with K.unroll(128) as key:
+                            passthrough = K.local_scalar("float32", init=K.float32(0.0))
+                            if use_dstate_in:
+                                K.ptx.ld.global_.f32(
+                                    passthrough, d_final_state.ptr_to([dstate_index_base + key])
+                                )
+                            K.ptx.st.global_.f32(
+                                d_initial_state.ptr_to([dstate_index_base + key]), passthrough
+                            )
+                _arrive_barrier(arena, _BAR_DSTATE0_ACC_STORED)
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, _BAR_SCHED_READY, sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(
+                        tile,
+                        arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
+                    )
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _arrive_barrier(arena, _BAR_TMEM_DONE)
+
+    return main
 
 
 def _normalized_config(config):
-    """Fill the accepted-branch defaults for one config entry."""
-    resolved = {key: value for key, value in config.items() if key != "label"}
-    resolved["seq_lens"] = tuple(resolved.get("seq_lens", (64,)))
-    resolved.setdefault("heads", 1)
-    heads = resolved["heads"]
-    resolved.setdefault("q_heads", heads)
-    resolved.setdefault("k_heads", heads)
-    resolved.setdefault("v_heads", heads)
-    resolved.setdefault("dtype", "bfloat16")
-    resolved.setdefault("num_sms", 148)
-    resolved.setdefault("scale", 1.0 / (_DK**0.5))
+    config = {key: value for key, value in config.items() if key != "label"}
+    config.setdefault("seq_lens", (64,))
+    config.setdefault("heads", 1)
+    config.setdefault("q_heads", config["heads"])
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("num_sms", 148)
+    config.setdefault("scale", 1.0 / (_DK**0.5))
     for key in (
         "l2norm",
         "safe_gate",
@@ -131,56 +3703,656 @@ def _normalized_config(config):
         "run_order",
         "order_generate",
     ):
-        resolved.setdefault(key, False)
-    return resolved
-
-
-def _make_prologue(config):
-    """Descriptor-building launch: 1 CTA of 1024 threads.
-
-    Builds the fourteen runtime-patched TMA descriptor arrays and, when the work
-    order is generated here rather than by the recompute pass, the longest-
-    processing-time work-item table.
-    """
-
-    @K.kernel(warps=32, arch="sm_100a", grid=1)
-    def prologue():
-        # --- kernel sketch starts here ---
-        pass
-
-    return prologue
-
-
-def _make_main(config):
-    """Persistent backward launch: one CTA per SM, 512 threads in seven roles."""
-
-    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=1)
-    def main():
-        # --- kernel sketch starts here ---
-        pass
-
-    return main
+        config.setdefault(key, False)
+    heads = int(config["heads"])
+    for name in ("q_heads", "k_heads", "v_heads"):
+        if heads % int(config[name]) != 0:
+            raise ValueError(f"{name}={config[name]} must divide heads={heads}")
+    return config
 
 
 def get_kernel(**config):
-    resolved = _normalized_config(config)
-    return [_make_prologue(resolved).func, _make_main(resolved).func]
+    config = _normalized_config(config)
+    num_sms = int(config.get("num_sms", 148))
+    prologue = _make_prologue(
+        run_order=bool(config.get("run_order", False)),
+        order_generate=bool(config.get("order_generate", False)),
+        dynamic_scheduler=bool(config.get("dynamic_scheduler", False)),
+        n_heads_out=int(config.get("n_heads_out", config.get("heads", 1))),
+    )
+    main = _make_main(
+        num_sms=num_sms,
+        beta_sigmoid=bool(config.get("beta_sigmoid", False)),
+        use_dstate_in=bool(config.get("use_dstate_in", False)),
+        use_dstate0=bool(config.get("use_dstate0", False)),
+        use_initial_state=bool(config.get("use_initial_state", False)),
+        safe_gate=bool(config.get("safe_gate", False)),
+        full_tiles=all(int(length) % _BT == 0 for length in config["seq_lens"]),
+        dynamic_scheduler=bool(config.get("dynamic_scheduler", False)),
+        l2norm=bool(config.get("l2norm", False)),
+        n_heads_out=int(config.get("n_heads_out", config.get("heads", 1))),
+        q_ratio=int(config.get("q_ratio", config["heads"] // config["q_heads"])),
+        k_ratio=int(config.get("k_ratio", config["heads"] // config["k_heads"])),
+        v_ratio=int(config.get("v_ratio", config["heads"] // config["v_heads"])),
+    )
+    return [prologue.func, main.func]
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8 != 0:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment != 0:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _make_work_items(torch, seq_lens, heads):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return torch.tensor(rows, dtype=torch.int32, device="cuda")
+
+
+def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias):
+    q_effective = q
+    k_effective = k
+    if l2norm:
+        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
+        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
+    gate_effective = gate
+    if safe_gate:
+        gate_effective = -5.0 * torch.sigmoid(
+            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
+        )
+    beta_effective = beta.sigmoid() if beta_sigmoid else beta
+    return q_effective, k_effective, gate_effective, beta_effective
+
+
+def _forward_and_checkpoints(
+    torch, q, k, v, gate, beta, w, cu_seqlens, *, scale, initial_state, checkpoint_dtype
+):
+    """FP64 chunk-entering state series for the GDN-2 recurrence.
+
+    Per-key decay first, the erase term reads the ALREADY-DECAYED state and is
+    gated per key channel, the write gate scales v, and the rank-1 update uses
+    the raw key.
+    """
+    from itertools import pairwise
+
+    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
+    batch_count = len(bounds) - 1
+    heads = gate.shape[1]
+    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
+    checkpoints = torch.zeros(
+        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
+    )
+    outputs = []
+    final_states = []
+    for batch, (begin, end) in enumerate(pairwise(bounds)):
+        if initial_state is None:
+            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
+        else:
+            state = initial_state[batch].transpose(-1, -2)
+        checkpoint_base = begin // _BT + batch
+        for local_token, token in enumerate(range(begin, end)):
+            if local_token % _BT == 0:
+                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
+                    checkpoint_dtype
+                )
+            state = gate[token].exp()[..., None] * state
+            erase = torch.einsum("hd,hdv->hv", beta[token] * k[token], state)
+            v_new = w[token] * v[token] - erase
+            state = state + torch.einsum("hd,hv->hdv", k[token], v_new)
+            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
+        final_states.append(state.transpose(-1, -2))
+    output = torch.stack(outputs)
+    return output, torch.stack(final_states), checkpoints
+
+
+def _io_dtype(torch, config):
+    return {"bfloat16": torch.bfloat16, "float16": torch.float16}[config.get("dtype", "bfloat16")]
+
+
+def _new_outputs(torch, config, total_tokens):
+    heads = config["heads"]
+    io_dtype = _io_dtype(torch, config)
+    result = {
+        "dq": torch.zeros(total_tokens, heads, _DK, dtype=io_dtype, device="cuda"),
+        "dk": torch.zeros(total_tokens, heads, _DK, dtype=io_dtype, device="cuda"),
+        "dv": torch.zeros(total_tokens, heads, _DV, dtype=io_dtype, device="cuda"),
+        "dgate": torch.zeros(total_tokens, heads, _DK, dtype=torch.float32, device="cuda"),
+        "dbeta": torch.zeros(total_tokens, heads, _DK, dtype=io_dtype, device="cuda"),
+        "dw": torch.zeros(total_tokens, heads, _DV, dtype=io_dtype, device="cuda"),
+    }
+    if config["use_dstate0"]:
+        result["d_initial_state"] = torch.zeros(
+            len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda"
+        )
+    return result
+
+
+def _prepare_work_tables(torch, config):
+    base = _make_work_items(torch, config["seq_lens"], config["heads"])
+
+    def one_side():
+        if config["run_order"]:
+            work_items = torch.empty_like(base)
+            staging = None if config["order_generate"] else base.clone()
+            sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+        else:
+            work_items = base.clone()
+            staging = None
+            sched_all = None
+        return {
+            "work_items": work_items,
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": staging,
+            "sched_all": sched_all,
+            "sched_ctr": (
+                torch.zeros(2, dtype=torch.int32, device="cuda")
+                if config["dynamic_scheduler"]
+                else None
+            ),
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _prepare_data(config, *, with_oracle):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260823)
+    total_tokens = sum(config["seq_lens"])
+    heads = config["heads"]
+    q_heads = config["q_heads"]
+    k_heads = config["k_heads"]
+    v_heads = config["v_heads"]
+    q = (0.2 * torch.randn(total_tokens, q_heads, _DK, device="cuda")).to(io_dtype)
+    k = (0.2 * torch.randn(total_tokens, k_heads, _DK, device="cuda")).to(io_dtype)
+    v = (0.2 * torch.randn(total_tokens, v_heads, _DV, device="cuda")).to(io_dtype)
+    io_dtype = _io_dtype(torch, config)
+    gate = torch.empty(total_tokens, heads, _DK, dtype=torch.float32, device="cuda").uniform_(
+        -1.5, -0.5
+    )
+    if config["safe_gate"]:
+        gate = 0.2 * torch.randn_like(gate)
+    # GDN-2 carries a per-key-channel erase gate and a per-value write gate,
+    # both in the I/O dtype: beta is [T, HO, DK] and w is [T, HO, DV].
+    beta = (0.3 * torch.randn(total_tokens, heads, _DK, device="cuda")).to(io_dtype)
+    if not config["beta_sigmoid"]:
+        beta = beta.float().sigmoid().to(io_dtype)
+    w = torch.rand(total_tokens, heads, _DV, device="cuda").to(io_dtype)
+    do = (0.2 * torch.randn(total_tokens, heads, _DV, device="cuda")).to(io_dtype)
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(config["seq_lens"]).cumsum(0).tolist()], dtype=torch.int32, device="cuda"
+    )
+    a_log = (
+        0.1 * torch.randn(heads, dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(heads, _DK, dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        0.01
+        * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float64, device="cuda")
+        if config["use_initial_state"]
+        else None
+    )
+    if initial_state is not None and with_oracle:
+        initial_state.requires_grad_(True)
+    d_final_state = (
+        0.02
+        * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        if config["use_dstate_in"]
+        else None
+    )
+
+    oracle = None
+    if with_oracle:
+        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
+        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
+        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
+        gate_ref = gate.double().detach().requires_grad_(True)
+        beta_ref = beta.double().detach().requires_grad_(True)
+        w_ref = w.double().detach().requires_grad_(True)
+        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
+            torch,
+            q_ref,
+            k_ref,
+            gate_ref,
+            beta_ref,
+            l2norm=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            beta_sigmoid=config["beta_sigmoid"],
+            a_log=a_log.double() if a_log is not None else None,
+            dt_bias=dt_bias.double() if dt_bias is not None else None,
+        )
+        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
+            torch,
+            q_effective,
+            k_effective,
+            v_ref,
+            gate_effective,
+            beta_effective,
+            w_ref,
+            cu_seqlens,
+            scale=config["scale"],
+            initial_state=initial_state,
+            checkpoint_dtype=io_dtype,
+        )
+        loss = (output_ref * do.double()).sum()
+        if d_final_state is not None:
+            loss = loss + (final_ref * d_final_state.double()).sum()
+        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref, w_ref]
+        if config["safe_gate"]:
+            grad_inputs.append(gate_effective)
+        if initial_state is not None:
+            grad_inputs.append(initial_state)
+        grads = torch.autograd.grad(loss, grad_inputs)
+        oracle = {
+            "dq": grads[0],
+            "dk": grads[1],
+            "dv": grads[2],
+            "dgate": grads[6] if config["safe_gate"] else grads[3],
+            "dbeta": grads[4],
+            "dw": grads[5],
+        }
+        if initial_state is not None:
+            oracle["d_initial_state"] = grads[-1]
+        checkpoints = checkpoints.detach()
+    else:
+        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+        checkpoints = (
+            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        ).to(torch.bfloat16)
+
+    workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+    return {
+        "config": config,
+        "q": q,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "w": w,
+        "do": do,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "checkpoints": checkpoints,
+        "d_final_state": d_final_state,
+        "tirx": _new_outputs(torch, config, total_tokens),
+        "source": _new_outputs(torch, config, total_tokens),
+        "work": _prepare_work_tables(torch, config),
+        "oracle": oracle,
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "_workspace_owners": (tirx_owner, source_owner),
+    }
 
 
 def prepare_data(**config):
-    raise NotImplementedError("gdn2 backward data construction is not implemented yet")
+    """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
+    return _prepare_data(config, with_oracle=True)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype.is_floating_point and tensor.element_size() == 2:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif tensor.dtype.is_floating_point and tensor.element_size() == 4:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return (
+        torch.tensor([int(word) for word in tensor_map.opaque], dtype=torch.uint64)
+        .view(torch.int64)
+        .to(device=tensor.device)
+    )
+
+
+def _base_tensor_maps(data):
+    config = data["config"]
+    total_tokens = data["q"].shape[0]
+
+    def headed(tensor, channels, heads, box_channels):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (box_channels, 1, _BT),
+        )
+
+    output = data["tirx"]
+    # Source index order: q0 k1 v2 gate3 do4 beta5 w6 dq7 dk8 dv9 dgate10
+    # dwo11 dbeta12 checkpoint13.  Only the FP32 gate pair uses a 32-channel box.
+    maps = [
+        headed(data["q"], _DK, config["q_heads"], 64),
+        headed(data["k"], _DK, config["k_heads"], 64),
+        headed(data["v"], _DV, config["v_heads"], 64),
+        headed(data["gate"], _DK, config["heads"], 32),
+        headed(data["do"], _DV, config["heads"], 64),
+        headed(data["beta"], _DK, config["heads"], 64),
+        headed(data["w"], _DV, config["heads"], 64),
+        headed(output["dq"], _DK, config["heads"], 64),
+        headed(output["dk"], _DK, config["heads"], 64),
+        headed(output["dv"], _DV, config["heads"], 64),
+        headed(output["dgate"], _DK, config["heads"], 32),
+        headed(output["dw"], _DV, config["heads"], 64),
+        headed(output["dbeta"], _DK, config["heads"], 64),
+    ]
+    checkpoints = data["checkpoints"]
+    maps.append(
+        _encode_tiled_map(
+            checkpoints,
+            (_DV, _DK, checkpoints.shape[0], config["heads"]),
+            (
+                checkpoints.stride(2) * checkpoints.element_size(),
+                checkpoints.stride(0) * checkpoints.element_size(),
+                checkpoints.stride(1) * checkpoints.element_size(),
+            ),
+            (64, _DK, 1, 1),
+        )
+    )
+    return maps
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data)
+    work = data["work"]["tirx"]
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_a_log = torch.zeros(config["heads"], dtype=torch.float32, device="cuda")
+    dummy_dt_bias = torch.zeros(config["heads"], _DK, dtype=torch.float32, device="cuda")
+    dummy_dstate_in = torch.zeros(1, dtype=torch.float32, device="cuda")
+    dummy_dstate_out = torch.zeros(1, dtype=torch.float32, device="cuda")
+    output = data["tirx"]
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *maps,
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["q"].view(torch.uint8).reshape(-1),
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            data["gate"].view(torch.uint8).reshape(-1),
+            data["do"].view(torch.uint8).reshape(-1),
+            output["dq"].view(torch.uint8).reshape(-1),
+            output["dk"].view(torch.uint8).reshape(-1),
+            output["dv"].view(torch.uint8).reshape(-1),
+            output["dgate"].view(torch.uint8).reshape(-1),
+            data["checkpoints"].view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["sched_all"] if work["sched_all"] is not None else dummy_i32,
+            len(config["seq_lens"]),
+            data["q"].stride(0) * data["q"].element_size(),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            data["gate"].stride(0) * data["gate"].element_size(),
+            data["do"].stride(0) * data["do"].element_size(),
+            output["dq"].stride(0) * output["dq"].element_size(),
+            output["dk"].stride(0) * output["dk"].element_size(),
+            output["dv"].stride(0) * output["dv"].element_size(),
+            output["dgate"].stride(0) * output["dgate"].element_size(),
+            data["checkpoints"].stride(0) * data["checkpoints"].element_size(),
+            _BT,
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["a_log"] if data["a_log"] is not None else dummy_a_log,
+            (
+                data["dt_bias"].reshape(-1)
+                if data["dt_bias"] is not None
+                else dummy_dt_bias.reshape(-1)
+            ),
+            data["cu_seqlens"],
+            output["dgate"].reshape(-1),
+            output.get("d_initial_state", dummy_dstate_out).reshape(-1),
+            (
+                data["d_final_state"].reshape(-1)
+                if data["d_final_state"] is not None
+                else dummy_dstate_in
+            ),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["sched_ctr"] if work["sched_ctr"] is not None else dummy_i32,
+            config["scale"],
+        )
+
+    launch._keep_alive = (
+        maps,
+        dummy_i32,
+        dummy_a_log,
+        dummy_dt_bias,
+        dummy_dstate_in,
+        dummy_dstate_out,
+    )
+    return launch
+
+
+_REFERENCE_SOURCE = None
+
+
+def _load_reference_source():
+    global _REFERENCE_SOURCE
+    if _REFERENCE_SOURCE is not None:
+        return _REFERENCE_SOURCE
+    import importlib
+    import os
+    import sys
+
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    python_root = os.path.join(root, "python")
+    if python_root not in sys.path:
+        sys.path.append(python_root)
+    import cudnn
+
+    cudnn_root = os.path.join(python_root, "cudnn")
+    if cudnn_root not in cudnn.__path__:
+        cudnn.__path__.append(cudnn_root)
+    _REFERENCE_SOURCE = importlib.import_module(
+        "cudnn.linear_attention.frost.kernel.gdn2_bprop_f16"
+    )
+    return _REFERENCE_SOURCE
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_gdn2_bwd_sm100(
+            data["q"],
+            data["k"],
+            data["v"],
+            data["gate"],
+            data["beta"],
+            data["w"],
+            data["do"],
+            data["checkpoints"],
+            output["dq"],
+            output["dk"],
+            output["dv"],
+            output["dgate"],
+            output["dbeta"],
+            output["dw"],
+            data["cu_seqlens"],
+            config["scale"],
+            use_initial_state=config["use_initial_state"],
+            d_initial_state=output.get("d_initial_state"),
+            d_final_state=data["d_final_state"],
+            use_qk_l2norm_in_kernel=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            gate_lower_bound=-5.0,
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=config["beta_sigmoid"],
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["sched_ctr"],
+            sched_all=work["sched_all"],
+            work_item_scratch=work["staging"],
+            order_in_prologue=config["run_order"],
+            tensormap_workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    return launch
+
+
+def _rms_ratio(torch, actual, expected):
+    actual = actual.detach().double()
+    expected = expected.detach().double()
+    denominator = expected.square().mean().sqrt().clamp_min(1e-12)
+    return float(((actual - expected).square().mean().sqrt() / denominator).item())
+
+
+def _validate_outputs(data, *, sources, with_oracle):
+    import math
+
+    import torch
+
+    config = data["config"]
+    limits = {
+        "dq": 0.10,
+        "dk": 0.10,
+        "dv": 0.10,
+        "dgate": 0.30,
+        "dbeta": 0.10,
+        "d_initial_state": 0.10,
+    }
+    failures = {}
+    if with_oracle:
+        if data["oracle"] is None:
+            raise AssertionError("oracle validation requested without oracle data")
+        for source_name in sources:
+            for output_name, expected in data["oracle"].items():
+                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
+                if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                    failures[f"{source_name}.{output_name}"] = ratio
+    if "tirx" in sources and "source" in sources:
+        for output_name in data["tirx"]:
+            ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
+            if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                failures[f"tirx_vs_source.{output_name}"] = ratio
+    if failures:
+        raise AssertionError(f"GDN-2 backward validation failed for {config}: {failures}")
 
 
 def run_test(**config):
-    raise NotImplementedError("gdn2 backward correctness is not implemented yet")
+    """Compare both kernels with the standalone FP64 recurrence oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _normalized_config(config)
+    data = _prepare_data(kernel_config, with_oracle=True)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
+    return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 
 def prepare_bench(**config):
-    raise NotImplementedError("gdn2 backward benchmark setup is not implemented yet")
+    """Compile the two TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _normalized_config(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then let bench_suite time the exact two-launch paths."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config, with_oracle=False)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    with_source = external_references_enabled()
+    references = None
+    if with_source:
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
 
 
 def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
-    raise NotImplementedError("gdn2 backward benchmarking is not implemented yet")
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
 
 
 __all__ = [
@@ -191,5 +4363,6 @@ __all__ = [
     "prepare_bench",
     "prepare_data",
     "run_bench",
+    "run_gpu",
     "run_test",
 ]

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -1,0 +1,192 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell BF16 Gated Delta Net v2 backward kernel.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_bwd`` entry).
+
+GDN-2 carries a per-key-channel erase gate ``beta`` and a per-value-channel
+write gate ``w``, so ``K_decay`` folds beta into the operand, ``Y`` uses
+``w * v``, and the kernel emits ``dw`` alongside a per-channel ``dbeta``.
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {"name": "cudnn_sm100_gdn2_bprop_f16", "category": "cudnn", "compute_capability": 10}
+
+CONFIGS = [
+    {"label": "basic", "seq_lens": (64,), "heads": 1},
+    {"label": "tail", "seq_lens": (17, 0, 33), "heads": 2},
+    {"label": "grouped", "seq_lens": (64,), "heads": 4, "q_heads": 4, "k_heads": 1, "v_heads": 1},
+    {"label": "l2norm", "seq_lens": (128,), "heads": 2, "l2norm": True},
+    {"label": "safe_gate", "seq_lens": (64,), "heads": 2, "safe_gate": True},
+    {"label": "beta_sigmoid", "seq_lens": (128,), "heads": 2, "beta_sigmoid": True},
+    {
+        "label": "state",
+        "seq_lens": (32, 48),
+        "heads": 2,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {"label": "dynamic", "seq_lens": (32, 48), "heads": 2, "dynamic_scheduler": True},
+    {"label": "order_scratch", "seq_lens": (32, 48), "heads": 2, "run_order": True},
+    {
+        "label": "order_generate",
+        "seq_lens": (32, 48),
+        "heads": 2,
+        "run_order": True,
+        "order_generate": True,
+    },
+]
+
+# The performance matrix spans every accepted specialization at production scale
+# plus the upstream benchmark's batch and sequence-length sweep, which runs at 64
+# heads with the fused q/k L2 norm enabled. Checkpoint construction stays outside
+# timing on both sides.
+BENCH_CONFIGS = [
+    {"label": "perf_basic_b1_s2048_h16", "seq_lens": (2048,), "heads": 16},
+    {"label": "perf_tail_b2_ragged_h16", "seq_lens": (2047, 4093), "heads": 16},
+    {
+        "label": "perf_grouped_b1_s8192_hq64_hk16_hv16",
+        "seq_lens": (8192,),
+        "heads": 64,
+        "q_heads": 64,
+        "k_heads": 16,
+        "v_heads": 16,
+    },
+    {"label": "perf_l2_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "l2norm": True},
+    {"label": "perf_l2_b4_s8192_h64", "seq_lens": (8192,) * 4, "heads": 64, "l2norm": True},
+    {"label": "perf_safe_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "safe_gate": True},
+    {"label": "perf_beta_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "beta_sigmoid": True},
+    {
+        "label": "perf_state_b1_s8192_h16",
+        "seq_lens": (8192,),
+        "heads": 16,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {
+        "label": "perf_dynamic_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "perf_order_scratch_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "run_order": True,
+    },
+    {
+        "label": "perf_order_generate_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "run_order": True,
+        "order_generate": True,
+    },
+    # Upstream benchmark sweep: sequence length at batch 4, then batch at 8192.
+    {"label": "perf_l2_b4_s2048_h64", "seq_lens": (2048,) * 4, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b4_s4096_h64", "seq_lens": (4096,) * 4, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b4_s16384_h64", "seq_lens": (16384,) * 4, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b4_s32768_h64", "seq_lens": (32768,) * 4, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b1_s8192_h64", "seq_lens": (8192,), "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b2_s8192_h64", "seq_lens": (8192,) * 2, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b8_s8192_h64", "seq_lens": (8192,) * 8, "heads": 64, "l2norm": True},
+    {"label": "perf_l2_b16_s8192_h64", "seq_lens": (8192,) * 16, "heads": 64, "l2norm": True},
+]
+
+
+# Frozen specialization, from ``gdn2_bprop_config.py``.
+_BT = 16
+_DK = 128
+_DV = 128
+
+
+def _normalized_config(config):
+    """Fill the accepted-branch defaults for one config entry."""
+    resolved = {
+        "label": config["label"],
+        "seq_lens": tuple(config["seq_lens"]),
+        "heads": config["heads"],
+        "dtype": config.get("dtype", "bfloat16"),
+        "l2norm": config.get("l2norm", False),
+        "safe_gate": config.get("safe_gate", False),
+        "beta_sigmoid": config.get("beta_sigmoid", False),
+        "use_initial_state": config.get("use_initial_state", False),
+        "use_dstate_in": config.get("use_dstate_in", False),
+        "use_dstate0": config.get("use_dstate0", False),
+        "dynamic_scheduler": config.get("dynamic_scheduler", False),
+        "run_order": config.get("run_order", False),
+        "order_generate": config.get("order_generate", False),
+    }
+    heads = resolved["heads"]
+    resolved["q_heads"] = config.get("q_heads", heads)
+    resolved["k_heads"] = config.get("k_heads", heads)
+    resolved["v_heads"] = config.get("v_heads", heads)
+    return resolved
+
+
+def _make_prologue(config):
+    """Descriptor-building launch: 1 CTA of 1024 threads.
+
+    Builds the fourteen runtime-patched TMA descriptor arrays and, when the work
+    order is generated here rather than by the recompute pass, the longest-
+    processing-time work-item table.
+    """
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue():
+        # --- kernel sketch starts here ---
+        pass
+
+    return prologue
+
+
+def _make_main(config):
+    """Persistent backward launch: one CTA per SM, 512 threads in seven roles."""
+
+    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=1)
+    def main():
+        # --- kernel sketch starts here ---
+        pass
+
+    return main
+
+
+def get_kernel(config):
+    resolved = _normalized_config(config)
+    return [_make_prologue(resolved).func, _make_main(resolved).func]
+
+
+def prepare_data(config):
+    raise NotImplementedError("gdn2 backward data construction is not implemented yet")
+
+
+def run_test(config):
+    raise NotImplementedError("gdn2 backward correctness is not implemented yet")
+
+
+def prepare_bench(config):
+    raise NotImplementedError("gdn2 backward benchmark setup is not implemented yet")
+
+
+def run_bench(config):
+    raise NotImplementedError("gdn2 backward benchmarking is not implemented yet")
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_test",
+]

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -3264,7 +3264,7 @@ def _make_main(
                             K.ptx.tcgen05.wait__ld.sync.aligned()
                             with K.unroll(2) as half:
                                 key_base = key_subtile * 16 + half * 8
-                                K.ptx.st.shared.v4.b32(
+                                K.ptx.st.shared.v2.b64(
                                     arena.ptr_to(
                                         [
                                             _SMEM_DSTATE
@@ -3276,10 +3276,10 @@ def _make_main(
                                             * 2
                                         ]
                                     ),
-                                    seed_words[half * 4],
-                                    seed_words[half * 4 + 1],
-                                    seed_words[half * 4 + 2],
-                                    seed_words[half * 4 + 3],
+                                    _pack_u32_pair(seed_words[half * 4], seed_words[half * 4 + 1]),
+                                    _pack_u32_pair(
+                                        seed_words[half * 4 + 2], seed_words[half * 4 + 3]
+                                    ),
                                 )
                         K.ptx.fence.proxy.async_.shared__cta()
                         _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -109,7 +109,10 @@ _TENSOR_MAP_BYTES = 128
 _TENSOR_MAP_WORDS = 16
 _TENSOR_MAP_ARRAYS = 14
 _MAIN_SMEM_BYTES = 225_280
-_TRY_WAIT_TICKS = 10_000_000
+# Suspend-time hint on every mbarrier try_wait.  The source spins with a hint of
+# one tick (SASS `NANOSLEEP.SYNCS 0x1` at all of its wait sites); a large hint
+# makes ptxas sleep past the release and pays that latency at every handshake.
+_TRY_WAIT_TICKS = 1
 _TMA_G2S_3D = (
     "cp.async.bulk.tensor.3d.shared::cta.global.tile"
     ".mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint"
@@ -320,10 +323,14 @@ _TMEM_K_RAW = 480
 
 
 def _elected():
-    lane = K.local_scalar("uint32")
-    pred = K.local_scalar("uint32")
-    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
-    return pred == K.uint32(1)
+    """Single-issuing-lane predicate, taken from the hardware election.
+
+    Comparing an elect_sync result against one hands ptxas a per-lane condition
+    it cannot prove selects a single lane, so it rebuilds the election inside a
+    WARPSYNC.COLLECTIVE/ENDCOLLECTIVE region with its own reconvergence at every
+    guard.  The hardware election yields the uniform predicate directly.
+    """
+    return K.cuda.elect_sync()
 
 
 def _copy_tensormap(src_map, dst):
@@ -368,14 +375,31 @@ def _wait_barrier(arena, byte_offset, stage, phase):
         )
 
 
-def _arrive_barrier(arena, byte_offset, stage=0):
-    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage), K.uint32(1))
+def _arrive_barrier(arena, byte_offset, stage=0, pred=None):
+    """Arrive on one mbarrier, optionally as a predicated single instruction.
+
+    A lane-guarded arrival written as a branch costs an elect collective region
+    and a reconvergence pair around one instruction; the reference carries no
+    such regions at all, so a single-instruction elected region is expressed as
+    an `@p` guard instead.
+    """
+    if pred is None:
+        K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage), K.uint32(1))
+    else:
+        K.ptx.mbarrier.arrive.shared.b64(
+            _barrier_ptr(arena, byte_offset, stage), K.uint32(1), pred=pred
+        )
 
 
-def _expect_tx(arena, byte_offset, stage, nbytes):
-    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
-        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
-    )
+def _expect_tx(arena, byte_offset, stage, nbytes, pred=None):
+    if pred is None:
+        K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+            _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+        )
+    else:
+        K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+            _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes), pred=pred
+        )
 
 
 def _tcgen_commit(arena, byte_offset, stage=0):
@@ -1043,8 +1067,9 @@ def _make_main(
                         next_tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_producer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_READY, sched_producer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_READY, sched_producer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_producer.advance()
 
                 head_q = head if q_ratio == 1 else head // q_ratio
@@ -1077,128 +1102,143 @@ def _make_main(
                     token = chunk * _BT
                     raw_stage = raw.stage
                     raw_phase = raw.phase
-                    with K.If(_elected()), K.Then():
-                        _wait_barrier(arena, _BAR_Q_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_Q_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_Q + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_q,
-                                K.int32(d_coord),
-                                K.cast(head_q, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_Q_READY, raw_stage),
-                                K.uint64(0),
-                            )
-                        _wait_barrier(arena, _BAR_K_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_K_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_K + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_k,
-                                K.int32(d_coord),
-                                K.cast(head_k, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_K_READY, raw_stage),
-                                K.uint64(0),
-                            )
-                        _wait_barrier(arena, _BAR_GATE_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_GATE_READY, raw_stage, 8192)
-                        for d_coord in (0, 32, 64, 96):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_GATE + K.cast(raw_stage, "int32") * 8192 + d_coord * 64]
-                                ),
-                                desc_gate,
-                                K.int32(d_coord),
+                    # One election owns this warp's whole per-chunk transfer group.  The
+                    # waits need no lane guard -- every lane in the warp waits on the same
+                    # phase -- while the expect_tx arrivals and the TMA issues must stay
+                    # single-lane, so they carry the predicate on the instruction instead of
+                    # sitting inside a divergent region and its reconvergence.
+                    tma_leader = K.cuda.elect_sync()
+                    _wait_barrier(arena, _BAR_Q_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_Q_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_Q + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_q,
+                            K.int32(d_coord),
+                            K.cast(head_q, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_Q_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    _wait_barrier(arena, _BAR_K_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_K_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_K + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_k,
+                            K.int32(d_coord),
+                            K.cast(head_k, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_K_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    _wait_barrier(arena, _BAR_GATE_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_GATE_READY, raw_stage, 8192, pred=tma_leader)
+                    for d_coord in (0, 32, 64, 96):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_GATE + K.cast(raw_stage, "int32") * 8192 + d_coord * 64]
+                            ),
+                            desc_gate,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_GATE_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    _wait_barrier(arena, _BAR_BETA_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_BETA_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_BETA + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_beta,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_BETA_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    # Entering state, issued between the erase gate and dO,
+                    # matching the source's load order.
+                    with K.If(chunk >= (0 if use_initial_state else 1)), K.Then():
+                        _wait_barrier(
+                            arena, _BAR_STATE_CG0_DONE, state_cursor.stage, state_cursor.phase
+                        )
+                        _wait_barrier(
+                            arena, _BAR_STATE_DONE, state_cursor.stage, state_cursor.phase
+                        )
+                        _expect_tx(
+                            arena, _BAR_STATE_READY, state_cursor.stage, 32768, pred=tma_leader
+                        )
+                        for value_coord in (0, 64):
+                            K.ptx[_TMA_G2S_4D](
+                                arena.ptr_to([_SMEM_STATE + value_coord * 256]),
+                                desc_state,
+                                K.int32(value_coord),
+                                K.int32(0),
+                                K.cast(chunk, "int32"),
                                 K.cast(head, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_GATE_READY, raw_stage),
+                                _barrier_ptr(arena, _BAR_STATE_READY, state_cursor.stage),
                                 K.uint64(0),
+                                pred=tma_leader,
                             )
-                        _wait_barrier(arena, _BAR_BETA_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_BETA_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_BETA + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_beta,
-                                K.int32(d_coord),
-                                K.cast(head, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_BETA_READY, raw_stage),
-                                K.uint64(0),
-                            )
-                        # Entering state, issued between the erase gate and dO,
-                        # matching the source's load order.
-                        with K.If(chunk >= (0 if use_initial_state else 1)), K.Then():
-                            _wait_barrier(
-                                arena, _BAR_STATE_CG0_DONE, state_cursor.stage, state_cursor.phase
-                            )
-                            _wait_barrier(
-                                arena, _BAR_STATE_DONE, state_cursor.stage, state_cursor.phase
-                            )
-                            _expect_tx(arena, _BAR_STATE_READY, state_cursor.stage, 32768)
-                            for value_coord in (0, 64):
-                                K.ptx[_TMA_G2S_4D](
-                                    arena.ptr_to([_SMEM_STATE + value_coord * 256]),
-                                    desc_state,
-                                    K.int32(value_coord),
-                                    K.int32(0),
-                                    K.cast(chunk, "int32"),
-                                    K.cast(head, "int32"),
-                                    _barrier_ptr(arena, _BAR_STATE_READY, state_cursor.stage),
-                                    K.uint64(0),
-                                )
-                            state_cursor.advance()
-                        _wait_barrier(arena, _BAR_DO_DONE, raw_stage, raw_phase)
-                        _wait_barrier(arena, _BAR_DO_MMA_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_DO_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_DO + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_do,
-                                K.int32(d_coord),
-                                K.cast(head, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_DO_READY, raw_stage),
-                                K.uint64(0),
-                            )
-                        _wait_barrier(arena, _BAR_V_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_V_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_V + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_v,
-                                K.int32(d_coord),
-                                K.cast(head_v, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_V_READY, raw_stage),
-                                K.uint64(0),
-                            )
-                        _wait_barrier(arena, _BAR_W_DONE, raw_stage, raw_phase)
-                        _expect_tx(arena, _BAR_W_READY, raw_stage, 4096)
-                        for d_coord in (0, 64):
-                            K.ptx[_TMA_G2S_3D](
-                                arena.ptr_to(
-                                    [_SMEM_W + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
-                                ),
-                                desc_w,
-                                K.int32(d_coord),
-                                K.cast(head, "int32"),
-                                K.cast(token, "int32"),
-                                _barrier_ptr(arena, _BAR_W_READY, raw_stage),
-                                K.uint64(0),
-                            )
+                        state_cursor.advance()
+                    _wait_barrier(arena, _BAR_DO_DONE, raw_stage, raw_phase)
+                    _wait_barrier(arena, _BAR_DO_MMA_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_DO_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_DO + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_do,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_DO_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    _wait_barrier(arena, _BAR_V_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_V_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_V + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_v,
+                            K.int32(d_coord),
+                            K.cast(head_v, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_V_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
+                    _wait_barrier(arena, _BAR_W_DONE, raw_stage, raw_phase)
+                    _expect_tx(arena, _BAR_W_READY, raw_stage, 4096, pred=tma_leader)
+                    for d_coord in (0, 64):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to(
+                                [_SMEM_W + K.cast(raw_stage, "int32") * 4096 + d_coord * 32]
+                            ),
+                            desc_w,
+                            K.int32(d_coord),
+                            K.cast(head, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_W_READY, raw_stage),
+                            K.uint64(0),
+                            pred=tma_leader,
+                        )
 
                     raw.advance()
                 K.assign(tile, next_tile)
@@ -1423,8 +1463,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)
@@ -1789,8 +1830,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)
@@ -2095,8 +2137,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)
@@ -2235,43 +2278,47 @@ def _make_main(
                     k_words = K.alloc_local((8,), "uint32")
                     raw_segment = channel // 64
                     raw_channel = channel % 64
+                    # Issue the whole raw Q/K fragment before packing any of it:
+                    # packed a pair at a time, each pack sits one instruction
+                    # behind its own two loads.
+                    q_lo_stage = K.alloc_local((8,), "uint16")
+                    q_hi_stage = K.alloc_local((8,), "uint16")
+                    k_lo_stage = K.alloc_local((8,), "uint16")
+                    k_hi_stage = K.alloc_local((8,), "uint16")
                     with K.unroll(8) as pair:
-                        q_lo_bits = K.local_scalar("uint16")
-                        q_hi_bits = K.local_scalar("uint16")
-                        k_lo_bits = K.local_scalar("uint16")
-                        k_hi_bits = K.local_scalar("uint16")
                         K.ptx.ld.shared.b16(
-                            q_lo_bits,
+                            q_lo_stage[pair],
                             arena.ptr_to([_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2, channel)]),
                         )
                         K.ptx.ld.shared.b16(
-                            q_hi_bits,
+                            q_hi_stage[pair],
                             arena.ptr_to(
                                 [_raw_bf16_byte(_SMEM_Q, raw_stage, pair * 2 + 1, channel)]
                             ),
                         )
                         K.ptx.ld.shared.b16(
-                            k_lo_bits,
+                            k_lo_stage[pair],
                             arena.ptr_to([_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2, channel)]),
                         )
                         K.ptx.ld.shared.b16(
-                            k_hi_bits,
+                            k_hi_stage[pair],
                             arena.ptr_to(
                                 [_raw_bf16_byte(_SMEM_K, raw_stage, pair * 2 + 1, channel)]
                             ),
                         )
+                    with K.unroll(8) as pair:
                         K.assign(
                             q_words[pair],
                             K.bitwise_or(
-                                K.cast(q_lo_bits, "uint32"),
-                                K.shift_left(K.cast(q_hi_bits, "uint32"), K.uint32(16)),
+                                K.cast(q_lo_stage[pair], "uint32"),
+                                K.shift_left(K.cast(q_hi_stage[pair], "uint32"), K.uint32(16)),
                             ),
                         )
                         K.assign(
                             k_words[pair],
                             K.bitwise_or(
-                                K.cast(k_lo_bits, "uint32"),
-                                K.shift_left(K.cast(k_hi_bits, "uint32"), K.uint32(16)),
+                                K.cast(k_lo_stage[pair], "uint32"),
+                                K.shift_left(K.cast(k_hi_stage[pair], "uint32"), K.uint32(16)),
                             ),
                         )
                     q_tmem = (
@@ -2596,8 +2643,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)
@@ -2745,6 +2793,16 @@ def _make_main(
                     for token in range(16):
                         K.assign(dk_values[token], K.float32(0.0))
 
+                    # One reciprocal per token, shared by the restore path and the
+                    # inverse drain below.  has_dstate is a runtime predicate, so
+                    # its two consumers sit in different basic blocks and the
+                    # compiler cannot common the divides itself; issuing them as
+                    # one pass also keeps each MUFU off its consumer's critical
+                    # path.
+                    rcp_gate = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as token:
+                        K.assign(rcp_gate[token], _rcp_approx(gate_decay[token]))
+
                     with K.If(has_dstate), K.Then():
                         _wait_barrier(
                             arena,
@@ -2768,10 +2826,7 @@ def _make_main(
                         )
                         K.ptx.tcgen05.wait__ld.sync.aligned()
                         with K.unroll(16) as token:
-                            K.assign(
-                                dk_values[token],
-                                gate_last * _rcp_approx(gate_decay[token]) * restore[token],
-                            )
+                            K.assign(dk_values[token], gate_last * rcp_gate[token] * restore[token])
                             k_lo = K.local_scalar("float32")
                             k_hi = K.local_scalar("float32")
                             _unpack_bf16_pair(kraw[token // 2], k_lo, k_hi)
@@ -2823,8 +2878,7 @@ def _make_main(
                     )
                     with K.unroll(16) as token:
                         K.assign(
-                            dk_values[token],
-                            dk_values[token] + inverse[token] * _rcp_approx(gate_decay[token]),
+                            dk_values[token], dk_values[token] + inverse[token] * rcp_gate[token]
                         )
 
                     _wait_barrier(
@@ -2856,20 +2910,32 @@ def _make_main(
                     K.ptx.tcgen05.wait__ld.sync.aligned()
                     db_values = K.alloc_local((16,), "float32")
                     beta_self = K.alloc_local((16,), "float32")
+                    # Issue the whole erase-gate fragment before converting any of
+                    # it: one scalar load per token feeding its own cvt leaves the
+                    # convert one instruction behind the load, and the resulting
+                    # short-scoreboard stalls are the drain group's largest.
+                    beta_bits_stage = K.alloc_local((16,), "uint16")
                     with K.unroll(16) as token:
-                        beta_bits = K.local_scalar("uint16")
                         K.ptx.ld.shared.b16(
-                            beta_bits,
+                            beta_bits_stage[token],
                             arena.ptr_to([_raw_bf16_byte(_SMEM_BETA, raw_stage, token, channel)]),
                         )
-                        beta_value = K.local_scalar("float32")
-                        K.ptx.cvt.f32.bf16(beta_value, beta_bits)
-                        if beta_sigmoid:
-                            K.assign(beta_value, _tanh_approx(beta_value * 0.5) * 0.5 + 0.5)
-                            # The source rounds sigmoid(beta) through the io dtype
-                            # before using it, and the gradient depends on that.
-                            K.assign(beta_value, K.cast(K.cast(beta_value, "bfloat16"), "float32"))
-                        K.assign(beta_self[token], beta_value)
+                    with K.unroll(16) as token:
+                        K.ptx.cvt.f32.bf16(beta_self[token], beta_bits_stage[token])
+                    if beta_sigmoid:
+                        with K.unroll(16) as token:
+                            K.assign(
+                                beta_self[token], _tanh_approx(beta_self[token] * 0.5) * 0.5 + 0.5
+                            )
+                        # The source rounds sigmoid(beta) through the io dtype
+                        # before using it, and the gradient depends on that.
+                        with K.unroll(16) as token:
+                            K.assign(
+                                beta_self[token],
+                                K.cast(K.cast(beta_self[token], "bfloat16"), "float32"),
+                            )
+                    with K.unroll(16) as token:
+                        beta_value = beta_self[token]
 
                         kd_lo = K.local_scalar("float32")
                         kd_hi = K.local_scalar("float32")
@@ -2903,6 +2969,32 @@ def _make_main(
                         K.cast(kraw_col + K.shift_left(tmem_row, K.int32(16)), "uint32"),
                     )
                     K.ptx.tcgen05.wait__ld.sync.aligned()
+                    # Same staging as the decay drain above: the finalize is this
+                    # group's second read of the erase gate, and it has the same
+                    # load-to-use distance of one.
+                    reload_bits_stage = K.alloc_local((16,), "uint16")
+                    beta_reload_stage = K.alloc_local((16,), "float32")
+                    with K.unroll(16) as token:
+                        K.ptx.ld.shared.b16(
+                            reload_bits_stage[token],
+                            arena.ptr_to([_raw_bf16_byte(_SMEM_BETA, raw_stage, token, channel)]),
+                        )
+                    with K.unroll(16) as token:
+                        K.ptx.cvt.f32.bf16(beta_reload_stage[token], reload_bits_stage[token])
+                    if beta_sigmoid:
+                        # Third of the three sigmoid sites: the operand build, the
+                        # decay drain, and here.  Each reloads and rounds
+                        # independently, which is what the reference does.
+                        with K.unroll(16) as token:
+                            K.assign(
+                                beta_reload_stage[token],
+                                _tanh_approx(beta_reload_stage[token] * 0.5) * 0.5 + 0.5,
+                            )
+                        with K.unroll(16) as token:
+                            K.assign(
+                                beta_reload_stage[token],
+                                K.cast(K.cast(beta_reload_stage[token], "bfloat16"), "float32"),
+                            )
                     with K.unroll(16) as token:
                         q_lo = K.local_scalar("float32")
                         q_hi = K.local_scalar("float32")
@@ -2926,21 +3018,7 @@ def _make_main(
                             )
                             K.assign(q_value, q_value * q_norm)
                             K.assign(k_value, k_value * k_norm)
-                        reload_bits = K.local_scalar("uint16")
-                        K.ptx.ld.shared.b16(
-                            reload_bits,
-                            arena.ptr_to([_raw_bf16_byte(_SMEM_BETA, raw_stage, token, channel)]),
-                        )
-                        beta_reload = K.local_scalar("float32")
-                        K.ptx.cvt.f32.bf16(beta_reload, reload_bits)
-                        if beta_sigmoid:
-                            # Third of the three sigmoid sites: the operand build,
-                            # the decay drain, and here.  Each reloads and rounds
-                            # independently, which is what the reference does.
-                            K.assign(beta_reload, _tanh_approx(beta_reload * 0.5) * 0.5 + 0.5)
-                            K.assign(
-                                beta_reload, K.cast(K.cast(beta_reload, "bfloat16"), "float32")
-                            )
+                        beta_reload = beta_reload_stage[token]
                         K.assign(
                             dgate_values[token],
                             q_value * dq_values[token]
@@ -3101,14 +3179,31 @@ def _make_main(
                     _arrive_barrier(arena, _BAR_QK_RAW_DONE, qk_stage)
                     _wait_barrier(arena, _BAR_DQ_TMASTG_DONE, 0, (serial + 1) & 1)
                     _wait_barrier(arena, _BAR_DK_TMASTG_DONE, 0, (serial + 1) & 1)
+                    # Round the whole fragment before storing any of it, and keep
+                    # each destination's stores together: interleaving a convert
+                    # with its own store puts every store one instruction behind
+                    # the rounding it waits on.
+                    dq_bits = K.alloc_local((16,), "uint16")
+                    dk_bits = K.alloc_local((16,), "uint16")
+                    with K.unroll(16) as token:
+                        K.assign(
+                            dq_bits[token],
+                            K.reinterpret("uint16", K.cast(dq_values[token], "bfloat16")),
+                        )
+                    with K.unroll(16) as token:
+                        K.assign(
+                            dk_bits[token],
+                            K.reinterpret("uint16", K.cast(dk_values[token], "bfloat16")),
+                        )
                     with K.unroll(16) as token:
                         K.ptx.st.shared.b16(
                             arena.ptr_to([_raw_bf16_byte(_SMEM_DQ, 0, token, channel)]),
-                            K.reinterpret("uint16", K.cast(dq_values[token], "bfloat16")),
+                            dq_bits[token],
                         )
+                    with K.unroll(16) as token:
                         K.ptx.st.shared.b16(
                             arena.ptr_to([_raw_bf16_byte(_SMEM_DK, 0, token, channel)]),
-                            K.reinterpret("uint16", K.cast(dk_values[token], "bfloat16")),
+                            dk_bits[token],
                         )
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_DQ_TMASTG_READY)
@@ -3124,14 +3219,21 @@ def _make_main(
                         K.assign(dgate_values[token], suffix)
                     _wait_barrier(arena, _BAR_DGATE_TMASTG_DONE, 0, (serial + 1) & 1)
                     _wait_barrier(arena, _BAR_DB_TMASTG_DONE, 0, (serial + 1) & 1)
+                    db_bits = K.alloc_local((16,), "uint16")
+                    with K.unroll(16) as token:
+                        K.assign(
+                            db_bits[token],
+                            K.reinterpret("uint16", K.cast(db_values[token], "bfloat16")),
+                        )
                     with K.unroll(16) as token:
                         K.ptx.st.shared.f32(
                             arena.ptr_to([_raw_f32_byte(_SMEM_DGATE, 0, token, channel)]),
                             dgate_values[token],
                         )
+                    with K.unroll(16) as token:
                         K.ptx.st.shared.b16(
                             arena.ptr_to([_raw_bf16_byte(_SMEM_DB, 0, token, channel)]),
-                            K.reinterpret("uint16", K.cast(db_values[token], "bfloat16")),
+                            db_bits[token],
                         )
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_DGATE_TMASTG_READY)
@@ -3146,8 +3248,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)
@@ -3602,33 +3705,66 @@ def _make_main(
 
                     value_segment = group_thread // 64
                     value_column = group_thread - value_segment * 64
-                    for token in range(16):
-                        element = (
-                            value_segment * 1024
-                            + token * 64
-                            + _swizzle_xor_128b(token, value_column, 2)
-                        )
-                        dy_bits = K.local_scalar("uint16")
-                        w_bits = K.local_scalar("uint16")
-                        v_bits = K.local_scalar("uint16")
-                        K.ptx.ld.shared.b16(dy_bits, arena.ptr_to([_SMEM_DY + element * 2]))
-                        K.ptx.ld.shared.b16(
-                            w_bits, arena.ptr_to([_SMEM_W + raw_stage * 4096 + element * 2])
-                        )
-                        K.ptx.ld.shared.b16(
-                            v_bits, arena.ptr_to([_SMEM_V + raw_stage * 4096 + element * 2])
-                        )
-                        dy_value = K.cast(K.reinterpret("bfloat16", dy_bits), "float32")
-                        w_value = K.cast(K.reinterpret("bfloat16", w_bits), "float32")
-                        v_value = K.cast(K.reinterpret("bfloat16", v_bits), "float32")
-                        K.ptx.st.shared.b16(
-                            arena.ptr_to([_SMEM_DV + dv_stage * 4096 + element * 2]),
-                            K.reinterpret("uint16", K.cast(w_value * dy_value, "bfloat16")),
-                        )
-                        K.ptx.st.shared.b16(
-                            arena.ptr_to([_SMEM_DWO + dwo_stage * 4096 + element * 2]),
-                            K.reinterpret("uint16", K.cast(v_value * dy_value, "bfloat16")),
-                        )
+                    # Issued a token at a time, each of the three reads is consumed
+                    # one instruction later and the converts stall on shared memory.
+                    # Stage the reads a half-fragment at a time instead: eight
+                    # tokens keeps 24 loads in flight without stretching the live
+                    # range far enough to spill this group's 184-register budget.
+                    elements = [
+                        value_segment * 1024
+                        + token * 64
+                        + _swizzle_xor_128b(token, value_column, 2)
+                        for token in range(16)
+                    ]
+                    for half in range(1):
+                        span = range(16)
+                        dy_bits = K.alloc_local((16,), "uint16")
+                        w_bits = K.alloc_local((16,), "uint16")
+                        v_bits = K.alloc_local((16,), "uint16")
+                        for slot, token in enumerate(span):
+                            K.ptx.ld.shared.b16(
+                                dy_bits[slot], arena.ptr_to([_SMEM_DY + elements[token] * 2])
+                            )
+                            K.ptx.ld.shared.b16(
+                                w_bits[slot],
+                                arena.ptr_to([_SMEM_W + raw_stage * 4096 + elements[token] * 2]),
+                            )
+                            K.ptx.ld.shared.b16(
+                                v_bits[slot],
+                                arena.ptr_to([_SMEM_V + raw_stage * 4096 + elements[token] * 2]),
+                            )
+                        dy_value = K.alloc_local((16,), "float32")
+                        w_value = K.alloc_local((16,), "float32")
+                        v_value = K.alloc_local((16,), "float32")
+                        for slot in range(16):
+                            K.assign(
+                                dy_value[slot],
+                                K.cast(K.reinterpret("bfloat16", dy_bits[slot]), "float32"),
+                            )
+                        for slot in range(16):
+                            K.assign(
+                                w_value[slot],
+                                K.cast(K.reinterpret("bfloat16", w_bits[slot]), "float32"),
+                            )
+                        for slot in range(16):
+                            K.assign(
+                                v_value[slot],
+                                K.cast(K.reinterpret("bfloat16", v_bits[slot]), "float32"),
+                            )
+                        for slot, token in enumerate(span):
+                            K.ptx.st.shared.b16(
+                                arena.ptr_to([_SMEM_DV + dv_stage * 4096 + elements[token] * 2]),
+                                K.reinterpret(
+                                    "uint16", K.cast(w_value[slot] * dy_value[slot], "bfloat16")
+                                ),
+                            )
+                        for slot, token in enumerate(span):
+                            K.ptx.st.shared.b16(
+                                arena.ptr_to([_SMEM_DWO + dwo_stage * 4096 + elements[token] * 2]),
+                                K.reinterpret(
+                                    "uint16", K.cast(v_value[slot] * dy_value[slot], "bfloat16")
+                                ),
+                            )
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_DV_TMASTG_READY, dv_stage)
                     _arrive_barrier(arena, _BAR_DWO_TMASTG_READY, dwo_stage)
@@ -3767,8 +3903,9 @@ def _make_main(
                         tile,
                         arena.ptr_to([_SMEM_SCHED + K.cast(sched_consumer.stage, "int32") * 4]),
                     )
-                    with K.If(_elected()), K.Then():
-                        _arrive_barrier(arena, _BAR_SCHED_DONE, sched_consumer.stage)
+                    _arrive_barrier(
+                        arena, _BAR_SCHED_DONE, sched_consumer.stage, pred=K.cuda.elect_sync()
+                    )
                     sched_consumer.advance()
                 else:
                     K.assign(tile, tile + num_sms)


### PR DESCRIPTION
Ports cuDNN Frontend's GDN-2 backward pass
(`python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py`, commit
`aded9909`) to TIRx. Scope is the two-launch replay path: the backward prologue,
which builds fourteen runtime-patched TMA descriptor arrays and optionally the
LPT work order, and the persistent backward main kernel.

The main kernel runs 512 threads in sixteen warps across seven specialized
roles: a gate warpgroup that runs the log2-domain prefix scan and materializes
the four decay operands, a value warpgroup, a gradient-drain warpgroup, and
single warps for the register-resident MMA chains, the tcgen05 issue queue, the
TMA loads with a work-stealing ticket scheduler, and the store epilogue.

## Structure

Shared memory is one flat byte pool of 225,280 B against a 227 KB cap, with
every coordinate, swizzle, stage and alias expressed as scalar arithmetic on a
byte offset; the matrix descriptors are assembled from hardware immediates, so
the kernel carries no layout objects. Declaration order is semantic — a fill
buffer places the generic-client tiles at the 128 KB midpoint, and the
tcgen05-descriptor operands sit below it. Tensor memory ends exactly at column
512 and carries two load-bearing aliases whose safety rests on the in-order
issue queue and the barrier chain rather than on offsets alone.

Synchronization is a frozen table of seventy mbarrier objects over 123 physical
slots, plus five named barriers. Register budgets are 128/184/136/64 across the
roles, an exact partition of the file: the four decrementing warps release 8192
registers and the two incrementing warpgroups acquire exactly that.

Against the sibling KDA backward the algebra differs in more than naming: the
per-key erase gate arrives as its own `[BT, DK]` tile and folds into `K_decay`
only, a per-value write gate produces `Y = W·V − Sᵀ K_decay`, `dW_out = V·dY` is
a new output written by a scalar pass that keeps V and W live past the point KDA
releases them, dBeta becomes per-channel, and dGate gains the corresponding
term.

## Correctness

Ten configurations pass against a differentiable fp64 recurrence oracle: the
plain path, a ragged batch containing a zero-length sequence, grouped heads,
the fused q/k L2 norm, the safe-gate and beta-sigmoid variants, initial state
with both state gradients, the dynamic scheduler, and both prologue ordering
modes. On all six gradients the port is bit-identical to the upstream kernel on
identical inputs, so the oracle is a check on both rather than the arbiter.

One tolerance is deliberately loose. On multi-sequence shapes dBeta differs
from the oracle by about 8.7e-5 while the port and the upstream kernel agree to
the bit, so the tolerance covers a property of the reference algebra, not a
discrepancy introduced here.

## Performance

Complete nineteen-shape matrix, reference time over TIRx time. Eleven rows cover
the specializations at production scale; eight mirror the upstream benchmark's
own batch and sequence-length sweep at 64 heads with the fused norm on.

| group | shapes | ratio |
| --- | --- | --- |
| specializations | 11 | 0.995 - 1.020 |
| upstream sweep | 8 | 1.009 - 1.013 |

19/19 above the gate, minimum 0.9952. Reproduced across three complete matrices,
per-run minima 0.9930, 0.9959 and 0.9952.

The port reached parity by lengthening the instruction stream, not shortening
it. Paired profiling showed it already executing fewer instructions than the
reference — 27.9M against 29.5M static SASS — while taking 2.5% more time, so
the deficit was exposed latency; five separate attempts to remove instructions
were neutral or regressions, including one that removed genuinely redundant
converts and selects and cost 0.0125 on a required shape.

What paid was restructuring per-token chains by dependency level: issue a whole
fragment of shared reads, then convert them, then compute, so a consumer is no
longer one instruction behind its own load. The staged width is itself a
parameter and wanted the complete sixteen-token fragment — narrowing it to four
regressed every required shape.

The last change was the largest. The TMA warp's per-chunk block held ten barrier
waits, eight expect-tx arrivals and eight tensor-copy issues inside a single
elected-lane region, which is a divergent region entered every chunk; the kernel
carried `WARPSYNC.COLLECTIVE`/`ENDCOLLECTIVE`/`BSSY`/`BSYNC` at 8/8/20/20
against the reference's zero. The waits need no lane guard at all, since every
lane spins on the same barrier and phase, so they now run warp-wide while the
arrivals and issues carry the guard as an instruction predicate. That moved the
tightest shape by +0.0116 and took the matrix from one failing shape to none.

Five codegen-tuning database entries are updated with these results, including
the boundary cases: predicating regions that each wrapped a single arrival was
worth nothing, matching the reference's one-tick mbarrier suspend hint against
the port's ten million produced no timing win on any of three parents, and two
spellings of the lane election turned out to lower to identical machine code.
