### PR TITLE
feat(kernel): port cuDNN CSA compressor forward

### DIFF
--- a/.agents/sketch/cudnn_sm100_csa_compressor_fwd.md
+++ b/.agents/sketch/cudnn_sm100_csa_compressor_fwd.md
@@ -1,0 +1,254 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5),
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 CSA compressor forward: coarse execution sketch
+
+This is a non-executable execution sketch for
+[`tirx_kernels/cudnn/csa/compressor_fwd_sm100.py`](../../tirx_kernels/cudnn/csa/compressor_fwd_sm100.py).
+It freezes the source kernel's one-row/one-column-group CTA mapping, scalar or
+paired lane ownership, APE hoist, ragged segment scan, overlap-window branches,
+serial FP32 reduction order, and BF16 traffic. After the initial sketch review,
+the linked module becomes the executable source of truth and this file remains
+frozen.
+
+The source is
+`python/cudnn/csa/compressor/compressor_sm100.py::_compressor_fwd_kernel` at
+commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`. Ratio 4 with
+`coff in {1,2}` and `d in {65,128,512}` is in scope. The separate ratio-128
+kernel, backward kernel, and head dimensions outside this validated dispatch
+domain are out of scope.
+
+## Line-info evidence
+
+The writer exports are under
+`.porting/compressor_fwd_sm100/writer_source_export/`; every artifact targets
+`sm_100a`, declares `.reqntid 64,1,1`, and carries usable `.loc` directives into
+the source file.
+
+| specialization | vec | PTX SHA256 | lines | `.loc` | branch evidence |
+| --- | ---: | --- | ---: | ---: | --- |
+| d65_c1 | 1 | `ad4a5aef93ca7bed6a2883d648965ef960310dc1bd39a3310c20e2e9e9b90b46` | 480 | 125 | scalar, own-block window |
+| d65_c2 | 1 | `7ff03b62976ef50640ba8bbd658df02aa0f15036cfc3d4d8984102793aeb9fdd` | 662 | 186 | scalar, overlap window |
+| d128_c1 | 2 | `f5a8b961321df26d554d5b47693bf3f8368451bc1d879cbb862075e88f169510` | 613 | 168 | paired, own-block window |
+| d128_c2 | 2 | `19e9c7b32a4500d0c8222334626a678eb2ef4b021c92e8bcca6202bfb4005b28` | 1077 | 335 | paired, overlap window |
+| d512_c1 | 2 | `7587c4f17344400da14a3cd7c58564027005d9bb102ca9f33ffef16c27adc81c` | 613 | 168 | paired, wider grid.y |
+| d512_c2 | 2 | `991dd7b1c4030931986ee098b0a17bfe09b675a2e315685800487ae9b18a958e` | 1089 | 338 | paired, wider grid.y |
+
+Instruction counts below use instruction lines minus predicated lines.
+
+## Execution roles at a glance
+
+| role | threads | owned work | communication |
+| --- | --- | --- | --- |
+| compressor lane | all 64 CTA threads | one output row `bb=blockIdx.x`, and `vec` adjacent head columns selected by `blockIdx.y*64+threadIdx.x` | none; every output element is thread-local |
+
+There is no producer/consumer split, shared memory, TMEM, barrier, pipe, stage,
+phase, warp exchange, or CTA exchange. Both warps execute the same independent
+lane program. A thread whose column is outside `d/vec` exits; a CTA whose row is
+outside `nb_total` exits.
+
+## Primitive vocabulary
+
+- `g2r_ape(dst, address, vec)`: copy one or two FP32 APE values from GMEM to registers.
+  `# instruction_selection: ld.global.b32 or ld.global.v2.b32; extent: one (k,lane-group) slice`
+- `g2r_previous_bf16(dst, address, vec)`: conditionally copy a coff-2 previous-half score/KV slice.
+  `# instruction_selection: ld.global.b16 for vec1; packed ld.global.b32 followed by mov.b32 lane extraction for vec2; extent: one (k,lane-group) slice`
+- `g2r_own_bf16(dst, address, vec)`: copy an own-block score/KV slice.
+  `# instruction_selection: ld.global.b16 or ld.global.v2.b16; extent: one (k,lane-group) slice`
+- `bf16_add_ape(dst, score_bits, ape)`: widen score and add APE with the source rounding.
+  `# instruction_selection: add.rn.f32.bf16; extent: one window lane`
+- `bf16_to_f32(dst, bits)`: widen a KV lane.
+  `# instruction_selection: cvt.f32.bf16; extent: one window lane`
+- `ordered_max(dst, candidate)`: replace the running maximum only when candidate is greater.
+  `# instruction_selection: setp.gt.f32 + selp.f32; extent: one serial comparison`
+- `source_exp(dst, x)`: one CuTe exponential after subtracting the maximum.
+  `# instruction_selection: 11 arithmetic instructions: sub.f32; fma.rn.f32; cvt.sat.f32.f32; fma.rm.f32; add.f32; neg.f32; two fma.rn.f32; shl.b32; ex2.approx.ftz.f32; mul.f32; extent: one scalar. Two mov.b32 constant initializations are shared across every exponent and lane of the thread.`
+- `ordered_add(dst, value)`: append one term to a serial FP32 accumulation.
+  `# instruction_selection: add.f32; extent: one scalar term`
+- `rounded_weight(dst, exponent, denominator)`: form one probability.
+  `# instruction_selection: div.rn.f32; extent: one scalar term`
+- `rounded_product(dst, left, right)`: form the source-pinned weighted KV product.
+  `# instruction_selection: mul.rn.f32; extent: one scalar term`
+- `r2g_bf16(out, address, vec)`: round and store one or two output lanes.
+  `# instruction_selection: cvt.rn.bf16.f32 + st.global.b16, or cvt.rn.bf16x2.f32 + st.global.b32; extent: one lane-group`
+
+No primitive above contains another algorithmic phase or changes thread ownership.
+
+## Complete sketch
+
+```python
+P = specialize(ratio=4, d in {65, 128, 512}, coff in {1, 2})
+vec = 2 if d % 2 == 0 else 1
+W = coff * d
+win = 8 if coff == 2 else 4
+ncol = d // vec
+
+ABI = (
+    kv_bf16_flat, score_bf16_flat, ape_f32_flat,
+    cu_seqlens_i32, cu_seqlens_comp_i32, out_bf16_flat,
+    nb_total_i32, n_seq_i32,
+)
+launch(grid=(nb_total, ceil_div(ncol, 64), 1), block=(64, 1, 1), arch="sm_100a")
+# instruction_selection: `.reqntid 64,1,1`; extent: one specialization
+
+bb = block_idx_x
+col = block_idx_y * 64 + thread_idx_x
+if col < ncol:
+    cvec = col * vec
+
+    # All APE traffic is before nb_valid and before the row/segment work. The
+    # k order remains 0..win-1 even though coff=2 alternates physical halves.
+    ape_k = registers_f32(win * vec)
+    for k in static_range(win):
+        colbase = cvec if coff == 1 or k < 4 else d + cvec
+        g2r_ape(ape_k[k*vec:(k+1)*vec],
+                ape + ((k % 4) * W + colbase), vec)
+        # instruction_selection: `ld.global.b32` (vec1) or
+        #   `ld.global.v2.b32` (vec2); extent: win static slices
+
+    nb_valid = g2r_i32(cu_seqlens_comp[n_seq])
+    # instruction_selection: `ld.global.b32`; extent: one scalar per active thread
+
+    if bb < nb_total:
+        # Padding rows deliberately keep the initial (seq_idx,bis)=(0,0).
+        seq_idx = 0
+        bis = 0
+        if bb < nb_valid:
+            bis = bb
+            for s in dynamic_range(n_seq):
+                cs = g2r_i32(cu_seqlens_comp[s])
+                ce = g2r_i32(cu_seqlens_comp[s + 1])
+                # instruction_selection: scalar `ld.global.b32` loads; extent:
+                #   source-order segment scan. Generated PTX uses a nounroll loop
+                #   with integer comparisons/selects over groups of boundaries.
+                if bb >= cs and bb < ce:
+                    seq_idx = s
+                    bis = bb - cs
+
+        token_base = g2r_i32(cu_seqlens[seq_idx])
+        # instruction_selection: `ld.global.b32`; extent: one selected segment base
+        tok0 = token_base + bis * 4
+
+        scores = registers_f32(win * vec)
+        values = registers_f32(win * vec)
+        for k in static_range(win):
+            if coff == 2 and k < 4:
+                if bis > 0:
+                    offset = (tok0 - 4 + k) * W + cvec
+                    score_bits = registers_bf16(vec)
+                    value_bits = registers_bf16(vec)
+                    g2r_previous_bf16(score_bits, score + offset, vec)
+                    # instruction_selection: vec1 `ld.global.b16`; vec2 packed
+                    #   `ld.global.b32` plus `mov.b32` extraction; extent: one
+                    #   previous-block score slice
+                    g2r_previous_bf16(value_bits, kv + offset, vec)
+                    # instruction_selection: same conditional packed/scalar family;
+                    #   extent: one previous-block KV slice
+                for lane in static_range(vec):
+                    # Preserve source/PTX order: defaults are constructed for both
+                    # paths after the guarded slice loads.
+                    scores[k*vec+lane] = -inf
+                    values[k*vec+lane] = 0.0
+                    # instruction_selection: immediate/move construction; extent:
+                    #   one unconditional pair per lane
+                    if bis > 0:
+                        bf16_add_ape(scores[k*vec+lane], score_bits[lane], ape_k[k*vec+lane])
+                        # instruction_selection: `add.rn.f32.bf16`; extent: one lane
+                        bf16_to_f32(values[k*vec+lane], value_bits[lane])
+                        # instruction_selection: `cvt.f32.bf16`; extent: one lane
+                    # The overwrite and APE add stay guarded, so non-finite APE
+                    # cannot affect the invalid half of a segment's first block.
+            else:
+                offset = ((tok0 + k - 4) * W + d + cvec) if coff == 2 else ((tok0 + k) * W + cvec)
+                score_bits = registers_bf16(vec)
+                value_bits = registers_bf16(vec)
+                g2r_own_bf16(score_bits, score + offset, vec)
+                # instruction_selection: `ld.global.b16` or `ld.global.v2.b16`;
+                #   extent: one own-block score slice
+                g2r_own_bf16(value_bits, kv + offset, vec)
+                # instruction_selection: same width; extent: one own-block KV slice
+                for lane in static_range(vec):
+                    bf16_add_ape(scores[k*vec+lane], score_bits[lane], ape_k[k*vec+lane])
+                    # instruction_selection: `add.rn.f32.bf16`; extent: one lane
+                    bf16_to_f32(values[k*vec+lane], value_bits[lane])
+                    # instruction_selection: `cvt.f32.bf16`; extent: one lane
+
+        output = registers_f32(vec)
+        for lane in static_range(vec):
+            maximum = scores[lane]
+            for k in static_range(1, win):
+                ordered_max(maximum, scores[k*vec+lane])
+                # instruction_selection: `setp.gt.f32` + `selp.f32`; extent: win-1 serial comparisons
+
+            denominator = 0.0
+            exponent = registers_f32(win)
+            # Constants 0f4B400001 and 0f437C0000 are initialized by two shared
+            # mov.b32 instructions once per thread; the other constants below are
+            # instruction immediates.
+            for k in static_range(win):
+                source_exp(exponent[k], scores[k*vec+lane] - maximum)
+                # instruction_selection: the fixed 11-instruction arithmetic
+                #   range-reduction/FMA/`ex2` sequence listed above; extent: one
+                #   scalar exponent, plus the two thread-shared constant moves
+                ordered_add(denominator, exponent[k])
+                # instruction_selection: `add.f32`; extent: one serial denominator term
+
+            accumulator = 0.0
+            for k in static_range(win):
+                probability = rounded_weight(exponent[k], denominator)
+                # instruction_selection: `div.rn.f32`; extent: one scalar probability
+                product = rounded_product(values[k*vec+lane], probability)
+                # instruction_selection: source-pinned `mul.rn.f32`; extent: one scalar product
+                ordered_add(accumulator, product)
+                # instruction_selection: `add.f32`; extent: one serial output term
+            output[lane] = accumulator
+
+        r2g_bf16(out + bb*d + cvec, output, vec)
+        # instruction_selection: scalar BF16 conversion/store or packed BF16x2
+        #   conversion plus 32-bit store; extent: one thread-owned lane-group
+```
+
+## Static specialization boundary
+
+| axis | accepted values | emitted-code consequence |
+| --- | --- | --- |
+| ratio | 4 | fixes a four-row APE and windows of 4 or 8 |
+| coff | 1, 2 | selects own-block-only versus overlap window, W, APE half, and register count |
+| d | 65, 128, 512 | selects scalar versus paired traffic and `grid.y`; d512 changes address constants but not the lane program |
+| vec | derived 1 or 2 | selects scalar/v2 loads and scalar/packed output conversion/store |
+| rows_per_cta | 1 | one `blockIdx.x` row, including padding rows |
+| threads | 64 | two K warps and source-identical column grouping |
+
+## TIRx and benchmark contract
+
+- Registry name `cudnn_sm100_csa_compressor_fwd`, category `cudnn`, compute capability 10.
+- Device implementation imports only `tirx_kernels.kern as K`; all memory and key arithmetic instructions use plain K expressions or `K.ptx`.
+- Correctness includes the source ratio-4 matrix, static-capacity padding, empty output, determinism, and an independent FP32 eager oracle.
+- The performance matrix is exactly `(batch,d) in {(1,128),(3,128),(1,512),(3,512)}` with every sequence length 8192 and coff=2.
+- The only performance gate is a complete bench-suite run with the pinned cuDNN Frontend source reference; every row requires `mean(source_us)/mean(tirx_us) > 0.99`.
+
+## Instruction-selection summary
+
+| source decision | generated consequence |
+| --- | --- |
+| APE list built before row work | all 4/8 APE loads are hoisted above `nb_valid` and the segment scan |
+| `vec=1` | scalar `ld.global.b32` APE, scalar `ld.global.b16` score/KV, scalar BF16 store |
+| `vec=2` | `ld.global.v2.b32` APE; packed `ld.global.b32` + extraction for conditional previous-half score/KV; `ld.global.v2.b16` for own-block score/KV; `cvt.rn.bf16x2.f32` and `st.global.b32` |
+| BF16 score plus FP32 APE | fused `add.rn.f32.bf16`, not separate conversion and add |
+| invalid previous block | immediate `-inf`/zero with neither source load nor APE add |
+| serial maximum | ordered `setp.gt.f32`/`selp.f32` chain, no reduction primitive |
+| `cute_math.exp` | 11 line-associated arithmetic instructions around `ex2.approx.ftz.f32`, repeated 4/8 times per lane; two constant `mov.b32` instructions are shared by the thread, and the denominator `add.f32` is a separate operation |
+| `ex[k] / den` | `div.rn.f32`, not reciprocal approximation |
+| `_fmul_rn` | inline `mul.rn.f32`, opaque to contraction |
+| serial weighted sum | rounded product followed by `add.f32` in k order |
+
+For the paired exports, coff=1 contains 8 each of the exp-expansion arithmetic,
+division, and rounded multiply instructions; coff=2 contains 16 each because
+both adjacent lanes evaluate an 8-element window. The scalar exports contain 4
+or 8 respectively. These counts describe static instructions, not dynamic
+executions.

