### PR TITLE
docs: establish Kern authoring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# TIRx kernels
+# Kern kernels on TIRx
 
-High-performance GPU kernels written in [TIRx](https://github.com/apache/tvm).
+High-performance GPU kernels authored in
+[Kern](tirx_kernels/kern/README.md) and compiled through
+[TIRx](https://github.com/apache/tvm).
 
 ## Kernels
 
@@ -9,7 +11,7 @@ All kernels target `sm_100a`. **Kernel** is the registry name accepted by the
 directory under `tirx_kernels/`. Each bucket holds the kernels ported from one
 upstream project.
 
-`basic/` — native TIRx kernels, with no single upstream project:
+`basic/` — native Kern kernels, with no single upstream project:
 
 | Kernel                | Module                   | What it is |
 | --------------------- | ------------------------ | ---------- |

--- a/tirx_kernels/kern/README.md
+++ b/tirx_kernels/kern/README.md
@@ -36,7 +36,6 @@ def zero(out: K.gptr(K.f32)):
   Keep the default `check_ir=True`. `allowed_func_calls` is only for a task that
   explicitly owns a named runtime-call exception.
 
-The canonical modules under `tirx_kernels/` are the source of truth for
-complete implementation patterns. In particular, use kernels with a schedule
-structure similar to the workload being implemented; do not copy API spellings
-from historical TIRx parser kernels.
+You can learn Kern APIs and complete implementation patterns from the canonical
+modules under `tirx_kernels/`. Do not copy API spellings from historical TIRx
+parser kernels.

--- a/tirx_kernels/kern/README.md
+++ b/tirx_kernels/kern/README.md
@@ -1,0 +1,42 @@
+# Kern authoring guide
+
+Kern is the canonical source language for kernels in this package. It is a
+traced, PTX-level DSL over TIRx:
+
+```python
+# Do not enable `from __future__ import annotations` in a Kern module. Kern
+# reads live annotations while tracing the function at decoration time.
+import tirx_kernels.kern as K
+
+
+@K.kernel(warps=1, arch="sm_100a", grid=False)
+def zero(out: K.gptr(K.f32)):
+    K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(0))
+```
+
+`@K.kernel` returns a `K.Kernel`. Its principal views are:
+
+- `zero.func`: the pre-lowering TIRx `PrimFunc` used by analysis tools and
+  package runners;
+- `zero.mod`: an `IRModule` containing that function;
+- `zero.compile()`: a runnable module compiled through the TIRx pipeline.
+
+## Authoring contract
+
+- Kernel entries use `@K.kernel`; parser entry points and raw TIRx builder
+  forwarding are not part of the author-facing API.
+- `K.gptr`, `K.TensorMap`, and scalar dtype annotations define the entry ABI.
+- `K.cta_id`, `K.warp_id`, `K.lane_id`, and `K.thread_id` are the entry-owned
+  coordinates. `K.specialize()` defines named warp roles when the schedule is
+  warp-specialized.
+- Shared memory is owned by `K.smem_pool()`. PTX and CUDA instructions are
+  spelled through `K.ptx` and `K.cuda`; higher-level reusable instruction
+  sequences live under `K.idioms`.
+- Every kernel is checked against the low-level IR contract when it is traced.
+  Keep the default `check_ir=True`. `allowed_func_calls` is only for a task that
+  explicitly owns a named runtime-call exception.
+
+The canonical modules under `tirx_kernels/` are the source of truth for
+complete implementation patterns. In particular, use kernels with a schedule
+structure similar to the workload being implemented; do not copy API spellings
+from historical TIRx parser kernels.


### PR DESCRIPTION
## Summary

- define Kern as the canonical author-facing DSL on top of TIRx
- document the Kernel/launch contract and low-level IR enforcement boundary
- point the repository overview at the canonical Kern guide

## Validation

- documentation-only change
- git diff --check