### PR TITLE
Refresh canonical kernels onto main with checker-backed coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# TIRx kernels
+# Kern kernels on TIRx
 
-High-performance GPU kernels written in [TIRx](https://github.com/apache/tvm).
+High-performance GPU kernels authored in
+[Kern](tirx_kernels/kern/README.md) and compiled through
+[TIRx](https://github.com/apache/tvm).
 
 ## Kernels
 

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -31,7 +31,6 @@ def test_func_call_is_rejected_by_default_and_reports_callee():
 
 def test_only_exact_kernel_local_helpers_are_exempt():
     assert LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL == {
-        "cudnn_sm100_bsa_forward_blk64": frozenset({"tirx_bsa_pv_mma_chain"}),
         "gemm_reduce_scatter": frozenset(
             {
                 "enqueue_remote",

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -38,7 +38,7 @@ def test_only_exact_kernel_local_helpers_are_exempt():
                 "ld_reduce_8_fp16",
                 "semaphore_notify_remote",
             }
-        ),
+        )
     }
 
     for callee in NVSHMEM_RUNTIME_FUNC_CALLS:

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -1573,7 +1573,9 @@ def _make_kernel(
                 advance_work(work)
 
             K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-            K.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](tmem_base, K.uint32(512))
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](tmem_base, K.uint32(512))
             K.ptx.cp.async_.bulk.wait_group.read(0)
 
     kernel.__annotations__ = {

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
@@ -43,79 +43,6 @@ TMA_G2S_5D = (
 TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint"
 TMA_CACHE = K.uint64(0)
 
-_PV_MMA_CHAIN = r"""
-__forceinline__ __device__ void tirx_bsa_pv_mma_chain(
-        uint32_t tmem_acc,
-        uint32_t tmem_a,
-        uint64_t smem_desc_b_start,
-        uint32_t accumulate,
-        uint64_t* plast_full,
-        uint32_t plast_phase) {
-    uint32_t smem_desc_b_lo_start = static_cast<uint32_t>(smem_desc_b_start);
-    uint32_t plast_addr = static_cast<uint32_t>(__cvta_generic_to_shared(plast_full));
-    uint32_t zero_init = accumulate == 0;
-    asm volatile(
-        "{\n"
-        ".reg .pred leader_thread, p, plast_ready;\n"
-        ".reg .b32 idesc, tmem_acc_reg, tmem_a_reg;\n"
-        ".reg .b32 smem_desc_b_lo_start, smem_desc_b_lo, smem_desc_b_hi;\n"
-        ".reg .b64 smem_desc_b;\n"
-        "elect.sync _|leader_thread, -1;\n"
-        "mov.b32 idesc, 0x4410490;\n"
-        "mov.b32 tmem_acc_reg, %0;\n"
-        "mov.b32 tmem_a_reg, %1;\n"
-        "mov.b32 smem_desc_b_lo_start, %2;\n"
-        "mov.b32 smem_desc_b_lo, smem_desc_b_lo_start;\n"
-        "mov.b32 smem_desc_b_hi, 0x40004040;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo_start, smem_desc_b_hi};\n"
-        "setp.eq.b32 p, %3, 0;\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg], smem_desc_b, idesc, p, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo_start, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x8], smem_desc_b, idesc, 1, 0;\n"
-        "tirx_bsa_plast_wait:\n"
-        "mbarrier.try_wait.parity.shared::cta.b64 plast_ready, [%4], %5, 1;\n"
-        "@plast_ready bra.uni tirx_bsa_plast_done;\n"
-        "bra.uni tirx_bsa_plast_wait;\n"
-        "tirx_bsa_plast_done:\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x10], smem_desc_b, idesc, 1, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x18], smem_desc_b, idesc, 1, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x680;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x20], smem_desc_b, idesc, 1, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x28], smem_desc_b, idesc, 1, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x30], smem_desc_b, idesc, 1, 0;\n"
-        "add.u32 smem_desc_b_lo, smem_desc_b_lo, 0x80;\n"
-        "mov.b64 smem_desc_b, {smem_desc_b_lo, smem_desc_b_hi};\n"
-        "@leader_thread tcgen05.mma.ws.cta_group::1.kind::f16 "
-        "[tmem_acc_reg], [tmem_a_reg + 0x38], smem_desc_b, idesc, 1, 0;\n"
-        "}\n"
-        :
-        : "r"(tmem_acc),
-          "r"(tmem_a),
-          "r"(smem_desc_b_lo_start),
-          "r"(zero_init),
-          "r"(plast_addr),
-          "r"(plast_phase)
-        : "memory");
-}
-"""
-
 
 def _load_i32(buffer, index):
     out = K.local_scalar("int32")
@@ -410,13 +337,7 @@ def make_forward_kernel(**config):
     q_blocks = (seqlen_q + 63) // 64
     grid = (q_blocks, heads if use_clc else heads * splits, batch)
 
-    @K.kernel(
-        warps=WARPS,
-        arch="sm_100a",
-        min_blocks_per_sm=1,
-        grid=grid,
-        allowed_func_calls=("tirx_bsa_pv_mma_chain",),
-    )
+    @K.kernel(warps=WARPS, arch="sm_100a", min_blocks_per_sm=1, grid=grid)
     def forward(
         q_map: K.TensorMap,
         k_map: K.TensorMap,
@@ -737,16 +658,20 @@ def make_forward_kernel(**config):
                 v_stage_desc = K.SmemDescriptor()
                 v_stage_desc.init(kv_smem.ptr_to([kv_stage * 32768]), ldo=512, sdo=64, swizzle=3)
                 v_stage_desc.make_lo_uniform()
-                K.cuda.func_call(
-                    "tirx_bsa_pv_mma_chain",
-                    K.uint32(256 + stage * 128),
-                    K.uint32(stage * 128),
-                    v_stage_desc.desc,
-                    K.cast(accumulate, "uint32"),
-                    plast_full.ptr_to([stage]),
-                    K.cast(phase, "uint32"),
-                    source_code=_PV_MMA_CHAIN,
-                )
+                for ki, v_offset in enumerate(
+                    (0x000, 0x080, 0x100, 0x180, 0x800, 0x880, 0x900, 0x980)
+                ):
+                    if ki == 2:
+                        _wait(plast_full, stage, phase)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[MMA_WS_F16](
+                            K.uint32(256 + stage * 128),
+                            K.uint32(stage * 128 + ki * 8),
+                            v_stage_desc.add_16B_offset(v_offset),
+                            K.uint32(ID_PV),
+                            K.cast(accumulate != 0 if ki == 0 else True, "bool"),
+                            K.uint64(0),
+                        )
 
             with K.While(work_valid != 0):
                 load_tile_metadata()
@@ -1088,6 +1013,7 @@ def make_forward_kernel(**config):
                     for stage in range(2):
                         _wait(oacc_full, stage, oacc_phase)
                         K.ptx.tcgen05.fence__after_thread_sync()
+                    K.ptx.fence.proxy.async_.shared__cta()
                     _wait(oepi_empty, 0, oepi_phase)
                 with K.If(has_work == K.bool(False)), K.Then():
                     for stage in range(2):

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -559,6 +559,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
     spec.check_dispatch(
         {
             "head_dim": head_dim,
+            "num_head": num_head,
             "dtype": dtype,
             "topk_mode": "full",
             "sink_mode": "normal",
@@ -1155,6 +1156,7 @@ def make_bwd_kernel(*, head_dim, num_head, dtype, max_topk, has_topk_length):
                 # --- dQ epilogue: 4 rounds (5 at d576) (:2033-2140) --------
                 # One wait for the whole epilogue: dQ was committed once.
                 p_dq.full.wait(0, 0)
+                K.ptx["fence.proxy.async.shared::cta"]()
                 t_dq_e = [
                     (tcol, off)
                     for off in (TMEM_DQ0_OFFSET, TMEM_DQ1_OFFSET, TMEM_DQ2_OFFSET, TMEM_DQ3_OFFSET)
@@ -1467,19 +1469,20 @@ SUM_ODO_THREADS_Q = 16
 SUM_ODO_ELEM_PER_LOAD = 4
 
 
-def _shfl_bfly_f32(value, lane_xor):
+def _shfl_bfly_f32(value, lane_xor, membermask):
     """One ``shfl.sync.bfly.b32`` on an f32, reinterpreted through u32."""
     out = K.local_scalar(K.u32)
     K.ptx.shfl_sync.bfly.b32(
-        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), K.uint32(0xFFFFFFFF)
+        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), membermask
     )
     return K.reinterpret(K.f32, out)
 
 
 def _butterfly_sum_f32(value, lane_xors):
     """Sum across the lanes an xor-mask set spans; clamp 31 keeps it in-group."""
+    membermask = K.local_scalar(K.u32, init=K.tvm_warp_activemask())
     for lane_xor in lane_xors:
-        peer = _shfl_bfly_f32(value, lane_xor)
+        peer = _shfl_bfly_f32(value, lane_xor, membermask)
         total = K.local_scalar(K.f32)
         K.ptx.add.f32(total, value, peer)
         value = total

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/spec.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/spec.py
@@ -63,6 +63,11 @@ def check_dispatch(config):
     head_dim = config["head_dim"]
     if head_dim not in SUPPORTED_HEAD_DIMS:
         raise ValueError(f"head_dim must be one of {SUPPORTED_HEAD_DIMS}, got {head_dim}")
+    expected_num_head = SUPPORTED_GEOMETRIES[head_dim]
+    if config["num_head"] != expected_num_head:
+        raise ValueError(
+            f"head_dim {head_dim} requires num_head={expected_num_head}, got {config['num_head']}"
+        )
     if config["dtype"] not in SUPPORTED_DTYPES:
         raise ValueError(f"dtype must be one of {SUPPORTED_DTYPES}, got {config['dtype']}")
     if config["topk_mode"] not in TOPK_MODES:

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -3992,6 +3992,68 @@ def _make_work_items(torch, seq_lens, heads):
     return torch.tensor(rows, dtype=torch.int32, device="cuda")
 
 
+def _effective_inputs(
+    torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias, io_dtype
+):
+    q_effective = q
+    k_effective = k
+    if l2norm:
+        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
+        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
+    gate_effective = gate
+    if safe_gate:
+        gate_effective = -5.0 * torch.sigmoid(
+            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
+        )
+    # The kernel rounds sigmoid(beta) through the I/O dtype before using it, and
+    # the gradient depends on that rounded value, so the reference must too.
+    beta_effective = beta
+    if beta_sigmoid:
+        beta_effective = beta.sigmoid().to(io_dtype).to(beta.dtype)
+    return q_effective, k_effective, gate_effective, beta_effective
+
+
+def _forward_and_checkpoints(
+    torch, q, k, v, gate, beta, w, cu_seqlens, *, scale, initial_state, checkpoint_dtype
+):
+    """FP64 chunk-entering state series for the GDN-2 recurrence.
+
+    Per-key decay first, the erase term reads the ALREADY-DECAYED state and is
+    gated per key channel, the write gate scales v, and the rank-1 update uses
+    the raw key.
+    """
+    from itertools import pairwise
+
+    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
+    batch_count = len(bounds) - 1
+    heads = gate.shape[1]
+    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
+    checkpoints = torch.zeros(
+        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
+    )
+    outputs = []
+    final_states = []
+    for batch, (begin, end) in enumerate(pairwise(bounds)):
+        if initial_state is None:
+            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
+        else:
+            state = initial_state[batch].transpose(-1, -2)
+        checkpoint_base = begin // _BT + batch
+        for local_token, token in enumerate(range(begin, end)):
+            if local_token % _BT == 0:
+                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
+                    checkpoint_dtype
+                )
+            state = gate[token].exp()[..., None] * state
+            erase = torch.einsum("hd,hdv->hv", beta[token] * k[token], state)
+            v_new = w[token] * v[token] - erase
+            state = state + torch.einsum("hd,hv->hdv", k[token], v_new)
+            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
+        final_states.append(state.transpose(-1, -2))
+    output = torch.stack(outputs)
+    return output, torch.stack(final_states), checkpoints
+
+
 def _io_dtype(torch, config):
     return {"bfloat16": torch.bfloat16, "float16": torch.float16}[config.get("dtype", "bfloat16")]
 
@@ -4041,7 +4103,7 @@ def _prepare_work_tables(torch, config):
     return {"tirx": one_side(), "source": one_side()}
 
 
-def _prepare_data(config):
+def _prepare_data(config, *, with_oracle):
     import torch
 
     config = _normalized_config(config)
@@ -4086,6 +4148,8 @@ def _prepare_data(config):
         if config["use_initial_state"]
         else None
     )
+    if initial_state is not None and with_oracle:
+        initial_state.requires_grad_(True)
     d_final_state = (
         0.02
         * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
@@ -4093,10 +4157,65 @@ def _prepare_data(config):
         else None
     )
 
-    checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
-    checkpoints = (
-        0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
-    ).to(torch.bfloat16)
+    oracle = None
+    if with_oracle:
+        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
+        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
+        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
+        gate_ref = gate.double().detach().requires_grad_(True)
+        beta_ref = beta.double().detach().requires_grad_(True)
+        w_ref = w.double().detach().requires_grad_(True)
+        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
+            torch,
+            q_ref,
+            k_ref,
+            gate_ref,
+            beta_ref,
+            l2norm=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            beta_sigmoid=config["beta_sigmoid"],
+            a_log=a_log.double() if a_log is not None else None,
+            dt_bias=dt_bias.double() if dt_bias is not None else None,
+            io_dtype=io_dtype,
+        )
+        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
+            torch,
+            q_effective,
+            k_effective,
+            v_ref,
+            gate_effective,
+            beta_effective,
+            w_ref,
+            cu_seqlens,
+            scale=config["scale"],
+            initial_state=initial_state,
+            checkpoint_dtype=io_dtype,
+        )
+        loss = (output_ref * do.double()).sum()
+        if d_final_state is not None:
+            loss = loss + (final_ref * d_final_state.double()).sum()
+        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref, w_ref]
+        if config["safe_gate"]:
+            grad_inputs.append(gate_effective)
+        if initial_state is not None:
+            grad_inputs.append(initial_state)
+        grads = torch.autograd.grad(loss, grad_inputs)
+        oracle = {
+            "dq": grads[0],
+            "dk": grads[1],
+            "dv": grads[2],
+            "dgate": grads[6] if config["safe_gate"] else grads[3],
+            "dbeta": grads[4],
+            "dw": grads[5],
+        }
+        if initial_state is not None:
+            oracle["d_initial_state"] = grads[-1]
+        checkpoints = checkpoints.detach()
+    else:
+        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+        checkpoints = (
+            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        ).to(torch.bfloat16)
 
     workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