--- a/.agents/skills/tirx-codegen-tuning/references/db/issue-loads-before-conversions.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/issue-loads-before-conversions.md
@@ -43,6 +43,36 @@ independent work or a real synchronization boundary. Program order is the
 lever; which side of a barrier ptxas finally places the work is not something
 the kernel controls.
 
+When an overlap window has an always-valid half and a predicated half, issue
+the always-valid group first, then the predicated group, and delay consumers of
+both. Otherwise the predicate and the first half's conversion chain can cut the
+load issue window in two even though each half is staged internally.
+
+```python
+previous_words = K.alloc_local([N], "uint32")
+current_words = K.alloc_local([N], "uint32")
+
+# before: the first conversion chain separates the two load groups.
+with K.If(has_previous):
+    load_group(previous_words, previous_ptr)
+    convert_group(previous_values, previous_words)
+load_group(current_words, current_ptr)
+convert_group(current_values, current_words)
+
+# after: every independent load is issued before either conversion chain.
+load_group(current_words, current_ptr)
+with K.If(has_previous):
+    load_group(previous_words, previous_ptr)
+with K.If(has_previous):
+    convert_group(previous_values, previous_words)
+convert_group(current_values, current_words)
+```
+
+If ordinary local-array staging still compiles to the old schedule, a bounded
+multi-output device helper can give every load a distinct output register and
+make the issue boundary real. Use it only after final SASS proves that the
+compiler erased the ordinary rewrite.
+
 ## Rationale
 
 The benchmark harness zeroes a 256 MB buffer before every timed iteration, so
