### PR TITLE
feat(kernel): port cuDNN SM100 block-sparse attention forward

### DIFF
--- a/.agents/sketch/cudnn/sm100_bsa_forward_blk64.md
+++ b/.agents/sketch/cudnn/sm100_bsa_forward_blk64.md
@@ -1,0 +1,1317 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116),
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 blk64 block-sparse attention forward: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch. It freezes the launch contract,
+linear storage, sixteen-warp role split, sparse gather order, asynchronous
+protocols, online row-statistics dataflow, split-P publication, correction
+exchange, output path, singleton-cluster CLC branch, and split-KV combine for
+[`tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py`](../../../tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py).
+That module and its private implementation package are the executable source of
+truth after the reviewer gate; this sketch remains frozen.
+
+The source is the production `bsa_attn_fwd_blk64_cutedsl` path in cuDNN
+Frontend. The producer comes from
+`python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py`;
+the split reduction comes from adjacent `bsa_fwd_combine.py`; the wrapper and
+compile policy are in `python/cudnn/block_sparse_attention/_interface.py`.
+Source-line citations below use those files at commit
+`7b5327b32907b9dd21d85a393d62f9573d7f0116`.
+
+First-class layouts are forbidden throughout the sketch and implementation.
+All device SMEM is one linear byte allocation. The source's layout objects are
+resolved here into scalar extents, byte offsets, index functions, swizzle bits,
+TensorMap fields, and raw MMA descriptors. TMEM regions are integer columns;
+register fragments are ordinary scalar/vector arrays. “Tile” in prose means a
+logical rectangular region, never a TIRx tile primitive or layout-bearing value.
+
+## Scope and specializations
+
+The fixed producer geometry is BF16 MHA, `D=DV=128`, Q rows 64, one grouped KV
+iteration of 256 tokens assembled from four indexed sparse blocks of 64, one-CTA
+UMMA, and FP32 score/output accumulation. The producer always uses 512 threads,
+one Q stage, three aliased K/V stages, two alternating score/P stages, two O
+accumulator stages, and all 512 TMEM columns. Source `bsa_fwd_sm100.py:53-188`.
+
+In scope:
+
+| axis | accepted values | device-code consequence |
+| --- | --- | --- |
+| input presentation | BHSD / BSHD | BSHD is made contiguous as BHSD by the wrapper before either timed launch; producer addressing is the same |
+| sparse count | fixed / per-Q-block variable | fixed reads one scalar; variable loads `block_nums[b,h,qb]`; the latter may specialize an empty-tile branch |
+| block tail mask | present / absent | present loads physical `block_sizes[block_id]`; absent substitutes 64 without a GMEM access |
+| scheduling | static / CLC | static uses ordinary `K.cta_id()`; CLC explicitly calls `K.cta_id_in_cluster([1,1,1])` and dedicates warp 15 to cluster launch control |
+| split-KV | 1..256, including wrapper `auto` | values greater than one produce FP32 partial O/LSE, disable CLC, and launch the independent 128-thread combine |
+| K/V stride width | normal i32 / active i64 | only the K/V global address and TensorMap stride path widens; normal metadata and loop counters stay i32 |
+| output dtype | BF16 final / FP32 producer partial | FP32 only when split-KV is active; final combine converts to BF16 |
+| scale | default `1/sqrt(128)` / runtime f32 | producer carries both the natural and log2-domain scale |
+
+Out of scope: FP16, GQA/MQA, causal attention, `D` or `DV` other than 128,
+sparse block sizes other than 64, Q tiles other than 64, grouped KV tiles other
+than 256, multi-CTA MMA, cluster dimensions greater than one, and every SM90,
+SM110-specific, or SM120 sibling. Tile primitives are out of scope.
+
+Static and split producer launches are ordinary launches. CLC is an explicit
+singleton-cluster launch even though every dimension has extent one; presence
+of `clusterCtaIdx.*`, not the numeric extent, is the contract. Split-KV and CLC
+are mutually exclusive (`_interface.py:1167-1179`).
+
+## Line-info export used for instruction selection
+
+The writer exported and ran three structurally distinct production paths and a
+generated intermediate. The manifest is preserved at
+`.porting/block_sparse_attention_forward_sm100_blk64/writer_source_export/manifest.md`.
+
+| export | result | artifact SHA256 | relevant launch |
+| --- | --- | --- | --- |
+| static | source O/LSE and FP32 gathered oracle PASS | `1b43896ab9956289433237434a80d47c26bd3f7a3626cbb32acf918f5d4e9ee9` | `.reqntid 512,1,1`, ordinary CTA |
+| CLC | source O/LSE and oracle PASS | `0c88704ea28668e20e0bf46a96621d8c771ae8f3f16eb41988a1246b1d484779` | `.reqntid 512,1,1`, CLC instructions and singleton cluster request |
+| split producer | source partial/final result and oracle PASS | `83cd2a7372f594088dc12a21e05120020107a7bfe51830cbd12177893f8247d3` | `.reqntid 512,1,1`, ordinary CTA |
+| split combine | same split PASS | `ce81938a9ed60c37576f4384a5ec28e86c93772d3b8987f52ac7a4a636763a70` | `.reqntid 128,1,1`, ordinary CTA |
+| static clean MLIR | same static PASS | `0ddeda5829230f9b85cc82e2e0f794a844c2ebe2a22b350a0d57c8c2083fe1de` | resolves dynamic storage fields and source mappings |
+
+The static producer contains 64 `tcgen05.mma.ws.cta_group::1.kind::f16`,
+32 `tcgen05.ld.sync.aligned.32x32b.x32.b32`, 16
+`tcgen05.st.sync.aligned.32x32b.x16.b32`, eight x32 TMEM stores, 15
+`tcgen05.commit...mbarrier::arrive`, 40 tensor bulk copies, and 518
+`ex2.approx.ftz.f32` sites in its statically replicated bodies. Counts describe
+the exported anchor, not dynamic work. The CLC export adds 26
+`clusterlaunchcontrol` sites while retaining the same MMA/TMEM families. The
+combine export confirms scalar LSE `cp.async.ca`, 16-byte O
+`cp.async.cg`, `shfl.sync.bfly`, packed f32x2 multiply/add, BF16x2 conversion,
+and vector global stores.
+
+## Pipeline at a glance
+
+Producer: 16 warps. Static and split specializations use `SingleTileScheduler`:
+each CTA owns exactly its launch coordinate `(q_block, q_head, batch, split)`,
+executes it once, and then becomes invalid. Only the CLC specialization is
+persistent; every role consumes the same CLC response sequence and communicates
+only through the named pipelines.
+
+| warps | role-local program | publication / reuse edges |
+| --- | --- | --- |
+| 0..3 | stage-0 score consumer: load 128 FP32 S values per row from TMEM, apply two 64-token masks, update online max/sum, convert P to BF16 and store it back to the aliased TMEM stage | consumes `SPO.full[0]`; early first 32 P columns release `SPO.empty[0]`; last P columns commit `P_LAST.full[0]`; named barriers publish stats readiness while `SMSTAT.empty[0]` alone protects stats-storage reuse |
+| 4..7 | identical stage-1 score consumer for the alternating S/P region | same edges for stage 1 |
+| 8..11 | correction: consume softmax rescale factors, rescale previous TMEM O stages, wait for final O, combine the two stage statistics, exchange/reduce warp pairs in aliased K/V SMEM, form BF16 O (or FP32 split partial) and LSE | consumes named softmax-stat arrivals and `O_ACC.full`; releases `SMSTAT.empty`/`SPO.empty`; produces `O_EPI.full` |
+| 12 | sole MMA issuer and TMEM allocator: QK into alternating S stages, then split-arrival PV into alternating O stages | consumes Q/K/V TMA-full, `SPO.empty`, `P_LAST.full`; releases Q/K/V stages; produces `SPO.full` and `O_ACC.full` |
+| 13 | epilogue: waits for corrected shared O and TMA-stores one 64x128 output region | consumes `O_EPI.full`, bulk-group wait releases shared output |
+| 14 | sole TMA producer: load Q once, then reverse sparse K/V stream into the three-stage union | consumes Q/KV empty barriers; TMA transaction completion produces their full barriers |
+| 15 | static/split: register-decreased idle warp; CLC: acquire the empty CLC slot and issue `try_cancel` into its full mbarrier | all 512 threads consume each CLC response and release the empty slot |
+
+The load order for `N = padded_sparse_blocks/4` grouped iterations is exactly
+`Q, K[N-1], K[N-2], {V[N-1-i], K[N-3-i]} for i=0..N-3, V[1], V[0]`.
+The MMA order is `S0, S1`, then alternating `PV(stage), QK(stage)` pairs, then
+the two final `PV` operations. Sparse block count is rounded to a multiple of
+eight before division by four, so `N` is even and both stage epilogues exist.
+
+The correction warps initially release both O stages because no old O exists.
+For later score groups they use the online-softmax rescale supplied by the
+matching score warpgroup before letting MMA overwrite/accumulate that stage.
+The first 32 columns of each P stage are deliberately published separately
+from the last 96; this is load-bearing overlap, not an optional optimization.
+
+## Primitive vocabulary
+
+Structural declarations carry no computation and no layout object:
+
+```python
+specialize(...)                    # static Python/JIT branch values
+launch(...)                        # grid, block, cluster-presence and SMEM bytes
+gmem_region(name, dtype, extents, strides)
+smem_bytes(name, base, bytes, alignment)
+tmem_columns(name, first, count, dtype)
+rmem_words(name, count, dtype)
+tensormap(name, rank, dtype, box, strides, swizzle, oob_fill)
+byte_ptr(linear_base, scalar_byte_offset)
+pipeline_state(stages, index, phase, count)
+work_cursor(q_blocks, heads, batch, splits, persistent_limit)
+```
+
+Every physical SMEM mapping is a scalar function. `swizzle343(x)` means the
+source/export's `S<3,4,3>` bit permutation,
+`x ^ (((x >> 7) & 7) << 4)`, applied to the source element address before
+scaling by two BF16 bytes. The logical tuple decomposition below is explicit so
+the implementation never reconstructs a layout object.
+
+Directional movement:
+
+```python
+copy_g2s_tma(tmap, coords, dst_byte, mbarrier)
+copy_s2g_tma(tmap, coords, src_byte)
+copy_g2s_async(src_ptr, dst_byte, bytes, valid_bytes)
+copy_t2r(src_tmem_col, dst_regs, words)
+copy_r2t(src_regs, dst_tmem_col, words)
+copy_t2s(src_tmem_col, dst_byte, words)
+copy_r2s(src_regs, dst_byte, words)
+copy_s2r(src_byte, dst_regs, words)
+load_global(src_ptr, dtype, lanes)
+store_global(dst_ptr, values, dtype, lanes)
+load_shared(src_byte, dtype, lanes)
+store_shared(dst_byte, values, dtype, lanes)
+```
+
+Basic computation remains decomposed:
+
+```python
+fill(dst, value)
+maximum(dst, lhs, rhs)
+add(dst, lhs, rhs, lanes=1)
+mul(dst, lhs, rhs, lanes=1)
+fma(dst, lhs, rhs, acc, lanes=1)
+exp2(dst, src)
+log2(dst, src)
+rcp(dst, src)
+cast(dst, src, rounding="rn")
+gemm(dst_tmem, a_smem_or_tmem, b_smem, accumulate, descriptor)
+reduce_max_warp(dst, src, width)
+reduce_sum_warp(dst, src, width)
+```
+
+Synchronization remains visible:
+
+```python
+elect_one(); arrive(barrier); arrive_expect_tx(barrier, bytes)
+wait(barrier, phase); release(barrier); commit_tmem(barrier)
+fence_mbarrier_init_cluster(); fence_async_shared_cta()
+fence_after_thread_sync(); fence_tmem_store(); sync_warp(); sync_cta()
+cp_async_commit_group(); cp_async_wait_group(pending)
+named_barrier_arrive(id, threads); named_barrier_arrive_wait(id, threads)
+alloc_tmem(columns); free_tmem(columns)
+cluster_try_cancel(full_mbarrier, response); cluster_query_wait()
+```
+
+## Complete producer sketch
+
+```python
+# ---------------------------------------------------------------------------
+# Fixed specialization, ABI, and launch
+# source main:53-188,226-677; export PTX:14-43
+# ---------------------------------------------------------------------------
+P = specialize(
+    B, H, SQ, SKV,
+    has_block_sizes, has_variable_counts, allow_empty,
+    kv_splits, use_clc, use_i64_kv_strides, output_dtype,
+)
+M = 64
+N = 256
+D = DV = 128
+SPARSE = 64
+WARPS = 16
+THREADS = 512
+Q_STAGES = 1
+KV_STAGES = 3
+SP_STAGES = 2
+SPLIT_P_COLS = 32
+
+ABI = (
+    Q_bf16, K_bf16, V_bf16, O_bf16_or_f32, LSE_f32,
+    map_Q, map_K, map_V, map_O,
+    softmax_scale_log2, softmax_scale,
+    scheduler_params,
+    block_index_i32, optional_block_sizes_i32,
+    uniform_block_count_i32, optional_block_nums_i32,
+    optional_split_offsets_i32,
+)
+
+if P.use_clc:
+    cta = cta_id_in_cluster([1, 1, 1])
+    # instruction_selection: runtime cluster-dimension launch attribute plus
+    #   `clusterlaunchcontrol.*`; extent: explicit singleton cluster launch
+else:
+    cta = cta_id()
+    # instruction_selection: ordinary `%ctaid.*` launch metadata with no
+    #   cluster launch attribute; extent: one ordinary producer launch
+
+launch(
+    grid=((ceil_div(SQ,64), H, B) if P.use_clc
+          else (ceil_div(SQ,64), H*kv_splits, B)),
+    block=(512, 1, 1),
+    arch="sm_100a",
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=217088,
+)
+# instruction_selection: `.reqntid 512,1,1`, `.minnctapersm 1`,
+#   `.extern .shared .align 1024`; extent: one producer specialization
+# Register reallocation is source-exact: softmax warps 0..7 request 184,
+# correction warps 8..11 request 88, and MMA/load/epilogue/idle or CLC warps
+# 12..15 decrease to 48 via `setmaxnreg`.
+
+# ---------------------------------------------------------------------------
+# One-dimensional SMEM and explicit physical mappings
+# generated MLIR fields at writer export lines 188-215
+# ---------------------------------------------------------------------------
+SMEM = smem_bytes("producer", base=0, bytes=217088, alignment=1024)
+
+Q_PIPE       = smem_bytes("q_mbars",       0,   16, 8)  # full@0, empty@8
+KV_PIPE      = smem_bytes("kv_mbars",      16,  48, 8)  # full@16..32, empty@40..56
+SPO_PIPE     = smem_bytes("spo_mbars",     64,  32, 8)  # full@64,72; empty@80,88
+P_LAST_PIPE  = smem_bytes("plast_mbars",   96,  32, 8)  # full@96,104; empty@112,120
+O_ACC_PIPE   = smem_bytes("oacc_mbars",    128, 32, 8)  # full@128,136; empty@144,152
+SMSTAT_PIPE  = smem_bytes("smstat_mbars",  160, 32, 8)  # full@160,168; empty@176,184
+O_EPI_PIPE   = smem_bytes("oepi_mbars",    192, 32, 8)  # full@192,200; empty@208,216
+TMEM_HOLD    = smem_bytes("tmem_pointer",  224, 4,  4)
+REDUCE_MBAR  = smem_bytes("reduce_mbars",  232, 16, 8)
+SCALE_STATS  = smem_bytes("row_stats",     248, 2048, 8)
+PAIR_STATS   = smem_bytes("pair_stats",    2296,1024, 8)
+
+# CLC only: 16 bytes of mbarrier storage at 3320 and a 16-byte-aligned,
+# 16-byte response at 3344. Static/split reserve zero bytes. Alignment leaves
+# the following large regions unchanged in every mode.
+CLC_MBAR     = smem_bytes("clc_mbars",      3320, 16 if P.use_clc else 0, 8)
+CLC_RESPONSE = smem_bytes("clc_response",  3344, 16 if P.use_clc else 0, 16)
+Q_SMEM       = smem_bytes("Q",              4096, 16384, 1024)
+KV_UNION     = smem_bytes("K_V_exchange_O", 20480, 196608, 1024)
+
+# Exact source/export address functions, returning BF16 element offsets
+# relative to the named linear region.
+def q_elem(m0, m1, d0, d1):
+    return swizzle343(64*m0 + m1 + 16*d0 + 4096*d1)
+
+def k_elem(stage, n0, n1, d0, d1):
+    return swizzle343(64*n0 + n1 + 16*d0 + 16384*d1 + 32768*stage)
+
+def v_elem(stage, n0, sparse4, d16, d4, dhalf):
+    return swizzle343(n0 + 4096*sparse4 + 64*d16
+                      + 1024*d4 + 16384*dhalf + 32768*stage)
+
+# Per-sparse-block TMA destinations inside one K/V stage.
+K_SLOT = (0, 2, 1, 3)
+def k_tma_elem(stage, sub, token64, dim64, half):
+    return 32768*stage + 4096*K_SLOT[sub] + swizzle343(64*token64 + dim64 + 16384*half)
+
+def v_tma_elem(stage, sub, dim64, token64, half):
+    return 32768*stage + 8192*sub + swizzle343(dim64 + 64*token64 + 4096*half)
+
+# The correction exchange aliases the beginning of KV_UNION as FP32.
+def exchange_f32(corr_warp, lane, chunk, word):
+    return corr_warp*(4*32*32) + chunk*(32*32) + lane*4 + word
+
+# Corrected O aliases KV_UNION after 32768 BF16 elements = 65536 bytes, so its
+# absolute SMEM base is 20480+65536=86016. Both output dtypes use that byte base
+# but have distinct source-IR layouts and TensorMap boxes.
+# BF16: S<3,4,3> o ((8,8),(64,2),(1,2)):((64,512),(1,4096),(0,8192)).
+def o_bf16_elem(r8, r_outer8, c64, c_half, stage):
+    return swizzle343(64*r8 + 512*r_outer8 + c64 + 4096*c_half + 8192*stage)
+
+# FP32 split partial: S<3,4,3> o
+# ((8,8),(32,4),(1,2)):((32,256),(1,2048),(0,8192)).
+def o_f32_elem(r8, r_outer8, c32, c_quarter, stage):
+    return swizzle343(32*r8 + 256*r_outer8 + c32
+                      + 2048*c_quarter + 8192*stage)
+
+O_SMEM_BASE = KV_UNION.base + 65536
+
+S_TMEM = (0, 128)       # FP32 score columns
+P_TMEM = (0, 128)       # BF16 P aliases S, source address uses 2x column scale
+O_TMEM = (256, 384)     # FP32 output accumulators
+TMEM_COLUMNS = 512
+
+# SCALE_STATS planes are [stage][128 correction lanes]: sum at plane 0,
+# row-max at plane 1. PAIR_STATS stores (sum,max) for four correction warps.
+def scale_stat(stage, lane128, plane):
+    return 248 + 4*(lane128 + stage*128 + plane*2*128)
+
+def pair_stat(warp, lane, field):
+    return 2296 + 4*(warp*64 + lane*2 + field)
+
+# ---------------------------------------------------------------------------
+# TensorMaps and raw descriptors
+# source main:388-548; export clean MLIR types 17-43,112
+# ---------------------------------------------------------------------------
+map_Q = tensormap("Q", rank=4, dtype=bf16, box=(64,64,1,1),
+                  swizzle="128B/S<3,4,3>", oob_fill="zero")
+map_K = tensormap("K sparse sub-block", rank=5, dtype=bf16,
+                  box=(64,64,1,1,(1,1)), swizzle="128B/S<3,4,3>",
+                  stride_width=(i64 if P.use_i64_kv_strides else i32))
+map_V = tensormap("V sparse sub-block", rank=5, dtype=bf16,
+                  box=(64,64,2,1,(1,1)), swizzle="128B/S<3,4,3>",
+                  stride_width=(i64 if P.use_i64_kv_strides else i32))
+if P.output_dtype == bf16:
+    map_O = tensormap("O bf16", rank=4, dtype=bf16, box=(64,64,1,1),
+                      swizzle="128B/S<3,4,3>")
+else:
+    map_O = tensormap("O partial f32", rank=4, dtype=f32, box=(32,64,1,1),
+                      swizzle="128B/S<3,4,3>")
+
+# ---------------------------------------------------------------------------
+# Pipeline construction and prologue
+# source main:733-922; export PTX source locations 725-819
+# ---------------------------------------------------------------------------
+Q_PROD   = pipeline_state(1, index=0, phase=1, count=0)
+Q_CONS   = pipeline_state(1, index=0, phase=0, count=0)
+KV_PROD  = pipeline_state(3, index=0, phase=1, count=0)
+KV_CONS  = pipeline_state(3, index=0, phase=0, count=0)
+SPO_CONS_PHASE = [0, 0]          # MMA waits on P/old-O availability
+SPO_FULL_PHASE = [0, 0]          # softmax waits on score publication
+P_LAST_CONS_PHASE = [0, 0]       # MMA; toggles with the matching SPO stage
+SMSTAT_PROD_PHASE = [1, 1]       # softmax acquires empty stats slots
+SMSTAT_CONS_PHASE = [0, 0]       # correction releases them
+OACC_CONS_PHASE = 0              # correction; toggles only for live tiles
+OEPI_PROD_PHASE = 1              # correction; toggles for live and empty tiles
+OEPI_CONS_PHASE = 0              # epilogue; toggles once for every tile
+CLC_PROD = pipeline_state(1, index=0, phase=1, count=0)
+CLC_CONS = pipeline_state(1, index=0, phase=0, count=0)
+
+if elected_lane_of_warp(0):
+    prefetch_descriptor(map_Q)
+    # instruction_selection: `prefetch.tensormap`; extent: one descriptor
+    prefetch_descriptor(map_K)
+    # instruction_selection: `prefetch.tensormap`; extent: one descriptor
+    prefetch_descriptor(map_V)
+    # instruction_selection: `prefetch.tensormap`; extent: one descriptor
+    prefetch_descriptor(map_O)
+    # instruction_selection: `prefetch.tensormap`; extent: one descriptor
+
+if elected_lane_of_warp(0):
+    init_barrier(Q_PIPE.full[0], arrivals=1)
+    init_barrier(Q_PIPE.empty[0], arrivals=1)
+    # instruction_selection: `mbarrier.init.shared.b64`; extent: 1 full + 1 empty
+    for stage in 0..2:
+        init_barrier(KV_PIPE.full[stage], arrivals=1)
+        init_barrier(KV_PIPE.empty[stage], arrivals=1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 3 full + 3 empty
+    for stage in 0..1:
+        init_barrier(SPO_PIPE.full[stage], arrivals=1)
+        init_barrier(SPO_PIPE.empty[stage], arrivals=256)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 2 full + 2 empty
+        init_barrier(P_LAST_PIPE.full[stage], arrivals=4)
+        init_barrier(P_LAST_PIPE.empty[stage], arrivals=1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 2 full + 2 empty
+        init_barrier(O_ACC_PIPE.full[stage], arrivals=1)
+        init_barrier(O_ACC_PIPE.empty[stage], arrivals=128)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 2 full + 2 empty
+        init_barrier(SMSTAT_PIPE.full[stage], arrivals=128)
+        init_barrier(SMSTAT_PIPE.empty[stage], arrivals=128)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 2 full + 2 empty
+        init_barrier(O_EPI_PIPE.full[stage], arrivals=128)
+        init_barrier(O_EPI_PIPE.empty[stage], arrivals=32)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: 2 full + 2 empty
+if elected_lane_of_warp(15):
+    init_barrier(REDUCE_MBAR + 0, arrivals=64)
+    # instruction_selection: `mbarrier.init.shared.b64`; extent: scalar
+    init_barrier(REDUCE_MBAR + 8, arrivals=64)
+    # instruction_selection: `mbarrier.init.shared.b64`; extent: scalar
+fence_mbarrier_init_cluster()
+# instruction_selection: first `fence.mbarrier_init.release.cluster` after all
+#   ordinary pipeline and reduction mbarriers; extent: CTA, with no sync yet
+
+if P.use_clc:
+    if elected_lane_of_warp(0):
+        init_barrier(CLC_MBAR.full[0], arrivals=1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: one CLC full slot
+        init_barrier(CLC_MBAR.empty[0], arrivals=512)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: one CLC empty slot
+    fence_mbarrier_init_cluster()
+    # instruction_selection: second `fence.mbarrier_init.release.cluster`;
+    #   extent: CLC full/empty pair only
+    sync_cta()
+    # instruction_selection: first `bar.sync 0`; extent: CLC-create CTA sync
+sync_cta()
+# instruction_selection: static/split's only `bar.sync 0`, or CLC's second
+#   `bar.sync 0`; extent: `pipeline_init_wait` across all 512 threads
+
+if warp == 12:
+    alloc_tmem(512)
+    # instruction_selection: `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`;
+    #   extent: one elected MMA-warp lane
+sync_named_tmem_pointer(warps=0..12)
+# instruction_selection: `bar.sync`; extent: named 13-warp rendezvous
+
+# The actual source dispatch order is CLC/empty -> load -> MMA -> epilogue ->
+# softmax -> correction. The role bodies below are factored by role for review,
+# but implementation branch order remains identical to the source.
+#
+# Static/split scheduler contract used by every role:
+#   work = launch coordinate; scheduler.advance() marks it invalid. There is no
+#   grid-stride or persistent cursor in these modes.
+# Every role begins with `work = scheduler.initial_work_tile_info()`.
+#
+# CLC scheduler contract. Warp 15 overlaps production of the *next* work record
+# with execution of the current one. For every current valid record it performs:
+if P.use_clc and warp == 15:
+    work = scheduler.initial_work_tile_info()
+    while work.valid:
+        wait(CLC_MBAR.empty[CLC_PROD.index], CLC_PROD.phase)
+        # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+        #   extent: one producer acquire of the 512-arrival empty slot
+        cluster_try_cancel(CLC_MBAR.full[CLC_PROD.index], CLC_RESPONSE)
+        # instruction_selection: `clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes`;
+        #   extent: one 16-byte next-work query into the full barrier
+        advance(CLC_PROD)
+
+        # Warp 15 is also one of the 512 consumers, so it executes the same
+        # converged response protocol as every computational role.
+        sync_cta()
+        # instruction_selection: `bar.sync`; extent: all 512 threads before response
+        wait(CLC_MBAR.full[CLC_CONS.index], CLC_CONS.phase)
+        # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+        #   extent: all consumer threads observe the completed response
+        work = decode_clc_response(CLC_RESPONSE)
+        # instruction_selection: `clusterlaunchcontrol.query_cancel` and scalar
+        #   response decode; extent: one next `(q_block,head,batch,0)` record
+        release(CLC_MBAR.empty[CLC_CONS.index])
+        # instruction_selection: `mbarrier.arrive.shared.b64`; extent: all 512
+        advance(CLC_CONS)
+
+    # Producer tail is separate from response consumption.
+    wait(CLC_MBAR.empty[CLC_PROD.index], CLC_PROD.phase)
+    # instruction_selection: CLC producer-tail mbarrier wait; extent: the final
+    #   outstanding query slot, separate from the per-record consumer step
+
+# In every load/MMA/epilogue/softmax/correction CLC role below, each written
+# `work = scheduler.advance()` expands to: `sync_cta`; wait CLC full at
+# `CLC_CONS.phase`; decode the 16-byte response; every thread releases CLC empty;
+# advance `CLC_CONS`. Static/split expansion only invalidates the one work item.
+
+# ---------------------------------------------------------------------------
+# Warp 14: Q and reverse sparse K/V TMA producer
+# source main:1149-1300,2322-2418; exported .loc 1227-1301,2341-2409
+# ---------------------------------------------------------------------------
+if warp == 14:
+    while work.valid:
+        qb, h, b, split = work.coordinates
+        raw_count, split_start = sparse_count_and_offset(work)
+        process = (raw_count > 0) if P.allow_empty else True
+        NITER = round_up(raw_count, 8) // 4
+
+        # Each requested index is clamped to the last live entry so padded
+        # groups are safe; the block-size mask later zeros phantom columns.
+        def sparse_id(i):
+            return block_index[b,h,qb,split_start + min(i, raw_count-1)]
+
+        if process:
+            wait(Q_PIPE.empty[0], Q_PROD.phase)
+            # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+            #   extent: one stage wait
+            arrive_expect_tx(Q_PIPE.full[0], 64*128*2)
+            # instruction_selection: `mbarrier.arrive.expect_tx.shared.b64`;
+            #   extent: elected TMA lane
+            for d_half in 0..1:
+                copy_g2s_tma(map_Q, (d_half*64, qb*64, h, b),
+                             Q_SMEM + 2*q_elem(..., d_half), Q_PIPE.full[0])
+                # instruction_selection: `cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+                #   extent: exactly two 64x64 BF16 issues, one per D half
+            advance(Q_PROD)
+
+            for kind, reverse_group in load_sequence(NITER):
+                wait(KV_PIPE.empty[KV_PROD.index], KV_PROD.phase)
+                # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+                #   extent: one three-stage acquire
+                arrive_expect_tx(KV_PIPE.full[KV_PROD.index], 4*64*128*2)
+                # instruction_selection: `mbarrier.arrive.expect_tx.shared.b64`;
+                #   extent: elected TMA lane
+                for sub in 0..3:
+                    sid = sparse_id(reverse_group*4 + sub)
+                    if kind == K:
+                        for d_half in 0..1:
+                            copy_g2s_tma(map_K, (d_half, sid, h, b),
+                                         KV_UNION + 2*k_tma_elem(
+                                             KV_PROD.index, sub, ..., d_half),
+                                         KV_PIPE.full[KV_PROD.index])
+                            # instruction_selection: `cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+                            #   extent: exactly two 64x64 BF16 issues per K
+                            #   sparse sub-block, eight issues for the K group
+                    else:
+                        copy_g2s_tma(map_V, (sid, h, b),
+                                     KV_UNION + 2*v_tma_elem(KV_PROD.index, sub, ...),
+                                     KV_PIPE.full[KV_PROD.index])
+                        # instruction_selection: same 5-D tensor-bulk family;
+                        #   extent: exactly one 64x128 BF16 issue per V sparse
+                        #   sub-block, four issues for the V group
+                advance(KV_PROD)
+
+        scheduler.prefetch_next()
+        work = scheduler.advance()
+
+    wait(KV_PIPE.empty[KV_PROD.index], KV_PROD.phase)
+    # instruction_selection: `mbarrier.try_wait.parity.shared.b64`; extent: producer tail
+    wait(Q_PIPE.empty[0], Q_PROD.phase)
+    # instruction_selection: same mbarrier wait family; extent: Q producer tail
+
+# ---------------------------------------------------------------------------
+# Warp 12: sole WS QK/PV issuer
+# source main:1301-1580; exported .loc 1385-1519 and helper-attributed sites
+# ---------------------------------------------------------------------------
+if warp == 12:
+    while work.valid:
+        raw_count = sparse_count(work)
+        process = (raw_count > 0) if P.allow_empty else True
+        NITER = round_up(raw_count, 8) // 4
+
+        if process:
+            wait(Q_PIPE.full[0], Q_CONS.phase)
+            # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+            #   extent: one Q wait
+            fence_after_thread_sync()
+            # instruction_selection: `tcgen05.fence::after_thread_sync`;
+            #   extent: elected MMA warp after the Q full wait
+            advance(Q_CONS)
+
+            for stage in (0, 1):
+                wait(KV_PIPE.full[KV_CONS.index], KV_CONS.phase)
+                # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+                #   extent: one K stage
+                fence_after_thread_sync()
+                # instruction_selection: `tcgen05.fence::after_thread_sync`;
+                #   extent: elected MMA warp after each K full wait
+                for k_phase in 0..7:
+                    gemm(S_TMEM[stage], q_desc_at(Q_SMEM,k_phase),
+                         k_desc_at(KV_UNION,KV_CONS.index,k_phase),
+                         accumulate=(k_phase != 0),
+                         descriptor=QK_ISSUE_64x256x16_WS_SS)
+                    # instruction_selection: `tcgen05.mma.ws.cta_group::1.kind::f16`;
+                    #   extent: exactly eight issues; k_phase 0 carries
+                    #   accumulate=0 and k_phase 1..7 carry accumulate=1
+                commit_tmem(SPO_PIPE.full[stage])
+                # instruction_selection: `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`;
+                #   extent: one score stage
+                release(KV_PIPE.empty[KV_CONS.index])
+                # instruction_selection: `mbarrier.arrive.shared.b64`; extent: one stage
+                advance(KV_CONS)
+
+            initialized = [False, False]
+            for pair in 0..((NITER-2)//2 - 1):
+                for stage in (0, 1):
+                    wait(SPO_PIPE.empty[stage], SPO_CONS_PHASE[stage])
+                    # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+                    #   extent: one P/old-O reuse wait
+                    wait(KV_PIPE.full[KV_CONS.index], KV_CONS.phase)
+                    # instruction_selection: same mbarrier wait family; extent: one V stage
+                    fence_after_thread_sync()
+                    # instruction_selection: `tcgen05.fence::after_thread_sync`;
+                    #   extent: elected MMA warp after each V full wait
+                    for issue in 0..1:
+                        gemm(O_TMEM[stage], P_TMEM[stage] + issue*PV_A_STEP,
+                             KV_UNION + 2*v_elem(KV_CONS.index, issue,...),
+                             accumulate=(initialized[stage] or issue > 0),
+                             descriptor=PV_ISSUE_64x32x128_WS_TS)
+                        # instruction_selection: `tcgen05.mma.ws.cta_group::1.kind::f16`;
+                        #   extent: exactly two issues using the early 32 P columns
+                    wait(P_LAST_PIPE.full[stage], P_LAST_CONS_PHASE[stage])
+                    # instruction_selection: `mbarrier.try_wait.parity.shared::cta.b64`;
+                    #   extent: the split arrival, after issue 2 and before issue 3
+                    for issue in 2..7:
+                        gemm(O_TMEM[stage], P_TMEM[stage] + issue*PV_A_STEP,
+                             KV_UNION + 2*v_elem(KV_CONS.index, issue,...),
+                             accumulate=True, descriptor=PV_ISSUE_64x32x128_WS_TS)
+                        # instruction_selection: same WS f16 MMA family;
+                        #   extent: exactly six remaining issues
+                    release(KV_PIPE.empty[KV_CONS.index])
+                    # instruction_selection: `mbarrier.arrive.shared.b64`; extent: V stage
+                    advance(KV_CONS)
+
+                    wait(KV_PIPE.full[KV_CONS.index], KV_CONS.phase)
+                    # instruction_selection: mbarrier wait family; extent: next K stage
+                    fence_after_thread_sync()
+                    # instruction_selection: `tcgen05.fence::after_thread_sync`;
+                    #   extent: elected MMA warp after the next K full wait
+                    for k_phase in 0..7:
+                        gemm(S_TMEM[stage], q_desc_at(Q_SMEM,k_phase),
+                             k_desc_at(KV_UNION,KV_CONS.index,k_phase),
+                             accumulate=(k_phase != 0),
+                             descriptor=QK_ISSUE_64x256x16_WS_SS)
+                        # instruction_selection: WS f16 MMA family; extent:
+                        #   exactly eight issues, first zero-init and seven accumulate
+                    commit_tmem(SPO_PIPE.full[stage])
+                    # instruction_selection: tcgen05 commit-to-mbarrier; extent: score stage
+                    release(KV_PIPE.empty[KV_CONS.index])
+                    # instruction_selection: mbarrier arrive; extent: K stage
+                    advance(KV_CONS)
+                    SPO_CONS_PHASE[stage] ^= 1
+                    P_LAST_CONS_PHASE[stage] ^= 1
+                    initialized[stage] = True
+
+            release(Q_PIPE.empty[0])
+            # instruction_selection: `mbarrier.arrive.shared.b64`; extent: Q stage
+
+            for stage in (0, 1):
+                wait(SPO_PIPE.empty[stage], SPO_CONS_PHASE[stage])
+                # instruction_selection: mbarrier wait family; extent: final P stage
+                wait(KV_PIPE.full[KV_CONS.index], KV_CONS.phase)
+                # instruction_selection: mbarrier wait family; extent: final V stage
+                fence_after_thread_sync()
+                # instruction_selection: `tcgen05.fence::after_thread_sync`;
+                #   extent: elected MMA warp after the final V full wait
+                for issue in 0..1:
+                    gemm(O_TMEM[stage], P_TMEM[stage] + issue*PV_A_STEP,
+                         KV_UNION + 2*v_elem(KV_CONS.index, issue,...),
+                         accumulate=(initialized[stage] or issue > 0),
+                         descriptor=PV_ISSUE_64x32x128_WS_TS)
+                    # instruction_selection: WS f16 MMA family; extent: two early issues
+                wait(P_LAST_PIPE.full[stage], P_LAST_CONS_PHASE[stage])
+                # instruction_selection: CTA-qualified mbarrier parity wait;
+                #   extent: after issue 2 and before issue 3
+                for issue in 2..7:
+                    gemm(O_TMEM[stage], P_TMEM[stage] + issue*PV_A_STEP,
+                         KV_UNION + 2*v_elem(KV_CONS.index, issue,...),
+                         accumulate=True, descriptor=PV_ISSUE_64x32x128_WS_TS)
+                    # instruction_selection: WS f16 MMA family; extent: six late issues
+                commit_tmem(O_ACC_PIPE.full[stage])
+                # instruction_selection: tcgen05 commit-to-mbarrier; extent: O stage
+                release(KV_PIPE.empty[KV_CONS.index])
+                # instruction_selection: mbarrier arrive; extent: final V stage
+                advance(KV_CONS)
+                SPO_CONS_PHASE[stage] ^= 1
+                P_LAST_CONS_PHASE[stage] ^= 1
+
+        work = scheduler.advance()
+
+# ---------------------------------------------------------------------------
+# Warp 13: corrected O epilogue (source dispatches this before softmax/correction)
+# source main:2218-2311; exported .loc 2291-2296
+# ---------------------------------------------------------------------------
+if warp == 13:
+    epi_consumer_phase = OEPI_CONS_PHASE
+    while work.valid:
+        wait(O_EPI_PIPE.full[0], epi_consumer_phase)
+        # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+        #   extent: one corrected shared O region
+        issue_count = 2 if P.output_dtype == bf16 else 4
+        for issue in 0..issue_count-1:
+            output_row = issue*(64 if P.output_dtype == bf16 else 32)
+            copy_s2g_tma(map_O, output_coordinates(work, output_row),
+                         O_SMEM_BASE + issue*8192)
+            # instruction_selection: `cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint`;
+            #   extent: exactly two issues for BF16 final O or four issues for
+            #   FP32 split partial O, all sourced from absolute SMEM base 86016
+        cp_async_commit_group()
+        # instruction_selection: `cp.async.bulk.commit_group`; extent: one O group
+        cp_async_wait_group(0)
+        # instruction_selection: `cp.async.bulk.wait_group.read 0`; extent: O group
+        release(O_EPI_PIPE.empty[0])
+        # instruction_selection: `mbarrier.arrive.shared.b64`; extent: 32 epilogue lanes
+        epi_consumer_phase ^= 1
+        work = scheduler.advance()
+    OEPI_CONS_PHASE = epi_consumer_phase
+
+# ---------------------------------------------------------------------------
+# Warps 0..7: two four-warp online row-statistics groups
+# source main:1581-1867; exported .loc 1665-1854
+# ---------------------------------------------------------------------------
+if warp in 0..7:
+    stage = 0 if warp < 4 else 1
+    local_warp = warp & 3
+    lane128 = local_warp*32 + lane
+    s_phase = SPO_FULL_PHASE[stage]
+    stat_empty_phase = SMSTAT_PROD_PHASE[stage]
+
+    while work.valid:
+        raw_count = sparse_count(work)
+        has_work = (raw_count > 0) if P.allow_empty else True
+        NITER = round_up(raw_count, 8) // 4
+        WG_ITERS = NITER // 2
+        row_max = -inf
+        row_sum = 0.0
+
+        wait(SMSTAT_PIPE.empty[stage], stat_empty_phase)
+        # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+        #   extent: one stats slot acquire
+        stat_empty_phase ^= 1
+
+        if has_work:
+            for it in 0..WG_ITERS-1:
+                wait(SPO_PIPE.full[stage], s_phase)
+                # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+                #   extent: one score-stage wait
+                copy_t2r(S_TMEM[stage] + 0, score[0:32], 32)
+                # instruction_selection: `tcgen05.ld.sync.aligned.32x32b.x32.b32`;
+                #   extent: one 32-column score fragment
+                copy_t2r(S_TMEM[stage] + 32, score[32:64], 32)
+                # instruction_selection: same TMEM-load family; extent: one fragment
+                copy_t2r(S_TMEM[stage] + 64, score[64:96], 32)
+                # instruction_selection: same TMEM-load family; extent: one fragment
+                copy_t2r(S_TMEM[stage] + 96, score[96:128], 32)
+                # instruction_selection: same TMEM-load family; extent: one fragment
+
+                bs_lo, bs_hi = block_sizes_for(it, stage, local_warp//2)
+                for j in 0..63:
+                    score[j] = score[j] if j < bs_lo else -inf
+                    # instruction_selection: `shr.u32`, full/zero `setp` plus
+                    #   `bra.uni`, then per-bit `and.b32`, `setp.eq.u32`, and
+                    #   predicated `mov.f32`; extent: two 32-value branches
+                    score[64+j] = score[64+j] if j < bs_hi else -inf
+                    # instruction_selection: same branch/and/setp/predicated-move
+                    #   family; extent: the second 64-token sparse block
+
+                tile_max = reduce_max_register_local(score[0:128])
+                # instruction_selection: unrolled register-local `max.ftz.f32`;
+                #   extent: 128 values owned by this thread, no warp shuffle
+                if it == 0:
+                    new_max = tile_max
+                    row_max_safe = new_max if new_max != -inf else 0.0
+                    old_scale = 0.0
+                    # instruction_selection: `setp`/branch/moves; extent: first group
+                else:
+                    new_max = maximum(row_max, tile_max)
+                    row_max_safe = new_max if new_max != -inf else 0.0
+                    delta = row_max-row_max_safe
+                    # instruction_selection: scalar `sub.f32`; extent: one row
+                    delta_scaled = delta*softmax_scale_log2
+                    # instruction_selection: scalar `mul.f32`; extent: one row
+                    old_scale = exp2(delta_scaled)
+                    # instruction_selection: `ex2.approx.ftz.f32`; extent:
+                    #   scalar row rescale after the separate subtract/multiply
+                    if delta_scaled >= -8.0:
+                        new_max = row_max
+                        row_max_safe = row_max
+                        old_scale = 1.0
+                        # instruction_selection: `setp.ge.f32` plus branch/moves;
+                        #   extent: exact BF16 `rescale_threshold=8` path
+                if it > 0:
+                    store_shared(scale_stat(stage,lane128,0), old_scale)
+                    # instruction_selection: `st.shared.b32`; extent: scalar
+                named_barrier_arrive(stage*4 + local_warp, threads=64)
+                # instruction_selection: `bar.arrive`; extent: softmax/correction warp pair
+
+                negative_scale_log2 = -softmax_scale_log2
+                # instruction_selection: scalar `neg.f32`; extent: one row
+                negative_rowmax_scaled = row_max_safe*negative_scale_log2
+                # instruction_selection: scalar `mul.f32`; extent: one row,
+                #   prepared separately before the packed score FMAs
+                for pair in 0..63:
+                    score_scaled[2*pair:2*pair+2] = fma(
+                        score[2*pair:2*pair+2],
+                        (softmax_scale_log2, softmax_scale_log2),
+                        (negative_rowmax_scaled, negative_rowmax_scaled), lanes=2)
+                    # instruction_selection: `fma.rn.f32x2`; extent: 64 packed
+                    #   scale-and-subtract pairs before any exponentiation
+                    prob_f32[2*pair] = exp2(score_scaled[2*pair])
+                    prob_f32[2*pair+1] = exp2(score_scaled[2*pair+1])
+                    # instruction_selection: `ex2.approx.ftz.f32`;
+                    #   extent: two values per explicit pair
+                row_sum = row_sum*old_scale + reduce_sum(prob_f32)
+                # instruction_selection: one scalar `mul.f32` for old
+                #   `row_sum*old_scale`, an explicit packed `add.rn.f32x2`
+                #   probability-reduction tree, then one scalar add;
+                #   extent: one complete 128-value row
+
+                for chunk in 0..3:
+                    cast(p_bf16x2[chunk], prob_f32[chunk*32:(chunk+1)*32], rounding="rn")
+                    # instruction_selection: `cvt.rn.satfinite.bf16x2.f32`;
+                    #   extent: explicit 16-pair loop
+                    copy_r2t(p_bf16x2[chunk], P_TMEM[stage] + chunk*16, 16)
+                    # instruction_selection: `tcgen05.st.sync.aligned.32x32b.x16.b32`;
+                    #   extent: one 32-column BF16 P fragment
+                    if chunk == 0:
+                        fence_tmem_store()
+                        # instruction_selection: `tcgen05.wait::st.sync.aligned`;
+                        #   extent: first 32 columns
+                        release(SPO_PIPE.empty[stage])
+                        # instruction_selection: `mbarrier.arrive.shared.b64`;
+                        #   extent: early P publication
+
+                fence_tmem_store()
+                # instruction_selection: `tcgen05.wait::st.sync.aligned`; extent: P stage
+                sync_warp()
+                # instruction_selection: `bar.warp.sync`; extent: one softmax warp
+                if elected_lane:
+                    arrive(P_LAST_PIPE.full[stage])
+                    # instruction_selection: `mbarrier.arrive.shared.b64`;
+                    #   extent: last-96-column publication
+                wait(SMSTAT_PIPE.empty[stage], stat_empty_phase)
+                # instruction_selection: mbarrier parity wait; extent: correction reuse
+                stat_empty_phase ^= 1
+                row_max = new_max
+                s_phase ^= 1
+
+            store_shared(scale_stat(stage,lane128,0), row_sum)
+            # instruction_selection: `st.shared.b32`; extent: final row sum
+            store_shared(scale_stat(stage,lane128,1), row_max)
+            # instruction_selection: `st.shared.b32`; extent: final row max
+            named_barrier_arrive(stage*4 + local_warp, threads=64)
+            # instruction_selection: `bar.arrive`; extent: final stats publication
+        else:
+            named_barrier_arrive(stage*4 + local_warp, threads=64)
+            # instruction_selection: `bar.arrive`; extent: synthetic empty publication
+
+        work = scheduler.advance()
+
+    SPO_FULL_PHASE[stage] = s_phase
+    SMSTAT_PROD_PHASE[stage] = stat_empty_phase
+
+    wait(SMSTAT_PIPE.empty[stage], stat_empty_phase)
+    # instruction_selection: mbarrier parity wait; extent: stats producer tail
+    arrive(TMEM_ALLOC_NAMED)
+    # instruction_selection: `bar.arrive`; extent: TMEM lifetime handoff
+
+# ---------------------------------------------------------------------------
+# Warps 8..11: correction, warp-pair exchange, O/LSE production
+# source main:1868-2217; exported .loc 1903-2215
+# ---------------------------------------------------------------------------
+if warp in 8..11:
+    corr_warp = warp - 8
+    lane128 = corr_warp*32 + lane
+    sm_stats_consumer_phase = SMSTAT_CONS_PHASE[0]
+    o_corr_consumer_phase = OACC_CONS_PHASE
+    corr_epi_producer_phase = OEPI_PROD_PHASE
+    for stage in (0, 1):
+        release(SPO_PIPE.empty[stage])
+        # instruction_selection: `mbarrier.arrive.shared.b64`; extent: initial O-empty token
+
+    while work.valid:
+        raw_count = sparse_count(work)
+        has_work = (raw_count > 0) if P.allow_empty else True
+        if has_work:
+            # The first score group establishes stats but has no old O to rescale.
+            named_barrier_arrive_wait(0*4+corr_warp, threads=64)
+            # instruction_selection: `bar.sync`; extent: paired softmax/correction warps
+            release(SMSTAT_PIPE.empty[0])
+            # instruction_selection: `mbarrier.arrive.shared.b64`; extent: stage 0 stats
+            named_barrier_arrive_wait(1*4+corr_warp, threads=64)
+            # instruction_selection: `bar.sync`; extent: paired warps
+            sm_stats_consumer_phase ^= 1
+
+            for pair in 0..((round_up(raw_count,8)//4 - 2)//2 - 1):
+                for stage in (0, 1):
+                    named_barrier_arrive_wait(stage*4+corr_warp, threads=64)
+                    # instruction_selection: `bar.sync`; extent: paired warps
+                    scale = load_shared(scale_stat(stage,lane128,0), f32, 1)
+                    # instruction_selection: `ld.shared.b32`; extent: scalar
+                    if warp_vote_any(scale < 1.0):
+                        copy_t2r(O_TMEM[stage], o_regs, 32)
+                        # instruction_selection: `tcgen05.ld.sync.aligned.32x32b.x32.b32`;
+                        #   extent: explicit four-fragment 4x32dp32 load
+                        mul(o_regs, o_regs, scale, lanes=2)
+                        # instruction_selection: `mul.rn.f32x2`; extent: explicit packed loop
+                        copy_r2t(o_regs, O_TMEM[stage], 32)
+                        # instruction_selection: `tcgen05.st.sync.aligned.32x32b.x32.b32`;
+                        #   extent: explicit four-fragment store
+                        fence_tmem_store()
+                        # instruction_selection: `tcgen05.wait::st.sync.aligned`; extent: O stage
+                    release(SPO_PIPE.empty[stage])
+                    # instruction_selection: mbarrier arrive; extent: rescaled O reuse
+                    release(SMSTAT_PIPE.empty[1-stage])
+                    # instruction_selection: mbarrier arrive; extent: stats reuse
+                sm_stats_consumer_phase ^= 1
+
+            release(SMSTAT_PIPE.empty[1])
+            # instruction_selection: mbarrier arrive; extent: final loop balance
+            for stage in (0, 1):
+                named_barrier_arrive_wait(stage*4+corr_warp, threads=64)
+                # instruction_selection: `bar.sync`; extent: final stats
+                row_sum[stage] = load_shared(scale_stat(stage,lane128,0), f32, 1)
+                # instruction_selection: `ld.shared.b32`; extent: scalar
+                row_max[stage] = load_shared(scale_stat(stage,lane128,1), f32, 1)
+                # instruction_selection: `ld.shared.b32`; extent: scalar
+                release(SMSTAT_PIPE.empty[stage])
+                # instruction_selection: mbarrier arrive; extent: final stats reuse
+
+            max_local = maximum(valid_max(row_max[0]), valid_max(row_max[1]))
+            # instruction_selection: `max.ftz.f32`; extent: scalar row
+            delta0 = row_max[0] - max_local
+            delta1 = row_max[1] - max_local
+            # instruction_selection: `sub.f32`; extent: one per live stage
+            scaled_delta0 = delta0*softmax_scale_log2
+            scaled_delta1 = delta1*softmax_scale_log2
+            # instruction_selection: `mul.f32`; extent: one per live stage
+            scale0 = exp2(scaled_delta0) if row_sum[0] > 0 else 0
+            scale1 = exp2(scaled_delta1) if row_sum[1] > 0 else 0
+            # instruction_selection: `ex2.approx.ftz.f32`; extent: one per stage
+            sum_stage1 = row_sum[1]*scale1
+            # instruction_selection: `mul.f32`; extent: scalar stage-1 term
+            sum_local = fma(row_sum[0], scale0, sum_stage1)
+            # instruction_selection: `fma.rn.f32`; extent: scalar stage-0 term
+
+            for stage in (0, 1):
+                wait(O_ACC_PIPE.full[stage], o_corr_consumer_phase)
+                # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+                #   extent: final O stage
+                fence_after_thread_sync()
+                # instruction_selection: `tcgen05.fence::after_thread_sync`;
+                #   extent: each correction warp after each O-accumulator wait
+            wait(O_EPI_PIPE.empty[0], corr_epi_producer_phase)
+            # instruction_selection: mbarrier parity wait; extent: output region acquire
+        else:
+            for stage in (0, 1):
+                named_barrier_arrive_wait(stage*4+corr_warp, threads=64)
+                # instruction_selection: `bar.sync`; extent: synthetic empty stats
+                release(SMSTAT_PIPE.empty[stage])
+                # instruction_selection: mbarrier arrive; extent: stats reuse
+            scale0 = scale1 = sum_local = max_local = 0.0
+            wait(O_EPI_PIPE.empty[0], corr_epi_producer_phase)
+            # instruction_selection: mbarrier parity wait; extent: output acquire
+
+        partner = corr_warp ^ 2
+        store_shared(pair_stat(partner,lane,0), sum_local)
+        # instruction_selection: `st.shared.b32`; extent: scalar
+        store_shared(pair_stat(partner,lane,1), max_local)
+        # instruction_selection: `st.shared.b32`; extent: scalar
+        mbarrier_arrive_and_wait(REDUCE_MBAR + 8*(corr_warp&1), phase=0)
+        # instruction_selection: `mbarrier.arrive.shared.b64` plus parity wait;
+        #   extent: first rendezvous of one 64-thread correction warp pair
+        partner_sum = load_shared(pair_stat(corr_warp,lane,0), f32, 1)
+        # instruction_selection: `ld.shared.b32`; extent: scalar
+        partner_max = load_shared(pair_stat(corr_warp,lane,1), f32, 1)
+        # instruction_selection: `ld.shared.b32`; extent: scalar
+        max_total = maximum(max_local, partner_max)
+        # instruction_selection: `max.ftz.f32`; extent: scalar
+        own_delta = max_local-max_total
+        peer_delta = partner_max-max_total
+        # instruction_selection: `sub.f32`; extent: one own + one peer scalar
+        own_delta_scaled = own_delta*softmax_scale_log2
+        peer_delta_scaled = peer_delta*softmax_scale_log2
+        # instruction_selection: `mul.f32`; extent: one own + one peer scalar
+        own_rescale = exp2(own_delta_scaled) if sum_local > 0 else 0
+        peer_rescale = exp2(peer_delta_scaled) if partner_sum > 0 else 0
+        # instruction_selection: `ex2.approx.ftz.f32`; extent: own + peer
+        peer_sum_scaled = partner_sum*peer_rescale
+        # instruction_selection: `mul.f32`; extent: scalar peer contribution
+        total_sum = fma(sum_local, own_rescale, peer_sum_scaled)
+        # instruction_selection: `fma.rn.f32`; extent: scalar own contribution
+        inv_total = rcp(total_sum) if total_sum > 0 else 0
+        # instruction_selection: `rcp.approx.ftz.f32`; extent: scalar
+
+        if has_work and not (P.allow_empty and scale0 == 0 and scale1 == 0):
+            copy_t2r(O_TMEM[0], o0_regs, 32)
+            # instruction_selection: `tcgen05.ld.sync.aligned.32x32b.x32.b32`;
+            #   extent: explicit 4x32dp32 fragments
+            copy_t2r(O_TMEM[1], o1_regs, 32)
+            # instruction_selection: same TMEM-load family; extent: explicit fragments
+            own_weight = own_rescale*inv_total
+            own_scale0 = scale0*own_weight
+            own_scale1 = scale1*own_weight
+            # instruction_selection: `mul.f32`; extent: exactly three scalar
+            #   weight products (`own_weight`, `own_scale0`, `own_scale1`)
+            mul(o1_scaled, o1_regs, own_scale1, lanes=2)
+            fma(exchange_regs, o0_regs, own_scale0, o1_scaled, lanes=2)
+            # instruction_selection: packed `mul.rn.f32x2` for O1 followed by
+            #   packed `fma.rn.f32x2` for O0; extent: explicit fragment loop
+            copy_r2s(exchange_regs, KV_UNION + 4*exchange_f32(corr_warp,lane,...), 32)
+            # instruction_selection: `st.shared.v4.b32`; extent: explicit exchange loop
+        else:
+            fill(exchange_regs, 0.0)
+            # instruction_selection: `mov.f32`; extent: explicit fragment loop
+            copy_r2s(exchange_regs, KV_UNION + 4*exchange_f32(corr_warp,lane,...), 32)
+            # instruction_selection: `st.shared.v4.b32`; extent: explicit exchange loop
+
+        mbarrier_arrive_and_wait(REDUCE_MBAR + 8*(corr_warp&1), phase=1)
+        # instruction_selection: mbarrier arrive and parity wait; extent: second
+        #   rendezvous of the same warp pair; the next tile starts again at phase 0
+        if corr_warp < 2:
+            copy_s2r(own_exchange, own_regs, 32)
+            # instruction_selection: `ld.shared.v4.b32`; extent: explicit vector loop
+            copy_s2r(peer_exchange, peer_regs, 32)
+            # instruction_selection: `ld.shared.v4.b32`; extent: explicit vector loop
+            add(final_regs, own_regs, peer_regs, lanes=2)
+            # instruction_selection: `add.rn.f32x2`; extent: explicit packed loop
+            if P.output_dtype == bf16:
+                cast(final_bf16x2, final_regs, rounding="rn")
+                # instruction_selection: `cvt.rn.satfinite.bf16x2.f32`;
+                #   extent: explicit packed loop
+                copy_r2s(final_bf16x2, O_SMEM_BASE + 2*o_bf16_elem(...), 16)
+                # instruction_selection: `st.shared.v4.b32`; extent: BF16 O vectors
+            else:
+                copy_r2s(final_regs, O_SMEM_BASE + 4*o_f32_elem(...), 32)
+                # instruction_selection: `st.shared.v4.b32`; extent: FP32 split
+                #   partial vectors in the same corrected shared-O region
+
+        fence_async_shared_cta()
+        # instruction_selection: `fence.proxy.async.shared::cta`; extent: correction warps
+        if corr_warp < 2 and row_is_in_SQ:
+            log_sum = log2(total_sum) if total_sum > 0 else -inf
+            # instruction_selection: `lg2.approx.ftz.f32`; extent: scalar row
+            lse_log2 = fma(max_total, softmax_scale_log2, log_sum)
+            # instruction_selection: `fma.rn.f32`; extent: scalar row
+            lse = lse_log2*ln2 if total_sum > 0 else -inf
+            # instruction_selection: `mul.f32`; extent: final scalar ln2 conversion
+            store_global(LSE_ptr(work,row), lse, f32, 1)
+            # instruction_selection: `st.global.b32`; extent: scalar row
+
+        if has_work:
+            for stage in (0, 1):
+                release(SPO_PIPE.empty[stage])
+                # instruction_selection: mbarrier arrive; extent: O accumulator reuse
+        arrive(O_EPI_PIPE.full[0])
+        # instruction_selection: `mbarrier.arrive.shared.b64`; extent: all 128
+        #   correction threads publish the corrected shared O
+        if has_work:
+            o_corr_consumer_phase ^= 1
+            # extent: only live tiles consumed O_ACC full generations
+        sm_stats_consumer_phase ^= 1
+        corr_epi_producer_phase ^= 1
+        work = scheduler.advance()
+
+    OACC_CONS_PHASE = o_corr_consumer_phase
+    SMSTAT_CONS_PHASE = [sm_stats_consumer_phase, sm_stats_consumer_phase]
+    OEPI_PROD_PHASE = corr_epi_producer_phase
+    wait(O_EPI_PIPE.empty[0], corr_epi_producer_phase)
+    # instruction_selection: mbarrier parity wait; extent: correction producer tail
+    arrive(TMEM_ALLOC_NAMED)
+    # instruction_selection: `bar.arrive`; extent: TMEM lifetime handoff
+
+# MMA warp waits for score/correction arrivals, then owns deallocation.
+if warp == 12:
+    relinquish_tmem_alloc_permit()
+    # instruction_selection: `tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned`;
+    #   extent: elected MMA warp before the lifetime barrier
+    sync_named_tmem_pointer(warps=0..12)
+    # instruction_selection: `bar.sync 2,416`; extent: 13-warp TMEM lifetime rendezvous
+    free_tmem(512)
+    # instruction_selection: `tcgen05.dealloc.cta_group::1.sync.aligned.b32`;
+    #   extent: one elected MMA-warp lane
+```
+
+The query-tail predicate is applied only at final O/LSE stores; TMA O uses
+TensorMap bounds. Block-tail masking happens before maximum/exp. An empty sparse
+tile does not issue Q/K/V or MMA, does not release nonexistent `SPO` generations,
+still balances the stats and output pipelines, writes O zero, and writes LSE
+`-inf`. Split offsets select disjoint sparse-index ranges. With
+`aligned_base=floor(floor(valid/kv_splits)/8)*8`, the source uses aligned
+offsets `min(aligned_base*s + min(valid-aligned_base*kv_splits, 8*s), valid)`
+when `aligned_base>0`; otherwise—including the 256-split path—it uses even
+ceil-distributed offsets `ceil(valid*s/kv_splits)`. Each split producer follows
+the same program and folds `split*H` into its output-head axis.
+
+## Complete split-KV combine sketch
+
+The combine exists only for `kv_splits > 1`. Its production specialization is
+`tile_m=16`, `k_block_size=64`, `stages=4`, `threads=128`,
+`max_splits=2**ceil(log2(kv_splits))`. The physical split extent used by the
+source LSE layout is `max(8,max_splits)`, even when `max_splits==2`. It is an ordinary launch and has no TMEM,
+TMA, cluster, or warp specialization; all four warps execute the same row/column
+program. Source combine `22-147,250-606`; wrapper `_interface.py:885-1005`.
+
+```python
+launch(
+    grid=(ceil_div(SQ*H,16), ceil_div(128,64), B),
+    block=(128,1,1), arch="sm_100a",
+    dynamic_smem_bytes=combine_storage_bytes(max(8,max_splits)),
+)
+# instruction_selection: `.reqntid 128,1,1`, ordinary CTA metadata, and
+#   `.extern .shared .align 1024`; extent: one combine specialization
+cta = cta_id()
+# instruction_selection: ordinary `%ctaid.*`; extent: one combine CTA
+
+LSE_SPLIT_STORAGE = max(8, max_splits)
+COMB = smem_bytes("combine", 0, combine_storage_bytes(LSE_SPLIT_STORAGE), 128)
+LSE_S = smem_bytes("split_lse", 0, LSE_SPLIT_STORAGE*16*4, 128)
+MAX_SPLIT_S = smem_bytes("max_valid_split", align_up(end(LSE_S),128), 16*4, 128)
+O_RING = smem_bytes("partial_o_ring", align_up(end(MAX_SPLIT_S),128),
+                    4*16*64*4, 128)
+# For max_splits=2 this is exactly LSE=[0,512), MAX_SPLIT=[512,576),
+# padding=[576,640), and O_RING=[640,17024), for 17024 dynamic SMEM bytes.
+
+# Source atom is S<4,0,4> composed with ordered (8,16), order=(1,0),
+# tiled along split. Resolving it gives the scalar element XOR below. O is a
+# plain stage-major 16x64 FP32 ring.
+def lse_smem(split, row):
+    linear = 16*split + row
+    return LSE_S.base + 4*(linear ^ ((linear >> 4) & 0xF))
+
+def o_ring(stage, row, col):
+    return O_RING.base + 4*(col + 64*row + 16*64*stage)
+
+if dynamic_num_splits_is_one:
+    return
+
+row0 = tidx // 16
+row1 = row0 + 8
+col0 = (tidx % 16) * 4
+# extent: each of 128 threads owns exactly two rows separated by 8 and four
+# adjacent FP32/BF16 output columns in each row.
+
+for assigned_row in lse_copy_rows_for_thread(tidx, tile_m=16):
+    for split in per_thread_splits(max_splits):
+        if assigned_row_is_valid and split < num_splits:
+            copy_g2s_async(LSE_partial[split,b,assigned_row,h],
+                           lse_smem(split,assigned_row), 4, 4)
+            # instruction_selection: `cp.async.ca.shared.global ...,4,4`;
+            #   extent: scalar LSE
+        else:
+            store_shared(lse_smem(split,assigned_row), -inf, f32, 1)
+            # instruction_selection: `st.shared.b32`; extent: scalar fill
+cp_async_commit_group()
+# instruction_selection: `cp.async.commit_group`; extent: LSE generation
+
+for stage in 0..2:
+    if stage < num_splits:
+        if row0_is_valid:
+            copy_g2s_async(O_partial[stage,b,row0,h,col0:col0+4],
+                           o_ring(stage,row0,col0), 16, 16)
+        if row1_is_valid:
+            copy_g2s_async(O_partial[stage,b,row1,h,col0:col0+4],
+                           o_ring(stage,row1,col0), 16, 16)
+        # instruction_selection: `cp.async.cg.shared.global ...,16,16`;
+        #   extent: exactly two FP32x4 issues, one per owned row
+    cp_async_commit_group()
+    # instruction_selection: `cp.async.commit_group`; extent: one O-ring stage
+
+cp_async_wait_group(3)
+# instruction_selection: `cp.async.wait_group 3`; extent: LSE/initial O
+sync_cta()
+# instruction_selection: `bar.sync 0`; extent: CTA
+
+copy_s2r(LSE_S, lse_regs, assigned_split_row_values)
+# instruction_selection: `ld.shared.b32`; extent: explicit split values
+lse_max = reduce_max_warp(max(lse_regs), width=8)
+# instruction_selection: `max.f32` plus `shfl.sync.bfly.b32` with 4,2,1;
+#   extent: one row across split lanes
+max_valid_split = reduce_max_warp(last_non_inf_split(lse_regs), width=8)
+# instruction_selection: `max.s32` plus `shfl.sync.bfly.b32`;
+#   extent: one row
+sum_exp = 0.0
+for split in assigned_splits:
+    lse_log2 = lse_regs[split]*log2e
+    max_log2 = safe(lse_max)*log2e
+    # instruction_selection: `mul.f32`; extent: exactly two scalar products
+    scale_delta = lse_log2-max_log2
+    # instruction_selection: `sub.f32`; extent: scalar split
+    scale[split] = exp2(scale_delta)
+    # instruction_selection: `ex2.approx.ftz.f32`; extent: scalar split
+    sum_exp = add(sum_exp, scale[split])
+    # instruction_selection: `add.f32`; extent: scalar split
+sum_exp = reduce_sum_warp(sum_exp, width=8)
+# instruction_selection: `shfl.sync.bfly.b32` plus `add.f32`; extent: one row
+final_lse = log2(sum_exp)*ln2 + lse_max
+# instruction_selection: `lg2.approx.ftz.f32` plus `fma.rn.f32`; extent: row
+inv_sum = rcp_rn(sum_exp) if finite_positive(sum_exp) else 0.0
+# instruction_selection: `rcp.rn.f32`; extent: scalar, not approximate reciprocal
+for split in assigned_splits:
+    scale[split] = mul(scale[split], inv_sum)
+    # instruction_selection: `mul.f32`; extent: scalar split
+    store_shared(lse_smem(split,row), scale[split], f32, 1)
+    # instruction_selection: `st.shared.b32`; extent: scalar split weight
+store_shared(MAX_SPLIT_S + 4*row, max_valid_split, i32, 1)
+# instruction_selection: `st.shared.b32`; extent: scalar row bound
+if k_block == 0 and row_is_valid:
+    store_global(final_LSE[b,row,h], final_lse, f32, 1)
+    # instruction_selection: `st.global.b32`; extent: scalar row
+
+sync_cta()
+# instruction_selection: `bar.sync 0`; extent: CTA
+fill(o_acc_f32[row0], 0.0)
+fill(o_acc_f32[row1], 0.0)
+# instruction_selection: `mov.f32`; extent: two independent FP32x4 row accumulators
+load_stage = 3
+compute_stage = 0
+thread_max_valid_split = max(max_valid_split[row0], max_valid_split[row1])
+for split in 0..thread_max_valid_split:
+    weight0 = load_shared(lse_smem(split,row0), f32, 1)
+    weight1 = load_shared(lse_smem(split,row1), f32, 1)
+    # instruction_selection: `ld.shared.b32`; extent: one scalar per owned row
+    next_split = split + 3
+    if next_split <= thread_max_valid_split:
+        if row0_is_valid:
+            copy_g2s_async(O_partial[next_split,b,row0,h,col0:col0+4],
+                           o_ring(load_stage,row0,col0), 16, 16)
+        if row1_is_valid:
+            copy_g2s_async(O_partial[next_split,b,row1,h,col0:col0+4],
+                           o_ring(load_stage,row1,col0), 16, 16)
+        # instruction_selection: `cp.async.cg.shared.global ...,16,16`;
+        #   extent: exactly two FP32x4 issues, one per owned row
+    cp_async_commit_group()
+    # instruction_selection: `cp.async.commit_group`; extent: O-ring generation
+    load_stage = (load_stage + 1) % 4
+    cp_async_wait_group(3)
+    # instruction_selection: `cp.async.wait_group 3`; extent: current O stage
+    copy_s2r(o_ring(compute_stage,row0,col0), partial0, 4)
+    copy_s2r(o_ring(compute_stage,row1,col0), partial1, 4)
+    # instruction_selection: `ld.shared.v2.b64`; extent: two independent FP32x4 rows
+    compute_stage = (compute_stage + 1) % 4
+    if row0_is_valid and weight0 > 0:
+        for pair in 0..1:
+            mul(weighted0[pair], partial0[pair], weight0, lanes=2)
+            # instruction_selection: `mul.f32x2`; extent: two pairs for row0
+        for pair in 0..1:
+            add(o_acc_f32[row0,pair], o_acc_f32[row0,pair],
+                weighted0[pair], lanes=2)
+            # instruction_selection: `add.f32x2`; extent: two pairs for row0,
+            #   kept separate from multiply to preserve source rounding
+    if row1_is_valid and weight1 > 0:
+        for pair in 0..1:
+            mul(weighted1[pair], partial1[pair], weight1, lanes=2)
+            # instruction_selection: `mul.f32x2`; extent: two pairs for row1
+        for pair in 0..1:
+            add(o_acc_f32[row1,pair], o_acc_f32[row1,pair],
+                weighted1[pair], lanes=2)
+            # instruction_selection: `add.f32x2`; extent: two pairs for row1
+
+cast(o0_bf16x2, o_acc_f32[row0], rounding="rn")
+cast(o1_bf16x2, o_acc_f32[row1], rounding="rn")
+# instruction_selection: `cvt.rn.bf16x2.f32`; extent: two pairs per owned row
+if row0_is_valid:
+    store_global(final_O[b,row0,h,col0:col0+4], o0_bf16x2, bf16, 4)
+    # instruction_selection: `st.global.v2.b32`; extent: one BF16x4 row store
+if row1_is_valid:
+    store_global(final_O[b,row1,h,col0:col0+4], o1_bf16x2, bf16, 4)
+    # instruction_selection: `st.global.v2.b32`; extent: one BF16x4 row store
+```
+
+Rows outside `SQ*H` are filled with `-inf` before the max-valid-split reduction
+so they cannot read a stale O stage. A split with LSE `-inf` has zero weight.
+When every split is empty, final LSE remains `-inf` and O remains zero. A
+dynamic one-split combine request returns early, although the wrapper normally
+does not launch this kernel for one split.
+
+## Static specialization boundary
+
+The implementation may construct separate TIRx PrimFuncs for the following
+compile-time branches, but must not change the execution skeleton:
+
+| branch | specialized differences |
+| --- | --- |
+| `has_block_sizes` | physical-block size GMEM loads and two 64-column masks versus constant 64 |
+| fixed / variable count | scalar fixed count versus `block_nums[b,h,qb]`; variable count changes scheduler arguments |
+| `allow_empty` | empty-tile control path and zero/-inf output; split buckets can also be empty when the requested split count exceeds a row's live sparse blocks |
+| static / CLC | ordinary versus explicit singleton-cluster launch tags, CLC storage and warp-15 body |
+| `kv_splits` | scheduler split axis, split-offset metadata, output dtype/head folding, and independent combine specialization |
+| i32 / i64 K/V strides | K/V TensorMap and address stride width only |
+| final BF16 / partial FP32 O | correction writes the specialized dtype into the same shared-O region; only O descriptor/output ABI and issue count differ |
+
+In CLC, the persistent work order and all pipeline phase variables survive
+across response records; a role must not restart a phase because sparse counts
+can change between adjacent records. Static/split executes one launch coordinate
+per CTA, so its phase state has only that one record. Both acquisition modes use
+the same role body after the work coordinate has been obtained.
+
+## TIRx module, correctness, and benchmark contract
+
+The public module exports `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`,
+`get_kernel`, `prepare_data`, `prepare_bench`, `run_test`, `run_gpu`, and
+`run_bench` following repository conventions. `get_kernel` returns one PrimFunc
+for `kv_splits=1` and producer plus combine for `kv_splits>1`. Device code uses
+`import tirx_kernels.kern as K` exclusively.
+
+Correctness is the module's fixed 22-row matrix: BHSD/BSHD, Q tails 1/63/65,
+masked/unmasked, custom scale, fixed/variable/empty counts, static/CLC,
+split 1/2/3/8/256 and auto-to-2, and the active i64 K/V-stride case. Every row
+must run with no skip. O and LSE are compared both with the production source
+and a gathered FP32 oracle; empty rows require exact O zero and LSE `-inf`.
+Split rows additionally validate producer FP32 partial O/LSE before combine.
+
+Performance truth is only `python -m tirx_kernels.bench_suite`. The frozen
+11-row matrix covers short/long and batch/head scaling, static/CLC, fixed,
+variable and empty counts, split 2/4/8, and i64 K/V addressing. Every row must
+contain five finite positive Proton samples for source and TIRx, `status == ok`,
+no error, and strict `mean(source)/mean(tirx) > 0.99`.
+
+## Instruction-selection summary
+
+- Producer launch: 512 threads, one CTA UMMA, 217088 bytes dynamic SMEM aligned
+  to 1024, minimum one CTA/SM. CLC alone carries explicit singleton cluster
+  metadata and cluster-launch-control instructions.
+- Q uses exactly two 4-D tensor-bulk G2S issues. Each K group uses eight 5-D
+  issues (two per sparse sub-block), each V group uses four (one per sparse
+  sub-block), and O uses exactly two BF16 or four FP32 4-D tensor-bulk S2G
+  issues from absolute shared address 86016.
+- QK is SMEM/SMEM WS f16 MMA into FP32 TMEM. PV is TMEM/SMEM WS f16 MMA into
+  FP32 TMEM. `tcgen05.commit` publishes score and output generations.
+- Score/P uses x32 FP32 TMEM loads, BF16x2 RN conversion, and x16 BF16 TMEM
+  stores. Correction uses x32 TMEM loads/stores and packed f32x2 arithmetic.
+- All stage reuse uses mbarrier parity state. Named barriers pair each softmax
+  warp with one correction warp. Two 64-arrival mbarriers protect correction
+  warp-pair exchange.
+- Combine uses scalar `cp.async.ca` for LSE, 16-byte `cp.async.cg` for partial O,
+  four committed stages with wait-group 3, width-8 butterfly reductions,
+  packed f32x2 weighted accumulation, BF16x2 conversion, and vector stores.
+
+These choices are selected by explicit placement, scalar physical mappings,
+descriptor fields, role ownership, and schedule. Opcode counts are evidence
+from the preserved exports; no hidden computation is encoded in them.

--- a/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
@@ -1,6 +1,6 @@
 # Bound hoisting by live-range cost
 
-**Symptoms:** `register_pressure`, `local_memory_traffic`, `low_occupancy`
+**Symptoms:** `register_pressure`, `local_memory_traffic`, `low_occupancy`, `underfilled_pipeline`, `schedule_regression`
 
 ## Symptom
 
@@ -31,6 +31,25 @@ for no in T.unroll(MMA_N // EPI_TILE):
     _store_chunk(reg_words, T.meta_var(no * EPI_TILE))
 ```
 
+Apply the same rule when a wide producer fragment feeds both a consumer and a
+chunk-local reduction. Publish one chunk after its local work instead of keeping
+the whole fragment live until every chunk is ready.
+
+```python
+# before: all chunks remain live until publication begins.
+for chunk in T.unroll(CHUNKS):
+    _compute_fragment(fragment[chunk])
+for chunk in T.unroll(CHUNKS):
+    _reduce_chunk(fragment[chunk])
+    _publish_chunk(fragment[chunk])
+
+# after: finish and publish one chunk at a time.
+for chunk in T.unroll(CHUNKS):
+    _compute_fragment(fragment[chunk])
+    _reduce_chunk(fragment[chunk])
+    _publish_chunk(fragment[chunk])
+```
+
 ## Rationale
 
 One measured FP32 bias hoist regressed 6.6%; by contrast, staging a larger load
@@ -43,6 +62,12 @@ dependency stayed live across every epilogue. After repairing collective
 deallocation ordering, the once-per-CTA form was still about 0.1 us slower on
 the FP8 guards and only 2/5 targeted rows passed. Reducing a tail operation
 count did not repay the longer recurrent live range.
+
+In another pipeline, chunking a wide producer fragment under the same register
+caps and with zero spilling reduced elapsed cycles from 23,433 to 23,294 and
+executed instructions from 11,495 to 11,406. The two critical benchmark ratios
+moved from 0.981x/0.989x to 0.987x/0.997x; a later role-budget adjustment supplied
+the remaining margin without undoing the shorter fragment lifetime.
 
 ## Boundary
 
@@ -58,9 +83,15 @@ items that were previously independent. Measure both one-work CTAs, where the
 hoist can only add lifetime, and high-trip-count CTAs, where removing repeated
 tail operations has a chance to repay it.
 
+Do not publish earlier than the chunk's own correctness and scheduling boundary.
+Moving publication and release ahead of the chunk-local reduction reduced one
+profile from 23,294 to 22,771 cycles, but its critical benchmark ratio regressed
+from 0.987x to 0.986x. The shortest apparent lifetime was not the best accepted
+schedule; the final form kept reduction before publication.
+
 ## Verification
 
 Compare registers and dynamic LDL/STL before instruction count, and sweep the
 tightest specialization where one spill can reverse the result. Verify the
-compute and store order in emitted PTX/SASS before treating a shorter lifetime
-as a legal candidate.
+compute, reduction, first-publication, and release order in emitted PTX/SASS
+before treating a shorter lifetime as a legal candidate.

--- a/.agents/skills/tirx-codegen-tuning/references/db/keep-trace-time-loops-at-trace-time.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/keep-trace-time-loops-at-trace-time.md
@@ -1,6 +1,6 @@
 # Keep trace-time loops at trace time
 
-**Symptoms:** `register_spill`, `local_memory`, `runtime_loop`, `massive_slowdown`
+**Symptoms:** `register_spill`, `local_memory`, `runtime_loop`, `massive_slowdown`, `long_scoreboard`
 
 ## Symptom
 
@@ -27,6 +27,19 @@ for i in range(STATIC_TRIPS):
 When porting parser kernels, translate a source `T.serial` to the DSL's runtime
 loop construct, but leave a source Python `range` as Python `range`.
 
+When the source deliberately spells a small fixed device loop as unrolled, keep
+that contract explicit instead of relying on a serial loop with a constant bound.
+
+```python
+# before: fixed bound, but the fragment still has a runtime index.
+with K.serial(1, GROUPS, unroll=False) as group:
+    score = combine(score, registers[group])
+
+# after: preserve the source's explicitly unrolled device loop.
+with K.unroll(1, GROUPS) as group:
+    score = combine(score, registers[group])
+```
+
 ## Rationale
 
 Two sparse-attention forward ports changed fixed Python loops into runtime
@@ -40,12 +53,21 @@ to 1.347 ms, matching the 1.357 ms parser baseline; its sibling moved from
 10.83 ms to 1.041 ms, matching the 1.041 ms baseline. Their complete 55-case
 correctness matrix passed after the change.
 
+In a separate fixed-group reduction, changing two constant-bound serial loops
+to explicit unroll removed a 512-byte local depot. PTX local
+declaration/load/store occurrences fell from 169/8/160 to 0/0/0 while 64
+tensor-core issues and 40 tensor-copy instructions stayed unchanged. The
+critical short-shape ratio rose from 0.375x to 0.996x, and the final 23-case
+correctness matrix passed.
+
 ## Boundary
 
 Only apply this to compile-time structural loops. Runtime trip counts and loops
 that are deliberately represented by `T.serial` remain device loops; source
 `T.unroll` remains an explicit unrolled device loop. Trace expansion can increase
-code size, so it is not a general replacement for runtime iteration.
+code size, so it is not a general replacement for runtime iteration. Explicit
+device unrolling is best reserved for small fixed trip counts where preserving
+the source order and scalar indexing is important.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
@@ -1,6 +1,6 @@
 # Sweep register budgets by role and shape
 
-**Symptoms:** `register_spill`, `excess_address_math`, `low_occupancy`
+**Symptoms:** `register_spill`, `excess_address_math`, `low_occupancy`, `register_budget_mismatch`, `schedule_regression`
 
 ## Symptom
 
@@ -51,6 +51,14 @@ rows on two GPUs, retained zero failures across the correctness matrix, and
 helped the final 66-row suite clear its strict gate at a 0.9907x minimum. The
 same value had regressed other outputs when applied globally.
 
+Budget redistribution can matter even when total allocation and spill counts
+stay fixed. One 16-warp pipeline kept its collective total at 2048 registers
+while changing three role budgets from 192/80/48 to 192/88/40. Both forms had
+zero local and shared spilling, but the correction-preserving allocation reduced
+elapsed cycles from 23,294 to 22,896 and executed instructions from 11,406 to
+11,377. It subsequently passed complete targeted and full matrices at 0.995x
+and 1.002x minimum ratios.
+
 ## Boundary
 
 An occupancy proof only shows that a larger budget is affordable; it does not
@@ -71,10 +79,18 @@ did not complete in 240 s. Compute the release-versus-require arithmetic for the
 whole kernel, not for the role being changed.
 
 Check whether registers bind at all before sweeping. Zero local and zero shared
-spilling on both sides means no role is starved and a larger cap buys nothing.
-Where the sweep did pay, it was narrow: a collective-issuing warpgroup improved
-by 0.1-1.0% at 56 registers, and funding a further rise to 72 out of the reduce
-role regressed the shapes that role dominates.
+spilling rules out an obvious capacity failure, but does not prove that role
+budgets are schedule-insensitive: redistribution at a fixed total can still
+change issue order and the critical path. Increasing the total cap without a
+resource argument remains unlikely to help. Where a sweep did pay, it was
+narrow: a collective-issuing warpgroup improved by 0.1-1.0% at 56 registers,
+and funding a further rise to 72 out of the reduce role regressed the shapes
+that role dominates.
+
+Eliminating a spill counter is also not sufficient acceptance evidence. A
+shape-scoped rebalance removed six shared-spilling requests, yet its two
+critical benchmark ratios were only 0.981x and 0.989x. Continue through the
+performance matrix after the generated-code symptom is repaired.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ list.
 - **CSA compression:**
   [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
 - **Sparse attention:**
-  [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+  [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py),
+  [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
 
 ### FlashAttention ports
 

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -31,6 +31,7 @@ def test_func_call_is_rejected_by_default_and_reports_callee():
 
 def test_only_exact_kernel_local_helpers_are_exempt():
     assert LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL == {
+        "cudnn_sm100_bsa_forward_blk64": frozenset({"tirx_bsa_pv_mma_chain"}),
         "cudnn_sm100_csa_compressor_fwd": frozenset(
             {
                 "tirx_csa_exp_constants",

--- a/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk64.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk64.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cudnn_sm100_bsa_forward_blk64
+selection_rationale: The selected defaults cover a small ordinary singleton-split launch, a medium variable-sparsity CLC launch, and a large eight-way split-plus-combine launch; the full matrix additionally covers long-query static and CLC scheduling, empty sparse rows, split counts 2/4/8, masked and unmasked blocks, ragged Q/KV tails, batch/head occupancy, and 64-bit KV strides.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: p00_b1_h1_sq64_skv4096_kv16_nomask_s1_static, default: true, selection_role: small}
+  - {config: p01_b1_h2_sq4097_skv8191_kv64_mask_s1_static, default: false}
+  - {config: p02_b2_h8_sq4096_skv8191_kv32_mask_s1_static, default: false}
+  - {config: p03_b1_h4_sq8192_skv4096_kv16_mask_s1_clc, default: false}
+  - {config: p04_b1_h8_sq4096_skv8192_maxkv32_var_mask_s1_clc, default: true, selection_role: medium}
+  - {config: p05_b2_h4_sq4097_skv8191_maxkv32_empty_mask_s1_clc, default: false}
+  - {config: p06_b1_h4_sq1024_skv32768_kv256_mask_s2_static, default: false}
+  - {config: p07_b1_h4_sq4097_skv16384_maxkv128_var_mask_s2_static, default: false}
+  - {config: p08_b1_h4_sq2048_skv32768_kv256_mask_s4_static, default: false}
+  - {config: p09_b1_h8_sq2048_skv65536_kv512_nomask_s8_static, default: true, selection_role: large}
+  - {config: p10_b1_h4_sq4096_skv8192_kv32_mask_s1_static_i64kv, default: false}

--- a/tirx_kernels/cudnn/bsa/__init__.py
+++ b/tirx_kernels/cudnn/bsa/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/__init__.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
@@ -1,0 +1,378 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Inputs, launch wiring and validation for the SM100 blk64 BSA forward pass.
+
+Upstream source: ``python/cudnn/block_sparse_attention/_interface.py``.
+"""
+
+import math
+
+import torch
+
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_256B = 2
+
+
+class _AlignedTensorMap:
+    """Host storage for one 64-byte-aligned, 128-byte TensorMap payload."""
+
+    def __init__(self):
+        import ctypes
+
+        self._storage = ctypes.create_string_buffer(128 + 64)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tensormap(tensor, dtype, global_dims, global_strides, box_dims):
+    """Encode the exact rank-4/rank-5 descriptors consumed by the producer."""
+    import ctypes
+
+    import tvm
+
+    rank = len(global_dims)
+    descriptor = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        descriptor.ptr,
+        dtype,
+        rank,
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *global_dims,
+        *global_strides,
+        *box_dims,
+        *((1,) * rank),
+        0,  # CU_TENSOR_MAP_INTERLEAVE_NONE
+        _TMA_SWIZZLE_128B,
+        _TMA_L2_256B,
+        0,  # CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    )
+    return descriptor
+
+
+def _build_tensor_maps(q, k, v, out, *, seqlen_q, seqlen_kv, heads, batch):
+    """Build the Q/K/V/O maps in the source kernel's fused block coordinates."""
+    physical_blocks = (seqlen_kv + 63) // 64
+    q_strides = (128 * 2, seqlen_q * 128 * 2, heads * seqlen_q * 128 * 2)
+    kv_strides = (128 * 2, 64 * 2, 64 * 128 * 2, seqlen_kv * 128 * 2)
+    out_element_size = out.element_size()
+    out_heads = out.shape[1]
+    out_strides = (
+        128 * out_element_size,
+        seqlen_q * 128 * out_element_size,
+        out_heads * seqlen_q * 128 * out_element_size,
+    )
+    return {
+        "q": _encode_tensormap(
+            q, "bfloat16", (128, seqlen_q, heads, batch), q_strides, (64, 64, 1, 1)
+        ),
+        "k": _encode_tensormap(
+            k,
+            "bfloat16",
+            (64, 64, 2, physical_blocks, batch * heads),
+            kv_strides,
+            (64, 64, 1, 1, 1),
+        ),
+        "v": _encode_tensormap(
+            v,
+            "bfloat16",
+            (64, 64, 2, physical_blocks, batch * heads),
+            kv_strides,
+            (64, 64, 2, 1, 1),
+        ),
+        "o": _encode_tensormap(
+            out,
+            "float32" if out.dtype == torch.float32 else "bfloat16",
+            (128, seqlen_q, out_heads, batch),
+            out_strides,
+            ((32 if out.dtype == torch.float32 else 64), 64, 1, 1),
+        ),
+    }
+
+
+def _resolve_splits(value):
+    if value == "auto":
+        return 2
+    return int(value)
+
+
+def _counts_from_pattern(config, q_blocks, device):
+    batch = config["batch"]
+    heads = config["num_heads"]
+    maximum = config["kv_blocks"]
+    mode = config["block_count_mode"]
+    if mode == "fixed":
+        return torch.full((batch, heads, q_blocks), maximum, dtype=torch.int32, device=device)
+
+    pattern = config["block_count_pattern"]
+    if pattern is None:
+        values = (0, 1, maximum) if mode == "variable_empty" else (1, max(1, maximum // 2), maximum)
+    else:
+        values = []
+        for item in pattern.split(","):
+            item = item.strip()
+            if item == "max":
+                values.append(maximum)
+            elif item == "mid":
+                values.append(max(1, maximum // 2))
+            else:
+                values.append(int(item))
+        values = tuple(values)
+    flat = torch.arange(batch * heads * q_blocks, device=device)
+    chosen = torch.tensor(values, dtype=torch.int32, device=device)[flat % len(values)]
+    return chosen.reshape(batch, heads, q_blocks)
+
+
+def _build_split_offsets(counts, num_splits):
+    split_ids = torch.arange(num_splits + 1, dtype=torch.int64, device=counts.device)
+    valid = counts.to(torch.int64).clamp_min(0)
+    average = valid // num_splits
+    aligned_base = average // 8 * 8
+    remainder = valid - aligned_base * num_splits
+    even = (valid[..., None] * split_ids + num_splits - 1) // num_splits
+    aligned = aligned_base[..., None] * split_ids + torch.minimum(
+        remainder[..., None], split_ids * 8
+    )
+    aligned = torch.minimum(aligned, valid[..., None])
+    return torch.where((aligned_base == 0)[..., None], even, aligned).to(torch.int32).contiguous()
+
+
+def _make_sparse_metadata(config, *, q_blocks, physical_blocks, device):
+    maximum = config["kv_blocks"]
+    total = config["batch"] * config["num_heads"] * q_blocks
+    rows = torch.empty((total, maximum), dtype=torch.int32, device=device)
+    base = torch.arange(maximum, dtype=torch.int64, device=device)
+    # A coprime-ish stride spreads the selected blocks through the KV sequence;
+    # the final slot is pinned to the physical tail so block_sizes coverage is
+    # deterministic whenever a row consumes its full roster.
+    stride = max(1, physical_blocks // maximum)
+    for row in range(total):
+        values = (base * stride + row * 7) % physical_blocks
+        if maximum > 0:
+            values[-1] = physical_blocks - 1
+        rows[row] = values.to(torch.int32)
+    return rows.reshape(config["batch"], config["num_heads"], q_blocks, maximum)
+
+
+def _strided_kv(generator, shape, *, use_i64):
+    batch, heads, seqlen, dim = shape
+    base = torch.randn(
+        batch * heads * seqlen * dim, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    if not use_i64:
+        return base.reshape(shape)
+    if batch != 1:
+        raise ValueError("the Int64-stride probe requires a singleton batch")
+    return torch.as_strided(base, shape, (2**31, seqlen * dim, dim, 1))
+
+
+def prepare_data(**config):
+    if not torch.cuda.is_available():
+        import unittest
+
+        raise unittest.SkipTest("CUDA is required")
+
+    batch = config["batch"]
+    heads = config["num_heads"]
+    seqlen_q = config["seqlen_q"]
+    seqlen_kv = config["seqlen_kv"]
+    q_blocks = (seqlen_q + 63) // 64
+    physical_blocks = (seqlen_kv + 63) // 64
+    if config["kv_blocks"] > physical_blocks:
+        raise ValueError("kv_blocks exceeds the physical KV block count")
+
+    generator = torch.Generator(device="cuda").manual_seed(config["seed"])
+    q_bhsd = torch.randn(
+        batch, heads, seqlen_q, 128, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    k_bhsd = _strided_kv(
+        generator, (batch, heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
+    )
+    v_bhsd = _strided_kv(
+        generator, (batch, heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
+    )
+    if config["tensor_layout"] == "bshd":
+        q_user = q_bhsd.transpose(1, 2).contiguous()
+        k_user = k_bhsd.transpose(1, 2).contiguous()
+        v_user = v_bhsd.transpose(1, 2).contiguous()
+        # TIRx consumes the wrapper-normalized native BHSD buffers.
+        q_bhsd, k_bhsd, v_bhsd = (
+            q_user.transpose(1, 2).contiguous(),
+            k_user.transpose(1, 2).contiguous(),
+            v_user.transpose(1, 2).contiguous(),
+        )
+    else:
+        q_user, k_user, v_user = q_bhsd, k_bhsd, v_bhsd
+
+    block_index = _make_sparse_metadata(
+        config, q_blocks=q_blocks, physical_blocks=physical_blocks, device="cuda"
+    )
+    block_sizes = torch.full((physical_blocks,), 64, dtype=torch.int32, device="cuda")
+    block_sizes[-1] = seqlen_kv - (physical_blocks - 1) * 64
+    block_nums = _counts_from_pattern(config, q_blocks, "cuda")
+    num_splits = _resolve_splits(config["kv_splits"])
+    split_offsets = (
+        _build_split_offsets(block_nums, num_splits)
+        if num_splits > 1
+        else torch.empty(1, dtype=torch.int32, device="cuda")
+    )
+    softmax_scale = (
+        1.0 / math.sqrt(128) if config["softmax_scale"] is None else float(config["softmax_scale"])
+    )
+
+    final_out = torch.empty((batch, heads, seqlen_q, 128), dtype=torch.bfloat16, device="cuda")
+    final_lse = torch.empty((batch, heads, seqlen_q), dtype=torch.float32, device="cuda")
+    if num_splits > 1:
+        partial_out = torch.empty(
+            (batch, num_splits * heads, seqlen_q, 128), dtype=torch.float32, device="cuda"
+        )
+        partial_lse = torch.empty(
+            (batch, num_splits * heads, seqlen_q), dtype=torch.float32, device="cuda"
+        )
+    else:
+        partial_out = torch.empty(1, dtype=torch.float32, device="cuda")
+        partial_lse = final_lse
+
+    producer_out = partial_out if num_splits > 1 else final_out
+    tensor_maps = _build_tensor_maps(
+        q_bhsd,
+        k_bhsd,
+        v_bhsd,
+        producer_out,
+        seqlen_q=seqlen_q,
+        seqlen_kv=seqlen_kv,
+        heads=heads,
+        batch=batch,
+    )
+
+    return {
+        "config": dict(config),
+        "inputs": {
+            "q": q_bhsd,
+            "k": k_bhsd,
+            "v": v_bhsd,
+            "q_user": q_user,
+            "k_user": k_user,
+            "v_user": v_user,
+            "block_index": block_index,
+            "block_sizes": block_sizes,
+            "block_nums": block_nums,
+            "split_offsets": split_offsets,
+            "softmax_scale": softmax_scale,
+        },
+        "tirx": {
+            "out": final_out,
+            "lse": final_lse,
+            "partial_out": partial_out,
+            "partial_lse": partial_lse,
+        },
+        "source": {"out": None, "lse": None},
+        "derived": {"num_splits": num_splits, "q_blocks": q_blocks},
+        "tensor_maps": tensor_maps,
+    }
+
+
+def tirx_launch(executables, data):
+    inputs = data["inputs"]
+    outputs = data["tirx"]
+    tensor_maps = data["tensor_maps"]
+    forward = executables[0]
+    num_splits = data["derived"]["num_splits"]
+    producer_lse = outputs["partial_lse"]
+
+    def launch():
+        forward(
+            tensor_maps["q"].ptr,
+            tensor_maps["k"].ptr,
+            tensor_maps["v"].ptr,
+            tensor_maps["o"].ptr,
+            producer_lse.reshape(-1),
+            inputs["block_index"].reshape(-1),
+            inputs["block_sizes"].reshape(-1),
+            inputs["block_nums"].reshape(-1),
+            inputs["split_offsets"].reshape(-1),
+            inputs["softmax_scale"] * math.log2(math.e),
+        )
+        if num_splits > 1:
+            executables[1](
+                outputs["partial_out"].reshape(-1),
+                outputs["partial_lse"].reshape(-1),
+                outputs["out"].reshape(-1),
+                outputs["lse"].reshape(-1),
+            )
+
+    return launch
+
+
+def _oracle(data):
+    inputs = data["inputs"]
+    config = data["config"]
+    q = inputs["q"].float()
+    k = inputs["k"].float()
+    v = inputs["v"].float()
+    block_index = inputs["block_index"]
+    block_sizes = inputs["block_sizes"]
+    block_nums = inputs["block_nums"]
+    batch, heads, seqlen_q, _ = q.shape
+    out = torch.zeros_like(q)
+    lse = torch.full((batch, heads, seqlen_q), -float("inf"), device=q.device)
+    for b in range(batch):
+        for h in range(heads):
+            for qb in range((seqlen_q + 63) // 64):
+                q0, q1 = qb * 64, min(qb * 64 + 64, seqlen_q)
+                count = (
+                    config["kv_blocks"]
+                    if config["block_count_mode"] == "fixed"
+                    else int(block_nums[b, h, qb])
+                )
+                if count <= 0:
+                    continue
+                tokens = []
+                for slot in range(count):
+                    sparse_id = int(block_index[b, h, qb, slot])
+                    size = int(block_sizes[sparse_id]) if config["has_block_sizes"] else 64
+                    tokens.extend(range(sparse_id * 64, min(sparse_id * 64 + size, k.shape[2])))
+                token_ids = torch.tensor(tokens, dtype=torch.long, device=q.device)
+                gathered_k = k[b, h].index_select(0, token_ids)
+                gathered_v = v[b, h].index_select(0, token_ids)
+                score = q[b, h, q0:q1] @ gathered_k.T * inputs["softmax_scale"]
+                probability = torch.softmax(score, dim=-1)
+                out[b, h, q0:q1] = probability @ gathered_v
+                lse[b, h, q0:q1] = torch.logsumexp(score, dim=-1)
+    return out, lse
+
+
+def validate_outputs(data, *, sources, with_oracle=True):
+    if not with_oracle:
+        if "source" in sources and data["source"]["out"] is not None:
+            torch.testing.assert_close(
+                data["tirx"]["out"].float(), data["source"]["out"].float(), atol=3e-2, rtol=3e-2
+            )
+        return
+
+    expected_out, expected_lse = _oracle(data)
+    for source in sources:
+        actual = data[source]
+        if actual["out"] is None or actual["lse"] is None:
+            raise AssertionError(f"{source} did not produce outputs")
+        torch.testing.assert_close(
+            actual["out"].float(),
+            expected_out,
+            atol=3e-2,
+            rtol=3e-2,
+            msg=lambda message: f"{source}.out: {message}",
+        )
+        # Empty rows legitimately carry -inf; assert matching finiteness first
+        # so close-comparison diagnostics remain local to live rows.
+        finite = torch.isfinite(expected_lse)
+        if not torch.equal(torch.isfinite(actual["lse"]), finite):
+            raise AssertionError(f"{source}.lse finiteness differs from the oracle")
+        torch.testing.assert_close(
+            actual["lse"][finite],
+            expected_lse[finite],
+            atol=2e-3,
+            rtol=2e-3,
+            msg=lambda message: f"{source}.lse: {message}",
+        )

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/kernel.py
@@ -1,0 +1,444 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM100 blk64 block-sparse attention forward device programs.
+
+Upstream sources:
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py`` and
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_combine.py``.
+"""
+
+import math
+
+import tirx_kernels.kern as K
+
+from . import source_kernel
+
+HEAD_DIM = 128
+QUERY_TILE = 64
+SPARSE_BLOCK = 64
+LOG2_E = math.log2(math.e)
+LN_2 = math.log(2.0)
+
+
+def _load_bf16(buffer, index):
+    bits = K.local_scalar("uint16")
+    K.ptx.ld.global_.b16(bits, buffer.ptr_to([index]))
+    return K.cast(K.reinterpret("bfloat16", bits), "float32")
+
+
+def _load_i32(buffer, index):
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, buffer.ptr_to([index]))
+    return value
+
+
+def _store_bf16(buffer, index, value):
+    bits = K.local_scalar("uint16")
+    K.ptx.cvt.rn.bf16.f32(bits, value)
+    K.ptx.st.global_.b16(buffer.ptr_to([index]), bits)
+
+
+def _exp2(value):
+    out = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(out, value)
+    return out
+
+
+def _log2(value):
+    out = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(out, value)
+    return out
+
+
+def _shfl_xor_f32(value, lane_xor):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret("uint32", value), K.uint32(lane_xor), K.uint32(31), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret("float32", out)
+
+
+def _shfl_xor_i32(value, lane_xor):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret("uint32", value), K.uint32(lane_xor), K.uint32(31), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret("int32", out)
+
+
+def _warp_sum(value):
+    for lane_xor in (16, 8, 4, 2, 1):
+        value = value + _shfl_xor_f32(value, lane_xor)
+    return value
+
+
+def _resolve_splits(value):
+    if value == "auto":
+        return 2
+    return int(value)
+
+
+def make_forward_kernel(**config):
+    batch = int(config["batch"])
+    num_heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    max_blocks = int(config["kv_blocks"])
+    num_splits = _resolve_splits(config["kv_splits"])
+    has_block_sizes = bool(config["has_block_sizes"])
+    has_block_nums = config["block_count_mode"] != "fixed"
+    use_clc = bool(config["use_clc"])
+    q_blocks = (seqlen_q + QUERY_TILE - 1) // QUERY_TILE
+    grid = (q_blocks, num_heads if use_clc else num_heads * num_splits, batch)
+
+    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=grid)
+    def forward(
+        q: K.gptr[K.bf16],
+        k: K.gptr[K.bf16],
+        v: K.gptr[K.bf16],
+        out_bf16: K.gptr[K.bf16],
+        out_f32: K.gptr[K.f32],
+        lse: K.gptr[K.f32],
+        block_index: K.gptr[K.i32],
+        block_sizes: K.gptr[K.i32],
+        block_nums: K.gptr[K.i32],
+        split_offsets: K.gptr[K.i32],
+        softmax_scale: K.f32,
+    ):
+        # Numerically direct bring-up transcription of the sparse block/split
+        # contract.  The source-shaped TMA/TMEM datapath replaces this loop in
+        # the implementation-review revision.
+        if use_clc:
+            q_block, head, batch_idx = K.cta_id_in_cluster([q_blocks, num_heads, batch])
+            split = K.int32(0)
+        else:
+            q_block, head_split, batch_idx = K.cta_id([q_blocks, num_heads * num_splits, batch])
+            split = head_split // num_heads
+            head = head_split - split * num_heads
+
+        warp = K.warp_id()
+        lane = K.thread_id() & 31
+        count_index = (batch_idx * num_heads + head) * q_blocks + q_block
+        raw_count = K.local_scalar("int32")
+        split_start = K.local_scalar("int32", init=0)
+        if num_splits > 1:
+            split_base = count_index * (num_splits + 1)
+            K.assign(split_start, _load_i32(split_offsets, split_base + split))
+            split_end = _load_i32(split_offsets, split_base + split + 1)
+            K.assign(raw_count, split_end - split_start)
+        elif has_block_nums:
+            K.assign(raw_count, _load_i32(block_nums, count_index))
+        else:
+            K.assign(raw_count, K.int32(max_blocks))
+
+        with K.unroll(4) as row_group:
+            row = warp + row_group * 16
+            query = q_block * QUERY_TILE + row
+            with K.If(query < seqlen_q), K.Then():
+                row_max = K.local_scalar("float32", init=K.float32(-float("inf")))
+                row_sum = K.local_scalar("float32", init=K.float32(0.0))
+                accum = K.alloc_local((4,), "float32")
+                with K.unroll(4) as j:
+                    K.assign(accum[j], K.float32(0.0))
+
+                block_slot = K.local_scalar("int32", init=0)
+                with K.While(block_slot < raw_count):
+                    meta_index = count_index * max_blocks + split_start + block_slot
+                    sparse_id = _load_i32(block_index, meta_index)
+                    block_size = K.local_scalar("int32")
+                    if has_block_sizes:
+                        K.assign(block_size, _load_i32(block_sizes, sparse_id))
+                    else:
+                        K.assign(block_size, K.int32(SPARSE_BLOCK))
+                    token_in_block = K.local_scalar("int32", init=0)
+                    with K.While(token_in_block < block_size):
+                        token = sparse_id * SPARSE_BLOCK + token_in_block
+                        with K.If(token < seqlen_kv), K.Then():
+                            dot = K.local_scalar("float32", init=K.float32(0.0))
+                            with K.unroll(4) as j:
+                                dim = lane + j * 32
+                                q_idx = (
+                                    (batch_idx * num_heads + head) * seqlen_q + query
+                                ) * 128 + dim
+                                kv_idx = (
+                                    (batch_idx * num_heads + head) * seqlen_kv + token
+                                ) * 128 + dim
+                                K.assign(dot, dot + _load_bf16(q, q_idx) * _load_bf16(k, kv_idx))
+                            K.assign(dot, _warp_sum(dot))
+                            score = dot * softmax_scale
+                            new_max = K.local_scalar("float32")
+                            K.ptx.max.f32(new_max, row_max, score)
+                            old_weight = _exp2((row_max - new_max) * K.float32(LOG2_E))
+                            new_weight = _exp2((score - new_max) * K.float32(LOG2_E))
+                            with K.unroll(4) as j:
+                                dim = lane + j * 32
+                                value_idx = (
+                                    (batch_idx * num_heads + head) * seqlen_kv + token
+                                ) * 128 + dim
+                                K.assign(
+                                    accum[j],
+                                    accum[j] * old_weight + new_weight * _load_bf16(v, value_idx),
+                                )
+                            K.assign(row_sum, row_sum * old_weight + new_weight)
+                            K.assign(row_max, new_max)
+                        K.assign(token_in_block, token_in_block + 1)
+                    K.assign(block_slot, block_slot + 1)
+
+                valid_sum = row_sum > K.float32(0.0)
+                inv_sum = K.if_then_else(valid_sum, K.float32(1.0) / row_sum, K.float32(0.0))
+                out_head = split * num_heads + head if num_splits > 1 else head
+                with K.unroll(4) as j:
+                    dim = lane + j * 32
+                    out_idx = (
+                        (batch_idx * (num_heads * num_splits) + out_head) * seqlen_q + query
+                    ) * 128 + dim
+                    if num_splits > 1:
+                        K.ptx.st.global_.f32(out_f32.ptr_to([out_idx]), accum[j] * inv_sum)
+                    else:
+                        _store_bf16(out_bf16, out_idx, accum[j] * inv_sum)
+                with K.If(lane == 0), K.Then():
+                    lse_idx = (batch_idx * (num_heads * num_splits) + out_head) * seqlen_q + query
+                    lse_value = K.if_then_else(
+                        valid_sum,
+                        row_max + _log2(row_sum) * K.float32(LN_2),
+                        K.float32(-float("inf")),
+                    )
+                    K.ptx.st.global_.f32(lse.ptr_to([lse_idx]), lse_value)
+
+    return forward
+
+
+def make_combine_kernel(**config):
+    batch = int(config["batch"])
+    num_heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    num_splits = _resolve_splits(config["kv_splits"])
+    max_splits = 1 << (num_splits - 1).bit_length()
+    lse_split_storage = max(8, max_splits)
+    lse_slots_per_thread = lse_split_storage // 8
+    lse_bytes = lse_split_storage * 16 * 4
+    max_split_offset = (lse_bytes + 127) // 128 * 128
+    o_ring_offset = (max_split_offset + 16 * 4 + 127) // 128 * 128
+    smem_bytes = o_ring_offset + 4 * 16 * 64 * 4
+    row_tiles = (seqlen_q * num_heads + 15) // 16
+
+    @K.kernel(warps=4, arch="sm_100a", min_blocks_per_sm=1, grid=(row_tiles, 2, batch))
+    def combine(
+        out_partial: K.gptr[K.f32],
+        lse_partial: K.gptr[K.f32],
+        out: K.gptr[K.bf16],
+        lse: K.gptr[K.f32],
+    ):
+        row_tile, dim_tile, batch_idx = K.cta_id([row_tiles, 2, batch])
+        tid = K.thread_id()
+        raw = K.alloc_buffer((smem_bytes,), K.u8, scope="shared.dyn", align=1024)
+
+        def view(shape, dtype, byte_offset):
+            return K.decl_buffer(
+                shape, dtype, data=raw.data, byte_offset=byte_offset, scope="shared.dyn", align=128
+            )
+
+        s_lse = view((lse_split_storage * 16,), K.f32, 0)
+        s_max_split = view((16,), K.i32, max_split_offset)
+        s_o = view((4 * 16 * 64,), K.f32, o_ring_offset)
+
+        def lse_smem_index(split, row):
+            linear = split * 16 + row
+            return K.bitwise_xor(linear, K.bitwise_and(K.shift_right(linear, 4), 15))
+
+        def partial_lse_index(split, flat_row):
+            query = flat_row - (flat_row // seqlen_q) * seqlen_q
+            head = flat_row // seqlen_q
+            return (
+                batch_idx * (num_splits * num_heads) + split * num_heads + head
+            ) * seqlen_q + query
+
+        def load_o_stage(split, stage, row0, row1, col):
+            for row in (row0, row1):
+                flat_row = row_tile * 16 + row
+                with K.If(flat_row < seqlen_q * num_heads), K.Then():
+                    lidx = partial_lse_index(split, flat_row)
+                    K.ptx["cp.async.cg.shared.global"](
+                        s_o.ptr_to([stage * 1024 + row * 64 + col]),
+                        out_partial.ptr_to([lidx * 128 + dim_tile * 64 + col]),
+                        16,
+                        16,
+                    )
+
+        # LSE staging map: contiguous row lanes and eight split lanes.  Slots
+        # beyond the logical split count remain physical -inf entries because
+        # the source always allocates at least eight split rows.
+        lse_row = tid & 15
+        lse_split0 = tid >> 4
+        lse_flat_row = row_tile * 16 + lse_row
+        with K.unroll(lse_slots_per_thread) as slot:
+            split = lse_split0 + slot * 8
+            dst = s_lse.ptr_to([lse_smem_index(split, lse_row)])
+            with K.If((lse_flat_row < seqlen_q * num_heads) & (split < num_splits)):
+                with K.Then():
+                    K.ptx["cp.async.ca.shared.global"](
+                        dst, lse_partial.ptr_to([partial_lse_index(split, lse_flat_row)]), 4, 4
+                    )
+                with K.Else():
+                    K.ptx.st.shared.u32(dst, K.uint32(0xFF800000))
+        K.ptx.cp.async_.commit_group()
+
+        row0 = tid >> 4
+        row1 = row0 + 8
+        col = (tid & 15) * 4
+        for stage in range(3):
+            if stage < num_splits:
+                load_o_stage(stage, stage, row0, row1, col)
+            K.ptx.cp.async_.commit_group()
+
+        K.ptx.cp.async_.wait_group(3)
+        K.ptx.bar.sync(K.uint32(0))
+
+        # Transposed LSE readback: eight lanes cooperate on one row, and each
+        # lane owns split indices separated by eight.
+        stats_row = tid >> 3
+        stats_split0 = tid & 7
+        lse_regs = K.alloc_local((lse_slots_per_thread,), "float32")
+        with K.unroll(lse_slots_per_thread) as slot:
+            K.ptx.ld.shared.f32(
+                lse_regs[slot], s_lse.ptr_to([lse_smem_index(stats_split0 + slot * 8, stats_row)])
+            )
+
+        local_max = K.local_scalar("float32", init=K.float32(-float("inf")))
+        local_last = K.local_scalar("int32", init=K.int32(-1))
+        with K.unroll(lse_slots_per_thread) as slot:
+            K.ptx.max.f32(local_max, local_max, lse_regs[slot])
+            with K.If(lse_regs[slot] != K.float32(-float("inf"))), K.Then():
+                K.assign(local_last, stats_split0 + slot * 8)
+        for lane_xor in (4, 2, 1):
+            other_max = _shfl_xor_f32(local_max, lane_xor)
+            K.ptx.max.f32(local_max, local_max, other_max)
+            other_last = _shfl_xor_i32(local_last, lane_xor)
+            K.ptx.max.s32(local_last, local_last, other_last)
+
+        safe_max = K.if_then_else(local_max == K.float32(-float("inf")), K.float32(0.0), local_max)
+        local_sum = K.local_scalar("float32", init=K.float32(0.0))
+        with K.unroll(lse_slots_per_thread) as slot:
+            K.assign(lse_regs[slot], _exp2((lse_regs[slot] - safe_max) * K.float32(LOG2_E)))
+            K.assign(local_sum, local_sum + lse_regs[slot])
+        for lane_xor in (4, 2, 1):
+            K.assign(local_sum, local_sum + _shfl_xor_f32(local_sum, lane_xor))
+
+        inv_sum = K.local_scalar("float32", init=K.float32(0.0))
+        with K.If((local_last >= 0) & (local_sum > K.float32(0.0))), K.Then():
+            K.ptx.rcp.rn.f32(inv_sum, local_sum)
+        with K.unroll(lse_slots_per_thread) as slot:
+            K.ptx.mul.f32(lse_regs[slot], lse_regs[slot], inv_sum)
+            K.ptx.st.shared.f32(
+                s_lse.ptr_to([lse_smem_index(stats_split0 + slot * 8, stats_row)]), lse_regs[slot]
+            )
+        with K.If(stats_split0 == 0), K.Then():
+            K.ptx.st.shared.u32(
+                s_max_split.ptr_to([stats_row]), K.reinterpret("uint32", local_last)
+            )
+            flat_row = row_tile * 16 + stats_row
+            with K.If((dim_tile == 0) & (flat_row < seqlen_q * num_heads)), K.Then():
+                final_lse = K.local_scalar("float32", init=K.float32(-float("inf")))
+                with K.If(local_last >= 0), K.Then():
+                    lg = _log2(local_sum)
+                    K.ptx.fma.rn.f32(final_lse, lg, K.float32(LN_2), local_max)
+                query = flat_row - (flat_row // seqlen_q) * seqlen_q
+                head = flat_row // seqlen_q
+                K.ptx.st.global_.f32(
+                    lse.ptr_to([(batch_idx * num_heads + head) * seqlen_q + query]), final_lse
+                )
+
+        K.ptx.bar.sync(K.uint32(0))
+
+        max0_bits = K.local_scalar("uint32")
+        max1_bits = K.local_scalar("uint32")
+        K.ptx.ld.shared.u32(max0_bits, s_max_split.ptr_to([row0]))
+        K.ptx.ld.shared.u32(max1_bits, s_max_split.ptr_to([row1]))
+        max_split = K.local_scalar("int32")
+        K.ptx.max.s32(
+            max_split, K.reinterpret("int32", max0_bits), K.reinterpret("int32", max1_bits)
+        )
+        acc0 = K.alloc_local((4,), "float32")
+        acc1 = K.alloc_local((4,), "float32")
+        with K.unroll(4) as j:
+            K.assign(acc0[j], K.float32(0.0))
+            K.assign(acc1[j], K.float32(0.0))
+        load_stage = K.local_scalar("int32", init=3)
+        compute_stage = K.local_scalar("int32", init=0)
+        split = K.local_scalar("int32", init=0)
+        with K.While(split <= max_split):
+            with K.If(split + 3 <= max_split), K.Then():
+                load_o_stage(split + 3, load_stage, row0, row1, col)
+            K.ptx.cp.async_.commit_group()
+            weight0 = K.local_scalar("float32")
+            weight1 = K.local_scalar("float32")
+            K.ptx.ld.shared.f32(weight0, s_lse.ptr_to([lse_smem_index(split, row0)]))
+            K.ptx.ld.shared.f32(weight1, s_lse.ptr_to([lse_smem_index(split, row1)]))
+            K.assign(load_stage, K.bitwise_and(load_stage + 1, 3))
+            K.ptx.cp.async_.wait_group(3)
+            part0 = K.alloc_local((4,), "float32")
+            part1 = K.alloc_local((4,), "float32")
+            part0_lo = K.local_scalar("uint64")
+            part0_hi = K.local_scalar("uint64")
+            part1_lo = K.local_scalar("uint64")
+            part1_hi = K.local_scalar("uint64")
+            K.ptx["ld.shared.v2.b64"](
+                part0_lo, part0_hi, s_o.ptr_to([compute_stage * 1024 + row0 * 64 + col])
+            )
+            K.ptx.mov.b64(part0[0], part0[1], part0_lo)
+            K.ptx.mov.b64(part0[2], part0[3], part0_hi)
+            K.ptx["ld.shared.v2.b64"](
+                part1_lo, part1_hi, s_o.ptr_to([compute_stage * 1024 + row1 * 64 + col])
+            )
+            K.ptx.mov.b64(part1[0], part1[1], part1_lo)
+            K.ptx.mov.b64(part1[2], part1[3], part1_hi)
+            K.assign(compute_stage, K.bitwise_and(compute_stage + 1, 3))
+            for row_acc, part, weight, row in (
+                (acc0, part0, weight0, row0),
+                (acc1, part1, weight1, row1),
+            ):
+                with (
+                    K.If((row_tile * 16 + row < seqlen_q * num_heads) & (weight > K.float32(0.0))),
+                    K.Then(),
+                ):
+                    with K.unroll(2) as pair:
+                        weighted = K.alloc_local((2,), "float32")
+                        packed_weight = K.local_scalar("uint64")
+                        packed_part = K.local_scalar("uint64")
+                        packed_result = K.local_scalar("uint64")
+                        packed_acc = K.local_scalar("uint64")
+                        K.ptx.mov.b64(packed_weight, weight, weight)
+                        K.ptx.mov.b64(packed_part, part[pair * 2], part[pair * 2 + 1])
+                        K.ptx.mul.rn.f32x2(packed_result, packed_part, packed_weight)
+                        K.ptx.mov.b64(weighted[0], weighted[1], packed_result)
+                        K.ptx.mov.b64(packed_acc, row_acc[pair * 2], row_acc[pair * 2 + 1])
+                        K.ptx.mov.b64(packed_part, weighted[0], weighted[1])
+                        K.ptx.add.rn.f32x2(packed_result, packed_acc, packed_part)
+                        K.ptx.mov.b64(row_acc[pair * 2], row_acc[pair * 2 + 1], packed_result)
+            K.assign(split, split + 1)
+
+        for row_acc, row in ((acc0, row0), (acc1, row1)):
+            flat_row = row_tile * 16 + row
+            with K.If(flat_row < seqlen_q * num_heads), K.Then():
+                packed0 = K.local_scalar("uint32")
+                packed1 = K.local_scalar("uint32")
+                K.ptx.cvt.rn.bf16x2.f32(packed0, row_acc[1], row_acc[0])
+                K.ptx.cvt.rn.bf16x2.f32(packed1, row_acc[3], row_acc[2])
+                query = flat_row - (flat_row // seqlen_q) * seqlen_q
+                head = flat_row // seqlen_q
+                out_index = (
+                    ((batch_idx * num_heads + head) * seqlen_q + query) * 128 + dim_tile * 64 + col
+                )
+                K.ptx.st.global_.v2.b32(out.ptr_to([out_index]), packed0, packed1)
+
+    return combine
+
+
+def get_kernel(**config):
+    forward = source_kernel.make_forward_kernel(**config).func
+    if _resolve_splits(config["kv_splits"]) == 1:
+        return [forward]
+    return [forward, make_combine_kernel(**config).func]

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
@@ -1,0 +1,119 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Lazy loader for the upstream SM100 blk64 BSA forward pass.
+
+Upstream source: ``python/cudnn/block_sparse_attention/_interface.py``.
+"""
+
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+_PACKAGE = "cudnn.block_sparse_attention"
+_INTERFACE = f"{_PACKAGE}._interface"
+
+
+def checkout_root():
+    configured = os.environ.get("CUDNN_FRONTEND_PATH")
+    if configured:
+        return Path(configured).resolve()
+    return Path(__file__).resolve().parents[4] / ".reference-deps" / "cudnn-frontend"
+
+
+def _bind_checkout():
+    package_dir = checkout_root() / "python" / "cudnn" / "block_sparse_attention"
+    if not package_dir.is_dir():
+        raise RuntimeError(
+            f"cuDNN Frontend checkout does not contain block sparse attention: {package_dir}"
+        )
+
+    existing = sys.modules.get(_PACKAGE)
+    if existing is not None:
+        bound = getattr(existing, "__path__", None)
+        if bound and Path(next(iter(bound))).resolve() == package_dir.resolve():
+            return
+        raise RuntimeError(
+            f"{_PACKAGE} was already imported from {bound}; cannot bind it to {package_dir}"
+        )
+
+    cudnn = importlib.import_module("cudnn")
+    package = types.ModuleType(_PACKAGE)
+    package.__path__ = [str(package_dir)]
+    package.__package__ = _PACKAGE
+    sys.modules[_PACKAGE] = package
+    cudnn.block_sparse_attention = package
+
+
+def load_interface():
+    _bind_checkout()
+    return importlib.import_module(_INTERFACE)
+
+
+def compile_reference(data):
+    """Compile lazily and return the no-argument upstream launch closure."""
+    interface = load_interface()
+    config = data["config"]
+    inputs = data["inputs"]
+    source_batches = None
+    if config["batch"] > 1:
+        source_batches = tuple(
+            (
+                inputs["q_user"][batch_idx : batch_idx + 1].clone(),
+                inputs["k_user"][batch_idx : batch_idx + 1].clone(),
+                inputs["v_user"][batch_idx : batch_idx + 1].clone(),
+                inputs["block_index"][batch_idx : batch_idx + 1].clone(),
+                inputs["block_nums"][batch_idx : batch_idx + 1].clone(),
+            )
+            for batch_idx in range(config["batch"])
+        )
+
+    def call_source(q, k, v, block_index, block_nums):
+        return interface.bsa_attn_fwd_blk64_cutedsl(
+            q,
+            k,
+            v,
+            block_index,
+            inputs["block_sizes"] if config["has_block_sizes"] else None,
+            q2k_block_nums=(block_nums if config["block_count_mode"] != "fixed" else None),
+            softmax_scale=inputs["softmax_scale"],
+            layout=config["tensor_layout"],
+            block_sparse_num=(0 if config["block_count_mode"] != "fixed" else config["kv_blocks"]),
+            allow_empty_block_nums=config["block_count_mode"] == "variable_empty",
+            use_clc=config["use_clc"],
+            kv_splits=config["kv_splits"],
+        )
+
+    def launch():
+        # The pinned source's static scheduler launches only batch 0 when B>1.
+        # Preserve the source device program and cover the full operation by
+        # invoking that same specialization once per batch in the reference.
+        if config["batch"] == 1:
+            out, lse = call_source(
+                inputs["q_user"],
+                inputs["k_user"],
+                inputs["v_user"],
+                inputs["block_index"],
+                inputs["block_nums"],
+            )
+        else:
+            outputs = []
+            lses = []
+            for q, k, v, block_index, block_nums in source_batches:
+                out_batch, lse_batch = call_source(q, k, v, block_index, block_nums)
+                outputs.append(out_batch)
+                lses.append(lse_batch)
+            out = torch.cat(outputs, dim=0)
+            lse = torch.cat(lses, dim=0)
+        if config["tensor_layout"] == "bshd":
+            out = out.transpose(1, 2).contiguous()
+        data["source"]["out"] = out
+        data["source"]["lse"] = lse
+
+    return launch

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
@@ -1,0 +1,1187 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Source-shaped SM100 blk64 BSA producer.
+
+The shared arena is one-dimensional.  Every swizzle, stage and alias below is
+expressed by scalar byte/element arithmetic; no first-class layout is used.
+"""
+
+import math
+
+import tirx_kernels.kern as K
+
+M = 64
+N = 256
+D = 128
+WARPS = 16
+KV_STAGES = 3
+STAGES = 2
+TMEM_COLS = 512
+LOG2_E = math.log2(math.e)
+LN2 = math.log(2.0)
+NEG_INF = -float("inf")
+
+ID_QK = 0x04400490
+ID_PV = 0x04410490
+MMA_WS_F16 = "tcgen05.mma.ws.cta_group::1.kind::f16"
+TCGEN_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+TMEM_LD32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+TMEM_ST32 = "tcgen05.st.sync.aligned.32x32b.x32.b32"
+TMEM_ST16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_G2S_5D = (
+    "cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+TMA_CACHE = K.uint64(0)
+
+_PV_MMA_CHAIN = r"""
+__forceinline__ __device__ void tirx_bsa_pv_mma_chain(
+        uint32_t tmem_acc,
+        uint32_t tmem_a,
+        uint64_t smem_desc_b_start,
+        uint32_t accumulate,
+        uint64_t* plast_full,
+        uint32_t plast_phase) {
+    uint32_t smem_desc_b_lo_start = static_cast<uint32_t>(smem_desc_b_start);
+    uint32_t plast_addr = static_cast<uint32_t>(__cvta_generic_to_shared(plast_full));
+    uint32_t zero_init = accumulate == 0;
+    asm volatile(
+        "{\n"
+        ".reg .pred leader_thread, p, plast_ready;\n"
+        ".reg .b32 idesc, tmem_acc_reg, tmem_a_reg;\n"
+        ".reg .b32 smem_desc_b_lo_start, smem_desc_b_lo, smem_desc_b_hi;\n"
+        ".reg .b64 smem_desc_b;\n"
+        "elect.sync _|leader_thread, -1;\n"
+        "mov.b32 idesc, 0x4410490;\n"
+        "mov.b32 tmem_acc_reg, %0;\n"
+        "mov.b32 tmem_a_reg, %1;\n"
+        "mov.b32 smem_desc_b_lo_start, %2;\n"
+        "mov.b32 smem_desc_b_lo, smem_desc_b_lo_start;\n"
+        "mov.b32 smem_desc_b_hi, 0x40004040;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo_start, smem_desc_b_hi};\n"
+        "setp.eq.b32 p, %3, 0;\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg], smem_desc_b, idesc, p, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo_start, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x8], smem_desc_b, idesc, 1, 0;\n"
+        "tirx_bsa_plast_wait:\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 plast_ready, [%4], %5, 1;\n"
+        "@plast_ready bra.uni tirx_bsa_plast_done;\n"
+        "bra.uni tirx_bsa_plast_wait;\n"
+        "tirx_bsa_plast_done:\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x10], smem_desc_b, idesc, 1, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x18], smem_desc_b, idesc, 1, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x680;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x20], smem_desc_b, idesc, 1, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x28], smem_desc_b, idesc, 1, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x30], smem_desc_b, idesc, 1, 0;\n"
+        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
+        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
+        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
+        "[tmem_acc_reg], [tmem_a_reg + 0x38], smem_desc_b, idesc, 1, 0;\n"
+        "}\n"
+        :
+        : "r"(tmem_acc),
+          "r"(tmem_a),
+          "r"(smem_desc_b_lo_start),
+          "r"(zero_init),
+          "r"(plast_addr),
+          "r"(plast_phase)
+        : "memory");
+}
+"""
+
+
+def _load_i32(buffer, index):
+    out = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(out, buffer.ptr_to([index]))
+    return out
+
+
+def _ld_shared_f32(buffer, index):
+    out = K.local_scalar("float32")
+    K.ptx.ld.shared.f32(out, buffer.ptr_to([index]))
+    return out
+
+
+def _st_shared_f32(buffer, index, value):
+    K.ptx.st.shared.f32(buffer.ptr_to([index]), value)
+
+
+def _exp2(value):
+    out = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(out, value)
+    return out
+
+
+def _log2(value):
+    out = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(out, value)
+    return out
+
+
+def _rcp(value):
+    out = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(out, value)
+    return out
+
+
+def _packed(op, dst, base, a, b, scale0, scale1, add0=None, add1=None):
+    lhs = K.local_scalar("uint64")
+    rhs = K.local_scalar("uint64")
+    result = K.local_scalar("uint64")
+    K.ptx.mov.b64(lhs, a, b)
+    K.ptx.mov.b64(rhs, scale0, scale1)
+    if add0 is None:
+        K.ptx[op](result, lhs, rhs)
+    else:
+        addend = K.local_scalar("uint64")
+        K.ptx.mov.b64(addend, add0, add1)
+        K.ptx[op](result, lhs, rhs, addend)
+    K.ptx.mov.b64(dst[base], dst[base + 1], result)
+
+
+def _max3(dst, a, b, c):
+    K.ptx.max.f32(dst, a, b, c)
+
+
+def _reduce_max_128(values):
+    acc = K.alloc_local((4,), "float32")
+    K.ptx.max.f32(acc[0], values[0], values[1])
+    K.ptx.max.f32(acc[1], values[2], values[3])
+    K.ptx.max.f32(acc[2], values[4], values[5])
+    K.ptx.max.f32(acc[3], values[6], values[7])
+    with K.unroll(1, 16) as group:
+        base = group * 8
+        _max3(acc[0], acc[0], values[base], values[base + 1])
+        _max3(acc[1], acc[1], values[base + 2], values[base + 3])
+        _max3(acc[2], acc[2], values[base + 4], values[base + 5])
+        _max3(acc[3], acc[3], values[base + 6], values[base + 7])
+    K.ptx.max.f32(acc[0], acc[0], acc[1])
+    _max3(acc[0], acc[0], acc[2], acc[3])
+    return acc[0]
+
+
+def _reduce_sum_128(values, old_sum, old_scale, first):
+    acc = K.alloc_local((8,), "float32")
+    with K.unroll(8) as j:
+        K.assign(acc[j], values[j])
+    if not first:
+        scaled = K.local_scalar("float32")
+        K.ptx.mul.f32(scaled, old_sum, old_scale)
+        K.assign(acc[0], acc[0] + scaled)
+    with K.unroll(1, 16) as group:
+        base = group * 8
+        with K.unroll(4) as pair:
+            _packed(
+                "add.rn.f32x2",
+                acc,
+                pair * 2,
+                acc[pair * 2],
+                acc[pair * 2 + 1],
+                values[base + pair * 2],
+                values[base + pair * 2 + 1],
+            )
+    for lo, hi in ((0, 2), (4, 6), (0, 4)):
+        _packed("add.rn.f32x2", acc, lo, acc[lo], acc[lo + 1], acc[hi], acc[hi + 1])
+    return acc[0] + acc[1]
+
+
+def _apply_mask64(values, base, block_size):
+    with K.If(block_size < 64), K.Then():
+        with K.unroll(2) as half:
+            shift = K.max((half + 1) * 32 - block_size, 0)
+            mask = K.local_scalar("uint32")
+            K.ptx.shr.u32(mask, K.uint32(0xFFFFFFFF), K.cast(shift, "uint32"))
+            with K.If(mask != K.uint32(0xFFFFFFFF)):
+                with K.Then():
+                    with K.If(mask == 0):
+                        with K.Then():
+                            with K.unroll(32) as bit:
+                                K.assign(values[base + half * 32 + bit], K.float32(NEG_INF))
+                        with K.Else():
+                            with K.unroll(32) as bit:
+                                bit_mask = K.shift_left(K.uint32(1), K.cast(bit, "uint32"))
+                                live = K.bitwise_and(mask, bit_mask) != 0
+                                K.assign(
+                                    values[base + half * 32 + bit],
+                                    K.if_then_else(
+                                        live, values[base + half * 32 + bit], K.float32(NEG_INF)
+                                    ),
+                                )
+
+
+def _tmem_load32(dst, base, address):
+    K.ptx[TMEM_LD32](*(dst[base + i] for i in range(32)), K.cast(address, "uint32"))
+
+
+def _tmem_store16(src, base, address):
+    K.ptx[TMEM_ST16](K.cast(address, "uint32"), *(src[base + i] for i in range(16)))
+
+
+def _tmem_rescale(address, scale):
+    regs = K.alloc_local((32,), "float32")
+    with K.unroll(4) as chunk:
+        _tmem_load32(regs, 0, address + chunk * 32)
+        with K.unroll(16) as pair:
+            _packed(
+                "mul.rn.f32x2", regs, pair * 2, regs[pair * 2], regs[pair * 2 + 1], scale, scale
+            )
+        K.ptx[TMEM_ST32](K.cast(address + chunk * 32, "uint32"), *(regs[i] for i in range(32)))
+    K.ptx.tcgen05.wait__st.sync.aligned()
+
+
+def _mbar_arrive_wait(barrier, stage, phase):
+    barrier.arrive(stage)
+    _wait(barrier, stage, phase)
+
+
+def _wait(barrier, stage, phase):
+    K.cuda.mbarrier_wait(barrier.ptr_to([stage]), phase)
+
+
+def _stats_arrive(stage, warp):
+    K.ptx.bar.arrive(K.cast(3 + stage * 4 + warp, "uint32"), K.uint32(64))
+
+
+def _stats_sync(stage, warp):
+    K.ptx.bar.sync(K.cast(3 + stage * 4 + warp, "uint32"), K.uint32(64))
+
+
+def _query_cancel_response(response_buffer, q_block, head, batch_idx, work_valid):
+    response = K.local_scalar("uint128")
+    canceled = K.local_scalar("uint32")
+    K.ptx.ld.acquire.cta.shared.b128(response, K.address_of(response_buffer[0]))
+    K.ptx.clusterlaunchcontrol.query_cancel.is_canceled.pred.b128(canceled, response)
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__x.b32.b128(
+        q_block, response, pred=canceled
+    )
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__y.b32.b128(
+        head, response, pred=canceled
+    )
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__z.b32.b128(
+        batch_idx, response, pred=canceled
+    )
+    K.assign(work_valid, K.cast(canceled, "int32"))
+    K.ptx.fence.proxy.async_.shared__cta()
+
+
+def _exchange_store(exchange, warp, lane, tmem0, tmem1, scale0, scale1, zero):
+    a = K.alloc_local((32,), "float32")
+    b = K.alloc_local((32,), "float32")
+    out = K.alloc_local((32,), "float32")
+    with K.unroll(4) as chunk:
+        if zero:
+            with K.unroll(32) as j:
+                K.assign(out[j], K.float32(0.0))
+        else:
+            _tmem_load32(a, 0, tmem0 + chunk * 32)
+            _tmem_load32(b, 0, tmem1 + chunk * 32)
+            with K.unroll(16) as pair:
+                _packed("mul.rn.f32x2", out, pair * 2, b[pair * 2], b[pair * 2 + 1], scale1, scale1)
+                _packed(
+                    "fma.rn.f32x2",
+                    out,
+                    pair * 2,
+                    a[pair * 2],
+                    a[pair * 2 + 1],
+                    scale0,
+                    scale0,
+                    out[pair * 2],
+                    out[pair * 2 + 1],
+                )
+        with K.unroll(8) as group:
+            off = warp * 4096 + chunk * 1024 + lane * 4 + group * 128
+            K.ptx.st.shared.v4.f32(
+                exchange.ptr_to([off]),
+                out[group * 4],
+                out[group * 4 + 1],
+                out[group * 4 + 2],
+                out[group * 4 + 3],
+            )
+
+
+def _exchange_reduce_store(exchange, o_raw, corr_warp, lane, split_output):
+    partner = corr_warp ^ 2
+    a = K.alloc_local((32,), "float32")
+    b = K.alloc_local((32,), "float32")
+    summed = K.alloc_local((32,), "float32")
+    row = (corr_warp & 1) * 32 + lane
+    lane_swizzle = lane & 7
+    with K.unroll(4) as chunk:
+        with K.unroll(8) as group:
+            own = corr_warp * 4096 + chunk * 1024 + lane * 4 + group * 128
+            peer = partner * 4096 + chunk * 1024 + lane * 4 + group * 128
+            K.ptx.ld.shared.v4.f32(
+                a[group * 4],
+                a[group * 4 + 1],
+                a[group * 4 + 2],
+                a[group * 4 + 3],
+                exchange.ptr_to([own]),
+            )
+            K.ptx.ld.shared.v4.f32(
+                b[group * 4],
+                b[group * 4 + 1],
+                b[group * 4 + 2],
+                b[group * 4 + 3],
+                exchange.ptr_to([peer]),
+            )
+        with K.unroll(16) as pair:
+            _packed(
+                "add.rn.f32x2",
+                summed,
+                pair * 2,
+                a[pair * 2],
+                a[pair * 2 + 1],
+                b[pair * 2],
+                b[pair * 2 + 1],
+            )
+        if split_output:
+            with K.unroll(8) as group:
+                col = ((chunk * 8 + group) ^ lane_swizzle) * 4
+                elem = 32 * row + 2048 * (col >> 5) + (col & 31)
+                K.ptx.st.shared.v4.f32(
+                    o_raw.ptr_to([elem]),
+                    summed[group * 4],
+                    summed[group * 4 + 1],
+                    summed[group * 4 + 2],
+                    summed[group * 4 + 3],
+                )
+        else:
+            packed = K.alloc_local((16,), "uint32")
+            with K.unroll(16) as pair:
+                K.ptx.cvt.rn.satfinite.bf16x2.f32(
+                    packed[pair], summed[pair * 2 + 1], summed[pair * 2]
+                )
+            with K.unroll(4) as group:
+                col = ((chunk * 4 + group) ^ lane_swizzle) * 8
+                elem = 64 * row + 4096 * (col >> 6) + (col & 63)
+                K.ptx.st.shared.v4.u32(
+                    o_raw.ptr_to([elem]),
+                    packed[group * 4],
+                    packed[group * 4 + 1],
+                    packed[group * 4 + 2],
+                    packed[group * 4 + 3],
+                )
+
+
+def _resolve_splits(value):
+    return 2 if value == "auto" else int(value)
+
+
+def make_forward_kernel(**config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    max_blocks = int(config["kv_blocks"])
+    splits = _resolve_splits(config["kv_splits"])
+    use_clc = bool(config["use_clc"])
+    has_sizes = bool(config["has_block_sizes"])
+    has_nums = config["block_count_mode"] != "fixed"
+    allow_empty = config["block_count_mode"] == "variable_empty"
+    split_output = splits > 1
+    fixed_unsplit = not has_nums and not split_output
+    q_blocks = (seqlen_q + 63) // 64
+    grid = (q_blocks, heads if use_clc else heads * splits, batch)
+
+    @K.kernel(
+        warps=WARPS,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=grid,
+        allowed_func_calls=("tirx_bsa_pv_mma_chain",),
+    )
+    def forward(
+        q_map: K.TensorMap,
+        k_map: K.TensorMap,
+        v_map: K.TensorMap,
+        o_map: K.TensorMap,
+        lse: K.gptr[K.f32],
+        block_index: K.gptr[K.i32],
+        block_sizes: K.gptr[K.i32],
+        block_nums: K.gptr[K.i32],
+        split_offsets: K.gptr[K.i32],
+        softmax_scale_log2: K.f32,
+    ):
+        if use_clc:
+            # CLC requires cluster-launch semantics, but its work coordinates
+            # are the global CTA ids.  The source launches singleton clusters;
+            # keep that explicit contract independently from the grid shape.
+            K.cta_id_in_cluster([1, 1, 1])
+            initial_q_block, initial_head, initial_batch = K.cta_id([q_blocks, heads, batch])
+            initial_split = K.int32(0)
+        else:
+            initial_q_block, initial_head_split, initial_batch = K.cta_id(
+                [q_blocks, heads * splits, batch]
+            )
+            initial_split = initial_head_split // heads
+            initial_head = initial_head_split - initial_split * heads
+
+        q_block = K.local_scalar("int32", init=initial_q_block)
+        head = K.local_scalar("int32", init=initial_head)
+        batch_idx = K.local_scalar("int32", init=initial_batch)
+        split = K.local_scalar("int32", init=initial_split)
+        work_valid = K.local_scalar("int32", init=1)
+        clc_consumer_phase = K.local_scalar("int32", init=0)
+
+        warp = K.warp_id()
+        lane = K.thread_id() & 31
+        tid = K.thread_id()
+
+        arena = K.alloc_buffer((217088,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.smem_pool(base=arena)
+        pool = smem.pool
+        # Exact generated SharedStorage prefix, in declaration order.
+        q_full = K.TMABar(pool, 1)
+        q_empty = K.TCGen05Bar(pool, 1)
+        kv_full = K.TMABar(pool, 3)
+        kv_empty = K.TCGen05Bar(pool, 3)
+        spo_full = K.TCGen05Bar(pool, 2)
+        spo_empty = K.MBarrier(pool, 2)
+        plast_full = K.MBarrier(pool, 2)
+        plast_empty = K.TCGen05Bar(pool, 2)
+        oacc_full = K.TCGen05Bar(pool, 2)
+        oacc_empty = K.MBarrier(pool, 2)
+        stats_full = K.MBarrier(pool, 2)
+        stats_empty = K.MBarrier(pool, 2)
+        oepi_full = K.MBarrier(pool, 2)
+        oepi_empty = K.MBarrier(pool, 2)
+        tmem_mailbox = pool.alloc((1,), "uint32", align=4)
+        pool.alloc((4,), "uint8")
+        reduce_bar = K.MBarrier(pool, 2, leader=(warp == 15) & (K.cuda.elect_sync() != K.uint32(0)))
+        stats_smem = pool.alloc((512,), "float32", align=8)
+        pair_smem = pool.alloc((256,), "float32", align=8)
+        if use_clc:
+            clc_full = K.TMABar(pool, 1)
+            clc_empty = K.MBarrier(pool, 1)
+            pool.alloc((8,), "uint8")
+            clc_response = pool.alloc((4,), "uint32", align=16)
+        pool.alloc((4096 - pool.offset,), "uint8")
+        q_smem = pool.alloc((8192,), "bfloat16", align=1024)
+        kv_smem = pool.alloc((98304,), "bfloat16", align=1024)
+        assert pool.offset == 217088
+
+        exchange = K.decl_buffer(
+            (16384,),
+            "float32",
+            data=kv_smem.data,
+            byte_offset=20480,
+            scope="shared.dyn",
+            align=1024,
+        )
+        if split_output:
+            o_smem = K.decl_buffer(
+                (16384,),
+                "float32",
+                data=kv_smem.data,
+                byte_offset=86016,
+                scope="shared.dyn",
+                align=1024,
+            )
+        else:
+            o_smem = K.decl_buffer(
+                (16384,),
+                "bfloat16",
+                data=kv_smem.data,
+                byte_offset=86016,
+                scope="shared.dyn",
+                align=1024,
+            )
+
+        # The source initializes each protocol from thread 0, except the two
+        # correction reduction barriers (warp 15's elected lane).
+        q_full.init(1)
+        q_empty.init(1)
+        kv_full.init(1)
+        kv_empty.init(1)
+        spo_full.init(1)
+        spo_empty.init(256)
+        plast_full.init(4)
+        plast_empty.init(1)
+        oacc_full.init(1)
+        oacc_empty.init(128)
+        stats_full.init(128)
+        stats_empty.init(128)
+        oepi_full.init(128)
+        oepi_empty.init(32)
+        reduce_bar.init(64)
+
+        with K.If(warp == 0), K.Then():
+            with K.If(K.cuda.elect_sync()), K.Then():
+                K.ptx.prefetch.tensormap(K.address_of(q_map))
+                K.ptx.prefetch.tensormap(K.address_of(k_map))
+                K.ptx.prefetch.tensormap(K.address_of(v_map))
+                K.ptx.prefetch.tensormap(K.address_of(o_map))
+
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if use_clc:
+            clc_full.init(1)
+            clc_empty.init(512)
+            K.ptx.fence.mbarrier_init.release.cluster()
+            K.cuda.cta_sync()
+        K.cuda.cta_sync()
+
+        raw_count = K.local_scalar("int32")
+        split_start = K.local_scalar("int32", init=0)
+        count_index = (batch_idx * heads + head) * q_blocks + q_block
+
+        def load_tile_metadata():
+            K.assign(split_start, 0)
+            if split_output:
+                split_base = count_index * (splits + 1)
+                K.assign(split_start, _load_i32(split_offsets, split_base + split))
+                split_end = _load_i32(split_offsets, split_base + split + 1)
+                K.assign(raw_count, split_end - split_start)
+            elif has_nums:
+                K.assign(raw_count, _load_i32(block_nums, count_index))
+            else:
+                K.assign(raw_count, K.int32(max_blocks))
+
+        def advance_work():
+            if use_clc:
+                K.cuda.cta_sync()
+                _wait(clc_full, 0, clc_consumer_phase)
+                _query_cancel_response(clc_response, q_block, head, batch_idx, work_valid)
+                clc_empty.arrive(0, remote=0, pred=K.bool(True), count=1)
+                K.assign(clc_consumer_phase, clc_consumer_phase ^ 1)
+            else:
+                K.assign(work_valid, 0)
+
+        has_work = raw_count > 0 if allow_empty else K.bool(True)
+        n_iter = ((raw_count + 7) & -8) // 4
+
+        def sparse_id(logical):
+            clamped = K.min(logical, K.max(raw_count - 1, 0))
+            return _load_i32(block_index, count_index * max_blocks + split_start + clamped)
+
+        sp = K.specialize(chain_dispatch=True)
+        r_softmax = sp.role("softmax", warps=range(0, 8), regs=192 if fixed_unsplit else 184)
+        r_correction = sp.role("correction", warps=range(8, 12), regs=88)
+        r_mma = sp.role("mma", warps=[12], regs=40 if fixed_unsplit else 48)
+        r_epilogue = sp.role("epilogue", warps=[13], regs=40 if fixed_unsplit else 48)
+        r_load = sp.role("load", warps=[14], regs=40 if fixed_unsplit else 48)
+        r_idle = sp.role("idle", warps=[15], regs=40 if fixed_unsplit else 48)
+
+        # Source dispatch order: idle/CLC, load, MMA, epilogue, softmax,
+        # correction. Static and split specializations own one work item.
+        with r_idle:
+            if use_clc:
+                clc_producer_phase = K.local_scalar("int32", init=1)
+                with K.While(work_valid != 0):
+                    _wait(clc_empty, 0, clc_producer_phase)
+                    with K.If(lane == 0), K.Then():
+                        clc_full.arrive(0, tx_count=16, remote=0)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[
+                            "clusterlaunchcontrol.try_cancel.async.shared::cta"
+                            ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128"
+                        ](K.address_of(clc_response[0]), K.address_of(clc_full.buf[0]))
+                    K.assign(clc_producer_phase, clc_producer_phase ^ 1)
+                    advance_work()
+                _wait(clc_empty, 0, clc_producer_phase)
+
+        with r_load:
+            q_prod_phase = K.local_scalar("int32", init=1)
+            kv_stage = K.local_scalar("int32", init=0)
+            kv_phase = K.local_scalar("int32", init=1)
+
+            def advance_kv():
+                K.assign(kv_stage, kv_stage + 1)
+                with K.If(kv_stage == 3), K.Then():
+                    K.assign(kv_stage, 0)
+                    K.assign(kv_phase, kv_phase ^ 1)
+
+            def load_group(kind, reverse_group):
+                _wait(kv_empty, kv_stage, kv_phase)
+                with K.If(K.cuda.elect_sync()), K.Then():
+                    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                        kv_full.ptr_to([kv_stage]), K.uint32(65536)
+                    )
+                    with K.unroll(4) as sub:
+                        sid = sparse_id(reverse_group * 4 + sub)
+                        if kind == 0:
+                            slot = K.if_then_else(
+                                sub == 0,
+                                0,
+                                K.if_then_else(sub == 1, 2, K.if_then_else(sub == 2, 1, 3)),
+                            )
+                            with K.unroll(2) as half:
+                                dst_elem = kv_stage * 32768 + slot * 4096 + half * 16384
+                                K.ptx[TMA_G2S_5D](
+                                    kv_smem.ptr_to([dst_elem]),
+                                    K.address_of(k_map),
+                                    K.int32(0),
+                                    K.int32(0),
+                                    K.cast(half, "int32"),
+                                    sid,
+                                    batch_idx * heads + head,
+                                    K.cuda.cvta_generic_to_shared(kv_full.ptr_to([kv_stage])),
+                                    TMA_CACHE,
+                                )
+                        else:
+                            dst_elem = kv_stage * 32768 + sub * 8192
+                            K.ptx[TMA_G2S_5D](
+                                kv_smem.ptr_to([dst_elem]),
+                                K.address_of(v_map),
+                                K.int32(0),
+                                K.int32(0),
+                                K.int32(0),
+                                sid,
+                                batch_idx * heads + head,
+                                K.cuda.cvta_generic_to_shared(kv_full.ptr_to([kv_stage])),
+                                TMA_CACHE,
+                            )
+                advance_kv()
+
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                with K.If(has_work), K.Then():
+                    _wait(q_empty, 0, q_prod_phase)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                            q_full.ptr_to([0]), K.uint32(16384)
+                        )
+                        with K.unroll(2) as half:
+                            K.ptx[TMA_G2S_4D](
+                                q_smem.ptr_to([half * 4096]),
+                                K.address_of(q_map),
+                                K.cast(half * 64, "int32"),
+                                q_block * 64,
+                                head,
+                                batch_idx,
+                                K.cuda.cvta_generic_to_shared(q_full.ptr_to([0])),
+                                TMA_CACHE,
+                            )
+                    K.assign(q_prod_phase, q_prod_phase ^ 1)
+                    load_group(0, n_iter - 1)
+                    load_group(0, n_iter - 2)
+                    i = K.local_scalar("int32", init=0)
+                    with K.While(i < n_iter - 2):
+                        load_group(1, n_iter - 1 - i)
+                        load_group(0, n_iter - 3 - i)
+                        K.assign(i, i + 1)
+                    load_group(1, 1)
+                    load_group(1, 0)
+                advance_work()
+            _wait(kv_empty, kv_stage, kv_phase)
+            _wait(q_empty, 0, q_prod_phase)
+
+        with r_mma:
+            K.ptx[TMEM_ALLOC](K.address_of(tmem_mailbox[0]), K.uint32(TMEM_COLS))
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            q_desc = K.SmemDescriptor()
+            q_desc.init(q_smem.ptr_to([0]), ldo=1024, sdo=64, swizzle=3)
+            q_desc.make_lo_uniform()
+            q_phase = K.local_scalar("int32", init=0)
+            kv_stage = K.local_scalar("int32", init=0)
+            kv_phase = K.local_scalar("int32", init=0)
+            spo_phase0 = K.local_scalar("int32", init=0)
+            spo_phase1 = K.local_scalar("int32", init=0)
+            acc0 = K.local_scalar("int32", init=0)
+            acc1 = K.local_scalar("int32", init=0)
+
+            def advance_kv_cons():
+                K.assign(kv_stage, kv_stage + 1)
+                with K.If(kv_stage == 3), K.Then():
+                    K.assign(kv_stage, 0)
+                    K.assign(kv_phase, kv_phase ^ 1)
+
+            def issue_qk(stage):
+                k_stage_desc = K.SmemDescriptor()
+                k_stage_desc.init(kv_smem.ptr_to([kv_stage * 32768]), ldo=1024, sdo=64, swizzle=3)
+                k_stage_desc.make_lo_uniform()
+                for ki in range(8):
+                    q_off = (ki & 3) * 2 + (ki // 4) * 512
+                    k_off = (ki & 3) * 2 + (ki // 4) * 2048
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[MMA_WS_F16](
+                            K.cast(tmem_base + stage * 128, "uint32"),
+                            q_desc.add_16B_offset(q_off),
+                            k_stage_desc.add_16B_offset(k_off),
+                            K.uint32(ID_QK),
+                            K.cast(ki != 0, "bool"),
+                            K.uint64(0),
+                        )
+                with K.If(K.cuda.elect_sync()), K.Then():
+                    K.ptx[TCGEN_COMMIT](spo_full.ptr_to([stage]))
+
+            def issue_pv(stage, accumulate, phase):
+                v_stage_desc = K.SmemDescriptor()
+                v_stage_desc.init(kv_smem.ptr_to([kv_stage * 32768]), ldo=512, sdo=64, swizzle=3)
+                v_stage_desc.make_lo_uniform()
+                K.cuda.func_call(
+                    "tirx_bsa_pv_mma_chain",
+                    K.uint32(256 + stage * 128),
+                    K.uint32(stage * 128),
+                    v_stage_desc.desc,
+                    K.cast(accumulate, "uint32"),
+                    plast_full.ptr_to([stage]),
+                    K.cast(phase, "uint32"),
+                    source_code=_PV_MMA_CHAIN,
+                )
+
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                K.assign(acc0, 0)
+                K.assign(acc1, 0)
+                with K.If(has_work), K.Then():
+                    _wait(q_full, 0, q_phase)
+                    K.ptx.tcgen05.fence__after_thread_sync()
+                    with K.unroll(2) as stage:
+                        _wait(kv_full, kv_stage, kv_phase)
+                        K.ptx.tcgen05.fence__after_thread_sync()
+                        issue_qk(stage)
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            K.ptx[TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                        advance_kv_cons()
+
+                    pairs = (n_iter - 2) // 2
+                    pair = K.local_scalar("int32", init=0)
+                    with K.While(pair < pairs):
+                        for stage in range(2):
+                            phase = K.if_then_else(stage == 0, spo_phase0, spo_phase1)
+                            _wait(spo_empty, stage, phase)
+                            _wait(kv_full, kv_stage, kv_phase)
+                            K.ptx.tcgen05.fence__after_thread_sync()
+                            issue_pv(stage, K.if_then_else(stage == 0, acc0, acc1), phase)
+                            with K.If(K.cuda.elect_sync()), K.Then():
+                                K.ptx[TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                            advance_kv_cons()
+                            _wait(kv_full, kv_stage, kv_phase)
+                            K.ptx.tcgen05.fence__after_thread_sync()
+                            issue_qk(stage)
+                            with K.If(K.cuda.elect_sync()), K.Then():
+                                K.ptx[TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                            advance_kv_cons()
+                            if stage == 0:
+                                K.assign(spo_phase0, spo_phase0 ^ 1)
+                                K.assign(acc0, 1)
+                            else:
+                                K.assign(spo_phase1, spo_phase1 ^ 1)
+                                K.assign(acc1, 1)
+                        K.assign(pair, pair + 1)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[TCGEN_COMMIT](q_empty.ptr_to([0]))
+
+                    for stage in range(2):
+                        phase = K.if_then_else(stage == 0, spo_phase0, spo_phase1)
+                        _wait(spo_empty, stage, phase)
+                        _wait(kv_full, kv_stage, kv_phase)
+                        K.ptx.tcgen05.fence__after_thread_sync()
+                        issue_pv(stage, K.if_then_else(stage == 0, acc0, acc1), phase)
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            K.ptx[TCGEN_COMMIT](oacc_full.ptr_to([stage]))
+                            K.ptx[TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                        advance_kv_cons()
+                        if stage == 0:
+                            K.assign(spo_phase0, spo_phase0 ^ 1)
+                        else:
+                            K.assign(spo_phase1, spo_phase1 ^ 1)
+                    K.assign(q_phase, q_phase ^ 1)
+                advance_work()
+
+            K.ptx[TMEM_RELINQUISH]()
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            allocated = K.local_scalar("uint32")
+            K.ptx.ld.shared.u32(allocated, tmem_mailbox.ptr_to([0]))
+            K.ptx[TMEM_DEALLOC](allocated, K.uint32(TMEM_COLS))
+
+        with r_epilogue:
+            oepi_phase = K.local_scalar("int32", init=0)
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                _wait(oepi_full, 0, oepi_phase)
+                with K.If(K.cuda.elect_sync()), K.Then():
+                    out_head = split * heads + head if split_output else head
+                    if split_output:
+                        with K.unroll(4) as quarter:
+                            K.ptx[TMA_S2G_4D](
+                                K.address_of(o_map),
+                                K.cast(quarter * 32, "int32"),
+                                q_block * 64,
+                                out_head,
+                                batch_idx,
+                                o_smem.ptr_to([quarter * 2048]),
+                                TMA_CACHE,
+                            )
+                    else:
+                        with K.unroll(2) as half:
+                            K.ptx[TMA_S2G_4D](
+                                K.address_of(o_map),
+                                K.cast(half * 64, "int32"),
+                                q_block * 64,
+                                out_head,
+                                batch_idx,
+                                o_smem.ptr_to([half * 4096]),
+                                TMA_CACHE,
+                            )
+                    K.ptx.cp.async_.bulk.commit_group()
+                K.ptx.cp.async_.bulk.wait_group.read(0)
+                oepi_empty.arrive(0)
+                K.assign(oepi_phase, oepi_phase ^ 1)
+                advance_work()
+
+        with r_softmax:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            stage = K.if_then_else(warp < 4, 0, 1)
+            local_warp = warp & 3
+            tid128 = tid & 127
+            score_phase = K.local_scalar("int32", init=0)
+            stats_phase = K.local_scalar("int32", init=1)
+            row_max = K.local_scalar("float32", init=K.float32(NEG_INF))
+            row_sum = K.local_scalar("float32", init=K.float32(0.0))
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                K.assign(row_max, K.float32(NEG_INF))
+                K.assign(row_sum, K.float32(0.0))
+                _wait(stats_empty, stage, stats_phase)
+                K.assign(stats_phase, stats_phase ^ 1)
+
+                with K.If(has_work), K.Then():
+                    wg_count = n_iter // 2
+                    iteration = K.local_scalar("int32", init=0)
+                    with K.While(iteration < wg_count):
+                        _wait(spo_full, stage, score_phase)
+                        score = K.alloc_local((128,), "float32")
+                        with K.unroll(4) as chunk:
+                            _tmem_load32(score, chunk * 32, tmem_base + stage * 128 + chunk * 32)
+
+                        reverse_group = n_iter - 1 - (iteration * 2 + stage)
+                        warp_col = local_warp // 2
+                        logical_lo = reverse_group * 4 + warp_col
+                        logical_hi = logical_lo + 2
+                        bs_lo = K.local_scalar("int32")
+                        bs_hi = K.local_scalar("int32")
+                        if has_sizes:
+                            K.assign(
+                                bs_lo,
+                                K.if_then_else(
+                                    logical_lo < raw_count,
+                                    _load_i32(block_sizes, sparse_id(logical_lo)),
+                                    0,
+                                ),
+                            )
+                            K.assign(
+                                bs_hi,
+                                K.if_then_else(
+                                    logical_hi < raw_count,
+                                    _load_i32(block_sizes, sparse_id(logical_hi)),
+                                    0,
+                                ),
+                            )
+                        else:
+                            K.assign(bs_lo, K.if_then_else(logical_lo < raw_count, 64, 0))
+                            K.assign(bs_hi, K.if_then_else(logical_hi < raw_count, 64, 0))
+                        _apply_mask64(score, 0, bs_lo)
+                        _apply_mask64(score, 64, bs_hi)
+
+                        tile_max = _reduce_max_128(score)
+                        first = iteration == 0
+                        old_scale = K.local_scalar("float32")
+                        new_max = K.local_scalar("float32")
+                        row_max_safe = K.local_scalar("float32")
+                        with K.If(first):
+                            with K.Then():
+                                K.assign(new_max, tile_max)
+                                K.assign(
+                                    row_max_safe,
+                                    K.if_then_else(tile_max != K.float32(NEG_INF), tile_max, 0.0),
+                                )
+                                K.assign(old_scale, K.float32(0.0))
+                            with K.Else():
+                                K.ptx.max.f32(new_max, row_max, tile_max)
+                                K.assign(
+                                    row_max_safe,
+                                    K.if_then_else(new_max != K.float32(NEG_INF), new_max, 0.0),
+                                )
+                                delta = K.local_scalar("float32")
+                                K.ptx.sub.f32(delta, row_max, row_max_safe)
+                                delta_scaled = K.local_scalar("float32")
+                                K.ptx.mul.f32(delta_scaled, delta, softmax_scale_log2)
+                                K.assign(old_scale, _exp2(delta_scaled))
+                                with K.If(delta_scaled >= K.float32(-8.0)), K.Then():
+                                    K.assign(new_max, row_max)
+                                    K.assign(row_max_safe, row_max)
+                                    K.assign(old_scale, K.float32(1.0))
+                        with K.If(first == K.bool(False)), K.Then():
+                            _st_shared_f32(stats_smem, stage * 128 + tid128, old_scale)
+                        _stats_arrive(stage, local_warp)
+
+                        negative_scale = K.local_scalar("float32")
+                        K.ptx.neg.f32(negative_scale, softmax_scale_log2)
+                        negative_rowmax = K.local_scalar("float32")
+                        K.ptx.mul.f32(negative_rowmax, row_max_safe, negative_scale)
+                        sum_acc = K.alloc_local((8,), "float32")
+                        scaled_old_sum = K.local_scalar("float32")
+                        K.ptx.mul.f32(scaled_old_sum, row_sum, old_scale)
+                        K.assign(sum_acc[0], scaled_old_sum)
+                        with K.unroll(1, 8) as acc_idx:
+                            K.assign(sum_acc[acc_idx], K.float32(0.0))
+                        packed_p = K.alloc_local((16,), "uint32")
+                        for chunk in range(4):
+                            for subgroup in range(4):
+                                with K.unroll(4) as acc_pair:
+                                    pair = subgroup * 4 + acc_pair
+                                    score_base = chunk * 32 + pair * 2
+                                    scaled = K.alloc_local((2,), "float32")
+                                    _packed(
+                                        "fma.rn.f32x2",
+                                        scaled,
+                                        0,
+                                        score[score_base],
+                                        score[score_base + 1],
+                                        softmax_scale_log2,
+                                        softmax_scale_log2,
+                                        negative_rowmax,
+                                        negative_rowmax,
+                                    )
+                                    exp0 = _exp2(scaled[0])
+                                    exp1 = _exp2(scaled[1])
+                                    K.ptx.cvt.rn.satfinite.bf16x2.f32(packed_p[pair], exp1, exp0)
+                                    _packed(
+                                        "add.rn.f32x2",
+                                        sum_acc,
+                                        acc_pair * 2,
+                                        sum_acc[acc_pair * 2],
+                                        sum_acc[acc_pair * 2 + 1],
+                                        exp0,
+                                        exp1,
+                                    )
+                            _tmem_store16(packed_p, 0, tmem_base + stage * 128 + chunk * 16)
+                            if chunk == 0:
+                                K.ptx.tcgen05.wait__st.sync.aligned()
+                                spo_empty.arrive(stage)
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        K.cuda.warp_sync()
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            plast_full.arrive(stage)
+                        for lo, hi in ((0, 2), (4, 6), (0, 4)):
+                            _packed(
+                                "add.rn.f32x2",
+                                sum_acc,
+                                lo,
+                                sum_acc[lo],
+                                sum_acc[lo + 1],
+                                sum_acc[hi],
+                                sum_acc[hi + 1],
+                            )
+                        K.assign(row_sum, sum_acc[0] + sum_acc[1])
+                        K.assign(row_max, new_max)
+                        _wait(stats_empty, stage, stats_phase)
+                        K.assign(stats_phase, stats_phase ^ 1)
+                        K.assign(score_phase, score_phase ^ 1)
+                        K.assign(iteration, iteration + 1)
+
+                    _st_shared_f32(stats_smem, stage * 128 + tid128, row_sum)
+                    _st_shared_f32(stats_smem, 256 + stage * 128 + tid128, row_max)
+                    _stats_arrive(stage, local_warp)
+                with K.If(has_work == K.bool(False)), K.Then():
+                    _stats_arrive(stage, local_warp)
+                advance_work()
+
+            _wait(stats_empty, stage, stats_phase)
+            K.ptx.bar.arrive(K.uint32(2), K.uint32(416))
+
+        with r_correction:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            corr_warp = warp - 8
+            tid128 = tid & 127
+            lane_corr = tid & 31
+            oacc_phase = K.local_scalar("int32", init=0)
+            oepi_phase = K.local_scalar("int32", init=1)
+            scale0 = K.local_scalar("float32", init=K.float32(0.0))
+            scale1 = K.local_scalar("float32", init=K.float32(0.0))
+            sum_local = K.local_scalar("float32", init=K.float32(0.0))
+            max_safe = K.local_scalar("float32", init=K.float32(0.0))
+            spo_empty.arrive(0)
+            spo_empty.arrive(1)
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                K.assign(scale0, K.float32(0.0))
+                K.assign(scale1, K.float32(0.0))
+                K.assign(sum_local, K.float32(0.0))
+                K.assign(max_safe, K.float32(0.0))
+                with K.If(has_work), K.Then():
+                    _stats_sync(0, corr_warp)
+                    stats_empty.arrive(0)
+                    _stats_sync(1, corr_warp)
+                    corr_pairs = (n_iter - 2) // 2
+                    pair = K.local_scalar("int32", init=0)
+                    with K.While(pair < corr_pairs):
+                        with K.unroll(2) as stage:
+                            _stats_sync(stage, corr_warp)
+                            scale = _ld_shared_f32(stats_smem, stage * 128 + tid128)
+                            ballot = K.local_scalar("uint32")
+                            K.ptx.vote_sync.ballot.b32(
+                                ballot, K.ptx.pred(scale < K.float32(1.0)), K.uint32(0xFFFFFFFF)
+                            )
+                            with K.If(ballot != 0), K.Then():
+                                _tmem_rescale(tmem_base + 256 + stage * 128, scale)
+                            spo_empty.arrive(stage)
+                            stats_empty.arrive(1 - stage)
+                        K.assign(pair, pair + 1)
+                    stats_empty.arrive(1)
+
+                    sum0 = K.local_scalar("float32", init=K.float32(0.0))
+                    sum1 = K.local_scalar("float32", init=K.float32(0.0))
+                    maximum0 = K.local_scalar("float32", init=K.float32(NEG_INF))
+                    maximum1 = K.local_scalar("float32", init=K.float32(NEG_INF))
+                    for stage in range(2):
+                        _stats_sync(stage, corr_warp)
+                        if stage == 0:
+                            K.assign(sum0, _ld_shared_f32(stats_smem, tid128))
+                            K.assign(maximum0, _ld_shared_f32(stats_smem, 256 + tid128))
+                        else:
+                            K.assign(sum1, _ld_shared_f32(stats_smem, 128 + tid128))
+                            K.assign(maximum1, _ld_shared_f32(stats_smem, 384 + tid128))
+                        stats_empty.arrive(stage)
+                    valid0 = sum0 > 0
+                    valid1 = sum1 > 0
+                    rm0 = K.if_then_else(valid0, maximum0, K.float32(NEG_INF))
+                    rm1 = K.if_then_else(valid1, maximum1, K.float32(NEG_INF))
+                    max_local = K.local_scalar("float32")
+                    K.ptx.max.f32(max_local, rm0, rm1)
+                    K.assign(
+                        max_safe, K.if_then_else(max_local > K.float32(NEG_INF), max_local, 0.0)
+                    )
+                    K.assign(
+                        scale0,
+                        K.if_then_else(valid0, _exp2((rm0 - max_safe) * softmax_scale_log2), 0.0),
+                    )
+                    K.assign(
+                        scale1,
+                        K.if_then_else(valid1, _exp2((rm1 - max_safe) * softmax_scale_log2), 0.0),
+                    )
+                    K.assign(sum_local, sum0 * scale0 + sum1 * scale1)
+                    for stage in range(2):
+                        _wait(oacc_full, stage, oacc_phase)
+                        K.ptx.tcgen05.fence__after_thread_sync()
+                    _wait(oepi_empty, 0, oepi_phase)
+                with K.If(has_work == K.bool(False)), K.Then():
+                    for stage in range(2):
+                        _stats_sync(stage, corr_warp)
+                        stats_empty.arrive(stage)
+                    K.assign(scale0, K.float32(0.0))
+                    K.assign(scale1, K.float32(0.0))
+                    K.assign(sum_local, K.float32(0.0))
+                    K.assign(max_safe, K.float32(0.0))
+                    _wait(oepi_empty, 0, oepi_phase)
+
+                partner = corr_warp ^ 2
+                _st_shared_f32(pair_smem, partner * 64 + lane_corr * 2, sum_local)
+                _st_shared_f32(pair_smem, partner * 64 + lane_corr * 2 + 1, max_safe)
+                _mbar_arrive_wait(reduce_bar, corr_warp & 1, 0)
+                peer_sum = _ld_shared_f32(pair_smem, corr_warp * 64 + lane_corr * 2)
+                peer_max = _ld_shared_f32(pair_smem, corr_warp * 64 + lane_corr * 2 + 1)
+                max_total = K.local_scalar("float32")
+                K.ptx.max.f32(max_total, max_safe, peer_max)
+                max_total_safe = K.if_then_else(max_total > K.float32(NEG_INF), max_total, 0.0)
+                own_rescale = K.if_then_else(
+                    sum_local > 0, _exp2((max_safe - max_total_safe) * softmax_scale_log2), 0.0
+                )
+                peer_rescale = K.if_then_else(
+                    peer_sum > 0, _exp2((peer_max - max_total_safe) * softmax_scale_log2), 0.0
+                )
+                total_sum = sum_local * own_rescale + peer_sum * peer_rescale
+                inv_total = K.if_then_else(total_sum > 0, _rcp(total_sum), 0.0)
+                own_weight = own_rescale * inv_total
+                own_scale0 = scale0 * own_weight
+                own_scale1 = scale1 * own_weight
+                zero = allow_empty and ((own_scale0 == 0) & (own_scale1 == 0))
+                if allow_empty:
+                    with K.If(zero):
+                        with K.Then():
+                            _exchange_store(
+                                exchange,
+                                corr_warp,
+                                lane_corr,
+                                tmem_base + 256,
+                                tmem_base + 384,
+                                own_scale0,
+                                own_scale1,
+                                True,
+                            )
+                        with K.Else():
+                            _exchange_store(
+                                exchange,
+                                corr_warp,
+                                lane_corr,
+                                tmem_base + 256,
+                                tmem_base + 384,
+                                own_scale0,
+                                own_scale1,
+                                False,
+                            )
+                else:
+                    _exchange_store(
+                        exchange,
+                        corr_warp,
+                        lane_corr,
+                        tmem_base + 256,
+                        tmem_base + 384,
+                        own_scale0,
+                        own_scale1,
+                        False,
+                    )
+                _mbar_arrive_wait(reduce_bar, corr_warp & 1, 1)
+                with K.If(corr_warp < 2), K.Then():
+                    _exchange_reduce_store(exchange, o_smem, corr_warp, lane_corr, split_output)
+                K.ptx.fence.proxy.async_.shared__cta()
+                out_row = (corr_warp & 1) * 32 + lane_corr
+                with K.If((corr_warp < 2) & (q_block * 64 + out_row < seqlen_q)), K.Then():
+                    out_head = split * heads + head if split_output else head
+                    lse_index = (
+                        (batch_idx * (heads * splits) + out_head) * seqlen_q
+                        + q_block * 64
+                        + out_row
+                    )
+                    lse_value = K.if_then_else(
+                        total_sum > 0,
+                        (max_total_safe * softmax_scale_log2 + _log2(total_sum)) * K.float32(LN2),
+                        K.float32(NEG_INF),
+                    )
+                    K.ptx.st.global_.f32(lse.ptr_to([lse_index]), lse_value)
+                with K.If(has_work), K.Then():
+                    spo_empty.arrive(0)
+                    spo_empty.arrive(1)
+                oepi_full.arrive(0)
+                K.assign(oepi_phase, oepi_phase ^ 1)
+                with K.If(has_work), K.Then():
+                    K.assign(oacc_phase, oacc_phase ^ 1)
+                advance_work()
+            _wait(oepi_empty, 0, oepi_phase)
+            K.ptx.bar.arrive(K.uint32(2), K.uint32(416))
+
+    return forward

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/spec.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/spec.py
@@ -1,0 +1,357 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Configuration matrix for the SM100 blk64 BSA forward port.
+
+Upstream sources:
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py`` and
+``python/cudnn/block_sparse_attention/_interface.py``.
+"""
+
+
+def _config(
+    label,
+    *,
+    batch,
+    num_heads,
+    seqlen_q,
+    seqlen_kv,
+    kv_blocks,
+    tensor_layout="bhsd",
+    has_block_sizes=True,
+    block_count_mode="fixed",
+    block_count_pattern=None,
+    use_clc=False,
+    kv_splits=1,
+    softmax_scale=None,
+    use_int64_kv_strides=False,
+    seed=0,
+):
+    return {
+        "label": label,
+        "batch": batch,
+        "num_heads": num_heads,
+        "seqlen_q": seqlen_q,
+        "seqlen_kv": seqlen_kv,
+        "kv_blocks": kv_blocks,
+        "tensor_layout": tensor_layout,
+        "has_block_sizes": has_block_sizes,
+        "block_count_mode": block_count_mode,
+        "block_count_pattern": block_count_pattern,
+        "use_clc": use_clc,
+        "kv_splits": kv_splits,
+        "softmax_scale": softmax_scale,
+        "use_int64_kv_strides": use_int64_kv_strides,
+        "seed": seed,
+    }
+
+
+def correctness_configs():
+    configs = []
+    seed = 6400
+
+    def add(label, **kwargs):
+        nonlocal seed
+        seed += 1
+        configs.append(_config(label, seed=seed, **kwargs))
+
+    for tensor_layout in ("bhsd", "bshd"):
+        for kv_splits in (1, 2):
+            add(
+                f"b1_h2_sq128_skv256_kv2_mask_{tensor_layout}_s{kv_splits}_static",
+                batch=1,
+                num_heads=2,
+                seqlen_q=128,
+                seqlen_kv=256,
+                kv_blocks=2,
+                tensor_layout=tensor_layout,
+                kv_splits=kv_splits,
+            )
+    add(
+        "b2_h1_sq64_skv255_kv2_mask_bhsd_s1_static",
+        batch=2,
+        num_heads=1,
+        seqlen_q=64,
+        seqlen_kv=255,
+        kv_blocks=2,
+    )
+    for seqlen_q in (1, 63, 65):
+        for kv_splits in (1, 2):
+            add(
+                f"b1_h1_sq{seqlen_q}_skv256_kv2_mask_bhsd_s{kv_splits}_static",
+                batch=1,
+                num_heads=1,
+                seqlen_q=seqlen_q,
+                seqlen_kv=256,
+                kv_blocks=2,
+                kv_splits=kv_splits,
+            )
+
+    add(
+        "b1_h1_sq129_skv512_kv4_nomask_scale0125_bhsd_s1_static",
+        batch=1,
+        num_heads=1,
+        seqlen_q=129,
+        seqlen_kv=512,
+        kv_blocks=4,
+        has_block_sizes=False,
+        softmax_scale=0.125,
+    )
+    for label, mode, pattern, mask, clc, splits in (
+        (
+            "b1_h2_sq129_skv512_maxkv4_var_1_3_4_mask_bhsd_s1_static",
+            "variable",
+            "1,3,4",
+            True,
+            False,
+            1,
+        ),
+        (
+            "b1_h2_sq129_skv512_maxkv4_var_1_3_4_mask_bhsd_s1_clc_auto",
+            "variable",
+            "1,3,4",
+            True,
+            True,
+            1,
+        ),
+        ("b1_h2_sq129_skv512_kv4_mask_bhsd_s1_clc", "fixed", None, True, True, 1),
+        (
+            "b1_h2_sq129_skv512_maxkv4_var_0_1_4_mask_bhsd_s1_clc",
+            "variable_empty",
+            "0,1,4",
+            True,
+            True,
+            1,
+        ),
+        (
+            "b1_h2_sq129_skv512_maxkv4_var_0_1_4_mask_bhsd_s2_static",
+            "variable_empty",
+            "0,1,4",
+            True,
+            False,
+            2,
+        ),
+        (
+            "b1_h2_sq129_skv512_maxkv4_var_1_3_4_nomask_bhsd_s1_static",
+            "variable",
+            "1,3,4",
+            False,
+            False,
+            1,
+        ),
+    ):
+        add(
+            label,
+            batch=1,
+            num_heads=2,
+            seqlen_q=129,
+            seqlen_kv=512,
+            kv_blocks=4,
+            has_block_sizes=mask,
+            block_count_mode=mode,
+            block_count_pattern=pattern,
+            use_clc=clc,
+            kv_splits=splits,
+        )
+
+    for label, sq, skv, blocks, mask, splits in (
+        ("b1_h1_sq65_skv4095_kv48_mask_bhsd_s3_static", 65, 4095, 48, True, 3),
+        ("b1_h1_sq65_skv4096_kv64_nomask_bhsd_s8_static", 65, 4096, 64, False, 8),
+        ("b1_h1_sq1_skv16384_kv256_mask_bhsd_s256_static", 1, 16384, 256, True, 256),
+        ("b1_h1_sq64_skv16384_kv256_mask_bhsd_sauto2_static", 64, 16384, 256, True, "auto"),
+    ):
+        add(
+            label,
+            batch=1,
+            num_heads=1,
+            seqlen_q=sq,
+            seqlen_kv=skv,
+            kv_blocks=blocks,
+            has_block_sizes=mask,
+            kv_splits=splits,
+        )
+    add(
+        "b1_h1_sq65_skv512_kv4_mask_bhsd_s1_static_i64kv",
+        batch=1,
+        num_heads=1,
+        seqlen_q=65,
+        seqlen_kv=512,
+        kv_blocks=4,
+        use_int64_kv_strides=True,
+    )
+    assert len(configs) == 23
+    return configs
+
+
+def benchmark_configs():
+    rows = (
+        (
+            "p00_b1_h1_sq64_skv4096_kv16_nomask_s1_static",
+            1,
+            1,
+            64,
+            4096,
+            16,
+            False,
+            "fixed",
+            False,
+            1,
+            False,
+        ),
+        (
+            "p01_b1_h2_sq4097_skv8191_kv64_mask_s1_static",
+            1,
+            2,
+            4097,
+            8191,
+            64,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+        ),
+        (
+            "p02_b2_h8_sq4096_skv8191_kv32_mask_s1_static",
+            2,
+            8,
+            4096,
+            8191,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+        ),
+        (
+            "p03_b1_h4_sq8192_skv4096_kv16_mask_s1_clc",
+            1,
+            4,
+            8192,
+            4096,
+            16,
+            True,
+            "fixed",
+            True,
+            1,
+            False,
+        ),
+        (
+            "p04_b1_h8_sq4096_skv8192_maxkv32_var_mask_s1_clc",
+            1,
+            8,
+            4096,
+            8192,
+            32,
+            True,
+            "variable",
+            True,
+            1,
+            False,
+        ),
+        (
+            "p05_b2_h4_sq4097_skv8191_maxkv32_empty_mask_s1_clc",
+            2,
+            4,
+            4097,
+            8191,
+            32,
+            True,
+            "variable_empty",
+            True,
+            1,
+            False,
+        ),
+        (
+            "p06_b1_h4_sq1024_skv32768_kv256_mask_s2_static",
+            1,
+            4,
+            1024,
+            32768,
+            256,
+            True,
+            "fixed",
+            False,
+            2,
+            False,
+        ),
+        (
+            "p07_b1_h4_sq4097_skv16384_maxkv128_var_mask_s2_static",
+            1,
+            4,
+            4097,
+            16384,
+            128,
+            True,
+            "variable_empty",
+            False,
+            2,
+            False,
+        ),
+        (
+            "p08_b1_h4_sq2048_skv32768_kv256_mask_s4_static",
+            1,
+            4,
+            2048,
+            32768,
+            256,
+            True,
+            "fixed",
+            False,
+            4,
+            False,
+        ),
+        (
+            "p09_b1_h8_sq2048_skv65536_kv512_nomask_s8_static",
+            1,
+            8,
+            2048,
+            65536,
+            512,
+            False,
+            "fixed",
+            False,
+            8,
+            False,
+        ),
+        (
+            "p10_b1_h4_sq4096_skv8192_kv32_mask_s1_static_i64kv",
+            1,
+            4,
+            4096,
+            8192,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            True,
+        ),
+    )
+    configs = []
+    for seed, row in enumerate(rows, start=7400):
+        label, batch, heads, sq, skv, blocks, mask, mode, clc, splits, i64kv = row
+        pattern = (
+            "0,1,max" if mode == "variable_empty" else "1,mid,max" if mode == "variable" else None
+        )
+        configs.append(
+            _config(
+                label,
+                batch=batch,
+                num_heads=heads,
+                seqlen_q=sq,
+                seqlen_kv=skv,
+                kv_blocks=blocks,
+                has_block_sizes=mask,
+                block_count_mode=mode,
+                block_count_pattern=pattern,
+                use_clc=clc,
+                kv_splits=splits,
+                use_int64_kv_strides=i64kv,
+                seed=seed,
+            )
+        )
+    return configs

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py
@@ -1,0 +1,113 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Block-sparse attention forward pass using the cuDNN Frontend SM100 blk64 path.
+
+Upstream sources:
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py``,
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_helpers.py``,
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_combine.py``, and
+``python/cudnn/block_sparse_attention/_interface.py``.
+"""
+
+from ._block_sparse_attention_forward_sm100_blk64 import data as _data
+from ._block_sparse_attention_forward_sm100_blk64 import kernel as _kernel
+from ._block_sparse_attention_forward_sm100_blk64 import reference as _reference
+from ._block_sparse_attention_forward_sm100_blk64 import spec as _spec
+
+KERNEL_META = {
+    "name": "cudnn_sm100_bsa_forward_blk64",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _spec.correctness_configs()
+BENCH_CONFIGS = _spec.benchmark_configs()
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def get_kernel(**config):
+    return _kernel.get_kernel(**config)
+
+
+def prepare_data(**config):
+    return _data.prepare_data(**config)
+
+
+def run_test(**config):
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch()
+    source_launch = _reference.compile_reference(data)
+    source_launch()
+    torch.cuda.synchronize()
+    _data.validate_outputs(data, sources=("tirx", "source"))
+
+
+def prepare_bench(**config):
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    data = prepare_data(**_without_label(config))
+    tirx_launch = _data.tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+        source_launch = _reference.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _data.validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -28,6 +28,7 @@ NVSHMEM_RUNTIME_FUNC_CALLS = frozenset(
 )
 LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL: Mapping[str, frozenset[str]] = MappingProxyType(
     {
+        "cudnn_sm100_bsa_forward_blk64": frozenset({"tirx_bsa_pv_mma_chain"}),
         "cudnn_sm100_csa_compressor_fwd": frozenset(
             {
                 "tirx_csa_exp_constants",


### PR DESCRIPTION
## Summary

- port the cuDNN Frontend SM100 block-sparse attention forward blk64 specialization to the `tirx_kernels.kern` API
- preserve the source pipeline structure, including TMA/TMEM/TCGen05 staging, static and variable sparse metadata, singleton CLC, split-KV combine, ragged tails, and 64-bit KV strides
- add source/oracle correctness coverage, curated bench-suite workloads, registry integration, and the narrow low-level helper contract
- record three reusable measured codegen findings for fixed-loop unrolling, role-scoped register budgets, and fragment lifetime chunking

Upstream source: NVIDIA/cudnn-frontend at `7b5327b32907b9dd21d85a393d62f9573d7f0116`.

## Validation

- latest paired TVM build at `994e0216d734bf3e02806d8ebf383dafa80e41b9`: passed
- full kernel correctness matrix: 23/23 passed, 0 failed, 0 skipped
- `tests/test_low_level_ir.py` and `tests/test_kern_api.py`: 15 passed
- bench-suite import gate: 75 kernels imported successfully
- changed-file pre-commit hooks: passed

## Performance

The sole performance criterion was `python -m tirx_kernels.bench_suite` with the cuDNN Frontend reference, five independent Proton rounds per implementation, and the strict `mean(reference) / mean(tirx) > 0.99` row gate.

| Generation | Rows | Minimum | Mean | Maximum |
|---|---:|---:|---:|---:|
| Targeted | 11/11 | 1.00932x | 1.34381x | 2.16592x |
| Full | 11/11 | 1.00116x | 1.34893x | 2.18512x |

Both accepted generations completed with zero interference retries. Each accepted row contains exactly five finite positive samples for TIRx and the reference; no samples were spliced across runs.