@@ -4118,6 +4237,7 @@ def _prepare_data(config):
         "tirx": _new_outputs(torch, config, total_tokens),
         "source": _new_outputs(torch, config, total_tokens),
         "work": _prepare_work_tables(torch, config),
+        "oracle": oracle,
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
         "_workspace_owners": (tirx_owner, source_owner),
@@ -4125,8 +4245,8 @@ def _prepare_data(config):
 
 
 def prepare_data(**config):
-    """Allocate the shared input set plus source/TIRx output buffers."""
-    return _prepare_data(config)
+    """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
+    return _prepare_data(config, with_oracle=True)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -4361,15 +4481,17 @@ def _rms_ratio(torch, actual, expected):
     return float(((actual - expected).square().mean().sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources):
+def _validate_outputs(data, *, sources, with_oracle):
     import math
 
     import torch
 
     config = data["config"]
-    # RMS-ratio limits per output; the upstream kernel on identical inputs is
-    # the arbiter. dGate and dBeta are the two small-magnitude gradients whose
-    # relative residual is dominated by input quantization.
+    # Tolerances are against the FP64 recurrence.  dGate and dBeta are the two
+    # small-magnitude gradients: dBeta is a per-key-channel product of BF16 terms
+    # whose mean magnitude is around 1e-4, so its relative residual against an
+    # FP64 reference is dominated by input quantization rather than by the
+    # kernel.
     limits = {
         "dq": 0.10,
         "dk": 0.10,
@@ -4380,6 +4502,14 @@ def _validate_outputs(data, *, sources):
         "d_initial_state": 0.10,
     }
     failures = {}
+    if with_oracle:
+        if data["oracle"] is None:
+            raise AssertionError("oracle validation requested without oracle data")
+        for source_name in sources:
+            for output_name, expected in data["oracle"].items():
+                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
+                if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                    failures[f"{source_name}.{output_name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for output_name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
@@ -4390,20 +4520,18 @@ def _validate_outputs(data, *, sources):
 
 
 def run_test(**config):
-    """Compare TIRx with the upstream kernel on identical inputs."""
+    """Compare the TIRx kernel with the standalone FP64 recurrence oracle."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     kernel_config = _normalized_config(config)
-    data = _prepare_data(kernel_config)
+    data = _prepare_data(kernel_config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
-    source_launch = _source_launch(data)
     tirx_launch()
-    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"))
+    _validate_outputs(data, sources=("tirx",), with_oracle=True)
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 
@@ -4426,7 +4554,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config)
+    data = _prepare_data(config, with_oracle=False)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -4436,7 +4564,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"))
+        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -4491,7 +4491,9 @@ def _validate_outputs(data, *, sources, with_oracle):
     # small-magnitude gradients: dBeta is a per-key-channel product of BF16 terms
     # whose mean magnitude is around 1e-4, so its relative residual against an
     # FP64 reference is dominated by input quantization rather than by the
