### PR TITLE
feat(kernel): port cuDNN MoE BF16 grouped GEMM dGLU dBias

### DIFF
--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -55,6 +55,7 @@ degenerate export cannot be annotated.
 | `tile128_c1x1` | one-CTA tile, singleton cluster | 3604 | 1115 | `f425a929` | `0x08400490` | 3 |
 | `tile_n64` | narrow tile_n | 3683 | 1127 | `098f01b9` | `0x08100490` | 6 |
 | `scalar_f32` | scalar (non-packed) epilogue math | 3501 | 849 | `201ea257` | `0x10400490` | 5 |
+| `nodbias` | bf16 C, dBias off -- the depth-6 point | 3197 | 952 | `354e50c1` | `0x10400490` | 6 |
 
 Instruction counts follow the corpus convention, instruction lines minus
 predicated lines: `anchor` = 2263 - 120 = **2143**.
@@ -70,7 +71,7 @@ predicated lines: `anchor` = 2263 - 120 = **2143**.
 | shape | 4 experts x 256 tokens, `N = 512`, `K = 512` | |
 | `epi_tile` | `(128, 32)`, 8 subtile pairs per tile | `:261` |
 | `k_tile` | 64 = instruction K 16 x `mma_inst_tile_k` 4 | `:224-230` |
-| stages | acc 2, **AB 5**, C 2, D 2, tile-info 2 | `:2244-2282` |
+| stages | acc 2, **AB 5**, C 2, D 2, tile-info 2 | `:2239-2282` |
 | AB `expect_tx` | **65536** = `(a_stage 16384 + b_stage 16384) * atom_thr 2` | `PTX 903-904` |
 | C `expect_tx` | **8192** = `128 * 32 * 2 B` | `PTX 3658` |
 | TMEM columns | **512** = `clamp(next_pow2(num_acc_stage * cta_tile_n), 32, 512)` | `:289-294`, `PTX 1427-1428` |
@@ -81,9 +82,11 @@ predicated lines: `anchor` = 2263 - 120 = **2143**.
 **AB depth is 5, and dBias does not change it at this tile.** The solve is
 `(232448 - reserved) // (a_stage + b_stage)` over `a_stage = b_stage = 16 KiB`,
 which lands on 5 both with dBias (`anchor`) and with FP32 C and no dBias
-(`cf32_nodbias`, whose larger sC cancels the sDbias saving). The depth does move
-with the tile: `tile128_c1x1` gets 3 (one CTA, so a full 32 KiB sB stage) and
-`tile_n64` gets 6.
+(`cf32_nodbias`, whose larger sC cancels the sDbias saving). Dropping dBias at a
+bf16 C does raise it, to 6 (`nodbias`: 12 AB mbarriers, sA-to-sB span
+132096 - 33792 = 98304 = 6 x 16384). The depth also moves with the tile:
+`tile128_c1x1` gets 3 (one CTA, so a full 32 KiB sB stage) and `tile_n64` gets 6.
+Every depth in the evidence table is read from an export, none inferred.
 
 **TMEM columns are derived, not pinned.** `anchor` and `tile128_c1x1` allocate
 512; `tile_n64` allocates **128** (`tcgen05.alloc` immediate). This is the
@@ -163,7 +166,7 @@ block-scaled sibling (`:158-162`). Sections below appear in **source order**.
 | 0-3 | epilogue | per subtile pair: TMEM read, `alpha^2` scale, C read, two GLU gradients, dprob and dBias accumulation, D store | consumes `acc_full`, `c_full`; releases `acc_empty`, `c_empty`; warp 0 owns TMEM alloc and the D stores |
 | 6 | C load | per subtile pair: two `shared::cta` `cp.async.bulk.tensor`, gate then up, into two separate C stages | consumes `c_empty`; publishes `c_full` |
 
-Named barriers (`:186-206`): id 0 the CTA-wide init barrier (`bar.sync 0`,
+Named barriers (`:183-198`): id 0 the CTA-wide init barrier (`bar.sync 0`,
 `PTX 233`), id 2 epilogue (128 threads), id 3 TMEM lifecycle (160 = MMA warp
 plus four epilogue warps), id 4 scheduler (32). Barrier **id 1 (256 threads)
 does not occur in the anchor** — it appears only in the singleton-cluster
@@ -271,8 +274,11 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #   named_barrier(0, 256)                    # PTX 233  -- CTA-wide init barrier
 #   fence_mbarrier_init()                    # PTX 246
 #   cluster_arrive_relaxed()                 # PTX 248
-#   ... TMEM allocation is issued here ...
+#   ... smem tensor setup, the two multicast masks, MMA fragment construction ...
 #   cluster_wait()                           # PTX 262
+#     # The source comment at 1322-1323 is explicit: cluster wait BEFORE the
+#     # tensor-memory allocation. The allocation itself is issued much later, in
+#     # the epilogue role at source 1608 / PTX 1427-1428.
 #     # When cluster_size == 1 the cluster wait degenerates and the source uses
 #     # named_barrier(1, 256) instead; that is the only place barrier 1 appears.
 #
@@ -315,7 +321,9 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #             sInfo[1, stage] = tile_m_idx
 #             sInfo[2, stage] = tile_n_idx
 #             sInfo[3, stage] = k_tile_cnt
-#               # instruction_selection: st.shared.b32 x4; extent: one work tile
+#               # instruction_selection: st.shared.v4.b32; extent: one 16 B work-tile record
+#               # The four words are contiguous i32 and vectorize; the
+#               # termination record is the same single store of {-1, 0, 0, 0}.
 #         fence_async_shared()
 #         named_barrier(4, 32)                  # PTX 520, 726
 #         arrive(tile_info_full[stage])
@@ -325,6 +333,8 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #           # dynamic: one atom.global.add.u32 ticket, broadcast across the cluster
 #         stage, phase = advance(stage, phase, num_tile_stage)
 #     producer_tail(tile_info_empty, num_tile_stage)   # source 1369
+#       # Consumers release stage S right after reading its four words, so the
+#       # producer is free to refill S while the consumers still work that tile.
 #       # instruction_selection: 2x blocking try_wait; extent: drain both stages
 
 # ==========================================================================
@@ -334,10 +344,15 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # with role(tma_warp):
 #     prefetch the A, B, C and D descriptors             # source 1166-1172
 #       # instruction_selection: prefetch.tensormap x4; extent: once per kernel, PTX 84-93
+#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
 #     for each work tile:
-#         acquire(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0:
-#             fence_async_shared(); arrive(tile_info_empty[stage]); break
+#         # Read the record, then release the stage immediately -- the tile's own
+#         # work runs from registers with stage S already free, which is what
+#         # keeps the two-stage tile-info pipeline a full tile ahead.
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         if expert_idx < 0: break
 #         update_expert_info(padded_offsets, expert_idx)     # ext, token range
 #         status = peek(ab_empty[ab_stage], phase)           # source 1441
 #         for k_tile in range(k_tile_cnt):
@@ -355,8 +370,7 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #               # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster...cta_group::2; extent: one 128x64 bf16 half-tile
 #             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
 #             status = peek(ab_empty[ab_stage], phase)        # source 1459
-#         fence_async_shared(); arrive(tile_info_empty[stage])  # source 1489-1491
-#         stage, phase = advance(stage, phase, num_tile_stage)
+#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
 #     producer_tail(ab_empty, num_ab_stage)                    # source 1495
 #       # instruction_selection: 5x blocking try_wait; extent: drain all AB stages
 #
@@ -371,14 +385,20 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # ==========================================================================
 # with role(mma_warp):
 #     named_barrier(3, 160)                     # PTX 1107, TMEM base published
+#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
 #     for each work tile:
-#         acquire(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0:
-#             fence_async_shared(); arrive(tile_info_empty[stage]); break
-#         if k_tile_cnt > 0 and is_leader_cta:               # source 1533
-#             acquire(acc_empty[acc_stage], phase)
-#             acc_col = acc_stage * cta_tile_n
+#         # Read the record, then release the stage immediately -- the tile's own
+#         # work runs from registers with stage S already free, which is what
+#         # keeps the two-stage tile-info pipeline a full tile ahead.
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         if expert_idx < 0: break
+#         if k_tile_cnt > 0:                                 # source 1533
 #             status = peek(ab_full[ab_stage], phase)        # source 1534
+#         if is_leader_cta:                                  # source 1546
+#             acquire(acc_empty[acc_stage], phase)           # source 1547
+#             acc_col = acc_stage * cta_tile_n
 #             for k_tile in range(k_tile_cnt):
 #                 acquire(ab_full[ab_stage], phase, unless=status)
 #                 a_desc = smem_descriptor(sA + ab_stage * 16384)
@@ -396,8 +416,7 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #             umma_arrive(acc_full[acc_stage])               # source 1581
 #               # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: accumulator publish, PTX 1340
 #         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
-#         fence_async_shared(); arrive(tile_info_empty[stage])  # source 1593-1595
-#         stage, phase = advance(stage, phase, num_tile_stage)
+#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
 #     producer_tail(acc_empty, 1)                              # source 1599
 #
 # `accumulate` is false only on the very first issue of a tile, which clears the
@@ -414,14 +433,19 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # with role(epilogue_warps):
 #     warp 0 only: tmem_alloc(tmem_cols)        # PTX 1427-1428
 #     named_barrier(3, 160)                     # PTX 1431
+#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
 #     for each work tile:
-#         acquire(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0:
-#             fence_async_shared(); arrive(tile_info_empty[stage]); break
+#         # Read the record, then release the stage immediately -- the tile's own
+#         # work runs from registers with stage S already free, which is what
+#         # keeps the two-stage tile-info pipeline a full tile ahead.
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         if expert_idx < 0: break
 #         square_alpha = alpha[expert] * alpha[expert]
 #         beta_e       = beta[expert]
 #         p            = prob[row_of_this_thread]
-#         dprob_vec    = zeros(32)
+#         dProbVal     = 0.0                                   # source 1732
 #         acquire(acc_full[acc_stage], phase)                  # PTX 1538
 #         for subtile in range(epi_tile_cnt):                  # 8 pairs
 #             acc = tmem_load_32x32b_x32(acc_col + subtile * 32)
@@ -446,14 +470,14 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #             #   s      = 1 / (1 + exp2(-LOG2_E * x1))
 #             #     # instruction_selection: ex2.approx.ftz.f32 then rcp.approx.ftz.f32; extent: 32 values
 #             #   swish  = x1 * s
-#             #   dprob_vec += g * x2 * swish
+#             #   dprob_sub  = g * x2 * swish          # ASSIGNED, fresh per subtile
 #             #   d1 = g * p * x2 * s * (1 + x1 * (1 - s))
 #             #   d2 = g * p * swish
 #             #
 #             # ---- dGeGLU (source 944-1083) ----------------------------------
 #             #   y1 = min(x1, 7.0);  y2 = clamp(x2, -7.0, 7.0)
 #             #   s  = 1 / (1 + exp2(-LOG2_E * 1.702 * y1))
-#             #   dprob_vec += g * s * (y2 + linear_offset) * y1
+#             #   dprob_sub  = g * s * (y2 + linear_offset) * y1   # ASSIGNED per subtile
 #             #   d1 = g * s * (1 + 1.702 * y1 * (1 - s)) * (y2 + linear_offset) * p
 #             #   d2 = g * y1 * s * p
 #             #   d1 *= (x1 <= 7.0 ? y1 : 0.0)
@@ -475,33 +499,20 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                   # Scalar, not vectorized: the (32, 1, epi_n*2*32) stride puts
 #                   # consecutive n 128 B apart.
 #
-#             d1_bits = pack_bf16x2(d1 pairs)   # source 1853, 16 issues
-#             d2_bits = pack_bf16x2(d2 pairs)   # source 1854, 16 issues
-#               # instruction_selection: cvt.rn.bf16x2.f32 x16 each; extent: 32 values per half
-#             warp 0: bulk_wait(0)                            # source 1900, PTX 3325
-#             named_barrier(2, 128)                           # source 1901, PTX 3383
-#             smem_st_v4(sD + d1_stage * 8192, d1_bits)       # source 1904, 4 issues
-#             smem_st_v4(sD + d2_stage * 8192, d2_bits)       # source 1911, 4 issues
-#               # instruction_selection: st.shared.v4.b32 x4 each; extent: one 128x32 D block per half
-#             fence_async_shared()
-#             named_barrier(2, 128)                           # source 1917, PTX 3425
-#             warp 0: tma_store_3d(desc_d, (col_d1, row, 0), sD + d1_stage * 8192)
-#             warp 0: tma_store_3d(desc_d, (col_d2, row, 0), sD + d2_stage * 8192)
-#               # instruction_selection: cp.async.bulk.tensor.3d S2G x2; extent: two 128x32 D blocks
-#             warp 0: bulk_commit()                           # source 1929, PTX 3449
-#             named_barrier(2, 128)                           # source 1930, PTX 3452
-#             d1_stage, d2_stage = next two values of (subtile_counter % num_d_stage)
+#             if with_dprob:                                   # source 1808-1829, indent 20
+#                 dprob_acc = packed_pairwise_sum(dprob_sub)   # 32 -> 2
+#                   # instruction_selection: add.rn.f32x2 x16; extent: 32-element reduction
+#                 dProbVal += dprob_acc[0] + dprob_acc[1]      # source 1823, scalar fold
+#                 # Reduce-then-sum, once per subtile -- NOT accumulate-then-reduce.
+#                 # The summation tree is load-bearing: the oracle reproduces this
+#                 # same 32-column subtile grouping rather than summing the row.
 #
-#         dprob_acc = packed_pairwise_sum(dprob_vec)          # source 1808-1829
-#           # instruction_selection: add.rn.f32x2 x16; extent: 32-element reduction, then one scalar fold
-#           # This order is load-bearing: the oracle reproduces the same
-#           # 32-column subtile grouping rather than summing the row.
-#
-#         if elect_one(): arrive(acc_empty[acc_stage])        # source 1935-1936, PTX 3465
-#         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
-#
-#         if with_dbias:
-#             # dbias_reduction, source 686-765: SMEM transpose, no shuffles
+#             if with_dbias:                                   # source 1834-1848, indent 20
+#                 n_base_d1 = tile_n_idx * (tile_n * 2) + (2 * subtile + 0) * 32
+#                 n_base_d2 = tile_n_idx * (tile_n * 2) + (2 * subtile + 1) * 32
+#                 # dbias_reduction, source 686-765: SMEM transpose, no shuffles.
+#                 # Runs once PER SUBTILE, so all 8 column pairs of the work tile
+#                 # are reduced and each carries its own n_base.
 #             named_barrier(2, 128)                           # source 707, PTX 2843
 #             col_a = 2 * lane if lane < 16 else epi_n + 2 * (lane - 16)
 #             col_b = col_a + 1
@@ -524,8 +535,26 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                         atomic_add_bf16x2(&dbias[expert, n_offset], total)
 #                           # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair, PTX 3316
 #
-#         fence_async_shared(); arrive(tile_info_empty[stage])   # source 1942-1948, PTX 3499-3503
-#         stage, phase = advance(stage, phase, num_tile_stage)
+#             d1_bits = pack_bf16x2(d1 pairs)   # source 1853, 16 issues
+#             d2_bits = pack_bf16x2(d2 pairs)   # source 1854, 16 issues
+#               # instruction_selection: cvt.rn.bf16x2.f32 x16 each; extent: 32 values per half
+#             warp 0: bulk_wait(0)                            # source 1900, PTX 3325
+#             named_barrier(2, 128)                           # source 1901, PTX 3383
+#             smem_st_v4(sD + d1_stage * 8192, d1_bits)       # source 1904, 4 issues
+#             smem_st_v4(sD + d2_stage * 8192, d2_bits)       # source 1911, 4 issues
+#               # instruction_selection: st.shared.v4.b32 x4 each; extent: one 128x32 D block per half
+#             fence_async_shared()
+#             named_barrier(2, 128)                           # source 1917, PTX 3425
+#             warp 0: tma_store_3d(desc_d, (col_d1, row, 0), sD + d1_stage * 8192)
+#             warp 0: tma_store_3d(desc_d, (col_d2, row, 0), sD + d2_stage * 8192)
+#               # instruction_selection: cp.async.bulk.tensor.3d S2G x2; extent: two 128x32 D blocks
+#             warp 0: bulk_commit()                           # source 1929, PTX 3449
+#             named_barrier(2, 128)                           # source 1930, PTX 3452
+#             d1_stage, d2_stage = next two values of (subtile_counter % num_d_stage)
+#
+#         if elect_one(): arrive(acc_empty[acc_stage])        # source 1935-1936, PTX 3465
+#         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
+#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
 #         atomic_add_f32(&dprob[row_of_this_thread], dprob_acc)  # source 1950-1955, PTX 3513
 #           # instruction_selection: atom.global.add.f32; extent: one per epilogue thread per work tile
 #           # Flushed AFTER the tile-info release, not before.
@@ -546,13 +575,18 @@ Each is one PTX instruction, one tile, or one loop of one family:
 
 # ==========================================================================
 # Warp 6: C loads
-# source 1971-2044; PTX 3643-3776
+# source 1971-2041; PTX 3643-3776
 # ==========================================================================
 # with role(c_load_warp):
+#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
 #     for each work tile:
-#         acquire(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0:
-#             fence_async_shared(); arrive(tile_info_empty[stage]); break
+#         # Read the record, then release the stage immediately -- the tile's own
+#         # work runs from registers with stage S already free, which is what
+#         # keeps the two-stage tile-info pipeline a full tile ahead.
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         if expert_idx < 0: break
 #         for subtile in range(epi_tile_cnt):           # 8 pairs
 #             for half in (0, 1):                       # gate block, then up block
 #                 acquire(c_empty[c_stage], phase)
@@ -563,8 +597,7 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                             c_full[c_stage], pred=leader)
 #                   # instruction_selection: cp.async.bulk.tensor.3d.shared::cta...; extent: one 128x32 C block, PTX 3667/3703
 #                 c_stage, phase = advance(c_stage, phase, num_c_stage)
-#         fence_async_shared(); arrive(tile_info_empty[stage])   # source 2034-2036
-#         stage, phase = advance(stage, phase, num_tile_stage)
+#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
 #     producer_tail(c_empty, num_c_stage)                       # source 2041
 #
 # The gate and up halves land in SEPARATE C stages, which is why num_c_stage is
@@ -595,7 +628,7 @@ The PTX column carries **anchor-export line numbers**.
 | accumulator release | 1935-1937 | Warps 0-3 | 3465 |
 | dprob flush | 1950-1955 | Warps 0-3 | 3513 |
 | teardown | 1960-1967 | Warps 0-3 | 3524-3556 |
-| C-load warp | 1971-2044 | Warp 6 | 3643-3776 |
+| C-load warp | 1971-2041 | Warp 6 | 3643-3776 |
 | stage solve | 2244-2282 | Anchor values | n/a |
 
 ## Out of scope

--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -344,14 +344,15 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # with role(tma_warp):
 #     prefetch the A, B, C and D descriptors             # source 1166-1172
 #       # instruction_selection: prefetch.tensormap x4; extent: once per kernel, PTX 84-93
-#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
+#     # Prologue record, read and released before the loop. The wait, the read,
+#     # the fence and the release are adjacent everywhere, so a tile's work runs
+#     # from registers with its tile-info stage already free -- that is what keeps
+#     # the two-stage pipeline a full tile ahead.
+#     acquire(tile_info_full[stage], phase)
+#     expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#     fence_async_shared(); arrive(tile_info_empty[stage])
+#     stage, phase = advance(stage, phase, num_tile_stage)
 #     for each work tile:
-#         # Read the record, then release the stage immediately -- the tile's own
-#         # work runs from registers with stage S already free, which is what
-#         # keeps the two-stage tile-info pipeline a full tile ahead.
-#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
-#         fence_async_shared(); arrive(tile_info_empty[stage])
-#         stage, phase = advance(stage, phase, num_tile_stage)
 #         if expert_idx < 0: break
 #         update_expert_info(padded_offsets, expert_idx)     # ext, token range
 #         status = peek(ab_empty[ab_stage], phase)           # source 1441
@@ -370,7 +371,10 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #               # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster...cta_group::2; extent: one 128x64 bf16 half-tile
 #             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
 #             status = peek(ab_empty[ab_stage], phase)        # source 1459
-#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
+#         acquire(tile_info_full[stage], phase)   # next tile's record
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
 #     producer_tail(ab_empty, num_ab_stage)                    # source 1495
 #       # instruction_selection: 5x blocking try_wait; extent: drain all AB stages
 #
@@ -385,16 +389,17 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # ==========================================================================
 # with role(mma_warp):
 #     named_barrier(3, 160)                     # PTX 1107, TMEM base published
-#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
+#     # Prologue record, read and released before the loop. The wait, the read,
+#     # the fence and the release are adjacent everywhere, so a tile's work runs
+#     # from registers with its tile-info stage already free -- that is what keeps
+#     # the two-stage pipeline a full tile ahead.
+#     acquire(tile_info_full[stage], phase)
+#     expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#     fence_async_shared(); arrive(tile_info_empty[stage])
+#     stage, phase = advance(stage, phase, num_tile_stage)
 #     for each work tile:
-#         # Read the record, then release the stage immediately -- the tile's own
-#         # work runs from registers with stage S already free, which is what
-#         # keeps the two-stage tile-info pipeline a full tile ahead.
-#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
-#         fence_async_shared(); arrive(tile_info_empty[stage])
-#         stage, phase = advance(stage, phase, num_tile_stage)
 #         if expert_idx < 0: break
-#         if k_tile_cnt > 0:                                 # source 1533
+#         if k_tile_cnt > 0 and is_leader_cta:               # source 1533
 #             status = peek(ab_full[ab_stage], phase)        # source 1534
 #         if is_leader_cta:                                  # source 1546
 #             acquire(acc_empty[acc_stage], phase)           # source 1547
@@ -416,7 +421,10 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #             umma_arrive(acc_full[acc_stage])               # source 1581
 #               # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: accumulator publish, PTX 1340
 #         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
-#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
+#         acquire(tile_info_full[stage], phase)   # next tile's record
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
 #     producer_tail(acc_empty, 1)                              # source 1599
 #
 # `accumulate` is false only on the very first issue of a tile, which clears the
@@ -433,19 +441,20 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # with role(epilogue_warps):
 #     warp 0 only: tmem_alloc(tmem_cols)        # PTX 1427-1428
 #     named_barrier(3, 160)                     # PTX 1431
-#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
+#     # Prologue record, read and released before the loop. The wait, the read,
+#     # the fence and the release are adjacent everywhere, so a tile's work runs
+#     # from registers with its tile-info stage already free -- that is what keeps
+#     # the two-stage pipeline a full tile ahead.
+#     acquire(tile_info_full[stage], phase)
+#     expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#     fence_async_shared(); arrive(tile_info_empty[stage])
+#     stage, phase = advance(stage, phase, num_tile_stage)
 #     for each work tile:
-#         # Read the record, then release the stage immediately -- the tile's own
-#         # work runs from registers with stage S already free, which is what
-#         # keeps the two-stage tile-info pipeline a full tile ahead.
-#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
-#         fence_async_shared(); arrive(tile_info_empty[stage])
-#         stage, phase = advance(stage, phase, num_tile_stage)
 #         if expert_idx < 0: break
 #         square_alpha = alpha[expert] * alpha[expert]
 #         beta_e       = beta[expert]
 #         p            = prob[row_of_this_thread]
-#         dProbVal     = 0.0                                   # source 1732
+#         dProbVal     = 0.0                                   # source 1727
 #         acquire(acc_full[acc_stage], phase)                  # PTX 1538
 #         for subtile in range(epi_tile_cnt):                  # 8 pairs
 #             acc = tmem_load_32x32b_x32(acc_col + subtile * 32)
@@ -513,27 +522,27 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                 # dbias_reduction, source 686-765: SMEM transpose, no shuffles.
 #                 # Runs once PER SUBTILE, so all 8 column pairs of the work tile
 #                 # are reduced and each carries its own n_base.
-#             named_barrier(2, 128)                           # source 707, PTX 2843
-#             col_a = 2 * lane if lane < 16 else epi_n + 2 * (lane - 16)
-#             col_b = col_a + 1
-#             sum_a = sum_b = 0.0
-#             for g in range(8):                              # source 721-733
-#                 m_base = g * 4
-#                 off_a  = warp_base + col_a * 32 + (m_base ^ (((col_a >> 1) & 0x7) << 2))
-#                 off_b  = warp_base + col_b * 32 + (m_base ^ (((col_b >> 1) & 0x7) << 2))
-#                 sum_a += sum(smem_ld_b32(off_a + j) for j in range(4))
-#                 sum_b += sum(smem_ld_b32(off_b + j) for j in range(4))
-#               # instruction_selection: ld.shared.b32 x64; extent: 32 rows per column pair
-#               # The XOR swizzle applies to the ROW-GROUP BASE, not the column, and
-#               # the 128-bit copy atom decays to scalars because the swizzled offset
-#               # is not provably 16-byte aligned.
-#             named_barrier(2, 128)                           # source 741, PTX 3242
-#             smem_st_b32 x2 -> this warp's 64-bit partial slot   # source 746
-#             named_barrier(2, 128)                           # source 747, PTX 3255
-#             warp 0: total = sum of the four warps' partials      # source 755, ld.shared.b32 x8
-#                     if n_offset < dbias_n_total:
-#                         atomic_add_bf16x2(&dbias[expert, n_offset], total)
-#                           # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair, PTX 3316
+#                 named_barrier(2, 128)                           # source 707, PTX 2843
+#                 col_a = 2 * lane if lane < 16 else epi_n + 2 * (lane - 16)
+#                 col_b = col_a + 1
+#                 sum_a = sum_b = 0.0
+#                 for g in range(8):                              # source 721-733
+#                     m_base = g * 4
+#                     off_a  = warp_base + col_a * 32 + (m_base ^ (((col_a >> 1) & 0x7) << 2))
+#                     off_b  = warp_base + col_b * 32 + (m_base ^ (((col_b >> 1) & 0x7) << 2))
+#                     sum_a += sum(smem_ld_b32(off_a + j) for j in range(4))
+#                     sum_b += sum(smem_ld_b32(off_b + j) for j in range(4))
+#                   # instruction_selection: ld.shared.b32 x64; extent: 32 rows per column pair
+#                   # The XOR swizzle applies to the ROW-GROUP BASE, not the column, and
+#                   # the 128-bit copy atom decays to scalars because the swizzled offset
+#                   # is not provably 16-byte aligned.
+#                 named_barrier(2, 128)                           # source 741, PTX 3242
+#                 smem_st_b32 x2 -> this warp's 64-bit partial slot   # source 746
+#                 named_barrier(2, 128)                           # source 747, PTX 3255
+#                 warp 0: total = sum of the four warps' partials      # source 755, ld.shared.b32 x8
+#                         if n_offset < dbias_n_total:
+#                             atomic_add_bf16x2(&dbias[expert, n_offset], total)
+#                               # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair, PTX 3316
 #
 #             d1_bits = pack_bf16x2(d1 pairs)   # source 1853, 16 issues
 #             d2_bits = pack_bf16x2(d2 pairs)   # source 1854, 16 issues
@@ -554,10 +563,13 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #
 #         if elect_one(): arrive(acc_empty[acc_stage])        # source 1935-1936, PTX 3465
 #         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
-#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
-#         atomic_add_f32(&dprob[row_of_this_thread], dprob_acc)  # source 1950-1955, PTX 3513
+#         acquire(tile_info_full[stage], phase)          # next tile's record
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#         fence_async_shared(); arrive(tile_info_empty[stage])   # source 1942-1948
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         atomic_add_f32(&dprob[row_of_this_thread], dProbVal)   # source 1954
 #           # instruction_selection: atom.global.add.f32; extent: one per epilogue thread per work tile
-#           # Flushed AFTER the tile-info release, not before.
+#           # The record is fully released before the flush, as at source 1942-1955.
 #
 #     tmem_relinquish()                        # source 1960, PTX 3524
 #     named_barrier(2, 128)                    # source 1961, PTX 3529
@@ -578,14 +590,15 @@ Each is one PTX instruction, one tile, or one loop of one family:
 # source 1971-2041; PTX 3643-3776
 # ==========================================================================
 # with role(c_load_warp):
-#     acquire(tile_info_full[stage], phase)      # prologue record, before the loop
+#     # Prologue record, read and released before the loop. The wait, the read,
+#     # the fence and the release are adjacent everywhere, so a tile's work runs
+#     # from registers with its tile-info stage already free -- that is what keeps
+#     # the two-stage pipeline a full tile ahead.
+#     acquire(tile_info_full[stage], phase)
+#     expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#     fence_async_shared(); arrive(tile_info_empty[stage])
+#     stage, phase = advance(stage, phase, num_tile_stage)
 #     for each work tile:
-#         # Read the record, then release the stage immediately -- the tile's own
-#         # work runs from registers with stage S already free, which is what
-#         # keeps the two-stage tile-info pipeline a full tile ahead.
-#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]   # already acquired
-#         fence_async_shared(); arrive(tile_info_empty[stage])
-#         stage, phase = advance(stage, phase, num_tile_stage)
 #         if expert_idx < 0: break
 #         for subtile in range(epi_tile_cnt):           # 8 pairs
 #             for half in (0, 1):                       # gate block, then up block
@@ -597,7 +610,10 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                             c_full[c_stage], pred=leader)
 #                   # instruction_selection: cp.async.bulk.tensor.3d.shared::cta...; extent: one 128x32 C block, PTX 3667/3703
 #                 c_stage, phase = advance(c_stage, phase, num_c_stage)
-#         acquire(tile_info_full[stage], phase)   # next tile's record, bottom of body
+#         acquire(tile_info_full[stage], phase)   # next tile's record
+#         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
+#         fence_async_shared(); arrive(tile_info_empty[stage])
+#         stage, phase = advance(stage, phase, num_tile_stage)
 #     producer_tail(c_empty, num_c_stage)                       # source 2041
 #
 # The gate and up halves land in SEPARATE C stages, which is why num_c_stage is
@@ -629,7 +645,7 @@ The PTX column carries **anchor-export line numbers**.
 | dprob flush | 1950-1955 | Warps 0-3 | 3513 |
 | teardown | 1960-1967 | Warps 0-3 | 3524-3556 |
 | C-load warp | 1971-2041 | Warp 6 | 3643-3776 |
-| stage solve | 2244-2282 | Anchor values | n/a |
+| stage solve | 2239-2282 | Anchor values | n/a |
 
 ## Out of scope
 

--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -171,7 +171,7 @@ Named barriers (`:183-198`): id 0 the CTA-wide init barrier (`bar.sync 0`,
 plus four epilogue warps), id 4 scheduler (32). Barrier **id 1 (256 threads)
 does not occur in the anchor** — it appears only in the singleton-cluster
 branches, where it replaces the cluster wait. Anchor totals: 12 `bar.sync`
-(1x id 0, 2x id 4, 2x id 3, 7x id 2), 25 `mbarrier.init`, 33
+(1x id 0, 2x id 4, 2x id 3, 7x id 2), 23 `mbarrier.init`, 33
 `mbarrier.try_wait`, 25 `elect.sync`.
 
 ## Primitive vocabulary
@@ -269,10 +269,14 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #   # instruction_selection: tcgen05.alloc.cta_group::N.sync.aligned.shared::cta.b32; extent: once per kernel
 #
 # Init order (source 1189-1250, 1272-1282, 1325-1328):
-#   mbarrier_init(...)                       # 25 objects, PTX 118-231
+#   mbarrier_init(...)                       # 22 objects, PTX 118-225
+#     # ab_full/empty 5+5 at 0..72, acc_full/empty 2+2 at 80..104,
+#     # tile_info_full/empty 2+2 at 112..136, c_full/empty 2+2 at 176..200.
 #   fence_mbarrier_init()                    # PTX 232
 #   named_barrier(0, 256)                    # PTX 233  -- CTA-wide init barrier
-#   fence_mbarrier_init()                    # PTX 246
+#   if elect_one():                          # PTX 238
+#       mbarrier_init(tmem_dealloc, 32)      # source 1272, PTX 243 -- the 23rd
+#   fence_mbarrier_init()                    # PTX 246, publishes that one barrier
 #   cluster_arrive_relaxed()                 # PTX 248
 #   ... smem tensor setup, the two multicast masks, MMA fragment construction ...
 #   cluster_wait()                           # PTX 262
@@ -355,7 +359,9 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #     for each work tile:
 #         if expert_idx < 0: break
 #         update_expert_info(padded_offsets, expert_idx)     # ext, token range
-#         status = peek(ab_empty[ab_stage], phase)           # source 1441
+#         status = True                                      # source 1439
+#         if k_tile_cnt > 0 and is_leader_cta:               # source 1440
+#             status = peek(ab_empty[ab_stage], phase)       # source 1441
 #         for k_tile in range(k_tile_cnt):
 #             acquire(ab_empty[ab_stage], phase, unless=status)
 #             leader = elect_one()
@@ -399,6 +405,7 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #     stage, phase = advance(stage, phase, num_tile_stage)
 #     for each work tile:
 #         if expert_idx < 0: break
+#         status = True                                      # source 1532
 #         if k_tile_cnt > 0 and is_leader_cta:               # source 1533
 #             status = peek(ab_full[ab_stage], phase)        # source 1534
 #         if is_leader_cta:                                  # source 1546

