### PR TITLE
build(infra): load cuDNN Frontend references from the pinned source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ remain externally managed runtime/compiler dependencies.
 | `tvm.tirx`       | all kernels (compile + run)        | The TIRx compiler. Put it on `PYTHONPATH`, e.g. `/path/to/tir/python`. |
 | `torch`          | all kernels                        | CUDA build matching your GPU.                          |
 | `deep_gemm`      | FP8 GEMM and `deepgemm_*` baselines | Used for optimized reference kernels and the MegaMoE timer. |
+| cuDNN Frontend (`cudnn`) | `cudnn_*` correctness and baselines | Source install pinned in the lock (v1.28.0); replaces any released `nvidia-cudnn-frontend` wheel, which lacks the CuTeDSL kernel sources. |
 | `flashinfer`     | `nvfp4_gemm` baseline | Used for reference implementations. |
 | `flash-attn` + CUTLASS DSL | `flash_attention_backward_sm100` baseline | Current SM100 forward/backward reference. |
 | `sglang` (+ CUTLASS DSL) | `deepgemm_sm100_fp8_paged_mqa_logits` reference | Optional `sglang_cutedsl` benchmark reference. |

--- a/reference-dependencies.json
+++ b/reference-dependencies.json
@@ -1,7 +1,7 @@
 {
   "schema": 1,
   "python_requirements": [
-    "nvidia-cutlass-dsl[cu13]==4.6.2",
+    "nvidia-cutlass-dsl[cu13]==4.7.0",
     "nvidia-cuda-cccl==13.2.75",
     "quack-kernels==0.6.4"
   ],
@@ -83,6 +83,17 @@
       "url": "https://github.com/MiniMax-AI/MSA.git",
       "revision": "80434d7f67877c6570ca19cac444b84bc9855dac",
       "install_subdirectory": "."
+    },
+    {
+      "name": "cudnn-frontend",
+      "import_name": "cudnn",
+      "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+      "revision": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+      "install_subdirectory": ".",
+      "build_requirements": [
+        "pybind11==2.13.6",
+        "pybind11-global==2.13.6"
+      ]
     }
   ]
 }

--- a/scripts/install_reference_dependencies.py
+++ b/scripts/install_reference_dependencies.py
@@ -83,7 +83,14 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
 
 def source_build_environment() -> dict[str, str]:
     env = os.environ.copy()
-    cccl = distribution("nvidia-cuda-cccl")
+    try:
+        cccl = distribution("nvidia-cuda-cccl")
+    except PackageNotFoundError:
+        # The cccl headers come from the global requirement group, which a
+        # targeted --only run skips; sources that need them fail in their own
+        # builds, and the rest must not be blocked on an unrelated header set.
+        print("nvidia-cuda-cccl is not installed; building without its headers", flush=True)
+        return env
     utility = next(
         (
             Path(file.locate())
@@ -144,13 +151,16 @@ def target_versions(target: Path) -> dict[str, str]:
     }
 
 
-def install(lock: dict[str, Any], source_root: Path) -> None:
-    requirements = lock["python_requirements"]
-    run(sys.executable, "-m", "pip", "install", "--upgrade", *lock["test_requirements"])
-    run(sys.executable, "-m", "pip", "install", "--upgrade", "--no-deps", *requirements)
+def install(lock: dict[str, Any], source_root: Path, only: set[str] | None = None) -> None:
+    if only is None:
+        requirements = lock["python_requirements"]
+        run(sys.executable, "-m", "pip", "install", "--upgrade", *lock["test_requirements"])
+        run(sys.executable, "-m", "pip", "install", "--upgrade", "--no-deps", *requirements)
     build_env = source_build_environment()
     source_root.mkdir(parents=True, exist_ok=True)
     for name, isolated in lock.get("isolated_python_requirements", {}).items():
+        if only is not None and name not in only:
+            continue
         target = source_root / name
         run(
             sys.executable,
@@ -164,11 +174,24 @@ def install(lock: dict[str, Any], source_root: Path) -> None:
             *isolated,
         )
     for source in lock["sources"]:
+        if only is not None and source["name"] not in only:
+            continue
         checkout = checkout_source(source, source_root)
         materialize_source_links(source, checkout)
         if import_uses_checkout(source, checkout):
             print(f"{source['name']} already imports from its pinned checkout", flush=True)
             continue
+        build_requirements = source.get("build_requirements", [])
+        if build_requirements:
+            run(
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--no-deps",
+                *build_requirements,
+            )
         install_path = checkout / source["install_subdirectory"]
         run(
             sys.executable,
@@ -183,9 +206,8 @@ def install(lock: dict[str, Any], source_root: Path) -> None:
         )
 
 
-def check(lock: dict[str, Any], source_root: Path) -> None:
-    failures: list[str] = []
-    for requirement in [*lock["python_requirements"], *lock["test_requirements"]]:
+def check_installed_pins(requirements: list[str], failures: list[str]) -> None:
+    for requirement in requirements:
         package, expected = requirement_pin(requirement)
         try:
             actual = version(package)
@@ -195,7 +217,15 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
         if actual != expected:
             failures.append(f"{package}=={actual}, expected {expected}")
 
+
+def check(lock: dict[str, Any], source_root: Path, only: set[str] | None = None) -> None:
+    failures: list[str] = []
+    if only is None:
+        check_installed_pins([*lock["python_requirements"], *lock["test_requirements"]], failures)
+
     for name, requirements in lock.get("isolated_python_requirements", {}).items():
+        if only is not None and name not in only:
+            continue
         target = source_root / name
         if not target.is_dir():
             failures.append(f"missing isolated dependency directory: {target}")
@@ -210,6 +240,8 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
                 failures.append(f"{package}=={actual} under {target}, expected {expected}")
 
     for source in lock["sources"]:
+        if only is not None and source["name"] not in only:
+            continue
         checkout = source_root / source["name"]
         if not (checkout / ".git").exists():
             failures.append(f"missing checkout: {checkout}")
@@ -236,6 +268,7 @@ def check(lock: dict[str, Any], source_root: Path) -> None:
             materialize_source_links(source, checkout)
         except (FileNotFoundError, RuntimeError) as error:
             failures.append(str(error))
+        check_installed_pins(source.get("build_requirements", []), failures)
         resolved_import_paths = import_paths(source["import_name"])
         if not resolved_import_paths:
             failures.append(f"cannot find import {source['import_name']!r}")
@@ -261,20 +294,39 @@ def main() -> None:
         help=f"checkout directory (default: {DEFAULT_SOURCE_ROOT})",
     )
     parser.add_argument("--check", action="store_true", help="verify the installed lock only")