@@ -66,6 +96,16 @@ count -- four shared loads per thread rather than eight -- gained on every
 specialization that ran it (+0.0015, +0.0056, +0.0022) with an untouched control
 dispatch flat, once the batch covered the whole trip count.
 
+An eight-position overlap window supplied the predicated-boundary case. A
+plain load-first rewrite and a typed-load helper both collapsed to the same 832
+final instructions at 48 registers. Grouping each half separately changed the
+binary but still failed both measured shapes. Issuing the eight always-valid
+score/value loads before the eight predicated score/value loads, with all 16
+ahead of the first BF16 conversion, reduced long-scoreboard samples from 1299
+to 552. The final allocation was 53 registers with no spill; all 18 correctness
+cases passed, and the complete four-shape benchmark matrix measured
+1.0249-1.1635x against the reference.
+
 ## Boundary
 
 It can regress when the staged raw values spill or the loads usually hit cache.
@@ -87,8 +127,18 @@ but the final cubin remained identical at 661 instructions, 92 registers, and
 the same relevant opcode counts. With no generated-code lever left, the rewrite
 was reverted before timing.
 
+Staging width is not monotonic. In the predicated-window experiment, a
+half-window boundary paid the code-size and live-range cost without passing the
+benchmark, and a smaller group restored the old register count without
+recovering performance. Preserve the full issue window only while the extra
+outputs remain in registers, and do not use an opaque multi-output helper for
+loads whose independence, address validity, or ordering is not statically
+established.
+
 ## Verification
 
 Confirm the load issue window and load-to-first-consumer distance in SASS, then
 measure long-scoreboard stalls, registers, spills, and the complete shape