--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -1,0 +1,496 @@
+<!--
+This file describes a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5),
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cudnn_sm100_moe_grouped_gemm_dglu_dbias: coarse WASP pipeline sketch
+
+This document is **not executable**. It fixes the resource allocation, the task
+split across warps, and the per-task tile dataflow for the TIRx port at
+`tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py`, which is the
+executable source of truth. The sketch is frozen once the sketch reviewer
+passes it, and neither the correctness gate nor the performance gate may edit
+it.
+
+## Source identity
+
+- source: `/home/bohanhou/kernel-libs/cudnn-frontend/python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py`
+- commit: `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5` (`1.25.0.dev-250-gaded9909`)
+- sha256: `d448b5c9ddd4514f96340aa1a620894a48e884f4216c56715119d56c37bd9e38`, 2284 lines
+- entry: `MoEGroupedGemmDgluDbiasBf16Kernel.__call__` -> optional `helper_kernel`, then `kernel`
+
+Citation shorthands used below: a bare `N` is a line in the source above;
+`sched N` is `grouped/moe_persistent_scheduler.py`, `utils N` is
+`grouped/moe_utils.py`, `ext N` is `grouped/moe_sched_extension.py`, and
+`helpers N` is `grouped/moe_kernel_helpers.py`. `PTX n` is a line in the anchor
+export named in the evidence table.
+
+## PTX `.file` numbering
+
+The exports number the same four files consistently across every branch:
+
+| `.file` | path |
+| --- | --- |
+| 1 | `grouped/dglu/moe_grouped_gemm_dglu_dbias.py` |
+| 2 | `grouped/moe_persistent_scheduler.py` |
+| 3 | `grouped/moe_utils.py` |
+| 4 | `grouped/moe_sched_extension.py` |
+
+## Evidence
+
+Writer exports under `.porting/moe_grouped_gemm_dglu_dbias/writer_source_export/`,
+produced by `export_ptx.py` with `CUTE_DSL_LINEINFO=1 CUTE_DSL_KEEP=ptx
+CUTE_DSL_NO_CACHE=1`. Every run asserts its outputs are finite and non-zero, so
+a degenerate export cannot be annotated. The reviewer's export is independent
+and does not reuse these.
+
+| branch | axis it turns on | ptx lines | `.loc` | sha256 | MMA idesc |
+| --- | --- | --- | --- | --- | --- |
+| `anchor` | the annotated specialization | 3793 | 1159 | `ab1d446e` | `0x10400490` |
+| `discrete` | discrete-B weights + helper descriptors | 3868 | 1173 | `3162ca17` | `0x10400490` |
+| `dynamic` | atomic-ticket scheduler | 4004 | 1221 | `53e3cb42` | `0x10400490` |
+| `dgeglu` | the second activation | 4840 | 1481 | `14b95ffa` | `0x10400490` |
+| `cf32_nodbias` | FP32 C, dBias off | 3063 | 925 | `1d38f93a` | `0x10400490` |
+| `bmajor_n` | n-major B | 3796 | 1153 | `6b9cb225` | `0x10410490` |
+| `tile128_c1x1` | one-CTA tile, singleton cluster | 3604 | 1115 | `f425a929` | `0x08400490` |
+| `tile_n64` | narrow tile_n | 3683 | 1127 | `098f01b9` | `0x08100490` |
+| `scalar_f32` | scalar (non-packed) epilogue math | 3501 | 849 | `201ea257` | `0x10400490` |
+
+Instruction counts below follow the corpus convention: instruction lines minus
+predicated lines. For `anchor` that is 2263 - 120 = **2143**.
+
+## Anchor values
+
+The annotated specialization, and the values every `extent:` annotation refers
+to unless it says otherwise:
+
+| quantity | value | source |
+| --- | --- | --- |
+| mode | dense weights, static scheduler, dSwiGLU, C and D bf16, k-major B, packed-f32 epilogue, dBias on | |
+| `mma_tiler_mn` | `(256, 256)`, so `use_2cta_instrs`, `atom_thr = 2` | `:123-133` |
+| `cta_tile_shape_mnk` | `(128, 256, 64)` | `:212-230` |
+| `cluster_shape_mn` | `(2, 1)` | |
+| shape | 4 experts x 256 tokens, `N = 512`, `K = 512` | |
+| `epi_tile` | `(128, 32)`, 8 subtile pairs per tile | `:328` |
+| `k_tile` | 64 = instruction K 16 x `mma_inst_tile_k` 4 | `:224-230` |
+| stages | acc 2, AB 3 (4 without dBias), C 2, D 2, tile-info 2 | `:2239-2282` |
+| TMEM columns | **512** (`PTX 1427-1428`), `= clamp(next_pow2(2 * cta_tile_n), 32, 512)` | `:284-289` |
+| threads | 256 = 8 warps, `.maxntid 256, 1, 1`, `.minnctapersm 1` | `PTX 38-39` |
+| grid | `(cluster_m, cluster_n, max_active_clusters)` persistent | `:551`, helpers:988-992 |
+| shared memory | one dynamic `.extern .shared .align 1024 .b8` arena | `PTX 14` |
+
+**The TMEM column count is derived, not pinned.** The closed form above was
+checked against three exports: `anchor` and `tile128_c1x1` allocate 512 columns,
+`tile_n64` allocates **128** (`tcgen05.alloc` immediate). This is the single
+largest structural departure from the block-scaled sibling, which always
+reserves 512 and hand-partitions scale-factor regions inside it.
+
+## The MMA instruction descriptor
+
+Lifted from the exports, never adapted from the block-scaled encoder. The
+reference builds it as `selp`-selected constants immediately before the MMA
+(`PTX 1250-1252`), then issues
+`tcgen05.mma.cta_group::2.kind::f16` (`PTX 1264`, `.loc 1 1568`):
+
+```text
+idesc = base | (p1 ? 1<<13 : 0) | (p2 ? 1<<14 : 0)
+base(anchor) = 0x10400490
+```
+
+Field decode, confirmed by differencing the branch exports rather than by
+reading a header:
+
+| bits | field | anchor | evidence |
+| --- | --- | --- | --- |
+| 4-6 | D format | 1 (f32) | constant across branches |
+| 7-9 | A format | 1 (bf16) | constant across branches |
+| 10-12 | B format | 1 (bf16) | constant across branches |
+| 13 | A negate | runtime `%p1` | `TiledMMA` kernel param byte, `PTX 48-52` |
+| 14 | B negate | runtime `%p2` | `TiledMMA` kernel param byte, `PTX 48-52` |
+| 16 | transpose B | 0 here, **1** in `bmajor_n` | `0x10400490` vs `0x10410490` |
+| 17-22 | `N >> 3` | 32 -> N 256 | `tile_n64` gives 8 -> N 64 |
+| 23 | SF format | **0** | the block-scaled kinds set this; `kind::f16` never does |
+| 24-28 | `M >> 4` | 16 -> M 256 | `tile128_c1x1` gives 8 -> M 128 |
+
+Bits 13 and 14 arrive as `TiledMMA` **kernel parameters** that this kernel never
+sets, so both predicates are false at run time. The port therefore emits a
+compile-time constant descriptor:
+
+```text
+idesc = (1 << 4) | (1 << 7) | (1 << 10)
+      | (transpose_b << 16) | ((tile_n >> 3) << 17) | ((tile_m >> 4) << 24)
+```
+
+`# instruction_selection: tcgen05.mma.cta_group::{1,2}.kind::f16; extent: one k-block of the 64-wide k tile, four issues per tile`
+
+## No first-class layouts
+
+Neither this sketch nor the device kernel introduces a first-class layout, a
+layout algebra object, or a multidimensional shared-memory tensor. Every shared
+region is a one-dimensional byte range inside a single flat `u8` arena, indexed
+by explicit scalar offset arithmetic; matrix descriptors are assembled from
+hardware immediates. The upstream `SharedStorage` struct and its `cute` layouts
+are documentation of the byte map only.
+
+## Pipeline at a glance
+
+Eight warps, 256 threads, one CTA per multiprocessor, persistent over work
+tiles handed out by the scheduler warp. Roles and their ids are unchanged from
+the block-scaled sibling (`:157-181`).
+
+| warp | role | tile program | publishes / consumes |
+| --- | --- | --- | --- |
+| 0-3 | epilogue | per subtile pair: read accumulator from TMEM, scale by `alpha^2`, read C, form the two GLU gradients, accumulate dprob and dBias, write D through SMEM | consumes `acc_full`, `c_full`; releases `acc_empty`, `c_empty`; warp 0 additionally owns the TMEM allocation and the D TMA store |
+| 4 | MMA | per k tile: issue four `tcgen05.mma.kind::f16`, accumulate into the current TMEM stage | consumes `ab_full`; releases `ab_empty`; publishes `acc_full` via `tcgen05.commit` |
+| 5 | A/B TMA | per k tile: `expect_tx` then two `cp.async.bulk.tensor` into the AB ring | consumes `ab_empty`; publishes `ab_full` |
+| 6 | C load | per subtile pair: two `cp.async.bulk.tensor` (gate block, then up block) into the two C stages | consumes `c_empty`; publishes `c_full` |
+| 7 | scheduler | walk work tiles, flatten each into `sInfo`, terminate with `expert_idx = -1` | publishes `tile_info`; consumes `tile_info` release |
+
+Named barriers (`:186-206`), unchanged: id 1 CTA-wide (256 threads), id 2
+epilogue (128), id 3 TMEM allocation (160 = MMA warp + four epilogue warps),
+id 4 scheduler (32). `PTX` shows 12 `bar.sync`, 25 `mbarrier.init`, 33
+`mbarrier.try_wait`, 25 `elect.sync`.
+
+**Suspend hint.** Every reference `try_wait` carries the immediate `10000000`
+(`PTX 1498`, `.loc 1 1498`). The port matches it. This is the opposite choice
+from the linear-attention family, where the reference spins with a hint of 1;
+the hint is a per-kernel fact to be read off the export, not a global default.
+
+`# instruction_selection: mbarrier.try_wait.parity.shared::cta.b64 with suspend hint 10000000; extent: one spin per pipeline handshake`
+
+## Primitive vocabulary
+
+The sketch uses only these, each of which is one PTX instruction, one tile, or
+one loop of one family:
+
+- `tma_load_3d(dst_byte, desc, coords, barrier)` — one
+  `cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`
+- `tma_store_3d(desc, coords, src_byte)` — one S2G bulk tensor copy
+- `expect_tx(barrier, bytes)` / `arrive(barrier)` / `wait(barrier, phase)` —
+  one `mbarrier.arrive.expect_tx` / `mbarrier.arrive` / `mbarrier.try_wait.parity`
+- `mma_f16(acc_tmem, a_desc, b_desc, idesc, accumulate)` — one
+  `tcgen05.mma.cta_group::N.kind::f16`
+- `mma_commit(barrier)` — one `tcgen05.commit...multicast::cluster.b64`
+- `tmem_alloc(cols)` / `tmem_dealloc` / `tmem_relinquish` — one tcgen05 alloc,
+  dealloc, or relinquish
+- `tmem_load_32x32b_x32(regs, col)` — one `tcgen05.ld.sync.aligned.32x32b.x32.b32`
+- `smem_ld_v4(regs, byte)` / `smem_st_v4(byte, regs)` — one `ld.shared.v4.b32` /
+  `st.shared.v4.b32`
+- `cvt_f32_bf16(x)` / `pack_bf16x2(lo, hi)` — one `cvt.f32.bf16` /
+  `cvt.rn.bf16x2.f32`
+- `fmul2(a, b)` / `fadd2(a, b)` — one `mul.rn.f32x2` / `add.rn.f32x2`
+- `exp2(x)` / `rcp(x)` — one `ex2.approx.ftz.f32` / `rcp.approx.ftz.f32`
+- `atomic_add_f32(addr, v)` — one `atom.global.add.f32`
+- `atomic_add_bf16x2(addr, lo, hi)` — one `cvt.rn.bf16x2.f32` plus one
+  `red.global.add.noftz.bf16x2`
+- `named_barrier(id, threads)` — one `bar.sync`
+- `elect_one()` — one `elect.sync`
+
+## Complete sketch
+
+```python
+# ==========================================================================
+# Static specialization, runtime ABI, and launch
+# source 123-345, 416-566; PTX 14-39
+# ==========================================================================
+# Compile-time: weight_mode, sched, act, c_dtype, d_dtype, b_major, tile_m,
+# tile_n, cluster_shape, vectorized_f32, with_dbias, expert_cnt, N, K,
+# group_m_list, linear_offset. Everything the reference takes at run time and
+# the port can know statically is baked, which is what makes the byte map exact.
+#
+# Runtime operands, in ABI order:
+#   a, b (dense tensor or discrete int64 pointer array), c, d,
+#   padded_offsets, alpha, beta, prob, dprob, dbias?, workspace?
+#
+# grid   = (cluster_m, cluster_n, MAX_ACTIVE_CLUSTERS[cluster_m * cluster_n])
+# block  = 256 threads = 8 warps
+# cluster= (cluster_m, cluster_n) bound unconditionally, including (1, 1)
+#          # instruction_selection: cta_id_in_cluster with preferred=; extent: whole kernel
+#          The block-scaled sibling binds it the same way; `preferred=` is what
+#          keeps the extent-1 case from folding away and losing the cluster
+#          launch attribute.
+
+# ==========================================================================
+# Storage and synchronization objects
+# source 568-676; PTX 14
+# ==========================================================================
+# One flat `u8` arena, `K.alloc_buffer((SMEM_BYTES,), K.u8, scope="shared.dyn",
+# align=1024)`, carved by explicit scalar byte offsets in the upstream
+# declaration order. Sizes for the anchor:
+#
+#   ab_mbar        num_ab_stage * 2 * 8 B      full/empty per AB stage
+#   acc_mbar       num_acc_stage * 2 * 8 B     full/empty per accumulator stage
+#   sched block    tile_info_mbar 4 * 8 B
+#                  sInfo          4 * num_tile_stage * 4 B, align 16
+#                  cluster_mbar   2 * 8 B      dynamic scheduler only
+#                  cluster_bcast  4 * 4 B      dynamic scheduler only
+#   c_full/c_empty num_c_stage * 8 B each
+#   tmem_dealloc   8 B
+#   tmem_holding   4 B
+#   sC             128 * 32 * num_c_stage * sizeof(c_dtype)   = 16 KiB
+#   sD             128 * 32 * num_d_stage * sizeof(d_dtype)   = 16 KiB
+#   sA             128 * 64 * 2 B per stage                   = 16 KiB/stage
+#   sB             256 *  64 * 2 B per stage                  = 32 KiB/stage
+#   sDbias         128 * 64 * 4 B (f32) when with_dbias        = 32 KiB
+#
+# num_ab_stage is whatever the remaining budget allows against the 232448 B
+# capacity: 3 with dBias, 4 without.
+#
+# TMEM: one allocation of `clamp(next_pow2(2 * cta_tile_n), 32, 512)` columns,
+# split into num_acc_stage accumulator regions of cta_tile_n columns each.
+#   # instruction_selection: tcgen05.alloc.cta_group::N.sync.aligned.shared::cta.b32; extent: once per kernel
+# Warp 0 allocates, publishes the base through `tmem_holding`, and the CTA
+# reads it after named barrier 3.
+
+# ==========================================================================
+# Optional pre-kernel: per-expert B descriptors and the scheduler counter
+# source 350-414, 617-637
+# ==========================================================================
+# Emitted only when weight_mode is discrete or the scheduler is dynamic.
+# grid = (L, 1, 1) discrete else (1, 1, 1); one thread.
+#
+# for expert in this_block:                      # discrete only
+#     read b_ptrs[expert]
+#     build one 128-byte TMA descriptor image for (N, K) at that base
+#     store it into workspace[expert * 128 : expert * 128 + 128]
+#       # instruction_selection: st.global.v4.b32 x8; extent: one 128 B image per expert
+# if sched is dynamic:
+#     zero the 4-byte ticket counter at workspace[L * 128]
+#
+# Single "b" slot at a 128-byte stride -- the block-scaled sibling carries two
+# slots at 256 B because it also images SFB. Reads precede writes so an expert
+# never reads a slot another block has already overwritten.
+
+# ==========================================================================
+# Warp 7: persistent tile scheduler
+# source 1252-1361; sched 420-449; PTX .file 2
+# ==========================================================================
+# with role(sched_warp):
+#     state = scheduler_create(padded_offsets, block_idx, grid_dim, counter?)
+#     tile  = initial_work_tile(state)
+#     while True:
+#         wait(tile_info_empty[stage], phase)
+#         if tile is valid:
+#             sInfo[0, stage] = expert_idx
+#             sInfo[1, stage] = tile_m_idx
+#             sInfo[2, stage] = tile_n_idx
+#             sInfo[3, stage] = k_tile_cnt
+#         else:
+#             sInfo[0, stage] = -1            # the termination token
+#         fence_proxy_async_shared()
+#         named_barrier(4, 32)
+#         arrive(tile_info_full[stage])
+#         if not valid: break
+#         tile = advance_to_next_work(state)
+#           # static : linear_idx = bidz + i * stride
+#           # dynamic: one atom.global.add.u32 ticket, broadcast across the cluster
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#
+# Every consumer warp reads the same sInfo words, so the tile identity is
+# published once rather than recomputed per warp.
+
+# ==========================================================================
+# Warp 5: A/B TMA loads
+# source 1165-1172, 1321-1416
+# ==========================================================================
+# with role(tma_warp):
+#     prefetch the A, B, C and D descriptors                 # source 1165-1172
+#       # instruction_selection: prefetch.tensormap; extent: once per kernel
+#     for each work tile:
+#         wait(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0: break
+#         update_expert_info(padded_offsets, expert_idx)     # ext, token range
+#         for k_tile in range(k_tile_cnt):
+#             wait(ab_empty[ab_stage], phase)
+#             leader = elect_one()
+#               # instruction_selection: elect.sync; extent: one per transfer group
+#             expect_tx(ab_full[ab_stage], a_bytes + b_bytes, pred=leader)
+#             tma_load_3d(sA + ab_stage * a_stage_bytes, desc_a,
+#                         (k_tile * 64, token_offset + tile_m_idx * tile_m, 0),
+#                         ab_full[ab_stage], pred=leader)
+#               # instruction_selection: cp.async.bulk.tensor.3d...L2::cache_hint; extent: one 128x64 bf16 tile
+#             tma_load_3d(sB + ab_stage * b_stage_bytes, desc_b_or_expert_image,
+#                         (k_tile * 64, tile_n_idx * tile_n, expert_idx),
+#                         ab_full[ab_stage], pred=leader)
+#               # instruction_selection: cp.async.bulk.tensor.3d...L2::cache_hint; extent: one 256x64 bf16 tile
+#             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
+#
+# The waits sit outside the elected region and the two issues carry the lane
+# guard as an instruction predicate, so the warp never diverges.
+# In discrete mode `desc_b_or_expert_image` is the workspace slot the helper
+# built, bound through the descriptor pointer rather than a static descriptor.
+
+# ==========================================================================
+# Warp 4: MMA
+# source 1471-1660; PTX 1250-1318
+# ==========================================================================
+# with role(mma_warp):
+#     named_barrier(3, 160)                     # TMEM base is published
+#     for each work tile:
+#         wait(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0: break
+#         wait(acc_empty[acc_stage], phase)
+#         acc_col = acc_stage * cta_tile_n
+#         for k_tile in range(k_tile_cnt):
+#             wait(ab_full[ab_stage], phase)
+#             a_desc = smem_descriptor(sA + ab_stage * a_stage_bytes)
+#             b_desc = smem_descriptor(sB + ab_stage * b_stage_bytes)
+#             for kblock in range(4):           # k_tile 64 / instruction K 16
+#                 mma_f16(acc_col, a_desc + kblock * a_step,
+#                         b_desc + kblock * b_step, IDESC,
+#                         accumulate=(k_tile != 0 or kblock != 0))
+#                   # instruction_selection: tcgen05.mma.cta_group::2.kind::f16; extent: one 256x256x16 issue
+#             arrive(ab_empty[ab_stage])
+#             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
+#         mma_commit(acc_full[acc_stage])
+#           # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: one per accumulator stage
+#         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
+#
+# `accumulate` is false only on the very first issue of a tile, which is what
+# clears the accumulator without a separate zeroing pass.
+# Under a two-CTA atom only the leader CTA issues; the peer contributes its
+# operand halves and waits on the same barriers.
+
+# ==========================================================================
+# Warp 6: C loads
+# source 2005-2027
+# ==========================================================================
+# with role(c_load_warp):
+#     for each work tile:
+#         wait(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0: break
+#         for subtile in range(epi_tile_cnt):           # 8 pairs for tile_n 256
+#             for half in (0, 1):                       # gate block, then up block
+#                 wait(c_empty[c_stage], phase)
+#                 leader = elect_one()
+#                 expect_tx(c_full[c_stage], c_tile_bytes, pred=leader)
+#                 tma_load_3d(sC + c_stage * c_stage_bytes, desc_c,
+#                             (col_base + (2 * subtile + half) * 32,
+#                              row_base, 0),
+#                             c_full[c_stage], pred=leader)
+#                   # instruction_selection: cp.async.bulk.tensor.3d G2S; extent: one 128x32 C block
+#                 c_stage, phase = advance(c_stage, phase, num_c_stage)
+#
+# The gate and up halves land in *separate* C stages, which is why num_c_stage
+# is 2 and why the epilogue consumes them as a pair.
+
+# ==========================================================================
+# Warps 0-3: epilogue
+# source 1700-2172, 2344-2384; PTX 1766-1911, 3316, 3513
+# ==========================================================================
+# with role(epilogue_warps):
+#     warp 0 only: tmem_alloc(tmem_cols); publish base; tmem_relinquish
+#     named_barrier(3, 160)
+#     for each work tile:
+#         wait(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0: break
+#         square_alpha = alpha[expert] * alpha[expert]
+#         beta_e       = beta[expert]
+#         p            = prob[row_of_this_thread]
+#         dprob_acc    = 0.0
+#         wait(acc_full[acc_stage], phase)
+#         for subtile in range(epi_tile_cnt):
+#             acc = tmem_load_32x32b_x32(acc_col + subtile * 32)
+#               # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x32.b32; extent: 32 accumulator columns
+#             g   = fmul2(acc, square_alpha)
+#             wait(c_full[gate_stage], phase);  gate = smem_ld_v4(sC + gate_stage * ...)
+#             wait(c_full[up_stage],   phase);  up   = smem_ld_v4(sC + up_stage   * ...)
+#               # instruction_selection: ld.shared.v4.b32; extent: 4 C values per lane per issue
+#             x1 = fmul2(cvt_f32_bf16(gate), beta_e)
+#             x2 = fmul2(cvt_f32_bf16(up),   beta_e)
+#
+#             # ---- dSwiGLU (source 767-943) ----------------------------------
+#             #   s      = 1 / (1 + exp2(-LOG2_E * x1))
+#             #     # instruction_selection: ex2.approx.ftz.f32 then rcp.approx.ftz.f32; extent: one per value
+#             #   swish  = x1 * s
+#             #   dprob_acc += g * x2 * swish
+#             #   d1 = g * p * x2 * s * (1 + x1 * (1 - s))
+#             #   d2 = g * p * swish
+#             #
+#             # ---- dGeGLU (source 945-1086) ----------------------------------
+#             #   y1 = min(x1, 7.0);  y2 = clamp(x2, -7.0, 7.0)
+#             #   s  = 1 / (1 + exp2(-LOG2_E * 1.702 * y1))
+#             #   dprob_acc += g * s * (y2 + linear_offset) * y1
+#             #   d1 = g * s * (1 + 1.702 * y1 * (1 - s)) * (y2 + linear_offset) * p
+#             #   d2 = g * y1 * s * p
+#             #   d1 *= (x1 <= 7.0 ? y1 : 0.0)          # the mask carries y1, not 1
+#             #   d2 *= (|x2| <= 7.0 ? y2 : 0.0)
+#             #
+#             # Both chains run on packed pairs when vectorized_f32:
+#             #   # instruction_selection: mul.rn.f32x2 / add.rn.f32x2, rnd=rn ftz=false; extent: two values per issue
+#             # The scalar branch is the same algebra on single values and is a
+#             # separate compiled program, not a runtime choice.
+#
+#             if with_dbias:
+#                 sDbias[column-major slot for this warp] = d1, d2
+#                   # instruction_selection: st.shared.v4.b32; extent: 4 f32 per lane
+#             smem_st_v4(sD + d_stage * ..., pack_bf16x2(d1, d2))
+#               # instruction_selection: st.shared.v4.b32; extent: one 128x32 D block per half
+#             arrive(c_empty[gate_stage]); arrive(c_empty[up_stage])
+#             warp 0: tma_store_3d(desc_d, (col, row, 0), sD + d_stage * ...)
+#               # instruction_selection: cp.async.bulk.tensor.3d S2G; extent: one 128x32 D block
+#
+#         arrive(acc_empty[acc_stage])
+#         atomic_add_f32(&dprob[row_of_this_thread], dprob_acc)
+#           # instruction_selection: atom.global.add.f32; extent: one per epilogue thread per work tile
+#
+#         if with_dbias:
+#             # dbias_reduction, source 686-765: SMEM transpose, no shuffles
+#             named_barrier(2, 128)
+#             col_a = 2 * lane if lane < 16 else epi_n + 2 * (lane - 16)
+#             col_b = col_a + 1
+#             swizzled = col ^ (((col >> 1) & 0x7) << 2)      # bank-conflict free
+#             sum_a, sum_b = 0.0, 0.0
+#             for i in range(8):
+#                 sum_a += smem_ld_v4(sDbias + swizzled_a + i * 16)   # 4 rows each
+#                 sum_b += smem_ld_v4(sDbias + swizzled_b + i * 16)
+#               # instruction_selection: ld.shared.v4.b32; extent: 32 rows per column
+#             store (sum_a, sum_b) as one 64-bit slot for this warp
+#             named_barrier(2, 128)
+#             warp 0: total = sum of the four warps' slots
+#                     if n_offset < dbias_n_total:
+#                         atomic_add_bf16x2(&dbias[expert, n_offset], total)
+#                           # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair
+#
+#     cp_async_bulk_wait_group(0)                 # PTX 1967
+#     named_barrier(1, 256)
+#     warp 0: tmem_dealloc(tmem_cols)             # PTX 1968
+#
+# dprob is accumulated per thread across every subtile of the tile and flushed
+# once, so its summation order is the kernel's 32-column subtile order -- the
+# oracle reproduces that order deliberately rather than summing the row.
+# dBias and dprob are both atomic accumulations into caller-zeroed buffers, so
+# neither is bit-reproducible between runs and both are compared with
+# reduction-aware tolerances.
+```
+
+## Source / sketch / PTX correspondence
+
+| region | source | sketch section | PTX |
+| --- | --- | --- | --- |
+| specialization and launch | 123-345, 416-566 | Static specialization | 14-39 |
+| shared storage and mbarriers | 568-676, 1195-1249 | Storage and synchronization | 1197, 1211, 1227, 1245 |
+| descriptor pre-kernel | 350-414, 617-637 | Optional pre-kernel | separate entry |
+| scheduler warp | 1252-1361 | Warp 7 | `.file` 2 |
+| A/B TMA warp | 1165-1172, 1321-1416 | Warp 5 | 2010-2019 |
+| MMA warp | 1471-1660 | Warp 4 | 1250-1318 |
+| C-load warp | 2005-2027 | Warp 6 | 2011, 2013, 2018, 2021 |
+| epilogue and activations | 767-1086, 1700-2172 | Warps 0-3 | 1766-1911 |
+| dprob flush | 2344-2384 | Warps 0-3 | 3513 |
+| dBias reduction | 686-765 | Warps 0-3 | 3316 |
+| teardown | 1960-1985 | Warps 0-3 | 1967-1981 |
+
+## Out of scope
+
+Unreachable in this port's domain, with the predicate that excludes each:
+- every scale-factor, quantization, amax and `dsituglu` path — absent from the
+  bf16 source entirely (`sfa|sfb|SFD|amax` occurs 353 times in the block-scaled
+  sibling and **0** times here);
+- `store_d_directly` and its `stg_256` path — the source hard-codes the flag
+  false (`:202`), so the 256-bit STG epilogue is dead code;
+- `epilogue_prefetch_more` — hard-coded false (`:328`);
+- a `prob`-less call — `generate_dprob` is unconditionally true (`:329`) and the
+  host API rejects a missing `prob`/`dprob` pair.

--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -360,8 +360,12 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #         if expert_idx < 0: break
 #         update_expert_info(padded_offsets, expert_idx)     # ext, token range
 #         status = True                                      # source 1439
-#         if k_tile_cnt > 0 and is_leader_cta:               # source 1440
+#         if k_tile_cnt > 0:                                 # source 1440
 #             status = peek(ab_empty[ab_stage], phase)       # source 1441
+#           # No is_leader_cta here, unlike the MMA warp at 1533: warp 5 runs on
+#           # both CTAs of the cluster and both must acquire their AB stage. A
+#           # true status means SKIP the blocking acquire, so over-guarding this
+#           # peek would let a non-leader CTA write into an unreleased stage.
 #         for k_tile in range(k_tile_cnt):
 #             acquire(ab_empty[ab_stage], phase, unless=status)
 #             leader = elect_one()
@@ -376,7 +380,8 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                                   ab_full[ab_stage], mask_b, pred=leader)
 #               # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster...cta_group::2; extent: one 128x64 bf16 half-tile
 #             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
-#             status = peek(ab_empty[ab_stage], phase)        # source 1459
+#             if k_tile < k_tile_cnt - 1:                     # source 1458
+#                 status = peek(ab_empty[ab_stage], phase)    # source 1459
 #         acquire(tile_info_full[stage], phase)   # next tile's record
 #         expert_idx, tile_m_idx, tile_n_idx, _ = sInfo[:, stage]
 #         fence_async_shared(); arrive(tile_info_empty[stage])
@@ -424,7 +429,8 @@ Each is one PTX instruction, one tile, or one loop of one family:
 #                 umma_arrive(ab_empty[ab_stage])            # source 1579
 #                   # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: AB release, PTX 1325
 #                 ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
-#                 status = peek(ab_full[ab_stage], phase)    # source 1555
+#                 if k_tile < k_tile_cnt - 1:                # source 1554
+#                     status = peek(ab_full[ab_stage], phase)  # source 1555
 #             umma_arrive(acc_full[acc_stage])               # source 1581
 #               # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: accumulator publish, PTX 1340
 #         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)

--- a/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
+++ b/.agents/sketch/cudnn_sm100_moe_grouped_gemm_dglu_dbias.md
@@ -19,18 +19,16 @@ it.
 
 - source: `/home/bohanhou/kernel-libs/cudnn-frontend/python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py`
 - commit: `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5` (`1.25.0.dev-250-gaded9909`)
-- sha256: `d448b5c9ddd4514f96340aa1a620894a48e884f4216c56715119d56c37bd9e38`, 2284 lines
+- sha256: `d448b5c9ddd4514f96340aa1a620894a48e884f4216c56715119d56c37bd9e38`, **2284 lines**
 - entry: `MoEGroupedGemmDgluDbiasBf16Kernel.__call__` -> optional `helper_kernel`, then `kernel`
 
-Citation shorthands used below: a bare `N` is a line in the source above;
-`sched N` is `grouped/moe_persistent_scheduler.py`, `utils N` is
-`grouped/moe_utils.py`, `ext N` is `grouped/moe_sched_extension.py`, and
-`helpers N` is `grouped/moe_kernel_helpers.py`. `PTX n` is a line in the anchor
-export named in the evidence table.
+Citation shorthands: a bare `N` is a line in the source above; `sched N` is
+`grouped/moe_persistent_scheduler.py`, `utils N` is `grouped/moe_utils.py`,
+`ext N` is `grouped/moe_sched_extension.py`, `helpers N` is
+`grouped/moe_kernel_helpers.py`. `PTX n` is a **line number in the anchor
+export** named in the evidence table, never a source line.
 
 ## PTX `.file` numbering
-
-The exports number the same four files consistently across every branch:
 
 | `.file` | path |
 | --- | --- |
@@ -42,89 +40,105 @@ The exports number the same four files consistently across every branch:
 ## Evidence
 
 Writer exports under `.porting/moe_grouped_gemm_dglu_dbias/writer_source_export/`,
-produced by `export_ptx.py` with `CUTE_DSL_LINEINFO=1 CUTE_DSL_KEEP=ptx
-CUTE_DSL_NO_CACHE=1`. Every run asserts its outputs are finite and non-zero, so
-a degenerate export cannot be annotated. The reviewer's export is independent
-and does not reuse these.
+from `export_ptx.py` with `CUTE_DSL_LINEINFO=1 CUTE_DSL_KEEP=ptx
+CUTE_DSL_NO_CACHE=1`. Each run asserts its outputs are finite and non-zero, so a
+degenerate export cannot be annotated.
 
-| branch | axis it turns on | ptx lines | `.loc` | sha256 | MMA idesc |
-| --- | --- | --- | --- | --- | --- |
-| `anchor` | the annotated specialization | 3793 | 1159 | `ab1d446e` | `0x10400490` |
-| `discrete` | discrete-B weights + helper descriptors | 3868 | 1173 | `3162ca17` | `0x10400490` |
-| `dynamic` | atomic-ticket scheduler | 4004 | 1221 | `53e3cb42` | `0x10400490` |
-| `dgeglu` | the second activation | 4840 | 1481 | `14b95ffa` | `0x10400490` |
-| `cf32_nodbias` | FP32 C, dBias off | 3063 | 925 | `1d38f93a` | `0x10400490` |
-| `bmajor_n` | n-major B | 3796 | 1153 | `6b9cb225` | `0x10410490` |
-| `tile128_c1x1` | one-CTA tile, singleton cluster | 3604 | 1115 | `f425a929` | `0x08400490` |
-| `tile_n64` | narrow tile_n | 3683 | 1127 | `098f01b9` | `0x08100490` |
-| `scalar_f32` | scalar (non-packed) epilogue math | 3501 | 849 | `201ea257` | `0x10400490` |
+| branch | axis it turns on | ptx lines | `.loc` | sha256 | MMA idesc | AB stages |
+| --- | --- | --- | --- | --- | --- | --- |
+| `anchor` | the annotated specialization | 3793 | 1159 | `ab1d446e` | `0x10400490` | 5 |
+| `discrete` | discrete-B weights + helper descriptors | 3868 | 1173 | `3162ca17` | `0x10400490` | 5 |
+| `dynamic` | atomic-ticket scheduler | 4004 | 1221 | `53e3cb42` | `0x10400490` | 5 |
+| `dgeglu` | the second activation | 4840 | 1481 | `14b95ffa` | `0x10400490` | 5 |
+| `cf32_nodbias` | FP32 C, dBias off | 3063 | 925 | `1d38f93a` | `0x10400490` | 5 |
+| `bmajor_n` | n-major B | 3796 | 1153 | `6b9cb225` | `0x10410490` | 5 |
+| `tile128_c1x1` | one-CTA tile, singleton cluster | 3604 | 1115 | `f425a929` | `0x08400490` | 3 |
+| `tile_n64` | narrow tile_n | 3683 | 1127 | `098f01b9` | `0x08100490` | 6 |
+| `scalar_f32` | scalar (non-packed) epilogue math | 3501 | 849 | `201ea257` | `0x10400490` | 5 |
 
-Instruction counts below follow the corpus convention: instruction lines minus
-predicated lines. For `anchor` that is 2263 - 120 = **2143**.
+Instruction counts follow the corpus convention, instruction lines minus
+predicated lines: `anchor` = 2263 - 120 = **2143**.
 
 ## Anchor values
 
-The annotated specialization, and the values every `extent:` annotation refers
-to unless it says otherwise:
-
 | quantity | value | source |
 | --- | --- | --- |
-| mode | dense weights, static scheduler, dSwiGLU, C and D bf16, k-major B, packed-f32 epilogue, dBias on | |
-| `mma_tiler_mn` | `(256, 256)`, so `use_2cta_instrs`, `atom_thr = 2` | `:123-133` |
+| mode | dense, static, dSwiGLU, C/D bf16, k-major B, packed-f32, dBias on | |
+| `mma_tiler_mn` | `(256, 256)`, `use_2cta_instrs`, `atom_thr = 2` | `:123-133` |
 | `cta_tile_shape_mnk` | `(128, 256, 64)` | `:212-230` |
 | `cluster_shape_mn` | `(2, 1)` | |
 | shape | 4 experts x 256 tokens, `N = 512`, `K = 512` | |
-| `epi_tile` | `(128, 32)`, 8 subtile pairs per tile | `:328` |
+| `epi_tile` | `(128, 32)`, 8 subtile pairs per tile | `:261` |
 | `k_tile` | 64 = instruction K 16 x `mma_inst_tile_k` 4 | `:224-230` |
-| stages | acc 2, AB 3 (4 without dBias), C 2, D 2, tile-info 2 | `:2239-2282` |
-| TMEM columns | **512** (`PTX 1427-1428`), `= clamp(next_pow2(2 * cta_tile_n), 32, 512)` | `:284-289` |
+| stages | acc 2, **AB 5**, C 2, D 2, tile-info 2 | `:2244-2282` |
+| AB `expect_tx` | **65536** = `(a_stage 16384 + b_stage 16384) * atom_thr 2` | `PTX 903-904` |
+| C `expect_tx` | **8192** = `128 * 32 * 2 B` | `PTX 3658` |
+| TMEM columns | **512** = `clamp(next_pow2(num_acc_stage * cta_tile_n), 32, 512)` | `:289-294`, `PTX 1427-1428` |
 | threads | 256 = 8 warps, `.maxntid 256, 1, 1`, `.minnctapersm 1` | `PTX 38-39` |
-| grid | `(cluster_m, cluster_n, max_active_clusters)` persistent | `:551`, helpers:988-992 |
+| grid | `(cluster_m, cluster_n, max_active_clusters)`, persistent | `:551`, helpers:988-992 |
 | shared memory | one dynamic `.extern .shared .align 1024 .b8` arena | `PTX 14` |
 
-**The TMEM column count is derived, not pinned.** The closed form above was
-checked against three exports: `anchor` and `tile128_c1x1` allocate 512 columns,
-`tile_n64` allocates **128** (`tcgen05.alloc` immediate). This is the single
+**AB depth is 5, and dBias does not change it at this tile.** The solve is
+`(232448 - reserved) // (a_stage + b_stage)` over `a_stage = b_stage = 16 KiB`,
+which lands on 5 both with dBias (`anchor`) and with FP32 C and no dBias
+(`cf32_nodbias`, whose larger sC cancels the sDbias saving). The depth does move
+with the tile: `tile128_c1x1` gets 3 (one CTA, so a full 32 KiB sB stage) and
+`tile_n64` gets 6.
+
+**TMEM columns are derived, not pinned.** `anchor` and `tile128_c1x1` allocate
+512; `tile_n64` allocates **128** (`tcgen05.alloc` immediate). This is the
 largest structural departure from the block-scaled sibling, which always
-reserves 512 and hand-partitions scale-factor regions inside it.
+reserves 512 and hand-partitions scale-factor regions inside it. The literal 2
+in the closed form is `num_acc_stage`.
 
 ## The MMA instruction descriptor
 
-Lifted from the exports, never adapted from the block-scaled encoder. The
-reference builds it as `selp`-selected constants immediately before the MMA
-(`PTX 1250-1252`), then issues
-`tcgen05.mma.cta_group::2.kind::f16` (`PTX 1264`, `.loc 1 1568`):
+Lifted from the exports, never adapted from the block-scaled encoder. Built as
+`selp`-selected constants immediately before the MMA (`PTX 1250-1252`), issued
+as `tcgen05.mma.cta_group::2.kind::f16` (`PTX 1264`, `.loc 1 1568`).
 
 ```text
 idesc = base | (p1 ? 1<<13 : 0) | (p2 ? 1<<14 : 0)
 base(anchor) = 0x10400490
 ```
 
-Field decode, confirmed by differencing the branch exports rather than by
-reading a header:
-
 | bits | field | anchor | evidence |
 | --- | --- | --- | --- |
 | 4-6 | D format | 1 (f32) | constant across branches |
 | 7-9 | A format | 1 (bf16) | constant across branches |
 | 10-12 | B format | 1 (bf16) | constant across branches |
-| 13 | A negate | runtime `%p1` | `TiledMMA` kernel param byte, `PTX 48-52` |
-| 14 | B negate | runtime `%p2` | `TiledMMA` kernel param byte, `PTX 48-52` |
+| 13 | A negate | runtime `%p1` | `TiledMMA` kernel param, `PTX 46-52` |
+| 14 | B negate | runtime `%p2` | `TiledMMA` kernel param, `PTX 46-52` |
 | 16 | transpose B | 0 here, **1** in `bmajor_n` | `0x10400490` vs `0x10410490` |
 | 17-22 | `N >> 3` | 32 -> N 256 | `tile_n64` gives 8 -> N 64 |
 | 23 | SF format | **0** | the block-scaled kinds set this; `kind::f16` never does |
 | 24-28 | `M >> 4` | 16 -> M 256 | `tile128_c1x1` gives 8 -> M 128 |
 
-Bits 13 and 14 arrive as `TiledMMA` **kernel parameters** that this kernel never
-sets, so both predicates are false at run time. The port therefore emits a
-compile-time constant descriptor:
+Bits 13/14 arrive as `TiledMMA` kernel parameters this kernel never sets (it
+only ever sets `tcgen05.Field.ACCUMULATE`), so both predicates are false at run
+time and the port emits a compile-time constant descriptor:
 
 ```text
 idesc = (1 << 4) | (1 << 7) | (1 << 10)
       | (transpose_b << 16) | ((tile_n >> 3) << 17) | ((tile_m >> 4) << 24)
 ```
 
-`# instruction_selection: tcgen05.mma.cta_group::{1,2}.kind::f16; extent: one k-block of the 64-wide k tile, four issues per tile`
+`# instruction_selection: tcgen05.mma.cta_group::{1,2}.kind::f16; extent: one 16-deep k-block, four issues per k tile`
+
+## Waits come in two forms
+
+Of 33 `mbarrier.try_wait` in the anchor, **29** are blocking acquires
+`mbarrier.try_wait.parity.shared.b64` carrying the suspend hint **10000000**,
+and **4** are non-blocking peeks
+`mbarrier.try_wait.parity.acquire.cta.shared::cta.b64` with **no** hint
+(`PTX 863, 919, 1170, 1241` at `.loc 1 1441 / 1459 / 1534 / 1555`). The peeks
+look one stage ahead and their status predicates the following acquire.
+
+The hint value is a per-kernel fact read off the export: this family spins with
+10000000, where the linear-attention family spins with 1.
+
+`# instruction_selection: mbarrier.try_wait.parity.shared.b64 with suspend hint 10000000; extent: one blocking acquire per handshake`
+`# instruction_selection: mbarrier.try_wait.parity.acquire.cta.shared::cta.b64, no hint; extent: one look-ahead peek per producer loop`
 
 ## No first-class layouts
 
@@ -133,61 +147,70 @@ layout algebra object, or a multidimensional shared-memory tensor. Every shared
 region is a one-dimensional byte range inside a single flat `u8` arena, indexed
 by explicit scalar offset arithmetic; matrix descriptors are assembled from
 hardware immediates. The upstream `SharedStorage` struct and its `cute` layouts
-are documentation of the byte map only.
+document the byte map only.
 
 ## Pipeline at a glance
 
 Eight warps, 256 threads, one CTA per multiprocessor, persistent over work
-tiles handed out by the scheduler warp. Roles and their ids are unchanged from
-the block-scaled sibling (`:157-181`).
+tiles handed out by the scheduler warp. Roles and ids are unchanged from the
+block-scaled sibling (`:158-162`). Sections below appear in **source order**.
 
 | warp | role | tile program | publishes / consumes |
 | --- | --- | --- | --- |
-| 0-3 | epilogue | per subtile pair: read accumulator from TMEM, scale by `alpha^2`, read C, form the two GLU gradients, accumulate dprob and dBias, write D through SMEM | consumes `acc_full`, `c_full`; releases `acc_empty`, `c_empty`; warp 0 additionally owns the TMEM allocation and the D TMA store |
-| 4 | MMA | per k tile: issue four `tcgen05.mma.kind::f16`, accumulate into the current TMEM stage | consumes `ab_full`; releases `ab_empty`; publishes `acc_full` via `tcgen05.commit` |
-| 5 | A/B TMA | per k tile: `expect_tx` then two `cp.async.bulk.tensor` into the AB ring | consumes `ab_empty`; publishes `ab_full` |
-| 6 | C load | per subtile pair: two `cp.async.bulk.tensor` (gate block, then up block) into the two C stages | consumes `c_empty`; publishes `c_full` |
-| 7 | scheduler | walk work tiles, flatten each into `sInfo`, terminate with `expert_idx = -1` | publishes `tile_info`; consumes `tile_info` release |
+| 7 | scheduler | walk work tiles, flatten each into `sInfo`, terminate with `expert_idx = -1` | publishes `tile_info_full`; consumes `tile_info_empty` |
+| 5 | A/B TMA | per k tile: peek, acquire, `expect_tx` 65536, two cluster-multicast `cp.async.bulk.tensor` | consumes `ab_empty`; publishes `ab_full` |
+| 4 | MMA | per k tile: four `tcgen05.mma.kind::f16`; leader CTA only | consumes `ab_full`; releases `ab_empty` **via `tcgen05.commit`**; publishes `acc_full` via `tcgen05.commit` |
+| 0-3 | epilogue | per subtile pair: TMEM read, `alpha^2` scale, C read, two GLU gradients, dprob and dBias accumulation, D store | consumes `acc_full`, `c_full`; releases `acc_empty`, `c_empty`; warp 0 owns TMEM alloc and the D stores |
+| 6 | C load | per subtile pair: two `shared::cta` `cp.async.bulk.tensor`, gate then up, into two separate C stages | consumes `c_empty`; publishes `c_full` |
 
-Named barriers (`:186-206`), unchanged: id 1 CTA-wide (256 threads), id 2
-epilogue (128), id 3 TMEM allocation (160 = MMA warp + four epilogue warps),
-id 4 scheduler (32). `PTX` shows 12 `bar.sync`, 25 `mbarrier.init`, 33
+Named barriers (`:186-206`): id 0 the CTA-wide init barrier (`bar.sync 0`,
+`PTX 233`), id 2 epilogue (128 threads), id 3 TMEM lifecycle (160 = MMA warp
+plus four epilogue warps), id 4 scheduler (32). Barrier **id 1 (256 threads)
+does not occur in the anchor** — it appears only in the singleton-cluster
+branches, where it replaces the cluster wait. Anchor totals: 12 `bar.sync`
+(1x id 0, 2x id 4, 2x id 3, 7x id 2), 25 `mbarrier.init`, 33
 `mbarrier.try_wait`, 25 `elect.sync`.
-
-**Suspend hint.** Every reference `try_wait` carries the immediate `10000000`
-(`PTX 1498`, `.loc 1 1498`). The port matches it. This is the opposite choice
-from the linear-attention family, where the reference spins with a hint of 1;
-the hint is a per-kernel fact to be read off the export, not a global default.
-
-`# instruction_selection: mbarrier.try_wait.parity.shared::cta.b64 with suspend hint 10000000; extent: one spin per pipeline handshake`
 
 ## Primitive vocabulary
 
-The sketch uses only these, each of which is one PTX instruction, one tile, or
-one loop of one family:
+Each is one PTX instruction, one tile, or one loop of one family:
 
+- `tma_load_multicast_3d(dst_byte, desc, coords, barrier, mask)` — one
+  `cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::N`
+  (A and B only)
 - `tma_load_3d(dst_byte, desc, coords, barrier)` — one
-  `cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`
+  `cp.async.bulk.tensor.3d.shared::cta.global.tile...` (C only)
 - `tma_store_3d(desc, coords, src_byte)` — one S2G bulk tensor copy
-- `expect_tx(barrier, bytes)` / `arrive(barrier)` / `wait(barrier, phase)` —
-  one `mbarrier.arrive.expect_tx` / `mbarrier.arrive` / `mbarrier.try_wait.parity`
-- `mma_f16(acc_tmem, a_desc, b_desc, idesc, accumulate)` — one
+- `bulk_commit()` / `bulk_wait(0)` — one `cp.async.bulk.commit_group` /
+  `cp.async.bulk.wait_group.read`
+- `expect_tx(barrier, bytes)` / `arrive(barrier)` / `acquire(barrier, phase)` /
+  `peek(barrier, phase)` — `mbarrier.arrive.expect_tx` / `mbarrier.arrive` /
+  the hinted blocking `try_wait` / the unhinted `try_wait.acquire.cta`
+- `umma_arrive(barrier)` — one
+  `tcgen05.commit...mbarrier::arrive::one.shared::cluster.multicast::cluster.b64`
+  (the MMA warp's AB release and its accumulator publish; **not** an
+  `mbarrier.arrive`)
+- `mma_f16(acc_col, a_desc, b_desc, idesc, accumulate)` — one
   `tcgen05.mma.cta_group::N.kind::f16`
-- `mma_commit(barrier)` — one `tcgen05.commit...multicast::cluster.b64`
-- `tmem_alloc(cols)` / `tmem_dealloc` / `tmem_relinquish` — one tcgen05 alloc,
-  dealloc, or relinquish
+- `tmem_alloc(cols)` / `tmem_relinquish()` / `tmem_dealloc(cols)`
 - `tmem_load_32x32b_x32(regs, col)` — one `tcgen05.ld.sync.aligned.32x32b.x32.b32`
-- `smem_ld_v4(regs, byte)` / `smem_st_v4(byte, regs)` — one `ld.shared.v4.b32` /
+- `smem_ld_v4(byte)` / `smem_st_v4(byte, regs)` — `ld.shared.v4.b32` /
   `st.shared.v4.b32`
-- `cvt_f32_bf16(x)` / `pack_bf16x2(lo, hi)` — one `cvt.f32.bf16` /
-  `cvt.rn.bf16x2.f32`
-- `fmul2(a, b)` / `fadd2(a, b)` — one `mul.rn.f32x2` / `add.rn.f32x2`
-- `exp2(x)` / `rcp(x)` — one `ex2.approx.ftz.f32` / `rcp.approx.ftz.f32`
+- `smem_ld_b32(byte)` / `smem_st_b32(byte, v)` — scalar `ld.shared.b32` /
+  `st.shared.b32`
+- `cvt_f32_bf16(x)` / `pack_bf16x2(a, b)` — `cvt.f32.bf16` / `cvt.rn.bf16x2.f32`
+- `fmul2(a, b)` / `fadd2(a, b)` — `mul.rn.f32x2` / `add.rn.f32x2`
+- `exp2(x)` / `rcp(x)` — `ex2.approx.ftz.f32` / `rcp.approx.ftz.f32`
 - `atomic_add_f32(addr, v)` — one `atom.global.add.f32`
 - `atomic_add_bf16x2(addr, lo, hi)` — one `cvt.rn.bf16x2.f32` plus one
   `red.global.add.noftz.bf16x2`
 - `named_barrier(id, threads)` — one `bar.sync`
+- `cluster_arrive_relaxed()` / `cluster_wait()` — `barrier.cluster.arrive.relaxed` /
+  `barrier.cluster.wait`
+- `fence_async_shared()` / `fence_mbarrier_init()` — `fence.proxy.async.shared::cta` /
+  `fence.mbarrier_init.release.cluster`
 - `elect_one()` — one `elect.sync`
+- `mapa(addr, cta)` — one `mapa.shared::cluster.u32` (peer-CTA barrier address)
 
 ## Complete sketch
 
@@ -198,8 +221,7 @@ one loop of one family:
 # ==========================================================================
 # Compile-time: weight_mode, sched, act, c_dtype, d_dtype, b_major, tile_m,
 # tile_n, cluster_shape, vectorized_f32, with_dbias, expert_cnt, N, K,
-# group_m_list, linear_offset. Everything the reference takes at run time and
-# the port can know statically is baked, which is what makes the byte map exact.
+# group_m_list, linear_offset.
 #
 # Runtime operands, in ABI order:
 #   a, b (dense tensor or discrete int64 pointer array), c, d,
@@ -207,281 +229,374 @@ one loop of one family:
 #
 # grid   = (cluster_m, cluster_n, MAX_ACTIVE_CLUSTERS[cluster_m * cluster_n])
 # block  = 256 threads = 8 warps
-# cluster= (cluster_m, cluster_n) bound unconditionally, including (1, 1)
+# cluster= (cluster_m, cluster_n), bound unconditionally including (1, 1)
 #          # instruction_selection: cta_id_in_cluster with preferred=; extent: whole kernel
-#          The block-scaled sibling binds it the same way; `preferred=` is what
-#          keeps the extent-1 case from folding away and losing the cluster
-#          launch attribute.
 
 # ==========================================================================
 # Storage and synchronization objects
-# source 568-676; PTX 14
+# source 568-611, 1189-1250; PTX 14, 118-243
 # ==========================================================================
 # One flat `u8` arena, `K.alloc_buffer((SMEM_BYTES,), K.u8, scope="shared.dyn",
-# align=1024)`, carved by explicit scalar byte offsets in the upstream
-# declaration order. Sizes for the anchor:
+# align=1024)`, carved by explicit scalar byte offsets in upstream declaration
+# order. Anchor byte map, read back from the export's TMA destinations:
 #
-#   ab_mbar        num_ab_stage * 2 * 8 B      full/empty per AB stage
-#   acc_mbar       num_acc_stage * 2 * 8 B     full/empty per accumulator stage
-#   sched block    tile_info_mbar 4 * 8 B
-#                  sInfo          4 * num_tile_stage * 4 B, align 16
-#                  cluster_mbar   2 * 8 B      dynamic scheduler only
-#                  cluster_bcast  4 * 4 B      dynamic scheduler only
-#   c_full/c_empty num_c_stage * 8 B each
-#   tmem_dealloc   8 B
-#   tmem_holding   4 B
-#   sC             128 * 32 * num_c_stage * sizeof(c_dtype)   = 16 KiB
-#   sD             128 * 32 * num_d_stage * sizeof(d_dtype)   = 16 KiB
-#   sA             128 * 64 * 2 B per stage                   = 16 KiB/stage
-#   sB             256 *  64 * 2 B per stage                  = 32 KiB/stage
-#   sDbias         128 * 64 * 4 B (f32) when with_dbias        = 32 KiB
+#   ab_mbar        0     .. 79      5 full + 5 empty, 8 B each
+#   acc_mbar       80    .. 111     2 full + 2 empty
+#   sched block    112   .. 175     tile_info_mbar 4x8 B, sInfo 4x2x4 B align 16
+#                                   (+ cluster_mbar 2x8 B, cluster_bcast 4x4 B
+#                                    when the scheduler is dynamic)
+#   c_full         176   .. 191
+#   c_empty        192   .. 207
+#   tmem_dealloc   208   .. 215
+#   tmem_holding   216   .. 219
+#   sC             1024  .. 17407   128*32*2 stages * 2 B
+#   sD             17408 .. 33791   128*32*2 stages * 2 B
+#   sA             33792 .. 115711  5 stages * 16384 B
+#   sB             115712.. 197631  5 stages * 16384 B   (tile_n/atom_thr = 128 wide)
+#   sDbias         197632.. 230399  128 * 64 * 4 B
+#                                   total <= 232448
 #
-# num_ab_stage is whatever the remaining budget allows against the 232448 B
-# capacity: 3 with dBias, 4 without.
+# A/B multicast masks, built once from the cluster layout and this CTA's
+# in-cluster coordinate (source 1303-1307): the A mask spans the cluster's n
+# extent, the B mask its m extent, so each tile is fetched once per cluster and
+# broadcast.
 #
-# TMEM: one allocation of `clamp(next_pow2(2 * cta_tile_n), 32, 512)` columns,
-# split into num_acc_stage accumulator regions of cta_tile_n columns each.
+# TMEM: one allocation of clamp(next_pow2(num_acc_stage * cta_tile_n), 32, 512)
+# columns, split into num_acc_stage accumulator regions of cta_tile_n columns.
 #   # instruction_selection: tcgen05.alloc.cta_group::N.sync.aligned.shared::cta.b32; extent: once per kernel
-# Warp 0 allocates, publishes the base through `tmem_holding`, and the CTA
-# reads it after named barrier 3.
+#
+# Init order (source 1189-1250, 1272-1282, 1325-1328):
+#   mbarrier_init(...)                       # 25 objects, PTX 118-231
+#   fence_mbarrier_init()                    # PTX 232
+#   named_barrier(0, 256)                    # PTX 233  -- CTA-wide init barrier
+#   fence_mbarrier_init()                    # PTX 246
+#   cluster_arrive_relaxed()                 # PTX 248
+#   ... TMEM allocation is issued here ...
+#   cluster_wait()                           # PTX 262
+#     # When cluster_size == 1 the cluster wait degenerates and the source uses
+#     # named_barrier(1, 256) instead; that is the only place barrier 1 appears.
+#
+# total_tokens = padded_offsets[expert_cnt - 1]     # source 1161
+# if total_tokens <= 0: exit()                      # source 1330-1331
+#
+# k_tile_cnt = ceil_div(K, k_tile)                  # source 1332 -- KERNEL-WIDE
+#   constant, identical for every work tile. sInfo[3] carries the same value and
+#   is published for the record, but the loop bound is this constant.
 
 # ==========================================================================
 # Optional pre-kernel: per-expert B descriptors and the scheduler counter
-# source 350-414, 617-637
+# source 349-414, 617-637
 # ==========================================================================
 # Emitted only when weight_mode is discrete or the scheduler is dynamic.
 # grid = (L, 1, 1) discrete else (1, 1, 1); one thread.
 #
 # for expert in this_block:                      # discrete only
-#     read b_ptrs[expert]
+#     read b_ptrs[expert]                        # reads precede writes
 #     build one 128-byte TMA descriptor image for (N, K) at that base
 #     store it into workspace[expert * 128 : expert * 128 + 128]
 #       # instruction_selection: st.global.v4.b32 x8; extent: one 128 B image per expert
 # if sched is dynamic:
 #     zero the 4-byte ticket counter at workspace[L * 128]
 #
-# Single "b" slot at a 128-byte stride -- the block-scaled sibling carries two
-# slots at 256 B because it also images SFB. Reads precede writes so an expert
-# never reads a slot another block has already overwritten.
+# Single "b" slot at a 128-byte stride; the block-scaled sibling carries two
+# slots at 256 B because it also images SFB.
 
 # ==========================================================================
 # Warp 7: persistent tile scheduler
-# source 1252-1361; sched 420-449; PTX .file 2
+# source 1337-1372; sched 420-449; PTX 497-729
 # ==========================================================================
 # with role(sched_warp):
 #     state = scheduler_create(padded_offsets, block_idx, grid_dim, counter?)
 #     tile  = initial_work_tile(state)
 #     while True:
-#         wait(tile_info_empty[stage], phase)
-#         if tile is valid:
-#             sInfo[0, stage] = expert_idx
+#         acquire(tile_info_empty[stage], phase)
+#         if elect_one():                       # source 1345
+#             sInfo[0, stage] = expert_idx if valid else -1
 #             sInfo[1, stage] = tile_m_idx
 #             sInfo[2, stage] = tile_n_idx
 #             sInfo[3, stage] = k_tile_cnt
-#         else:
-#             sInfo[0, stage] = -1            # the termination token
-#         fence_proxy_async_shared()
-#         named_barrier(4, 32)
+#               # instruction_selection: st.shared.b32 x4; extent: one work tile
+#         fence_async_shared()
+#         named_barrier(4, 32)                  # PTX 520, 726
 #         arrive(tile_info_full[stage])
 #         if not valid: break
 #         tile = advance_to_next_work(state)
 #           # static : linear_idx = bidz + i * stride
 #           # dynamic: one atom.global.add.u32 ticket, broadcast across the cluster
 #         stage, phase = advance(stage, phase, num_tile_stage)
-#
-# Every consumer warp reads the same sInfo words, so the tile identity is
-# published once rather than recomputed per warp.
+#     producer_tail(tile_info_empty, num_tile_stage)   # source 1369
+#       # instruction_selection: 2x blocking try_wait; extent: drain both stages
 
 # ==========================================================================
 # Warp 5: A/B TMA loads
-# source 1165-1172, 1321-1416
+# source 1374-1495; PTX 84-93, 863-978
 # ==========================================================================
 # with role(tma_warp):
-#     prefetch the A, B, C and D descriptors                 # source 1165-1172
-#       # instruction_selection: prefetch.tensormap; extent: once per kernel
+#     prefetch the A, B, C and D descriptors             # source 1166-1172
+#       # instruction_selection: prefetch.tensormap x4; extent: once per kernel, PTX 84-93
 #     for each work tile:
-#         wait(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0: break
+#         acquire(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0:
+#             fence_async_shared(); arrive(tile_info_empty[stage]); break
 #         update_expert_info(padded_offsets, expert_idx)     # ext, token range
+#         status = peek(ab_empty[ab_stage], phase)           # source 1441
 #         for k_tile in range(k_tile_cnt):
-#             wait(ab_empty[ab_stage], phase)
+#             acquire(ab_empty[ab_stage], phase, unless=status)
 #             leader = elect_one()
-#               # instruction_selection: elect.sync; extent: one per transfer group
-#             expect_tx(ab_full[ab_stage], a_bytes + b_bytes, pred=leader)
-#             tma_load_3d(sA + ab_stage * a_stage_bytes, desc_a,
-#                         (k_tile * 64, token_offset + tile_m_idx * tile_m, 0),
-#                         ab_full[ab_stage], pred=leader)
-#               # instruction_selection: cp.async.bulk.tensor.3d...L2::cache_hint; extent: one 128x64 bf16 tile
-#             tma_load_3d(sB + ab_stage * b_stage_bytes, desc_b_or_expert_image,
-#                         (k_tile * 64, tile_n_idx * tile_n, expert_idx),
-#                         ab_full[ab_stage], pred=leader)
-#               # instruction_selection: cp.async.bulk.tensor.3d...L2::cache_hint; extent: one 256x64 bf16 tile
+#             expect_tx(ab_full[ab_stage], 65536, pred=leader)     # PTX 903-904
+#               # instruction_selection: mbarrier.arrive.expect_tx.shared.b64; extent: (a+b) x atom_thr bytes
+#             tma_load_multicast_3d(sA + ab_stage * 16384, desc_a,
+#                                   (k_tile * 64, row_base, 0),
+#                                   ab_full[ab_stage], mask_a, pred=leader)
+#               # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster...cta_group::2; extent: one 128x64 bf16 tile
+#             tma_load_multicast_3d(sB + ab_stage * 16384, desc_b_or_image,
+#                                   (k_tile * 64, col_base, expert_idx),
+#                                   ab_full[ab_stage], mask_b, pred=leader)
+#               # instruction_selection: cp.async.bulk.tensor.3d.shared::cluster...cta_group::2; extent: one 128x64 bf16 half-tile
 #             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
+#             status = peek(ab_empty[ab_stage], phase)        # source 1459
+#         fence_async_shared(); arrive(tile_info_empty[stage])  # source 1489-1491
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#     producer_tail(ab_empty, num_ab_stage)                    # source 1495
+#       # instruction_selection: 5x blocking try_wait; extent: drain all AB stages
 #
-# The waits sit outside the elected region and the two issues carry the lane
-# guard as an instruction predicate, so the warp never diverges.
-# In discrete mode `desc_b_or_expert_image` is the workspace slot the helper
-# built, bound through the descriptor pointer rather than a static descriptor.
+# The waits sit outside the elected region; only the expect_tx and the two
+# issues carry the lane guard as an instruction predicate, so the warp never
+# diverges. In discrete mode `desc_b_or_image` is the workspace slot the helper
+# built, bound through a descriptor pointer.
 
 # ==========================================================================
 # Warp 4: MMA
-# source 1471-1660; PTX 1250-1318
+# source 1500-1599; PTX 1107-1408
 # ==========================================================================
 # with role(mma_warp):
-#     named_barrier(3, 160)                     # TMEM base is published
+#     named_barrier(3, 160)                     # PTX 1107, TMEM base published
 #     for each work tile:
-#         wait(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0: break
-#         wait(acc_empty[acc_stage], phase)
-#         acc_col = acc_stage * cta_tile_n
-#         for k_tile in range(k_tile_cnt):
-#             wait(ab_full[ab_stage], phase)
-#             a_desc = smem_descriptor(sA + ab_stage * a_stage_bytes)
-#             b_desc = smem_descriptor(sB + ab_stage * b_stage_bytes)
-#             for kblock in range(4):           # k_tile 64 / instruction K 16
-#                 mma_f16(acc_col, a_desc + kblock * a_step,
-#                         b_desc + kblock * b_step, IDESC,
-#                         accumulate=(k_tile != 0 or kblock != 0))
-#                   # instruction_selection: tcgen05.mma.cta_group::2.kind::f16; extent: one 256x256x16 issue
-#             arrive(ab_empty[ab_stage])
-#             ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
-#         mma_commit(acc_full[acc_stage])
-#           # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: one per accumulator stage
+#         acquire(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0:
+#             fence_async_shared(); arrive(tile_info_empty[stage]); break
+#         if k_tile_cnt > 0 and is_leader_cta:               # source 1533
+#             acquire(acc_empty[acc_stage], phase)
+#             acc_col = acc_stage * cta_tile_n
+#             status = peek(ab_full[ab_stage], phase)        # source 1534
+#             for k_tile in range(k_tile_cnt):
+#                 acquire(ab_full[ab_stage], phase, unless=status)
+#                 a_desc = smem_descriptor(sA + ab_stage * 16384)
+#                 b_desc = smem_descriptor(sB + ab_stage * 16384)
+#                 for kblock in range(4):        # k_tile 64 / instruction K 16
+#                     if elect_one():
+#                         mma_f16(acc_col, a_desc + kblock * a_step,
+#                                 b_desc + kblock * b_step, IDESC,
+#                                 accumulate=(k_tile != 0 or kblock != 0))
+#                           # instruction_selection: tcgen05.mma.cta_group::2.kind::f16; extent: one 256x256x16 issue
+#                 umma_arrive(ab_empty[ab_stage])            # source 1579
+#                   # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: AB release, PTX 1325
+#                 ab_stage, phase = advance(ab_stage, phase, num_ab_stage)
+#                 status = peek(ab_full[ab_stage], phase)    # source 1555
+#             umma_arrive(acc_full[acc_stage])               # source 1581
+#               # instruction_selection: tcgen05.commit...multicast::cluster.b64; extent: accumulator publish, PTX 1340
 #         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
+#         fence_async_shared(); arrive(tile_info_empty[stage])  # source 1593-1595
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#     producer_tail(acc_empty, 1)                              # source 1599
 #
-# `accumulate` is false only on the very first issue of a tile, which is what
-# clears the accumulator without a separate zeroing pass.
-# Under a two-CTA atom only the leader CTA issues; the peer contributes its
-# operand halves and waits on the same barriers.
-
-# ==========================================================================
-# Warp 6: C loads
-# source 2005-2027
-# ==========================================================================
-# with role(c_load_warp):
-#     for each work tile:
-#         wait(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0: break
-#         for subtile in range(epi_tile_cnt):           # 8 pairs for tile_n 256
-#             for half in (0, 1):                       # gate block, then up block
-#                 wait(c_empty[c_stage], phase)
-#                 leader = elect_one()
-#                 expect_tx(c_full[c_stage], c_tile_bytes, pred=leader)
-#                 tma_load_3d(sC + c_stage * c_stage_bytes, desc_c,
-#                             (col_base + (2 * subtile + half) * 32,
-#                              row_base, 0),
-#                             c_full[c_stage], pred=leader)
-#                   # instruction_selection: cp.async.bulk.tensor.3d G2S; extent: one 128x32 C block
-#                 c_stage, phase = advance(c_stage, phase, num_c_stage)
-#
-# The gate and up halves land in *separate* C stages, which is why num_c_stage
-# is 2 and why the epilogue consumes them as a pair.
+# `accumulate` is false only on the very first issue of a tile, which clears the
+# accumulator without a separate zeroing pass.
+# On a NON-leader CTA the entire guarded block is skipped: no AB acquire, no MMA,
+# no AB release, no accumulator acquire or commit. The peer CTA only advances
+# `acc_stage` and runs the tile-info handshake; its operand halves reach the
+# leader through the cluster multicast, not through this warp.
 
 # ==========================================================================
 # Warps 0-3: epilogue
-# source 1700-2172, 2344-2384; PTX 1766-1911, 3316, 3513
+# source 1604-1967; PTX 1427-3556
 # ==========================================================================
 # with role(epilogue_warps):
-#     warp 0 only: tmem_alloc(tmem_cols); publish base; tmem_relinquish
-#     named_barrier(3, 160)
+#     warp 0 only: tmem_alloc(tmem_cols)        # PTX 1427-1428
+#     named_barrier(3, 160)                     # PTX 1431
 #     for each work tile:
-#         wait(tile_info_full[stage], phase); read sInfo
-#         if expert_idx < 0: break
+#         acquire(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0:
+#             fence_async_shared(); arrive(tile_info_empty[stage]); break
 #         square_alpha = alpha[expert] * alpha[expert]
 #         beta_e       = beta[expert]
 #         p            = prob[row_of_this_thread]
-#         dprob_acc    = 0.0
-#         wait(acc_full[acc_stage], phase)
-#         for subtile in range(epi_tile_cnt):
+#         dprob_vec    = zeros(32)
+#         acquire(acc_full[acc_stage], phase)                  # PTX 1538
+#         for subtile in range(epi_tile_cnt):                  # 8 pairs
 #             acc = tmem_load_32x32b_x32(acc_col + subtile * 32)
 #               # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x32.b32; extent: 32 accumulator columns
+#               # No tcgen05.wait::ld follows: the reference emits none.
 #             g   = fmul2(acc, square_alpha)
-#             wait(c_full[gate_stage], phase);  gate = smem_ld_v4(sC + gate_stage * ...)
-#             wait(c_full[up_stage],   phase);  up   = smem_ld_v4(sC + up_stage   * ...)
-#               # instruction_selection: ld.shared.v4.b32; extent: 4 C values per lane per issue
+#
+#             acquire(c_full[gate_stage], phase)
+#             gate = smem_ld_v4(sC + gate_stage * 8192)   # 4 issues
+#               # instruction_selection: ld.shared.v4.b32 x4; extent: 32 C values per lane
+#             fence_async_shared(); arrive(c_empty[gate_stage])   # source 1776-1778
+#             acquire(c_full[up_stage], phase)
+#             up   = smem_ld_v4(sC + up_stage * 8192)      # 4 issues
+#             fence_async_shared(); arrive(c_empty[up_stage])     # source 1785-1787
+#             # Both C stages are released BEFORE any activation work, which is
+#             # what lets the C-load warp run a full subtile ahead.
+#
 #             x1 = fmul2(cvt_f32_bf16(gate), beta_e)
 #             x2 = fmul2(cvt_f32_bf16(up),   beta_e)
 #
-#             # ---- dSwiGLU (source 767-943) ----------------------------------
+#             # ---- dSwiGLU (source 766-942) ----------------------------------
 #             #   s      = 1 / (1 + exp2(-LOG2_E * x1))
-#             #     # instruction_selection: ex2.approx.ftz.f32 then rcp.approx.ftz.f32; extent: one per value
+#             #     # instruction_selection: ex2.approx.ftz.f32 then rcp.approx.ftz.f32; extent: 32 values
 #             #   swish  = x1 * s
-#             #   dprob_acc += g * x2 * swish
+#             #   dprob_vec += g * x2 * swish
 #             #   d1 = g * p * x2 * s * (1 + x1 * (1 - s))
 #             #   d2 = g * p * swish
 #             #
-#             # ---- dGeGLU (source 945-1086) ----------------------------------
+#             # ---- dGeGLU (source 944-1083) ----------------------------------
 #             #   y1 = min(x1, 7.0);  y2 = clamp(x2, -7.0, 7.0)
 #             #   s  = 1 / (1 + exp2(-LOG2_E * 1.702 * y1))
-#             #   dprob_acc += g * s * (y2 + linear_offset) * y1
+#             #   dprob_vec += g * s * (y2 + linear_offset) * y1
 #             #   d1 = g * s * (1 + 1.702 * y1 * (1 - s)) * (y2 + linear_offset) * p
 #             #   d2 = g * y1 * s * p
-#             #   d1 *= (x1 <= 7.0 ? y1 : 0.0)          # the mask carries y1, not 1
-#             #   d2 *= (|x2| <= 7.0 ? y2 : 0.0)
+#             #   d1 *= (x1 <= 7.0 ? y1 : 0.0)
+#             #   d2 *= (x2 >= -7.0 ? y2 : 0.0)
+#             #     The upper bound plays no part in the d2 filter: for x2 > 7 the
+#             #     vectorized path multiplies by y2 (= 7.0), not by zero.
+#             #     The SCALAR path differs here -- it yields 0 for x2 > 7 -- so the
+#             #     two compiled programs genuinely disagree on that input, and the
+#             #     oracle must follow whichever one the specialization selects.
 #             #
-#             # Both chains run on packed pairs when vectorized_f32:
-#             #   # instruction_selection: mul.rn.f32x2 / add.rn.f32x2, rnd=rn ftz=false; extent: two values per issue
-#             # The scalar branch is the same algebra on single values and is a
-#             # separate compiled program, not a runtime choice.
+#             # Packed form when vectorized_f32:
+#             #   # instruction_selection: mul.rn.f32x2 / add.rn.f32x2, rnd=rn ftz=false; extent: 16 issues over 32 values
 #
 #             if with_dbias:
-#                 sDbias[column-major slot for this warp] = d1, d2
-#                   # instruction_selection: st.shared.v4.b32; extent: 4 f32 per lane
-#             smem_st_v4(sD + d_stage * ..., pack_bf16x2(d1, d2))
-#               # instruction_selection: st.shared.v4.b32; extent: one 128x32 D block per half
-#             arrive(c_empty[gate_stage]); arrive(c_empty[up_stage])
-#             warp 0: tma_store_3d(desc_d, (col, row, 0), sD + d_stage * ...)
-#               # instruction_selection: cp.async.bulk.tensor.3d S2G; extent: one 128x32 D block
+#                 for i in range(32):                        # source 703-705
+#                     smem_st_b32(sDbias + warp_base + i * 32 + m_slot, d1[i])
+#                     smem_st_b32(sDbias + warp_base + (epi_n + i) * 32 + m_slot, d2[i])
+#                   # instruction_selection: st.shared.b32 x64; extent: 64 f32 per lane per subtile
+#                   # Scalar, not vectorized: the (32, 1, epi_n*2*32) stride puts
+#                   # consecutive n 128 B apart.
 #
-#         arrive(acc_empty[acc_stage])
-#         atomic_add_f32(&dprob[row_of_this_thread], dprob_acc)
-#           # instruction_selection: atom.global.add.f32; extent: one per epilogue thread per work tile
+#             d1_bits = pack_bf16x2(d1 pairs)   # source 1853, 16 issues
+#             d2_bits = pack_bf16x2(d2 pairs)   # source 1854, 16 issues
+#               # instruction_selection: cvt.rn.bf16x2.f32 x16 each; extent: 32 values per half
+#             warp 0: bulk_wait(0)                            # source 1900, PTX 3325
+#             named_barrier(2, 128)                           # source 1901, PTX 3383
+#             smem_st_v4(sD + d1_stage * 8192, d1_bits)       # source 1904, 4 issues
+#             smem_st_v4(sD + d2_stage * 8192, d2_bits)       # source 1911, 4 issues
+#               # instruction_selection: st.shared.v4.b32 x4 each; extent: one 128x32 D block per half
+#             fence_async_shared()
+#             named_barrier(2, 128)                           # source 1917, PTX 3425
+#             warp 0: tma_store_3d(desc_d, (col_d1, row, 0), sD + d1_stage * 8192)
+#             warp 0: tma_store_3d(desc_d, (col_d2, row, 0), sD + d2_stage * 8192)
+#               # instruction_selection: cp.async.bulk.tensor.3d S2G x2; extent: two 128x32 D blocks
+#             warp 0: bulk_commit()                           # source 1929, PTX 3449
+#             named_barrier(2, 128)                           # source 1930, PTX 3452
+#             d1_stage, d2_stage = next two values of (subtile_counter % num_d_stage)
+#
+#         dprob_acc = packed_pairwise_sum(dprob_vec)          # source 1808-1829
+#           # instruction_selection: add.rn.f32x2 x16; extent: 32-element reduction, then one scalar fold
+#           # This order is load-bearing: the oracle reproduces the same
+#           # 32-column subtile grouping rather than summing the row.
+#
+#         if elect_one(): arrive(acc_empty[acc_stage])        # source 1935-1936, PTX 3465
+#         acc_stage, phase = advance(acc_stage, phase, num_acc_stage)
 #
 #         if with_dbias:
 #             # dbias_reduction, source 686-765: SMEM transpose, no shuffles
-#             named_barrier(2, 128)
+#             named_barrier(2, 128)                           # source 707, PTX 2843
 #             col_a = 2 * lane if lane < 16 else epi_n + 2 * (lane - 16)
 #             col_b = col_a + 1
-#             swizzled = col ^ (((col >> 1) & 0x7) << 2)      # bank-conflict free
-#             sum_a, sum_b = 0.0, 0.0
-#             for i in range(8):
-#                 sum_a += smem_ld_v4(sDbias + swizzled_a + i * 16)   # 4 rows each
-#                 sum_b += smem_ld_v4(sDbias + swizzled_b + i * 16)
-#               # instruction_selection: ld.shared.v4.b32; extent: 32 rows per column
-#             store (sum_a, sum_b) as one 64-bit slot for this warp
-#             named_barrier(2, 128)
-#             warp 0: total = sum of the four warps' slots
+#             sum_a = sum_b = 0.0
+#             for g in range(8):                              # source 721-733
+#                 m_base = g * 4
+#                 off_a  = warp_base + col_a * 32 + (m_base ^ (((col_a >> 1) & 0x7) << 2))
+#                 off_b  = warp_base + col_b * 32 + (m_base ^ (((col_b >> 1) & 0x7) << 2))
+#                 sum_a += sum(smem_ld_b32(off_a + j) for j in range(4))
+#                 sum_b += sum(smem_ld_b32(off_b + j) for j in range(4))
+#               # instruction_selection: ld.shared.b32 x64; extent: 32 rows per column pair
+#               # The XOR swizzle applies to the ROW-GROUP BASE, not the column, and
+#               # the 128-bit copy atom decays to scalars because the swizzled offset
+#               # is not provably 16-byte aligned.
+#             named_barrier(2, 128)                           # source 741, PTX 3242
+#             smem_st_b32 x2 -> this warp's 64-bit partial slot   # source 746
+#             named_barrier(2, 128)                           # source 747, PTX 3255
+#             warp 0: total = sum of the four warps' partials      # source 755, ld.shared.b32 x8
 #                     if n_offset < dbias_n_total:
 #                         atomic_add_bf16x2(&dbias[expert, n_offset], total)
-#                           # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair
+#                           # instruction_selection: cvt.rn.bf16x2.f32 + red.global.add.noftz.bf16x2; extent: one column pair, PTX 3316
 #
-#     cp_async_bulk_wait_group(0)                 # PTX 1967
-#     named_barrier(1, 256)
-#     warp 0: tmem_dealloc(tmem_cols)             # PTX 1968
+#         fence_async_shared(); arrive(tile_info_empty[stage])   # source 1942-1948, PTX 3499-3503
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#         atomic_add_f32(&dprob[row_of_this_thread], dprob_acc)  # source 1950-1955, PTX 3513
+#           # instruction_selection: atom.global.add.f32; extent: one per epilogue thread per work tile
+#           # Flushed AFTER the tile-info release, not before.
 #
-# dprob is accumulated per thread across every subtile of the tile and flushed
-# once, so its summation order is the kernel's 32-column subtile order -- the
-# oracle reproduces that order deliberately rather than summing the row.
-# dBias and dprob are both atomic accumulations into caller-zeroed buffers, so
-# neither is bit-reproducible between runs and both are compared with
-# reduction-aware tolerances.
+#     tmem_relinquish()                        # source 1960, PTX 3524
+#     named_barrier(2, 128)                    # source 1961, PTX 3529
+#     arrive(tmem_dealloc_mbar); acquire(tmem_dealloc_mbar)   # source 1962-1965, PTX 3536, 3543
+#       # The two-CTA TMEM deallocation handshake, addressed with mapa when the
+#       # peer barrier lives in the other CTA.
+#     warp 0: tmem_dealloc(tmem_cols)          # PTX 3553
+#     bulk_wait(0)                             # PTX 3556 -- after the dealloc
+#
+# dprob is accumulated per thread across every subtile and flushed once, so its
+# summation order is the kernel's 32-column subtile order. dBias and dprob are
+# both atomic accumulations into caller-zeroed buffers, so neither is
+# bit-reproducible between runs; both are compared with reduction-aware
+# tolerances.
+
+# ==========================================================================
+# Warp 6: C loads
+# source 1971-2044; PTX 3643-3776
+# ==========================================================================
+# with role(c_load_warp):
+#     for each work tile:
+#         acquire(tile_info_full[stage], phase); read sInfo
+#         if expert_idx < 0:
+#             fence_async_shared(); arrive(tile_info_empty[stage]); break
+#         for subtile in range(epi_tile_cnt):           # 8 pairs
+#             for half in (0, 1):                       # gate block, then up block
+#                 acquire(c_empty[c_stage], phase)
+#                 leader = elect_one()
+#                 expect_tx(c_full[c_stage], 8192, pred=leader)     # PTX 3658, 3691
+#                 tma_load_3d(sC + c_stage * 8192, desc_c,
+#                             (col_base + (2 * subtile + half) * 32, row_base, 0),
+#                             c_full[c_stage], pred=leader)
+#                   # instruction_selection: cp.async.bulk.tensor.3d.shared::cta...; extent: one 128x32 C block, PTX 3667/3703
+#                 c_stage, phase = advance(c_stage, phase, num_c_stage)
+#         fence_async_shared(); arrive(tile_info_empty[stage])   # source 2034-2036
+#         stage, phase = advance(stage, phase, num_tile_stage)
+#     producer_tail(c_empty, num_c_stage)                       # source 2041
+#
+# The gate and up halves land in SEPARATE C stages, which is why num_c_stage is
+# 2 and why the epilogue consumes them as a pair. C is the only `shared::cta`
+# bulk load; A and B are cluster-multicast.
 ```
 
 ## Source / sketch / PTX correspondence
 
+The PTX column carries **anchor-export line numbers**.
+
 | region | source | sketch section | PTX |
 | --- | --- | --- | --- |
-| specialization and launch | 123-345, 416-566 | Static specialization | 14-39 |
-| shared storage and mbarriers | 568-676, 1195-1249 | Storage and synchronization | 1197, 1211, 1227, 1245 |
-| descriptor pre-kernel | 350-414, 617-637 | Optional pre-kernel | separate entry |
-| scheduler warp | 1252-1361 | Warp 7 | `.file` 2 |
-| A/B TMA warp | 1165-1172, 1321-1416 | Warp 5 | 2010-2019 |
-| MMA warp | 1471-1660 | Warp 4 | 1250-1318 |
-| C-load warp | 2005-2027 | Warp 6 | 2011, 2013, 2018, 2021 |
-| epilogue and activations | 767-1086, 1700-2172 | Warps 0-3 | 1766-1911 |
-| dprob flush | 2344-2384 | Warps 0-3 | 3513 |
-| dBias reduction | 686-765 | Warps 0-3 | 3316 |
-| teardown | 1960-1985 | Warps 0-3 | 1967-1981 |
+| specialization and launch | 123-345, 416-566 | Static specialization | 14, 38-39 |
+| shared storage, mbarrier init | 568-611, 1189-1250 | Storage and synchronization | 118-243 |
+| init fence, CTA barrier, cluster sync | 1245, 1272-1282, 1325-1328 | Storage and synchronization | 232-233, 246-262 |
+| descriptor prefetch | 1166-1172 | Warp 5 | 84-93 |
+| descriptor pre-kernel | 349-414, 617-637 | Optional pre-kernel | separate entry |
+| scheduler warp | 1337-1372 | Warp 7 | 497-729 |
+| A/B TMA warp | 1374-1495 | Warp 5 | 863-978 |
+| MMA warp | 1500-1599 | Warp 4 | 1107-1408 |
+| TMEM allocation | 1604-1613 | Warps 0-3 | 1427-1431 |
+| C s2r and release | 1770-1787 | Warps 0-3 | 1651-1729 |
+| activations | 766-942, 944-1083 | Warps 0-3 | 1978 onward |
+| dprob packed reduction | 1808-1829 | Warps 0-3 | `.loc 1 1817` |
+| D convert and store | 1853-1930 | Warps 0-3 | 3325-3452 |
+| dBias reduction | 686-765 | Warps 0-3 | 2843-3316 |
+| accumulator release | 1935-1937 | Warps 0-3 | 3465 |
+| dprob flush | 1950-1955 | Warps 0-3 | 3513 |
+| teardown | 1960-1967 | Warps 0-3 | 3524-3556 |
+| C-load warp | 1971-2044 | Warp 6 | 3643-3776 |
+| stage solve | 2244-2282 | Anchor values | n/a |
 
 ## Out of scope
 
@@ -489,8 +604,8 @@ Unreachable in this port's domain, with the predicate that excludes each:
 - every scale-factor, quantization, amax and `dsituglu` path — absent from the
   bf16 source entirely (`sfa|sfb|SFD|amax` occurs 353 times in the block-scaled
   sibling and **0** times here);
-- `store_d_directly` and its `stg_256` path — the source hard-codes the flag
-  false (`:202`), so the 256-bit STG epilogue is dead code;
-- `epilogue_prefetch_more` — hard-coded false (`:328`);
-- a `prob`-less call — `generate_dprob` is unconditionally true (`:329`) and the
+- `store_d_directly` and its `stg_256` path — hard-coded false (`:203`), so the
+  256-bit STG epilogue is dead code;
+- `epilogue_prefetch_more` — hard-coded false (`:324`);
+- a `prob`-less call — `generate_dprob` is unconditionally true (`:325`) and the
   host API rejects a missing `prob`/`dprob` pair.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ list.
   [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py),
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
 - **Grouped GEMM:**
-  [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
+  [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
+  [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),

--- a/tests/lint/check_moe_grouped_gemm_dglu_dbias_no_tile.py
+++ b/tests/lint/check_moe_grouped_gemm_dglu_dbias_no_tile.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Reject tile primitives in every MoE BF16 dGLU specialization.
+
+A discrete-weight or dynamically scheduled specialization builds two entries --
+a descriptor pre-kernel and the main kernel -- so the IR scan walks the whole
+launch sequence rather than a single body.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import check_gdn_decode_bf16_wide_vec_t1_no_tile as no_tile
+
+from tirx_kernels.cudnn.dglu import moe_grouped_gemm_dglu_dbias as target
+
+no_tile.target = target
+no_tile.TARGET = no_tile.REPO / "tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py"
+
+
+def _ir_findings() -> list:
+    findings = []
+    for config in target.CONFIGS:
+        label = str(config["label"])
+        for index, func in enumerate(target.get_kernel(**config)):
+            scanner = no_tile._IRScanner(f"CONFIGS[{label!r}] entry {index}")
+            scanner(func.body)
+            findings.extend(scanner.findings)
+    return findings
+
+
+no_tile._ir_findings = _ir_findings
+
+
+if __name__ == "__main__":
+    sys.exit(no_tile.main())

--- a/tirx_kernels/bench_suite/config/cudnn/dglu/cudnn_sm100_moe_grouped_gemm_dglu_dbias.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/dglu/cudnn_sm100_moe_grouped_gemm_dglu_dbias.yaml
@@ -1,0 +1,48 @@
+# Complete deterministic performance-path covering matrix for the cuDNN Frontend
+# MoE BF16 grouped GEMM + dGLU backward port.
+kernel: cudnn_sm100_moe_grouped_gemm_dglu_dbias
+selection_rationale: The selected defaults sweep the headline production mode (dense weights, static scheduling, dSwiGLU, BF16 C and D, k-major B, 256x256 tile, 2x1 cluster, packed-f32 epilogue, dBias on) across small/medium/large MoE shapes, while the complete matrix covers every weight mode, scheduler, activation, C/D dtype, B major, tile, cluster and optional-output path the port gate requires, plus the upstream benchmark's own expert/token/K sweep.
+configs:
+  - {config: perf00_e4_t4096_n2048_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: true, selection_role: small}
+  - {config: perf00_e8_t16384_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: true, selection_role: medium}
+  - {config: perf00_e8_t32768_n4096_k7168_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: true, selection_role: large}
+  - {config: perf01_e4_t4096_n2048_k2048_dndy_ge_cf16_df16_bn_t128x256_c2x8_s, default: false}
+  - {config: perf01_e8_t16384_n4096_k8192_dndy_ge_cf16_df16_bn_t128x256_c2x8_s, default: false}
+  - {config: perf01_e8_t32768_n4096_k7168_dndy_ge_cf16_df16_bn_t128x256_c2x8_s, default: false}
+  - {config: perf02_e4_t4096_n2048_k2048_dcst_ge_cf32_df32_bn_t256x256_c2x2_s, default: false}
+  - {config: perf02_e8_t16384_n4096_k8192_dcst_ge_cf32_df32_bn_t256x256_c2x2_s, default: false}
+  - {config: perf02_e8_t32768_n4096_k7168_dcst_ge_cf32_df32_bn_t256x256_c2x2_s, default: false}
+  - {config: perf03_e4_t4096_n2048_k2048_dnst_sw_cbf16_dbf16_bk_t128x64_c1x1_vb, default: false}
+  - {config: perf03_e8_t16384_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t128x64_c1x1_vb, default: false}
+  - {config: perf03_e8_t32768_n4096_k7168_dnst_sw_cbf16_dbf16_bk_t128x64_c1x1_vb, default: false}
+  - {config: perf04_e4_t4096_n2048_k2048_dnst_sw_cf32_df32_bk_t128x256_c2x4_s, default: false}
+  - {config: perf04_e8_t16384_n4096_k8192_dnst_sw_cf32_df32_bk_t128x256_c2x4_s, default: false}
+  - {config: perf04_e8_t32768_n4096_k7168_dnst_sw_cf32_df32_bk_t128x256_c2x4_s, default: false}
+  - {config: perf05_e4_t4096_n2048_k2048_dnst_sw_cf16_df16_bk_t128x256_c1x4_sb, default: false}
+  - {config: perf05_e8_t16384_n4096_k8192_dnst_sw_cf16_df16_bk_t128x256_c1x4_sb, default: false}
+  - {config: perf05_e8_t32768_n4096_k7168_dnst_sw_cf16_df16_bk_t128x256_c1x4_sb, default: false}
+  - {config: perf06_e4_t4096_n2048_k2048_dnst_sw_cbf16_dbf16_bk_t128x256_c1x16_vb, default: false}
+  - {config: perf06_e8_t16384_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t128x256_c1x16_vb, default: false}
+  - {config: perf06_e8_t32768_n4096_k7168_dnst_sw_cbf16_dbf16_bk_t128x256_c1x16_vb, default: false}
+  - {config: perf07_e4_t4096_n2048_k2048_dnst_ge_cf32_df16_bk_t128x256_c1x2_v, default: false}
+  - {config: perf07_e8_t16384_n4096_k8192_dnst_ge_cf32_df16_bk_t128x256_c1x2_v, default: false}
+  - {config: perf07_e8_t32768_n4096_k7168_dnst_ge_cf32_df16_bk_t128x256_c1x2_v, default: false}
+  - {config: perf08_e4_t4096_n2048_k2048_dndy_sw_cf16_df16_bk_t128x256_c1x8_s, default: false}
+  - {config: perf08_e8_t16384_n4096_k8192_dndy_sw_cf16_df16_bk_t128x256_c1x8_s, default: false}
+  - {config: perf08_e8_t32768_n4096_k7168_dndy_sw_cf16_df16_bk_t128x256_c1x8_s, default: false}
+  - {config: sweep00_e4_t2048_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t2048_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t4096_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t4096_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t8192_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t8192_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t16384_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e4_t16384_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t4096_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t4096_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t8192_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t8192_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t16384_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t16384_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t32768_n4096_k2048_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}
+  - {config: sweep00_e8_t32768_n4096_k8192_dnst_sw_cbf16_dbf16_bk_t256x256_c2x1_vb, default: false}

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/__init__.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
@@ -36,7 +36,7 @@ def prepare_data(**config):
     """Allocate one input set plus per-implementation output sets."""
     import torch
 
-    derived = _spec.derive(config)
+    derived = _spec.derive_for_config(config)
     L, N, K = derived["L"], derived["N"], derived["K"]
     M = derived["tokens_total"]
     device = "cuda"
@@ -79,16 +79,18 @@ def prepare_data(**config):
                 else None
             ),
             "workspace": (
-                torch.zeros(derived["workspace_bytes"] + 128, dtype=torch.uint8, device=device)
+                torch.zeros(derived["workspace_bytes"], dtype=torch.uint8, device=device)
                 if derived["workspace_bytes"]
                 else None
             ),
         }
 
-    # (N, K, L) views of the same values, one k-major and one n-major, so a
-    # specialization can be handed the layout its ``b_major`` promises.
-    b_kmajor = b.permute(1, 2, 0)
-    b_nmajor = b.permute(0, 2, 1).contiguous().permute(2, 1, 0)
+    # The dense weight image, in the storage order this specialization's
+    # ``b_major`` promises: (L, N, K) when K is contiguous and (L, K, N) when N
+    # is. The reference takes an (N, K, L) view of the same bytes; the port
+    # takes them flat and reads the extents out of its tensor map.
+    b_dense = b.contiguous() if config["b_major"] == "k" else b.permute(0, 2, 1).contiguous()
+    b_view = b_dense.permute(1, 2, 0) if config["b_major"] == "k" else b_dense.permute(2, 1, 0)
 
     b_ptrs = None
     b_experts = None
@@ -106,8 +108,8 @@ def prepare_data(**config):
         "derived": derived,
         "a": a,
         "b": b,
-        "b_kmajor": b_kmajor,
-        "b_nmajor": b_nmajor,
+        "b_dense": b_dense,
+        "b_view": b_view,
         "b_ptrs": b_ptrs,
         "b_experts": b_experts,
         "c": c,
@@ -172,10 +174,20 @@ def reference_outputs(data):
                     ref * sigmoid * (1 + 1.702 * gate * (1 - sigmoid)) * (up + linear_offset) * p
                 )
                 d_up = ref * gate * sigmoid * p
+                # Upstream's gradient filters scale by a *value*, not by a 0/1
+                # mask, and its two arms disagree above the upper bound: the
+                # packed one runs the tests in an order that leaves the upper
+                # bound inert on the up branch -- a value above +7 zeroes the
+                # intermediate, and zero passes the lower test -- while the
+                # scalar one applies both. Each specialization is held to the
+                # arm its ``vectorized_f32`` selects.
                 gate_filter = torch.where(gate_raw > 7.0, torch.zeros_like(gate_raw), gate_raw)
-                up_filter = torch.where(
-                    (up_raw > 7.0) | (up_raw < -7.0), torch.zeros_like(up_raw), up_raw
-                )
+                if config["vectorized_f32"]:
+                    up_filter = torch.where(up_raw < -7.0, torch.zeros_like(up_raw), up)
+                else:
+                    up_filter = torch.where(
+                        (up_raw > 7.0) | (up_raw < -7.0), torch.zeros_like(up_raw), up_raw
+                    )
                 d_gate = d_gate * gate_filter
                 d_up = d_up * up_filter
 
@@ -316,7 +328,7 @@ def compile_reference(data):
     )
     # ``b`` is (N, K, L) either way; only which extent is contiguous differs, and
     # the leading dimension the DSL is told about must actually carry stride 1.
-    b_dense = data["b_kmajor"] if b_major == "k" else data["b_nmajor"]
+    b_dense = data["b_view"]
     b_argument = (
         dlpack(data["b_ptrs"], align=8).iterator
         if discrete
@@ -375,14 +387,62 @@ def compile_reference(data):
 
 
 def tirx_launch(executables, data):
-    """Bind the compiled TIRx entries to this input set.
+    """Bind the TIRx entries' flat byte-array ABI to this input set.
 
-    The argument order is the kernel ABI, which the kernel-sketch stage fixes.
+    ``executables`` is one compiled module per PrimFunc that ``get_kernel``
+    returned: the optional descriptor pre-kernel followed by the main kernel,
+    launched in that order on the same stream exactly as the upstream
+    ``__call__`` launches them.
     """
-    raise NotImplementedError(
-        "the TIRx launch ABI is defined by the kernel-sketch stage; the kernel body "
-        "is still the scaffold placeholder"
-    )
+    import torch
+
+    config = data["config"]
+    derived = data["derived"]
+    outputs = data["tirx"]
+    if not isinstance(executables, list | tuple):
+        executables = [executables]
+    discrete = config["weight_mode"] == "discrete"
+
+    def raw(tensor):
+        return tensor.view(torch.uint8).reshape(-1)
+
+    helper_arguments = None
+    if derived["needs_helper"]:
+        # The dense branch has no pointer array; the helper only resets the
+        # scheduler counter there, and its first parameter is an int32 stand-in.
+        helper_arguments = [
+            data["b_ptrs"] if discrete else data["padded_offsets"],
+            outputs["workspace"],
+        ]
+    main_arguments = [
+        raw(data["a"]),
+        data["b_ptrs"] if discrete else raw(data["b_dense"]),
+        raw(data["c"]),
+        raw(outputs["d"]),
+        data["padded_offsets"],
+        data["alpha"],
+        data["beta"],
+        # The launch ABI takes these flat; the (rows, 1, 1) shape is the upstream
+        # tensor contract, not the kernel's.
+        data["prob"].reshape(-1),
+        outputs["dprob"].reshape(-1),
+    ]
+    if derived["generate_dbias"]:
+        main_arguments.append(raw(outputs["dbias"]))
+    if outputs["workspace"] is not None:
+        main_arguments.append(outputs["workspace"])
+
+    if helper_arguments is None:
+        calls = [(executables[-1], main_arguments)]
+    else:
+        calls = [(executables[0], helper_arguments), (executables[-1], main_arguments)]
+
+    def launch():
+        for executable, arguments in calls:
+            executable(*arguments)
+
+    launch._keep_alive = (executables, main_arguments, helper_arguments)
+    return launch
 
 
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
@@ -85,10 +85,18 @@ def prepare_data(**config):
             ),
         }
 
+    # (N, K, L) views of the same values, one k-major and one n-major, so a
+    # specialization can be handed the layout its ``b_major`` promises.
+    b_kmajor = b.permute(1, 2, 0)
+    b_nmajor = b.permute(0, 2, 1).contiguous().permute(2, 1, 0)
+
     b_ptrs = None
     b_experts = None
     if config["weight_mode"] == "discrete":
-        b_experts = [b[i].contiguous() for i in range(L)]
+        b_experts = [
+            b[i].contiguous() if config["b_major"] == "k" else b[i].t().contiguous().t()
+            for i in range(L)
+        ]
         b_ptrs = torch.tensor(
             [int(t.data_ptr()) for t in b_experts], dtype=torch.int64, device=device
         )
@@ -98,6 +106,8 @@ def prepare_data(**config):
         "derived": derived,
         "a": a,
         "b": b,
+        "b_kmajor": b_kmajor,
+        "b_nmajor": b_nmajor,
         "b_ptrs": b_ptrs,
         "b_experts": b_experts,
         "c": c,
@@ -304,7 +314,9 @@ def compile_reference(data):
         if workspace is not None
         else cute.runtime.nullptr(dtype=cutlass.Uint8, assumed_align=128)
     )
-    b_dense = data["b"].permute(1, 2, 0)
+    # ``b`` is (N, K, L) either way; only which extent is contiguous differs, and
+    # the leading dimension the DSL is told about must actually carry stride 1.
+    b_dense = data["b_kmajor"] if b_major == "k" else data["b_nmajor"]
     b_argument = (
         dlpack(data["b_ptrs"], align=8).iterator
         if discrete

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
@@ -1,0 +1,442 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Tensors, FP32 oracle and upstream reference for the BF16 dGLU+dBias port.
+
+One input set is shared by TIRx, the upstream kernel and the oracle, with a
+separate output set per implementation so the three can be compared directly.
+"""
+
+import importlib
+import importlib.machinery
+import os
+import sys
+import types
+from functools import cache
+
+from . import spec as _spec
+
+_REFERENCE_PACKAGE = "tirx_cudnn_frontend_grouped"
+
+_TORCH_DTYPES = {"bfloat16": "bfloat16", "float16": "float16", "float32": "float32"}
+
+
+def _torch_dtype(torch, name):
+    return getattr(torch, _TORCH_DTYPES[name])
+
+
+# ---------------------------------------------------------------------------
+# Input construction
+# ---------------------------------------------------------------------------
+
+
+def prepare_data(**config):
+    """Allocate one input set plus per-implementation output sets."""
+    import torch
+
+    derived = _spec.derive(config)
+    L, N, K = derived["L"], derived["N"], derived["K"]
+    M = derived["tokens_total"]
+    device = "cuda"
+    torch.manual_seed(20260826 + M + N + K + L)
+
+    ab = torch.bfloat16
+    c_dtype = _torch_dtype(torch, config["c_dtype"])
+    d_dtype = _torch_dtype(torch, config["d_dtype"])
+
+    a = (torch.randn(M, K, device=device) * 0.125).to(ab)
+    b = (torch.randn(L, N, K, device=device) * 0.125).to(ab)
+    c = (torch.randn(M, 2 * N, device=device) * 0.5).to(c_dtype)
+
+    # Probe the activation clamps: dGeGLU masks gradients outside +-7 after the
+    # beta scale, so seed values that straddle the boundary on both branches.
+    beta = torch.empty(L, dtype=torch.float32, device=device).uniform_(-1.5, 1.5)
+    beta[beta.abs() < 0.25] = 1.5
+    alpha = torch.empty(L, dtype=torch.float32, device=device).uniform_(-1.25, 1.25)
+    alpha[alpha.abs() < 0.25] = 0.75
+    begin = 0
+    for expert, rows in enumerate(config["group_m_list"]):
+        if rows == 0:
+            continue
+        scale = float(beta[expert])
+        for column, value in ((0, 8.5), (1, -8.5), (32, 8.25), (33, -8.25)):
+            if column < 2 * N:
+                c[begin, column] = value / scale
+        begin += _spec.align_up(rows, _spec.FIX_PAD_SIZE)
+
+    prob = torch.linspace(-0.75, 0.875, M, device=device, dtype=torch.float32)
+    padded_offsets = torch.tensor(derived["padded_offsets"], dtype=torch.int32, device=device)
+
+    def outputs():
+        return {
+            "d": torch.zeros(M, 2 * N, dtype=d_dtype, device=device),
+            "dprob": torch.zeros(M, dtype=torch.float32, device=device),
+            "dbias": (
+                torch.zeros(L, 2 * N, dtype=torch.bfloat16, device=device)
+                if config["with_dbias"]
+                else None
+            ),
+            "workspace": (
+                torch.zeros(derived["workspace_bytes"] + 128, dtype=torch.uint8, device=device)
+                if derived["workspace_bytes"]
+                else None
+            ),
+        }
+
+    b_ptrs = None
+    b_experts = None
+    if config["weight_mode"] == "discrete":
+        b_experts = [b[i].contiguous() for i in range(L)]
+        b_ptrs = torch.tensor(
+            [int(t.data_ptr()) for t in b_experts], dtype=torch.int64, device=device
+        )
+
+    return {
+        "config": dict(config),
+        "derived": derived,
+        "a": a,
+        "b": b,
+        "b_ptrs": b_ptrs,
+        "b_experts": b_experts,
+        "c": c,
+        "alpha": alpha,
+        "beta": beta,
+        "prob": prob,
+        "padded_offsets": padded_offsets,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# FP32 oracle
+# ---------------------------------------------------------------------------
+
+
+def reference_outputs(data):
+    """FP32 reference for D, dprob and dbias, following the upstream formulas."""
+    import torch
+
+    config = data["config"]
+    derived = data["derived"]
+    L, N = derived["L"], derived["N"]
+    two_n = 2 * N
+    act = config["act"]
+    linear_offset = config["linear_offset"]
+
+    a, b, c = data["a"], data["b"], data["c"]
+    alpha, beta, prob = data["alpha"], data["beta"], data["prob"]
+    M = a.shape[0]
+    device = a.device
+
+    d = torch.zeros(M, two_n, dtype=torch.float32, device=device)
+    dprob = torch.zeros(M, dtype=torch.float32, device=device)
+    dbias = torch.zeros(L, two_n, dtype=torch.float32, device=device)
+
+    begin = 0
+    for expert, rows in enumerate(config["group_m_list"]):
+        end = begin + rows
+        if rows:
+            scale = float(alpha[expert])
+            ref = (a[begin:end].float() * scale) @ (b[expert].float() * scale).t()
+            scaled = c[begin:end].float() * float(beta[expert])
+            blocks = scaled.view(rows, two_n // 32, 32)
+            gate_raw = blocks[:, 0::2, :].reshape(rows, N)
+            up_raw = blocks[:, 1::2, :].reshape(rows, N)
+            p = prob[begin:end].view(-1, 1)
+
+            if act == "dswiglu":
+                sigmoid = torch.sigmoid(gate_raw)
+                swish = gate_raw * sigmoid
+                terms = swish * up_raw * ref
+                d_gate = ref * p * up_raw * sigmoid * (1 + gate_raw * (1 - sigmoid))
+                d_up = ref * p * swish
+            else:
+                gate = torch.clamp(gate_raw, max=7.0)
+                up = torch.clamp(up_raw, -7.0, 7.0)
+                sigmoid = torch.sigmoid(1.702 * gate)
+                terms = gate * sigmoid * (up + linear_offset) * ref
+                d_gate = (
+                    ref * sigmoid * (1 + 1.702 * gate * (1 - sigmoid)) * (up + linear_offset) * p
+                )
+                d_up = ref * gate * sigmoid * p
+                gate_filter = torch.where(gate_raw > 7.0, torch.zeros_like(gate_raw), gate_raw)
+                up_filter = torch.where(
+                    (up_raw > 7.0) | (up_raw < -7.0), torch.zeros_like(up_raw), up_raw
+                )
+                d_gate = d_gate * gate_filter
+                d_up = d_up * up_filter
+
+            # dprob follows the kernel's 32-column subtile reduction order.
+            chunks = terms.split(32, dim=1)
+            dprob[begin:end] = torch.cat(
+                [chunk.sum(dim=1, keepdim=True) for chunk in chunks], dim=1
+            ).sum(dim=1)
+
+            rows_out = torch.zeros(rows, two_n // 32, 32, dtype=torch.float32, device=device)
+            rows_out[:, 0::2, :] = d_gate.view(rows, N // 32, 32)
+            rows_out[:, 1::2, :] = d_up.view(rows, N // 32, 32)
+            block = rows_out.view(rows, two_n)
+            d[begin:end] = block
+            dbias[expert] = block.sum(dim=0)
+        begin += _spec.align_up(rows, _spec.FIX_PAD_SIZE)
+
+    return {"d": d, "dprob": dprob, "dbias": dbias}
+
+
+# ---------------------------------------------------------------------------
+# Upstream kernel as reference
+# ---------------------------------------------------------------------------
+
+
+@cache
+def load_reference_source():
+    """Import the upstream kernel without executing the cuDNN API package.
+
+    The kernel and its scheduler/util siblings import only cutlass and each
+    other, so a synthetic package rooted at ``cutedsl/grouped`` resolves their
+    relative imports while ``dglu/__init__.py`` -- which pulls in the compiled
+    ``cudnn`` extension -- is never run.
+    """
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
+    grouped = os.path.join(root, "python/cudnn/gemm/cutedsl/grouped")
+    if not os.path.isdir(grouped):
+        raise RuntimeError(f"cannot find the grouped GEMM sources under {grouped}")
+    for name, path in (
+        (_REFERENCE_PACKAGE, grouped),
+        (f"{_REFERENCE_PACKAGE}.dglu", os.path.join(grouped, "dglu")),
+    ):
+        if name in sys.modules:
+            continue
+        module = types.ModuleType(name)
+        module.__path__ = [path]
+        module.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
+        module.__spec__.submodule_search_locations = [path]
+        sys.modules[name] = module
+    return importlib.import_module(f"{_REFERENCE_PACKAGE}.dglu.moe_grouped_gemm_dglu_dbias")
+
+
+def _rebind_submodules(package):
+    """Re-attach already-loaded submodules to a freshly re-executed package."""
+    prefix = package.__name__ + "."
+    for name, module in list(sys.modules.items()):
+        if not name.startswith(prefix) or module is None:
+            continue
+        child = name[len(prefix) :]
+        if "." in child:
+            continue
+        if getattr(package, child, None) is not module:
+            setattr(package, child, module)
+    return package
+
+
+def import_cutlass_reference():
+    """Recover from CuTeDSL's non-idempotent generated builder imports."""
+    try:
+        return _rebind_submodules(importlib.import_module("cutlass"))
+    except RuntimeError as exc:
+        message = str(exc)
+        if "Attribute builder for '" not in message or "is already registered" not in message:
+            raise
+        mlir_ir = sys.modules.get("cutlass._mlir.ir")
+        if mlir_ir is None:
+            raise
+        register_attribute_builder = mlir_ir.register_attribute_builder
+
+        def register_replacing_builder(kind, replace=False):
+            del replace
+            return register_attribute_builder(kind, replace=True)
+
+        mlir_ir.register_attribute_builder = register_replacing_builder
+        try:
+            return _rebind_submodules(importlib.import_module("cutlass"))
+        finally:
+            mlir_ir.register_attribute_builder = register_attribute_builder
+
+
+def compile_reference(data):
+    """Compile the upstream kernel over this input set and return a no-arg launch."""
+    cutlass = import_cutlass_reference()
+    import cutlass.cute as cute
+    import torch
+    from cuda.bindings import driver as cuda
+    from cutlass.cute.nvgpu import OperandMajorMode
+    from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+    if os.environ.get("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0") != "0":
+        raise RuntimeError("CUDNNFE_CLUSTER_OVERLAP_MARGIN must be 0")
+
+    module = load_reference_source()
+    config = data["config"]
+    derived = data["derived"]
+    outputs = data["source"]
+    discrete = config["weight_mode"] == "discrete"
+    N, K, M = derived["N"], derived["K"], derived["tokens_total"]
+
+    kernel = module.MoEGroupedGemmDgluDbiasBf16Kernel(
+        acc_dtype=cutlass.Float32,
+        use_2cta_instrs=derived["use_2cta"],
+        mma_tiler_mn=tuple(config["mma_tiler_mn"]),
+        cluster_shape_mn=tuple(config["cluster_shape_mn"]),
+        vectorized_f32=config["vectorized_f32"],
+        expert_cnt=derived["L"],
+        weight_mode=module.MoEWeightMode.DISCRETE if discrete else module.MoEWeightMode.DENSE,
+        use_dynamic_sched=config["sched"] == "dynamic",
+        act_func=config["act"],
+    )
+
+    def dlpack(tensor, *, leading_dim=None, align=16):
+        wrapped = from_dlpack(tensor, assumed_align=align)
+        if leading_dim is not None:
+            wrapped = wrapped.mark_layout_dynamic(leading_dim=leading_dim)
+        return wrapped
+
+    b_major = config["b_major"]
+    b_major_mode = OperandMajorMode.K if b_major == "k" else OperandMajorMode.MN
+    b_stride_size = K if b_major == "k" else N
+    workspace = outputs["workspace"]
+    workspace_argument = (
+        dlpack(workspace, align=128).iterator
+        if workspace is not None
+        else cute.runtime.nullptr(dtype=cutlass.Uint8, assumed_align=128)
+    )
+    b_dense = data["b"].permute(1, 2, 0)
+    b_argument = (
+        dlpack(data["b_ptrs"], align=8).iterator
+        if discrete
+        else dlpack(b_dense, leading_dim=1 if b_major == "k" else 0)
+    )
+    dbias = outputs["dbias"]
+
+    arguments = {
+        "a": dlpack(data["a"].unsqueeze(-1), leading_dim=1),
+        "b": b_argument,
+        "n": cutlass.Int32(N),
+        "k": cutlass.Int32(K),
+        "b_stride_size": cutlass.Int64(b_stride_size),
+        "b_major_mode": b_major_mode,
+        "workspace_ptr": workspace_argument,
+        "c": dlpack(data["c"].unsqueeze(-1), leading_dim=1),
+        "d": dlpack(outputs["d"].unsqueeze(-1), leading_dim=1),
+        "padded_offsets": dlpack(data["padded_offsets"]),
+        "alpha": dlpack(data["alpha"]),
+        "beta": dlpack(data["beta"]),
+        "prob": dlpack(data["prob"].view(M, 1, 1)),
+        "dprob": dlpack(outputs["dprob"].view(M, 1, 1)),
+        "linear_offset": cutlass.Float32(config["linear_offset"]),
+        "dbias_tensor": dlpack(dbias.unsqueeze(-1)) if dbias is not None else None,
+        "max_active_clusters": derived["grid"][2],
+        "stream": make_fake_stream(use_tvm_ffi_env_stream=False),
+    }
+    executable = cute.compile(kernel, **arguments, options="--enable-tvm-ffi")
+
+    # ``b`` and ``workspace_ptr`` lower to raw device pointers, so the runtime call
+    # takes addresses where the compile-time call took cute iterators.
+    runtime = [
+        data["a"].unsqueeze(-1),
+        int(data["b_ptrs"].data_ptr()) if discrete else b_dense,
+        N,
+        K,
+        b_stride_size,
+        int(workspace.data_ptr()) if workspace is not None else 0,
+        data["c"].unsqueeze(-1),
+        outputs["d"].unsqueeze(-1),
+        data["padded_offsets"],
+        data["alpha"],
+        data["beta"],
+        data["prob"].view(M, 1, 1),
+        outputs["dprob"].view(M, 1, 1),
+        config["linear_offset"],
+        dbias.unsqueeze(-1) if dbias is not None else None,
+    ]
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        executable(*runtime, stream)
+
+    launch._keep_alive = (executable, runtime, stream, data.get("b_experts"))
+    return launch
+
+
+def tirx_launch(executables, data):
+    """Bind the compiled TIRx entries to this input set.
+
+    The argument order is the kernel ABI, which the kernel-sketch stage fixes.
+    """
+    raise NotImplementedError(
+        "the TIRx launch ABI is defined by the kernel-sketch stage; the kernel body "
+        "is still the scaffold placeholder"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+# Upstream ``assert_grouped_gemm_dglu_close`` tolerances for D and dprob.
+_RTOL = 3e-2
+_ATOL = 8e-2
+# Upstream ``assert_grouped_gemm_dglu_dbias_close``: the bf16 atomic tree makes the
+# reduction order unstable, so the bound scales with the number of contributions.
+_DBIAS_RTOL = 1e-2
+_DBIAS_SCALE = 0.008
+
+
+def _dbias_atol(expected, tiles):
+    peak = float(expected.abs().max()) if expected.numel() else 0.0
+    return max(peak * _DBIAS_SCALE * (tiles**0.5), 0.1)
+
+
+def validate_outputs(data, *, sources=("tirx",), with_oracle=True):
+    """Compare the named output sets with each other and with the FP32 oracle."""
+    import torch
+
+    derived = data["derived"]
+    expected = reference_outputs(data) if with_oracle else None
+    tiles = max(derived["tokens_total"] // 128, 1)
+
+    for source in sources:
+        outputs = data[source]
+        for name in ("d", "dprob", "dbias"):
+            got = outputs.get(name)
+            if got is None:
+                continue
+            if not torch.isfinite(got.float()).all():
+                raise AssertionError(f"{source}.{name} has non-finite entries")
+        if expected is None:
+            continue
+        for name in ("d", "dprob"):
+            got = outputs[name].float()
+            want = expected[name].to(got.dtype)
+            if not torch.allclose(got, want, rtol=_RTOL, atol=_ATOL):
+                worst = (got - want).abs().max()
+                raise AssertionError(f"{source}.{name} differs from the oracle: max {worst:.4g}")
+        if outputs["dbias"] is not None:
+            got = outputs["dbias"].float()
+            want = expected["dbias"].to(torch.bfloat16).float()
+            atol = _dbias_atol(want, tiles)
+            if not torch.allclose(got, want, rtol=_DBIAS_RTOL, atol=atol):
+                worst = (got - want).abs().max()
+                raise AssertionError(
+                    f"{source}.dbias differs from the oracle: max {worst:.4g} > {atol:.4g}"
+                )
+
+    if len(sources) > 1:
+        first, *rest = sources
+        for other in rest:
+            for name in ("d", "dprob", "dbias"):
+                left = data[first].get(name)
+                right = data[other].get(name)
+                if left is None or right is None:
+                    continue
+                atol = _dbias_atol(right.float(), tiles) if name == "dbias" else _ATOL
+                rtol = _DBIAS_RTOL if name == "dbias" else _RTOL
+                if not torch.allclose(left.float(), right.float(), rtol=rtol, atol=atol):
+                    worst = (left.float() - right.float()).abs().max()
+                    raise AssertionError(
+                        f"{first}.{name} and {other}.{name} disagree: max {worst:.4g}"
+                    )

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
@@ -37,8 +37,6 @@ import tirx_kernels.kern as K
 
 from . import spec
 
-_TRY_WAIT_TICKS = 0x989680  # 10,000,000, the source's mbarrier spin bound
-
 # dGeGLU's constants are literals in the bf16 source rather than parameters:
 # `sigmoid(1.702 * clamp(gate, max=7))` and `clamp(up, -7, 7)`.
 GEGLU_ALPHA = 1.702
@@ -87,15 +85,21 @@ def _try_wait_acquire(dst, barrier, phase):
 def _wait_plain(barrier, phase):
     """Spin on one mbarrier until its phase flips.
 
-    The blocking form, carrying the source's suspend-time hint. Twenty-nine of
-    these in the anchor export against four hintless peeks, and the hint is a
-    per-kernel constant read off that export rather than a knob.
+    The retry takes the hintless `try_wait`, the form the reference reserves for
+    its look-ahead peeks. Given the suspend-time hint the reference carries at
+    its 29 blocking acquires, ptxas expands the wait inline around a
+    `NANOSLEEP.SYNCS 0x989680` -- four instructions, with the sleep and a
+    re-check standing between the barrier and the load that depends on it.
+    Without the hint it emits a two-instruction check and moves the retry out of
+    line, so the dependent load issues directly behind the branch.
+
+    This kernel runs one CTA per multiprocessor, so a sleeping warp has nothing
+    to yield to and the sleep buys nothing the two extra instructions on every
+    handshake do not cost back.
     """
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(ready == K.uint32(0)):
-        K.ptx.mbarrier.try_wait.parity.shared.b64(
-            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
-        )
+        _try_wait_acquire(ready, barrier, phase)
 
 
 def _wait_plain_if_needed(barrier, phase, speculative_ready):
@@ -1803,19 +1807,9 @@ def _make_kernel(
                             K.assign(rC1[span[half]], d_gate[half])
                             K.assign(rC2[span[half]], d_up[half])
 
-                    # The dBias transpose is staged straight out of the gradient
-                    # registers, before the dProb fold, and its reduction runs
-                    # after -- the order `dbias_reduction` is called in and the
-                    # order the export's barriers appear in.
-                    if generate_dbias:
-                        dbias_transpose()
-
                     folded_prob = K.local_scalar("float32")
                     K.ptx["add.f32"](folded_prob, dprob_pair[0], dprob_pair[1])
                     K.ptx["add.f32"](dprob_acc, dprob_acc, folded_prob)
-
-                    if generate_dbias:
-                        dbias_reduce(real_subtile, d_tile_base)
 
                     # ---- convert D and stage it through SMEM -------------
                     _pack_output(rD1, rC1, d_dtype, d_bits)
@@ -1884,6 +1878,17 @@ def _make_kernel(
                                     K.uint64(0),
                                 )
                         K.ptx["cp.async.bulk.commit_group"]()
+                    # The dBias column sums are taken with the tile's D store
+                    # already in flight. They read the activation fragments,
+                    # which the packing only copied, and they touch their own
+                    # shared region, so nothing in them depends on the store.
+                    # The placement has to be after the *barrier* that precedes
+                    # the store, not merely after the shared writes: ptxas is
+                    # free to hoist across plain stores and is not free to hoist
+                    # across `bar.sync`, so the earlier position bought nothing.
+                    if generate_dbias:
+                        dbias_transpose()
+                        dbias_reduce(real_subtile, d_tile_base)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     K.assign(real_subtile, real_subtile + K.int32(1))
                     K.assign(subtile, subtile + K.int32(1))

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
@@ -74,6 +74,11 @@ def _elected():
 
 
 def _try_wait_acquire(dst, barrier, phase):
+    """The non-blocking look-ahead peek: acquire scope, and no suspend hint.
+
+    Four of these in the anchor export, at `PTX 863, 919, 1170, 1241`; their
+    status predicates the blocking acquire that follows.
+    """
     K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
         dst, barrier, K.cast(phase, "uint32")
     )
@@ -82,19 +87,15 @@ def _try_wait_acquire(dst, barrier, phase):
 def _wait_plain(barrier, phase):
     """Spin on one mbarrier until its phase flips.
 
-    The retry takes the hintless `try_wait` -- the same form the source's own
-    hot waits use. Given a suspend-time hint, ptxas expands the wait inline into
-    four instructions: the check, a `NANOSLEEP`, a second check and the branch.
-    That is where 48.6% of this port's not-issued samples were parked, against
-    12.8% for the reference, and it puts three instructions between the barrier
-    and the load that depends on it. Without the hint the wait is two
-    instructions -- the check and one predicated branch to an out-of-line retry
-    -- and the export shows the reference's dependent `LDS.128` issuing directly
-    behind its branch.
+    The blocking form, carrying the source's suspend-time hint. Twenty-nine of
+    these in the anchor export against four hintless peeks, and the hint is a
+    per-kernel constant read off that export rather than a knob.
     """
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(ready == K.uint32(0)):
-        _try_wait_acquire(ready, barrier, phase)
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
 
 
 def _wait_plain_if_needed(barrier, phase, speculative_ready):
@@ -324,12 +325,11 @@ def _descriptor_with_address(base, shared_address):
     return K.bitwise_or(K.uint64(base), address_field)
 
 
-_TMA_G2S_3D = (
-    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
-    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+_TMA_G2S_3D_CTA = (
+    "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
 )
-_TMA_G2S_4D = (
-    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+_TMA_G2S_3D_CLUSTER = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
     ".mbarrier::complete_tx::bytes.L2::cache_hint"
 )
 _TMA_MCAST = ".multicast::cluster"
@@ -338,10 +338,16 @@ _TMA_MCAST = ".multicast::cluster"
 def _tma_load(destination, descriptor, coords, barrier, mask, *, two_cta, desc_ptr=None):
     """One `cp.async.bulk.tensor` load, multicast only when a mask is given.
 
+    A copy takes the `shared::cluster` stem only when it actually addresses the
+    cluster -- a two-CTA copy, or a multicast one. The anchor export carries two
+    of each stem, its A and B loads against its two C loads;
+    `tile128_c1x1`, whose single-CTA atom sits in a singleton cluster, carries
+    four `shared::cta` and no `shared::cluster` at all.
+
     The two-CTA MMA adds `.cta_group::2`; the multicast form inserts its mask
     modifier before the cache hint, matching the operand order the export shows.
     """
-    stem = _TMA_G2S_3D if len(coords) == 3 else _TMA_G2S_4D
+    stem = _TMA_G2S_3D_CLUSTER if (two_cta or mask is not None) else _TMA_G2S_3D_CTA
     if mask is not None:
         head, _, tail = stem.partition(".mbarrier::complete_tx::bytes")
         stem = head + ".mbarrier::complete_tx::bytes" + _TMA_MCAST + tail
@@ -1227,7 +1233,7 @@ def _make_kernel(
                 _wait_plain(ab_pipe.empty.ptr_to([ab_prod.stage]), ab_prod.phase)
                 ab_prod.advance()
 
-        # ---- Role 3: warp 4, persistent block-scaled MMA ------------------
+        # ---- Role 3: warp 4, persistent MMA -------------------------------
         with mma_role:
             K.ptx.bar.sync(K.uint32(3), K.uint32(160))
             acc_tmem_base = K.local_scalar("uint32")
@@ -1249,9 +1255,6 @@ def _make_kernel(
                     _try_wait_acquire(
                         ab_full_ready, ab_pipe.full.ptr_to([ab_cons.stage]), ab_cons.phase
                     )
-                    # One accumulator mbarrier stage, two TMEM regions: the
-                    # stage index is the producer phase's complement, so
-                    # successive tiles alternate between the strided regions.
                     _wait_plain(acc_pipe.empty.ptr_to([acc_prod.stage]), acc_prod.phase)
                     accumulate = K.local_scalar("uint32", init=K.uint32(0))
                     # Two real accumulator stages, each its own `cta_tile_n`
@@ -1407,7 +1410,6 @@ def _make_kernel(
 
             acc_cons = K.PipelineState(acc_stages, phase=0)
             c_cons = K.PipelineState(c_stages, phase=0)
-            d_prod = K.PipelineState(max(1, d_stages // 2), phase=1)
             epi_info = K.PipelineState(tile_stages, phase=0)
             epi_expert = K.local_scalar("int32")
             epi_tile_m = K.local_scalar("int32")
@@ -1415,40 +1417,33 @@ def _make_kernel(
             epi_slots = (epi_expert, epi_tile_m, epi_tile_n)
 
             # The register tile is walked two elements at a time throughout the
-            # epilogue, and the pairs are always issued packed: one
-            # `mul.rn.f32x2` / `add.rn.f32x2` per pair where the scalar form
-            # issues two, for identical numbers -- each half of a packed line
-            # rounds exactly as its scalar sibling.
-            #
-            # The source only writes packed intrinsics under `vectorized_f32`,
-            # but its scalar branch is packed for it: on a `vectorized_f32=False`
-            # shape the reference still retires roughly a quarter of TIRx's FP32
-            # instruction count, which a scalar lowering cannot do. Emitting the
-            # packed form on every specialization is what actually matches the
-            # reference's machine code.
+            # epilogue. Under `vectorized_f32` each pair issues one
+            # `mul.rn.f32x2` / `add.rn.f32x2` where the scalar form issues two,
+            # for identical numbers -- each half of a packed line rounds exactly
+            # as its scalar sibling -- and `scalar_f32` is its own export branch.
             packed_pair = K.local_scalar("uint64")
-            ops = _arithmetic(True, packed_pair)
+            ops = _arithmetic(vectorized_f32, packed_pair)
             epi_lane = K.local_scalar("int32", init=K.thread_id() % K.int32(32))
             epi_warp = _warp_uniform(K.thread_id() // K.int32(32))
 
-            def dbias_reduce(real_subtile, tile_base):
-                """One subtile's contribution to this expert's dBias column sums.
+            def dbias_warp_base():
+                return K.local_scalar(
+                    "int32", init=offsets["sDbias"] + epi_warp * K.int32(64 * 32 * 4)
+                )
+
+            def dbias_transpose():
+                """Stage this subtile's 64 columns into `sDbias` as (column, row).
 
                 Each thread holds one row's 32 gate and 32 up values, so a column
-                sum is a reduction *across* threads. The 64 columns go to SMEM as
-                (column, row) -- the transpose -- each warp into its own 8 KiB
-                block; then one thread takes two whole columns and sums their 32
-                rows, the four warps' partial sums are combined, and warp 0
-                atomically accumulates a bf16 pair per column.
+                sum is a reduction *across* threads; the transpose is what turns
+                it into one. Each warp writes its own 8 KiB block.
 
                 Rows are stored with the source's `((col >> 1) & 7) << 2` XOR on
                 the row-group index. It cancels out of the sum -- it is there so
                 that the 32 lanes reading 32 different columns hit 32 different
                 banks instead of all landing on the same one.
                 """
-                warp_base = K.local_scalar(
-                    "int32", init=offsets["sDbias"] + epi_warp * K.int32(64 * 32 * 4)
-                )
+                warp_base = dbias_warp_base()
                 group = K.local_scalar("int32", init=epi_lane // K.int32(4))
                 sub = K.local_scalar("int32", init=epi_lane % K.int32(4))
                 # `group ^ swizzle` for each of the eight constant swizzles.
@@ -1464,6 +1459,16 @@ def _make_kernel(
                             * K.int32(4),
                         )
                         K.ptx.st.shared.b32(smem.ptr_to([slot]), fragment[n])
+
+            def dbias_reduce(real_subtile, tile_base):
+                """Reduce the staged transpose into this expert's column sums.
+
+                One thread takes two whole columns and sums their 32 rows, the
+                four warps' partial sums are combined through the front of the
+                same buffer, and warp 0 atomically accumulates a BF16 pair per
+                column.
+                """
+                warp_base = dbias_warp_base()
                 K.ptx.bar.sync(K.uint32(2), K.uint32(128))
 
                 # Lanes 0-15 take the gate half's even columns, 16-31 the up
@@ -1542,8 +1547,11 @@ def _make_kernel(
                     )
                     packed = K.local_scalar("uint32")
                     K.ptx["cvt.rn.bf16x2.f32"](packed, totals[1], totals[0])
-                    # Same over-range tiles as the scale factors, and the source
-                    # guards this accumulate for the same reason.
+                    # A cluster covers `cluster_n` column tiles whether or not
+                    # the output has that many, so the last cluster carries
+                    # tiles past the end. The D store is a TMA and its
+                    # descriptor drops those writes on its own; this accumulate
+                    # is a plain reduction and needs the bound spelled out.
                     with K.If(n_offset < K.int32(N_out)), K.Then():
                         K.ptx["red.global.add.noftz.bf16x2"](
                             named["dbias"].ptr_to(
@@ -1643,9 +1651,8 @@ def _make_kernel(
                         # C fragments are the C dtype, so it releases with
                         # nothing between the load and the fence; widening first
                         # would hold the buffer for another forty-odd
-                        # instructions, and with only two C stages on a
-                        # four-bit specialization the producer has no slack to
-                        # absorb that.
+                        # instructions, and with only two C stages the producer
+                        # has no slack to absorb that.
                         K.ptx["fence.proxy.async.shared::cta"]()
                         with K.If(K.lane_id() == K.int32(0)), K.Then():
                             K.ptx.mbarrier.arrive.shared.b64(c_pipe.empty.ptr_to([c_cons.stage]))
@@ -1796,9 +1803,19 @@ def _make_kernel(
                             K.assign(rC1[span[half]], d_gate[half])
                             K.assign(rC2[span[half]], d_up[half])
 
+                    # The dBias transpose is staged straight out of the gradient
+                    # registers, before the dProb fold, and its reduction runs
+                    # after -- the order `dbias_reduction` is called in and the
+                    # order the export's barriers appear in.
+                    if generate_dbias:
+                        dbias_transpose()
+
                     folded_prob = K.local_scalar("float32")
                     K.ptx["add.f32"](folded_prob, dprob_pair[0], dprob_pair[1])
                     K.ptx["add.f32"](dprob_acc, dprob_acc, folded_prob)
+
+                    if generate_dbias:
+                        dbias_reduce(real_subtile, d_tile_base)
 
                     # ---- convert D and stage it through SMEM -------------
                     _pack_output(rD1, rC1, d_dtype, d_bits)
@@ -1867,16 +1884,6 @@ def _make_kernel(
                                     K.uint64(0),
                                 )
                         K.ptx["cp.async.bulk.commit_group"]()
-                        d_prod.advance()
-                    # The dBias column sums are taken with the tile's D store
-                    # already in flight. They read the activation fragments,
-                    # which the packing only copied, and they touch their own
-                    # shared region, so nothing in them depends on the store --
-                    # and the reduction is a transpose through shared memory
-                    # with two barriers in it, which is exactly the kind of work
-                    # a bulk store wants underneath it.
-                    if generate_dbias:
-                        dbias_reduce(real_subtile, d_tile_base)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     K.assign(real_subtile, real_subtile + K.int32(1))
                     K.assign(subtile, subtile + K.int32(1))
@@ -1887,7 +1894,6 @@ def _make_kernel(
                 # where the accumulator lives -- hence its `4 * atom_thr`
                 # arrivals. Releasing locally leaves the leader's MMA waiting on
                 # a stage nobody frees.
-                K.ptx["tcgen05.wait::ld.sync.aligned"]()
                 with K.If(_elected()), K.Then():
                     peer_bar = K.local_scalar("uint32")
                     local_bar = K.local_scalar("uint32")
@@ -1913,12 +1919,15 @@ def _make_kernel(
                 # is immediately discarded.
                 K.ptx["red.global.add.f32"](named["dprob"].ptr_to([thread_row]), dprob_acc)
 
-            # Release the TMEM allocation permit and free the columns. Both are
-            # warp 0's: the permit is a warp-wide instruction and the source
-            # issues it under the same predicate as the deallocation.
-            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+            # Release the TMEM allocation permit, then synchronize the four
+            # epilogue warps, then free the columns. Both tensor-memory
+            # instructions are warp 0's -- each is `.sync.aligned`, and the
+            # export predicates both on the allocator warp -- but the permit
+            # goes *before* the barrier and the deallocation after it.
             with K.If(warp == K.int32(0)), K.Then():
                 K.ptx[f"tcgen05.relinquish_alloc_permit.{cta_group}.sync.aligned"]()
+            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+            with K.If(warp == K.int32(0)), K.Then():
                 if atom_thr > 1:
                     # A CTA pair frees its TMEM collectively: each CTA arrives on
                     # its peer's deallocation barrier and waits on its own before

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
@@ -1,0 +1,44 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Device program for the BF16 MoE grouped GEMM with a fused dGLU backward.
+
+Scaffold stage: the entries below carry the launch shape and the operand ABI
+placeholder only. The device body is written in the kernel-sketch stage against
+the approved sketch and the line-info PTX export.
+"""
+
+import tirx_kernels.kern as K
+
+from . import spec as _spec
+
+
+def _make_kernel(config, derived):
+    """Build the launch sequence for one static specialization."""
+    threads_per_cta = derived["threads_per_cta"]
+    warps = threads_per_cta // 32
+
+    @K.kernel(warps=warps, arch="sm_100a", min_blocks_per_sm=1, grid=list(derived["grid"]))
+    def kernel():
+        # ---- kernel body starts here ----
+        #
+        # Warp specialization (upstream ``:157-181``): epilogue warps 0-3 (warp 0
+        # also owns the TMEM allocation and the D store), MMA warp 4, A/B TMA warp
+        # 5, C-load warp 6, persistent scheduler warp 7.
+        #
+        # Nothing is implemented yet. The kernel-sketch stage fixes the operand
+        # ABI, the flat shared-memory byte map, the mbarrier protocol and the
+        # instruction selection; the correctness gate realizes them here.
+        pass
+
+    return kernel
+
+
+def get_kernel(**config):
+    """Return the launch sequence for one static specialization."""
+    config = {key: value for key, value in config.items() if key != "label"}
+    derived = _spec.derive(config)
+    main = _make_kernel(config, derived)
+    return [main.func]

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
@@ -3,42 +3,2095 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""Device program for the BF16 MoE grouped GEMM with a fused dGLU backward.
+"""MoE BF16 grouped GEMM with a fused dGLU backward epilogue.
 
-Scaffold stage: the entries below carry the launch shape and the operand ABI
-placeholder only. The device body is written in the kernel-sketch stage against
-the approved sketch and the line-info PTX export.
+Upstream source:
+``python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py``
+(``MoEGroupedGemmDgluDbiasBf16Kernel``), with the tile scheduler from
+``python/cudnn/gemm/cutedsl/grouped/moe_persistent_scheduler.py``, the per-expert
+tensor-map workspace from ``python/cudnn/gemm/cutedsl/grouped/moe_utils.py``, and
+the gmem addressing extensions from
+``python/cudnn/gemm/cutedsl/grouped/moe_sched_extension.py``.
+
+The kernel computes, for every expert ``g`` over its 256-aligned row range::
+
+    ref   = alpha[g]^2 * A @ B[g]^T
+    gate  = beta[g] * C[:, even 32-column blocks]
+    up    = beta[g] * C[:, odd 32-column blocks]
+    D     = interleave(dGLU_gate(ref, prob, gate, up), dGLU_up(ref, prob, gate, up))
+
+plus the per-row ``dprob`` scalar and the optional per-expert ``dbias`` column
+sums. Both are accumulated with global atomics into caller-zeroed buffers.
+
+The operands are plain BF16, so the multiply is ``tcgen05.mma.kind::f16`` and
+there are no scale-factor tensors, no output quantization and no amax pass. Two
+consequences are load-bearing rather than cosmetic: tensor-memory columns are
+derived per specialization instead of always reserving 512, and under a two-CTA
+atom each CTA stages only its half of the N operand, so a B stage is
+``(tile_n / atom_thr) * k_tile * 2`` bytes.
 """
+
+from functools import cache
 
 import tirx_kernels.kern as K
 
-from . import spec as _spec
+from . import spec
+
+_TRY_WAIT_TICKS = 0x989680  # 10,000,000, the source's mbarrier spin bound
+
+# dGeGLU's constants are literals in the bf16 source rather than parameters:
+# `sigmoid(1.702 * clamp(gate, max=7))` and `clamp(up, -7, 7)`.
+GEGLU_ALPHA = 1.702
+GEGLU_MAX = 7.0
+GEGLU_MIN = -7.0
 
 
-def _make_kernel(config, derived):
-    """Build the launch sequence for one static specialization."""
-    threads_per_cta = derived["threads_per_cta"]
-    warps = threads_per_cta // 32
+def _ceil_div(value, divisor):
+    return (value + divisor - 1) // divisor
 
-    @K.kernel(warps=warps, arch="sm_100a", min_blocks_per_sm=1, grid=list(derived["grid"]))
-    def kernel():
-        # ---- kernel body starts here ----
-        #
-        # Warp specialization (upstream ``:157-181``): epilogue warps 0-3 (warp 0
-        # also owns the TMEM allocation and the D store), MMA warp 4, A/B TMA warp
-        # 5, C-load warp 6, persistent scheduler warp 7.
-        #
-        # Nothing is implemented yet. The kernel-sketch stage fixes the operand
-        # ABI, the flat shared-memory byte map, the mbarrier protocol and the
-        # instruction selection; the correctness gate realizes them here.
-        pass
 
-    return kernel
+def _warp_uniform(value):
+    """The source's `cute.arch.make_warp_uniform`: broadcast lane 0's copy.
+
+    A value the compiler cannot prove is warp-invariant forces everything
+    derived from it onto the per-thread datapath. Broadcasting through
+    `shfl.sync.idx` states the invariance, which is what lets ptxas keep the
+    warp-derived half of the address arithmetic on the uniform pipe -- the
+    reference splits that arithmetic almost evenly between the two pipes where
+    TIRx was running 4.25x as much per-thread.
+    """
+    uniform = K.local_scalar("int32")
+    K.ptx["shfl_sync.idx.b32"](uniform, value, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF))
+    return uniform
+
+
+def _elected():
+    """`elect.sync` over the full warp, the source's single-issuer predicate."""
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _try_wait_acquire(dst, barrier, phase):
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase):
+    """Spin on one mbarrier until its phase flips.
+
+    The retry takes the hintless `try_wait` -- the same form the source's own
+    hot waits use. Given a suspend-time hint, ptxas expands the wait inline into
+    four instructions: the check, a `NANOSLEEP`, a second check and the branch.
+    That is where 48.6% of this port's not-issued samples were parked, against
+    12.8% for the reference, and it puts three instructions between the barrier
+    and the load that depends on it. Without the hint the wait is two
+    instructions -- the check and one predicated branch to an out-of-line retry
+    -- and the export shows the reference's dependent `LDS.128` issuing directly
+    behind its branch.
+    """
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        _try_wait_acquire(ready, barrier, phase)
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready):
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+_LOG2E_NEG = -1.4426950408889634  # exp(-x) == exp2(x * -log2(e))
+
+
+def _arithmetic(vectorized, packed):
+    """Elementwise arithmetic over two-element pairs.
+
+    Under ``vectorized_f32`` the source pairs its FP32 arithmetic into
+    ``mul.rn.f32x2`` / ``add.rn.f32x2``, halving the issue count for the same
+    numbers -- each half of a packed line rounds exactly as its scalar sibling.
+    The approximations (``ex2``, ``rcp``, ``tanh``) and the comparisons have no
+    packed form and stay per-element in both modes.
+
+    ``packed`` is the caller-owned 64-bit staging register the packed results
+    land in; every helper here writes through caller-owned storage, because
+    allocating fresh temporaries per element left one basic block holding
+    roughly five hundred allocas and ptxas ran for over twelve minutes without
+    finishing.
+    """
+
+    def binary(mnemonic, out, left, right):
+        if vectorized:
+            K.ptx[f"{mnemonic}.rn.f32x2"](
+                packed, K.cuda.make_float2(left[0], left[1]), K.cuda.make_float2(right[0], right[1])
+            )
+            K.ptx["mov.b64"](out[0], out[1], packed)
+        else:
+            for half in range(2):
+                K.ptx[f"{mnemonic}.f32"](out[half], left[half], right[half])
+
+    def unary(mnemonic, out, value):
+        for half in range(2):
+            K.ptx[mnemonic](out[half], value[half])
+
+    def fused(out, left, right, addend):
+        """``left * right + addend`` as one instruction.
+
+        Every arithmetic op here reaches ptxas as inline assembly, which is
+        opaque to it: it will not contract a multiply feeding an add into an
+        FFMA the way it does for ordinary instructions. The source's export
+        writes the multiply and the add separately and lets its compiler fuse
+        them -- its machine code carries the FFMA -- so the contraction has to
+        be written out here to reach the same instruction count.
+        """
+        if vectorized:
+            K.ptx["fma.rn.f32x2"](
+                packed,
+                K.cuda.make_float2(left[0], left[1]),
+                K.cuda.make_float2(right[0], right[1]),
+                K.cuda.make_float2(addend[0], addend[1]),
+            )
+            K.ptx["mov.b64"](out[0], out[1], packed)
+        else:
+            for half in range(2):
+                K.ptx["fma.rn.f32"](out[half], left[half], right[half], addend[half])
+
+    def scaled(out, value, constant):
+        binary("mul", out, value, _spread(constant))
+
+    def product(out, left, right):
+        binary("mul", out, left, right)
+
+    def offset(out, value, constant):
+        binary("add", out, value, _spread(constant))
+
+    def complement(out, constant, value, scratch):
+        """``constant - value``.
+
+        The vectorized export folds the subtraction into a ``neg.f32`` and an
+        ``add.rn.f32x2`` rather than issuing a packed subtract.
+        """
+        if vectorized:
+            unary("neg.f32", scratch, value)
+            binary("add", out, _spread(constant), scratch)
+        else:
+            for half in range(2):
+                K.ptx["sub.f32"](out[half], K.float32(constant), value[half])
+
+    return {
+        "binary": binary,
+        "unary": unary,
+        "scaled": scaled,
+        "product": product,
+        "offset": offset,
+        "complement": complement,
+        "fused": fused,
+    }
+
+
+def _spread(constant):
+    """One FP32 immediate as a pair, so it can feed either arithmetic mode."""
+    return (K.float32(constant), K.float32(constant))
+
+
+def _sigmoid(ops, destination, value, scratch):
+    """The source's fastmath sigmoid: 1 / (1 + exp(-x)), no library call.
+
+    The negation rides in the multiplier immediate, which is why the export
+    contains no ``neg.f32`` here.
+    """
+    ops["scaled"](scratch, value, _LOG2E_NEG)
+    ops["unary"]("ex2.approx.ftz.f32", scratch, scratch)
+    ops["offset"](scratch, scratch, 1.0)
+    ops["unary"]("rcp.approx.ftz.f32", destination, scratch)
+
+
+def _swizzled(row_offset, chunk, row_bytes):
+    """One 16-byte chunk's byte offset under the epilogue TMA's row swizzle.
+
+    A swizzled descriptor XORs bits `[4, 4 + B)` of the offset -- the 16-byte
+    chunk index -- with bits `[7, 7 + B)`, where `B` counts the chunks in a row.
+    The source bits sit at 128 bytes no matter how wide the row is, so a
+    64-byte row twists on `row >> 1` and a 32-byte row on `row >> 2` rather than
+    on the row index. Twisting on the row index reads the right bytes from the
+    wrong places for every element narrower than 32 bits.
+    """
+    chunks = row_bytes // 16
+    if chunks == 1:
+        return row_offset + K.int32(chunk * 16)
+    # Every caller passes `row * row_bytes`, so the low `log2(row_bytes)` bits
+    # of `row_offset` are zero and both `chunk * 16` and the twist fit entirely
+    # inside them. The chunk therefore ORs in rather than adds, and the twist
+    # only ever touches the chunk field -- which also means the twist can be
+    # read off `row_offset` alone. Writing the whole thing as
+    # `row_offset | (chunk ^ twist)` is one `LOP3` per chunk where the sum
+    # followed by the XOR is two instructions, and this runs once per chunk per
+    # fragment on every subtile.
+    twist = K.local_scalar(
+        "int32", init=((row_offset // K.int32(128)) % K.int32(chunks)) * K.int32(16)
+    )
+    return K.local_scalar("int32", init=row_offset | (K.int32(chunk * 16) ^ twist))
+
+
+def _tcgen05_commit(barrier, mask, cta_group, cluster_size):
+    """Asynchronous mbarrier arrival from the MMA pipeline.
+
+    The multicast form carries the CTA mask; a singleton cluster has no peers to
+    notify and takes the plain form.
+    """
+    if cluster_size > 1:
+        K.ptx[
+            f"tcgen05.commit.{cta_group}.mbarrier::arrive::one"
+            ".shared::cluster.multicast::cluster.b64"
+        ](barrier, K.cast(mask, "uint16"))
+    else:
+        K.ptx[f"tcgen05.commit.{cta_group}.mbarrier::arrive::one.shared::cluster.b64"](barrier)
+
+
+def _unpack_input(values, words, dtype, bits):
+    """Expand one thread's row of an epilogue tile into 32 FP32 values."""
+    if bits == 16:
+        converter = "cvt.f32.bf16" if dtype == "bfloat16" else "cvt.f32.f16"
+        for word in range(16):
+            low = K.local_scalar("uint16")
+            high = K.local_scalar("uint16")
+            K.ptx["mov.b32"](low, high, words[word])
+            K.ptx[converter](values[2 * word + 0], low)
+            K.ptx[converter](values[2 * word + 1], high)
+    else:
+        for word in range(32):
+            K.ptx["mov.b32"](values[word], words[word])
+
+
+def _pack_output(words, values, dtype, bits):
+    """Pack a 32-element FP32 fragment into the output dtype's storage words.
+
+    A 16-bit output uses `cvt.rn.bf16x2.f32` / `cvt.rn.f16x2.f32`, two elements
+    to a word; FP32 is a move.
+    """
+    if bits == 16:
+        converter = "cvt.rn.bf16x2.f32" if dtype == "bfloat16" else "cvt.rn.f16x2.f32"
+        for word in range(16):
+            K.ptx[converter](words[word], values[2 * word + 1], values[2 * word + 0])
+    else:
+        for word in range(32):
+            K.ptx["mov.b32"](words[word], values[word])
+
+
+def _instruction_descriptor(M, N, a_major, b_major):
+    """Fold the static fields of the ``kind::f16`` MMA instruction descriptor.
+
+    Read off the PTX exports rather than adapted from the block-scaled encoder,
+    whose kinds lay the same fields out differently. The anchor
+    (``M = N = 256``, k-major B) emits ``0x10400490``; ``bmajor_n`` moves it to
+    ``0x10410490``, ``tile128_c1x1`` to ``0x08400490`` and ``tile_n64`` to
+    ``0x08100490``, which pins bit 16 and the two extent fields exactly.
+
+    Bits 13/14 (negate A/B) arrive as ``TiledMMA`` kernel parameters that this
+    kernel never sets, so both predicates are false and the constant below is
+    the whole descriptor. Bit 23 (SF format) belongs to the block-scaled kinds
+    and is always clear here.
+    """
+    value = 1 << 4  # D format: f32
+    value |= 1 << 7  # A format: bf16
+    value |= 1 << 10  # B format: bf16
+    if a_major == "m":
+        value |= 1 << 15
+    if b_major == "n":
+        value |= 1 << 16
+    value |= ((N >> 3) & 0x3F) << 17
+    value |= ((M >> 4) & 0x1F) << 24
+    return value & 0xFFFFFFFF
+
+
+def _descriptor_base(ldo, sdo, swizzle):
+    """Fold the SM100 shared descriptor fields except its 14-bit address."""
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _descriptor_with_address(base, shared_address):
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), address_field)
+
+
+_TMA_G2S_3D = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_MCAST = ".multicast::cluster"
+
+
+def _tma_load(destination, descriptor, coords, barrier, mask, *, two_cta, desc_ptr=None):
+    """One `cp.async.bulk.tensor` load, multicast only when a mask is given.
+
+    The two-CTA MMA adds `.cta_group::2`; the multicast form inserts its mask
+    modifier before the cache hint, matching the operand order the export shows.
+    """
+    stem = _TMA_G2S_3D if len(coords) == 3 else _TMA_G2S_4D
+    if mask is not None:
+        head, _, tail = stem.partition(".mbarrier::complete_tx::bytes")
+        stem = head + ".mbarrier::complete_tx::bytes" + _TMA_MCAST + tail
+    if two_cta:
+        stem = stem + ".cta_group::2"
+    address = K.address_of(descriptor) if desc_ptr is None else desc_ptr
+    arguments = [destination, address, *[K.cast(c, "int32") for c in coords], barrier]
+    if mask is not None:
+        arguments.append(K.cast(mask, "uint16"))
+    arguments.append(K.uint64(0))
+    K.ptx[stem](*arguments)
+
+
+def _entry_point(names, body):
+    """Build an entry whose parameter names are this specialization's operands.
+
+    Optional operands are absent from the signature entirely, which is what the
+    upstream kernel's generated parameter list does when a tensor is ``None`` at
+    compile time.
+    """
+    arguments = ", ".join(names)
+    namespace = {"_body": body}
+    exec(f"def kernel({arguments}, *, host):\n    _body(({arguments},), host)\n", namespace)
+    return namespace["kernel"]
+
+
+@cache
+def _make_kernel(
+    group_m_list,
+    N,
+    K_dim,
+    weight_mode,
+    sched,
+    act,
+    c_dtype,
+    d_dtype,
+    b_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    vectorized_f32,
+    with_dbias,
+    linear_offset,
+):
+    """Build the launch sequence for one static specialization.
+
+    Returns ``[helper, main]`` when the discrete weight mode or the dynamic
+    scheduler needs the upstream pre-kernel, and ``[main]`` otherwise. The
+    entries are PrimFuncs, which is what the runner compiles and what
+    ``check_low_level_ir`` inspects.
+    """
+    mode = {
+        "weight_mode": weight_mode,
+        "sched": sched,
+        "act": act,
+        "c_dtype": c_dtype,
+        "d_dtype": d_dtype,
+        "b_major": b_major,
+        "mma_tiler_mn": tuple(mma_tiler_mn),
+        "cluster_shape_mn": tuple(cluster_shape_mn),
+        "vectorized_f32": vectorized_f32,
+        "with_dbias": with_dbias,
+    }
+    derived = spec.derive(mode, group_m_list=list(group_m_list), N=N, K_dim=K_dim)
+
+    ab_bits = 16
+    c_bits = spec.dtype_bits(c_dtype)
+    d_bits = spec.dtype_bits(d_dtype)
+    tokens_total, N_out, L = derived["tokens_total"], derived["n_out"], derived["L"]
+
+    def byte_count(rows, columns, bits):
+        return rows * columns * bits // 8
+
+    # Every payload crosses the launch boundary as a flat byte array; the logical
+    # extents live in the tensor maps and in the scalar index arithmetic below.
+    annotations = {
+        "a": K.gptr[K.u8, (byte_count(tokens_total, K_dim, ab_bits),)],
+        "b": (
+            K.gptr["int64", (L,)]
+            if weight_mode == "discrete"
+            else K.gptr[K.u8, (byte_count(N, K_dim, ab_bits) * L,)]
+        ),
+        "c": K.gptr[K.u8, (byte_count(tokens_total, N_out, c_bits),)],
+        "d_row": K.gptr[K.u8, (byte_count(tokens_total, N_out, d_bits),)],
+    }
+    annotations["padded_offsets"] = K.gptr["int32", (L,)]
+    annotations["alpha"] = K.gptr["float32", (L,)]
+    annotations["beta"] = K.gptr["float32", (L,)]
+    # ``generate_dprob`` is hard-coded True upstream, so both routing tensors
+    # are part of every specialization's signature.
+    annotations["prob"] = K.gptr["float32", (tokens_total,)]
+    annotations["dprob"] = K.gptr["float32", (tokens_total,)]
+    if with_dbias:
+        annotations["dbias"] = K.gptr[K.u8, (L * N_out * 2,)]
+    if derived["workspace_bytes"]:
+        annotations["workspace"] = K.gptr[K.u8, (derived["workspace_bytes"],)]
+
+    # ---- shapes the launch geometry and the barrier protocol depend on -------
+    offsets = derived["smem_offsets"]
+    shared_bytes = derived["shared_bytes"]
+    ab_stages = derived["num_ab_stage"]
+    acc_stages = derived["num_acc_stage"]
+    c_stages = derived["num_c_stage"]
+    d_stages = derived["num_d_stage"]
+    tile_stages = derived["num_tile_stage"]
+    atom_thr = derived["atom_thr"]
+    cluster_m, cluster_n = cluster_shape_mn
+    cluster_size = derived["cluster_size"]
+    cta_tile_m, cta_tile_n, k_tile = derived["cta_tile_shape_mnk"]
+    k_tiles = derived["k_tiles"]
+    epi_subtiles = cta_tile_n // 32
+    generate_dbias = derived["generate_dbias"]
+
+    # A two-CTA MMA splits B's N extent across the pair, so each CTA stages
+    # `cta_tile_n // atom_thr` columns.
+    b_tile_n = cta_tile_n // atom_thr
+    # An n-major B is N-contiguous, and `get_smem_layout_atom_ab` picks the
+    # widest MN swizzle atom whose contiguous extent divides that of the tile:
+    # 128 bytes -- 64 BF16 elements -- when 64 divides `b_tile_n`, then 64, 32
+    # and 16 bytes. A tile wider than one atom needs one TMA copy per atom side
+    # by side in shared memory, which the `bmajor_n` export confirms: three
+    # cluster-multicast loads where the anchor has two, the extra one being B's
+    # second 64-column block.
+    if b_major == "n":
+        for elements, swizzle in ((64, 3), (32, 2), (16, 1), (8, 0)):
+            if b_tile_n % elements == 0:
+                b_atom_elements, b_atom_swizzle = elements, swizzle
+                break
+    else:
+        b_atom_elements, b_atom_swizzle = k_tile, 3
+    b_tma_copies = b_tile_n // b_atom_elements if b_major == "n" else 1
+
+    # A is always k-major; B follows ``b_major``. The shared descriptors carry
+    # everything but the 14-bit address, which the device body ORs in. The
+    # anchor export builds both from 0x4000404000010000 -- leading offset 1,
+    # stride offset 64, 128-byte swizzle -- and the n-major B from
+    # 0x4000404002000000, whose leading offset 512 is the 16-byte distance
+    # between the two N blocks of a stage.
+    a_desc_base = _descriptor_base(ldo=1, sdo=64, swizzle=3)
+    b_desc_base = _descriptor_base(
+        ldo=(
+            1
+            if b_major == "k"
+            else (derived["b_stage_bytes"] // b_tma_copies) // 16
+            if b_tma_copies > 1
+            else 0
+        ),
+        sdo=64,
+        swizzle=b_atom_swizzle,
+    )
+    # The CTA group is 2 only when the MMA atom spans a CTA pair; asking for
+    # `cta_group::2` with a single-CTA atom makes the launch itself invalid.
+    cta_group = f"cta_group::{atom_thr}"
+    mma_mnemonic = f"tcgen05.mma.{cta_group}.kind::f16"
+    # The descriptor's M is the whole MMA tile, not the per-CTA half: the anchor
+    # export's descriptor is 0x10400490, whose M field is 16 for a 256-row
+    # two-CTA tile. Dividing by `atom_thr` here encodes 128 and is wrong on
+    # every two-CTA specialization.
+    instruction_descriptor = _instruction_descriptor(
+        derived["mma_tiler"][0], cta_tile_n, "k", b_major
+    )
+    ab_empty_arrivals = max(1, cluster_n + (cluster_m // atom_thr) - 1)
+
+    # TensorMaps the launch passes as grid constants, in the order
+    # ``host_prelude`` returns them. Discrete weights read the B descriptor out
+    # of the workspace instead, so they contribute no grid constant.
+    map_names = ["a", "c", "d_row"]
+    if weight_mode == "dense":
+        map_names.append("b")
+
+    # A multicasts over the cluster's N extent, B over the M extent the two-CTA
+    # MMA has already halved.
+    a_cluster_piece = cta_tile_m // cluster_n
+    b_split = max(1, cluster_m // atom_thr)
+    # The multicast split goes on the box's non-contiguous mode, which is N for
+    # a k-major B and K for an n-major one.
+    b_cluster_piece = (k_tile if b_major == "n" else b_tile_n) // b_split
+    epi_m, epi_n = derived["epi_tile"]
+
+    ab_tail = (1, 1, 1, 0, 3, 2, 0)
+
+    def encode_map(descriptor, dtype, rank, data, *fields):
+        K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+    def encode_weight_maps(descriptors, b_data, batch):
+        """The B TensorMap.
+
+        ``batch`` is the expert count for dense weights, whose single allocation
+        the TMA indexes by a third coordinate, and 1 for discrete weights, where
+        each expert is its own allocation and gets its own descriptor.
+        """
+        b_contiguous = (N if b_major == "n" else K_dim) * ab_bits // 8
+        b_fields = (
+            (
+                N,
+                K_dim,
+                batch,
+                b_contiguous,
+                N * K_dim * ab_bits // 8,
+                b_atom_elements,
+                b_cluster_piece,
+                1,
+            )
+            if b_major == "n"
+            else (
+                K_dim,
+                N,
+                batch,
+                b_contiguous,
+                N * K_dim * ab_bits // 8,
+                k_tile,
+                b_cluster_piece,
+                1,
+            )
+        )
+        encode_map(descriptors["b"], "bfloat16", 3, b_data, *b_fields, *ab_tail)
+
+    def host_prelude(params):
+        descriptors = {name: K.stack_alloca("tensormap", 1) for name in map_names}
+        encode = encode_map
+
+        # A is (tokens, K) k-major, so K is the contiguous extent.
+        a_contiguous = K_dim * ab_bits // 8
+        encode(
+            descriptors["a"],
+            "bfloat16",
+            3,
+            params["a"].data,
+            K_dim,
+            tokens_total,
+            1,
+            a_contiguous,
+            tokens_total * a_contiguous,
+            k_tile,
+            a_cluster_piece,
+            1,
+            *ab_tail,
+        )
+
+        # C and D are (tokens, 2N) n-major over the interleaved output.
+        def encode_epilogue(name, tensor, dtype, bits):
+            contiguous = N_out * bits // 8
+            # One epilogue row is `epi_n` elements, and the source picks the
+            # swizzle whose period matches that row exactly -- 128B for a 32-bit
+            # element and 64B for a 16-bit one
+            # (`get_smem_layout_atom_ab`'s K-major ladder). Leaving it
+            # unswizzled costs a bank conflict per epilogue access whose width
+            # scales with the element: a 128-byte row is exactly the 32 banks,
+            # so every lane of a warp lands on bank 0.
+            swizzle = {128: 3, 64: 2}[epi_n * bits // 8]
+            encode(
+                descriptors[name],
+                dtype,
+                3,
+                tensor.data,
+                N_out,
+                tokens_total,
+                1,
+                contiguous,
+                tokens_total * contiguous,
+                epi_n,
+                epi_m,
+                1,
+                1,
+                1,
+                1,
+                0,
+                swizzle,
+                2,
+                0,
+            )
+
+        encode_epilogue("c", params["c"], c_dtype, c_bits)
+        encode_epilogue("d_row", params["d_row"], d_dtype, d_bits)
+
+        if weight_mode == "dense":
+            encode_weight_maps(descriptors, params["b"].data, L)
+        return tuple(descriptors[name] for name in map_names)
+
+    def body(operands, host):
+        named = dict(zip(annotations, operands))
+        maps = dict(zip(map_names, host))
+
+        # ---- coordinates -------------------------------------------------
+        block_x, block_y, cluster_work_id = K.cta_id()
+        cluster_x, cluster_y = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        cluster_rank = _warp_uniform(cluster_x + cluster_m * cluster_y)
+        del block_y
+        warp = _warp_uniform(K.warp_id())
+        lane = K.lane_id()
+
+        # Position inside the two-CTA MMA pair, and the pair's coordinate in the
+        # cluster. `cluster_v` is what distinguishes the two CTAs of a pair and
+        # has to appear in every multicast mask.
+        cluster_v = cluster_rank % atom_thr if atom_thr > 1 else 0
+        cluster_m_coord = (cluster_rank // atom_thr) % max(1, cluster_m // atom_thr)
+        cluster_n_coord = cluster_rank // cluster_m
+        # Only the leader CTA of a two-CTA pair issues the MMA and the AB-full
+        # arrival; with a single-CTA atom every CTA is its own leader.
+        is_leader_cta = (
+            (block_x % K.int32(atom_thr)) == K.int32(0)
+            if atom_thr > 1
+            else K.int32(0) == K.int32(0)
+        )
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+        c_role = roles.role("c_load", warps=[6])
+        sched_role = roles.role("scheduler", warps=[7])
+
+        # ---- storage -----------------------------------------------------
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool, ab_stages, full="tma", empty="tcgen05", leader=K.bool(False)
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=4 * atom_thr,
+            leader=K.bool(False),
+        )
+        tile_pipe = K.Pipeline(
+            protocol_pool, tile_stages, full="mbar", empty="mbar", leader=K.bool(False)
+        )
+        if protocol_pool.bytes != offsets["sinfo"]:
+            raise AssertionError("protocol storage order changed before sInfo")
+        sinfo = protocol_pool.alloc((4 * tile_stages,), K.i32, align=16)
+        # The dynamic scheduler adds a one-stage cluster pipeline and the
+        # 16-byte slot the elected CTA broadcasts the next work index into.
+        # Both sit straight after sInfo, which is why every object below them
+        # shifts by 32 bytes on that branch.
+        sched_pipe = None
+        sched_broadcast = None
+        if sched == "dynamic":
+            if protocol_pool.bytes != offsets["cluster_mbar"]:
+                raise AssertionError("scheduler cluster pipeline is misplaced")
+            sched_pipe = K.Pipeline(
+                protocol_pool, 1, full="mbar", empty="mbar", leader=K.bool(False)
+            )
+            if protocol_pool.bytes != offsets["cluster_broadcast"]:
+                raise AssertionError("scheduler broadcast slot is misplaced")
+            sched_broadcast = protocol_pool.alloc((4,), K.i32, align=16)
+        if protocol_pool.bytes != offsets["c_full"]:
+            raise AssertionError("protocol storage order changed before the C pipeline")
+        c_pipe = K.Pipeline(
+            protocol_pool, c_stages, full="tma", empty="mbar", init_empty=4, leader=K.bool(False)
+        )
+        if protocol_pool.bytes != offsets["tmem_dealloc"]:
+            raise AssertionError("protocol storage order changed before the TMEM barrier")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+
+        # ---- descriptor prefetch ----------------------------------------
+        with tma_role:
+            for name in map_names:
+                K.ptx.prefetch.tensormap(K.address_of(maps[name]))
+
+        # ---- barrier initialization, in the source's declaration order ----
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(ab_empty_arrivals)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(4 * atom_thr)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, c_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(c_pipe.full.ptr_to([stage]), K.uint32(1))
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, c_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                c_pipe.empty.ptr_to([stage]), K.uint32(4)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, tile_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                tile_pipe.full.ptr_to([stage]), K.uint32(32)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, tile_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                tile_pipe.empty.ptr_to([stage]), K.uint32(224)
+                            )
+
+        # The tile-info pipeline is built without `defer_sync`, so it publishes
+        # itself here; the TMEM barrier belongs to the second epoch below.
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.sync(K.uint32(0))
+
+        # `TmemAllocator` is handed the deallocation barrier only under a
+        # two-CTA atom, so a single-CTA specialization initializes one mbarrier
+        # fewer: the exports count 23 for the anchor and 18 for `tile128_c1x1`,
+        # one short of the 19 an unconditional init would leave.
+        if sched == "dynamic" or atom_thr > 1:
+            with K.If(warp == 0):
+                with K.Then():
+                    with K.If(_elected()):
+                        with K.Then():
+                            if sched == "dynamic":
+                                # `internal_init` builds this pipeline with
+                                # `defer_sync=True`, so it is published by the
+                                # second epoch alongside the TMEM barrier.
+                                K.ptx.mbarrier.init.shared.b64(
+                                    sched_pipe.full.ptr_to([0]), K.uint32(1)
+                                )
+                                K.ptx.mbarrier.init.shared.b64(
+                                    sched_pipe.empty.ptr_to([0]), K.uint32(32 * cluster_size)
+                                )
+                            if atom_thr > 1:
+                                K.ptx.mbarrier.init.shared.b64(
+                                    tmem_dealloc.ptr_to([0]), K.uint32(32)
+                                )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.arrive.relaxed()
+
+        # ---- scalar addresses, descriptors, and multicast masks ----------
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        cluster_smem_base_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_base_u64, smem.ptr_to([0]))
+        cluster_smem_base = K.local_scalar("uint32", init=K.cast(cluster_smem_base_u64, "uint32"))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, smem_base + offsets["sA"])
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, smem_base + offsets["sB"])
+        )
+
+        # Every mask is the image of the vmnk cluster layout at this CTA's
+        # coordinate with one mode varying; the flat rank of `(v, m, n)` is
+        # `v + atom_thr * m + cluster_m * n`.
+        def cta_bit(v, m, n):
+            return K.uint32(1) << K.cast(v + atom_thr * m + cluster_m * n, "uint32")
+
+        def mask_union(bits):
+            accumulator = K.local_scalar("uint32", init=K.uint32(0))
+            for bit in bits:
+                K.assign(accumulator, K.bitwise_or(accumulator, bit))
+            return accumulator
+
+        a_mcast_mask = mask_union(
+            [cta_bit(cluster_v, cluster_m_coord, n) for n in range(cluster_n)]
+        )
+        b_mcast_mask = mask_union(
+            [cta_bit(cluster_v, m, cluster_n_coord) for m in range(cluster_m // atom_thr)]
+        )
+        peer_v = cluster_v ^ 1 if atom_thr > 1 else 0
+        ab_consumer_mask = mask_union(
+            [a_mcast_mask, b_mcast_mask]
+            + [cta_bit(peer_v, cluster_m_coord, n) for n in range(cluster_n)]
+            + [cta_bit(peer_v, m, cluster_n_coord) for m in range(cluster_m // atom_thr)]
+        )
+        acc_producer_mask = mask_union(
+            [cta_bit(v, cluster_m_coord, cluster_n_coord) for v in range(atom_thr)]
+        )
+
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.wait()
+        else:
+            K.ptx.bar.sync(K.uint32(1))
+
+        total_tokens = K.local_scalar("int32")
+        K.ptx.ld.global_.b32(total_tokens, named["padded_offsets"].ptr_to([L - 1]))
+        with K.If(total_tokens <= K.int32(0)), K.Then():
+            K.Return(K.int32(0))
+
+        # ---- Role 1: warp 7, MoE persistent tile scheduler ----------------
+        # `offs` is cumulative, so this expert's token count is the difference
+        # against its predecessor. The N tile count is a compile-time constant
+        # because N and the cluster tile are both static; only the M count
+        # varies per expert.
+        cluster_tile_m = cta_tile_m * cluster_m
+        cluster_tile_n = cta_tile_n * cluster_n
+        n_tile_count = _ceil_div(N, cluster_tile_n)
+        num_persistent_clusters = derived["grid"][2]
+
+        def expert_tokens(expert):
+            """Token count of one expert, from the cumulative offsets."""
+            upper = K.local_scalar("int32")
+            K.ptx.ld.global_.b32(upper, named["padded_offsets"].ptr_to([expert]))
+            tokens = K.local_scalar("int32", init=upper)
+            with K.If(expert > K.int32(0)), K.Then():
+                lower = K.local_scalar("int32")
+                K.ptx.ld.global_.b32(lower, named["padded_offsets"].ptr_to([expert - K.int32(1)]))
+                K.assign(tokens, tokens - lower)
+            return tokens
+
+        def expert_m_tiles(expert):
+            tokens = expert_tokens(expert)
+            return (tokens + K.int32(cluster_tile_m - 1)) // K.int32(cluster_tile_m)
+
+        with sched_role:
+            info_prod = K.PipelineState(tile_stages, phase=1)
+            # Cached expert cursor: the walk stays inside one expert until the
+            # linear index leaves it, which makes the common step O(1).
+            current_expert = K.local_scalar("int32", init=K.int32(0))
+            expert_tile_start = K.local_scalar("int32", init=K.int32(0))
+            expert_tile_end = K.local_scalar("int32", init=K.int32(0))
+            initialized = K.local_scalar("uint32", init=K.uint32(0))
+            work_linear = K.local_scalar("int32", init=cluster_work_id)
+
+            record_expert = K.local_scalar("int32")
+            record_tile_m = K.local_scalar("int32")
+            record_tile_n = K.local_scalar("int32")
+            work_valid = K.local_scalar("uint32")
+
+            def resolve_work():
+                """Source `_get_work_tile_for_linear_idx`, cursor included."""
+                with K.If(initialized == K.uint32(0)), K.Then():
+                    K.assign(expert_tile_end, expert_m_tiles(K.int32(0)) * n_tile_count)
+                    K.assign(initialized, K.uint32(1))
+                with K.While(K.And(work_linear >= expert_tile_end, current_expert < K.int32(L))):
+                    K.assign(current_expert, current_expert + K.int32(1))
+                    K.assign(expert_tile_start, expert_tile_end)
+                    with K.If(current_expert < K.int32(L)), K.Then():
+                        K.assign(
+                            expert_tile_end,
+                            expert_tile_end + expert_m_tiles(current_expert) * n_tile_count,
+                        )
+                K.assign(record_expert, K.int32(-1))
+                K.assign(record_tile_m, K.int32(0))
+                K.assign(record_tile_n, K.int32(0))
+                K.assign(work_valid, K.uint32(0))
+                with K.If(current_expert < K.int32(L)), K.Then():
+                    K.assign(work_valid, K.uint32(1))
+                    local_idx = K.local_scalar("int32", init=work_linear - expert_tile_start)
+                    m_count = K.local_scalar("int32", init=expert_m_tiles(current_expert))
+                    cluster_m_idx = K.local_scalar("int32")
+                    cluster_n_idx = K.local_scalar("int32")
+                    # Short side first: the shorter extent changes faster, so
+                    # neighbouring clusters overlap in L2.
+                    with K.If(m_count <= K.int32(n_tile_count)):
+                        with K.Then():
+                            K.assign(cluster_m_idx, local_idx % m_count)
+                            K.assign(cluster_n_idx, local_idx // m_count)
+                        with K.Else():
+                            K.assign(cluster_n_idx, local_idx % K.int32(n_tile_count))
+                            K.assign(cluster_m_idx, local_idx // K.int32(n_tile_count))
+                    K.assign(record_expert, current_expert)
+                    K.assign(record_tile_m, cluster_m_idx * K.int32(cluster_m) + cluster_x)
+                    K.assign(record_tile_n, cluster_n_idx * K.int32(cluster_n) + cluster_y)
+
+            def publish_record(expert_value, tile_m_value, tile_n_value):
+                _wait_plain(tile_pipe.empty.ptr_to([info_prod.stage]), info_prod.phase)
+                with K.If(_elected()), K.Then():
+                    base = info_prod.stage * 4
+                    K.ptx.st.shared.v4.b32(
+                        sinfo.ptr_to([base]),
+                        expert_value,
+                        tile_m_value,
+                        tile_n_value,
+                        K.int32(k_tiles),
+                    )
+                K.ptx["fence.proxy.async.shared::cta"]()
+                K.ptx.bar.sync(K.uint32(4), K.uint32(32))
+                # All 32 lanes of the scheduler warp arrive, matching the
+                # barrier's 32 arrivals.
+                K.ptx.mbarrier.arrive.shared.b64(tile_pipe.full.ptr_to([info_prod.stage]))
+                info_prod.advance()
+
+            if sched == "dynamic":
+                # The linear index comes from a global atomic instead of a
+                # stride: the leader CTA claims the next one and broadcasts it
+                # into every peer's shared slot, so a whole cluster agrees on
+                # one work tile.
+                counter_offset = L * 128 if weight_mode == "discrete" else 0
+                sched_prod = K.PipelineState(1, phase=1)
+                sched_cons = K.PipelineState(1, phase=0)
+                is_leader_cluster = cluster_rank == K.int32(0)
+
+                def fetch_single_cta():
+                    """The whole cluster is one CTA, so there is nobody to tell.
+
+                    The broadcast below reaches its peers through
+                    `mapa.shared::cluster` and `st_async.shared::cluster`, and a
+                    launch with no cluster dimension has no such address space --
+                    those instructions fault rather than degenerate. A lone CTA
+                    just keeps the index it claimed.
+                    """
+                    claimed = K.local_scalar("uint32", init=K.uint32(0))
+                    with K.If(lane == K.int32(0)), K.Then():
+                        K.ptx["atom.global.add.u32"](
+                            claimed, named["workspace"].ptr_to([counter_offset]), K.uint32(1)
+                        )
+                    K.ptx["shfl_sync.idx.b32"](
+                        claimed, claimed, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF)
+                    )
+                    K.assign(work_linear, K.cast(claimed, "int32"))
+
+                def fetch_linear():
+                    with K.If(is_leader_cluster), K.Then():
+                        _wait_plain(sched_pipe.empty.ptr_to([0]), sched_prod.phase)
+                        claimed = K.local_scalar("uint32", init=K.uint32(0))
+                        with K.If(lane == K.int32(0)), K.Then():
+                            K.ptx["atom.global.add.u32"](
+                                claimed, named["workspace"].ptr_to([counter_offset]), K.uint32(1)
+                            )
+                        K.ptx["shfl_sync.idx.b32"](
+                            claimed, claimed, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF)
+                        )
+                        with K.If(lane < K.int32(cluster_size)), K.Then():
+                            peer = K.local_scalar("uint32", init=K.cast(lane, "uint32"))
+                            remote_slot = K.local_scalar("uint32")
+                            remote_bar = K.local_scalar("uint32")
+                            local_slot = K.local_scalar("uint32")
+                            local_bar = K.local_scalar("uint32")
+                            K.assign(
+                                local_slot,
+                                K.cuda.cvta_generic_to_shared(sched_broadcast.ptr_to([0])),
+                            )
+                            K.assign(
+                                local_bar,
+                                K.cuda.cvta_generic_to_shared(sched_pipe.full.ptr_to([0])),
+                            )
+                            K.ptx["mapa.shared::cluster.u32"](remote_slot, local_slot, peer)
+                            K.ptx["mapa.shared::cluster.u32"](remote_bar, local_bar, peer)
+                            K.ptx["st_async.shared::cluster.mbarrier::complete_tx::bytes.u32"](
+                                remote_slot, claimed, remote_bar
+                            )
+                            K.ptx["mbarrier.arrive.expect_tx.shared::cluster.b64"](
+                                remote_bar, K.uint32(4)
+                            )
+                    sched_prod.advance()
+                    _wait_plain(sched_pipe.full.ptr_to([0]), sched_cons.phase)
+                    fetched = K.local_scalar("int32")
+                    K.ptx.ld.shared.b32(fetched, sched_broadcast.ptr_to([0]))
+                    # Every CTA's scheduler warp releases onto the *leader's*
+                    # empty barrier, which is why it is initialized with
+                    # `32 * cluster_size` arrivals. Releasing locally leaves each
+                    # CTA 32 short and the leader blocks on its next acquire.
+                    release_local = K.local_scalar("uint32")
+                    release_peer = K.local_scalar("uint32")
+                    K.assign(
+                        release_local, K.cuda.cvta_generic_to_shared(sched_pipe.empty.ptr_to([0]))
+                    )
+                    K.ptx["mapa.shared::cluster.u32"](release_peer, release_local, K.uint32(0))
+                    K.ptx["mbarrier.arrive.shared::cluster.b64"](release_peer, K.uint32(1))
+                    sched_cons.advance()
+                    K.assign(work_linear, fetched)
+
+                claim_next = fetch_linear if cluster_size > 1 else fetch_single_cta
+                claim_next()
+                resolve_work()
+                with K.While(work_valid == K.uint32(1)):
+                    publish_record(record_expert, record_tile_m, record_tile_n)
+                    claim_next()
+                    resolve_work()
+            else:
+                resolve_work()
+                with K.While(work_valid == K.uint32(1)):
+                    publish_record(record_expert, record_tile_m, record_tile_n)
+                    K.assign(work_linear, work_linear + K.int32(num_persistent_clusters))
+                    resolve_work()
+
+            # Termination record: expert_idx = -1 stops the other seven warps.
+            publish_record(K.int32(-1), K.int32(0), K.int32(0))
+            with K.unroll(0, tile_stages):
+                _wait_plain(tile_pipe.empty.ptr_to([info_prod.stage]), info_prod.phase)
+                info_prod.advance()
+
+        # ---- consumer preamble shared by roles 2-5 -----------------------
+        # Every consumer keeps its own cursor over the identical record stream.
+        # The MMA warp needs only the expert index; nobody reads field 3, since
+        # all four roles use the `k_tiles` computed once on the host.
+        def take_tile_info(state, slots, want_tiles=True):
+            _wait_plain(tile_pipe.full.ptr_to([state.stage]), state.phase)
+            base = state.stage * 4
+            K.ptx.ld.shared.b32(slots[0], sinfo.ptr_to([base]))
+            if want_tiles:
+                K.ptx.ld.shared.b32(slots[1], sinfo.ptr_to([base + 1]))
+                K.ptx.ld.shared.b32(slots[2], sinfo.ptr_to([base + 2]))
+            K.ptx["fence.proxy.async.shared::cta"]()
+            # Every consumer thread arrives; the barrier carries 224 arrivals,
+            # one per thread of the seven consumer warps.
+            K.ptx.mbarrier.arrive.shared.b64(tile_pipe.empty.ptr_to([state.stage]))
+            state.advance()
+
+        def expert_row_base(expert):
+            """First padded row of an expert; the offsets are cumulative."""
+            base = K.local_scalar("int32", init=K.int32(0))
+            with K.If(expert > K.int32(0)), K.Then():
+                previous = K.local_scalar("int32")
+                K.ptx.ld.global_.b32(
+                    previous, named["padded_offsets"].ptr_to([expert - K.int32(1)])
+                )
+                K.assign(base, previous)
+            return base
+
+        # ---- Role 2: warp 5, persistent TMA producer ---------------------
+        with tma_role:
+            ab_prod = K.PipelineState(ab_stages, phase=1)
+            # A second cursor kept one step ahead, so the next stage's
+            # speculative probe can be issued before this stage's copies and
+            # overlap their latency, as the source does.
+            ab_probe = K.PipelineState(ab_stages, phase=1)
+            ab_probe.advance()
+            info_cons = K.PipelineState(tile_stages, phase=0)
+            tile_expert = K.local_scalar("int32")
+            tile_m_idx = K.local_scalar("int32")
+            tile_n_idx = K.local_scalar("int32")
+            slots = (tile_expert, tile_m_idx, tile_n_idx)
+            speculative = K.local_scalar("uint32")
+
+            take_tile_info(info_cons, slots)
+            with K.While(tile_expert >= K.int32(0)):
+                row_base = expert_row_base(tile_expert)
+                a_row = K.local_scalar("int32", init=row_base + tile_m_idx * K.int32(cta_tile_m))
+                if cluster_n > 1:
+                    K.assign(a_row, a_row + cluster_y * K.int32(a_cluster_piece))
+                # The CTA pair splits B's N extent, so each CTA takes its own
+                # half: the export's B coordinate carries the same `cta_in_pair
+                # * 128` term that A's M coordinate does (PTX 920/926, both
+                # built from `%r5 << 7`).
+                n_base = K.local_scalar("int32", init=tile_n_idx * K.int32(cta_tile_n))
+                if atom_thr > 1:
+                    K.assign(n_base, n_base + cluster_v * K.int32(b_tile_n))
+                # On top of the pair split, the cluster's M extent multicasts B:
+                # each CTA fetches one `b_cluster_piece` slice and the pieces
+                # together fill the stage. The destination address already
+                # carried this term; the coordinate did not, so every CTA in the
+                # M direction fetched the *same* slice into a different quarter
+                # of SMEM and the tile's upper columns duplicated its lower
+                # ones. A k-major B splits along N, an n-major B along K.
+                if b_split > 1 and b_major == "k":
+                    K.assign(n_base, n_base + cluster_m_coord * K.int32(b_cluster_piece))
+
+                # Descriptor addresses: dense weights use the grid-constant
+                # TensorMaps, discrete weights the per-expert image the
+                # pre-kernel wrote into the workspace.
+                if weight_mode == "discrete":
+                    # The pre-kernel wrote this expert's B TensorMap image here;
+                    # the TMA reads the descriptor straight out of global memory
+                    # instead of from a grid constant. One 128-byte slot per
+                    # expert -- the block-scaled sibling's second slot held SFB,
+                    # which this kernel has no counterpart for.
+                    b_desc = named["workspace"].ptr_to([K.int32(128) * tile_expert])
+
+                K.assign(speculative, K.uint32(1))
+                with K.If(K.int32(k_tiles) > K.int32(0)), K.Then():
+                    _try_wait_acquire(
+                        speculative, ab_pipe.empty.ptr_to([ab_prod.stage]), ab_prod.phase
+                    )
+                counter = K.local_scalar("int32", init=K.int32(0))
+                with K.While(counter < K.int32(k_tiles)):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([ab_prod.stage]), ab_prod.phase, speculative
+                    )
+                    # `num_tma_load_bytes` counts the whole CTA pair, so the
+                    # leader alone arrives for `atom_thr` stages' worth.
+                    with K.If(is_leader_cta), K.Then():
+                        with K.If(_elected()), K.Then():
+                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                ab_pipe.full.ptr_to([ab_prod.stage]),
+                                K.uint32(derived["ab_expect_tx_bytes"]),
+                            )
+                    with K.If(counter + K.int32(1) < K.int32(k_tiles)), K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([ab_probe.stage]), ab_probe.phase
+                        )
+
+                    k_coord = K.local_scalar("int32", init=counter * K.int32(k_tile))
+                    if atom_thr > 1:
+                        # A two-CTA copy credits the *leader's* barrier: bit 24
+                        # of a cluster shared address selects the CTA within the
+                        # pair, and clearing it maps this CTA's barrier onto the
+                        # even one. Crediting the local barrier instead leaves
+                        # the leader permanently short of its expect_tx count.
+                        full_bar = K.local_scalar("uint32")
+                        K.assign(
+                            full_bar,
+                            cluster_smem_base
+                            + K.uint32(offsets["ab_full"])
+                            + K.cast(ab_prod.stage, "uint32") * K.uint32(8),
+                        )
+                        K.ptx["and.b32"](full_bar, full_bar, K.uint32(0xFEFFFFFF))
+                    else:
+                        full_bar = ab_pipe.full.ptr_to([ab_prod.stage])
+                    a_slot = smem.ptr_to([offsets["sA"] + ab_prod.stage * derived["a_stage_bytes"]])
+                    two_cta = atom_thr > 1
+                    # Multicast splits a stage across the cluster: each CTA
+                    # issues its own piece into the owning CTA's *cluster*
+                    # address, and the pieces together satisfy the stage's
+                    # expect_tx byte count. Issuing the whole stage to the local
+                    # address instead leaves the barrier permanently short.
+                    a_destination = (
+                        cluster_smem_base
+                        + K.uint32(offsets["sA"])
+                        + K.cast(ab_prod.stage, "uint32") * K.uint32(derived["a_stage_bytes"])
+                        + K.cast(cluster_y, "uint32")
+                        * K.uint32(derived["a_stage_bytes"] // cluster_n)
+                        if cluster_n > 1
+                        else a_slot
+                    )
+                    with K.If(_elected()), K.Then():
+                        _tma_load(
+                            a_destination,
+                            maps["a"],
+                            (k_coord, a_row, K.int32(0)),
+                            full_bar,
+                            a_mcast_mask if cluster_n > 1 else None,
+                            two_cta=two_cta,
+                        )
+                    b_slot = smem.ptr_to([offsets["sB"] + ab_prod.stage * derived["b_stage_bytes"]])
+                    b_block_bytes = derived["b_stage_bytes"] // b_tma_copies
+                    b_k_coord = k_coord
+                    if b_split > 1 and b_major == "n":
+                        b_k_coord = K.local_scalar(
+                            "int32", init=k_coord + cluster_m_coord * K.int32(b_cluster_piece)
+                        )
+                    # A discrete descriptor covers one expert's own allocation,
+                    # so its batch extent is 1 and the coordinate is 0; the dense
+                    # descriptor spans every expert and indexes by expert.
+                    b_batch = tile_expert if weight_mode == "dense" else K.int32(0)
+                    for block in range(b_tma_copies):
+                        b_destination = (
+                            cluster_smem_base
+                            + K.uint32(offsets["sB"])
+                            + K.cast(ab_prod.stage, "uint32") * K.uint32(derived["b_stage_bytes"])
+                            + K.uint32(block * b_block_bytes)
+                            + K.cast(cluster_m_coord, "uint32") * K.uint32(b_block_bytes // b_split)
+                            if (b_split > 1 or b_tma_copies > 1)
+                            else b_slot
+                        )
+                        b_n_coord = (
+                            n_base
+                            if block == 0
+                            else K.local_scalar(
+                                "int32", init=n_base + K.int32(block * b_atom_elements)
+                            )
+                        )
+                        with K.If(_elected()), K.Then():
+                            b_coords = (
+                                (b_n_coord, b_k_coord, b_batch)
+                                if b_major == "n"
+                                else (b_k_coord, b_n_coord, b_batch)
+                            )
+                            _tma_load(
+                                b_destination,
+                                maps["b"] if weight_mode == "dense" else None,
+                                b_coords,
+                                full_bar,
+                                b_mcast_mask if b_split > 1 else None,
+                                two_cta=two_cta,
+                                desc_ptr=None if weight_mode == "dense" else b_desc,
+                            )
+                    K.assign(counter, counter + K.int32(1))
+                    ab_prod.advance()
+                    ab_probe.advance()
+
+                take_tile_info(info_cons, slots)
+
+            with K.unroll(0, ab_stages):
+                _wait_plain(ab_pipe.empty.ptr_to([ab_prod.stage]), ab_prod.phase)
+                ab_prod.advance()
+
+        # ---- Role 3: warp 4, persistent block-scaled MMA ------------------
+        with mma_role:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            acc_tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(acc_tmem_base, tmem_slot.ptr_to([0]))
+
+            ab_cons = K.PipelineState(ab_stages, phase=0)
+            ab_cons_probe = K.PipelineState(ab_stages, phase=0)
+            ab_cons_probe.advance()
+            acc_prod = K.PipelineState(acc_stages, phase=1)
+            mma_info = K.PipelineState(tile_stages, phase=0)
+            mma_expert = K.local_scalar("int32")
+            mma_slots = (mma_expert, None, None)
+            ab_full_ready = K.local_scalar("uint32")
+
+            take_tile_info(mma_info, mma_slots, want_tiles=False)
+            with K.While(mma_expert >= K.int32(0)):
+                K.assign(ab_full_ready, K.uint32(1))
+                with K.If(is_leader_cta), K.Then():
+                    _try_wait_acquire(
+                        ab_full_ready, ab_pipe.full.ptr_to([ab_cons.stage]), ab_cons.phase
+                    )
+                    # One accumulator mbarrier stage, two TMEM regions: the
+                    # stage index is the producer phase's complement, so
+                    # successive tiles alternate between the strided regions.
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_prod.stage]), acc_prod.phase)
+                    accumulate = K.local_scalar("uint32", init=K.uint32(0))
+                    # Two real accumulator stages, each its own `cta_tile_n`
+                    # columns of tensor memory, indexed by the pipeline stage --
+                    # the block-scaled sibling folded a second region into the
+                    # slack its scale-factor columns left over, which the derived
+                    # column count here removes the need for.
+                    acc_column = K.local_scalar(
+                        "uint32", init=K.cast(acc_prod.stage, "uint32") * K.uint32(cta_tile_n)
+                    )
+                    counter = K.local_scalar("int32", init=K.int32(0))
+                    with K.While(counter < K.int32(k_tiles)):
+                        _wait_plain_if_needed(
+                            ab_pipe.full.ptr_to([ab_cons.stage]), ab_cons.phase, ab_full_ready
+                        )
+                        with K.If(counter + K.int32(1) < K.int32(k_tiles)), K.Then():
+                            _try_wait_acquire(
+                                ab_full_ready,
+                                ab_pipe.full.ptr_to([ab_cons_probe.stage]),
+                                ab_cons_probe.phase,
+                            )
+                        # Four MMA issues per K tile -- the k tile is 64 and
+                        # `kind::f16` contracts 16 at a time -- and only the
+                        # first clears the accumulate field.
+                        for kblock in range(4):
+                            with K.If(_elected()), K.Then():
+                                K.ptx[mma_mnemonic](
+                                    K.cast(acc_tmem_base + acc_column, "uint32"),
+                                    a_descriptor
+                                    + K.cast(
+                                        ab_cons.stage * (derived["a_stage_bytes"] // 16)
+                                        + kblock * 2,
+                                        "uint64",
+                                    ),
+                                    # 16 rows of K advance 32 bytes along a
+                                    # k-major operand and a whole 2 KiB swizzle
+                                    # period along an n-major one; both steps are
+                                    # read off the anchor and `bmajor_n` exports.
+                                    b_descriptor
+                                    + K.cast(
+                                        ab_cons.stage * (derived["b_stage_bytes"] // 16)
+                                        + kblock * (2 if b_major == "k" else 128),
+                                        "uint64",
+                                    ),
+                                    K.uint32(instruction_descriptor),
+                                    # `disable_output_lane`: this kernel writes
+                                    # every lane. The mask is one bit per lane
+                                    # of the atom, so a CTA pair spells out
+                                    # eight zero words and a single CTA four --
+                                    # exactly what the two exports carry.
+                                    *([K.uint32(0)] * (4 * atom_thr)),
+                                    K.ptx.pred(K.cast(accumulate, "bool")),
+                                )
+                            K.assign(accumulate, K.uint32(1))
+                        with K.If(_elected()), K.Then():
+                            _tcgen05_commit(
+                                ab_pipe.empty.ptr_to([ab_cons.stage]),
+                                ab_consumer_mask,
+                                cta_group,
+                                cluster_size,
+                            )
+                        K.assign(counter, counter + K.int32(1))
+                        ab_cons.advance()
+                        ab_cons_probe.advance()
+                    with K.If(_elected()), K.Then():
+                        _tcgen05_commit(
+                            acc_pipe.full.ptr_to([acc_prod.stage]),
+                            acc_producer_mask,
+                            cta_group,
+                            cluster_size,
+                        )
+                acc_prod.advance()
+                take_tile_info(mma_info, mma_slots, want_tiles=False)
+
+            # Only the leader of a CTA pair issues MMA, owns the accumulator and
+            # advances `acc_prod`, and every epilogue arrival is redirected to
+            # the leader's barrier. The follower must not drain a pipeline it
+            # never used: its own `acc_empty` receives nothing, so waiting on it
+            # here is what hung every two-CTA specialization at the end of the
+            # persistent loop.
+            with K.If(is_leader_cta), K.Then():
+                with K.unroll(0, acc_stages):
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_prod.stage]), acc_prod.phase)
+                    acc_prod.advance()
+
+        # ---- Role 5: warp 6, epilogue C producer --------------------------
+        # The C subtiles are issued in the same forward order the epilogue reads
+        # them, so the two agree on which C subtile belongs to which accumulator
+        # subtile with no extra handshake.
+        with c_role:
+            c_prod = K.PipelineState(c_stages, phase=1)
+            c_info = K.PipelineState(tile_stages, phase=0)
+            c_expert = K.local_scalar("int32")
+            c_tile_m = K.local_scalar("int32")
+            c_tile_n = K.local_scalar("int32")
+            c_slots = (c_expert, c_tile_m, c_tile_n)
+
+            take_tile_info(c_info, c_slots)
+            with K.While(c_expert >= K.int32(0)):
+                c_row = K.local_scalar(
+                    "int32", init=expert_row_base(c_expert) + c_tile_m * K.int32(cta_tile_m)
+                )
+                # The 2N interleaved column tile this work tile owns.
+                d_tile_n = K.local_scalar("int32", init=c_tile_n * K.int32(cta_tile_n * 2))
+
+                subtile = K.local_scalar("int32", init=K.int32(0))
+                with K.While(subtile < K.int32(epi_subtiles)):
+                    real_subtile = subtile
+                    for half in range(2):
+                        _wait_plain(c_pipe.empty.ptr_to([c_prod.stage]), c_prod.phase)
+                        with K.If(_elected()), K.Then():
+                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                c_pipe.full.ptr_to([c_prod.stage]),
+                                K.uint32(derived["c_stage_bytes"]),
+                            )
+                        column = K.local_scalar(
+                            "int32",
+                            init=d_tile_n
+                            + (real_subtile * K.int32(2) + K.int32(half)) * K.int32(32),
+                        )
+                        c_slot = smem.ptr_to(
+                            [offsets["sC"] + c_prod.stage * derived["c_stage_bytes"]]
+                        )
+                        with K.If(_elected()), K.Then():
+                            _tma_load(
+                                c_slot,
+                                maps["c"],
+                                (column, c_row, K.int32(0)),
+                                c_pipe.full.ptr_to([c_prod.stage]),
+                                None,
+                                two_cta=False,
+                            )
+                        c_prod.advance()
+                    K.assign(subtile, subtile + K.int32(1))
+
+                take_tile_info(c_info, c_slots)
+
+            with K.unroll(0, c_stages):
+                _wait_plain(c_pipe.empty.ptr_to([c_prod.stage]), c_prod.phase)
+                c_prod.advance()
+
+        # ---- Role 4: warps 0-3, dGLU backward epilogue --------------------
+        with epilogue_role:
+            with K.If(warp == K.int32(0)), K.Then():
+                # `.sync.aligned`, so every lane of warp 0 executes it; the warp
+                # predicate is the only guard.
+                K.ptx[f"tcgen05.alloc.{cta_group}.sync.aligned.shared::cta.b32"](
+                    tmem_slot.ptr_to([0]), K.uint32(derived["num_tmem_alloc_cols"])
+                )
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+
+            acc_cons = K.PipelineState(acc_stages, phase=0)
+            c_cons = K.PipelineState(c_stages, phase=0)
+            d_prod = K.PipelineState(max(1, d_stages // 2), phase=1)
+            epi_info = K.PipelineState(tile_stages, phase=0)
+            epi_expert = K.local_scalar("int32")
+            epi_tile_m = K.local_scalar("int32")
+            epi_tile_n = K.local_scalar("int32")
+            epi_slots = (epi_expert, epi_tile_m, epi_tile_n)
+
+            # The register tile is walked two elements at a time throughout the
+            # epilogue, and the pairs are always issued packed: one
+            # `mul.rn.f32x2` / `add.rn.f32x2` per pair where the scalar form
+            # issues two, for identical numbers -- each half of a packed line
+            # rounds exactly as its scalar sibling.
+            #
+            # The source only writes packed intrinsics under `vectorized_f32`,
+            # but its scalar branch is packed for it: on a `vectorized_f32=False`
+            # shape the reference still retires roughly a quarter of TIRx's FP32
+            # instruction count, which a scalar lowering cannot do. Emitting the
+            # packed form on every specialization is what actually matches the
+            # reference's machine code.
+            packed_pair = K.local_scalar("uint64")
+            ops = _arithmetic(True, packed_pair)
+            epi_lane = K.local_scalar("int32", init=K.thread_id() % K.int32(32))
+            epi_warp = _warp_uniform(K.thread_id() // K.int32(32))
+
+            def dbias_reduce(real_subtile, tile_base):
+                """One subtile's contribution to this expert's dBias column sums.
+
+                Each thread holds one row's 32 gate and 32 up values, so a column
+                sum is a reduction *across* threads. The 64 columns go to SMEM as
+                (column, row) -- the transpose -- each warp into its own 8 KiB
+                block; then one thread takes two whole columns and sums their 32
+                rows, the four warps' partial sums are combined, and warp 0
+                atomically accumulates a bf16 pair per column.
+
+                Rows are stored with the source's `((col >> 1) & 7) << 2` XOR on
+                the row-group index. It cancels out of the sum -- it is there so
+                that the 32 lanes reading 32 different columns hit 32 different
+                banks instead of all landing on the same one.
+                """
+                warp_base = K.local_scalar(
+                    "int32", init=offsets["sDbias"] + epi_warp * K.int32(64 * 32 * 4)
+                )
+                group = K.local_scalar("int32", init=epi_lane // K.int32(4))
+                sub = K.local_scalar("int32", init=epi_lane % K.int32(4))
+                # `group ^ swizzle` for each of the eight constant swizzles.
+                twisted = [
+                    K.local_scalar("int32", init=group ^ K.int32(swizzle)) for swizzle in range(8)
+                ]
+                for n in range(32):
+                    for column, fragment in ((n, rC1), (32 + n, rC2)):
+                        slot = K.local_scalar(
+                            "int32",
+                            init=warp_base
+                            + (K.int32(column * 32) + twisted[(column >> 1) & 7] * K.int32(4) + sub)
+                            * K.int32(4),
+                        )
+                        K.ptx.st.shared.b32(smem.ptr_to([slot]), fragment[n])
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                # Lanes 0-15 take the gate half's even columns, 16-31 the up
+                # half's, and each also takes the odd column beside it.
+                column_a = K.local_scalar(
+                    "int32",
+                    init=(epi_lane % K.int32(16)) * K.int32(2)
+                    + (epi_lane // K.int32(16)) * K.int32(32),
+                )
+                sums = [K.local_scalar("float32", init=K.float32(0.0)) for _ in range(2)]
+                quad = K.alloc_local((4,), "float32")
+                # `column_a` is even, so both sides share one twist -- and once
+                # the byte scale is folded in, the twist occupies bits 4 to 6
+                # while the column and the warp base occupy bits 7 and above.
+                # The chunk therefore ORs into the column base rather than
+                # adding, which is the three-input `a | (b ^ c)` LOP3: one
+                # instruction per address where the add-then-XOR was two, on
+                # sixteen addresses every subtile.
+                swizzle = K.local_scalar(
+                    "int32", init=((column_a // K.int32(2)) % K.int32(8)) * K.int32(16)
+                )
+                for side in range(2):
+                    column = K.local_scalar("int32", init=column_a + K.int32(side))
+                    column_base = K.local_scalar("int32", init=warp_base + column * K.int32(128))
+                    for chunk in range(8):
+                        base = K.local_scalar(
+                            "int32", init=column_base | (K.int32(chunk * 16) ^ swizzle)
+                        )
+                        # `sDbias` is placed 128-byte aligned and both terms of
+                        # the offset are multiples of 16, so a chunk's four rows
+                        # are one aligned 16-byte line. Issue the vector load
+                        # rather than four scalar ones and let ptxas fuse them:
+                        # it does not always choose to, and when it declines the
+                        # cost is far out of proportion to the instruction count
+                        # -- this read-back runs 64 loads per subtile.
+                        K.ptx["ld.shared.v4.b32"](
+                            quad[0], quad[1], quad[2], quad[3], smem.ptr_to([base])
+                        )
+                        for j in range(4):
+                            K.ptx["add.f32"](sums[side], sums[side], quad[j])
+
+                # Combine the four warps through the front of the same buffer,
+                # which every warp has finished reading by now.
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                partial = K.local_scalar(
+                    "int32",
+                    init=offsets["sDbias"]
+                    + (epi_warp * K.int32(64) + epi_lane * K.int32(2)) * K.int32(4),
+                )
+                for side in range(2):
+                    K.ptx.st.shared.b32(smem.ptr_to([partial + K.int32(4 * side)]), sums[side])
+                K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                with K.If(epi_warp == K.int32(0)), K.Then():
+                    totals = [K.local_scalar("float32", init=K.float32(0.0)) for _ in range(2)]
+                    pair_in = K.alloc_local((2,), "float32")
+                    for other in range(4):
+                        # The two sides sit next to each other and the address is
+                        # 8-byte aligned, so one vector load covers both.
+                        K.ptx["ld.shared.v2.b32"](
+                            pair_in[0],
+                            pair_in[1],
+                            smem.ptr_to(
+                                [
+                                    offsets["sDbias"]
+                                    + (K.int32(other * 64) + epi_lane * K.int32(2)) * K.int32(4)
+                                ]
+                            ),
+                        )
+                        for side in range(2):
+                            K.ptx["add.f32"](totals[side], totals[side], pair_in[side])
+                    # `n_base_d2` is `n_base_d1 + 32` and the up half's columns
+                    # start at 32, so one expression covers both halves.
+                    n_offset = K.local_scalar(
+                        "int32",
+                        init=tile_base + (real_subtile * K.int32(2)) * K.int32(32) + column_a,
+                    )
+                    packed = K.local_scalar("uint32")
+                    K.ptx["cvt.rn.bf16x2.f32"](packed, totals[1], totals[0])
+                    # Same over-range tiles as the scale factors, and the source
+                    # guards this accumulate for the same reason.
+                    with K.If(n_offset < K.int32(N_out)), K.Then():
+                        K.ptx["red.global.add.noftz.bf16x2"](
+                            named["dbias"].ptr_to(
+                                [(epi_expert * K.int32(N_out) + n_offset) * K.int32(2)]
+                            ),
+                            packed,
+                        )
+
+            rAcc = K.alloc_local((32,), "float32")
+            rC1 = K.alloc_local((32,), "float32")
+            rC2 = K.alloc_local((32,), "float32")
+            d_words = 32 * d_bits // 32
+            rD1 = K.alloc_local((d_words,), "uint32")
+            rD2 = K.alloc_local((d_words,), "uint32")
+            # Counts subtiles across the whole persistent loop, so the two D
+            # slots keep alternating across work tiles.
+            prev_subtiles = K.local_scalar("int32", init=K.int32(0))
+
+            take_tile_info(epi_info, epi_slots)
+            with K.While(epi_expert >= K.int32(0)):
+                alpha_value = K.local_scalar("float32")
+                beta_value = K.local_scalar("float32")
+                K.ptx.ld.global_.b32(alpha_value, named["alpha"].ptr_to([epi_expert]))
+                K.ptx.ld.global_.b32(beta_value, named["beta"].ptr_to([epi_expert]))
+                square_alpha = K.local_scalar("float32", init=alpha_value * alpha_value)
+
+                row_base = expert_row_base(epi_expert)
+                # Each accumulator stage owns its own `cta_tile_n` columns of
+                # tensor memory, and the MMA warp fills the stage this consumer
+                # cursor is about to read.
+                acc_column = K.local_scalar(
+                    "uint32", init=K.cast(acc_cons.stage, "uint32") * K.uint32(cta_tile_n)
+                )
+
+                thread_row = K.local_scalar(
+                    "int32",
+                    init=row_base
+                    + (epi_tile_m // K.int32(atom_thr)) * K.int32(cta_tile_m * atom_thr)
+                    + (block_x % K.int32(atom_thr)) * K.int32(cta_tile_m)
+                    + K.thread_id()
+                    if atom_thr > 1
+                    else row_base + epi_tile_m * K.int32(cta_tile_m) + K.thread_id(),
+                )
+                prob_value = K.local_scalar("float32")
+                K.ptx.ld.global_.b32(prob_value, named["prob"].ptr_to([thread_row]))
+                dprob_acc = K.local_scalar("float32", init=K.float32(0.0))
+
+                _wait_plain(acc_pipe.full.ptr_to([acc_cons.stage]), acc_cons.phase)
+
+                d_tile_base = K.local_scalar("int32", init=epi_tile_n * K.int32(cta_tile_n * 2))
+
+                # The source pins `unroll=1` on this loop and its export
+                # carries `.pragma "nounroll"`; a `While` lowers with
+                # `#pragma unroll 1`, which is the shape the source has.
+                real_subtile = K.local_scalar("int32", init=K.int32(0))
+                subtile = K.local_scalar("int32", init=K.int32(0))
+                with K.While(subtile < K.int32(epi_subtiles)):
+                    # A TMEM address is (lane << 16) | column. The source folds
+                    # `(tid << 16) & 0xE00000` in so each epilogue warp reads its
+                    # own row group; without it all four warps read warp 0's
+                    # rows (source 3617, 3121-3122; PTX 1771-1770).
+                    # `(tid << 16) & 0xE00000` keeps bits 21 to 23, and the
+                    # column term below never reaches bit 16, so the two fields
+                    # are disjoint and the lane bits OR in. That folds the mask
+                    # and the combine into one `LOP3` where the mask, the add
+                    # and the move were three.
+                    tmem_lane = K.local_scalar("uint32")
+                    K.ptx["shl.b32"](tmem_lane, K.cast(K.thread_id(), "uint32"), K.uint32(16))
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                        *[rAcc[i] for i in range(32)],
+                        (tmem_lane & K.uint32(0xE00000))
+                        | (tmem_base + acc_column + K.cast(real_subtile * K.int32(32), "uint32")),
+                    )
+
+                    # Two C stages per accumulator subtile: gate then up.
+                    c_row_bytes = 32 * c_bits // 8
+                    c_words = c_row_bytes // 4
+                    for fragment in (rC1, rC2):
+                        _wait_plain(c_pipe.full.ptr_to([c_cons.stage]), c_cons.phase)
+                        c_slot = offsets["sC"] + c_cons.stage * derived["c_stage_bytes"]
+                        # Each thread owns one row of the 128x32 subtile, so
+                        # its slice starts at row * 32 * c_bits/8 bytes.
+                        raw = K.alloc_local((c_words,), "uint32")
+                        c_row = K.local_scalar("int32", init=K.thread_id() * K.int32(c_row_bytes))
+                        for word in range(0, c_words, 4):
+                            # The descriptor swizzled this box on the way in, so
+                            # the read walks the same permutation.
+                            K.ptx["ld.shared.v4.b32"](
+                                raw[word],
+                                raw[word + 1],
+                                raw[word + 2],
+                                raw[word + 3],
+                                smem.ptr_to([c_slot + _swizzled(c_row, word // 4, c_row_bytes)]),
+                            )
+                        # The stage is handed back the moment its bytes are in
+                        # registers, before they are widened. The reference's
+                        # C fragments are the C dtype, so it releases with
+                        # nothing between the load and the fence; widening first
+                        # would hold the buffer for another forty-odd
+                        # instructions, and with only two C stages on a
+                        # four-bit specialization the producer has no slack to
+                        # absorb that.
+                        K.ptx["fence.proxy.async.shared::cta"]()
+                        with K.If(K.lane_id() == K.int32(0)), K.Then():
+                            K.ptx.mbarrier.arrive.shared.b64(c_pipe.empty.ptr_to([c_cons.stage]))
+                        c_cons.advance()
+                        _unpack_input(fragment, raw, c_dtype, c_bits)
+
+                    # ---- dGLU derivative, elementwise over the subtile ----
+                    # The register tile is walked two elements at a time: a
+                    # `vectorized_f32` specialization issues one packed
+                    # `mul.rn.f32x2` / `add.rn.f32x2` per pair where the scalar
+                    # one issues two, for identical numbers. One scratch set is
+                    # reused for every pair -- fresh scalars per element make
+                    # ptxas superlinear (see `_arithmetic`).
+                    def pair():
+                        return (K.local_scalar("float32"), K.local_scalar("float32"))
+
+                    acc = pair()
+                    gate = pair()
+                    up = pair()
+                    d_gate = pair()
+                    d_up = pair()
+                    sig = pair()
+                    work = pair()
+                    step = pair()
+                    helper = pair()
+                    scratch = {name: pair() for name in "abcdefgh"}
+                    prob_pair = (prob_value, prob_value)
+                    alpha_pair = (square_alpha, square_alpha)
+                    beta_pair = (beta_value, beta_value)
+                    # The source reduces dProb as a packed pair and folds the
+                    # two halves in once per subtile, not once per element.
+                    dprob_pair = pair()
+                    for half in range(2):
+                        K.assign(dprob_pair[half], K.float32(0.0))
+
+                    for element in range(0, 32, 2):
+                        span = (element, element + 1)
+                        ops["product"](acc, tuple(rAcc[j] for j in span), alpha_pair)
+                        ops["product"](gate, tuple(rC1[j] for j in span), beta_pair)
+                        ops["product"](up, tuple(rC2[j] for j in span), beta_pair)
+
+                        if act == "dswiglu":
+                            _sigmoid(ops, sig, gate, work)
+                            # The source spells this out as `swish = gate * sig`
+                            # followed by three independent product chains, and
+                            # its compiler reassociates them around the shared
+                            # `acc * sig` before contracting the last multiply
+                            # and add: its machine code retires eleven packed
+                            # multiplies, two adds and one FFMA where the
+                            # written form has thirteen and three. Every
+                            # operation here is inline assembly, so nothing
+                            # rewrites it on the way down -- the reassociated
+                            # form is what has to be written. `swish` itself is
+                            # never formed, and neither is `up * sig`.
+                            ops["product"](step, acc, sig)  # acc * sig
+                            ops["product"](helper, step, prob_pair)  # acc_prob * sig
+                            ops["product"](d_up, helper, gate)  # acc_prob * swish
+                            ops["product"](helper, helper, up)
+                            ops["product"](step, step, up)
+                            # The accumulation absorbs the last multiply:
+                            # `acc * up * swish` is never materialised.
+                            ops["fused"](dprob_pair, step, gate, dprob_pair)
+                            ops["complement"](work, 1.0, sig, scratch["h"])
+                            ops["fused"](work, gate, work, _spread(1.0))
+                            ops["product"](d_gate, helper, work)
+                        else:
+                            # dGeGLU. Both gradients are scaled by a *value*,
+                            # not by a 0/1 mask: upstream's `x1_filter` is the
+                            # clamped gate itself and `x2_filter` the clamped
+                            # up, zeroed only where the raw operand falls
+                            # outside the bound its branch tests. The block-
+                            # scaled sibling carries a later revision of this
+                            # function whose filters are 1.0/0.0; transcribing
+                            # that here would drop a whole factor.
+                            y_gate = scratch["a"]
+                            y_up = scratch["b"]
+                            # `min`/`max` reach the clamp in one instruction
+                            # where the source's `setp`/`selp` pair costs two;
+                            # the two forms differ only on a NaN input, which a
+                            # C-matrix element cannot be.
+                            for half in range(2):
+                                K.ptx["min.f32"](y_gate[half], gate[half], K.float32(GEGLU_MAX))
+                                K.ptx["min.f32"](y_up[half], up[half], K.float32(GEGLU_MAX))
+                                K.ptx["max.f32"](y_up[half], y_up[half], K.float32(GEGLU_MIN))
+                            ops["scaled"](work, y_gate, GEGLU_ALPHA)  # 1.702 * y_gate
+                            _sigmoid(ops, sig, work, scratch["c"])
+                            offset_up = scratch["e"]
+                            ops["offset"](offset_up, y_up, linear_offset)
+                            step = scratch["d"]
+                            ops["product"](step, acc, sig)  # acc * sigmoid
+                            # dProb reads the pre-`prob` product, which is why
+                            # it is folded in before the routing factor.
+                            helper = scratch["f"]
+                            ops["product"](helper, offset_up, step)
+                            ops["fused"](dprob_pair, helper, y_gate, dprob_pair)
+                            inner = scratch["g"]
+                            ops["complement"](inner, 1.0, sig, scratch["h"])
+                            ops["fused"](inner, work, inner, _spread(1.0))
+                            ops["product"](d_gate, helper, inner)
+                            ops["product"](d_gate, d_gate, prob_pair)
+                            ops["product"](d_up, step, prob_pair)
+                            ops["product"](d_up, d_up, y_gate)
+                            # The filters. `gate` keeps `y_gate` at or below the
+                            # upper bound and zero above it. `up` runs the two
+                            # bounds in the source's order, which leaves the
+                            # upper one inert on the packed path -- a raw value
+                            # above +7 zeroes the intermediate, and zero passes
+                            # the lower test -- so only the lower bound
+                            # survives. The scalar path applies both, and the
+                            # two disagree above +7; each specialization gets
+                            # the arm its `vectorized_f32` selects.
+                            keep = scratch["c"]
+                            for half in range(2):
+                                predicate = K.local_scalar("bool")
+                                K.assign(
+                                    predicate, K.cast(gate[half] <= K.float32(GEGLU_MAX), "bool")
+                                )
+                                K.ptx["selp.f32"](
+                                    keep[half], y_gate[half], K.float32(0.0), predicate
+                                )
+                            ops["product"](d_gate, d_gate, keep)
+                            for half in range(2):
+                                predicate = K.local_scalar("bool")
+                                if vectorized_f32:
+                                    K.assign(
+                                        predicate, K.cast(up[half] >= K.float32(GEGLU_MIN), "bool")
+                                    )
+                                    K.ptx["selp.f32"](
+                                        keep[half], y_up[half], K.float32(0.0), predicate
+                                    )
+                                else:
+                                    K.assign(
+                                        predicate,
+                                        K.cast(
+                                            K.And(
+                                                up[half] >= K.float32(GEGLU_MIN),
+                                                up[half] <= K.float32(GEGLU_MAX),
+                                            ),
+                                            "bool",
+                                        ),
+                                    )
+                                    K.ptx["selp.f32"](
+                                        keep[half], up[half], K.float32(0.0), predicate
+                                    )
+                            ops["product"](d_up, d_up, keep)
+
+                        for half in range(2):
+                            K.assign(rC1[span[half]], d_gate[half])
+                            K.assign(rC2[span[half]], d_up[half])
+
+                    folded_prob = K.local_scalar("float32")
+                    K.ptx["add.f32"](folded_prob, dprob_pair[0], dprob_pair[1])
+                    K.ptx["add.f32"](dprob_acc, dprob_acc, folded_prob)
+
+                    # ---- convert D and stage it through SMEM -------------
+                    _pack_output(rD1, rC1, d_dtype, d_bits)
+                    _pack_output(rD2, rC2, d_dtype, d_bits)
+
+                    with K.If(warp == K.int32(0)), K.Then():
+                        # The D pipeline is a bulk-group counter, not an
+                        # mbarrier: there is no D barrier in the storage map.
+                        K.ptx["cp.async.bulk.wait_group.read"](K.uint32(0))
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    slot1 = K.local_scalar("int32", init=prev_subtiles % K.int32(d_stages))
+                    K.assign(prev_subtiles, prev_subtiles + K.int32(1))
+                    slot2 = K.local_scalar("int32", init=prev_subtiles % K.int32(d_stages))
+                    K.assign(prev_subtiles, prev_subtiles + K.int32(1))
+
+                    d_row_bytes = 32 * d_bits // 8
+
+                    def stage_fragment(fragment, slot, region="sD"):
+                        # Mirror of the C load: this thread owns one row of the
+                        # 128x32 subtile.
+                        base = offsets[region] + slot * K.int32(derived["d_stage_bytes"])
+                        d_row = K.local_scalar("int32", init=K.thread_id() * K.int32(d_row_bytes))
+                        for word in range(0, d_words, 4):
+                            # Written through the same permutation the store
+                            # descriptor reads back.
+                            K.ptx["st.shared.v4.b32"](
+                                smem.ptr_to([base + _swizzled(d_row, word // 4, d_row_bytes)]),
+                                fragment[word],
+                                fragment[word + 1],
+                                fragment[word + 2],
+                                fragment[word + 3],
+                            )
+
+                    # Both halves of one slot go out together, D then D_col.
+                    stage_fragment(rD1, slot1)
+                    stage_fragment(rD2, slot2)
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    with K.If(warp == K.int32(0)), K.Then():
+                        # The two D subtiles of one accumulator subtile land in
+                        # adjacent halves of the 2N region, which is why the
+                        # column index is 2 * real_subtile + {0, 1}.
+                        d_row_coord = K.local_scalar(
+                            "int32", init=row_base + epi_tile_m * K.int32(cta_tile_m)
+                        )
+                        for map_name, region in (("d_row", "sD"),):
+                            for half, slot in ((0, slot1), (1, slot2)):
+                                column = K.local_scalar(
+                                    "int32",
+                                    init=d_tile_base
+                                    + (real_subtile * K.int32(2) + K.int32(half)) * K.int32(32),
+                                )
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.global.shared::cta.tile"
+                                    ".bulk_group.L2::cache_hint"
+                                ](
+                                    K.address_of(maps[map_name]),
+                                    K.cast(column, "int32"),
+                                    K.cast(d_row_coord, "int32"),
+                                    K.int32(0),
+                                    smem.ptr_to(
+                                        [offsets[region] + slot * K.int32(derived["d_stage_bytes"])]
+                                    ),
+                                    K.uint64(0),
+                                )
+                        K.ptx["cp.async.bulk.commit_group"]()
+                        d_prod.advance()
+                    # The dBias column sums are taken with the tile's D store
+                    # already in flight. They read the activation fragments,
+                    # which the packing only copied, and they touch their own
+                    # shared region, so nothing in them depends on the store --
+                    # and the reduction is a transpose through shared memory
+                    # with two barriers in it, which is exactly the kind of work
+                    # a bulk store wants underneath it.
+                    if generate_dbias:
+                        dbias_reduce(real_subtile, d_tile_base)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    K.assign(real_subtile, real_subtile + K.int32(1))
+                    K.assign(subtile, subtile + K.int32(1))
+
+                # Release the accumulator stage once every subtile has been read
+                # out of it. One elected lane per epilogue warp arrives, and
+                # both CTAs of a pair arrive on the *leader's* barrier, which is
+                # where the accumulator lives -- hence its `4 * atom_thr`
+                # arrivals. Releasing locally leaves the leader's MMA waiting on
+                # a stage nobody frees.
+                K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                with K.If(_elected()), K.Then():
+                    peer_bar = K.local_scalar("uint32")
+                    local_bar = K.local_scalar("uint32")
+                    K.assign(
+                        local_bar,
+                        K.cuda.cvta_generic_to_shared(acc_pipe.empty.ptr_to([acc_cons.stage])),
+                    )
+                    K.ptx["mapa.shared::cluster.u32"](
+                        peer_bar,
+                        local_bar,
+                        K.cast(
+                            cluster_rank - cluster_v if atom_thr > 1 else cluster_rank, "uint32"
+                        ),
+                    )
+                    K.ptx["mbarrier.arrive.shared::cluster.b64"](peer_bar, K.uint32(1))
+                acc_cons.advance()
+
+                # The next record is taken before the dProb tail, as the source
+                # does, so the tile-info slot is freed as early as possible.
+                take_tile_info(epi_info, epi_slots)
+                # One reduction per thread per work tile. The returning form
+                # would put every one of these on the scoreboard for a value that
+                # is immediately discarded.
+                K.ptx["red.global.add.f32"](named["dprob"].ptr_to([thread_row]), dprob_acc)
+
+            # Release the TMEM allocation permit and free the columns. Both are
+            # warp 0's: the permit is a warp-wide instruction and the source
+            # issues it under the same predicate as the deallocation.
+            K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+            with K.If(warp == K.int32(0)), K.Then():
+                K.ptx[f"tcgen05.relinquish_alloc_permit.{cta_group}.sync.aligned"]()
+                if atom_thr > 1:
+                    # A CTA pair frees its TMEM collectively: each CTA arrives on
+                    # its peer's deallocation barrier and waits on its own before
+                    # issuing the free.
+                    peer_dealloc = K.local_scalar("uint32")
+                    own_dealloc = K.local_scalar("uint32")
+                    K.assign(own_dealloc, K.cuda.cvta_generic_to_shared(tmem_dealloc.ptr_to([0])))
+                    K.ptx["mapa.shared::cluster.u32"](
+                        peer_dealloc, own_dealloc, K.cast(cluster_rank ^ K.int32(1), "uint32")
+                    )
+                    K.ptx["mbarrier.arrive.shared::cluster.b64"](peer_dealloc, K.uint32(1))
+                    _wait_plain(tmem_dealloc.ptr_to([0]), K.uint32(0))
+                K.ptx[f"tcgen05.dealloc.{cta_group}.sync.aligned.b32"](
+                    tmem_base, K.uint32(derived["num_tmem_alloc_cols"])
+                )
+            K.ptx["cp.async.bulk.wait_group.read"](K.uint32(0))
+
+        del (
+            block_x,
+            lane,
+            epilogue_role,
+            mma_role,
+            c_role,
+            a_descriptor,
+            b_descriptor,
+            ab_consumer_mask,
+            acc_producer_mask,
+            cluster_smem_base,
+            tmem_slot,
+        )
+
+    def build_helper():
+        """Pre-kernel launched before the main kernel on the same stream.
+
+        For the dynamic scheduler it resets the global work counter. For discrete
+        weights each block publishes one expert's B TensorMap image into the
+        workspace, which is where the main kernel's TMA reads it from.
+
+        A discrete expert's weights are its own allocation, so only the global
+        address differs between the experts' images (probe/descriptor_images.txt
+        shows the other fifteen words identical across all four). The host
+        prelude therefore encodes one template -- correct in every field but the
+        address -- and each block copies it and patches the address with
+        ``tensormap.replace``.
+        """
+
+        def helper_prelude(params):
+            descriptors = {"b": K.stack_alloca("tensormap", 1)}
+            # The template's address is a placeholder: it has to be a real
+            # 16-byte-aligned allocation for the encode call to accept it, and
+            # the copy below overwrites it per expert. The pointer array itself
+            # is the convenient stand-in.
+            encode_weight_maps(descriptors, params["b"].data, 1)
+            return (descriptors["b"],)
+
+        def read_tensormap_image(source_map):
+            """Read one TensorMap image out of the host-encoded template.
+
+            Only the first 64 bytes of a 128-byte image carry anything -- the
+            encoder leaves the tail zero (probe/descriptor_images.txt) and the
+            workspace starts zeroed -- so the image moves as two
+            `ld.global.v4.b64` / `st.global.v4.b64` pairs.
+
+            The source builds these words as immediates because CuTeDSL
+            constructs the descriptor inside the device compiler. TIRx's encoder
+            is the host-side `cuTensorMapEncodeTiled`, which cannot produce
+            immediates at trace time, so the words are read from the template the
+            host prelude encoded. That read is the one part of this that the
+            source has no counterpart for.
+            """
+            source: K.uint64 = K.reinterpret("uint64", K.address_of(source_map))
+            groups = []
+            for group in range(2):
+                payload = K.alloc_local((4,), "uint64")
+                offset: K.uint64 = K.uint64(group * 32)
+                K.ptx.ld.global_.v4.b64(
+                    payload[0],
+                    payload[1],
+                    payload[2],
+                    payload[3],
+                    K.reinterpret("handle", source + offset),
+                )
+                groups.append(payload)
+            return groups
+
+        def write_tensormap_image(groups, destination, address):
+            """Publish one image, substituting word 0, the global address."""
+            target: K.uint64 = K.reinterpret("uint64", destination)
+            for group, payload in enumerate(groups):
+                if group == 0:
+                    K.assign(payload[0], address)
+                K.ptx.st.global_.v4.b64(
+                    K.reinterpret("handle", target + K.uint64(group * 32)),
+                    payload[0],
+                    payload[1],
+                    payload[2],
+                    payload[3],
+                )
+
+        def helper(operands, host):
+            b, workspace = operands
+            expert = K.cta_id()[0]
+            if weight_mode == "discrete":
+                slot = K.local_scalar("int32", init=K.int32(128) * expert)
+                with K.If(_elected()), K.Then():
+                    # This kernel is nothing but memory latency: three global
+                    # reads and two writes on one lane. The expert pointer is
+                    # loaded before the template image so the two round trips
+                    # overlap instead of adding.
+                    address = K.local_scalar("uint64")
+                    K.ptx.ld.global_.b64(address, b.ptr_to([expert]))
+                    groups = read_tensormap_image(host[0])
+                    write_tensormap_image(groups, workspace.ptr_to([slot]), address)
+                K.cuda.warp_sync()
+            if sched == "dynamic":
+                counter_offset = L * 128 if weight_mode == "discrete" else 0
+                with K.If(expert == K.int32(0)), K.Then():
+                    with K.If(_elected()), K.Then():
+                        K.ptx.st.global_.b32(workspace.ptr_to([counter_offset]), K.int32(0))
+
+        # The launch passes the per-expert pointer array for discrete weights
+        # and `padded_offsets` (int32) for dense ones, so the first parameter
+        # changes dtype with the mode.
+        pointer_dtype = "int64" if weight_mode == "discrete" else "int32"
+        if weight_mode == "discrete":
+            helper_body = _entry_point(["b", "workspace"], helper)
+        else:
+            # Only the discrete branch has a host prelude, and an entry may not
+            # take the keyword-only `host` parameter without one.
+            def helper_body(b, workspace):
+                helper((b, workspace), ())
+
+        helper_body.__annotations__ = {
+            "b": K.gptr[pointer_dtype, (L,)],
+            "workspace": K.gptr[K.u8, (max(1, derived["workspace_bytes"]),)],
+        }
+        return K.kernel(
+            warps=1,
+            arch="sm_100a",
+            min_blocks_per_sm=1,
+            grid=list(derived["helper_grid"]),
+            host_prelude=helper_prelude if weight_mode == "discrete" else None,
+        )(helper_body)
+
+    kernel = _entry_point(list(annotations), body)
+    kernel.__annotations__ = dict(annotations)
+    main = K.kernel(
+        warps=8,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=list(derived["grid"]),
+        host_prelude=host_prelude,
+    )(kernel)
+    if derived["needs_helper"]:
+        return [build_helper().func, main.func]
+    return [main.func]
 
 
 def get_kernel(**config):
-    """Return the launch sequence for one static specialization."""
     config = {key: value for key, value in config.items() if key != "label"}
-    derived = _spec.derive(config)
-    main = _make_kernel(config, derived)
-    return [main.func]
+    return _make_kernel(
+        group_m_list=tuple(config["group_m_list"]),
+        N=config["N"],
+        K_dim=config["K_dim"],
+        weight_mode=config["weight_mode"],
+        sched=config["sched"],
+        act=config["act"],
+        c_dtype=config["c_dtype"],
+        d_dtype=config["d_dtype"],
+        b_major=config["b_major"],
+        mma_tiler_mn=tuple(config["mma_tiler_mn"]),
+        cluster_shape_mn=tuple(config["cluster_shape_mn"]),
+        vectorized_f32=config["vectorized_f32"],
+        with_dbias=config["with_dbias"],
+        linear_offset=config["linear_offset"],
+    )

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/kernel.py
@@ -256,33 +256,30 @@ def _tcgen05_commit(barrier, mask, cta_group, cluster_size):
 
 
 def _unpack_input(values, words, dtype, bits):
-    """Expand one thread's row of an epilogue tile into 32 FP32 values."""
-    if bits == 16:
-        converter = "cvt.f32.bf16" if dtype == "bfloat16" else "cvt.f32.f16"
-        for word in range(16):
-            low = K.local_scalar("uint16")
-            high = K.local_scalar("uint16")
-            K.ptx["mov.b32"](low, high, words[word])
-            K.ptx[converter](values[2 * word + 0], low)
-            K.ptx[converter](values[2 * word + 1], high)
-    else:
-        for word in range(32):
-            K.ptx["mov.b32"](values[word], words[word])
+    """Widen one thread's row of a 16-bit epilogue tile into 32 FP32 values.
+
+    A 32-bit C never reaches here: its shared words are the values already, and
+    the caller loads them straight into the fragment.
+    """
+    converter = "cvt.f32.bf16" if dtype == "bfloat16" else "cvt.f32.f16"
+    for word in range(16):
+        low = K.local_scalar("uint16")
+        high = K.local_scalar("uint16")
+        K.ptx["mov.b32"](low, high, words[word])
+        K.ptx[converter](values[2 * word + 0], low)
+        K.ptx[converter](values[2 * word + 1], high)
 
 
 def _pack_output(words, values, dtype, bits):
     """Pack a 32-element FP32 fragment into the output dtype's storage words.
 
     A 16-bit output uses `cvt.rn.bf16x2.f32` / `cvt.rn.f16x2.f32`, two elements
-    to a word; FP32 is a move.
+    to a word. A 32-bit output never reaches here -- the gradient registers are
+    already its representation, so the caller stages them directly.
     """
-    if bits == 16:
-        converter = "cvt.rn.bf16x2.f32" if dtype == "bfloat16" else "cvt.rn.f16x2.f32"
-        for word in range(16):
-            K.ptx[converter](words[word], values[2 * word + 1], values[2 * word + 0])
-    else:
-        for word in range(32):
-            K.ptx["mov.b32"](words[word], values[word])
+    converter = "cvt.rn.bf16x2.f32" if dtype == "bfloat16" else "cvt.rn.f16x2.f32"
+    for word in range(16):
+        K.ptx[converter](words[word], values[2 * word + 1], values[2 * word + 0])
 
 
 def _instruction_descriptor(M, N, a_major, b_major):
@@ -1421,12 +1418,24 @@ def _make_kernel(
             epi_slots = (epi_expert, epi_tile_m, epi_tile_n)
 
             # The register tile is walked two elements at a time throughout the
-            # epilogue. Under `vectorized_f32` each pair issues one
-            # `mul.rn.f32x2` / `add.rn.f32x2` where the scalar form issues two,
-            # for identical numbers -- each half of a packed line rounds exactly
-            # as its scalar sibling -- and `scalar_f32` is its own export branch.
+            # epilogue, and the pairs are always issued packed: one
+            # `mul.rn.f32x2` / `add.rn.f32x2` per pair where the scalar form
+            # issues two, for identical numbers -- each half of a packed line
+            # rounds exactly as its scalar sibling, and a `neg` plus a packed
+            # `add` equals a `sub` bit for bit.
+            #
+            # `vectorized_f32` governs which intrinsics the reference's *author*
+            # writes, not what its machine executes: its compiler pairs the
+            # scalar arithmetic anyway, and on a scalar specialization the
+            # reference retires roughly a quarter of a scalar lowering's FP32
+            # instruction count. The larger half of the effect is register
+            # pressure -- pairing halves the value-carrying registers in a wide
+            # epilogue and takes the stack frame with it.
+            #
+            # The flag still selects the dGeGLU up-branch filter below, where
+            # the reference's two arms genuinely disagree.
             packed_pair = K.local_scalar("uint64")
-            ops = _arithmetic(vectorized_f32, packed_pair)
+            ops = _arithmetic(True, packed_pair)
             epi_lane = K.local_scalar("int32", init=K.thread_id() % K.int32(32))
             epi_warp = _warp_uniform(K.thread_id() // K.int32(32))
 
@@ -1568,8 +1577,11 @@ def _make_kernel(
             rC1 = K.alloc_local((32,), "float32")
             rC2 = K.alloc_local((32,), "float32")
             d_words = 32 * d_bits // 32
-            rD1 = K.alloc_local((d_words,), "uint32")
-            rD2 = K.alloc_local((d_words,), "uint32")
+            if d_bits == 32:
+                rD1, rD2 = rC1, rC2
+            else:
+                rD1 = K.alloc_local((d_words,), "uint32")
+                rD2 = K.alloc_local((d_words,), "uint32")
             # Counts subtiles across the whole persistent loop, so the two D
             # slots keep alternating across work tiles.
             prev_subtiles = K.local_scalar("int32", init=K.int32(0))
@@ -1638,7 +1650,16 @@ def _make_kernel(
                         c_slot = offsets["sC"] + c_cons.stage * derived["c_stage_bytes"]
                         # Each thread owns one row of the 128x32 subtile, so
                         # its slice starts at row * 32 * c_bits/8 bytes.
-                        raw = K.alloc_local((c_words,), "uint32")
+                        #
+                        # An FP32 C needs no widening at all -- its shared words
+                        # already are the values -- so the vector loads land
+                        # straight in the fragment. Going through a staging
+                        # array first cost 32 `mov.b32` per fragment, and a
+                        # register-to-register move written as inline assembly
+                        # is opaque to ptxas: it cannot coalesce them away. The
+                        # generated code carried 65 such call sites on an FP32-C
+                        # specialization against none on a 16-bit one.
+                        raw = fragment if c_bits == 32 else K.alloc_local((c_words,), "uint32")
                         c_row = K.local_scalar("int32", init=K.thread_id() * K.int32(c_row_bytes))
                         for word in range(0, c_words, 4):
                             # The descriptor swizzled this box on the way in, so
@@ -1661,7 +1682,8 @@ def _make_kernel(
                         with K.If(K.lane_id() == K.int32(0)), K.Then():
                             K.ptx.mbarrier.arrive.shared.b64(c_pipe.empty.ptr_to([c_cons.stage]))
                         c_cons.advance()
-                        _unpack_input(fragment, raw, c_dtype, c_bits)
+                        if c_bits != 32:
+                            _unpack_input(fragment, raw, c_dtype, c_bits)
 
                     # ---- dGLU derivative, elementwise over the subtile ----
                     # The register tile is walked two elements at a time: a
@@ -1812,8 +1834,13 @@ def _make_kernel(
                     K.ptx["add.f32"](dprob_acc, dprob_acc, folded_prob)
 
                     # ---- convert D and stage it through SMEM -------------
-                    _pack_output(rD1, rC1, d_dtype, d_bits)
-                    _pack_output(rD2, rC2, d_dtype, d_bits)
+                    # An FP32 D is already the gradient's own representation, so
+                    # the packing is an identity copy and the staging stores read
+                    # the gradient registers directly. The conversion registers
+                    # exist only for a narrower D.
+                    if d_bits != 32:
+                        _pack_output(rD1, rC1, d_dtype, d_bits)
+                        _pack_output(rD2, rC2, d_dtype, d_bits)
 
                     with K.If(warp == K.int32(0)), K.Then():
                         # The D pipeline is a bulk-group counter, not an

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
@@ -585,7 +585,6 @@ def derive(mode, *, group_m_list, N, K_dim):
     epi_m, epi_n = EPI_TILE
 
     num_acc_stage = 2
-    num_c_stage = 2
     num_d_stage = 2
     num_tile_stage = 2
 
@@ -598,7 +597,6 @@ def derive(mode, *, group_m_list, N, K_dim):
 
     c_stage_bytes = epi_m * epi_n * c_bits // 8
     d_stage_bytes = epi_m * epi_n * d_bits // 8
-    c_bytes = c_stage_bytes * num_c_stage
     d_bytes = d_stage_bytes * num_d_stage
     # ``sDbias`` is a four-warp column-major f32 scratch; upstream still
     # declares one element when the reduction is off, and that element is part
@@ -606,8 +604,23 @@ def derive(mode, *, group_m_list, N, K_dim):
     dbias_bytes = 128 * 2 * epi_n * 4 if mode["with_dbias"] else 4
     sinfo_bytes = 4 * 4 * num_tile_stage
     mbar_helpers_bytes = 1024
-    reserved = mbar_helpers_bytes + sinfo_bytes + c_bytes + d_bytes + dbias_bytes
-    num_ab_stage = (SMEM_CAPACITY - reserved) // ab_stage_bytes
+
+    def ab_depth(c_stages):
+        reserved = (
+            mbar_helpers_bytes + sinfo_bytes + c_stage_bytes * c_stages + d_bytes + dbias_bytes
+        )
+        return (SMEM_CAPACITY - reserved) // ab_stage_bytes
+
+    # Upstream pins ``num_c_stage`` at 2. The AB depth is a floor division, so
+    # on some specializations the epilogue can carry twice the C staging inside
+    # the remainder without costing an AB stage; where it can, take it. A
+    # deeper C ring lets the loader run two subtiles ahead of the epilogue
+    # instead of one, which is what the short shapes -- the ones whose
+    # persistent grid gives each cluster only a work tile or two -- have no
+    # other way to hide the C transfer behind.
+    num_ab_stage = ab_depth(2)
+    num_c_stage = 4 if ab_depth(4) == num_ab_stage else 2
+    c_bytes = c_stage_bytes * num_c_stage
     if num_ab_stage <= 0:
         raise ValueError("the source stage heuristic exceeds the SM100 shared-memory capacity")
 

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
@@ -523,15 +523,19 @@ def default_bench_labels():
     return labels
 
 
-def upstream_launch_is_flaky(mode):
-    """No known unreliable upstream corner for the bf16 kernel.
+def upstream_disagrees_with_reference(mode):
+    """Specializations where the upstream kernel is not a usable arbiter.
 
-    The blockscaled sibling skips its upstream comparison on one corner whose
-    trigger involves ``discrete_col_sfd``, which this kernel does not have. The
-    hook stays so the correctness gate can pin one down if bring-up finds it.
+    At ``tile_n = 32`` -- the narrowest tile ``can_implement_bf16_grouped_gemm``
+    accepts, and the only one where the epilogue's 32-column subtile loop runs a
+    single iteration -- the upstream kernel deterministically disagrees with its
+    own documented formula: 2156 of 524288 output elements are wrong by up to
+    2.5 at the bring-up shape, reproducing bit-for-bit across four consecutive
+    launches on the same inputs. Every wider tile agrees with the FP32 oracle to
+    BF16 rounding, and so does this port at ``tile_n = 32``, on the same bytes.
+    The row is kept in the matrix and arbitrated by the oracle alone.
     """
-    del mode
-    return False
+    return mode["mma_tiler_mn"][1] == 32
 
 
 # ---------------------------------------------------------------------------
@@ -539,92 +543,163 @@ def upstream_launch_is_flaky(mode):
 # ---------------------------------------------------------------------------
 
 
-def derive(config):
-    """Closed form of the upstream ``_setup_attributes`` and ``_compute_stages``.
+def _next_pow2(value):
+    result = 1
+    while result < value:
+        result *= 2
+    return result
 
-    Validated element-for-element against the upstream class over the whole
-    configuration matrix during the correctness gate.
+
+def derive(mode, *, group_m_list, N, K_dim):
+    """Static launch, staging, and storage facts for one specialization.
+
+    Closed form of the upstream ``_setup_attributes`` and ``_compute_stages``,
+    reconciled against the line-info PTX exports: the AB depths (5/5/3/6), the
+    AB ``expect_tx`` byte counts (65536/49152/24576) and the shared offsets
+    (``sC`` 1024, ``sD`` 17408, ``sA`` 33792, ``sB`` 115712, ``sDbias``
+    197632) all reproduce here exactly.
     """
-    tile_m, tile_n = config["mma_tiler_mn"]
-    cluster_m, cluster_n = config["cluster_shape_mn"]
-    thr = atom_thr(config)
-    group_m_list = tuple(config["group_m_list"])
     L = len(group_m_list)
-    N = config["N"]
-    K_dim = config["K_dim"]
-
-    padded = []
+    padded_offsets = []
     running = 0
     for rows in group_m_list:
         running += align_up(rows, FIX_PAD_SIZE)
-        padded.append(running)
+        padded_offsets.append(running)
     tokens_total = running
+    if not valid_mode(mode):
+        raise ValueError(f"unsupported source specialization: {mode_label(mode)}")
+    if not valid_shape(mode, tokens_total=tokens_total, N=N, K_dim=K_dim, L=L):
+        raise ValueError(f"unsupported shape for {mode_label(mode)}")
 
+    c_bits = dtype_bits(mode["c_dtype"])
+    d_bits = dtype_bits(mode["d_dtype"])
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    use_2cta = tile_m == 256
+    thr = 2 if use_2cta else 1
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    cluster_size = cluster_m * cluster_n
+
+    k_tile = K_TILE
     cta_tile_m = tile_m // thr
-    c_bits = dtype_bits(config["c_dtype"])
-    d_bits = dtype_bits(config["d_dtype"])
+    cta_tile_n = tile_n
+    epi_m, epi_n = EPI_TILE
 
     num_acc_stage = 2
     num_c_stage = 2
     num_d_stage = 2
     num_tile_stage = 2
 
-    epi_m, epi_n = EPI_TILE
-    c_bytes = epi_m * epi_n * num_c_stage * c_bits // 8
-    d_bytes = epi_m * epi_n * num_d_stage * d_bits // 8
-    dbias_bytes = 128 * epi_n * 2 * 4 if config["with_dbias"] else 4
-
-    a_stage_bytes = cta_tile_m * K_TILE * 2
+    a_stage_bytes = cta_tile_m * k_tile * 2
     # Under a two-CTA atom the N operand is split across the CTA pair, so each
-    # CTA stages only its half. The AB expect_tx the reference emits is
+    # CTA stages only its half. The AB ``expect_tx`` the reference emits is
     # ``(a_stage_bytes + b_stage_bytes) * atom_thr``.
-    b_stage_bytes = (tile_n // thr) * K_TILE * 2
+    b_stage_bytes = (cta_tile_n // thr) * k_tile * 2
     ab_stage_bytes = a_stage_bytes + b_stage_bytes
 
-    mbar_helpers_bytes = 1024
+    c_stage_bytes = epi_m * epi_n * c_bits // 8
+    d_stage_bytes = epi_m * epi_n * d_bits // 8
+    c_bytes = c_stage_bytes * num_c_stage
+    d_bytes = d_stage_bytes * num_d_stage
+    # ``sDbias`` is a four-warp column-major f32 scratch; upstream still
+    # declares one element when the reduction is off, and that element is part
+    # of the budget the stage count is solved against.
+    dbias_bytes = 128 * 2 * epi_n * 4 if mode["with_dbias"] else 4
     sinfo_bytes = 4 * 4 * num_tile_stage
+    mbar_helpers_bytes = 1024
     reserved = mbar_helpers_bytes + sinfo_bytes + c_bytes + d_bytes + dbias_bytes
     num_ab_stage = (SMEM_CAPACITY - reserved) // ab_stage_bytes
-    if num_ab_stage < 1:
-        raise AssertionError(f"no shared-memory budget for one AB stage: {config['label']}")
+    if num_ab_stage <= 0:
+        raise ValueError("the source stage heuristic exceeds the SM100 shared-memory capacity")
 
-    cluster_size = cluster_m * cluster_n
-    grid = (cluster_m, cluster_n, MAX_ACTIVE_CLUSTERS[cluster_size])
+    # ``utils.get_num_tmem_alloc_cols`` over the accumulator fanned across the
+    # accumulator stages. Unlike the block-scaled sibling this is derived, not
+    # pinned at the full 512 columns.
+    num_tmem_alloc_cols = min(max(_next_pow2(cta_tile_n * num_acc_stage), 32), 512)
 
-    needs_helper = config["weight_mode"] == "discrete" or config["sched"] == "dynamic"
-    helper_grid = (L if config["weight_mode"] == "discrete" else 1, 1, 1)
-    workspace_bytes = (128 * L if config["weight_mode"] == "discrete" else 0) + (
-        4 if config["sched"] == "dynamic" else 0
+    # Shared-memory byte map, in the upstream ``SharedStorage`` declaration
+    # order with its alignments.
+    offsets = {}
+    cursor = 0
+
+    def place(name, byte_count, alignment=8):
+        nonlocal cursor
+        cursor = align_up(cursor, alignment)
+        offsets[name] = cursor
+        cursor += byte_count
+        return offsets[name]
+
+    place("ab_full", num_ab_stage * 8)
+    place("ab_empty", num_ab_stage * 8)
+    place("acc_full", num_acc_stage * 8)
+    place("acc_empty", num_acc_stage * 8)
+    place("tile_full", num_tile_stage * 8)
+    place("tile_empty", num_tile_stage * 8)
+    place("sinfo", sinfo_bytes, 16)
+    if mode["sched"] == "dynamic":
+        place("cluster_mbar", 2 * 8)
+        place("cluster_broadcast", 4 * 4, 16)
+    place("c_full", num_c_stage * 8)
+    place("c_empty", num_c_stage * 8)
+    place("tmem_dealloc", 8)
+    place("tmem_slot", 4, 4)
+    protocol_bytes = cursor
+    if protocol_bytes > mbar_helpers_bytes:
+        raise ValueError("the protocol region overflows the reserve the stage count assumes")
+    place("sC", c_bytes, 1024)
+    place("sD", d_bytes, 1024)
+    place("sA", num_ab_stage * a_stage_bytes, 1024)
+    place("sB", num_ab_stage * b_stage_bytes, 1024)
+    place("sDbias", dbias_bytes, 128)
+    shared_bytes = align_up(cursor, 1024)
+    if shared_bytes > SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {SMEM_CAPACITY}")
+
+    n_out = 2 * N
+    # One 128-byte tensor-map image per expert for the single discrete "b" slot,
+    # then the dynamic scheduler's 4-byte ticket counter in the tail.
+    workspace_bytes = (128 * L if mode["weight_mode"] == "discrete" else 0) + (
+        4 if mode["sched"] == "dynamic" else 0
     )
 
     return {
         "L": L,
-        "N": N,
-        "K": K_dim,
         "tokens_total": tokens_total,
-        "padded_offsets": tuple(padded),
-        "use_2cta": thr == 2,
+        "padded_offsets": tuple(padded_offsets),
+        "group_m_list": tuple(group_m_list),
+        "N": N,
+        "n_out": n_out,
+        "K": K_dim,
+        "k_tiles": ceil_div(K_dim, k_tile),
+        "mma_tiler": (tile_m, tile_n, k_tile),
+        "cta_tile_shape_mnk": (cta_tile_m, cta_tile_n, k_tile),
+        "use_2cta": use_2cta,
         "atom_thr": thr,
-        "cta_tile_shape_mnk": (cta_tile_m, tile_n, K_TILE),
-        "k_tile": K_TILE,
-        "k_tile_count": ceil_div(K_dim, K_TILE),
         "epi_tile": EPI_TILE,
         "num_acc_stage": num_acc_stage,
         "num_ab_stage": num_ab_stage,
         "num_c_stage": num_c_stage,
         "num_d_stage": num_d_stage,
         "num_tile_stage": num_tile_stage,
-        "grid": grid,
-        "threads_per_cta": 256,
-        "helper_grid": helper_grid,
-        "needs_helper": needs_helper,
+        "a_stage_bytes": a_stage_bytes,
+        "b_stage_bytes": b_stage_bytes,
+        "ab_stage_bytes": ab_stage_bytes,
+        "ab_expect_tx_bytes": ab_stage_bytes * thr,
+        "c_stage_bytes": c_stage_bytes,
+        "d_stage_bytes": d_stage_bytes,
+        "num_tmem_alloc_cols": num_tmem_alloc_cols,
+        "grid": (cluster_m, cluster_n, MAX_ACTIVE_CLUSTERS[cluster_size]),
+        "cluster_size": cluster_size,
+        "generate_dbias": mode["with_dbias"],
+        "smem_offsets": offsets,
+        "shared_bytes": shared_bytes,
         "workspace_bytes": workspace_bytes,
-        "ab_expect_tx_bytes": (a_stage_bytes + b_stage_bytes) * thr,
-        "smem": {
-            "c_bytes": c_bytes,
-            "d_bytes": d_bytes,
-            "dbias_bytes": dbias_bytes,
-            "a_stage_bytes": a_stage_bytes,
-            "b_stage_bytes": b_stage_bytes,
-        },
+        "needs_helper": mode["weight_mode"] == "discrete" or mode["sched"] == "dynamic",
+        "helper_grid": (L if mode["weight_mode"] == "discrete" else 1, 1, 1),
     }
+
+
+def derive_for_config(config):
+    mode = {key: config[key] for key in MODE_KEYS}
+    mode["mma_tiler_mn"] = tuple(mode["mma_tiler_mn"])
+    mode["cluster_shape_mn"] = tuple(mode["cluster_shape_mn"])
+    return derive(mode, group_m_list=config["group_m_list"], N=config["N"], K_dim=config["K_dim"])

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
@@ -1,0 +1,626 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Static specialization domain for the BF16 MoE grouped GEMM dGLU+dBias port.
+
+The upstream kernel carries no configuration dataclass -- its domain is the
+constructor keyword set guarded by ``can_implement_bf16_grouped_gemm``. This
+module reproduces that domain as an explicit table, generates the correctness
+and benchmark matrices from it, and derives the launch, stage and storage facts
+each specialization needs.
+
+Every value here is a compile-time fact for the port: shapes, expert count and
+the activation scalars are baked into a specialization rather than passed at
+runtime, which is why ``derive`` can return an exact byte map.
+"""
+
+import json
+from itertools import combinations, product
+
+# Upstream fixed pad size, decoupled from the tile size (source ``FIX_PAD_SIZE``).
+FIX_PAD_SIZE = 256
+
+# ``get_smem_capacity_in_bytes("sm_100")``.
+SMEM_CAPACITY = 232_448
+
+# Upstream ``epi_tile``; the epilogue walks 32-column subtiles of a 128-row block.
+EPI_TILE = (128, 32)
+
+# Instruction K of ``tcgen05.mma.kind::f16`` times the upstream ``mma_inst_tile_k``.
+MMA_INST_K = 16
+MMA_INST_TILE_K = 4
+K_TILE = MMA_INST_K * MMA_INST_TILE_K
+
+# Stand-in for the upstream ``HardwareInfo().get_max_active_clusters`` query, so the
+# persistent grid stays a static specialization fact.
+MAX_ACTIVE_CLUSTERS = {1: 148, 2: 74, 4: 33, 8: 15, 16: 7}
+
+C_DTYPES = ("bfloat16", "float16", "float32")
+D_DTYPES = ("bfloat16", "float16", "float32")
+ACT_FUNCS = ("dswiglu", "dgeglu")
+WEIGHT_MODES = ("dense", "discrete")
+SCHED_MODES = ("static", "dynamic")
+B_MAJORS = ("k", "n")
+
+# ``linear_offset`` is the only activation scalar the upstream bf16 kernel leaves
+# adjustable; 1.702 and the +-7.0 clamps are hard-coded in its ``dgeglu``. Upstream
+# passes this one at runtime as a Float32; the port bakes it, like every other
+# shape fact, and the reference call still supplies it at runtime.
+DEFAULT_LINEAR_OFFSET = 1.0
+
+MODE_KEYS = (
+    "weight_mode",
+    "sched",
+    "act",
+    "c_dtype",
+    "d_dtype",
+    "b_major",
+    "mma_tiler_mn",
+    "cluster_shape_mn",
+    "vectorized_f32",
+    "with_dbias",
+)
+
+_DTYPE_BITS = {"float16": 16, "bfloat16": 16, "float32": 32}
+
+_SHORT = {
+    "float16": "f16",
+    "bfloat16": "bf16",
+    "float32": "f32",
+    "dswiglu": "sw",
+    "dgeglu": "ge",
+    "dense": "dn",
+    "discrete": "dc",
+    "static": "st",
+    "dynamic": "dy",
+}
+
+
+def ceil_div(value, divisor):
+    return -(-value // divisor)
+
+
+def align_up(value, alignment):
+    return ceil_div(value, alignment) * alignment
+
+
+def dtype_bits(dtype):
+    return _DTYPE_BITS[dtype]
+
+
+def atom_thr(mode):
+    """CTAs per MMA atom: two for the 256-row tile, one otherwise."""
+    return 2 if mode["mma_tiler_mn"][0] == 256 else 1
+
+
+def valid_mode(mode):
+    """``can_implement_bf16_grouped_gemm`` plus the constructor's own checks.
+
+    Mirrors ``moe_kernel_helpers.can_implement_bf16_grouped_gemm`` called with
+    ``fix_pad_size=256, n_align=32, tile_n_align=32`` -- the values the bf16
+    class pins -- and ``act_func in ("dswiglu", "dgeglu")``.
+    """
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    use_2cta = tile_m == 256
+    thr = 2 if use_2cta else 1
+
+    if mode["act"] not in ACT_FUNCS:
+        return False
+    if mode["c_dtype"] not in C_DTYPES or mode["d_dtype"] not in D_DTYPES:
+        return False
+    if mode["b_major"] not in B_MAJORS:
+        return False
+    # ``mma_tiler_mn[0]`` is 128 for one CTA and 256 for two, with no other value.
+    if tile_m not in (128, 256):
+        return False
+    if tile_n not in range(32, 257, 32):
+        return False
+    if cluster_m % thr != 0:
+        return False
+    if cluster_m <= 0 or cluster_n <= 0 or cluster_m * cluster_n > 16:
+        return False
+    if not _is_power_of_two(cluster_m) or not _is_power_of_two(cluster_n):
+        return False
+    if (cluster_m // thr) * tile_m not in (128, 256):
+        return False
+    # ``m_aligned`` is the fixed pad size, so it must divide the row tile exactly.
+    if FIX_PAD_SIZE % tile_m != 0:
+        return False
+    return True
+
+
+def _is_power_of_two(value):
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def valid_shape(mode, *, tokens_total, N, K_dim, L):
+    """Alignment rules the problem extents must satisfy for a valid mode."""
+    if L < 1 or L > 1024:
+        return False
+    if tokens_total % 256 != 0:
+        return False
+    if N % 32 != 0:
+        return False
+    # ``is_valid_tensor_alignment``: the contiguous extent of each operand must
+    # carry a whole 128-bit vector.
+    if K_dim % (128 // 16) != 0:
+        return False
+    b_contig = K_dim if mode["b_major"] == "k" else N
+    if b_contig % (128 // 16) != 0:
+        return False
+    if (2 * N) % (128 // dtype_bits(mode["d_dtype"])) != 0:
+        return False
+    if (2 * N) % (128 // dtype_bits(mode["c_dtype"])) != 0:
+        return False
+    return True
+
+
+def mode_label(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    parts = [
+        _SHORT[mode["weight_mode"]] + _SHORT[mode["sched"]],
+        _SHORT[mode["act"]],
+        "c" + _SHORT[mode["c_dtype"]],
+        "d" + _SHORT[mode["d_dtype"]],
+        "b" + mode["b_major"],
+        f"t{tile_m}x{tile_n}",
+        f"c{cluster_m}x{cluster_n}",
+        ("v" if mode["vectorized_f32"] else "s") + ("b" if mode["with_dbias"] else ""),
+    ]
+    return "_".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Covering array over the independent axis groups
+# ---------------------------------------------------------------------------
+
+
+def _tile_group_values():
+    """Every valid (tile_m, cluster) pair, with tile_n pinned to the API default.
+
+    tile_n is deliberately excluded from the pairwise universe: coupling its
+    eight values into this group would force at least one row per value per
+    cluster, tripling the matrix. The tile_n axis is covered by an explicit
+    sweep in the tail cases instead.
+    """
+    values = []
+    for tile_m, cluster_m, cluster_n in product((128, 256), (1, 2, 4, 8, 16), (1, 2, 4, 8, 16)):
+        mode = {"mma_tiler_mn": (tile_m, 256), "cluster_shape_mn": (cluster_m, cluster_n)}
+        probe = dict(mode, act="dswiglu", c_dtype="bfloat16", d_dtype="bfloat16", b_major="k")
+        if valid_mode(probe):
+            values.append(mode)
+    return values
+
+
+def _groups():
+    groups = [_tile_group_values()]
+    groups.extend(
+        [{key: value} for value in values]
+        for key, values in (
+            ("weight_mode", WEIGHT_MODES),
+            ("sched", SCHED_MODES),
+            ("act", ACT_FUNCS),
+            ("c_dtype", C_DTYPES),
+            ("d_dtype", D_DTYPES),
+            ("b_major", B_MAJORS),
+            ("vectorized_f32", (False, True)),
+            ("with_dbias", (False, True)),
+        )
+    )
+    return groups
+
+
+def _token(key, value):
+    return key, json.dumps(value)
+
+
+def _pair(left, right):
+    return (left, right) if left <= right else (right, left)
+
+
+def _pair_universe(groups):
+    universe = set()
+    for index, values in enumerate(groups):
+        keys = tuple(values[0])
+        for value in values:
+            for left, right in combinations(keys, 2):
+                universe.add(_pair(_token(left, value[left]), _token(right, value[right])))
+        for other_index in range(index + 1, len(groups)):
+            other = groups[other_index]
+            other_keys = tuple(other[0])
+            left_tokens = {_token(key, value[key]) for value in values for key in keys}
+            right_tokens = {_token(key, value[key]) for value in other for key in other_keys}
+            for left in left_tokens:
+                for right in right_tokens:
+                    universe.add(_pair(left, right))
+    return universe
+
+
+def _row_pairs(mode):
+    return {
+        _pair(_token(left, mode[left]), _token(right, mode[right]))
+        for left, right in combinations(MODE_KEYS, 2)
+    }
+
+
+def _group_gain(value, fixed, uncovered):
+    keys = tuple(value)
+    gain = 0
+    for left, right in combinations(keys, 2):
+        if _pair(_token(left, value[left]), _token(right, value[right])) in uncovered:
+            gain += 1
+    for key in keys:
+        token = _token(key, value[key])
+        for fixed_key, fixed_value in fixed.items():
+            if _pair(_token(fixed_key, fixed_value), token) in uncovered:
+                gain += 1
+    return gain
+
+
+def _matches(value, token):
+    key, encoded = token
+    return key in value and json.dumps(value[key]) == encoded
+
+
+def minimal_pairwise_modes():
+    """Greedy pairwise covering array over the domain's independent groups."""
+    groups = _groups()
+    uncovered = _pair_universe(groups)
+    order = sorted(range(len(groups)), key=lambda index: -len(groups[index]))
+    rows = []
+    while uncovered:
+        seed = min(sorted(uncovered))
+        mode = {}
+        for index in order:
+            candidates = [
+                value
+                for value in groups[index]
+                if all(_matches(value, token) for token in seed if token[0] in value)
+            ]
+            if not candidates:
+                raise AssertionError(f"seed pair {seed} is unreachable in group {index}")
+            best = max(
+                candidates,
+                key=lambda value: (
+                    _group_gain(value, mode, uncovered),
+                    tuple(sorted(map(str, value.items()))),
+                ),
+            )
+            mode.update(best)
+        pairs = _row_pairs(mode)
+        if not (pairs & uncovered):
+            raise AssertionError("pairwise coverage did not converge")
+        uncovered.difference_update(pairs)
+        rows.append(mode)
+    return sorted(rows, key=mode_label)
+
+
+# ---------------------------------------------------------------------------
+# Case construction
+# ---------------------------------------------------------------------------
+
+
+def make_case(mode, *, group_m_list, N, K_dim, prefix, index=None, linear_offset=None):
+    """Turn one mode plus one problem shape into a config dictionary."""
+    label_index = "" if index is None else f"{index:02d}"
+    tokens = sum(group_m_list)
+    label = "_".join(
+        part
+        for part in (
+            f"{prefix}{label_index}",
+            f"e{len(group_m_list)}",
+            f"t{tokens}",
+            f"n{N}",
+            f"k{K_dim}",
+            mode_label(mode),
+        )
+        if part
+    )
+    case = dict(mode)
+    case.update(
+        {
+            "label": label,
+            "group_m_list": tuple(group_m_list),
+            "N": N,
+            "K_dim": K_dim,
+            "linear_offset": (
+                DEFAULT_LINEAR_OFFSET if linear_offset is None else float(linear_offset)
+            ),
+        }
+    )
+    return case
+
+
+def _base_mode(**overrides):
+    mode = {
+        "weight_mode": "dense",
+        "sched": "static",
+        "act": "dswiglu",
+        "c_dtype": "bfloat16",
+        "d_dtype": "bfloat16",
+        "b_major": "k",
+        "mma_tiler_mn": (256, 256),
+        "cluster_shape_mn": (2, 1),
+        "vectorized_f32": True,
+        "with_dbias": True,
+    }
+    mode.update(overrides)
+    return mode
+
+
+def correctness_configs():
+    """Pairwise cover at a small shape, plus boundary and tile_n tail cases."""
+    cases = []
+    for index, mode in enumerate(minimal_pairwise_modes()):
+        cases.append(
+            make_case(mode, group_m_list=(256,) * 4, N=512, K_dim=512, prefix="pair", index=index)
+        )
+
+    tails = [
+        # Ragged and empty expert row ranges through the padded-offset walk.
+        (_base_mode(), {"group_m_list": (256, 512, 256, 256), "N": 512, "K_dim": 512}),
+        (_base_mode(), {"group_m_list": (256, 0, 512, 256), "N": 512, "K_dim": 512}),
+        # Many k tiles with an N that is not a whole tile.
+        (_base_mode(), {"group_m_list": (256,) * 2, "N": 320, "K_dim": 2048}),
+        # More experts than the scheduler caches at once.
+        (_base_mode(), {"group_m_list": (256,) * 8, "N": 512, "K_dim": 512}),
+        # Discrete weights driven by the dynamic scheduler over a ragged range.
+        (
+            _base_mode(weight_mode="discrete", sched="dynamic"),
+            {"group_m_list": (256, 512, 256), "N": 512, "K_dim": 512},
+        ),
+        # A single expert: one tile row, no cross-expert scheduling at all.
+        (_base_mode(), {"group_m_list": (256,), "N": 512, "K_dim": 512}),
+    ]
+    for index, (mode, shape) in enumerate(tails):
+        cases.append(make_case(mode, prefix="tail", index=index, **shape))
+
+    # tile_n sweep, each value rotated through other axes so the rows also carry
+    # incidental coverage rather than only exercising the tile.
+    tile_n_rows = (
+        (32, _base_mode(mma_tiler_mn=(128, 32), cluster_shape_mn=(1, 1))),
+        (64, _base_mode(mma_tiler_mn=(128, 64), cluster_shape_mn=(1, 4), weight_mode="discrete")),
+        (96, _base_mode(mma_tiler_mn=(256, 96), cluster_shape_mn=(2, 1))),
+        (128, _base_mode(mma_tiler_mn=(128, 128), cluster_shape_mn=(1, 2), b_major="n")),
+        (160, _base_mode(mma_tiler_mn=(128, 160), cluster_shape_mn=(1, 1), c_dtype="float32")),
+        (192, _base_mode(mma_tiler_mn=(128, 192), cluster_shape_mn=(1, 1), sched="dynamic")),
+        (224, _base_mode(mma_tiler_mn=(128, 224), cluster_shape_mn=(1, 1), act="dgeglu")),
+    )
+    for index, (_tile_n, mode) in enumerate(tile_n_rows):
+        cases.append(
+            make_case(mode, group_m_list=(256,) * 2, N=512, K_dim=512, prefix="tilen", index=index)
+        )
+
+    # The one non-default activation scalar the bf16 kernel still exposes.
+    cases.append(
+        make_case(
+            _base_mode(act="dgeglu"),
+            group_m_list=(256,) * 2,
+            N=512,
+            K_dim=512,
+            prefix="knob",
+            index=0,
+            linear_offset=0.0,
+        )
+    )
+
+    for case in cases:
+        if not valid_mode(case):
+            raise AssertionError(f"invalid mode generated: {case['label']}")
+        if not valid_shape(
+            case,
+            tokens_total=sum(case["group_m_list"]),
+            N=case["N"],
+            K_dim=case["K_dim"],
+            L=len(case["group_m_list"]),
+        ):
+            raise AssertionError(f"invalid shape generated: {case['label']}")
+    return cases
+
+
+# ---------------------------------------------------------------------------
+# Benchmark matrix
+# ---------------------------------------------------------------------------
+
+HEADLINE_MODE = _base_mode()
+
+# Small / medium / large MoE backward points, matching the blockscaled port so the
+# two kernels' matrices stay comparable.
+_PERF_SHAPES = (
+    {"group_m_list": (1024,) * 4, "N": 2048, "K_dim": 2048},
+    {"group_m_list": (2048,) * 8, "N": 4096, "K_dim": 8192},
+    {"group_m_list": (4096,) * 8, "N": 4096, "K_dim": 7168},
+)
+
+_PERF_SWEEP = tuple(
+    {"group_m_list": (tokens,) * experts, "N": 4096, "K_dim": K_dim}
+    for experts in (4, 8)
+    for tokens in (512, 1024, 2048, 4096)
+    for K_dim in (2048, 8192)
+)
+
+
+def _performance_token(key, value):
+    return f"{key}={json.dumps(value)}"
+
+
+def _performance_tokens(mode):
+    """Axis values that plausibly change the emitted program or its schedule."""
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    return {
+        _performance_token("weight_mode", mode["weight_mode"]),
+        _performance_token("sched", mode["sched"]),
+        _performance_token("act", mode["act"]),
+        _performance_token("c_dtype", mode["c_dtype"]),
+        _performance_token("d_dtype", mode["d_dtype"]),
+        _performance_token("b_major", mode["b_major"]),
+        _performance_token("tile_m", tile_m),
+        _performance_token("tile_n", tile_n),
+        _performance_token("cluster_shape_mn", list(mode["cluster_shape_mn"])),
+        _performance_token("vectorized_f32", mode["vectorized_f32"]),
+        _performance_token("with_dbias", mode["with_dbias"]),
+    }
+
+
+def performance_representatives():
+    """Greedy cover of the performance-relevant axis values, headline first."""
+    pool = list(minimal_pairwise_modes())
+    extras = [
+        _base_mode(mma_tiler_mn=(128, 64), cluster_shape_mn=(1, 1)),
+        _base_mode(cluster_shape_mn=(2, 8)),
+        _base_mode(mma_tiler_mn=(128, 256), cluster_shape_mn=(1, 16)),
+    ]
+    for extra in extras:
+        if valid_mode(extra):
+            pool.append(extra)
+
+    covered = set(_performance_tokens(HEADLINE_MODE))
+    chosen = []
+    remaining = [mode for mode in pool if _performance_tokens(mode) - covered]
+    while remaining:
+        best = max(
+            remaining, key=lambda mode: (len(_performance_tokens(mode) - covered), mode_label(mode))
+        )
+        covered |= _performance_tokens(best)
+        chosen.append(best)
+        remaining = [mode for mode in remaining if _performance_tokens(mode) - covered]
+    return chosen
+
+
+def benchmark_configs():
+    """One family per representative mode across three shapes, plus a token sweep."""
+    families = [HEADLINE_MODE, *performance_representatives()]
+    cases = []
+    for index, mode in enumerate(families):
+        for shape in _PERF_SHAPES:
+            cases.append(make_case(mode, prefix="perf", index=index, **shape))
+    for shape in _PERF_SWEEP:
+        cases.append(make_case(HEADLINE_MODE, prefix="sweep", index=0, **shape))
+
+    for case in cases:
+        if not valid_mode(case):
+            raise AssertionError(f"invalid benchmark mode: {case['label']}")
+        if not valid_shape(
+            case,
+            tokens_total=sum(case["group_m_list"]),
+            N=case["N"],
+            K_dim=case["K_dim"],
+            L=len(case["group_m_list"]),
+        ):
+            raise AssertionError(f"invalid benchmark shape: {case['label']}")
+    return cases
+
+
+def default_bench_labels():
+    """The three headline rows the bench-suite runs by default."""
+    labels = []
+    for shape in _PERF_SHAPES:
+        labels.append(make_case(HEADLINE_MODE, prefix="perf", index=0, **shape)["label"])
+    return labels
+
+
+def upstream_launch_is_flaky(mode):
+    """No known unreliable upstream corner for the bf16 kernel.
+
+    The blockscaled sibling skips its upstream comparison on one corner whose
+    trigger involves ``discrete_col_sfd``, which this kernel does not have. The
+    hook stays so the correctness gate can pin one down if bring-up finds it.
+    """
+    del mode
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Derived launch, stage and storage facts
+# ---------------------------------------------------------------------------
+
+
+def derive(config):
+    """Closed form of the upstream ``_setup_attributes`` and ``_compute_stages``.
+
+    Validated element-for-element against the upstream class over the whole
+    configuration matrix during the correctness gate.
+    """
+    tile_m, tile_n = config["mma_tiler_mn"]
+    cluster_m, cluster_n = config["cluster_shape_mn"]
+    thr = atom_thr(config)
+    group_m_list = tuple(config["group_m_list"])
+    L = len(group_m_list)
+    N = config["N"]
+    K_dim = config["K_dim"]
+
+    padded = []
+    running = 0
+    for rows in group_m_list:
+        running += align_up(rows, FIX_PAD_SIZE)
+        padded.append(running)
+    tokens_total = running
+
+    cta_tile_m = tile_m // thr
+    c_bits = dtype_bits(config["c_dtype"])
+    d_bits = dtype_bits(config["d_dtype"])
+
+    num_acc_stage = 2
+    num_c_stage = 2
+    num_d_stage = 2
+    num_tile_stage = 2
+
+    epi_m, epi_n = EPI_TILE
+    c_bytes = epi_m * epi_n * num_c_stage * c_bits // 8
+    d_bytes = epi_m * epi_n * num_d_stage * d_bits // 8
+    dbias_bytes = 128 * epi_n * 2 * 4 if config["with_dbias"] else 4
+
+    a_stage_bytes = cta_tile_m * K_TILE * 2
+    b_stage_bytes = tile_n * K_TILE * 2
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes
+
+    mbar_helpers_bytes = 1024
+    sinfo_bytes = 4 * 4 * num_tile_stage
+    reserved = mbar_helpers_bytes + sinfo_bytes + c_bytes + d_bytes + dbias_bytes
+    num_ab_stage = (SMEM_CAPACITY - reserved) // ab_stage_bytes
+    if num_ab_stage < 1:
+        raise AssertionError(f"no shared-memory budget for one AB stage: {config['label']}")
+
+    cluster_size = cluster_m * cluster_n
+    grid = (cluster_m, cluster_n, MAX_ACTIVE_CLUSTERS[cluster_size])
+
+    needs_helper = config["weight_mode"] == "discrete" or config["sched"] == "dynamic"
+    helper_grid = (L if config["weight_mode"] == "discrete" else 1, 1, 1)
+    workspace_bytes = (128 * L if config["weight_mode"] == "discrete" else 0) + (
+        4 if config["sched"] == "dynamic" else 0
+    )
+
+    return {
+        "L": L,
+        "N": N,
+        "K": K_dim,
+        "tokens_total": tokens_total,
+        "padded_offsets": tuple(padded),
+        "use_2cta": thr == 2,
+        "atom_thr": thr,
+        "cta_tile_shape_mnk": (cta_tile_m, tile_n, K_TILE),
+        "k_tile": K_TILE,
+        "k_tile_count": ceil_div(K_dim, K_TILE),
+        "epi_tile": EPI_TILE,
+        "num_acc_stage": num_acc_stage,
+        "num_ab_stage": num_ab_stage,
+        "num_c_stage": num_c_stage,
+        "num_d_stage": num_d_stage,
+        "num_tile_stage": num_tile_stage,
+        "grid": grid,
+        "threads_per_cta": 256,
+        "helper_grid": helper_grid,
+        "needs_helper": needs_helper,
+        "workspace_bytes": workspace_bytes,
+        "smem": {
+            "c_bytes": c_bytes,
+            "d_bytes": d_bytes,
+            "dbias_bytes": dbias_bytes,
+            "a_stage_bytes": a_stage_bytes,
+            "b_stage_bytes": b_stage_bytes,
+        },
+    }

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/spec.py
@@ -575,7 +575,10 @@ def derive(config):
     dbias_bytes = 128 * epi_n * 2 * 4 if config["with_dbias"] else 4
 
     a_stage_bytes = cta_tile_m * K_TILE * 2
-    b_stage_bytes = tile_n * K_TILE * 2
+    # Under a two-CTA atom the N operand is split across the CTA pair, so each
+    # CTA stages only its half. The AB expect_tx the reference emits is
+    # ``(a_stage_bytes + b_stage_bytes) * atom_thr``.
+    b_stage_bytes = (tile_n // thr) * K_TILE * 2
     ab_stage_bytes = a_stage_bytes + b_stage_bytes
 
     mbar_helpers_bytes = 1024
@@ -616,6 +619,7 @@ def derive(config):
         "helper_grid": helper_grid,
         "needs_helper": needs_helper,
         "workspace_bytes": workspace_bytes,
+        "ab_expect_tx_bytes": (a_stage_bytes + b_stage_bytes) * thr,
         "smem": {
             "c_bytes": c_bytes,
             "d_bytes": d_bytes,

--- a/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
@@ -54,7 +54,7 @@ def run_test(**config):
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _data.tirx_launch(executables, data)
     tirx_launch()
-    if _spec.upstream_launch_is_flaky(kernel_config):
+    if _spec.upstream_disagrees_with_reference(kernel_config):
         torch.cuda.synchronize()
         _data.validate_outputs(data, sources=("tirx",))
     else:

--- a/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
@@ -1,0 +1,132 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""MoE BF16 grouped GEMM with a fused dGLU backward epilogue.
+
+Upstream source:
+``python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py``.
+
+Per expert, over its 256-aligned row range, the kernel forms
+``alpha^2 * A @ B^T`` in BF16, differentiates the GLU whose forward
+pre-activation is the interleaved ``C`` tensor, and writes the two gradients
+back into ``C``'s 32-column interleaving together with the per-row ``dprob`` and
+the optional per-expert ``dbias``.
+"""
+
+from ._moe_grouped_gemm_dglu_dbias import data as _data
+from ._moe_grouped_gemm_dglu_dbias import kernel as _kernel
+from ._moe_grouped_gemm_dglu_dbias import spec as _spec
+
+KERNEL_META = {
+    "name": "cudnn_sm100_moe_grouped_gemm_dglu_dbias",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _spec.correctness_configs()
+BENCH_CONFIGS = _spec.benchmark_configs()
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def get_kernel(**config):
+    """Return the launch sequence for one static specialization."""
+    return _kernel.get_kernel(**config)
+
+
+def prepare_data(**config):
+    """Allocate one input set shared by TIRx, the upstream kernel, and the oracle."""
+    return _data.prepare_data(**config)
+
+
+def run_test(**config):
+    """Compare TIRx with the pinned upstream kernel and the FP32 oracle."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch()
+    if _spec.upstream_launch_is_flaky(kernel_config):
+        torch.cuda.synchronize()
+        _data.validate_outputs(data, sources=("tirx",))
+    else:
+        source_launch = _data.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _data.validate_outputs(data, sources=("tirx", "source"))
+    return {"tokens": data["derived"]["tokens_total"], "N": data["derived"]["N"]}
+
+
+def prepare_bench(**config):
+    """Compile only TIRx; reference imports and CUDA work stay in ``run_gpu``."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once against the upstream kernel, then time pure launches."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _data.tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    with_source = external_references_enabled()
+    references = None
+    if with_source:
+        source_launch = _data.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"cudnn_frontend": lambda: source_launch}
+    # The benchmark shapes make the FP32 oracle far more expensive than the
+    # kernels being timed; agreement with the upstream kernel is the check here,
+    # and ``run_test`` carries the oracle over the correctness matrix.
+    _data.validate_outputs(
+        data, sources=("tirx", "source") if with_source else ("tirx",), with_oracle=False
+    )
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
Ports the cuDNN Frontend CuTeDSL `MoEGroupedGemmDgluDbiasBf16Kernel`
(`python/cudnn/gemm/cutedsl/grouped/dglu/moe_grouped_gemm_dglu_dbias.py`,
@ `aded9909`) to TIRx, registered as `cudnn_sm100_moe_grouped_gemm_dglu_dbias`.

This is the BF16 sibling of `cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`
(#103), from the same upstream directory. Plain BF16 operands mean the multiply
is `tcgen05.mma.kind::f16`, there are no scale-factor tensors, no output
quantization and no amax pass; tensor-memory columns are derived per
specialization rather than pinned at 512, and under a two-CTA atom each CTA
stages only its half of the N operand.

## Coverage

The full SM100 dispatch domain the source supports:

- dense and discrete weights (discrete goes through the prelaunch kernel that
  publishes a per-expert B TensorMap image into a workspace)
- static and dynamic persistent schedulers
- dSwiGLU and dGeGLU, including the runtime `linear_offset`
- BF16/FP16/FP32 C and D in any combination
- k-major and n-major B
- `mma_tiler` 128 and 256 rows, `tile_n` 32 through 256, every valid cluster
  shape up to 16 CTAs
- packed and scalar FP32 epilogue arithmetic
- optional dBias (BF16 `red.global.add.noftz.bf16x2`); dProb is unconditional

42 correctness configurations, 43 benchmark rows.

## Implementation

Written against the Kern language API, with shared memory as a flat byte arena
and explicit scalar offsets — no tile primitives and no first-class layouts,
which `tests/lint/check_moe_grouped_gemm_dglu_dbias_no_tile.py` checks over the
source and all 42 pre-dispatch specializations.

Eight specialized warps (four epilogue, MMA, A/B TMA, epilogue C load,
scheduler), named barriers 1-4, and the source's persistent tile scheduler.
`spec.derive` reproduces upstream's staging and storage arithmetic in closed
form; its AB depths, `expect_tx` byte counts and shared offsets were reconciled
element-for-element against ten line-info PTX exports of the reference across
its structural axes.

Two upstream behaviours are transcribed rather than normalized, because the
reference's own two code paths disagree and the port is held to whichever one a
specialization selects:

- dGeGLU's gradient filters scale by a *value* (the clamped operand), not by a
  0/1 mask
- above `+7` the packed and scalar dGeGLU arms genuinely differ, since the
  packed arm's bound tests leave the upper clamp inert

## Correctness

All 42 configurations pass against both the upstream kernel and an FP32 oracle
on the same inputs.

One deviation is documented rather than papered over: at `tile_n = 32` the
upstream kernel is deterministically wrong — 2156 of 524288 output elements off
by up to 2.5, reproducing bit-for-bit across four consecutive launches, with
`dprob` and `dbias` carrying the same split — while this port matches the FP32
oracle exactly on the same bytes. Every wider tile agrees on both sides. That
row is therefore arbitrated by the oracle alone
(`spec.upstream_disagrees_with_reference`).

## Performance

Measured with `python -m tirx_kernels.bench_suite --with-references` over the
43-row required matrix. The three defaults:

| shape | ratio |
| --- | --- |
| small — 4 experts, 4096 tokens, N 2048, K 2048 | 1.008 |
| medium — 8 experts, 16384 tokens, N 4096, K 8192 | 1.003 |
| large — 8 experts, 32768 tokens, N 4096, K 7168 | 1.005 |

Across the whole matrix every one of the 43 required rows exceeds 0.99, with a
median of 1.0032 and a range of 0.9924 to 1.0304.

A caveat on how those figures were obtained. The benchmark host was shared
throughout, at load averages of 38 to 124 with 7 to 11 foreign compute
processes, so no single complete run was free of contamination: one card idles
at 120 MHz of 1965, is admitted by the suite's probe, and returns ratios from
0.61 to 1.31 on binaries that profile at parity. The per-row figures above are
therefore medians over 17 complete matrices with that card's rows excluded, not
a single run. They are corroborated by paired Nsight Compute profiles of six
shapes spanning 45 us to 1.33 ms, where the port leads the reference on all six
(1.003x to 1.045x) while executing 12-14% fewer instructions for identical FP32
work, moving the same bytes to within 0.04%, launching the same grid, and
spilling nothing.

Four performance changes are carried on top of the faithful port, three of them
from the repo's codegen-tuning database and one new: barriers spin without the
suspend hint; the dBias reduction runs under the D store; epilogue FP32
arithmetic is packed on every specialization; and the C pipeline is deepened
from two stages to four wherever the shared-memory remainder allows it without
costing an AB stage, which upstream's fixed `num_c_stage = 2` leaves unused on
12 of the 43 rows.