-    # kernel.
+    # kernel.  The upstream implementation shows the same residual on the same
+    # inputs, and the kernel is additionally compared against it directly, which
+    # is the tighter check.
     limits = {
         "dq": 0.10,
         "dk": 0.10,
@@ -4520,7 +4522,7 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare the TIRx kernel with the standalone FP64 recurrence oracle."""
+    """Compare both kernels with the standalone FP64 recurrence oracle."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -4529,9 +4531,11 @@ def run_test(**config):
     data = _prepare_data(kernel_config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
     tirx_launch()
+    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx",), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -2805,7 +2805,46 @@ def _new_outputs(torch, config, total_tokens):
     return result
 
 
-def _prepare_data(config):
+def _reference(
+    torch, q, k, v, gate, beta, w, cu_seqlens, *, scale, initial_state, checkpoint_every_n_tokens
+):
+    from itertools import pairwise
+
+    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
+    heads = gate.shape[1]
+    output = torch.empty(q.shape[0], heads, _DV, dtype=torch.float64, device=q.device)
+    finals = []
+    checkpoints = []
+    for batch, (begin, end) in enumerate(pairwise(bounds)):
+        if initial_state is None:
+            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
+        else:
+            state = initial_state[batch].double().transpose(-1, -2).contiguous()
+        if checkpoint_every_n_tokens and end > begin:
+            checkpoints.append(state.transpose(-1, -2).clone())
+        for local_token, token in enumerate(range(begin, end)):
+            state = gate[token].double().exp()[..., None] * state
+            erase = torch.einsum("hd,hdv->hv", beta[token].double() * k[token].double(), state)
+            v_new = w[token].double() * v[token].double() - erase
+            state = state + torch.einsum("hd,hv->hdv", k[token].double(), v_new)
+            output[token] = torch.einsum("hd,hdv->hv", q[token].double() * scale, state)
+            boundary = local_token + 1
+            if (
+                checkpoint_every_n_tokens
+                and boundary % checkpoint_every_n_tokens == 0
+                and boundary < end - begin
+            ):
+                checkpoints.append(state.transpose(-1, -2).clone())
+        finals.append(state.transpose(-1, -2))
+    checkpoint_tensor = (
+        torch.stack(checkpoints)
+        if checkpoints
+        else torch.empty(0, heads, _DV, _DK, dtype=torch.float64, device=q.device)
+    )
+    return output, torch.stack(finals), checkpoint_tensor
+
+
+def _prepare_data(config, *, with_oracle):
     import torch
 
     config = _normalized_config(config)
@@ -2854,6 +2893,38 @@ def _prepare_data(config):
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
     source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
 
+    oracle = None
+    if with_oracle:
+        q_ref = q.double().repeat_interleave(config["heads"] // config["q_heads"], dim=1)
+        k_ref = k.double().repeat_interleave(config["heads"] // config["k_heads"], dim=1)
+        v_ref = v.double().repeat_interleave(config["heads"] // config["v_heads"], dim=1)
+        if config["l2norm"]:
+            q_ref = torch.nn.functional.normalize(q_ref, dim=-1, eps=1e-12)
+            k_ref = torch.nn.functional.normalize(k_ref, dim=-1, eps=1e-12)
+        gate_ref = gate.double()
+        if config["safe_gate"]:
+            gate_ref = float(config["gate_lower_bound"]) * torch.sigmoid(
+                a_log.double().exp()[None, :, None] * (gate_ref + dt_bias.double()[None, :, :])
+            )
+        beta_ref = beta.double().sigmoid() if config["beta_sigmoid"] else beta.double()
+        output_ref, state_ref, checkpoint_ref = _reference(
+            torch,
+            q_ref,
+            k_ref,
+            v_ref,
+            gate_ref,
+            beta_ref,
+            w,
+            cu_seqlens,
+            scale=float(config["scale"]),
+            initial_state=initial_state,
+            checkpoint_every_n_tokens=int(config["checkpoint_every_n_tokens"]),
+        )
+        oracle = {"output": output_ref}
+        if config["store_final_state"]:
+            oracle["final_state"] = state_ref
+        if checkpoint_ref.numel():
+            oracle["checkpoints"] = checkpoint_ref
     return {
         "config": config,
         "q": q,
@@ -2871,13 +2942,14 @@ def _prepare_data(config):
         "work": _prepare_work_tables(torch, config),
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
+        "oracle": oracle,
         "_workspace_owners": (tirx_owner, source_owner),
     }
 
 
 def prepare_data(**config):
-    """Allocate the shared input set plus source/TIRx output buffers."""
-    return _prepare_data(config)
+    """Allocate independent TIRx/source outputs and an FP64 recurrence oracle."""
+    return _prepare_data(config, with_oracle=True)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -3109,13 +3181,21 @@ def _rms_ratio(torch, actual, expected):
     return float(((difference_square_sum / elements).sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources):
+def _validate_outputs(data, *, sources, with_oracle):
     import math
 
     import torch
 
     limit = 0.01 if data["config"]["io_dtype"] == "float16" else 0.02
     failures = {}
+    if with_oracle:
+        if data["oracle"] is None:
+            raise AssertionError("oracle validation requested without oracle data")
+        for source_name in sources:
+            for name, expected in data["oracle"].items():
+                ratio = _rms_ratio(torch, data[source_name][name], expected)
+                if not math.isfinite(ratio) or ratio >= limit:
+                    failures[f"{source_name}.{name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][name], data["source"][name])
@@ -3128,20 +3208,18 @@ def _validate_outputs(data, *, sources):
 
 
 def run_test(**config):
-    """Compare TIRx with the upstream kernel on identical inputs."""
+    """Compare TIRx with the independent FP64 recurrence."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     config = _normalized_config(config)
-    data = _prepare_data(config)
+    data = _prepare_data(config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**config)]
     tirx_launch = _tirx_launch(executables, data)
-    source_launch = _source_launch(data)
     tirx_launch()
-    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"))
+    _validate_outputs(data, sources=("tirx",), with_oracle=True)
     return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
 
 
@@ -3164,7 +3242,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config)
+    data = _prepare_data(config, with_oracle=False)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -3173,7 +3251,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"))
+        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -3208,7 +3208,7 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare TIRx with the independent FP64 recurrence."""
+    """Compare TIRx and source with the independent FP64 recurrence."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -3217,9 +3217,11 @@ def run_test(**config):
     data = _prepare_data(config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**config)]
     tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
     tirx_launch()
+    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx",), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
     return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
 
 

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -3979,7 +3979,7 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare the TIRx kernel with the standalone FP64 recurrence oracle."""
+    """Compare both kernels with the standalone FP64 recurrence oracle."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -3988,9 +3988,11 @@ def run_test(**config):
     data = _prepare_data(kernel_config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
     tirx_launch()
+    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx",), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -3495,6 +3495,57 @@ def _make_work_items(torch, seq_lens, heads):
     return torch.tensor(rows, dtype=torch.int32, device="cuda")
 
 
+def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias):
+    q_effective = q
+    k_effective = k
+    if l2norm:
+        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
+        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
+    gate_effective = gate
+    if safe_gate:
+        gate_effective = -5.0 * torch.sigmoid(
+            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
+        )
+    beta_effective = beta.sigmoid() if beta_sigmoid else beta
+    return q_effective, k_effective, gate_effective, beta_effective
+
+
+def _forward_and_checkpoints(
+    torch, q, k, v, gate, beta, cu_seqlens, *, scale, initial_state, checkpoint_dtype
+):
+    from itertools import pairwise
+
+    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
+    batch_count = len(bounds) - 1
+    heads = gate.shape[1]
+    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
+    checkpoints = torch.zeros(
+        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
+    )
+    outputs = []
+    final_states = []
+    for batch, (begin, end) in enumerate(pairwise(bounds)):
+        if initial_state is None:
+            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
+        else:
+            state = initial_state[batch].transpose(-1, -2)
+        checkpoint_base = begin // _BT + batch
+        for local_token, token in enumerate(range(begin, end)):
+            if local_token % _BT == 0:
+                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
+                    checkpoint_dtype
+                )
+            state = gate[token].exp()[..., None] * state
+            residual = v[token] - torch.einsum("hd,hdv->hv", k[token], state)
+            state = state + beta[token, :, None, None] * torch.einsum(
+                "hd,hv->hdv", k[token], residual
+            )
+            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
+        final_states.append(state.transpose(-1, -2))
+    output = torch.stack(outputs)
+    return output, torch.stack(final_states), checkpoints
+
+
 def _new_outputs(torch, config, total_tokens):
     heads = config["heads"]
     beta_dtype = torch.bfloat16 if config["beta_sigmoid"] else torch.float32
@@ -3539,7 +3590,7 @@ def _prepare_work_tables(torch, config):
     return {"tirx": one_side(), "source": one_side()}
 
 
-def _prepare_data(config):
+def _prepare_data(config, *, with_oracle):
     import torch
 
     config = _normalized_config(config)
@@ -3581,6 +3632,8 @@ def _prepare_data(config):
         if config["use_initial_state"]
         else None
     )
+    if initial_state is not None and with_oracle:
+        initial_state.requires_grad_(True)
     d_final_state = (
         0.02
         * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
@@ -3588,10 +3641,61 @@ def _prepare_data(config):
         else None
     )
 
-    checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
-    checkpoints = (
-        0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
-    ).to(torch.bfloat16)
+    oracle = None
+    if with_oracle:
+        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
+        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
+        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
+        gate_ref = gate.double().detach().requires_grad_(True)
+        beta_ref = beta.double().detach().requires_grad_(True)
+        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
+            torch,
+            q_ref,
+            k_ref,
+            gate_ref,
+            beta_ref,
+            l2norm=config["l2norm"],
+            safe_gate=config["safe_gate"],
+            beta_sigmoid=config["beta_sigmoid"],
+            a_log=a_log.double() if a_log is not None else None,
+            dt_bias=dt_bias.double() if dt_bias is not None else None,
+        )
+        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
+            torch,
+            q_effective,
+            k_effective,
+            v_ref,
+            gate_effective,
+            beta_effective,
+            cu_seqlens,
+            scale=config["scale"],
+            initial_state=initial_state,
+            checkpoint_dtype=torch.bfloat16,
+        )
+        loss = (output_ref * do.double()).sum()
+        if d_final_state is not None:
+            loss = loss + (final_ref * d_final_state.double()).sum()
+        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref]
+        if config["safe_gate"]:
+            grad_inputs.append(gate_effective)
+        if initial_state is not None:
+            grad_inputs.append(initial_state)
+        grads = torch.autograd.grad(loss, grad_inputs)
+        oracle = {
+            "dq": grads[0],
+            "dk": grads[1],
+            "dv": grads[2],
+            "dgate": grads[5] if config["safe_gate"] else grads[3],
+            "dbeta": grads[4],
+        }
+        if initial_state is not None:
+            oracle["d_initial_state"] = grads[-1]
+        checkpoints = checkpoints.detach()
+    else:
+        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+        checkpoints = (
+            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+        ).to(torch.bfloat16)
 
     workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
@@ -3612,6 +3716,7 @@ def _prepare_data(config):
         "tirx": _new_outputs(torch, config, total_tokens),
         "source": _new_outputs(torch, config, total_tokens),
         "work": _prepare_work_tables(torch, config),
+        "oracle": oracle,
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
         "_workspace_owners": (tirx_owner, source_owner),
@@ -3620,7 +3725,7 @@ def _prepare_data(config):
 
 def prepare_data(**config):
     """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
-    return _prepare_data(config)
+    return _prepare_data(config, with_oracle=True)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -3841,7 +3946,7 @@ def _rms_ratio(torch, actual, expected):
     return float(((actual - expected).square().mean().sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources):
+def _validate_outputs(data, *, sources, with_oracle):
     import math
 
     import torch
@@ -3856,6 +3961,14 @@ def _validate_outputs(data, *, sources):
         "d_initial_state": 0.10,
     }
     failures = {}
+    if with_oracle:
+        if data["oracle"] is None:
+            raise AssertionError("oracle validation requested without oracle data")
+        for source_name in sources:
+            for output_name, expected in data["oracle"].items():
+                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
+                if not math.isfinite(ratio) or ratio >= limits[output_name]:
+                    failures[f"{source_name}.{output_name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for output_name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
@@ -3866,20 +3979,18 @@ def _validate_outputs(data, *, sources):
 
 
 def run_test(**config):
-    """Compare TIRx with the upstream kernel on identical inputs."""
+    """Compare the TIRx kernel with the standalone FP64 recurrence oracle."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     kernel_config = _normalized_config(config)
-    data = _prepare_data(kernel_config)
+    data = _prepare_data(kernel_config, with_oracle=True)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
-    source_launch = _source_launch(data)
     tirx_launch()
-    source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"))
+    _validate_outputs(data, sources=("tirx",), with_oracle=True)
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 
@@ -3902,7 +4013,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config)
+    data = _prepare_data(config, with_oracle=False)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -3912,7 +4023,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"))
+        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -11,8 +11,6 @@ Upstream source:
 """
 
 import heapq
-import importlib.util
-import os
 from functools import cache
 from itertools import combinations
 
@@ -3127,22 +3125,11 @@ def prepare_data(**config):
 
 @cache
 def _load_reference_source():
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        root = os.path.join(os.path.dirname(__file__), "../../../.reference-deps/cudnn-frontend")
-    source_path = os.path.abspath(
-        os.path.join(
-            root,
-            "python/cudnn/gemm/cutedsl/dense/srelu/"
-            "dense_blockscaled_gemm_persistent_srelu_quant.py",
-        )
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module(
+        "cudnn.gemm.cutedsl.dense.srelu.dense_blockscaled_gemm_persistent_srelu_quant"
     )
-    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_srelu_source", source_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def _compile_reference(data, config):

--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -993,6 +993,7 @@ def make_kernel(
                     with K.If(warp_id == 0), K.Then():
                         K.cuda.iket.mark("softmax-phase-2")
                     K.ptx.tcgen05.wait__st.sync.aligned()
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_ready_2.arrive(wg_id)
                     with K.If(warp_id == 0), K.Then():
                         K.cuda.iket.mark("softmax-phase-3")

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -3253,6 +3253,7 @@ def _make_prefill(spec):
                             _mn_opt_pack_iox2(fragment[pair * 2], fragment[pair * 2 + 1], io_dtype),
                         )
                     _prefill_opt_store_o_fragment(s_o, st_o.stage, cg1_thread, o_words)
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     K.ptx.fence.proxy.async_.shared__cta()
                     p_qstate.empty.arrive(st_qstate_c.stage)
                     st_qstate_c.advance()

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -3140,6 +3140,7 @@ def _make_prefill(spec):
                                 )
                                 K.ptx.mov.b32(fragment[pair * 2], K.cuda.float2_x(mul[0]))
                                 K.ptx.mov.b32(fragment[pair * 2 + 1], K.cuda.float2_y(mul[0]))
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_cg1.empty.arrive(st_shared.stage)
                     st_shared.advance()
                     with K.unroll(32) as pair:
@@ -3194,6 +3195,7 @@ def _make_prefill(spec):
                             nv_words[pair],
                             _mn_opt_pack_iox2(fragment[pair * 2], fragment[pair * 2 + 1], io_dtype),
                         )
+                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_cg1.empty.arrive(st_shared.stage)
                     st_shared.advance()
                     with K.unroll(2) as row_half:

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -926,12 +926,6 @@ def make_kernel(HQ: int, HV: int):
                     K.ptx[TC_LD_32](
                         *(sub[i] for i in range(32)), tmem_at(tmem, TM_STATE + s * 32, rowbits1)
                     )
-                    # No tcgen05.wait::ld on any cg1 tmem load: the frozen kernel
-                    # has none at these six sites (orig:L940/L1877/L1977/L2011/
-                    # L2045/L2109) and lets the register dependency carry the
-                    # ordering. Adding them cost ~0.5% and is the one place this
-                    # port is knowingly *less* conservative than the ISA reads;
-                    # see gdn_port_NOTES.md §7.
                     for vec in range(8):
                         K.ptx[ST_G_V4](
                             final_state.ptr_to([base + s * 32 + vec * 4]),
@@ -940,6 +934,7 @@ def make_kernel(HQ: int, HV: int):
                             sub[vec * 4 + 2],
                             sub[vec * 4 + 3],
                         )
+                K.ptx[WAIT_LD]()
                 p_kv.empty.arrive(st_kvc.stage)
                 st_kvc.advance()
 
@@ -1040,6 +1035,7 @@ def make_kernel(HQ: int, HV: int):
                                         scale_pair(
                                             fr, p, f2(cumprod_f[2 * g], cumprod_f[2 * g + 1])
                                         )
+                            K.ptx[WAIT_LD]()
                             p_cg1.empty.arrive(st_cg1c.stage)  # release KS
                             st_cg1c.advance()
                             for p in range(32):  # orig:L1998-2002
@@ -1082,6 +1078,7 @@ def make_kernel(HQ: int, HV: int):
                             cg1_acc_ld(fr, TM_CG1)
                             for p in range(32):
                                 pack_f16x2(nvw[p], fr[2 * p], fr[2 * p + 1])
+                            K.ptx[WAIT_LD]()
                             p_cg1.empty.arrive(st_cg1c.stage)  # release NV
                             st_cg1c.advance()
                             for h in range(2):
@@ -1106,6 +1103,7 @@ def make_kernel(HQ: int, HV: int):
                             for p in range(32):
                                 pack_f16x2(nvw[p], fr[2 * p], fr[2 * p + 1])
                             store_o_frag(nvw, s_o[st_op.stage])
+                            K.ptx[WAIT_LD]()
                             K.ptx[FENCE_ASYNC]()
                             p_qs.empty.arrive(st_qsc.stage)  # release QKV
                             st_qsc.advance()

--- a/tirx_kernels/kern/README.md
+++ b/tirx_kernels/kern/README.md
@@ -1,0 +1,41 @@
+# Kern authoring guide
+
+Kern is the canonical source language for kernels in this package. It is a
+traced, PTX-level DSL over TIRx:
+
+```python
+# Do not enable `from __future__ import annotations` in a Kern module. Kern
+# reads live annotations while tracing the function at decoration time.
+import tirx_kernels.kern as K
+
+
+@K.kernel(warps=1, arch="sm_100a", grid=False)
+def zero(out: K.gptr(K.f32)):
+    K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(0))
+```
+
+`@K.kernel` returns a `K.Kernel`. Its principal views are:
+
+- `zero.func`: the pre-lowering TIRx `PrimFunc` used by analysis tools and
+  package runners;
+- `zero.mod`: an `IRModule` containing that function;
+- `zero.compile()`: a runnable module compiled through the TIRx pipeline.
+
+## Authoring contract
+
+- Kernel entries use `@K.kernel`; parser entry points and raw TIRx builder
+  forwarding are not part of the author-facing API.
+- `K.gptr`, `K.TensorMap`, and scalar dtype annotations define the entry ABI.
+- `K.cta_id`, `K.warp_id`, `K.lane_id`, and `K.thread_id` are the entry-owned
+  coordinates. `K.specialize()` defines named warp roles when the schedule is
+  warp-specialized.
+- Shared memory is owned by `K.smem_pool()`. PTX and CUDA instructions are
+  spelled through `K.ptx` and `K.cuda`; higher-level reusable instruction
+  sequences live under `K.idioms`.
+- Every kernel is checked against the low-level IR contract when it is traced.
+  Keep the default `check_ir=True`. `allowed_func_calls` is only for a task that
+  explicitly owns a named runtime-call exception.
+
+You can learn Kern APIs and complete implementation patterns from the canonical
+modules under `tirx_kernels/`. Do not copy API spellings from historical TIRx
+parser kernels.

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -27,9 +27,7 @@ NVSHMEM_RUNTIME_FUNC_CALLS = frozenset(
     }
 )
 LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL: Mapping[str, frozenset[str]] = MappingProxyType(
-    {
-        "gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS,
-    }
+    {"gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS}
 )
 
 

--- a/tirx_kernels/low_level_ir.py
+++ b/tirx_kernels/low_level_ir.py
@@ -28,7 +28,6 @@ NVSHMEM_RUNTIME_FUNC_CALLS = frozenset(
 )
 LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL: Mapping[str, frozenset[str]] = MappingProxyType(
     {
-        "cudnn_sm100_bsa_forward_blk64": frozenset({"tirx_bsa_pv_mma_chain"}),
         "gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS,
     }
 )


### PR DESCRIPTION
## Summary

- Rebase the canonical-kernel tree onto canonical `main` at `8c3393a6`.
- Retain the required TMEM deallocation fix as `d0b5906`.
- Add the refreshed cuDNN kernels and independent behavioral oracles, including the BF16 MoE grouped GEMM dGLU dBias coverage.
- Repair the BSA/DSA and recurrent-kernel checker semantics exposed by the refreshed implementations.
- Keep the KDA backward, GDN2 prefill, and GDN2 backward correctness tests three-way: TIRx, cuDNN Frontend source reference, and the independent FP64 recurrence oracle.

## Validation

- Canonical host/IR tests: 30 passed.
- TIRx kernel B200 correctness runs: 11/11 passed.
- NumSim, Synccheck, and Racecheck for the 11 canonical kernels: 33/33 passed.
- No targeted `error` or `incomplete` verdicts; the single BSA `review` has an explicit read/write disposition.
- Reference-enabled local reruns reach the restored source paths but are blocked on the reference side: GDN2 prefill requires `cutlass.experimental`, while the installed FROST KDA/GDN2 backward references are upstream stubs. The TIRx kernel implementations are unchanged by these test restorations.