-matrix.
+matrix. For a predicated window, verify that the unconditional and conditional
+groups both precede the first consumer rather than checking each group in
+isolation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ list.
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
+- **CSA compression:**
+  [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
 - **Sparse attention:**
   [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
 

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -152,6 +152,31 @@ def test_thread_layout_is_not_a_kernel_entry_option():
         K.thread_id([32])
 
 
+def test_thread_only_entry_omits_warp_and_lane_scopes():
+    import pytest
+
+    @K.kernel(warps=2, arch="sm_100a", grid=False, warp_scope=False)
+    def probe(out: K.gptr(K.f32)):
+        K.ptx.st.global_.f32(out.ptr_to([K.thread_id()]), K.float32(0))
+
+    script = probe.func.script()
+    assert "T.thread_id([64])" in script
+    assert "T.warp_id" not in script
+    assert "T.lane_id" not in script
+
+    with pytest.raises(RuntimeError, match="warp_scope=False"):
+
+        @K.kernel(warps=2, arch="sm_100a", grid=False, warp_scope=False)
+        def invalid_warp(out: K.gptr(K.f32)):
+            K.ptx.st.global_.f32(out.ptr_to([K.warp_id()]), K.float32(0))
+
+    with pytest.raises(RuntimeError, match="warp_scope=False"):
+
+        @K.kernel(warps=2, arch="sm_100a", grid=False, warp_scope=False)
+        def invalid_lane(out: K.gptr(K.f32)):
+            K.ptx.st.global_.f32(out.ptr_to([K.lane_id()]), K.float32(0))
+
+
 def test_gptr_shape_reuses_entry_scalar_parameters():
     @K.kernel(warps=1, arch="sm_100a", grid=False)
     def probe(out: K.gptr(K.f32, shape=lambda p: (p["rows"], p["cols"])), rows: K.i32, cols: K.i32):

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -29,8 +29,17 @@ def test_func_call_is_rejected_by_default_and_reports_callee():
     assert "callee=unexpected_helper" in str(error.value)
 
 
-def test_only_exact_nvshmem_runtime_calls_are_exempt_for_gemm_reduce_scatter():
+def test_only_exact_kernel_local_helpers_are_exempt():
     assert LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL == {
+        "cudnn_sm100_csa_compressor_fwd": frozenset(
+            {
+                "tirx_csa_exp_constants",
+                "tirx_csa_load4_bf16x2",
+                "tirx_csa_ordered_max",
+                "tirx_csa_scan_boundary",
+                "tirx_csa_source_exp",
+            }
+        ),
         "gemm_reduce_scatter": frozenset(
             {
                 "enqueue_remote",
@@ -38,7 +47,7 @@ def test_only_exact_nvshmem_runtime_calls_are_exempt_for_gemm_reduce_scatter():
                 "ld_reduce_8_fp16",
                 "semaphore_notify_remote",
             }
-        )
+        ),
     }
 
     for callee in NVSHMEM_RUNTIME_FUNC_CALLS:

--- a/tirx_kernels/bench_suite/config/cudnn/csa/cudnn_sm100_csa_compressor_fwd.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/csa/cudnn_sm100_csa_compressor_fwd.yaml
@@ -1,0 +1,9 @@
+# Complete performance-path matrix for the cuDNN Frontend SM100 CSA
+# compressor forward port.
+kernel: cudnn_sm100_csa_compressor_fwd
+selection_rationale: The matrix crosses single- and three-sequence occupancy with both two-column-group d128 and large-head d512 source specializations; the defaults retain small, medium, and large representatives.
+configs:
+  - {config: perf_b1_s8192_d128_c2, default: true, selection_role: small}
+  - {config: perf_b3_s8192_d128_c2, default: true, selection_role: medium}
+  - {config: perf_b1_s8192_d512_c2, default: false}
+  - {config: perf_b3_s8192_d512_c2, default: true, selection_role: large}

--- a/tirx_kernels/cudnn/csa/__init__.py
+++ b/tirx_kernels/cudnn/csa/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
+++ b/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
@@ -1,0 +1,782 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM100 CSA compressor forward kernel.
+
+Upstream source:
+``python/cudnn/csa/compressor/compressor_sm100.py::_compressor_fwd_kernel``.
+"""
+
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cudnn_sm100_csa_compressor_fwd",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+_RATIO = 4
+_SUPPORTED_HEAD_DIMS = (65, 128, 512)
+_SUPPORTED_COFF = (1, 2)
+
+
+def _cfg(label: str, seq_lens: tuple[int, ...], head_dim: int, coff: int, capacity_pad: int = 0):
+    return {
+        "label": label,
+        "seq_lens": seq_lens,
+        "head_dim": head_dim,
+        "coff": coff,
+        "capacity_pad": capacity_pad,
+    }
+
+
+CONFIGS = [
+    _cfg("b1_s2048_d128_c2", (2048,), 128, 2),
+    _cfg("ragged_1023_2048_509_d128_c2", (1023, 2048, 509), 128, 2),
+    _cfg("b1_s2048_d512_c2", (2048,), 512, 2),
+    _cfg("short_3_515_1024_129_d128_c2", (3, 515, 1024, 129), 128, 2),
+    _cfg("b1_s260_d65_c2", (260,), 65, 2),
+    _cfg("emptyseg_64_0_253_3_d128_c2", (64, 0, 253, 3), 128, 2),
+    _cfg("b1_s2048_d128_c1", (2048,), 128, 1),
+    _cfg("ragged_1023_2048_509_d128_c1", (1023, 2048, 509), 128, 1),
+    _cfg("b1_s2048_d512_c1", (2048,), 512, 1),
+    _cfg("short_3_515_1024_129_d128_c1", (3, 515, 1024, 129), 128, 1),
+    _cfg("b1_s260_d65_c1", (260,), 65, 1),
+    _cfg("emptyseg_64_0_253_3_d128_c1", (64, 0, 253, 3), 128, 1),
+    _cfg("padding_short_d128_c2_p8", (3, 515, 1024, 129), 128, 2, 8),
+    _cfg("padding_ragged_d128_c2_p8", (1023, 2048, 509), 128, 2, 8),
+    _cfg("padding_short_d128_c1_p8", (3, 515, 1024, 129), 128, 1, 8),
+    _cfg("padding_ragged_d128_c1_p8", (1023, 2048, 509), 128, 1, 8),
+    _cfg("empty_output_d128_c2", (2,), 128, 2),
+    _cfg("empty_output_d128_c1", (2,), 128, 1),
+]
+
+BENCH_CONFIGS = [
+    _cfg("perf_b1_s8192_d128_c2", (8192,), 128, 2),
+    _cfg("perf_b3_s8192_d128_c2", (8192, 8192, 8192), 128, 2),
+    _cfg("perf_b1_s8192_d512_c2", (8192,), 512, 2),
+    _cfg("perf_b3_s8192_d512_c2", (8192, 8192, 8192), 512, 2),
+]
+
+
+def _validate(head_dim: int, coff: int) -> None:
+    if head_dim not in _SUPPORTED_HEAD_DIMS:
+        raise ValueError(f"head_dim={head_dim} is outside the ported source specializations")
+    if coff not in _SUPPORTED_COFF:
+        raise ValueError(f"coff={coff} is outside the source dispatch domain")
+
+
+_SOURCE_EXP_PTX = r"""
+// tirx.reqntid compressor_fwd_kernel 64 1 1
+__forceinline__ __device__ float tirx_csa_source_exp(
+        float value, float magic_bias, float magic_scale) {
+  float result;
+  asm volatile(
+      "{.reg .f32 rounded, exponent, offset, negated, reduced, fraction;\n"
+      " .reg .b32 exponent_bits;\n"
+      " fma.rn.f32 rounded, %1, 0f3BBB989D, 0f3F000000;\n"
+      " cvt.sat.f32.f32 rounded, rounded;\n"
+      " fma.rm.f32 exponent, rounded, %3, %2;\n"
+      " add.f32 offset, exponent, 0fCB40007F;\n"
+      " neg.f32 negated, offset;\n"
+      " fma.rn.f32 reduced, %1, 0f3FB8AA3B, negated;\n"
+      " fma.rn.f32 reduced, %1, 0f32A57060, reduced;\n"
+      " shl.b32 exponent_bits, exponent, 23;\n"
+      " ex2.approx.ftz.f32 fraction, reduced;\n"
+      " mul.f32 %0, fraction, exponent_bits;}\n"
+      : "=f"(result)
+      : "f"(value), "f"(magic_bias), "f"(magic_scale));
+  return result;
+}
+"""
+
+_EXP_CONSTANTS_PTX = r"""
+__forceinline__ __device__ void tirx_csa_exp_constants(
+        float& magic_bias, float& magic_scale) {
+  asm volatile(
+      "mov.b32 %0, 0f4B400001;\n"
+      "mov.b32 %1, 0f437C0000;\n"
+      : "=f"(magic_bias), "=f"(magic_scale));
+}
+"""
+
+_ORDERED_MAX_PTX = r"""
+__forceinline__ __device__ float tirx_csa_ordered_max(
+        float candidate, float current) {
+  float result;
+  asm volatile(
+      "{.reg .pred greater;\n"
+      " setp.gt.f32 greater, %1, %2;\n"
+      " selp.f32 %0, %1, %2, greater;}\n"
+      : "=f"(result)
+      : "f"(candidate), "f"(current));
+  return result;
+}
+"""
+
+_SCAN_BOUNDARY_PTX = r"""
+__forceinline__ __device__ void tirx_csa_scan_boundary(
+        int& seq_idx, int& block_in_sequence, int bb,
+        int sequence_number, int sequence_begin, int sequence_end) {
+  asm volatile(
+      "{.reg .pred before_begin, before_end;\n"
+      " .reg .s32 candidate_sequence, candidate_block;\n"
+      " setp.lt.s32 before_begin, %2, %4;\n"
+      " setp.lt.s32 before_end, %2, %5;\n"
+      " selp.b32 candidate_sequence, %3, %0, before_end;\n"
+      " sub.s32 candidate_block, %2, %4;\n"
+      " selp.b32 candidate_block, candidate_block, %1, before_end;\n"
+      " selp.b32 %0, %0, candidate_sequence, before_begin;\n"
+      " selp.b32 %1, %1, candidate_block, before_begin;}\n"
+      : "+r"(seq_idx), "+r"(block_in_sequence)
+      : "r"(bb), "r"(sequence_number), "r"(sequence_begin), "r"(sequence_end));
+}
+"""
+
+
+def _source_exp(value, magic_bias, magic_scale):
+    """Reproduce the source expansion with its literal PTX immediates."""
+    return K.cuda.func_call(
+        "tirx_csa_source_exp",
+        value,
+        magic_bias,
+        magic_scale,
+        source_code=_SOURCE_EXP_PTX,
+        return_type="float32",
+    )
+
+
+def _ordered_max(candidate, current):
+    """Select with the source kernel's strict ordered floating-point predicate."""
+    return K.cuda.func_call(
+        "tirx_csa_ordered_max",
+        candidate,
+        current,
+        source_code=_ORDERED_MAX_PTX,
+        return_type="float32",
+    )
+
+
+def _load4_bf16x2_source(stride_bytes: int) -> str:
+    offsets = [index * stride_bytes for index in range(4)]
+    return rf"""
+__forceinline__ __device__ void tirx_csa_load4_bf16x2(
+        unsigned int& score0, unsigned int& value0,
+        unsigned int& score1, unsigned int& value1,
+        unsigned int& score2, unsigned int& value2,
+        unsigned int& score3, unsigned int& value3,
+        const void* score_pointer, const void* value_pointer) {{
+  asm volatile(
+      "ld.global.b32 %0, [%8+{offsets[0]}];\n"
+      "ld.global.b32 %1, [%9+{offsets[0]}];\n"
+      "ld.global.b32 %2, [%8+{offsets[1]}];\n"
+      "ld.global.b32 %3, [%9+{offsets[1]}];\n"
+      "ld.global.b32 %4, [%8+{offsets[2]}];\n"
+      "ld.global.b32 %5, [%9+{offsets[2]}];\n"
+      "ld.global.b32 %6, [%8+{offsets[3]}];\n"
+      "ld.global.b32 %7, [%9+{offsets[3]}];\n"
+      : "=r"(score0), "=r"(value0), "=r"(score1), "=r"(value1),
+        "=r"(score2), "=r"(value2), "=r"(score3), "=r"(value3)
+      : "l"(score_pointer), "l"(value_pointer));
+}}
+"""
+
+
+def get_kernel(head_dim: int, coff: int, **kwargs):
+    """Return the static ``(head_dim, coff)`` specialization."""
+    _validate(head_dim, coff)
+    vec = 2 if head_dim % 2 == 0 else 1
+    ncol = head_dim // vec
+    width = coff * head_dim
+    win = 8 if coff == 2 else 4
+    load4_bf16x2_source = _load4_bf16x2_source(width * 2)
+
+    @K.kernel(
+        warps=2,
+        arch="sm_100a",
+        grid=lambda p: [p["nb_total"], K.ceildiv(ncol, 64), 1],
+        allowed_func_calls=(
+            "tirx_csa_exp_constants",
+            "tirx_csa_load4_bf16x2",
+            "tirx_csa_ordered_max",
+            "tirx_csa_scan_boundary",
+            "tirx_csa_source_exp",
+        ),
+        warp_scope=False,
+    )
+    def compressor_fwd(
+        kv: K.gptr[K.bf16],
+        score: K.gptr[K.bf16],
+        ape: K.gptr[K.f32],
+        cu_seqlens: K.gptr[K.i32],
+        cu_seqlens_comp: K.gptr[K.i32],
+        out: K.gptr[K.bf16],
+        nb_total: K.i32,
+        n_seq: K.i32,
+    ):
+        bb, block_y, _ = K.cta_id()
+        thread = K.thread_id()
+        col = block_y * K.int32(64) + thread
+        with K.If(col < ncol), K.Then():
+            column = col * K.int32(vec)
+
+            # The source hoists all APE traffic ahead of row validity checks.
+            ape_values = K.alloc_local([win * vec], "float32")
+            for k in range(win):
+                column_base = column
+                if coff == 2 and k >= 4:
+                    column_base = K.int32(head_dim) + column
+                ape_offset = K.int32((k % 4) * width) + column_base
+                if vec == 1:
+                    K.ptx.ld.global_.b32(ape_values[k], ape.ptr_to([ape_offset]))
+                else:
+                    K.ptx.ld.global_.v2.b32(
+                        ape_values[k * 2], ape_values[k * 2 + 1], ape.ptr_to([ape_offset])
+                    )
+
+            nb_valid = K.local_scalar("int32")
+            K.ptx.ld.global_.b32(nb_valid, cu_seqlens_comp.ptr_to([n_seq]))
+
+            with K.If(bb < nb_total), K.Then():
+                seq_idx = K.local_scalar("int32", init=K.int32(0))
+                block_in_sequence = K.local_scalar("int32", init=K.int32(0))
+                with K.If(bb < nb_valid), K.Then():
+                    K.assign(block_in_sequence, bb)
+                    sequence = K.local_scalar("int32", init=K.int32(0))
+
+                    sequence_begin = K.local_scalar("int32")
+                    K.ptx.ld.global_.b32(sequence_begin, cu_seqlens_comp.ptr_to([K.int32(0)]))
+
+                    def scan_boundary(sequence_number):
+                        sequence_end = K.local_scalar("int32")
+                        K.ptx.ld.global_.b32(
+                            sequence_end, cu_seqlens_comp.ptr_to([sequence_number + 1])
+                        )
+                        K.cuda.func_call(
+                            "tirx_csa_scan_boundary",
+                            seq_idx,
+                            block_in_sequence,
+                            bb,
+                            sequence_number,
+                            sequence_begin,
+                            sequence_end,
+                            source_code=_SCAN_BOUNDARY_PTX,
+                        )
+                        K.assign(sequence_begin, sequence_end)
+
+                    # Preserve the source compiler's nounroll 8/4/2/1 boundary
+                    # grouping rather than a scalar two-load loop.
+                    with K.While(sequence + 8 <= n_seq):
+                        for offset in range(8):
+                            scan_boundary(sequence + K.int32(offset))
+                        K.assign(sequence, sequence + 8)
+                    with K.If(sequence + 4 <= n_seq), K.Then():
+                        K.ptx.ld.global_.b32(sequence_begin, cu_seqlens_comp.ptr_to([sequence]))
+                        for offset in range(4):
+                            scan_boundary(sequence + K.int32(offset))
+                        K.assign(sequence, sequence + 4)
+                    with K.If(sequence + 2 <= n_seq), K.Then():
+                        K.ptx.ld.global_.b32(sequence_begin, cu_seqlens_comp.ptr_to([sequence]))
+                        for offset in range(2):
+                            scan_boundary(sequence + K.int32(offset))
+                        K.assign(sequence, sequence + 2)
+                    with K.If(sequence < n_seq), K.Then():
+                        K.ptx.ld.global_.b32(sequence_begin, cu_seqlens_comp.ptr_to([sequence]))
+                        scan_boundary(sequence)
+
+                token_base = K.local_scalar("int32")
+                K.ptx.ld.global_.b32(token_base, cu_seqlens.ptr_to([seq_idx]))
+                token = token_base + block_in_sequence * K.int32(4)
+
+                scores = K.alloc_local([win * vec], "float32")
+                values = K.alloc_local([win * vec], "float32")
+                if coff == 2 and vec == 2:
+                    score_words = K.alloc_local([win], "uint32")
+                    value_words = K.alloc_local([win], "uint32")
+                    own_offset = token * K.int32(width) + K.int32(head_dim) + column
+                    K.cuda.func_call(
+                        "tirx_csa_load4_bf16x2",
+                        score_words[4],
+                        value_words[4],
+                        score_words[5],
+                        value_words[5],
+                        score_words[6],
+                        value_words[6],
+                        score_words[7],
+                        value_words[7],
+                        score.ptr_to([own_offset]),
+                        kv.ptr_to([own_offset]),
+                        source_code=load4_bf16x2_source,
+                    )
+                for k in range(win):
+                    score_bits = K.alloc_local([vec], "uint16")
+                    value_bits = K.alloc_local([vec], "uint16")
+                    if coff == 2 and k < 4:
+                        with K.If(block_in_sequence > 0), K.Then():
+                            offset = (token - K.int32(4) + K.int32(k)) * K.int32(width) + column
+                            if vec == 1:
+                                K.ptx.ld.global_.b16(score_bits[0], score.ptr_to([offset]))
+                                K.ptx.ld.global_.b16(value_bits[0], kv.ptr_to([offset]))
+                            else:
+                                if k == 0:
+                                    K.cuda.func_call(
+                                        "tirx_csa_load4_bf16x2",
+                                        score_words[0],
+                                        value_words[0],
+                                        score_words[1],
+                                        value_words[1],
+                                        score_words[2],
+                                        value_words[2],
+                                        score_words[3],
+                                        value_words[3],
+                                        score.ptr_to([offset]),
+                                        kv.ptr_to([offset]),
+                                        source_code=load4_bf16x2_source,
+                                    )
+                                K.ptx.mov.b32(score_bits[0], score_bits[1], score_words[k])
+                                K.ptx.mov.b32(value_bits[0], value_bits[1], value_words[k])
+                        for lane in range(vec):
+                            K.ptx.mov.b32(scores[k * vec + lane], K.float32(float("-inf")))
+                            K.ptx.mov.b32(values[k * vec + lane], K.float32(0.0))
+                            with K.If(block_in_sequence > 0), K.Then():
+                                K.ptx.add.rn.f32.bf16(
+                                    scores[k * vec + lane],
+                                    score_bits[lane],
+                                    ape_values[k * vec + lane],
+                                )
+                                K.ptx.cvt.f32.bf16(values[k * vec + lane], value_bits[lane])
+                    else:
+                        if coff == 2:
+                            offset = (
+                                (token + K.int32(k - 4)) * K.int32(width)
+                                + K.int32(head_dim)
+                                + column
+                            )
+                        else:
+                            offset = (token + K.int32(k)) * K.int32(width) + column
+                        if vec == 1:
+                            K.ptx.ld.global_.b16(score_bits[0], score.ptr_to([offset]))
+                            K.ptx.ld.global_.b16(value_bits[0], kv.ptr_to([offset]))
+                        else:
+                            if coff == 2:
+                                K.ptx.mov.b32(score_bits[0], score_bits[1], score_words[k])
+                                K.ptx.mov.b32(value_bits[0], value_bits[1], value_words[k])
+                            else:
+                                K.ptx.ld.global_.v2.b16(
+                                    score_bits[0], score_bits[1], score.ptr_to([offset])
+                                )
+                                K.ptx.ld.global_.v2.b16(
+                                    value_bits[0], value_bits[1], kv.ptr_to([offset])
+                                )
+                        for lane in range(vec):
+                            K.ptx.add.rn.f32.bf16(
+                                scores[k * vec + lane], score_bits[lane], ape_values[k * vec + lane]
+                            )
+                            K.ptx.cvt.f32.bf16(values[k * vec + lane], value_bits[lane])
+
+                # CuTe materializes these two constants once and shares them across
+                # every scalar exponential expansion in the thread.
+                magic_bias = K.local_scalar("float32")
+                magic_scale = K.local_scalar("float32")
+                K.cuda.func_call(
+                    "tirx_csa_exp_constants",
+                    magic_bias,
+                    magic_scale,
+                    source_code=_EXP_CONSTANTS_PTX,
+                )
+
+                outputs = K.alloc_local([vec], "float32")
+                for lane in range(vec):
+                    maximum = K.local_scalar("float32")
+                    K.ptx.mov.b32(maximum, scores[lane])
+                    for k in range(1, win):
+                        K.assign(maximum, _ordered_max(scores[k * vec + lane], maximum))
+
+                    denominator = K.local_scalar("float32")
+                    K.ptx.mov.b32(denominator, K.float32(0.0))
+                    exponentials = K.alloc_local([win], "float32")
+                    for k in range(win):
+                        difference = K.local_scalar("float32")
+                        K.ptx["sub.f32"](difference, scores[k * vec + lane], maximum)
+                        K.assign(exponentials[k], _source_exp(difference, magic_bias, magic_scale))
+                        K.ptx["add.f32"](denominator, denominator, exponentials[k])
+
+                    accumulator = K.local_scalar("float32")
+                    K.ptx.mov.b32(accumulator, K.float32(0.0))
+                    for k in range(win):
+                        probability = K.local_scalar("float32")
+                        K.ptx.div.rn.f32(probability, exponentials[k], denominator)
+                        product = K.local_scalar("float32")
+                        K.ptx.mul.rn.f32(product, values[k * vec + lane], probability)
+                        K.ptx["add.f32"](accumulator, accumulator, product)
+                    K.ptx.mov.b32(outputs[lane], accumulator)
+
+                output_offset = bb * K.int32(head_dim) + column
+                if vec == 1:
+                    output_bits = K.local_scalar("uint16")
+                    K.ptx.cvt.rn.bf16.f32(output_bits, outputs[0])
+                    K.ptx.st.global_.b16(out.ptr_to([output_offset]), output_bits)
+                else:
+                    output_word = K.local_scalar("uint32")
+                    K.ptx.cvt.rn.bf16x2.f32(output_word, outputs[1], outputs[0])
+                    K.ptx.st.global_.b32(out.ptr_to([output_offset]), output_word)
+
+    return compressor_fwd.func
+
+
+def prepare_data(
+    seq_lens: tuple[int, ...],
+    head_dim: int,
+    coff: int,
+    capacity_pad: int = 0,
+    *,
+    seed: int = 1234,
+    **kwargs,
+):
+    """Create deterministic flat source-layout tensors and segment metadata."""
+    import torch
+
+    _validate(head_dim, coff)
+    if any(length < 0 for length in seq_lens):
+        raise ValueError("sequence lengths must be non-negative")
+    if capacity_pad < 0:
+        raise ValueError("capacity_pad must be non-negative")
+
+    total_tokens = sum(seq_lens)
+    width = coff * head_dim
+    token_prefix = [0]
+    block_prefix = [0]
+    for length in seq_lens:
+        token_prefix.append(token_prefix[-1] + length)
+        block_prefix.append(block_prefix[-1] + length // _RATIO)
+    nb_valid = block_prefix[-1]
+    nb_total = nb_valid + capacity_pad
+
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    kv = torch.randn(total_tokens, width, generator=generator, dtype=torch.float32).to(
+        device="cuda", dtype=torch.bfloat16
+    )
+    score = torch.randn(total_tokens, width, generator=generator, dtype=torch.float32).to(
+        device="cuda", dtype=torch.bfloat16
+    )
+    ape = torch.randn(_RATIO, width, generator=generator, dtype=torch.float32).cuda()
+    cu_seqlens = torch.tensor(token_prefix, dtype=torch.int32, device="cuda")
+    cu_seqlens_comp = torch.tensor(block_prefix, dtype=torch.int32, device="cuda")
+    guard_elements = 16
+    guard_value = -123.0
+
+    def guarded_output():
+        backing = torch.full(
+            (nb_total * head_dim + 2 * guard_elements,),
+            guard_value,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        view = backing[guard_elements : guard_elements + nb_total * head_dim]
+        return backing, view
+
+    out_backing, out = guarded_output()
+    source_out_backing, source_out = guarded_output()
+    repeat_out_backing, repeat_out = guarded_output()
+    return {
+        "kv": kv.reshape(-1),
+        "score": score.reshape(-1),
+        "ape": ape.reshape(-1),
+        "cu_seqlens": cu_seqlens,
+        "cu_seqlens_comp": cu_seqlens_comp,
+        "out": out,
+        "out_backing": out_backing,
+        "source_out": source_out,
+        "source_out_backing": source_out_backing,
+        "repeat_out": repeat_out,
+        "repeat_out_backing": repeat_out_backing,
+        "nb_total": nb_total,
+        "nb_valid": nb_valid,
+        "n_seq": len(seq_lens),
+        "seq_lens": seq_lens,
+        "head_dim": head_dim,
+        "coff": coff,
+        "guard_elements": guard_elements,
+        "guard_value": guard_value,
+    }
+
+
+def _launch(executable, data, output_key="out"):
+    if data["nb_total"] == 0:
+        return
+    executable(
+        data["kv"],
+        data["score"],
+        data["ape"],
+        data["cu_seqlens"],
+        data["cu_seqlens_comp"],
+        data[output_key],
+        data["nb_total"],
+        data["n_seq"],
+    )
+
+
+_REFERENCE_SOURCE = None
+
+
+def _load_reference_source():
+    global _REFERENCE_SOURCE
+    if _REFERENCE_SOURCE is not None:
+        return _REFERENCE_SOURCE
+
+    import importlib.util
+    import os
+    from pathlib import Path
+
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    source_path = Path(root) / "python/cudnn/csa/compressor/compressor_sm100.py"
+    if not source_path.is_file():
+        raise RuntimeError(f"CUDNN_FRONTEND_PATH does not contain {source_path.relative_to(root)}")
+    spec = importlib.util.spec_from_file_location(
+        "tirx_cudnn_frontend_csa_compressor_source", source_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load cuDNN Frontend compressor source from {source_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _REFERENCE_SOURCE = module
+    return module
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    device = torch.device("cuda", torch.cuda.current_device())
+    source.precompile_fwd(_RATIO, data["head_dim"], data["coff"], device)
+
+    def launch():
+        if data["nb_total"] == 0:
+            return
+        source.run_fwd(
+            data["kv"],
+            data["score"],
+            data["ape"],
+            data["cu_seqlens"],
+            data["cu_seqlens_comp"],
+            data["source_out"],
+            data["nb_total"],
+            _RATIO,
+            data["head_dim"],
+            data["coff"],
+        )
+
+    return launch
+
+
+def _eager_reference(data):
+    """Vectorized FP32 oracle, including source-defined capacity-padding rows."""
+    import torch
+
+    d = data["head_dim"]
+    coff = data["coff"]
+    width = coff * d
+    kv = data["kv"].view(-1, width).float()
+    score = data["score"].view(-1, width).float()
+    ape = data["ape"].view(_RATIO, width)
+    rows = []
+    token_base = 0
+    for length in data["seq_lens"]:
+        blocks = length // _RATIO
+        if blocks:
+            block_tokens = blocks * _RATIO
+            if coff == 1:
+                block_values = kv[token_base : token_base + block_tokens, :d].view(
+                    blocks, _RATIO, d
+                )
+                block_scores = score[token_base : token_base + block_tokens, :d].view(
+                    blocks, _RATIO, d
+                ) + ape[:, :d].unsqueeze(0)
+            else:
+                own_values = kv[token_base : token_base + block_tokens, d:].view(blocks, _RATIO, d)
+                own_scores = score[token_base : token_base + block_tokens, d:].view(
+                    blocks, _RATIO, d
+                ) + ape[:, d:].unsqueeze(0)
+                previous_values = torch.zeros_like(own_values)
+                previous_scores = torch.full_like(own_scores, float("-inf"))
+                if blocks > 1:
+                    previous_values[1:] = kv[
+                        token_base : token_base + (blocks - 1) * _RATIO, :d
+                    ].view(blocks - 1, _RATIO, d)
+                    previous_scores[1:] = score[
+                        token_base : token_base + (blocks - 1) * _RATIO, :d
+                    ].view(blocks - 1, _RATIO, d) + ape[:, :d].unsqueeze(0)
+                block_values = torch.cat((previous_values, own_values), dim=1)
+                block_scores = torch.cat((previous_scores, own_scores), dim=1)
+            rows.append((block_values * torch.softmax(block_scores, dim=1)).sum(dim=1))
+        token_base += length
+
+    padding = data["nb_total"] - data["nb_valid"]
+    if padding:
+        if coff == 1:
+            pad_values = kv[:_RATIO, :d]
+            pad_scores = score[:_RATIO, :d] + ape[:, :d]
+        else:
+            pad_values = torch.cat((torch.zeros_like(kv[:_RATIO, :d]), kv[:_RATIO, d:]), dim=0)
+            pad_scores = torch.cat(
+                (
+                    torch.full_like(score[:_RATIO, :d], float("-inf")),
+                    score[:_RATIO, d:] + ape[:, d:],
+                ),
+                dim=0,
+            )
+        pad_row = (pad_values * torch.softmax(pad_scores, dim=0)).sum(dim=0)
+        rows.append(pad_row.unsqueeze(0).expand(padding, d))
+    if not rows:
+        return torch.empty((0, d), dtype=torch.bfloat16, device=kv.device)
+    return torch.cat(rows, dim=0).to(torch.bfloat16)
+
+
+def _assert_guard(data, backing_key):
+    import torch
+
+    guard = data["guard_elements"]
+    expected = torch.full(
+        (guard,), data["guard_value"], dtype=torch.bfloat16, device=data[backing_key].device
+    )
+    backing = data[backing_key]
+    if not torch.equal(backing[:guard], expected) or not torch.equal(backing[-guard:], expected):
+        raise AssertionError(f"compressor forward wrote outside {backing_key}'s output view")
+
+
+def _validate_outputs(data, *, include_source: bool, include_oracle: bool):
+    import torch
+
+    actual = data["out"].view(data["nb_total"], data["head_dim"])
+    repeated = data["repeat_out"].view(data["nb_total"], data["head_dim"])
+    if not torch.equal(actual, repeated):
+        mismatch = int((actual != repeated).sum().item())
+        raise AssertionError(f"TIRx compressor forward is not deterministic ({mismatch} values)")
+    if include_source:
+        source = data["source_out"].view(data["nb_total"], data["head_dim"])
+        if not torch.equal(actual, source):
+            mismatch = int((actual != source).sum().item())
+            max_abs = float((actual.float() - source.float()).abs().max().item())
+            raise AssertionError(
+                f"TIRx differs from cuDNN Frontend source: mismatch={mismatch}, max_abs={max_abs}"
+            )
+    if include_oracle:
+        oracle = _eager_reference(data)
+        mismatch = int((actual != oracle).sum().item())
+        allowed = max(1, actual.numel() // 1000)
+        max_abs = (
+            float((actual.float() - oracle.float()).abs().max().item()) if actual.numel() else 0.0
+        )
+        if mismatch > allowed or max_abs > 1.6e-2:
+            raise AssertionError(
+                f"TIRx differs from FP32 eager oracle: mismatch={mismatch}/{allowed}, "
+                f"max_abs={max_abs}"
+            )
+    _assert_guard(data, "out_backing")
+    _assert_guard(data, "repeat_out_backing")
+    if include_source:
+        _assert_guard(data, "source_out_backing")
+
+
+def _kernel_config(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def prepare_bench(**config: Any):
+    """Compile the static TIRx specialization before GPU assignment."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config = _kernel_config(config)
+    state = {"config": config, "executable": compile_kernel(get_kernel(**config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_test(**config: Any):
+    """Compare TIRx with the pinned source and a standalone FP32 eager oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = _kernel_config(config)
+    data = prepare_data(**config)
+    snapshots = {
+        key: data[key].clone() for key in ("kv", "score", "ape", "cu_seqlens", "cu_seqlens_comp")
+    }
+    executable = compile_kernel(get_kernel(**config))
+    _launch(executable, data)
+    _launch(executable, data, "repeat_out")
+    source_launch = _source_launch(data)
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, include_source=True, include_oracle=True)
+    for key, snapshot in snapshots.items():
+        if not torch.equal(data[key], snapshot):
+            raise AssertionError(f"compressor forward modified input {key}")
+    return {"rows": data["nb_total"], "head_dim": data["head_dim"], "coff": data["coff"]}
+
+
+def run_gpu(
+    prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs: Any
+):
+    """Validate once, then expose only the two launch closures to bench_suite."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _kernel_config({**prepared["config"], **kwargs})
+    data = prepare_data(**config)
+    executable = prepared["executable"]
+
+    def tirx_launch():
+        _launch(executable, data)
+
+    def tirx_repeat_launch():
+        _launch(executable, data, "repeat_out")
+
+    tirx_launch()
+    tirx_repeat_launch()
+    torch.cuda.synchronize()
+
+    references = None
+    include_source = external_references_enabled()
+    if include_source:
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"cudnn_frontend": lambda: source_launch}
+    _validate_outputs(data, include_source=include_source, include_oracle=False)
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config: Any):
+    """Standalone wrapper over the bench-suite preparation and GPU stages."""
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -235,7 +235,7 @@ def _derived_gptr_shape(name, ann, scalar_params):
         raise ValueError(
             f"gptr parameter {name!r} shape refers to unknown scalar parameter {missing!r}"
         ) from error
-    if not isinstance(shape, (tuple, list)) or not shape:
+    if not isinstance(shape, tuple | list) or not shape:
         raise TypeError(f"gptr parameter {name!r} shape must return a non-empty tuple or list")
     for index, extent in enumerate(shape):
         if isinstance(extent, bool):
@@ -290,7 +290,7 @@ def _flat_frame(frame):
 def _resolve_grid(grid, params):
     if grid is None:
         return params["num_sms"] if "num_sms" in params else 1
-    if isinstance(grid, (list, tuple)):
+    if isinstance(grid, list | tuple):
         if not grid:
             raise ValueError("grid must contain at least one CTA dimension")
         dimensions = [_resolve_grid(dimension, params) for dimension in grid]
@@ -342,6 +342,7 @@ def kernel(
     host_prelude=None,
     allowed_func_calls: tuple[str, ...] = (),
     check_ir: bool = True,
+    warp_scope: bool = True,
 ):
     """Declare a kernel entry.
 
@@ -390,6 +391,12 @@ def kernel(
         keyword-only ``host`` parameter.  This is for real host/device
         contracts such as runtime TensorMap encoding; the returned values are
         IR objects owned by this one function, not a second body to splice.
+    warp_scope : bool, optional
+        Declare the entry's warp- and lane-id scopes. Disable this only for a
+        flat thread-only kernel that never calls ``K.warp_id()``,
+        ``K.lane_id()``, or defines warp roles. The CUDA lowering may still
+        materialize its standard warp-uniform launch helper independently of
+        these source-level scope declarations.
     """
 
     def decorator(fn):
@@ -436,8 +443,9 @@ def kernel(
                 # switch would let kernels silently change the launch ABI (or
                 # leave thread scope to a second builder owner), so it is not
                 # part of the kernel DSL contract.
-                session.warp_scope_id = I.warp_id([warps])
-                session.lane_id = I.lane_id([32])
+                if warp_scope:
+                    session.warp_scope_id = I.warp_id([warps])
+                    session.lane_id = I.lane_id([32])
                 session.thread_id = I.thread_id([session.nthreads])
                 _TLS.session = session
                 try:
@@ -495,9 +503,15 @@ def thread_id():
 
 def warp_id():
     """Warp-uniform CTA-local id owned by the current kernel entry."""
-    return current().warp_id()
+    value = current().warp_id()
+    if value is None:
+        raise RuntimeError("K.warp_id() is unavailable because @K.kernel set warp_scope=False")
+    return value
 
 
 def lane_id():
     """Warp-local lane id owned by the current kernel entry."""
-    return current().lane_id
+    value = current().lane_id
+    if value is None:
+        raise RuntimeError("K.lane_id() is unavailable because @K.kernel set warp_scope=False")
+    return value

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -27,7 +27,18 @@ NVSHMEM_RUNTIME_FUNC_CALLS = frozenset(
     }
 )
 LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL: Mapping[str, frozenset[str]] = MappingProxyType(
-    {"gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS}
+    {
+        "cudnn_sm100_csa_compressor_fwd": frozenset(
+            {
+                "tirx_csa_exp_constants",
+                "tirx_csa_load4_bf16x2",
+                "tirx_csa_ordered_max",
+                "tirx_csa_scan_boundary",
+                "tirx_csa_source_exp",
+            }
+        ),
+        "gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS,
+    }
 )
 
 


### PR DESCRIPTION
## Summary

- port `python/cudnn/csa/compressor/compressor_sm100.py::_compressor_fwd_kernel` from NVIDIA cuDNN Frontend at `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`
- implement the SM100 kernel through `import tirx_kernels.kern as K`, preserving the 64-thread CTA mapping, scalar/paired lane ownership, ragged scans, overlap windows, serial FP32 reduction order, and BF16 traffic
- add 18 correctness configurations, four authoritative benchmark workloads, source attribution, registry/README integration, and a frozen execution sketch
- extend the K API with thread-only scope support and narrow low-level IR helper exceptions required by this port
- record the measured predicated-window code-generation finding in the codegen-tuning database

## Correctness

- kernel correctness matrix: 18/18 passed against both the pinned cuDNN Frontend source and an independent FP32 oracle
- K API and low-level IR tests: 16 passed
- kernel self-test suite: 22 passed
- registry integration checks: 3 passed
- import gate: 75 kernels and 221 default workloads discovered
- license-header check and pre-commit hooks passed

## Performance

Authoritative `bench_suite` run 137 on apache/tvm main at `994e0216`, without any external TVM patch. The run used 9 rounds and had no interference retries. Ratio is cuDNN Frontend / TIRx, so values above 1.0 favor TIRx.

| workload | TIRx (us) | cuDNN Frontend (us) | ratio |
| --- | ---: | ---: | ---: |
| `perf_b1_s8192_d128_c2` | 6.557 | 6.758 | 1.030699x |
| `perf_b3_s8192_d128_c2` | 11.839 | 12.357 | 1.043740x |
| `perf_b1_s8192_d512_c2` | 14.533 | 14.847 | 1.021587x |
| `perf_b3_s8192_d512_c2` | 35.496 | 36.761 | 1.035621x |

Minimum ratio: **1.021587x**.

## Validation commands

- `python -m tirx_kernels.bench_suite --check-imports`
- `pytest -q tests/test_kern_api.py tests/test_low_level_ir.py`
- `python tests/lint/check_license_headers.py`
- `pre-commit run --files <changed files>`
- `CUDNN_FRONTEND_PATH=/home/bohanhou/kernel-libs/cudnn-frontend CUDNNFE_CSA_COMPRESSOR_FAST_LAUNCH=0 python -m tirx_kernels.bench_suite --with-references --no-report --workloads .porting/compressor_fwd_sm100/perf_matrix_workloads.yaml --rounds 9 --max-prepare-processes 1 --ready-backlog 1 --label reqntid_ab_off`