+    parser.add_argument(
+        "--only",
+        action="append",
+        metavar="NAME",
+        help=(
+            "restrict to the named source or isolated dependency set (repeatable); "
+            "the global python/test requirement groups are skipped when used"
+        ),
+    )
     args = parser.parse_args()
     lock = load_lock()
     source_root = args.source_root.resolve()
+    only: set[str] | None = None
+    if args.only:
+        known = {source["name"] for source in lock["sources"]} | set(
+            lock.get("isolated_python_requirements", {})
+        )
+        unknown = set(args.only) - known
+        if unknown:
+            raise SystemExit(f"unknown --only names: {', '.join(sorted(unknown))}")
+        only = set(args.only)
     if not args.check:
-        install(lock, source_root)
+        install(lock, source_root, only)
         run(
             sys.executable,
             str(Path(__file__).resolve()),
             "--check",
             "--source-root",
             str(source_root),
+            *[f"--only={name}" for name in sorted(only or ())],
         )
         return
-    check(lock, source_root)
+    check(lock, source_root, only)
 
 
 if __name__ == "__main__":

--- a/tirx_kernels/cudnn/_reference.py
+++ b/tirx_kernels/cudnn/_reference.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Import cuDNN Frontend reference kernels from the pinned source install.
+
+The reference implementations the ``cudnn`` ports compare against live in the
+``cudnn-frontend`` source checkout pinned in ``reference-dependencies.json``
+(v1.28.0) and installed editable by ``scripts/install_reference_dependencies.py``
+into ``.reference-deps/cudnn-frontend`` — replacing any released
+``nvidia-cudnn-frontend`` wheel, which predates the ``cudnn.gemm`` /
+``cudnn.linear_attention`` / ``cudnn.csa`` reorganization and carries older
+revisions of the kernels it does ship.
+
+Every reference — the FROST linear-attention kernels included — runs on the
+ambient CuTe-DSL, whose version the lock pins (the FROST kernels need >= 4.7.0,
+the first release that ships ``cutlass.experimental``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from functools import cache
+
+_INSTALL_HINT = "run `python scripts/install_reference_dependencies.py` first"
+
+
+def _rebind_submodules(package):
+    """Re-attach already-loaded submodules to a freshly re-executed package.
+
+    A failed ``import cutlass`` drops ``cutlass`` from ``sys.modules`` but leaves
+    every ``cutlass.*`` submodule behind. On the retry the package body re-runs,
+    and its inner ``import cutlass._mlir`` finds that submodule already loaded,
+    so the import system never binds it as an attribute of the new package
+    object. The upstream kernel reaches for ``cutlass._mlir.dialects.math`` in
+    its amax reduction and fails with an ``AttributeError`` that has nothing to
+    do with the kernel under test.
+    """
+    prefix = package.__name__ + "."
+    for name, module in list(sys.modules.items()):
+        if not name.startswith(prefix) or module is None:
+            continue
+        child = name[len(prefix) :]
+        if "." in child:
+            continue
+        if getattr(package, child, None) is not module:
+            setattr(package, child, module)
+    return package
+
+
+def import_cutlass_reference():
+    """Recover from CuTeDSL's non-idempotent generated builder imports."""
+    try:
+        return _rebind_submodules(importlib.import_module("cutlass"))
+    except RuntimeError as exc:
+        message = str(exc)
+        if "Attribute builder for '" not in message or "is already registered" not in message:
+            raise
+        mlir_ir = sys.modules.get("cutlass._mlir.ir")
+        if mlir_ir is None:
+            raise
+        register_attribute_builder = mlir_ir.register_attribute_builder
+
+        def register_replacing_builder(kind, replace=False):
+            del replace
+            return register_attribute_builder(kind, replace=True)
+
+        mlir_ir.register_attribute_builder = register_replacing_builder
+        try:
+            return _rebind_submodules(importlib.import_module("cutlass"))
+        finally:
+            mlir_ir.register_attribute_builder = register_attribute_builder
+
+
+@cache
+def load_reference_module(name: str):
+    """Import one cuDNN Frontend reference module from the pinned install."""
+    import_cutlass_reference()
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError as exc:
+        if exc.name and (name == exc.name or name.startswith(exc.name + ".")):
+            raise RuntimeError(
+                f"cannot import the cuDNN Frontend reference {name!r}; {_INSTALL_HINT}"
+            ) from exc
+        # A dependency of the reference is missing, not the reference itself;
+        # keep the original error rather than misattributing it to the install.
+        raise

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -9,11 +9,8 @@ Upstream source:
 ``python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py``.
 """
 
-import importlib
-import importlib.util
 import json
 import os
-import sys
 from functools import cache
 from itertools import combinations, product
 
@@ -1758,48 +1755,18 @@ def prepare_data(**config):
     }
 
 
-@cache
 def _load_reference_source():
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    source_path = os.path.join(
-        root, "python/cudnn/gemm/cutedsl/dense/amax/dense_blockscaled_gemm_persistent_amax.py"
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module(
+        "cudnn.gemm.cutedsl.dense.amax.dense_blockscaled_gemm_persistent_amax"
     )
-    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_amax_source", source_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def _import_cutlass_reference():
-    """Recover from CuTeDSL's non-idempotent generated builder imports."""
-    try:
-        return importlib.import_module("cutlass")
-    except RuntimeError as exc:
-        message = str(exc)
-        if "Attribute builder for '" not in message or "is already registered" not in message:
-            raise
-        mlir_ir = sys.modules.get("cutlass._mlir.ir")
-        if mlir_ir is None:
-            raise
-        register_attribute_builder = mlir_ir.register_attribute_builder
-
-        def register_replacing_builder(kind, replace=False):
-            del replace
-            return register_attribute_builder(kind, replace=True)
-
-        mlir_ir.register_attribute_builder = register_replacing_builder
-        try:
-            return importlib.import_module("cutlass")
-        finally:
-            mlir_ir.register_attribute_builder = register_attribute_builder
 
 
 def _compile_reference(data, config):
-    cutlass = _import_cutlass_reference()
+    from tirx_kernels.cudnn._reference import import_cutlass_reference
+
+    cutlass = import_cutlass_reference()
     import cutlass.cute as cute
     import torch
     from cuda.bindings import driver as cuda

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
@@ -5,55 +5,19 @@
 
 """Lazy loader for the upstream SM100 blk64 BSA forward pass.
 
-Upstream source: ``python/cudnn/block_sparse_attention/_interface.py``.
+Upstream source: ``python/cudnn/block_sparse_attention/_interface.py``, from the
+cuDNN Frontend source install pinned in ``reference-dependencies.json``.
 """
-
-import importlib
-import os
-import sys
-import types
-from pathlib import Path
 
 import torch
 
-_PACKAGE = "cudnn.block_sparse_attention"
-_INTERFACE = f"{_PACKAGE}._interface"
+from tirx_kernels.cudnn._reference import load_reference_module
 
-
-def checkout_root():
-    configured = os.environ.get("CUDNN_FRONTEND_PATH")
-    if configured:
-        return Path(configured).resolve()
-    return Path(__file__).resolve().parents[4] / ".reference-deps" / "cudnn-frontend"
-
-
-def _bind_checkout():
-    package_dir = checkout_root() / "python" / "cudnn" / "block_sparse_attention"
-    if not package_dir.is_dir():
-        raise RuntimeError(
-            f"cuDNN Frontend checkout does not contain block sparse attention: {package_dir}"
-        )
-
-    existing = sys.modules.get(_PACKAGE)
-    if existing is not None:
-        bound = getattr(existing, "__path__", None)
-        if bound and Path(next(iter(bound))).resolve() == package_dir.resolve():
-            return
-        raise RuntimeError(
-            f"{_PACKAGE} was already imported from {bound}; cannot bind it to {package_dir}"
-        )
-
-    cudnn = importlib.import_module("cudnn")
-    package = types.ModuleType(_PACKAGE)
-    package.__path__ = [str(package_dir)]
-    package.__package__ = _PACKAGE
-    sys.modules[_PACKAGE] = package
-    cudnn.block_sparse_attention = package
+_INTERFACE = "cudnn.block_sparse_attention._interface"
 
 
 def load_interface():
-    _bind_checkout()
-    return importlib.import_module(_INTERFACE)
+    return load_reference_module(_INTERFACE)
 
 
 def compile_reference(data):

--- a/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
+++ b/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
@@ -433,33 +433,10 @@ def _launch(executable, data, output_key="out"):
     )
 
 
-_REFERENCE_SOURCE = None
-
-
 def _load_reference_source():
-    global _REFERENCE_SOURCE
-    if _REFERENCE_SOURCE is not None:
-        return _REFERENCE_SOURCE
+    from tirx_kernels.cudnn._reference import load_reference_module
 
-    import importlib.util
-    import os
-    from pathlib import Path
-
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    source_path = Path(root) / "python/cudnn/csa/compressor/compressor_sm100.py"
-    if not source_path.is_file():
-        raise RuntimeError(f"CUDNN_FRONTEND_PATH does not contain {source_path.relative_to(root)}")
-    spec = importlib.util.spec_from_file_location(
-        "tirx_cudnn_frontend_csa_compressor_source", source_path
-    )
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load cuDNN Frontend compressor source from {source_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    _REFERENCE_SOURCE = module
-    return module
+    return load_reference_module("cudnn.csa.compressor.compressor_sm100")
 
 
 def _source_launch(data):

--- a/tirx_kernels/cudnn/dglu/_moe_blockscaled_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_blockscaled_grouped_gemm_dglu_dbias/data.py
@@ -16,13 +16,9 @@ Upstream sources:
 (``__call__`` argument contract, ``dswiglu``/``dgeglu``/``dsituglu``).
 """
 
-import importlib
-import importlib.machinery
-import importlib.util
 import os
-import sys
-import types
-from functools import cache
+
+from tirx_kernels.cudnn._reference import import_cutlass_reference, load_reference_module
 
 from . import spec
 
@@ -511,97 +507,17 @@ def reference_outputs(data):
 # Upstream kernel as reference
 # ---------------------------------------------------------------------------
 
-_REFERENCE_PACKAGE = "tirx_cudnn_frontend_grouped"
 
-
-@cache
 def load_reference_source():
-    """Import the upstream kernel module without executing the cuDNN API package.
+    """Import the upstream kernel from the pinned cuDNN Frontend install.
 
-    The kernel and its scheduler/util siblings import only cutlass and each other,
-    so a synthetic package rooted at ``cutedsl/grouped`` resolves their relative
-    imports while ``dglu/__init__.py`` -- which pulls in the compiled ``cudnn``
-    extension -- is never run.
+    The dotted import runs ``grouped/__init__`` and ``dglu/__init__`` on the
+    way down, which reach the compiled ``cudnn`` extension -- safe against the
+    source install, and cached so the cost is paid once per process.
     """
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    grouped = os.path.join(root, "python/cudnn/gemm/cutedsl/grouped")
-    if not os.path.isdir(grouped):
-        raise RuntimeError(f"cannot find the grouped GEMM sources under {grouped}")
-    for name, path in (
-        (_REFERENCE_PACKAGE, grouped),
-        (f"{_REFERENCE_PACKAGE}.dglu", os.path.join(grouped, "dglu")),
-    ):
-        if name in sys.modules:
-            continue
-        module = types.ModuleType(name)
-        module.__path__ = [path]
-        module.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
-        module.__spec__.submodule_search_locations = [path]
-        sys.modules[name] = module
-    return importlib.import_module(
-        f"{_REFERENCE_PACKAGE}.dglu.moe_blockscaled_grouped_gemm_dglu_dbias"
+    return load_reference_module(
+        "cudnn.gemm.cutedsl.grouped.dglu.moe_blockscaled_grouped_gemm_dglu_dbias"
     )
-
-
-def _rebind_submodules(package):
-    """Re-attach already-loaded submodules to a freshly re-executed package.
-
-    A failed ``import cutlass`` drops ``cutlass`` from ``sys.modules`` but leaves
-    every ``cutlass.*`` submodule behind. On the retry the package body re-runs,
-    and its inner ``import cutlass._mlir`` finds that submodule already loaded,
-    so the import system never binds it as an attribute of the new package
-    object. The upstream kernel reaches for ``cutlass._mlir.dialects.math`` in
-    its amax reduction and fails with an ``AttributeError`` that has nothing to
-    do with the kernel under test.
-    """
-    prefix = package.__name__ + "."
-    for name, module in list(sys.modules.items()):
-        if not name.startswith(prefix) or module is None:
-            continue
-        child = name[len(prefix) :]
-        if "." in child:
-            continue
-        if getattr(package, child, None) is not module:
-            setattr(package, child, module)
-    return package
-
-
-def import_cutlass_reference():
-    """Recover from CuTeDSL's non-idempotent generated builder imports."""
-    try:
-        return _rebind_submodules(importlib.import_module("cutlass"))
-    except RuntimeError as exc:
-        message = str(exc)
-        if "Attribute builder for '" not in message or "is already registered" not in message:
-            raise
-        mlir_ir = sys.modules.get("cutlass._mlir.ir")
-        if mlir_ir is None:
-            raise
-        register_attribute_builder = mlir_ir.register_attribute_builder
-
-        def register_replacing_builder(kind, replace=False):
-            del replace
-            return register_attribute_builder(kind, replace=True)
-
-        mlir_ir.register_attribute_builder = register_replacing_builder
-        try:
-            return _rebind_submodules(importlib.import_module("cutlass"))
-        finally:
-            mlir_ir.register_attribute_builder = register_attribute_builder
-
-
-def _cute_dtype(cutlass, dtype):
-    return {
-        "float4_e2m1fn": cutlass.Float4E2M1FN,
-        "float8_e4m3fn": cutlass.Float8E4M3FN,
-        "float8_e5m2": cutlass.Float8E5M2,
-        "float8_e8m0fnu": cutlass.Float8E8M0FNU,
-        "float16": cutlass.Float16,
-        "bfloat16": cutlass.BFloat16,
-        "float32": cutlass.Float32,
-    }[dtype]
 
 
 def compile_reference(data):

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
@@ -9,16 +9,11 @@ One input set is shared by TIRx, the upstream kernel and the oracle, with a
 separate output set per implementation so the three can be compared directly.
 """
 
-import importlib
-import importlib.machinery
 import os
-import sys
-import types
-from functools import cache
+
+from tirx_kernels.cudnn._reference import import_cutlass_reference, load_reference_module
 
 from . import spec as _spec
-
-_REFERENCE_PACKAGE = "tirx_cudnn_frontend_grouped"
 
 _TORCH_DTYPES = {"bfloat16": "bfloat16", "float16": "float16", "float32": "float32"}
 
@@ -213,71 +208,14 @@ def reference_outputs(data):
 # ---------------------------------------------------------------------------
 
 
-@cache
 def load_reference_source():
-    """Import the upstream kernel without executing the cuDNN API package.
+    """Import the upstream kernel from the pinned cuDNN Frontend install.
 
-    The kernel and its scheduler/util siblings import only cutlass and each
-    other, so a synthetic package rooted at ``cutedsl/grouped`` resolves their
-    relative imports while ``dglu/__init__.py`` -- which pulls in the compiled
-    ``cudnn`` extension -- is never run.
+    The dotted import runs ``grouped/__init__`` and ``dglu/__init__`` on the
+    way down, which reach the compiled ``cudnn`` extension -- safe against the
+    source install, and cached so the cost is paid once per process.
     """
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    grouped = os.path.join(root, "python/cudnn/gemm/cutedsl/grouped")
-    if not os.path.isdir(grouped):
-        raise RuntimeError(f"cannot find the grouped GEMM sources under {grouped}")
-    for name, path in (
-        (_REFERENCE_PACKAGE, grouped),
-        (f"{_REFERENCE_PACKAGE}.dglu", os.path.join(grouped, "dglu")),
-    ):
-        if name in sys.modules:
-            continue
-        module = types.ModuleType(name)
-        module.__path__ = [path]
-        module.__spec__ = importlib.machinery.ModuleSpec(name, None, is_package=True)
-        module.__spec__.submodule_search_locations = [path]
-        sys.modules[name] = module
-    return importlib.import_module(f"{_REFERENCE_PACKAGE}.dglu.moe_grouped_gemm_dglu_dbias")
-
-
-def _rebind_submodules(package):
-    """Re-attach already-loaded submodules to a freshly re-executed package."""
-    prefix = package.__name__ + "."
-    for name, module in list(sys.modules.items()):
-        if not name.startswith(prefix) or module is None:
-            continue
-        child = name[len(prefix) :]
-        if "." in child:
-            continue
-        if getattr(package, child, None) is not module:
-            setattr(package, child, module)
-    return package
-
-
-def import_cutlass_reference():
-    """Recover from CuTeDSL's non-idempotent generated builder imports."""
-    try:
-        return _rebind_submodules(importlib.import_module("cutlass"))
-    except RuntimeError as exc:
-        message = str(exc)
-        if "Attribute builder for '" not in message or "is already registered" not in message:
-            raise
-        mlir_ir = sys.modules.get("cutlass._mlir.ir")
-        if mlir_ir is None:
-            raise
-        register_attribute_builder = mlir_ir.register_attribute_builder
-
-        def register_replacing_builder(kind, replace=False):
-            del replace
-            return register_attribute_builder(kind, replace=True)
-
-        mlir_ir.register_attribute_builder = register_replacing_builder
-        try:
-            return _rebind_submodules(importlib.import_module("cutlass"))
-        finally:
-            mlir_ir.register_attribute_builder = register_attribute_builder
+    return load_reference_module("cudnn.gemm.cutedsl.grouped.dglu.moe_grouped_gemm_dglu_dbias")
 
 
 def compile_reference(data):

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/reference.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/reference.py
@@ -8,84 +8,30 @@
 Upstream source:
 ``python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py``.
 
-The kernel this port follows lives in a cuDNN Frontend source checkout named by
-``CUDNN_FRONTEND_PATH``, the contract the other cuDNN Frontend ports in this
-repository use. It is deliberately not the ``cudnn`` wheel that may also be
-installed: the released package can carry an older revision of this kernel (the
-1.26.0 wheel present during this port predates both fp16 element support and two
-of the kernel's TMEM ordering barriers), and benchmarking against it would
-compare TIRx to a different implementation than the one cited above.
-
-Only the ``cudnn.deepseek_sparse_attention`` subtree is redirected. The rest of
-``cudnn`` still resolves to the installed package, because ``cudnn.api_base``
-reaches a compiled extension that a source checkout alone does not provide, and
-because nothing this port follows lives outside the DSA subtree.
+The kernel this port follows resolves from the cuDNN Frontend source install
+pinned in ``reference-dependencies.json`` and installed by
+``scripts/install_reference_dependencies.py``. Released wheels are not an
+acceptable substitute: the 1.26.0 wheel present during this port predated both
+fp16 element support and two of the kernel's TMEM ordering barriers, which is
+why the install replaces any such wheel with the pinned source tree (whose DSA
+kernel is byte-identical to the revision cited above).
 """
 
-import importlib
-import os
-import sys
-import types
+from tirx_kernels.cudnn._reference import load_reference_module
 
 _DSA_PACKAGE = "cudnn.deepseek_sparse_attention"
 _INTERFACE_MODULE = f"{_DSA_PACKAGE}.sparse_attention_backward._interface_sm100"
 _KERNEL_MODULE = f"{_DSA_PACKAGE}.sparse_attention_backward.dsa_bwd_sm100"
 
 
-def checkout_root():
-    """Absolute path of the cuDNN Frontend source checkout."""
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if not root:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    return root
-
-
-def _dsa_package_dir():
-    package_dir = os.path.join(checkout_root(), "python", "cudnn", "deepseek_sparse_attention")
-    if not os.path.isdir(package_dir):
-        raise RuntimeError(f"CUDNN_FRONTEND_PATH does not contain the DSA package: {package_dir}")
-    return package_dir
-
-
-def _bind_checkout():
-    """Redirect ``cudnn.deepseek_sparse_attention`` at the checkout.
-
-    Idempotent: the bench suite retries workloads in the same process, and the
-    correctness runner imports this more than once per session.
-    """
-    package_dir = _dsa_package_dir()
-
-    existing = sys.modules.get(_DSA_PACKAGE)
-    if existing is not None:
-        bound = getattr(existing, "__path__", None)
-        if bound and os.path.realpath(next(iter(bound))) == os.path.realpath(package_dir):
-            return
-        raise RuntimeError(
-            f"{_DSA_PACKAGE} is already imported from {bound}; cannot rebind it to {package_dir}. "
-            "Import the reference before anything else pulls in the installed cuDNN DSA package."
-        )
-
-    # Importing the real ``cudnn`` first is what makes ``cudnn.api_base`` (and
-    # the compiled extension underneath it) resolvable for the checkout's code.
-    cudnn = importlib.import_module("cudnn")
-
-    package = types.ModuleType(_DSA_PACKAGE)
-    package.__path__ = [package_dir]
-    package.__package__ = _DSA_PACKAGE
-    sys.modules[_DSA_PACKAGE] = package
-    cudnn.deepseek_sparse_attention = package
-
-
 def load_interface():
     """Import and return the upstream SM100 host wrapper module."""
-    _bind_checkout()
-    return importlib.import_module(_INTERFACE_MODULE)
+    return load_reference_module(_INTERFACE_MODULE)
 
 
 def load_kernel_module():
     """Import and return the upstream kernel module."""
-    _bind_checkout()
-    return importlib.import_module(_KERNEL_MODULE)
+    return load_reference_module(_KERNEL_MODULE)
 
 
 def flash_attn_bwd_sm100():

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -4419,32 +4419,10 @@ def _tirx_launch(executables, data):
     return launch
 
 
-_REFERENCE_SOURCE = None
-
-
 def _load_reference_source():
-    global _REFERENCE_SOURCE
-    if _REFERENCE_SOURCE is not None:
-        return _REFERENCE_SOURCE
-    import importlib
-    import os
-    import sys
+    from tirx_kernels.cudnn._reference import load_reference_module
 
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    python_root = os.path.join(root, "python")
-    if python_root not in sys.path:
-        sys.path.append(python_root)
-    import cudnn
-
-    cudnn_root = os.path.join(python_root, "cudnn")
-    if cudnn_root not in cudnn.__path__:
-        cudnn.__path__.append(cudnn_root)
-    _REFERENCE_SOURCE = importlib.import_module(
-        "cudnn.linear_attention.frost.kernel.gdn2_bprop_f16"
-    )
-    return _REFERENCE_SOURCE
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn2_bprop_f16")
 
 
 def _source_launch(data):

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -3110,32 +3110,10 @@ def _tirx_launch(executables, data):
     return launch
 
 
-_REFERENCE_SOURCE = None
-
-
 def _load_reference_source():
-    global _REFERENCE_SOURCE
-    if _REFERENCE_SOURCE is not None:
-        return _REFERENCE_SOURCE
-    import importlib
-    import os
-    import sys
+    from tirx_kernels.cudnn._reference import load_reference_module
 
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    python_root = os.path.join(root, "python")
-    if python_root not in sys.path:
-        sys.path.append(python_root)
-    import cudnn
-
-    cudnn_root = os.path.join(python_root, "cudnn")
-    if cudnn_root not in cudnn.__path__:
-        cudnn.__path__.append(cudnn_root)
-    _REFERENCE_SOURCE = importlib.import_module(
-        "cudnn.linear_attention.frost.kernel.gdn2_prefill_f16"
-    )
-    return _REFERENCE_SOURCE
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn2_prefill_f16")
 
 
 def _source_launch(data):

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -3886,30 +3886,10 @@ def _tirx_launch(executables, data):
     return launch
 
 
-_REFERENCE_SOURCE = None
-
-
 def _load_reference_source():
-    global _REFERENCE_SOURCE
-    if _REFERENCE_SOURCE is not None:
-        return _REFERENCE_SOURCE
-    import importlib
-    import os
-    import sys
+    from tirx_kernels.cudnn._reference import load_reference_module
 
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    python_root = os.path.join(root, "python")
-    if python_root not in sys.path:
-        sys.path.append(python_root)
-    import cudnn
-
-    cudnn_root = os.path.join(python_root, "cudnn")
-    if cudnn_root not in cudnn.__path__:
-        cudnn.__path__.append(cudnn_root)
-    _REFERENCE_SOURCE = importlib.import_module("cudnn.linear_attention.frost.kernel.kda_bprop_f16")
-    return _REFERENCE_SOURCE
+    return load_reference_module("cudnn.linear_attention.frost.kernel.kda_bprop_f16")
 
 
 def _source_launch(data):

--- a/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
+++ b/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
@@ -11,10 +11,6 @@ Upstream source:
 """
 
 import heapq
-import importlib
-import importlib.util
-import os
-import sys
 from functools import cache
 from itertools import combinations, product
 
@@ -2502,50 +2498,18 @@ def prepare_data(**config):
     }
 
 
-@cache
 def _load_reference_source():
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    source_path = os.path.join(
-        root,
-        "python/cudnn/gemm/cutedsl/dense/swiglu/"
-        "dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py",
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module(
+        "cudnn.gemm.cutedsl.dense.swiglu.dense_blockscaled_gemm_persistent_swiglu_interleaved_quant"
     )
-    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_swiglu_source", source_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def _import_cutlass_reference():
-    """Recover from CuTeDSL's non-idempotent generated builder imports."""
-    try:
-        return importlib.import_module("cutlass")
-    except RuntimeError as exc:
-        message = str(exc)
-        if "Attribute builder for '" not in message or "is already registered" not in message:
-            raise
-        mlir_ir = sys.modules.get("cutlass._mlir.ir")
-        if mlir_ir is None:
-            raise
-        register_attribute_builder = mlir_ir.register_attribute_builder
-
-        def register_replacing_builder(kind, replace=False):
-            del replace
-            return register_attribute_builder(kind, replace=True)
-
-        mlir_ir.register_attribute_builder = register_replacing_builder
-        try:
-            return importlib.import_module("cutlass")
-        finally:
-            mlir_ir.register_attribute_builder = register_attribute_builder
 
 
 def _compile_reference(data, config):
-    cutlass = _import_cutlass_reference()
+    from tirx_kernels.cudnn._reference import import_cutlass_reference
+
+    cutlass = import_cutlass_reference()
     import cutlass.cute as cute
     import torch
     from cuda.bindings import driver as cuda

--- a/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
+++ b/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
@@ -10,10 +10,6 @@ Upstream source:
 """
 
 import heapq
-import importlib
-import importlib.util
-import os
-import sys
 from functools import cache
 from itertools import combinations, product
 
@@ -1615,48 +1611,16 @@ def prepare_data(**config):
     }
 
 
-@cache
 def _load_reference_source():
-    root = os.environ.get("CUDNN_FRONTEND_PATH")
-    if root is None:
-        raise RuntimeError("CUDNN_FRONTEND_PATH must point to a cuDNN Frontend source checkout")
-    source_path = os.path.join(
-        root, "python/cudnn/gemm/cutedsl/dense/swiglu/dense_gemm_persistent_swiglu.py"
-    )
-    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_swiglu_source", source_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    from tirx_kernels.cudnn._reference import load_reference_module
 
-
-def _import_cutlass_reference():
-    """Recover from CuTeDSL's non-idempotent generated builder imports."""
-    try:
-        return importlib.import_module("cutlass")
-    except RuntimeError as exc:
-        message = str(exc)
-        if "Attribute builder for '" not in message or "is already registered" not in message:
-            raise
-        mlir_ir = sys.modules.get("cutlass._mlir.ir")
-        if mlir_ir is None:
-            raise
-        register_attribute_builder = mlir_ir.register_attribute_builder
-
-        def register_replacing_builder(kind, replace=False):
-            del replace
-            return register_attribute_builder(kind, replace=True)
-
-        mlir_ir.register_attribute_builder = register_replacing_builder
-        try:
-            return importlib.import_module("cutlass")
-        finally:
-            mlir_ir.register_attribute_builder = register_attribute_builder
+    return load_reference_module("cudnn.gemm.cutedsl.dense.swiglu.dense_gemm_persistent_swiglu")
 
 
 def _compile_reference(data, config):
-    cutlass = _import_cutlass_reference()
+    from tirx_kernels.cudnn._reference import import_cutlass_reference
+
+    cutlass = import_cutlass_reference()
     import cutlass.cute as cute
     import torch
     from cuda.bindings import driver as cuda


### PR DESCRIPTION
Eliminates `CUDNN_FRONTEND_PATH`. The eleven `cudnn_*` ports loaded their
reference implementations from an undocumented env-var checkout through three
home-grown import patterns — direct `spec_from_file_location` file loads,
`sys.path` + `cudnn.__path__` surgery, and synthetic `sys.modules` grafting —
plus five copies of the CuTeDSL import-recovery helper. Net −364 lines.

## What replaces it

**cuDNN Frontend joins `reference-dependencies.json` as a pinned source**
(v1.28.0 @ `aded9909`, editable install into `.reference-deps/cudnn-frontend`),
so `python scripts/install_reference_dependencies.py` is now sufficient setup
for the cudnn correctness suites — the env var was an undocumented extra
requirement on top of the documented command. The install replaces any released
`nvidia-cudnn-frontend` wheel: the 1.26.0 wheel predates the
`cudnn.gemm` / `cudnn.linear_attention` / `cudnn.csa` reorganization and ships
none of the CuTeDSL kernel sources the ports reference (and an older DSA
revision). Every reference file the ports cite is byte-identical between the
revisions in play (`7b5327b3` and `aded9909`; the drift between them is
sdpa-fp8/Rubin-only), so no port's reference behavior changes.

All eleven loaders collapse into one module, `tirx_kernels/cudnn/_reference.py`:
`load_reference_module(dotted_name)` plus the previously five-times-copied
CuTeDSL "Attribute builder … already registered" recovery. Externally consumed
names (`load_reference_source`, `compile_reference`, the DSA
`load_interface`/`flash_attn_bwd_sm100`) keep their signatures.

**The shared CuTeDSL pin moves 4.6.2 → 4.7.0** — the first release whose wheels
ship `cutlass.experimental` — which un-breaks the three FROST linear-attention
references (`gdn2_bprop`, `gdn2_prefill`, `kda_bprop`): on 4.6 they could not
import at all, env var or not, and previously ran only via a hand-built
PYTHONPATH overlay. They now load like every other reference, with no special
path.

**Installer extensions** (`scripts/install_reference_dependencies.py`):
- `--only <name>` (repeatable): targeted install of named sources/isolated sets,
  skipping the global requirement groups — for shared machines where a full
  lock run would rebuild hand-managed installs.
- per-source `build_requirements`, installed before that source's editable
  install (cudnn-frontend's CMake build needs `pybind11` + `pybind11-global`).
- `source_build_environment()` tolerates a missing `nvidia-cuda-cccl` under
  targeted runs.

README gains the cuDNN Frontend row in the external-dependency table.

## Verification (all without the env var)

| check | result |
| --- | --- |
| all 12 reference targets import from the pinned install | 12/12 |
| `cudnn_sm100_dense_gemm_persistent_swiglu` (file-load pattern) full CONFIGS | 75/75 |
| `cudnn_sm100_moe_grouped_gemm_dglu_dbias` (grafting pattern) full CONFIGS | 42/42 |
| `cudnn_sm100_dsa_sparse_attention_backward` (subtree-redirect pattern) full CONFIGS | 12/12 |
| `cudnn_sm100_gdn2_bprop_f16` (FROST, previously unloadable) full CONFIGS | 10/10 |
| remaining seven cudnn kernels, single-config smoke | 7/7 |
| both swiglu references in one process (the old loaders shared one synthetic module name) | distinct modules, both pass |
| `bench_suite --with-references`, one row, no env prefix | tirx 41.8 µs vs cudnn_frontend 42.0 µs |
| flashinfer (declares a dependency on `nvidia-cudnn-frontend`) | imports; every consumed `cudnn.*` symbol present in 1.28 |
| `install_reference_dependencies.py --check`, pre-commit, license lint | clean |
| `grep -rn CUDNN_FRONTEND_PATH tirx_kernels tests scripts README.md` | zero hits |

Historical artifacts under `.agents/sketch/` keep their env-var mentions as
provenance records of past ports.
