### PR TITLE
test(kernel): drop PyTorch oracles; library baselines arbitrate correctness

### DIFF
--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -122,6 +122,7 @@ FILE_OVERRIDES = {
 
 # Native modules inside port buckets — package markers and our own harnesses.
 PORT_DIR_EXCEPTIONS = {
+    "tirx_kernels/cudnn/_reference.py",
     "tirx_kernels/deepep/utils/_buffer.py",
     "tirx_kernels/deepep/utils/_runtime.py",
     "tirx_kernels/flashinfer/utils/_flashkda_bench.py",

--- a/tirx_kernels/basic/allgather_gemm.py
+++ b/tirx_kernels/basic/allgather_gemm.py
@@ -678,6 +678,7 @@ def _make_device_kernel():
 
         Kern.ptx.ld.shared.u32(tmem_addr_local[0], tmem_addr.ptr_to([0]))
         Kern.cuda.trap_when_assert_failed(tmem_addr_local[0] == 0)
+
         def partitioned_loop(pipe_state, main_loop, epilogue1, epilogue2):
             with Kern.serial(PIPE_CYCLE) as ko:
                 with Kern.unroll(PIPELINE_DEPTH) as ks:
@@ -1206,6 +1207,8 @@ def _check_correctness(case: _Case) -> None:
     case.ag_out_torch[local].copy_(case.A)
     torch.testing.assert_close(case.ag_out_torch, gathered_A, rtol=0, atol=0)
 
+    # cuBLAS baseline: torch.matmul dispatches to cuBLAS, so this IS the
+    # library comparison.
     reference = torch.matmul(gathered_A, case.B.T)
     torch.testing.assert_close(case.out, reference, rtol=1e-3, atol=2e-2)
 

--- a/tirx_kernels/basic/fp16_bf16_gemm.py
+++ b/tirx_kernels/basic/fp16_bf16_gemm.py
@@ -670,6 +670,8 @@ def run_test(dtype, M, N, K, **kwargs):
     with target:
         ex = compile_kernel(kernel)
         ex(A, B, C_tvm)
+    # cuBLAS baseline: torch.matmul dispatches to cuBLAS, so this IS the
+    # library comparison.
     C_ref = torch.matmul(A, B.T)
     torch.testing.assert_close(C_tvm.cpu(), C_ref.cpu(), rtol=0.001, atol=0.01)
 

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -1262,6 +1262,8 @@ def _allocate_case(
 def _reference_outputs(
     runtime: DistributedRuntime, data: dict[str, torch.Tensor], config: GemmRSConfig
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # cuBLAS baseline: torch.mm dispatches to cuBLAS, so this IS the
+    # library comparison.
     partial = torch.mm(data["A"], data["B"].T)
     expected = torch.empty(
         (config.local_m, config.N), dtype=torch.float16, device=f"cuda:{runtime.device_index}"

--- a/tirx_kernels/basic/nvfp4_gemm.py
+++ b/tirx_kernels/basic/nvfp4_gemm.py
@@ -57,6 +57,8 @@ def prepare_data(M: int, N: int, K: int, *, return_origin: bool = False):
         B_origin, B_global_sf, sfLayout=SfLayout.layout_128x4, do_shuffle=False
     )
     alpha = 1.0 / (A_global_sf * B_global_sf)
+    # cuBLAS baseline: torch.mm on the pre-quantization operands dispatches
+    # to cuBLAS, so this IS the library comparison.
     C_ref = torch.mm(A_origin, B_origin.T)
     if return_origin:
         return (A_fp4, B_fp4, A_sf, B_sf, alpha, C_ref, A_origin, B_origin)
@@ -660,10 +662,7 @@ def make_kernel(M, N, KDIM):
                         )
                         K.ptx[_TCGEN05_CP_2SM](
                             K.Cast(
-                                "uint32",
-                                sfb_tmem_col
-                                + flat % 4 * SFB_n_chunks * 4
-                                + flat // 4 * 4,
+                                "uint32", sfb_tmem_col + flat % 4 * SFB_n_chunks * 4 + flat // 4 * 4
                             ),
                             sfb_cp_desc,
                         )

--- a/tirx_kernels/basic/rmsnorm.py
+++ b/tirx_kernels/basic/rmsnorm.py
@@ -270,9 +270,13 @@ def run_test(hidden_size, batch_size, **kwargs):
     output_tir = torch.empty((batch_size, hidden_size), dtype=torch.float16, device="cuda")
     ex(*_kernel_args(input_data, weights, output_tir))
     torch.cuda.synchronize()
-    input_f32 = input_data.to(torch.float32).cuda()
-    variance = input_f32.pow(2).mean(dim=-1, keepdim=True)
-    ref = (input_f32 * torch.rsqrt(variance + eps) * weights.float().cuda()).to(torch.float16)
+    # FlashInfer's rmsnorm on the same inputs is the arbiter (the same library
+    # the benchmark path compares against).
+    import flashinfer
+
+    ref = torch.empty_like(output_tir)
+    flashinfer.norm.rmsnorm(input_data, weights, eps, enable_pdl=False, out=ref)
+    torch.cuda.synchronize()
     torch.testing.assert_close(output_tir.cpu(), ref.cpu(), rtol=0.001, atol=0.001)
 
 

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -1731,17 +1731,6 @@ def prepare_data(**config):
     sfb = torch.ones(sf_shape_b, dtype=torch.float32, device="cuda").to(sf_torch_dtype)
     tirx_output = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
     source_output = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
-    expected_batches = []
-    for batch_index in range(L):
-        matches = (
-            a_data["k_indices"][batch_index][:, None] == b_data["k_indices"][batch_index][None, :]
-        )
-        expected_batches.append(
-            matches.to(torch.float32)
-            * a_data["values"][batch_index][:, None]
-            * b_data["values"][batch_index][None, :]
-        )
-    expected = torch.stack(expected_batches, dim=2)
     return {
         "a": a_data,
         "b": b_data,
@@ -1751,7 +1740,6 @@ def prepare_data(**config):
         "source_output": source_output,
         "tirx_amax": torch.zeros(1, dtype=torch.float32, device="cuda"),
         "source_amax": torch.zeros(1, dtype=torch.float32, device="cuda"),
-        "expected": expected,
     }
 
 
@@ -1861,59 +1849,40 @@ def _assert_close(torch, actual, expected, *, atol, rtol, label):
 
 
 def _validate_outputs(data, config, *, with_source):
+    """Hold TIRx to the upstream kernel's outputs on the same bytes.
+
+    The upstream implementation is the sole arbiter; numeric validation only
+    runs when the source ran.
+    """
     import torch
 
+    if not with_source:
+        return
     config = _without_label(config)
     M, N, L = (config[key] for key in ("M", "N", "L"))
     tolerance = 0.1 if _dtype_bits(config["c_dtype"]) <= 8 else 0.01
     tirx_output = _output_as_float(torch, data["tirx_output"], M, N, L, config["c_dtype"])
+    source_output = _output_as_float(torch, data["source_output"], M, N, L, config["c_dtype"])
     _assert_close(
         torch,
         tirx_output,
-        data["expected"],
+        source_output,
         atol=tolerance,
         rtol=tolerance,
-        label="TIRx output versus FP32 oracle",
+        label="TIRx output versus source output",
     )
-    expected_amax = data["expected"].abs().amax().reshape(1)
     _assert_close(
         torch,
         data["tirx_amax"],
-        expected_amax,
+        data["source_amax"],
         atol=0.1,
         rtol=0.1,
-        label="TIRx amax versus FP32 oracle",
+        label="TIRx amax versus source amax",
     )
-    if with_source:
-        source_output = _output_as_float(torch, data["source_output"], M, N, L, config["c_dtype"])
-        _assert_close(
-            torch,
-            source_output,
-            data["expected"],
-            atol=tolerance,
-            rtol=tolerance,
-            label="source output versus FP32 oracle",
-        )
-        _assert_close(
-            torch,
-            tirx_output,
-            source_output,
-            atol=tolerance,
-            rtol=tolerance,
-            label="TIRx output versus source output",
-        )
-        _assert_close(
-            torch,
-            data["source_amax"],
-            expected_amax,
-            atol=0.1,
-            rtol=0.1,
-            label="source amax versus FP32 oracle",
-        )
 
 
 def run_test(**config):
-    """Compare TIRx with both the pinned source and the FP32 oracle."""
+    """Compare TIRx with the pinned source kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -1926,7 +1895,7 @@ def run_test(**config):
     source_launch()
     torch.cuda.synchronize()
     _validate_outputs(data, kernel_config, with_source=True)
-    return {"max_abs": float(data["expected"].abs().amax().item())}
+    return {"max_abs": float(data["source_amax"].abs().amax().item())}
 
 
 def prepare_bench(**config):

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
@@ -306,73 +306,30 @@ def tirx_launch(executables, data):
     return launch
 
 
-def _oracle(data):
-    inputs = data["inputs"]
-    config = data["config"]
-    q = inputs["q"].float()
-    k = inputs["k"].float()
-    v = inputs["v"].float()
-    block_index = inputs["block_index"]
-    block_sizes = inputs["block_sizes"]
-    block_nums = inputs["block_nums"]
-    batch, heads, seqlen_q, _ = q.shape
-    out = torch.zeros_like(q)
-    lse = torch.full((batch, heads, seqlen_q), -float("inf"), device=q.device)
-    for b in range(batch):
-        for h in range(heads):
-            for qb in range((seqlen_q + 63) // 64):
-                q0, q1 = qb * 64, min(qb * 64 + 64, seqlen_q)
-                count = (
-                    config["kv_blocks"]
-                    if config["block_count_mode"] == "fixed"
-                    else int(block_nums[b, h, qb])
-                )
-                if count <= 0:
-                    continue
-                tokens = []
-                for slot in range(count):
-                    sparse_id = int(block_index[b, h, qb, slot])
-                    size = int(block_sizes[sparse_id]) if config["has_block_sizes"] else 64
-                    tokens.extend(range(sparse_id * 64, min(sparse_id * 64 + size, k.shape[2])))
-                token_ids = torch.tensor(tokens, dtype=torch.long, device=q.device)
-                gathered_k = k[b, h].index_select(0, token_ids)
-                gathered_v = v[b, h].index_select(0, token_ids)
-                score = q[b, h, q0:q1] @ gathered_k.T * inputs["softmax_scale"]
-                probability = torch.softmax(score, dim=-1)
-                out[b, h, q0:q1] = probability @ gathered_v
-                lse[b, h, q0:q1] = torch.logsumexp(score, dim=-1)
-    return out, lse
-
-
-def validate_outputs(data, *, sources, with_oracle=True):
-    if not with_oracle:
-        if "source" in sources and data["source"]["out"] is not None:
-            torch.testing.assert_close(
-                data["tirx"]["out"].float(), data["source"]["out"].float(), atol=3e-2, rtol=3e-2
-            )
-        return
-
-    expected_out, expected_lse = _oracle(data)
+def validate_outputs(data, *, sources, with_oracle=None):
+    """Hold TIRx to the upstream kernel's outputs on the same inputs."""
+    del with_oracle
     for source in sources:
         actual = data[source]
         if actual["out"] is None or actual["lse"] is None:
             raise AssertionError(f"{source} did not produce outputs")
+    if "tirx" in sources and "source" in sources:
         torch.testing.assert_close(
-            actual["out"].float(),
-            expected_out,
+            data["tirx"]["out"].float(),
+            data["source"]["out"].float(),
             atol=3e-2,
             rtol=3e-2,
-            msg=lambda message: f"{source}.out: {message}",
+            msg=lambda message: f"tirx vs source out: {message}",
         )
         # Empty rows legitimately carry -inf; assert matching finiteness first
         # so close-comparison diagnostics remain local to live rows.
-        finite = torch.isfinite(expected_lse)
-        if not torch.equal(torch.isfinite(actual["lse"]), finite):
-            raise AssertionError(f"{source}.lse finiteness differs from the oracle")
+        finite = torch.isfinite(data["source"]["lse"])
+        if not torch.equal(torch.isfinite(data["tirx"]["lse"]), finite):
+            raise AssertionError("tirx lse finiteness differs from the source")
         torch.testing.assert_close(
-            actual["lse"][finite],
-            expected_lse[finite],
+            data["tirx"]["lse"][finite],
+            data["source"]["lse"][finite],
             atol=2e-3,
             rtol=2e-3,
-            msg=lambda message: f"{source}.lse: {message}",
+            msg=lambda message: f"tirx vs source lse: {message}",
         )

--- a/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
+++ b/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
@@ -465,69 +465,6 @@ def _source_launch(data):
     return launch
 
 
-def _eager_reference(data):
-    """Vectorized FP32 oracle, including source-defined capacity-padding rows."""
-    import torch
-
-    d = data["head_dim"]
-    coff = data["coff"]
-    width = coff * d
-    kv = data["kv"].view(-1, width).float()
-    score = data["score"].view(-1, width).float()
-    ape = data["ape"].view(_RATIO, width)
-    rows = []
-    token_base = 0
-    for length in data["seq_lens"]:
-        blocks = length // _RATIO
-        if blocks:
-            block_tokens = blocks * _RATIO
-            if coff == 1:
-                block_values = kv[token_base : token_base + block_tokens, :d].view(
-                    blocks, _RATIO, d
-                )
-                block_scores = score[token_base : token_base + block_tokens, :d].view(
-                    blocks, _RATIO, d
-                ) + ape[:, :d].unsqueeze(0)
-            else:
-                own_values = kv[token_base : token_base + block_tokens, d:].view(blocks, _RATIO, d)
-                own_scores = score[token_base : token_base + block_tokens, d:].view(
-                    blocks, _RATIO, d
-                ) + ape[:, d:].unsqueeze(0)
-                previous_values = torch.zeros_like(own_values)
-                previous_scores = torch.full_like(own_scores, float("-inf"))
-                if blocks > 1:
-                    previous_values[1:] = kv[
-                        token_base : token_base + (blocks - 1) * _RATIO, :d
-                    ].view(blocks - 1, _RATIO, d)
-                    previous_scores[1:] = score[
-                        token_base : token_base + (blocks - 1) * _RATIO, :d
-                    ].view(blocks - 1, _RATIO, d) + ape[:, :d].unsqueeze(0)
-                block_values = torch.cat((previous_values, own_values), dim=1)
-                block_scores = torch.cat((previous_scores, own_scores), dim=1)
-            rows.append((block_values * torch.softmax(block_scores, dim=1)).sum(dim=1))
-        token_base += length
-
-    padding = data["nb_total"] - data["nb_valid"]
-    if padding:
-        if coff == 1:
-            pad_values = kv[:_RATIO, :d]
-            pad_scores = score[:_RATIO, :d] + ape[:, :d]
-        else:
-            pad_values = torch.cat((torch.zeros_like(kv[:_RATIO, :d]), kv[:_RATIO, d:]), dim=0)
-            pad_scores = torch.cat(
-                (
-                    torch.full_like(score[:_RATIO, :d], float("-inf")),
-                    score[:_RATIO, d:] + ape[:, d:],
-                ),
-                dim=0,
-            )
-        pad_row = (pad_values * torch.softmax(pad_scores, dim=0)).sum(dim=0)
-        rows.append(pad_row.unsqueeze(0).expand(padding, d))
-    if not rows:
-        return torch.empty((0, d), dtype=torch.bfloat16, device=kv.device)
-    return torch.cat(rows, dim=0).to(torch.bfloat16)
-
-
 def _assert_guard(data, backing_key):
     import torch
 
@@ -540,7 +477,7 @@ def _assert_guard(data, backing_key):
         raise AssertionError(f"compressor forward wrote outside {backing_key}'s output view")
 
 
-def _validate_outputs(data, *, include_source: bool, include_oracle: bool):
+def _validate_outputs(data, *, include_source: bool):
     import torch
 
     actual = data["out"].view(data["nb_total"], data["head_dim"])
@@ -555,18 +492,6 @@ def _validate_outputs(data, *, include_source: bool, include_oracle: bool):
             max_abs = float((actual.float() - source.float()).abs().max().item())
             raise AssertionError(
                 f"TIRx differs from cuDNN Frontend source: mismatch={mismatch}, max_abs={max_abs}"
-            )
-    if include_oracle:
-        oracle = _eager_reference(data)
-        mismatch = int((actual != oracle).sum().item())
-        allowed = max(1, actual.numel() // 1000)
-        max_abs = (
-            float((actual.float() - oracle.float()).abs().max().item()) if actual.numel() else 0.0
-        )
-        if mismatch > allowed or max_abs > 1.6e-2:
-            raise AssertionError(
-                f"TIRx differs from FP32 eager oracle: mismatch={mismatch}/{allowed}, "
-                f"max_abs={max_abs}"
             )
     _assert_guard(data, "out_backing")
     _assert_guard(data, "repeat_out_backing")
@@ -588,7 +513,7 @@ def prepare_bench(**config: Any):
 
 
 def run_test(**config: Any):
-    """Compare TIRx with the pinned source and a standalone FP32 eager oracle."""
+    """Compare TIRx with the pinned source kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -604,7 +529,7 @@ def run_test(**config: Any):
     source_launch = _source_launch(data)
     source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, include_source=True, include_oracle=True)
+    _validate_outputs(data, include_source=True)
     for key, snapshot in snapshots.items():
         if not torch.equal(data[key], snapshot):
             raise AssertionError(f"compressor forward modified input {key}")
@@ -640,7 +565,7 @@ def run_gpu(
         source_launch()
         torch.cuda.synchronize()
         references = {"cudnn_frontend": lambda: source_launch}
-    _validate_outputs(data, include_source=include_source, include_oracle=False)
+    _validate_outputs(data, include_source=include_source)
     return bench(
         {"tirx": tirx_launch},
         references=references,

--- a/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
+++ b/tirx_kernels/cudnn/dglu/_moe_grouped_gemm_dglu_dbias/data.py
@@ -123,7 +123,13 @@ def prepare_data(**config):
 
 
 def reference_outputs(data):
-    """FP32 reference for D, dprob and dbias, following the upstream formulas."""
+    """FP32 reference for D, dprob and dbias, following the upstream formulas.
+
+    Retained solely for the rows the upstream kernel cannot arbitrate --
+    ``spec.upstream_disagrees_with_reference`` (tile_n = 32, where upstream is
+    deterministically wrong). Every other row is validated against the upstream
+    kernel directly.
+    """
     import torch
 
     config = data["config"]

--- a/tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
@@ -70,7 +70,9 @@ def run_test(**config):
         source_launch = _data.compile_reference(data)
         source_launch()
         torch.cuda.synchronize()
-        _data.validate_outputs(data, sources=("tirx", "source"))
+        # The upstream kernel is the arbiter; the FP32 oracle runs only on the
+        # rows upstream cannot arbitrate (the sources=("tirx",) branch above).
+        _data.validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
     return {"tokens": data["derived"]["tokens_total"], "N": data["derived"]["N"]}
 
 

--- a/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
@@ -61,7 +61,9 @@ def run_test(**config):
         source_launch = _data.compile_reference(data)
         source_launch()
         torch.cuda.synchronize()
-        _data.validate_outputs(data, sources=("tirx", "source"))
+        # The upstream kernel is the arbiter; the FP32 oracle runs only on the
+        # rows upstream cannot arbitrate (the sources=("tirx",) branch above).
+        _data.validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
     return {"tokens": data["derived"]["tokens_total"], "N": data["derived"]["N"]}
 
 

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
@@ -144,69 +144,6 @@ def reference_forward(q, kv, attn_sink, topk_idxs, topk_length, softmax_scale, c
     return out, lse
 
 
-def reference_backward(
-    q, kv, attn_sink, topk_idxs, topk_length, dout, softmax_scale, out=None, chunk=64
-):
-    """Analytic FP32 backward over the gathered top-k rows.
-
-    With the sink modelled as an extra key carrying a zero value vector, the
-    softmax backward is ``dS_k = P_k * (dP_k - delta)`` with
-    ``delta = sum_d out*dout``, and the sink's own gradient is ``-P_sink * delta``.
-    """
-    seqlen_q, num_head, head_dim = q.shape
-    head_dim_v = spec.head_dim_v_for(head_dim)
-    seqlen_kv = kv.shape[0]
-    max_topk = topk_idxs.shape[1]
-    kv_f32 = kv.to(torch.float32)
-
-    dq = torch.zeros(seqlen_q, num_head, head_dim, dtype=torch.float32, device=q.device)
-    dkv = torch.zeros(seqlen_kv, head_dim, dtype=torch.float32, device=q.device)
-    d_sink = torch.zeros(num_head, dtype=torch.float32, device=q.device)
-
-    for start in range(0, seqlen_q, chunk):
-        stop = min(start + chunk, seqlen_q)
-        q_c = q[start:stop].to(torch.float32)
-        do_c = dout[start:stop].to(torch.float32)
-        idxs_c = topk_idxs[start:stop]
-        len_c = None if topk_length is None else topk_length[start:stop]
-        gathered, valid = _gather_valid(kv_f32, idxs_c, len_c, max_topk)
-
-        scores = torch.einsum("thd,tkd->thk", q_c, gathered) * softmax_scale
-        scores = scores.masked_fill(~valid.unsqueeze(1), float("-inf"))
-        lse_c = torch.logsumexp(scores, dim=-1)
-        lse_full = torch.logaddexp(lse_c, attn_sink.view(1, num_head))
-        p = torch.exp(scores - lse_full.unsqueeze(-1))
-
-        v = gathered[:, :, :head_dim_v]
-        out_c = (
-            torch.einsum("thk,tkd->thd", p, v) if out is None else out[start:stop].to(torch.float32)
-        )
-        delta = (out_c * do_c).sum(dim=-1)  # (chunk, H)
-
-        dp = torch.einsum("thd,tkd->thk", do_c, v)
-        ds = p * (dp - delta.unsqueeze(-1))
-        ds = torch.where(valid.unsqueeze(1), ds, torch.zeros_like(ds))
-
-        dq[start:stop] = torch.einsum("thk,tkd->thd", ds, gathered) * softmax_scale
-
-        # dK over the full head_dim, dV over the leading head_dim_v; both land in
-        # the same fused dKV buffer because K and V share one tensor.
-        dk_c = torch.einsum("thk,thd->tkd", ds, q_c) * softmax_scale
-        dv_c = torch.einsum("thk,thd->tkd", p, do_c)
-        contrib = dk_c
-        contrib[:, :, :head_dim_v] += dv_c
-        contrib = torch.where(valid.unsqueeze(-1), contrib, torch.zeros_like(contrib))
-
-        flat_idx = torch.where(valid, idxs_c, torch.zeros_like(idxs_c)).to(torch.long).reshape(-1)
-        flat_contrib = contrib.reshape(-1, head_dim)
-        dkv.index_add_(0, flat_idx, flat_contrib)
-
-        p_sink = torch.exp(attn_sink.view(1, num_head) - lse_full)
-        d_sink += (-p_sink * delta).sum(dim=0)
-
-    return dq, dkv, d_sink
-
-
 # --- TMA descriptors -------------------------------------------------------
 # The four rank-3 TensorMaps the `bwd` kernel consumes. Encoded host-side into
 # 64-byte-aligned 128-byte payloads, the same mechanism the FlashAttention
@@ -498,33 +435,27 @@ def tirx_launch(executables, data):
     return launch
 
 
-def validate_outputs(data, sources=("tirx",), with_oracle=True, atol=5e-2, rtol=5e-2):
-    """Compare the selected result sets against the FP32 oracle.
+def validate_outputs(data, sources=("tirx",), with_oracle=None, atol=5e-2, rtol=5e-2):
+    """Hold TIRx to the upstream kernel's outputs on the same inputs.
 
-    ``dkv`` is accumulated with global FP32 atomics, so its summation order varies
-    run to run on the kernel side and no bitwise comparison is available; the
-    oracle at the upstream tolerance is the arbiter.
+    ``dkv`` is accumulated with global FP32 atomics, so its summation order
+    varies run to run and no bitwise comparison is available; both
+    implementations sit within the upstream tolerance of the true value, so
+    they sit within twice it of each other -- the comparison below uses the
+    same tolerance.
     """
-    inputs = data["inputs"]
-    if not with_oracle:
-        return
-
-    dq_ref, dkv_ref, d_sink_ref = reference_backward(
-        inputs["q"],
-        inputs["kv"],
-        inputs["attn_sink"],
-        inputs["topk_idxs"],
-        inputs["topk_length"],
-        inputs["dout"],
-        inputs["softmax_scale"],
-        out=inputs["out"],
-    )
+    del with_oracle
     for source in sources:
         got = data[source]
-        for name, expected in (("dq", dq_ref), ("dkv", dkv_ref), ("d_sink", d_sink_ref)):
-            actual = got[name].to(torch.float32)
-            if not torch.isfinite(actual).all():
+        for name in ("dq", "dkv", "d_sink"):
+            if not torch.isfinite(got[name].to(torch.float32)).all():
                 raise AssertionError(f"{source}.{name} contains non-finite values")
+    if "tirx" in sources and "source" in sources:
+        for name in ("dq", "dkv", "d_sink"):
             torch.testing.assert_close(
-                actual, expected, atol=atol, rtol=rtol, msg=lambda m: f"{source}.{name}: {m}"
+                data["tirx"][name].to(torch.float32),
+                data["source"][name].to(torch.float32),
+                atol=atol,
+                rtol=rtol,
+                msg=lambda m, name=name: f"tirx vs source {name}: {m}",
             )

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -3992,68 +3992,6 @@ def _make_work_items(torch, seq_lens, heads):
     return torch.tensor(rows, dtype=torch.int32, device="cuda")
 
 
-def _effective_inputs(
-    torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias, io_dtype
-):
-    q_effective = q
-    k_effective = k
-    if l2norm:
-        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
-        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
-    gate_effective = gate
-    if safe_gate:
-        gate_effective = -5.0 * torch.sigmoid(
-            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
-        )
-    # The kernel rounds sigmoid(beta) through the I/O dtype before using it, and
-    # the gradient depends on that rounded value, so the reference must too.
-    beta_effective = beta
-    if beta_sigmoid:
-        beta_effective = beta.sigmoid().to(io_dtype).to(beta.dtype)
-    return q_effective, k_effective, gate_effective, beta_effective
-
-
-def _forward_and_checkpoints(
-    torch, q, k, v, gate, beta, w, cu_seqlens, *, scale, initial_state, checkpoint_dtype
-):
-    """FP64 chunk-entering state series for the GDN-2 recurrence.
-
-    Per-key decay first, the erase term reads the ALREADY-DECAYED state and is
-    gated per key channel, the write gate scales v, and the rank-1 update uses
-    the raw key.
-    """
-    from itertools import pairwise
-
-    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
-    batch_count = len(bounds) - 1
-    heads = gate.shape[1]
-    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
-    checkpoints = torch.zeros(
-        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
-    )
-    outputs = []
-    final_states = []
-    for batch, (begin, end) in enumerate(pairwise(bounds)):
-        if initial_state is None:
-            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
-        else:
-            state = initial_state[batch].transpose(-1, -2)
-        checkpoint_base = begin // _BT + batch
-        for local_token, token in enumerate(range(begin, end)):
-            if local_token % _BT == 0:
-                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
-                    checkpoint_dtype
-                )
-            state = gate[token].exp()[..., None] * state
-            erase = torch.einsum("hd,hdv->hv", beta[token] * k[token], state)
-            v_new = w[token] * v[token] - erase
-            state = state + torch.einsum("hd,hv->hdv", k[token], v_new)
-            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
-        final_states.append(state.transpose(-1, -2))
-    output = torch.stack(outputs)
-    return output, torch.stack(final_states), checkpoints
-
-
 def _io_dtype(torch, config):
     return {"bfloat16": torch.bfloat16, "float16": torch.float16}[config.get("dtype", "bfloat16")]
 
@@ -4103,7 +4041,7 @@ def _prepare_work_tables(torch, config):
     return {"tirx": one_side(), "source": one_side()}
 
 
-def _prepare_data(config, *, with_oracle):
+def _prepare_data(config):
     import torch
 
     config = _normalized_config(config)
@@ -4148,8 +4086,6 @@ def _prepare_data(config, *, with_oracle):
         if config["use_initial_state"]
         else None
     )
-    if initial_state is not None and with_oracle:
-        initial_state.requires_grad_(True)
     d_final_state = (
         0.02
         * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
@@ -4157,65 +4093,10 @@ def _prepare_data(config, *, with_oracle):
         else None
     )
 
-    oracle = None
-    if with_oracle:
-        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
-        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
-        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
-        gate_ref = gate.double().detach().requires_grad_(True)
-        beta_ref = beta.double().detach().requires_grad_(True)
-        w_ref = w.double().detach().requires_grad_(True)
-        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
-            torch,
-            q_ref,
-            k_ref,
-            gate_ref,
-            beta_ref,
-            l2norm=config["l2norm"],
-            safe_gate=config["safe_gate"],
-            beta_sigmoid=config["beta_sigmoid"],
-            a_log=a_log.double() if a_log is not None else None,
-            dt_bias=dt_bias.double() if dt_bias is not None else None,
-            io_dtype=io_dtype,
-        )
-        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
-            torch,
-            q_effective,
-            k_effective,
-            v_ref,
-            gate_effective,
-            beta_effective,
-            w_ref,
-            cu_seqlens,
-            scale=config["scale"],
-            initial_state=initial_state,
-            checkpoint_dtype=io_dtype,
-        )
-        loss = (output_ref * do.double()).sum()
-        if d_final_state is not None:
-            loss = loss + (final_ref * d_final_state.double()).sum()
-        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref, w_ref]
-        if config["safe_gate"]:
-            grad_inputs.append(gate_effective)
-        if initial_state is not None:
-            grad_inputs.append(initial_state)
-        grads = torch.autograd.grad(loss, grad_inputs)
-        oracle = {
-            "dq": grads[0],
-            "dk": grads[1],
-            "dv": grads[2],
-            "dgate": grads[6] if config["safe_gate"] else grads[3],
-            "dbeta": grads[4],
-            "dw": grads[5],
-        }
-        if initial_state is not None:
-            oracle["d_initial_state"] = grads[-1]
-        checkpoints = checkpoints.detach()
-    else:
-        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
-        checkpoints = (
-            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
-        ).to(torch.bfloat16)
+    checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+    checkpoints = (
+        0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+    ).to(torch.bfloat16)
 
     workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
@@ -4237,7 +4118,6 @@ def _prepare_data(config, *, with_oracle):
         "tirx": _new_outputs(torch, config, total_tokens),
         "source": _new_outputs(torch, config, total_tokens),
         "work": _prepare_work_tables(torch, config),
-        "oracle": oracle,
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
         "_workspace_owners": (tirx_owner, source_owner),
@@ -4245,8 +4125,8 @@ def _prepare_data(config, *, with_oracle):
 
 
 def prepare_data(**config):
-    """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
-    return _prepare_data(config, with_oracle=True)
+    """Allocate the shared input set plus source/TIRx output buffers."""
+    return _prepare_data(config)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -4481,19 +4361,15 @@ def _rms_ratio(torch, actual, expected):
     return float(((actual - expected).square().mean().sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources, with_oracle):
+def _validate_outputs(data, *, sources):
     import math
 
     import torch
 
     config = data["config"]
-    # Tolerances are against the FP64 recurrence.  dGate and dBeta are the two
-    # small-magnitude gradients: dBeta is a per-key-channel product of BF16 terms
-    # whose mean magnitude is around 1e-4, so its relative residual against an
-    # FP64 reference is dominated by input quantization rather than by the
-    # kernel.  The upstream implementation shows the same residual on the same
-    # inputs, and the kernel is additionally compared against it directly, which
-    # is the tighter check.
+    # RMS-ratio limits per output; the upstream kernel on identical inputs is
+    # the arbiter. dGate and dBeta are the two small-magnitude gradients whose
+    # relative residual is dominated by input quantization.
     limits = {
         "dq": 0.10,
         "dk": 0.10,
@@ -4504,14 +4380,6 @@ def _validate_outputs(data, *, sources, with_oracle):
         "d_initial_state": 0.10,
     }
     failures = {}
-    if with_oracle:
-        if data["oracle"] is None:
-            raise AssertionError("oracle validation requested without oracle data")
-        for source_name in sources:
-            for output_name, expected in data["oracle"].items():
-                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
-                if not math.isfinite(ratio) or ratio >= limits[output_name]:
-                    failures[f"{source_name}.{output_name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for output_name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
@@ -4522,20 +4390,20 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare both kernels with the standalone FP64 recurrence oracle."""
+    """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     kernel_config = _normalized_config(config)
-    data = _prepare_data(kernel_config, with_oracle=True)
+    data = _prepare_data(kernel_config)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
     source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"))
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 
@@ -4558,7 +4426,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config, with_oracle=False)
+    data = _prepare_data(config)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -4568,7 +4436,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        _validate_outputs(data, sources=("tirx", "source"))
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -2805,46 +2805,7 @@ def _new_outputs(torch, config, total_tokens):
     return result
 
 
-def _reference(
-    torch, q, k, v, gate, beta, w, cu_seqlens, *, scale, initial_state, checkpoint_every_n_tokens
-):
-    from itertools import pairwise
-
-    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
-    heads = gate.shape[1]
-    output = torch.empty(q.shape[0], heads, _DV, dtype=torch.float64, device=q.device)
-    finals = []
-    checkpoints = []
-    for batch, (begin, end) in enumerate(pairwise(bounds)):
-        if initial_state is None:
-            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
-        else:
-            state = initial_state[batch].double().transpose(-1, -2).contiguous()
-        if checkpoint_every_n_tokens and end > begin:
-            checkpoints.append(state.transpose(-1, -2).clone())
-        for local_token, token in enumerate(range(begin, end)):
-            state = gate[token].double().exp()[..., None] * state
-            erase = torch.einsum("hd,hdv->hv", beta[token].double() * k[token].double(), state)
-            v_new = w[token].double() * v[token].double() - erase
-            state = state + torch.einsum("hd,hv->hdv", k[token].double(), v_new)
-            output[token] = torch.einsum("hd,hdv->hv", q[token].double() * scale, state)
-            boundary = local_token + 1
-            if (
-                checkpoint_every_n_tokens
-                and boundary % checkpoint_every_n_tokens == 0
-                and boundary < end - begin
-            ):
-                checkpoints.append(state.transpose(-1, -2).clone())
-        finals.append(state.transpose(-1, -2))
-    checkpoint_tensor = (
-        torch.stack(checkpoints)
-        if checkpoints
-        else torch.empty(0, heads, _DV, _DK, dtype=torch.float64, device=q.device)
-    )
-    return output, torch.stack(finals), checkpoint_tensor
-
-
-def _prepare_data(config, *, with_oracle):
+def _prepare_data(config):
     import torch
 
     config = _normalized_config(config)
@@ -2893,38 +2854,6 @@ def _prepare_data(config, *, with_oracle):
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
     source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
 
-    oracle = None
-    if with_oracle:
-        q_ref = q.double().repeat_interleave(config["heads"] // config["q_heads"], dim=1)
-        k_ref = k.double().repeat_interleave(config["heads"] // config["k_heads"], dim=1)
-        v_ref = v.double().repeat_interleave(config["heads"] // config["v_heads"], dim=1)
-        if config["l2norm"]:
-            q_ref = torch.nn.functional.normalize(q_ref, dim=-1, eps=1e-12)
-            k_ref = torch.nn.functional.normalize(k_ref, dim=-1, eps=1e-12)
-        gate_ref = gate.double()
-        if config["safe_gate"]:
-            gate_ref = float(config["gate_lower_bound"]) * torch.sigmoid(
-                a_log.double().exp()[None, :, None] * (gate_ref + dt_bias.double()[None, :, :])
-            )
-        beta_ref = beta.double().sigmoid() if config["beta_sigmoid"] else beta.double()
-        output_ref, state_ref, checkpoint_ref = _reference(
-            torch,
-            q_ref,
-            k_ref,
-            v_ref,
-            gate_ref,
-            beta_ref,
-            w,
-            cu_seqlens,
-            scale=float(config["scale"]),
-            initial_state=initial_state,
-            checkpoint_every_n_tokens=int(config["checkpoint_every_n_tokens"]),
-        )
-        oracle = {"output": output_ref}
-        if config["store_final_state"]:
-            oracle["final_state"] = state_ref
-        if checkpoint_ref.numel():
-            oracle["checkpoints"] = checkpoint_ref
     return {
         "config": config,
         "q": q,
@@ -2942,14 +2871,13 @@ def _prepare_data(config, *, with_oracle):
         "work": _prepare_work_tables(torch, config),
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
-        "oracle": oracle,
         "_workspace_owners": (tirx_owner, source_owner),
     }
 
 
 def prepare_data(**config):
-    """Allocate independent TIRx/source outputs and an FP64 recurrence oracle."""
-    return _prepare_data(config, with_oracle=True)
+    """Allocate the shared input set plus source/TIRx output buffers."""
+    return _prepare_data(config)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -3181,21 +3109,13 @@ def _rms_ratio(torch, actual, expected):
     return float(((difference_square_sum / elements).sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources, with_oracle):
+def _validate_outputs(data, *, sources):
     import math
 
     import torch
 
     limit = 0.01 if data["config"]["io_dtype"] == "float16" else 0.02
     failures = {}
-    if with_oracle:
-        if data["oracle"] is None:
-            raise AssertionError("oracle validation requested without oracle data")
-        for source_name in sources:
-            for name, expected in data["oracle"].items():
-                ratio = _rms_ratio(torch, data[source_name][name], expected)
-                if not math.isfinite(ratio) or ratio >= limit:
-                    failures[f"{source_name}.{name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][name], data["source"][name])
@@ -3208,20 +3128,20 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare TIRx and source with the independent FP64 recurrence."""
+    """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     config = _normalized_config(config)
-    data = _prepare_data(config, with_oracle=True)
+    data = _prepare_data(config)
     executables = [compile_kernel(func) for func in get_kernel(**config)]
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
     source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"))
     return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
 
 
@@ -3244,7 +3164,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config, with_oracle=False)
+    data = _prepare_data(config)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -3253,7 +3173,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        _validate_outputs(data, sources=("tirx", "source"))
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -3495,57 +3495,6 @@ def _make_work_items(torch, seq_lens, heads):
     return torch.tensor(rows, dtype=torch.int32, device="cuda")
 
 
-def _effective_inputs(torch, q, k, gate, beta, *, l2norm, safe_gate, beta_sigmoid, a_log, dt_bias):
-    q_effective = q
-    k_effective = k
-    if l2norm:
-        q_effective = torch.nn.functional.normalize(q, dim=-1, eps=1e-12)
-        k_effective = torch.nn.functional.normalize(k, dim=-1, eps=1e-12)
-    gate_effective = gate
-    if safe_gate:
-        gate_effective = -5.0 * torch.sigmoid(
-            a_log.exp()[None, :, None] * (gate + dt_bias[None, :, :])
-        )
-    beta_effective = beta.sigmoid() if beta_sigmoid else beta
-    return q_effective, k_effective, gate_effective, beta_effective
-
-
-def _forward_and_checkpoints(
-    torch, q, k, v, gate, beta, cu_seqlens, *, scale, initial_state, checkpoint_dtype
-):
-    from itertools import pairwise
-
-    bounds = [int(value) for value in cu_seqlens.cpu().tolist()]
-    batch_count = len(bounds) - 1
-    heads = gate.shape[1]
-    checkpoint_rows = max((q.shape[0] // _BT) + batch_count, 1)
-    checkpoints = torch.zeros(
-        checkpoint_rows, heads, _DV, _DK, dtype=checkpoint_dtype, device=q.device
-    )
-    outputs = []
-    final_states = []
-    for batch, (begin, end) in enumerate(pairwise(bounds)):
-        if initial_state is None:
-            state = torch.zeros(heads, _DK, _DV, dtype=torch.float64, device=q.device)
-        else:
-            state = initial_state[batch].transpose(-1, -2)
-        checkpoint_base = begin // _BT + batch
-        for local_token, token in enumerate(range(begin, end)):
-            if local_token % _BT == 0:
-                checkpoints[checkpoint_base + local_token // _BT] = state.transpose(-1, -2).to(
-                    checkpoint_dtype
-                )
-            state = gate[token].exp()[..., None] * state
-            residual = v[token] - torch.einsum("hd,hdv->hv", k[token], state)
-            state = state + beta[token, :, None, None] * torch.einsum(
-                "hd,hv->hdv", k[token], residual
-            )
-            outputs.append(torch.einsum("hd,hdv->hv", q[token] * scale, state))
-        final_states.append(state.transpose(-1, -2))
-    output = torch.stack(outputs)
-    return output, torch.stack(final_states), checkpoints
-
-
 def _new_outputs(torch, config, total_tokens):
     heads = config["heads"]
     beta_dtype = torch.bfloat16 if config["beta_sigmoid"] else torch.float32
@@ -3590,7 +3539,7 @@ def _prepare_work_tables(torch, config):
     return {"tirx": one_side(), "source": one_side()}
 
 
-def _prepare_data(config, *, with_oracle):
+def _prepare_data(config):
     import torch
 
     config = _normalized_config(config)
@@ -3632,8 +3581,6 @@ def _prepare_data(config, *, with_oracle):
         if config["use_initial_state"]
         else None
     )
-    if initial_state is not None and with_oracle:
-        initial_state.requires_grad_(True)
     d_final_state = (
         0.02
         * torch.randn(len(config["seq_lens"]), heads, _DV, _DK, dtype=torch.float32, device="cuda")
@@ -3641,61 +3588,10 @@ def _prepare_data(config, *, with_oracle):
         else None
     )
 
-    oracle = None
-    if with_oracle:
-        q_ref = q.double().repeat_interleave(heads // q_heads, dim=1).detach().requires_grad_(True)
-        k_ref = k.double().repeat_interleave(heads // k_heads, dim=1).detach().requires_grad_(True)
-        v_ref = v.double().repeat_interleave(heads // v_heads, dim=1).detach().requires_grad_(True)
-        gate_ref = gate.double().detach().requires_grad_(True)
-        beta_ref = beta.double().detach().requires_grad_(True)
-        q_effective, k_effective, gate_effective, beta_effective = _effective_inputs(
-            torch,
-            q_ref,
-            k_ref,
-            gate_ref,
-            beta_ref,
-            l2norm=config["l2norm"],
-            safe_gate=config["safe_gate"],
-            beta_sigmoid=config["beta_sigmoid"],
-            a_log=a_log.double() if a_log is not None else None,
-            dt_bias=dt_bias.double() if dt_bias is not None else None,
-        )
-        output_ref, final_ref, checkpoints = _forward_and_checkpoints(
-            torch,
-            q_effective,
-            k_effective,
-            v_ref,
-            gate_effective,
-            beta_effective,
-            cu_seqlens,
-            scale=config["scale"],
-            initial_state=initial_state,
-            checkpoint_dtype=torch.bfloat16,
-        )
-        loss = (output_ref * do.double()).sum()
-        if d_final_state is not None:
-            loss = loss + (final_ref * d_final_state.double()).sum()
-        grad_inputs = [q_ref, k_ref, v_ref, gate_ref, beta_ref]
-        if config["safe_gate"]:
-            grad_inputs.append(gate_effective)
-        if initial_state is not None:
-            grad_inputs.append(initial_state)
-        grads = torch.autograd.grad(loss, grad_inputs)
-        oracle = {
-            "dq": grads[0],
-            "dk": grads[1],
-            "dv": grads[2],
-            "dgate": grads[5] if config["safe_gate"] else grads[3],
-            "dbeta": grads[4],
-        }
-        if initial_state is not None:
-            oracle["d_initial_state"] = grads[-1]
-        checkpoints = checkpoints.detach()
-    else:
-        checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
-        checkpoints = (
-            0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
-        ).to(torch.bfloat16)
+    checkpoint_rows = max(total_tokens // _BT + len(config["seq_lens"]), 1)
+    checkpoints = (
+        0.02 * torch.randn(checkpoint_rows, heads, _DV, _DK, dtype=torch.float32, device="cuda")
+    ).to(torch.bfloat16)
 
     workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 128
     tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
@@ -3716,7 +3612,6 @@ def _prepare_data(config, *, with_oracle):
         "tirx": _new_outputs(torch, config, total_tokens),
         "source": _new_outputs(torch, config, total_tokens),
         "work": _prepare_work_tables(torch, config),
-        "oracle": oracle,
         "tirx_workspace": tirx_workspace,
         "source_workspace": source_workspace,
         "_workspace_owners": (tirx_owner, source_owner),
@@ -3725,7 +3620,7 @@ def _prepare_data(config, *, with_oracle):
 
 def prepare_data(**config):
     """Allocate source/TIRx outputs and an independent FP64 recurrence oracle."""
-    return _prepare_data(config, with_oracle=True)
+    return _prepare_data(config)
 
 
 def _encode_tiled_map(tensor, dimensions, strides, box):
@@ -3946,7 +3841,7 @@ def _rms_ratio(torch, actual, expected):
     return float(((actual - expected).square().mean().sqrt() / denominator).item())
 
 
-def _validate_outputs(data, *, sources, with_oracle):
+def _validate_outputs(data, *, sources):
     import math
 
     import torch
@@ -3961,14 +3856,6 @@ def _validate_outputs(data, *, sources, with_oracle):
         "d_initial_state": 0.10,
     }
     failures = {}
-    if with_oracle:
-        if data["oracle"] is None:
-            raise AssertionError("oracle validation requested without oracle data")
-        for source_name in sources:
-            for output_name, expected in data["oracle"].items():
-                ratio = _rms_ratio(torch, data[source_name][output_name], expected)
-                if not math.isfinite(ratio) or ratio >= limits[output_name]:
-                    failures[f"{source_name}.{output_name}"] = ratio
     if "tirx" in sources and "source" in sources:
         for output_name in data["tirx"]:
             ratio = _rms_ratio(torch, data["tirx"][output_name], data["source"][output_name])
@@ -3979,20 +3866,20 @@ def _validate_outputs(data, *, sources, with_oracle):
 
 
 def run_test(**config):
-    """Compare both kernels with the standalone FP64 recurrence oracle."""
+    """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
     kernel_config = _normalized_config(config)
-    data = _prepare_data(kernel_config, with_oracle=True)
+    data = _prepare_data(kernel_config)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
     source_launch()
     torch.cuda.synchronize()
-    _validate_outputs(data, sources=("tirx", "source"), with_oracle=True)
+    _validate_outputs(data, sources=("tirx", "source"))
     return {"tokens": sum(kernel_config["seq_lens"]), "heads": kernel_config["heads"]}
 
 
@@ -4015,7 +3902,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     from tirx_kernels.runner import bench, external_references_enabled
 
     config = _normalized_config({**prepared["config"], **kwargs})
-    data = _prepare_data(config, with_oracle=False)
+    data = _prepare_data(config)
     tirx_launch = _tirx_launch(prepared["executables"], data)
     tirx_launch()
     torch.cuda.synchronize()
@@ -4025,7 +3912,7 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         source_launch = _source_launch(data)
         source_launch()
         torch.cuda.synchronize()
-        _validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        _validate_outputs(data, sources=("tirx", "source"))
         references = {"cudnn_frontend": lambda: source_launch}
     return bench(
         {"tirx": tirx_launch},

--- a/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
+++ b/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
@@ -2437,7 +2437,7 @@ def _decode_sf_storage(torch, storage, rows, columns, batch, vec_size):
 
 
 def prepare_data(**config):
-    """Allocate one patterned input set shared by TIRx, source, and oracle."""
+    """Allocate one patterned input set shared by TIRx and the source kernel."""
     import torch
 
     config = _without_label(config)
@@ -2457,27 +2457,6 @@ def prepare_data(**config):
     tirx_sfc = _sf_storage(torch, M, N // 2, L, config["sf_vec_size"], sf_dtype, 0.0)
     source_sfc = _sf_storage(torch, M, N // 2, L, config["sf_vec_size"], sf_dtype, 0.0)
     norm_const = torch.ones(1, dtype=torch.float32, device="cuda")
-    expected_ab12 = (
-        K_dim
-        * input_scale
-        * config["alpha"]
-        * a_data["factors"][:, None, :]
-        * b_data["factors"][None, :, :]
-    )
-    expected_c = torch.empty((M, N // 2, L), dtype=torch.float32, device="cuda")
-    tile_n = config["mma_tiler_mn"][1]
-    for tile_start in range(0, N, tile_n):
-        tile_width = min(tile_n, N - tile_start)
-        output_start = tile_start // 2
-        for pair_start in range(0, tile_width, 64):
-            width = min(32, tile_width - pair_start - 32)
-            up = expected_ab12[:, tile_start + pair_start : tile_start + pair_start + width, :]
-            gate = expected_ab12[
-                :, tile_start + pair_start + 32 : tile_start + pair_start + 32 + width, :
-            ]
-            expected_c[
-                :, output_start + pair_start // 2 : output_start + pair_start // 2 + width, :
-            ] = up * (gate * torch.sigmoid(gate))
     return {
         "a": a_data,
         "b": b_data,
@@ -2493,8 +2472,6 @@ def prepare_data(**config):
         "source_sfc": source_sfc,
         "norm_const": norm_const,
         "input_scale": input_scale,
-        "expected_ab12": expected_ab12,
-        "expected_c": expected_c,
     }
 
 
@@ -2617,91 +2594,13 @@ def _assert_close(torch, actual, expected, *, atol, rtol, label):
     )
 
 
-def _validate_one_side(data, config, prefix):
-    import torch
-
-    ab12_tolerance = 0.1 if config["ab12_dtype"].startswith("float8_") else 0.01
-    ab12 = data[f"{prefix}_ab12"]["source"]
-    c = data[f"{prefix}_c"]["source"]
-    _assert_close(
-        torch,
-        ab12,
-        data["expected_ab12"],
-        atol=ab12_tolerance,
-        rtol=ab12_tolerance,
-        label=f"{prefix} AB12 versus FP32 oracle",
-    )
-    if config["c_dtype"].startswith("float8_"):
-        decoded_sfc = _decode_sf_storage(
-            torch,
-            data[f"{prefix}_sfc"],
-            config["M"],
-            config["N"] // 2,
-            config["L"],
-            config["sf_vec_size"],
-        )
-        group_count = _ceil_div(config["N"] // 2, config["sf_vec_size"])
-        padded_columns = group_count * config["sf_vec_size"]
-        padded = torch.zeros(
-            (config["M"], padded_columns, config["L"]), dtype=torch.float32, device="cuda"
-        )
-        padded[:, : config["N"] // 2, :] = data["expected_c"]
-        expected_sfc = (
-            padded.reshape(config["M"], group_count, config["sf_vec_size"], config["L"])
-            .abs()
-            .amax(dim=2)
-            * (1.0 / (448.0 if config["c_dtype"] == "float8_e4m3fn" else 128.0))
-            * data["norm_const"].item()
-        )
-        sf_dtype = "float8_e8m0fnu" if config["sf_dtype"] == "int8" else config["sf_dtype"]
-        if sf_dtype == "float8_e8m0fnu":
-            expected_sfc = torch.where(
-                expected_sfc == 0,
-                torch.zeros_like(expected_sfc),
-                torch.pow(torch.tensor(2.0, device="cuda"), torch.ceil(torch.log2(expected_sfc))),
-            )
-        else:
-            expected_sfc = expected_sfc.to(_torch_dtype(torch, sf_dtype)).float()
-        _assert_close(
-            torch,
-            decoded_sfc,
-            expected_sfc,
-            atol=0.1,
-            rtol=0.1,
-            label=f"{prefix} SFC versus oracle",
-        )
-        expanded_sfc = decoded_sfc.repeat_interleave(config["sf_vec_size"], dim=1)[
-            :, : config["N"] // 2, :
-        ]
-        dequantized_c = c.float() * expanded_sfc / data["norm_const"].item()
-        _assert_close(
-            torch,
-            dequantized_c,
-            data["expected_c"],
-            atol=0.1,
-            rtol=0.1,
-            label=f"{prefix} dequantized C versus oracle",
-        )
-    else:
-        expected_c = data["expected_c"].to(_torch_dtype(torch, config["c_dtype"])).float()
-        _assert_close(
-            torch, c, expected_c, atol=0.01, rtol=0.01, label=f"{prefix} C versus FP32 oracle"
-        )
-    if config["ab_dtype"] == "float4_e2m1fn" and config["c_dtype"] == "bfloat16":
-        _assert_close(
-            torch,
-            data[f"{prefix}_amax"],
-            data["expected_c"].abs().amax().reshape(1),
-            atol=0.1,
-            rtol=0.1,
-            label=f"{prefix} amax versus oracle",
-        )
-
-
 def _validate_outputs(data, config, *, with_source):
-    _validate_one_side(data, config, "tirx")
+    """Hold TIRx to the upstream kernel's outputs on the same bytes.
+
+    The upstream implementation is the sole arbiter; numeric validation only
+    runs when the source ran.
+    """
     if with_source:
-        _validate_one_side(data, config, "source")
         import torch
 
         ab12_tolerance = 0.1 if config["ab12_dtype"].startswith("float8_") else 0.01
@@ -2759,7 +2658,7 @@ def _validate_outputs(data, config, *, with_source):
 
 
 def run_test(**config):
-    """Compare TIRx with cuDNN Frontend and the dequantized FP32 oracle."""
+    """Compare TIRx with the cuDNN Frontend kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -2774,7 +2673,7 @@ def run_test(**config):
     source_launch()
     torch.cuda.synchronize()
     _validate_outputs(data, kernel_config, with_source=True)
-    return {"max_abs": float(data["expected_ab12"].abs().amax().item())}
+    return {"max_abs": float(data["source_ab12"]["source"].float().abs().amax().item())}
 
 
 def prepare_bench(**config):

--- a/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
+++ b/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
@@ -1583,22 +1583,6 @@ def prepare_data(**config):
     source_ab12 = _output_tensor(torch, M, N, L, config["ab12_dtype"], config["c_major"])
     tirx_c = _output_tensor(torch, M, N // 2, L, config["c_dtype"], config["c_major"])
     source_c = _output_tensor(torch, M, N // 2, L, config["c_dtype"], config["c_major"])
-    expected_batches = []
-    for batch_index in range(L):
-        matches = (
-            a_data["k_indices"][batch_index][:, None] == b_data["k_indices"][batch_index][None, :]
-        )
-        expected_batches.append(
-            matches.to(torch.float32)
-            * a_data["values"][batch_index][:, None]
-            * b_data["values"][batch_index][None, :]
-            * config["alpha"]
-        )
-    expected_ab12 = torch.stack(expected_batches, dim=2)
-    blocks = expected_ab12.view(M, N // 32, 32, L)
-    x = blocks[:, 0::2].reshape(M, N // 2, L)
-    gate = blocks[:, 1::2].reshape(M, N // 2, L)
-    expected_c = x * (gate * torch.sigmoid(gate))
     return {
         "a": a_data,
         "b": b_data,
@@ -1606,8 +1590,6 @@ def prepare_data(**config):
         "source_ab12": source_ab12,
         "tirx_c": tirx_c,
         "source_c": source_c,
-        "expected_ab12": expected_ab12,
-        "expected_c": expected_c,
     }
 
 
@@ -1704,46 +1686,32 @@ def _assert_close(torch, actual, expected, *, label):
 
 
 def _validate_outputs(data, *, with_source):
+    """Hold TIRx to the upstream kernel's outputs on the same bytes.
+
+    The upstream implementation is the sole arbiter. Without it (references
+    disabled in a bench run) there is nothing to compare against, so numeric
+    validation only runs when the source ran.
+    """
     import torch
 
+    if not with_source:
+        return
     _assert_close(
         torch,
         data["tirx_ab12"]["source"],
-        data["expected_ab12"],
-        label="TIRx AB12 versus FP32 oracle",
+        data["source_ab12"]["source"].float(),
+        label="TIRx AB12 versus source",
     )
     _assert_close(
-        torch, data["tirx_c"]["source"], data["expected_c"], label="TIRx C versus FP32 oracle"
+        torch,
+        data["tirx_c"]["source"],
+        data["source_c"]["source"].float(),
+        label="TIRx C versus source",
     )
-    if with_source:
-        _assert_close(
-            torch,
-            data["source_ab12"]["source"],
-            data["expected_ab12"],
-            label="source AB12 versus FP32 oracle",
-        )
-        _assert_close(
-            torch,
-            data["source_c"]["source"],
-            data["expected_c"],
-            label="source C versus FP32 oracle",
-        )
-        _assert_close(
-            torch,
-            data["tirx_ab12"]["source"],
-            data["source_ab12"]["source"].float(),
-            label="TIRx AB12 versus source",
-        )
-        _assert_close(
-            torch,
-            data["tirx_c"]["source"],
-            data["source_c"]["source"].float(),
-            label="TIRx C versus source",
-        )
 
 
 def run_test(**config):
-    """Compare TIRx with cuDNN Frontend and the dequantized FP32 oracle."""
+    """Compare TIRx with the cuDNN Frontend kernel on identical inputs."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
@@ -1758,7 +1726,7 @@ def run_test(**config):
     source_launch()
     torch.cuda.synchronize()
     _validate_outputs(data, with_source=True)
-    return {"max_abs": float(data["expected_ab12"].abs().amax().item())}
+    return {"max_abs": float(data["source_ab12"]["source"].float().abs().amax().item())}
 
 
 def prepare_bench(**config):

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -689,104 +689,6 @@ def _closed_form_x(alloc: int, hidden: int, device: Any) -> Any:
     return torch.sin(rows * 0.373 + cols * 0.001).to(torch.bfloat16)
 
 
-def _simulate_combine_torch(
-    topk_idx: Any,
-    topk_weights: Any,
-    x_input: Any,
-    world_size: int,
-    num_tokens_max: int,
-    num_experts: int,
-    rank: int,
-    device: Any,
-) -> tuple[Any, Any, Any, Any, Any]:
-    """Small-rank oracle: simulate dispatch routing and the combine golden.
-
-    The reference ElasticBuffer segfaults below 8 ranks on this host, so 1/2/4-
-    rank bring-up validates against pure-torch semantics instead:
-    metadata/psum/topk_weights inputs are simulated per the dispatch contract
-    (one received token per (token, rank) group, master lane = group identity,
-    rows sorted by (src rank, src token)), and the golden combine output is
-    computed from the same rows: per local token, sum each contributing
-    group's x row in ascending master-lane order in fp32, then cast to bf16.
-    """
-
-    import numpy as np
-    import torch
-    import torch.distributed as dist
-
-    num_topk = topk_idx.shape[1]
-    hidden = x_input.shape[1]
-    experts_per_rank = num_experts // world_size
-    alloc = world_size * num_tokens_max
-
-    idx_all = [torch.empty_like(topk_idx) for _ in range(world_size)]
-    dist.all_gather(idx_all, topk_idx)
-    w_all = [torch.empty_like(topk_weights) for _ in range(world_size)]
-    dist.all_gather(w_all, topk_weights)
-    idx_all_np = [t.cpu().numpy() for t in idx_all]
-    w_all_np = [t.cpu().numpy() for t in w_all]
-
-    # Per-receiver received rows: recv_rows[g] = [(src_global, src * topk + master)]
-    recv_rows: list[list[tuple[int, int]]] = []
-    row_of: dict[tuple[int, int], int] = {}
-    for g in range(world_size):
-        rows: list[tuple[int, int]] = []
-        for s in range(world_size):
-            for t in range(idx_all_np[s].shape[0]):
-                lanes = idx_all_np[s][t]
-                groups: dict[int, int] = {}
-                for lane in range(num_topk):
-                    expert = int(lanes[lane])
-                    if expert >= 0:
-                        groups.setdefault(expert // experts_per_rank, lane)
-                if g in groups:
-                    rows.append((s * num_tokens_max + t, s * num_topk + groups[g]))
-        rows.sort()
-        for row_idx, (src_global, meta1) in enumerate(rows):
-            row_of[(g, src_global)] = row_idx
-        recv_rows.append(rows)
-
-    # This rank's kernel inputs
-    my_rows = recv_rows[rank]
-    num_recv = len(my_rows)
-    metadata = torch.zeros((alloc, 2 + num_topk), dtype=torch.int32, device=device)
-    if num_recv:
-        metadata[:num_recv, 0] = torch.tensor(
-            [r[0] for r in my_rows], dtype=torch.int32, device=device
-        )
-        metadata[:num_recv, 1] = torch.tensor(
-            [r[1] for r in my_rows], dtype=torch.int32, device=device
-        )
-    counts = [0] * world_size
-    for src_global, _ in my_rows:
-        counts[src_global // num_tokens_max] += 1
-    psum_rank = torch.tensor(np.cumsum(counts), dtype=torch.int32, device=device)
-    tw_input = torch.zeros((alloc, num_topk), dtype=torch.float32, device=device)
-    for i, (src_global, _) in enumerate(my_rows):
-        s, t = src_global // num_tokens_max, src_global % num_tokens_max
-        tw_input[i] = torch.tensor(w_all_np[s][t], dtype=torch.float32, device=device)
-
-    # Golden: per local token, sum groups' x rows in ascending master-lane order
-    local_num_tokens = topk_idx.shape[0]
-    my_idx_np = idx_all_np[rank]
-    my_w_np = w_all_np[rank]
-    golden_x = torch.zeros((local_num_tokens, hidden), dtype=torch.bfloat16, device=device)
-    cols = torch.arange(hidden, device=device, dtype=torch.float32).unsqueeze(0)
-    for t in range(local_num_tokens):
-        groups = {}
-        for lane in range(num_topk):
-            expert = int(my_idx_np[t][lane])
-            if expert >= 0:
-                groups.setdefault(expert // experts_per_rank, lane)
-        acc = torch.zeros((hidden,), dtype=torch.float32, device=device)
-        for g in sorted(groups, key=groups.get):
-            row = row_of[(g, rank * num_tokens_max + t)]
-            acc += torch.sin(row * 0.373 + cols).view(-1)
-        golden_x[t] = acc.to(torch.bfloat16)
-    golden_w = torch.where(topk_idx >= 0, topk_weights, torch.zeros_like(topk_weights))
-    return metadata, psum_rank, tw_input, golden_x, golden_w
-
-
 def _run_worker(
     runtime: Any, modules: dict[str, Any], mode: str, kwargs: dict[str, Any]
 ) -> dict[str, Any]:
@@ -830,41 +732,37 @@ def _run_worker(
     topk_idx_padded = torch.zeros((num_tokens_max, num_topk), dtype=torch.int64, device=device)
     topk_idx_padded[:local_num_tokens] = topk_idx
 
-    ref_buffer = None
-    handle = None
-    golden_x = golden_w = None
+    # The reference dispatch is the sole producer of the combine inputs
+    # (metadata/psum/topk_weights); the sub-8-rank torch bring-up simulator is
+    # gone, and ElasticBuffer segfaults below 8 ranks on this host anyway.
+    assert world_size == 8, "deepep combine requires world_size == 8 (source ElasticBuffer path)"
     with_references = mode == "test" or external_references_enabled()
-    if world_size == 8 and with_references:
-        # The reference runtime needs GIN disabled on this host (verified in the
-        # dispatch scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
-        os.environ.setdefault("EP_DISABLE_GIN", "1")
-        import deep_ep
+    # The reference runtime needs GIN disabled on this host (verified in the
+    # dispatch scaffolding: single-node NVLink LSA path works with EP_DISABLE_GIN=1).
+    os.environ.setdefault("EP_DISABLE_GIN", "1")
+    import deep_ep
 
-        ref_buffer = deep_ep.ElasticBuffer(
-            dist.group.WORLD,
-            num_max_tokens_per_rank=num_tokens_max,
-            hidden=hidden,
-            num_topk=num_topk,
-            prefer_overlap_with_compute=False,
-            explicitly_destroy=True,
-        )
-        _, _, recv_topk_weights, handle, _ = ref_buffer.dispatch(
-            x,
-            topk_idx=topk_idx,
-            topk_weights=topk_weights,
-            num_max_tokens_per_rank=num_tokens_max,
-            num_experts=num_experts,
-            expert_alignment=expert_alignment,
-            num_sms=num_sms,
-            do_cpu_sync=False,
-        )
-        metadata = handle.recv_src_metadata
-        psum_rank = handle.psum_num_recv_tokens_per_scaleup_rank
-        tw_input = recv_topk_weights
-    else:
-        metadata, psum_rank, tw_input, golden_x, golden_w = _simulate_combine_torch(
-            topk_idx, topk_weights, x_input, world_size, num_tokens_max, num_experts, rank, device
-        )
+    ref_buffer = deep_ep.ElasticBuffer(
+        dist.group.WORLD,
+        num_max_tokens_per_rank=num_tokens_max,
+        hidden=hidden,
+        num_topk=num_topk,
+        prefer_overlap_with_compute=False,
+        explicitly_destroy=True,
+    )
+    _, _, recv_topk_weights, handle, _ = ref_buffer.dispatch(
+        x,
+        topk_idx=topk_idx,
+        topk_weights=topk_weights,
+        num_max_tokens_per_rank=num_tokens_max,
+        num_experts=num_experts,
+        expert_alignment=expert_alignment,
+        num_sms=num_sms,
+        do_cpu_sync=False,
+    )
+    metadata = handle.recv_src_metadata
+    psum_rank = handle.psum_num_recv_tokens_per_scaleup_rank
+    tw_input = recv_topk_weights
 
     def tirx_launch() -> None:
         combine_fn(
@@ -896,29 +794,17 @@ def _run_worker(
 
             def _launch_and_check() -> None:
                 with torch.cuda.stream(runtime.timing_stream):
-                    if world_size == 8:
-                        ref_cx, ref_cw, _ = reference_launch()
+                    ref_cx, ref_cw, _ = reference_launch()
                     tirx_launch()
                 runtime.device.sync(runtime.compute_stream)
 
                 our_cx = combined_x[:local_num_tokens]
                 our_cw = combined_w[:local_num_tokens]
-                if world_size == 8:
-                    assert torch.equal(ref_cx, our_cx), (
-                        f"rank {rank}: combined_x mismatch "
-                        f"(max abs diff {(ref_cx.float() - our_cx.float()).abs().max().item()})"
-                    )
-                    assert torch.equal(ref_cw, our_cw), (
-                        f"rank {rank}: combined_topk_weights mismatch"
-                    )
-                else:
-                    assert torch.equal(golden_x, our_cx), (
-                        f"rank {rank}: combined_x mismatch vs torch golden "
-                        f"(max abs diff {(golden_x.float() - our_cx.float()).abs().max().item()})"
-                    )
-                    assert torch.equal(golden_w, our_cw), (
-                        f"rank {rank}: combined_topk_weights mismatch vs torch golden"
-                    )
+                assert torch.equal(ref_cx, our_cx), (
+                    f"rank {rank}: combined_x mismatch "
+                    f"(max abs diff {(ref_cx.float() - our_cx.float()).abs().max().item()})"
+                )
+                assert torch.equal(ref_cw, our_cw), f"rank {rank}: combined_topk_weights mismatch"
 
             check_error = ""
             try:
@@ -946,7 +832,7 @@ def _run_worker(
         with torch.cuda.stream(runtime.timing_stream):
             result = bench(
                 {"tirx": tirx_launch},
-                references={"deepep": build_reference} if ref_buffer is not None else None,
+                references={"deepep": build_reference} if with_references else None,
                 timer="kineto",
                 rounds=kwargs.get("rounds", 1),
                 cooldown_s=kwargs.get("cooldown_s", 1.0),

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/data.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/data.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 AND MIT
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""Operand construction, scale-factor packing and correctness oracles.
+"""Operand construction, scale-factor packing and the shared correctness gate.
 
 Everything here runs on the host, outside any timed closure.  The scale-factor
 layout is produced by DeepGEMM's own `transform_sf_into_required_layout`, so our
@@ -24,7 +24,6 @@ __all__ = [
     "assert_within_threshold",
     "bench_against_deepgemm",
     "calc_diff",
-    "dequantize",
     "quantize_a",
     "quantize_b",
     "require_sm100",
@@ -71,13 +70,13 @@ def calc_diff(x, y) -> float:
     return float(1 - 2 * (x * y).sum() / denominator)
 
 
-def max_diff_threshold(a_dtype: str, b_dtype: str) -> float:
-    """`QuantConfig.max_diff` from DeepGEMM's test generators."""
-    if a_dtype == "fp4" and b_dtype == "fp4":
-        return 0.02
-    if a_dtype == "fp4" or b_dtype == "fp4":
-        return 0.01
-    return 0.001
+# The correctness gate is a direct TIRx-vs-DeepGEMM output comparison: both
+# sides consume byte-identical quantized operands and run the same SM100 MMA
+# pipeline, and every registered config of all five entries measured
+# bitwise-identical (`calc_diff == 0.0`) when this gate replaced the
+# dequantized-torch oracle.  1e-6 leaves ULP-level margin while staying three
+# orders tighter than DeepGEMM's own accuracy thresholds (1e-3 fp8, 1e-2 fp4).
+DIRECT_DIFF_THRESHOLD = 1e-6
 
 
 def quantize_a(x, *, gran_k: int = 128, dtype: str = "fp8") -> tuple:
@@ -138,17 +137,6 @@ def transform_sf(sf, mn: int, k: int, recipe: tuple[int, int], num_groups: int |
     return deep_gemm.transform_sf_into_required_layout(sf, mn, k, recipe, num_groups)
 
 
-def broadcast_block_sf(sf, mn: int, gran_mn: int):
-    """Expand a `(mn / gran_mn, k / gran_k)` block scale to one row per MN element.
-
-    `cast_back_*` and DeepGEMM's own reference path both want a per-row scale;
-    `csrc/apis/layout.hpp:51-52` performs the same broadcast on the device side.
-    """
-    if gran_mn == 1:
-        return sf
-    return sf.repeat_interleave(gran_mn, dim=0)[:mn]
-
-
 def to_major(x, major: str):
     """Return the same logical `[MN, K]` tensor laid out K-major or MN-major.
 
@@ -166,18 +154,6 @@ def to_major(x, major: str):
         # K-major everywhere on SM100, so this combination should never be built.
         raise ValueError("packed FP4 operands are K-major only")
     return x.t().contiguous().t()
-
-
-def dequantize(quantized, sf_raw, *, dtype: str, gran_k: int, gran_mn: int = 1):
-    """Reconstruct the value a perfect GEMM would consume from this operand."""
-    from deep_gemm.utils.math import cast_back_from_fp4, cast_back_from_fp8
-
-    sf_rows = broadcast_block_sf(sf_raw, quantized.size(0), gran_mn)
-    if dtype == "fp8":
-        return cast_back_from_fp8(quantized, sf_rows, gran_k=gran_k)
-    if dtype == "fp4":
-        return cast_back_from_fp4(quantized, sf_rows, gran_k=gran_k)
-    raise ValueError(f"unsupported dtype: {dtype}")
 
 
 # --------------------------------------------------------------------------------------
@@ -200,8 +176,7 @@ def prepare_normal(
     """Build one dense-GEMM case, mirroring `generators.generate_normal`.
 
     Returns the tensors in the orientation the TMA descriptors address, the
-    packed scales, an output buffer, an optional accumulator input, and a
-    dequantized-matmul reference.
+    packed scales, an output buffer, and an optional accumulator input.
     """
     import torch
 
@@ -218,17 +193,10 @@ def prepare_normal(
     recipe_b = recipe_for(b_dtype, gran_k_b, is_a=False, is_wgrad=is_wgrad)
     b_q, b_sf = quantize_b(b_bf16, gran_k=gran_k_b, dtype=b_dtype, per_block=recipe_b[0] != 1)
 
-    # The reference consumes exactly what the kernel will: the dequantized values.
-    a_ref = dequantize(a_q, a_sf, dtype="fp8", gran_k=gran_k_a)
-    b_ref = dequantize(b_q, b_sf, dtype=b_dtype, gran_k=gran_k_b, gran_mn=recipe_b[0])
-
     out_dtype = torch.float32 if cd_dtype == "fp32" else torch.bfloat16
-    ref = (a_ref.float() @ b_ref.float().t()).to(out_dtype)
-
     c = None
     if accumulate:
         c = torch.randn((M, N), device="cuda", dtype=out_dtype)
-        ref = (ref.float() + c.float()).to(out_dtype)
     d = torch.empty((M, N), device="cuda", dtype=out_dtype)
 
     sfa = transform_sf(a_sf, M, K, recipe_for("fp8", gran_k_a, is_a=True))
@@ -257,7 +225,6 @@ def prepare_normal(
         "b_raw_sf": b_sf,
         "c": c,
         "d": d,
-        "ref": ref,
         "recipe_a": recipe_for("fp8", gran_k_a, is_a=True),
         "recipe_b": recipe_b,
         # Once `transform_sf` has run, the scales are per-row and already packed,
@@ -289,17 +256,6 @@ def _quantize_grouped_b(b_bf16, *, gran_k: int, dtype: str, per_block: bool):
     data = torch.stack([g[0] for g in groups])
     sf = torch.stack([g[1] for g in groups])
     return data, sf
-
-
-def _dequantize_grouped_b(b_q, b_sf, *, dtype: str, gran_k: int, gran_mn: int):
-    import torch
-
-    return torch.stack(
-        [
-            dequantize(b_q[i], b_sf[i], dtype=dtype, gran_k=gran_k, gran_mn=gran_mn)
-            for i in range(b_q.size(0))
-        ]
-    )
 
 
 # --------------------------------------------------------------------------------------
@@ -362,14 +318,6 @@ def prepare_m_grouped_contiguous(
     b_q, b_sf = _quantize_grouped_b(
         b_bf16, gran_k=gran_k_b, dtype=b_dtype, per_block=recipe_b[0] != 1
     )
-    a_ref = dequantize(a_q, a_sf, dtype="fp8", gran_k=gran_k_a)
-    b_ref = _dequantize_grouped_b(b_q, b_sf, dtype=b_dtype, gran_k=gran_k_b, gran_mn=recipe_b[0])
-
-    ref = torch.empty((M, N), device="cuda", dtype=torch.bfloat16)
-    for i, (start, _actual_end, aligned_end) in enumerate(spans):
-        ref[start:aligned_end] = (a_ref[start:aligned_end].float() @ b_ref[i].float().t()).to(
-            torch.bfloat16
-        )
     d = torch.empty((M, N), device="cuda", dtype=torch.bfloat16)
 
     psum_layout = grouped_layout if use_psum_layout else None
@@ -389,7 +337,6 @@ def prepare_m_grouped_contiguous(
         "sfb": sfb,
         "grouped_layout": grouped_layout,
         "d": d,
-        "ref": ref,
         "c": None,
         "alignment": alignment,
         "use_psum_layout": use_psum_layout,
@@ -481,17 +428,6 @@ def prepare_m_grouped_masked(
         b_bf16, gran_k=gran_k_b, dtype=b_dtype, per_block=recipe_b[0] != 1
     )
 
-    # Only `[g, :masked_m[g]]` is ever compared (`masked_slice_diff`), and
-    # `max_m` is the padded capacity -- typically ~16x the largest count -- so
-    # the oracle covers only the rows that can be read.  The compared values are
-    # unchanged; the rest of `ref` stays zero.
-    used_m = max(counts)
-    a_ref = dequantize(a_q_flat, a_sf_flat, dtype="fp8", gran_k=gran_k_a).view(
-        num_groups, max_m, K
-    )[:, :used_m]
-    b_ref = _dequantize_grouped_b(b_q, b_sf, dtype=b_dtype, gran_k=gran_k_b, gran_mn=recipe_b[0])
-    ref = torch.zeros((num_groups, max_m, N), device="cuda", dtype=torch.bfloat16)
-    ref[:, :used_m] = torch.einsum("gmk,gnk->gmn", a_ref.float(), b_ref.float()).to(torch.bfloat16)
     d = torch.empty((num_groups, max_m, N), device="cuda", dtype=torch.bfloat16)
 
     sfa = transform_sf(a_sf, max_m, K, recipe_for("fp8", gran_k_a, is_a=True), num_groups)
@@ -511,7 +447,6 @@ def prepare_m_grouped_masked(
         "masked_m": masked_m,
         "grouped_layout": masked_m,
         "d": d,
-        "ref": ref,
         "c": None,
         "a_dtype": "fp8",
         "b_dtype": b_dtype,
@@ -539,16 +474,18 @@ def prepare_m_grouped_masked(
 
 
 def assert_within_threshold(diff, data, *, kernel: str, detail: str, **extra) -> dict:
-    """Raise unless `diff` clears the dtype-derived threshold; else return the row.
+    """Raise unless the TIRx-vs-DeepGEMM diff clears the direct threshold.
 
-    Every entry module compares one number against `max_diff_threshold` and
+    Every entry module compares one number against `DIRECT_DIFF_THRESHOLD` and
     reports the same two keys, so the check lives here and each module supplies
     only its own identifying `detail`.
     """
-    threshold = max_diff_threshold(data["a_dtype"], data["b_dtype"])
-    if not diff < threshold:
-        raise AssertionError(f"{kernel} {detail}: diff {diff:.3e} >= {threshold:.0e}")
-    return {"diff": diff, "threshold": threshold, **extra}
+    del data
+    if not diff < DIRECT_DIFF_THRESHOLD:
+        raise AssertionError(
+            f"{kernel} {detail}: TIRx-vs-DeepGEMM diff {diff:.3e} >= {DIRECT_DIFF_THRESHOLD:.0e}"
+        )
+    return {"diff": diff, "threshold": DIRECT_DIFF_THRESHOLD, **extra}
 
 
 def bench_against_deepgemm(
@@ -756,20 +693,12 @@ def prepare_bmm(*, expr: str, H: int, R: int, D: int, B: int, seed: int = 0) -> 
     for i in range(H):
         y_q[i], y_sf[i] = per_block_cast_to_fp8(y[i], use_ue8m0=True)
 
-    x_ref = dequantize(
-        x_q.view(-1, R), x_sf.view(-1, ceil_div(R, gran_k)), dtype="fp8", gran_k=gran_k
-    ).view(B, H, R)
-    y_ref = torch.stack(
-        [dequantize(y_q[i], y_sf[i], dtype="fp8", gran_k=gran_k, gran_mn=gran_k) for i in range(H)]
-    )
-    ref = torch.einsum("bhr,hdr->bhd", x_ref.float(), y_ref.float()).to(torch.bfloat16)
     z = torch.empty((B, H, D), device="cuda", dtype=torch.bfloat16)
 
     # The `(batch, m, n, k)` views `fp8_bmm` actually sees.
     a = x_q.permute(1, 0, 2)
     sfa_raw = x_sf.permute(1, 0, 2)
     d_view = z.permute(1, 0, 2)
-    ref_view = ref.permute(1, 0, 2)
 
     sfa = transform_sf(sfa_raw, B, R, (1, gran_k), H)
     sfb = transform_sf(y_sf, D, R, (gran_k, gran_k), H)
@@ -785,7 +714,6 @@ def prepare_bmm(*, expr: str, H: int, R: int, D: int, B: int, seed: int = 0) -> 
         "sfa": sfa,
         "sfb": sfb,
         "d": d_view,
-        "ref": ref_view,
         "c": None,
         "z": z,
         # `fp8_einsum` permutes each SF operand before handing it to `fp8_bmm`,
@@ -849,13 +777,6 @@ def _prepare_bmm_bhd_hdr_bhr(*, H: int, R: int, D: int, B: int, gran_k: int) -> 
     for i in range(H):
         y_q[i], y_sf[i] = per_block_cast_to_fp8(y[i], use_ue8m0=True)
 
-    x_ref = dequantize(
-        x_q.view(-1, D), x_sf.view(-1, ceil_div(D, gran_k)), dtype="fp8", gran_k=gran_k
-    ).view(B, H, D)
-    y_ref = torch.stack(
-        [dequantize(y_q[i], y_sf[i], dtype="fp8", gran_k=gran_k, gran_mn=gran_k) for i in range(H)]
-    )
-    ref = torch.einsum("bhd,hdr->bhr", x_ref.float(), y_ref.float()).to(torch.bfloat16)
     z = torch.empty((B, H, R), device="cuda", dtype=torch.bfloat16)
 
     sfa = transform_sf(x_sf.permute(1, 0, 2), B, D, (1, gran_k), H)
@@ -872,7 +793,6 @@ def _prepare_bmm_bhd_hdr_bhr(*, H: int, R: int, D: int, B: int, gran_k: int) -> 
         "sfa": sfa,
         "sfb": sfb,
         "d": z.permute(1, 0, 2),
-        "ref": ref.permute(1, 0, 2),
         "c": None,
         "z": z,
         # See the note in `_prepare_bmm_bhr_hdr_bhd`: the already-packed scales
@@ -905,17 +825,6 @@ def _prepare_bmm_bhd_bhr_hdr(*, H: int, R: int, D: int, B: int, gran_k: int) -> 
     x_q, x_sf = x_q.view(B, H, D), x_sf.view(ceil_div(B, gran_k), H, D)
     y_q, y_sf = y_q.view(B, H, R), y_sf.view(ceil_div(B, gran_k), H, R)
 
-    # `per_channel` scales along the reduction axis (B), so dequantizing means
-    # broadcasting each 128-row block's scale back over its rows.
-    x_ref = (
-        x_q.float().view(B, -1)
-        * x_sf.view(ceil_div(B, gran_k), -1).repeat_interleave(gran_k, dim=0)[:B]
-    ).view(B, H, D)
-    y_ref = (
-        y_q.float().view(B, -1)
-        * y_sf.view(ceil_div(B, gran_k), -1).repeat_interleave(gran_k, dim=0)[:B]
-    ).view(B, H, R)
-    ref = z0 + torch.einsum("bhd,bhr->hdr", x_ref, y_ref)
     z = z0.clone()
 
     sfa = transform_sf(x_sf.permute(1, 2, 0), D, B, (1, gran_k), H)
@@ -932,7 +841,6 @@ def _prepare_bmm_bhd_bhr_hdr(*, H: int, R: int, D: int, B: int, gran_k: int) -> 
         "sfa": sfa,
         "sfb": sfb,
         "d": z,
-        "ref": ref,
         "c": z,
         "z": z,
         "z0": z0,
@@ -995,28 +903,6 @@ def k_grouped_quantize(x, ks: list[int], *, gran_k: int, group_ends: list[int] |
     return quantized, sf
 
 
-def k_grouped_dequantize(q, sf, ks: list[int], *, gran_k: int, group_ends: list[int] | None = None):
-    """Undo `k_grouped_quantize`, giving the values the MMA actually consumes."""
-    import itertools
-
-    import torch
-    from deep_gemm.utils.math import ceil_div
-
-    if group_ends is None:
-        group_ends = list(itertools.accumulate(ks))
-    out = torch.zeros(q.shape, dtype=torch.float32, device=q.device)
-    sf_row = 0
-    for k, end in zip(ks, group_ends):
-        if k == 0:
-            continue
-        start = end - k
-        rows = ceil_div(k, gran_k)
-        block = sf[sf_row : sf_row + rows]
-        sf_row += rows
-        out[start:end] = q[start:end].float() * block.repeat_interleave(gran_k, dim=0)[:k]
-    return out
-
-
 def prepare_k_grouped(
     *,
     num_groups: int,
@@ -1067,17 +953,6 @@ def prepare_k_grouped(
 
     a_q, a_sf = k_grouped_quantize(a_bf16, ks, gran_k=gran_k, group_ends=group_ends)
     b_q, b_sf = k_grouped_quantize(b_bf16, ks, gran_k=gran_k, group_ends=group_ends)
-    a_ref = k_grouped_dequantize(a_q, a_sf, ks, gran_k=gran_k, group_ends=group_ends)
-    b_ref = k_grouped_dequantize(b_q, b_sf, ks, gran_k=gran_k, group_ends=group_ends)
-
-    import itertools
-
-    ends_it = group_ends or list(itertools.accumulate(ks))
-    ref = c.clone()
-    for i, (k, end) in enumerate(zip(ks, ends_it)):
-        if k == 0:
-            continue
-        ref[i] += a_ref[end - k : end].t() @ b_ref[end - k : end]
     d = c.clone()
 
     sfa = deep_gemm.get_k_grouped_mn_major_tma_aligned_packed_ue8m0_tensor(
@@ -1106,7 +981,6 @@ def prepare_k_grouped(
         "grouped_layout": layout,
         "c": c,
         "d": d,
-        "ref": ref,
         "use_psum_layout": use_psum_layout,
         "gran_k_a": gran_k,
         "gran_k_b": gran_k,

--- a/tirx_kernels/deepgemm/fp8_bmm.py
+++ b/tirx_kernels/deepgemm/fp8_bmm.py
@@ -150,10 +150,14 @@ def _tirx_launch(data, config, executable=None):
 
 
 def run_test(**config):
-    """Compile, launch and compare against the dequantized-einsum oracle."""
+    """Compile, launch and compare against DeepGEMM on the same operands."""
     import torch
 
-    from ._sm100_fp8_fp4_gemm_1d1d.data import assert_within_threshold, calc_diff
+    from ._sm100_fp8_fp4_gemm_1d1d.data import (
+        assert_within_threshold,
+        calc_diff,
+        deepgemm_launch_bmm,
+    )
 
     config.pop("label", None)
     data = prepare_data(**config)
@@ -167,8 +171,17 @@ def run_test(**config):
     launch()
     torch.cuda.synchronize()
 
+    # DeepGEMM itself, on the same quantized operands, is the arbiter.  The
+    # accumulate entry reads C from its own output, so that output must be
+    # seeded with the same accumulator our launch started from; `z` and the
+    # DeepGEMM buffer share a layout, so the comparison needs no view games.
+    _, deepgemm_out = deepgemm_launch_bmm(
+        data, out=data["z0"].clone() if data["c"] is not None else None
+    )
+    torch.cuda.synchronize()
+
     return assert_within_threshold(
-        calc_diff(data["d"], data["ref"]),
+        calc_diff(data["z"], deepgemm_out),
         data,
         kernel="deepgemm_sm100_fp8_bmm",
         detail=(f"{data['expr']} batch={data['batch']} M={data['M']} N={data['N']} K={data['K']}"),

--- a/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
@@ -186,10 +186,14 @@ def _tirx_launch(data, config, executable=None):
 
 
 def run_test(**config):
-    """Compile, launch and compare against the dequantized-matmul oracle."""
+    """Compile, launch and compare against DeepGEMM on the same operands."""
     import torch
 
-    from ._sm100_fp8_fp4_gemm_1d1d.data import assert_within_threshold, calc_diff
+    from ._sm100_fp8_fp4_gemm_1d1d.data import (
+        assert_within_threshold,
+        calc_diff,
+        deepgemm_launch_normal,
+    )
 
     config.pop("label", None)
     data = prepare_data(seed=17, **config)
@@ -202,8 +206,13 @@ def run_test(**config):
     launch()
     torch.cuda.synchronize()
 
+    # DeepGEMM itself, on the same quantized operands, is the arbiter (the
+    # launcher seeds and runs once into its own output).
+    _, deepgemm_out = deepgemm_launch_normal(data)
+    torch.cuda.synchronize()
+
     return assert_within_threshold(
-        calc_diff(data["d"], data["ref"]),
+        calc_diff(data["d"], deepgemm_out),
         data,
         kernel="deepgemm_sm100_fp8_gemm_1d1d",
         detail=(

--- a/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
@@ -237,10 +237,14 @@ def _tirx_launch(data, config, executable=None):
 
 
 def run_test(**config):
-    """Compile, launch and compare against the dequantized-matmul oracle."""
+    """Compile, launch and compare against DeepGEMM on the same operands."""
     import torch
 
-    from ._sm100_fp8_fp4_gemm_1d1d.data import assert_within_threshold, calc_diff
+    from ._sm100_fp8_fp4_gemm_1d1d.data import (
+        assert_within_threshold,
+        calc_diff,
+        deepgemm_launch_k_grouped,
+    )
 
     config.pop("label", None)
     data = prepare_data(**config)
@@ -250,8 +254,13 @@ def run_test(**config):
     launch()
     torch.cuda.synchronize()
 
+    # DeepGEMM itself, on the same quantized operands, is the arbiter (the
+    # launcher seeds its own accumulator from C and runs once).
+    _, deepgemm_out = deepgemm_launch_k_grouped(data)
+    torch.cuda.synchronize()
+
     return assert_within_threshold(
-        calc_diff(data["d"], data["ref"]),
+        calc_diff(data["d"], deepgemm_out),
         data,
         kernel="deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
         detail=(

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
@@ -213,10 +213,15 @@ def _tirx_launch(data, config, executable=None):
 
 
 def run_test(**config):
-    """Compile, launch and compare against the dequantized-matmul oracle."""
+    """Compile, launch and compare against DeepGEMM on the same operands."""
     import torch
 
-    from ._sm100_fp8_fp4_gemm_1d1d.data import assert_within_threshold, calc_diff, psum_slice_diff
+    from ._sm100_fp8_fp4_gemm_1d1d.data import (
+        assert_within_threshold,
+        calc_diff,
+        deepgemm_launch_m_grouped_contiguous,
+        psum_slice_diff,
+    )
 
     config.pop("label", None)
     data = prepare_data(**config)
@@ -225,16 +230,20 @@ def run_test(**config):
     launch()
     torch.cuda.synchronize()
 
+    # DeepGEMM itself, on the same quantized operands, is the arbiter.
+    _, deepgemm_out = deepgemm_launch_m_grouped_contiguous(data)
+    torch.cuda.synchronize()
+
     if data["use_psum_layout"]:
         diff = psum_slice_diff(
             data["d"],
-            data["ref"],
+            deepgemm_out,
             data["grouped_layout"],
             data["alignment"],
             zero_padding=data["ensure_zero_padding"],
         )
     else:
-        diff = calc_diff(data["d"], data["ref"])
+        diff = calc_diff(data["d"], deepgemm_out)
     return assert_within_threshold(
         diff,
         data,

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
@@ -178,10 +178,14 @@ def _tirx_launch(data, config, executable=None):
 
 
 def run_test(**config):
-    """Compare only the valid rows of each group against the oracle."""
+    """Compare only the valid rows of each group against DeepGEMM."""
     import torch
 
-    from ._sm100_fp8_fp4_gemm_1d1d.data import assert_within_threshold, masked_slice_diff
+    from ._sm100_fp8_fp4_gemm_1d1d.data import (
+        assert_within_threshold,
+        deepgemm_launch_m_grouped_masked,
+        masked_slice_diff,
+    )
 
     config.pop("label", None)
     data = prepare_data(**config)
@@ -190,8 +194,13 @@ def run_test(**config):
     launch()
     torch.cuda.synchronize()
 
+    # DeepGEMM itself, on the same quantized operands, is the arbiter; only the
+    # `[g, :masked_m[g]]` rows are defined on either side.
+    _, deepgemm_out = deepgemm_launch_m_grouped_masked(data)
+    torch.cuda.synchronize()
+
     return assert_within_threshold(
-        masked_slice_diff(data["d"], data["ref"], data["masked_m"]),
+        masked_slice_diff(data["d"], deepgemm_out, data["masked_m"]),
         data,
         kernel="deepgemm_sm100_m_grouped_fp8_gemm_masked",
         detail=(f"g={data['num_groups']} N={data['N']} K={data['K']} b_dtype={data['b_dtype']}"),

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -809,8 +809,7 @@ def get_kernel(**kwargs: Any):
                         for math_wg_i in range(num_math_warpgroups):
                             tmem_addr = K.local_scalar(
                                 "uint32",
-                                init=K.uint32(tmem_col)
-                                + tmem_state.stage * K.uint32(umma_n),
+                                init=K.uint32(tmem_col) + tmem_state.stage * K.uint32(umma_n),
                             )
                             tmem_pipe.empty.wait(tmem_state.stage, tmem_state.phase ^ K.uint32(1))
                             # REGION D: block-scaled FP4 UMMA, D = KV @ Q^K.  The
@@ -1216,6 +1215,8 @@ def run_test(**kwargs: Any) -> None:
     config: MQALogitsConfig = data["config"]
     clean_logits = not config.compressed_logits
     deepgemm_logits = _run_deepgemm_mqa(data, clean_logits=clean_logits)
+    # Library-anchored: the torch ref is a yardstick, not the arbiter --
+    # DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
     deepgemm_diff = _assert_correct(data, deepgemm_logits, name="DeepGEMM")
     tirx_logits = _launch_tirx_mqa(data)
     torch.cuda.synchronize()

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -985,6 +985,8 @@ def run_test(**kwargs: Any) -> None:
     config: MQALogitsFP8Config = data["config"]
     clean_logits = not config.compressed_logits
     deepgemm_logits = _run_deepgemm_mqa(data, clean_logits=clean_logits)
+    # Library-anchored: the torch ref is a yardstick, not the arbiter --
+    # DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
     deepgemm_diff = _assert_correct(data, deepgemm_logits, name="DeepGEMM")
     tirx_logits = _launch_tirx_mqa(data)
     torch.cuda.synchronize()

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
@@ -1268,10 +1268,8 @@ def get_kernel(**kwargs: Any):
                             tmem_addr[0],
                             K.uint32(k),
                             runtime_desc_i[0],
-                            K.uint32(sfkv_tmem_col)
-                            + umma_group_idx * K.uint32(num_sfkv // 32),
-                            K.uint32(sfq_tmem_col)
-                            + umma_group_idx * K.uint32(num_sfq_atom // 32),
+                            K.uint32(sfkv_tmem_col) + umma_group_idx * K.uint32(num_sfkv // 32),
+                            K.uint32(sfq_tmem_col) + umma_group_idx * K.uint32(num_sfq_atom // 32),
                         )
                 with K.If(K.cuda.elect_sync()), K.Then():
                     full_tmem_barriers.arrive(
@@ -1525,7 +1523,6 @@ def _compile_tirx_paged_mqa_key(config: PagedMQALogitsFP4Config) -> tuple[tuple[
 
 
 def _compile_tirx_paged_mqa(config: PagedMQALogitsFP4Config) -> Any:
-
     compile_kwargs = _compile_tirx_paged_mqa_kwargs(config)
     return _compile_tirx_paged_mqa_for_config(**compile_kwargs)
 
@@ -1793,6 +1790,8 @@ def _assert_correct(data: dict[str, Any], logits: torch.Tensor, *, name: str) ->
 def run_test(**kwargs: Any) -> None:
     data = prepare_data(**kwargs)
     deepgemm_logits = _run_deepgemm_paged_mqa(data, clean_logits=False)
+    # Library-anchored: the torch ref is a yardstick, not the arbiter --
+    # DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
     deepgemm_diff = _assert_correct(data, deepgemm_logits, name="DeepGEMM")
     tirx_logits = _launch_tirx_paged_mqa(data)
     torch.cuda.synchronize()

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -1217,9 +1217,7 @@ def get_kernel(**kwargs: Any):
             # warp's tcgen05.alloc (see the UMMA role).
             K.ptx.bar.sync(9, K.uint32(num_math_threads + 2 * 32))
             math_wg_u32 = K.Cast("uint32", warpgroup_idx)
-            tmem_start_base = K.uint32(tmem_col) + math_wg_u32 * K.uint32(
-                umma_n * num_umma_stages
-            )
+            tmem_start_base = K.uint32(tmem_col) + math_wg_u32 * K.uint32(umma_n * num_umma_stages)
             math_thread_idx = K.local_scalar(
                 "uint32",
                 init=(K.Cast("uint32", K.warp_id_in_role()) % K.uint32(4)) * K.uint32(32)
@@ -1448,7 +1446,6 @@ def _compile_tirx_paged_mqa_key(config: PagedMQALogitsFP8Config) -> tuple[tuple[
 
 
 def _compile_tirx_paged_mqa(config: PagedMQALogitsFP8Config) -> Any:
-
     compile_kwargs = _compile_tirx_paged_mqa_kwargs(config)
     return _compile_tirx_paged_mqa_for_config(**compile_kwargs)
 
@@ -1798,6 +1795,8 @@ def run_test(**kwargs: Any) -> None:
     data = prepare_data(**kwargs)
     config: PagedMQALogitsFP8Config = data["config"]
     deepgemm_logits = _run_deepgemm_paged_mqa(data, clean_logits=False)
+    # Library-anchored: the torch ref is a yardstick, not the arbiter --
+    # DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
     deepgemm_diff = _assert_correct(data, deepgemm_logits, name="DeepGEMM")
     tirx_logits = _launch_tirx_paged_mqa(data)
     torch.cuda.synchronize()

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -1049,6 +1049,8 @@ def run_test(**kwargs: Any) -> None:
     data = prepare_data(**kwargs)
     deepgemm_d, deepgemm_sqr = _run_deepgemm_hc(data)
     torch.cuda.synchronize()
+    # Library-anchored: the torch ref is a yardstick, not the arbiter --
+    # DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
     deepgemm_diff = _assert_correct(data, deepgemm_d, deepgemm_sqr, name="DeepGEMM")
     tirx_d, tirx_sqr = _launch_tirx_hc(data)
     torch.cuda.synchronize()

--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -21,7 +21,6 @@ import os
 from functools import partial
 from typing import Any
 
-import numpy as np
 import torch
 
 import tirx_kernels.kern as K
@@ -1413,19 +1412,17 @@ def run_test(batch_size, seq_len, num_qo_heads, num_kv_heads, head_dim, is_causa
     launch()
     torch.cuda.synchronize()
 
-    q_ref = q.float().transpose(1, 2)
-    k_ref = k.float().transpose(1, 2)
-    v_ref = v.float().transpose(1, 2)
-    if num_qo_heads != num_kv_heads:
-        repeat_factor = num_qo_heads // num_kv_heads
-        k_ref = k_ref.repeat_interleave(repeat_factor, dim=1)
-        v_ref = v_ref.repeat_interleave(repeat_factor, dim=1)
-    scores = torch.matmul(q_ref, k_ref.transpose(-2, -1)) * (1.0 / math.sqrt(head_dim))
-    if is_causal:
-        mask = torch.triu(torch.ones(seq_len, seq_len, dtype=torch.bool), diagonal=1)
-        scores.masked_fill_(mask, float("-inf"))
-    ref = torch.matmul(torch.softmax(scores, dim=-1), v_ref).transpose(1, 2).to(torch.float16)
-    np.testing.assert_allclose(out.cpu().numpy(), ref.cpu().numpy(), rtol=0.01, atol=0.01)
+    # The upstream FA4 forward on the same inputs is the arbiter (the sibling
+    # backward port validates the same way via flash_attn.cute.interface).
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    with torch.no_grad():
+        ref = _flash_attn_fwd(
+            q=q_dev, k=k_dev, v=v_dev, softmax_scale=1.0 / math.sqrt(head_dim), causal=is_causal
+        )[0]
+    if not torch.isfinite(out).all():
+        raise AssertionError("output contains a non-finite value")
+    torch.testing.assert_close(out, ref, rtol=0.01, atol=0.01)
 
 
 def run_gpu(

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -17,7 +17,6 @@ from typing import Any
 from unittest import SkipTest
 
 import torch
-import torch.nn.functional as F
 
 import tirx_kernels.kern as K
 
@@ -547,9 +546,6 @@ def run_test(B: int, O: int, K: int) -> None:
     case = prepare_data(B, O, K)
     num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
     stage = _select_stage(B, O, K, num_sms)
-    linear_ref = F.linear(
-        case["input"].float(), case["weight"].float(), case["bias"].float()
-    ).bfloat16()
 
     for use_pdl in (False, True):
         tirx_out = torch.zeros_like(case["out"])
@@ -565,7 +561,6 @@ def run_test(B: int, O: int, K: int) -> None:
                 f"stage={stage}, use_pdl={use_pdl}: {differing} elements, "
                 f"max_abs_diff={max_diff}"
             )
-        torch.testing.assert_close(tirx_out.float(), linear_ref.float(), atol=1e-2, rtol=1e-2)
 
 
 def prepare_bench(B: int, O: int, K: int):

--- a/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
+++ b/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
@@ -599,48 +599,6 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
     return case
 
 
-def _reference_torch(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Token-serial reference, mirrors tests/kda/test_recurrent_kda_prefill.py::_reference.
-
-    O(total_tokens) python loop; intended for the small correctness configs.
-    """
-    import torch.nn.functional as F
-
-    cfg: FlashKDABf16FusedM128Config = case["config"]
-    scale = case["scale"]
-    q_flat = F.normalize(case["q"].float(), dim=-1)
-    k_flat = F.normalize(case["k"].float(), dim=-1)
-    v_flat = case["v"].float()
-    g_flat = case["g"].float()
-    beta_flat = torch.sigmoid(case["beta"].float())
-    gate = cfg.lower_bound * torch.sigmoid(
-        torch.exp(case["A_log"]).reshape(1, cfg.num_heads, 1)
-        * (g_flat + case["dt_bias"].reshape(1, cfg.num_heads, D_HEAD))
-    )
-    decay = torch.exp(gate)
-    if cfg.use_initial_state:
-        state = case["initial_state"].clone()
-    else:
-        state = torch.zeros(
-            (cfg.num_seqs, cfg.num_heads, D_HEAD, D_HEAD),
-            dtype=torch.bfloat16,
-            device=case["q"].device,
-        )
-    out = torch.empty_like(q_flat)
-    offsets = [0, *torch.cumsum(torch.tensor(cfg.seq_lens), dim=0).tolist()]
-    for sequence in range(cfg.num_seqs):
-        for token in range(offsets[sequence], offsets[sequence + 1]):
-            state_f32 = state[sequence].float()
-            decayed = state_f32 * decay[token].unsqueeze(1)
-            predicted = torch.einsum("hk,hvk->hv", k_flat[token], decayed)
-            residual = beta_flat[token].unsqueeze(-1) * (v_flat[token] - predicted)
-            updated = decayed + residual.unsqueeze(-1) * k_flat[token].unsqueeze(1)
-            state[sequence] = updated.to(torch.bfloat16)
-            projected = torch.einsum("hk,hvk->hv", q_flat[token], state[sequence].float())
-            out[token] = (scale * projected).to(torch.bfloat16)
-    return out.to(torch.bfloat16), state
-
-
 def _load_flashinfer_recurrent_kda():
     """Import the reference kernel from the installed flashinfer."""
     try:
@@ -2531,14 +2489,13 @@ def run_test(**kwargs: Any) -> None:
     compile_kernel(bf16_fused_m128(**kwargs))(*_tirx_args(case))
     torch.cuda.synchronize()
 
-    ref_out, ref_state = _reference_torch(case)
-    torch.testing.assert_close(case["out"], ref_out, rtol=4.01 / 128, atol=5e-3)
-    if cfg.store_final_state:
-        torch.testing.assert_close(case["final_state"], ref_state, rtol=4.01 / 128, atol=5e-3)
-
     flashinfer_out, flashinfer_state = _flashinfer_cuda_reference(case)
     torch.testing.assert_close(case["out"], flashinfer_out, rtol=4.01 / 128, atol=5e-3)
-    if cfg.store_final_state and flashinfer_state is not None:
+    if cfg.store_final_state:
+        # The state comparison must not silently vanish when the reference
+        # declines to return one.
+        if flashinfer_state is None:
+            raise AssertionError("store_final_state set but the reference returned no state")
         torch.testing.assert_close(
             case["final_state"],
             flashinfer_state.reshape(case["final_state"].shape),

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -758,62 +758,11 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the source math (direct_split16.cu:133-267)."""
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots = case["ssm_state_indices"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state = state_raw.as_strided(
-        (state_raw.numel() // slot_stride, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs, num_value_heads, HEAD_DIM), device=case["device"], dtype=torch.float32
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        slot = int(slots[n].item())
-        if slot < 0:
-            continue
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            qn = q[n, h] * (torch.rsqrt(q[n, h].pow(2).sum() + L2_EPS) * scale)
-            kn = k[n, h] * torch.rsqrt(k[n, h].pow(2).sum() + L2_EPS)
-            gamma = torch.exp(g[n, hv])
-            kq = torch.dot(kn, qn)
-
-            s = state[slot, hv].float()
-            decayed = s * gamma.unsqueeze(0)
-            pred = decayed @ kn
-            base = decayed @ qn
-            delta = (v[n, hv] - pred) * beta[n, hv]
-            state[slot, hv] = (decayed + delta.unsqueeze(1) * kn.unsqueeze(0)).to(torch.bfloat16)
-            out[n, hv] = base + delta * kq
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port reproduces the source's instruction selection and association orders,
 # so it should agree with the frozen export to within bf16 rounding, not merely
 # to an algorithmic tolerance.
 _RTOL = 2.0**-8
 _ATOL = 1.0e-4
-# The independent FP32 oracle accumulates in a different order, so it gets the
-# looser band.
-_ORACLE_RTOL = 2.0**-6
-_ORACLE_ATOL = 3.0e-4
 
 
 def prepare_bench(**kwargs: Any):
@@ -838,7 +787,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -855,24 +804,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same math
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerance checks above cannot express
+    # 2. invariants the tolerance checks above cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -1041,82 +1041,10 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the T=2 delta rule.
-
-    Written as the sequential recurrence the WY transform computes in blocked
-    form, which is the point: it agrees only if the WY algebra is right. It
-    keeps the kernel's two structural choices -- the recurrent state advances in
-    FP32 across both tokens (only the stored checkpoint is rounded to bf16), and
-    the initial slot is selected by the clamped num_accepted_tokens.
-    """
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots2d = case["ssm_state_indices_2d"]
-    nat = case["num_accepted_tokens"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state_slots = state_raw.numel() // slot_stride
-    state = state_raw.as_strided(
-        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
-        device=case["device"],
-        dtype=torch.float32,
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
-        init_slot = int(slots2d[n, accepted].item())
-        if init_slot < 0:
-            init_slot = 0
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            # FP32 carry across both tokens; only the checkpoint store rounds.
-            s = state[init_slot, hv].float()
-            for t in range(NUM_TOKENS):
-                row = n * NUM_TOKENS + t
-                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
-                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
-                gamma = torch.exp(g[row, hv])
-
-                decayed = s * gamma.unsqueeze(0)
-                pred = decayed @ kn
-                u = v[row, hv] - pred
-                delta = u * beta[row, hv]
-                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
-                out[row, hv] = s @ qn
-
-                slot = int(slots2d[n, t].item())
-                if slot >= 0:
-                    state[slot, hv] = s.to(torch.bfloat16)
-                else:
-                    out[row, hv] = 0.0
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port replicates the source's MMA chain, swizzle and association orders, so
 # it should agree with the frozen export to within bf16 rounding.
 _RTOL = 2.0**-8
 _ATOL = 2.0e-3
-# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
-# operands to bf16, so the band here is genuinely wider and measured, not
-# guessed: at scaffold time the export itself sat 6.1e-05 from the oracle.
-_ORACLE_RTOL = 2.0**-5
-_ORACLE_ATOL = 6.0e-3
 
 
 def prepare_bench(**kwargs: Any):
@@ -1141,7 +1069,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -1158,24 +1086,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same recurrence
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerances cannot express
+    # 2. invariants the tolerances cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -856,82 +856,10 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the T=3 delta rule (sequential form)."""
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    a_log = case["a_log"].float()
-    dt_bias = case["dt_bias"].float().reshape(spec["NUM_HEADS"], HEAD_DIM)
-    lower_bound = float(case["lower_bound"])
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots2d = case["ssm_state_indices_2d"]
-    nat = case["num_accepted_tokens"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state_slots = state_raw.numel() // slot_stride
-    state = state_raw.as_strided(
-        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
-        device=case["device"],
-        dtype=torch.float32,
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
-        init_slot = int(slots2d[n, accepted].item())
-        if init_slot < 0:
-            init_slot = 0
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            # FP32 carry across all tokens; only the checkpoint store rounds.
-            s = state[init_slot, hv].float()
-            for t in range(NUM_TOKENS):
-                row = n * NUM_TOKENS + t
-                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
-                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
-                # GATE_KIND == 1: the gate is derived here, not supplied.
-                # log_gate = lower_bound * sigmoid(exp(A_log[h]) * (g + dt_bias))
-                gate_a = torch.exp(a_log[h])
-                biased = g[row, hv] + dt_bias[h]
-                log_gate = lower_bound / (1.0 + torch.exp(-gate_a * biased))
-                gamma = torch.exp(log_gate)
-
-                decayed = s * gamma.unsqueeze(0)
-                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
-                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
-                out[row, hv] = s @ qn
-
-                slot = int(slots2d[n, t].item())
-                if slot >= 0:
-                    state[slot, hv] = s.to(torch.bfloat16)
-                else:
-                    out[row, hv] = 0.0
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port replicates the source's MMA chain, swizzle and association orders, so
 # it should agree with the frozen export to within bf16 rounding.
 _RTOL = 2.0**-8
 _ATOL = 2.0e-3
-# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
-# operands to bf16, so the band here is genuinely wider and measured, not
-# guessed: at scaffold time the export itself sat 3.1e-05 from the oracle.
-_ORACLE_RTOL = 2.0**-5
-_ORACLE_ATOL = 6.0e-3
 
 
 def prepare_bench(**kwargs: Any):
@@ -956,7 +884,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -973,24 +901,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same recurrence
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerances cannot express
+    # 2. invariants the tolerances cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -785,73 +785,10 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the T=4 delta rule (sequential form)."""
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots2d = case["ssm_state_indices_2d"]
-    nat = case["num_accepted_tokens"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state_slots = state_raw.numel() // slot_stride
-    state = state_raw.as_strided(
-        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
-        device=case["device"],
-        dtype=torch.float32,
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
-        init_slot = int(slots2d[n, accepted].item())
-        if init_slot < 0:
-            init_slot = 0
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            # FP32 carry across all tokens; only the checkpoint store rounds.
-            s = state[init_slot, hv].float()
-            for t in range(NUM_TOKENS):
-                row = n * NUM_TOKENS + t
-                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
-                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
-                gamma = torch.exp(g[row, hv])
-
-                decayed = s * gamma.unsqueeze(0)
-                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
-                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
-                out[row, hv] = s @ qn
-
-                slot = int(slots2d[n, t].item())
-                if slot >= 0:
-                    state[slot, hv] = s.to(torch.bfloat16)
-                else:
-                    out[row, hv] = 0.0
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port replicates the source's MMA chain, swizzle and association orders, so
 # it should agree with the frozen export to within bf16 rounding.
 _RTOL = 2.0**-8
 _ATOL = 2.0e-3
-# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
-# operands to bf16, so the band here is genuinely wider and measured, not
-# guessed: at scaffold time the export itself sat 6.1e-05 from the oracle.
-_ORACLE_RTOL = 2.0**-5
-_ORACLE_ATOL = 6.0e-3
 
 
 def prepare_bench(**kwargs: Any):
@@ -876,7 +813,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -893,24 +830,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same recurrence
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerances cannot express
+    # 2. invariants the tolerances cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
@@ -1107,74 +1107,10 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the T=5 delta rule (sequential form)."""
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots2d = case["ssm_state_indices_2d"]
-    nat = case["num_accepted_tokens"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state_slots = state_raw.numel() // slot_stride
-    state = state_raw.as_strided(
-        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
-        device=case["device"],
-        dtype=torch.float32,
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
-        init_slot = int(slots2d[n, accepted].item())
-        if init_slot < 0:
-            init_slot = 0
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            # FP32 carry across all tokens; only the checkpoint store rounds.
-            s = state[init_slot, hv].float()
-            for t in range(NUM_TOKENS):
-                row = n * NUM_TOKENS + t
-                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
-                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
-                gamma = torch.exp(g[row, hv])
-
-                decayed = s * gamma.unsqueeze(0)
-                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
-                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
-                out[row, hv] = s @ qn
-
-                slot = int(slots2d[n, t].item())
-                if slot >= 0:
-                    state[slot, hv] = s.to(torch.bfloat16)
-                else:
-                    out[row, hv] = 0.0
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port replicates the source's MMA chain, swizzle and association orders, so
 # it should agree with the frozen export to within bf16 rounding.
 _RTOL = 2.0**-8
 _ATOL = 2.0e-3
-# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
-# operands to bf16 -- and at T=5 the WY coefficients themselves come from a
-# bf16 Gram product of `k / prefix`, so this band is wider than the T<=4 one and
-# is re-measured at the correctness gate rather than inherited.
-_ORACLE_RTOL = 2.0**-5
-_ORACLE_ATOL = 6.0e-3
 
 
 def prepare_bench(**kwargs: Any):
@@ -1199,7 +1135,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -1216,24 +1152,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export (split {spec['VALUE_SPLIT']})\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same recurrence
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerances cannot express
+    # 2. invariants the tolerances cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -1257,74 +1257,10 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     return reference_out
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the T=6 delta rule (sequential form)."""
-    spec = case["spec"]
-    num_seqs = spec["NUM_SEQS"]
-    num_value_heads = spec["NUM_VALUE_HEADS"]
-    head_ratio = spec["HEAD_RATIO"]
-    slot_stride = spec["STATE_SLOT_STRIDE"]
-
-    q = case["q"][0].float()
-    k = case["k"][0].float()
-    v = case["v"][0].float()
-    g = case["g"][0].float()
-    beta = case["beta"][0].float()
-    slots2d = case["ssm_state_indices_2d"]
-    nat = case["num_accepted_tokens"]
-
-    state_raw = case["initial_state_raw"].clone()
-    state_slots = state_raw.numel() // slot_stride
-    state = state_raw.as_strided(
-        (state_slots, num_value_heads, HEAD_DIM, HEAD_DIM),
-        (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-    )
-    out = torch.zeros(
-        (num_seqs * NUM_TOKENS, num_value_heads, HEAD_DIM),
-        device=case["device"],
-        dtype=torch.float32,
-    )
-
-    scale = float(case["scale"])
-    for n in range(num_seqs):
-        accepted = min(max(int(nat[n].item()) - 1, 0), NUM_TOKENS - 1)
-        init_slot = int(slots2d[n, accepted].item())
-        if init_slot < 0:
-            init_slot = 0
-        for hv in range(num_value_heads):
-            h = hv // head_ratio
-            # FP32 carry across all tokens; only the checkpoint store rounds.
-            s = state[init_slot, hv].float()
-            for t in range(NUM_TOKENS):
-                row = n * NUM_TOKENS + t
-                qn = q[row, h] * (torch.rsqrt(q[row, h].pow(2).sum() + L2_EPS) * scale)
-                kn = k[row, h] * torch.rsqrt(k[row, h].pow(2).sum() + L2_EPS)
-                gamma = torch.exp(g[row, hv])
-
-                decayed = s * gamma.unsqueeze(0)
-                delta = (v[row, hv] - decayed @ kn) * beta[row, hv]
-                s = decayed + delta.unsqueeze(1) * kn.unsqueeze(0)
-                out[row, hv] = s @ qn
-
-                slot = int(slots2d[n, t].item())
-                if slot >= 0:
-                    state[slot, hv] = s.to(torch.bfloat16)
-                else:
-                    out[row, hv] = 0.0
-
-    return out.to(torch.bfloat16).unsqueeze(0), state_raw
-
-
 # The port replicates the source's MMA chain, swizzle and association orders, so
 # it should agree with the frozen export to within bf16 rounding.
 _RTOL = 2.0**-8
 _ATOL = 2.0e-3
-# The FP32 oracle is the sequential delta rule; the kernel rounds its MMA
-# operands to bf16 -- and at T=6 the WY coefficients themselves come from a
-# bf16 Gram product of `k / prefix`, so this band is wider than the T<=4 one and
-# is re-measured at the correctness gate rather than inherited.
-_ORACLE_RTOL = 2.0**-5
-_ORACLE_ATOL = 6.0e-3
 
 
 def prepare_bench(**kwargs: Any):
@@ -1349,7 +1285,7 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = case["tirx_state_raw"].clone()
 
-    # 1. the frozen cake export itself, on an independent state pool
+    # 1. the frozen cake export (the arbiter) itself, on an independent state pool
     reference_out = _flashinfer_reference(case)
     torch.testing.assert_close(
         tirx_out.float(),
@@ -1366,24 +1302,7 @@ def run_test(**kwargs: Any) -> None:
         msg=lambda m: f"state vs flashinfer cake export (split {spec['VALUE_SPLIT']})\n{m}",
     )
 
-    # 2. an independent FP32 oracle of the same recurrence
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        tirx_out.float(),
-        oracle_out.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"output vs FP32 oracle\n{m}",
-    )
-    torch.testing.assert_close(
-        tirx_state.float(),
-        oracle_state.float(),
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
-        msg=lambda m: f"state vs FP32 oracle\n{m}",
-    )
-
-    # 3. invariants the tolerances cannot express
+    # 2. invariants the tolerances cannot express
     num_seqs = spec["NUM_SEQS"]
     slot_stride = spec["STATE_SLOT_STRIDE"]
     payload = spec["NUM_VALUE_HEADS"] * HEAD_DIM * HEAD_DIM

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -979,92 +979,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """FP32 oracle: the same recurrence, written as dense torch.
-
-    Two semantics are easy to get wrong and are what this oracle exists to pin:
-
-    * the recurrent state is carried in **FP32** across the tokens of a row and
-      is only rounded to BF16 on the way to its checkpoint slot -- token ``t+1``
-      consumes the FP32 value, not the round-tripped one (recurrent_kda.py:708
-      writes ``sb1`` while ``s`` keeps its precision);
-    * ``rk`` appears twice in ``deltak = rk * bb * (ve - rk * pred)`` (:681);
-      one factor normalizes the key inside the prediction, the other normalizes
-      the key of the rank-1 update.
-
-    Returns ``(out, state_pool)`` with the pool laid out as the kernel sees it.
-    """
-    spec = case["spec"]
-    dev = case["device"]
-    tokens, heads = spec["NUM_TOKENS"], spec["NUM_VALUE_HEADS"]
-    n_seq, q_total = spec["NUM_SEQS"], spec["Q_TOTAL"]
-    ratio = spec["RATIO"]
-    mode = spec["GATE_MODE"]
-    lower_bound = case["lower_bound"]
-    scale = case["scale"]
-
-    f32 = torch.float32
-    q = case["q"].reshape(q_total, spec["NUM_HEADS"], HEAD_DIM).to(f32)
-    k = case["k"].reshape(q_total, spec["NUM_HEADS"], HEAD_DIM).to(f32)
-    v = case["v"].reshape(q_total, heads, HEAD_DIM).to(f32)
-    g = case["g"].reshape(q_total, heads, HEAD_DIM).to(f32)
-    beta = case["beta"].reshape(q_total, heads).to(f32)
-    dt_bias = case["dt_bias"].reshape(spec["NUM_HEADS"], HEAD_DIM).to(f32)
-    av = torch.exp(case["a_log"].to(f32))  # [H]
-    cu = case["cu_seqlens"].tolist()
-    idx = case["ssm_state_indices"].reshape(n_seq, tokens)
-
-    pool = _state_view(case["initial_state_raw"], case).to(f32).clone()
-    out = torch.zeros((q_total, heads, HEAD_DIM), device=dev, dtype=f32)
-
-    head_of = torch.arange(heads, device=dev) // ratio  # hv -> h
-
-    for n in range(n_seq):
-        token_base = cu[n]
-        seq_len = cu[n + 1] - token_base
-        # num_accepted_tokens is never supplied by SGLang, so ic collapses to 0.
-        slot0 = int(idx[n, 0])
-        state = pool[max(slot0, 0)].clone()  # [HV, V, K] f32
-
-        for t in range(tokens):
-            slot = int(idx[n, t])
-            in_row = t < seq_len
-            if not in_row:
-                continue  # written by nobody
-            if slot < 0:
-                out[token_base + t] = 0.0  # pad row
-                continue
-
-            p = token_base + t
-            qt, kt = q[p][head_of], k[p][head_of]  # [HV, K]
-            vt, gt, bt = v[p], g[p], beta[p]
-
-            x = gt + dt_bias[head_of]
-            if mode == GATE_MODE_SOFTPLUS:
-                sp = torch.log1p(torch.exp(x))
-                sp = torch.where(x > SOFTPLUS_LINEAR_THRESHOLD, x, sp)
-                gate = -av[head_of].unsqueeze(-1) * sp
-            else:
-                gate = lower_bound * torch.sigmoid(av[head_of].unsqueeze(-1) * x)
-            eg = torch.exp(gate)  # [HV, K]
-
-            rk = torch.rsqrt((kt * kt).sum(-1) + L2_EPS)  # [HV]
-            rq = torch.rsqrt((qt * qt).sum(-1) + L2_EPS) * scale
-
-            state = state * eg.unsqueeze(1)  # decay along K
-            pred = torch.einsum("hvk,hk->hv", state, kt)
-            deltak = rk.unsqueeze(-1) * bt.unsqueeze(-1) * (vt - rk.unsqueeze(-1) * pred)
-            state = state + deltak.unsqueeze(-1) * kt.unsqueeze(1)
-            out[p] = rq.unsqueeze(-1) * torch.einsum("hvk,hk->hv", state, qt)
-
-            # The checkpoint rounds to BF16; the carried state does not.
-            pool[slot] = state.to(torch.bfloat16).to(f32)
-
-    if q_total > cu[n_seq]:
-        out[cu[n_seq] :] = 0.0  # orphan suffix
-    return out.reshape(1, q_total, heads, HEAD_DIM), pool
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the FlashInfer CuTe DSL source on the reference state pool.
 
@@ -1105,9 +1019,6 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
 # Two bfloat16 ULP against the source, matching the one-warp sibling.
 _RTOL = 2.0**-7
 _ATOL = 1.0e-4
-# The FP32 oracle reassociates freely, so it only needs to agree to bf16 noise.
-_ORACLE_RTOL = 2.0**-6
-_ORACLE_ATOL = 3.0e-4
 
 
 def _assert_close(got, want, rtol, atol, what: str) -> None:
@@ -1145,18 +1056,11 @@ def run_test(**kwargs: Any) -> None:
     tirx_out = case["tirx_out"]
     tirx_state = _state_view(case["tirx_state_raw"], case)
 
-    # Primary oracle: the CuTe DSL source itself, on its own pool clone.
+    # The CuTe DSL source itself, on its own pool clone, is the arbiter.
     ref_out = _flashinfer_reference(case)
     ref_state = _state_view(case["reference_state_raw"], case)
     _assert_close(tirx_out, ref_out, _RTOL, _ATOL, "output vs flashinfer")
     _assert_close(tirx_state, ref_state, _RTOL, _ATOL, "state vs flashinfer")
-
-    # Secondary oracle: dense FP32 torch, from the untouched initial pool.
-    oracle_out, oracle_state = _torch_reference(case)
-    _assert_close(tirx_out, oracle_out, _ORACLE_RTOL, _ORACLE_ATOL, "output vs fp32 oracle")
-    _assert_close(
-        tirx_state.float(), oracle_state, _ORACLE_RTOL, _ORACLE_ATOL, "state vs fp32 oracle"
-    )
 
     # ---- branch-specific obligations -------------------------------------
     tokens, n_seq = spec["NUM_TOKENS"], spec["NUM_SEQS"]

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -888,71 +888,6 @@ def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _torch_reference(case: dict[str, Any]) -> tuple[torch.Tensor, torch.Tensor]:
-    """Independent FP32 oracle of the source math (recurrent_kda.py:88-148, :440-468).
-
-    Secondary to the FlashInfer comparison: it catches a shared-misreading of the
-    algorithm that a source-vs-port diff alone could not.
-    """
-    spec = case["spec"]
-    n_seq = spec["NUM_SEQS"]
-    hv = spec["NUM_VALUE_HEADS"]
-    h = spec["NUM_HEADS"]
-    ratio = hv // h
-    lower_bound = case["lower_bound"]
-    eps = case["eps"]
-    scale = case["scale"]
-
-    q = case["q"].float()[0]
-    k = case["k"].float()[0]
-    v = case["v"].float()[0]
-    g = case["g"].float()[0]
-    beta = case["beta"].float()[0]
-    a_log = case["a_log"].float()
-    dt_bias = case["dt_bias"].float().reshape(h, HEAD_DIM)
-    slots = case["ssm_state_indices"]
-
-    state = (
-        case["initial_state_raw"]
-        .float()
-        .as_strided(
-            (
-                case["initial_state_raw"].numel() // spec["STATE_SLOT_STRIDE"],
-                hv,
-                HEAD_DIM,
-                HEAD_DIM,
-            ),
-            (spec["STATE_SLOT_STRIDE"], HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
-        )
-        .clone()
-    )
-    out = torch.zeros((n_seq, hv, HEAD_DIM), device=q.device, dtype=torch.float32)
-
-    for n in range(n_seq):
-        slot = int(slots[n])
-        if slot < 0:
-            continue  # inactive row: output stays zero, state untouched
-        for vh in range(hv):
-            qh = vh // ratio
-            gate_in = g[n, vh] + dt_bias[qh]
-            a = torch.exp(a_log[qh])
-            if lower_bound is None:
-                gate = torch.exp2(-a * torch.log2(1.0 + torch.exp(gate_in)))
-            else:
-                gate = torch.exp2(lower_bound * _LOG2_E_T * torch.sigmoid(a * gate_in))
-            qn = q[n, qh] * (torch.rsqrt((q[n, qh] ** 2).sum() + eps) * scale)
-            kn = k[n, qh] * torch.rsqrt((k[n, qh] ** 2).sum() + eps)
-            s = state[slot, vh] * gate.unsqueeze(0)
-            delta = (v[n, vh] - s @ kn) * beta[n, vh]
-            s = s + torch.outer(delta, kn)
-            state[slot, vh] = s
-            out[n, vh] = s @ qn
-    return out, state
-
-
-_LOG2_E_T = 1.4426950408889634
-
-
 def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
     """Run the FlashInfer CuTe DSL source on the reference state pool."""
     import importlib
@@ -985,8 +920,6 @@ def _flashinfer_reference(case: dict[str, Any]) -> torch.Tensor:
 _RTOL = 2.0**-7
 _ATOL = 1.0e-4
 # The FP32 oracle reassociates freely, so it only needs to agree to bf16 noise.
-_ORACLE_RTOL = 2.0**-6
-_ORACLE_ATOL = 3.0e-4
 
 
 def prepare_bench(**kwargs: Any):
@@ -1013,15 +946,6 @@ def run_test(**kwargs: Any) -> None:
     torch.testing.assert_close(case["tirx_out"], flashinfer_out, rtol=_RTOL, atol=_ATOL)
     torch.testing.assert_close(
         case["tirx_state_raw"], case["reference_state_raw"], rtol=_RTOL, atol=_ATOL
-    )
-
-    # Secondary: an independent FP32 oracle of the same math.
-    oracle_out, oracle_state = _torch_reference(case)
-    torch.testing.assert_close(
-        case["tirx_out"].float().reshape(oracle_out.shape),
-        oracle_out,
-        rtol=_ORACLE_RTOL,
-        atol=_ORACLE_ATOL,
     )
 
     # Inactive (negative-slot) rows must be zeroed and must not touch state.

--- a/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
@@ -1615,44 +1615,16 @@ def _assert_raw_equal(actual, expected, config: dict[str, Any], *, name: str) ->
         raise AssertionError(f"{name}: {count} y_norm values differ")
 
 
-def _dequantize(output, data, config: dict[str, Any]):
-    import torch
-
-    M, H = int(config["M"]), int(config["H"])
-    packed = output["y"].view(M, H // 2)
-    nibbles = torch.stack((packed & 0x0F, packed >> 4), dim=-1).reshape(M, H).long()
-    table = torch.tensor(
-        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-        device="cuda",
-        dtype=torch.float32,
-    )
-    fp4 = table[nibbles]
-    scale_bytes = _logical_scale_bytes(output, config)
-    if int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3":
-        scales = scale_bytes.view(torch.float8_e4m3fn).float()
-        scales = scales / data["global_scale"].float()
-    else:
-        scales = torch.pow(2.0, scale_bytes.int() - 127)
-    return (fp4.view(M, -1, int(config["block_size"])) * scales[..., None]).reshape(M, H)
-
-
-def _math_oracle(data, snapshot, config: dict[str, Any]):
-    h_fp32 = (
-        snapshot["x"].view(int(config["M"]), int(config["H"])).float()
-        + snapshot["residual"].view(int(config["M"]), int(config["H"])).float()
-    )
-    rstd = (h_fp32.square().mean(dim=-1, keepdim=True) + float(config["eps"])).rsqrt()
-    h_narrow = h_fp32.to(_torch_input_dtype(str(config["input_dtype"])))
-    weight = data["weight"].float()
-    if int(_source_config(int(config["H"]))["cluster_n"]) == 1:
-        return h_narrow.float() * rstd * weight
-    product = (h_narrow * data["weight"]).to(_torch_input_dtype(str(config["input_dtype"])))
-    return product.float() * rstd
-
-
 def _assert_math(output, data, snapshot, config: dict[str, Any]) -> None:
+    """Zero-global-scale invariant only; FlashInfer's raw bytes are the arbiter.
+
+    A zero global scale must yield signed-zero FP4 payloads and scales, and the
+    bitwise FlashInfer comparison cannot distinguish "both wrong the same way"
+    for this degenerate input, so the invariant is asserted directly.
+    """
     import torch
 
+    del snapshot
     if (int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3") and float(
         data["global_scale"].item()
     ) == 0.0:
@@ -1660,26 +1632,6 @@ def _assert_math(output, data, snapshot, config: dict[str, Any]) -> None:
             _logical_scale_bytes(output, config)
         ):
             raise AssertionError("zero global scale must produce signed-zero FP4 and scales")
-        return
-    oracle = _math_oracle(data, snapshot, config)
-    dequantized = _dequantize(output, data, config)
-    if not torch.isfinite(dequantized).all():
-        raise AssertionError("dequantized output contains non-finite values")
-    torch.testing.assert_close(
-        dequantized,
-        oracle,
-        rtol=0.5,
-        atol=2.0,
-        msg=lambda message: f"independent FP32 add/RMSNorm oracle: {message}",
-    )
-    if bool(config["output_norm"]):
-        torch.testing.assert_close(
-            output["y_norm"],
-            oracle.to(_torch_input_dtype(str(config["input_dtype"]))),
-            rtol=1e-2,
-            atol=1e-2,
-            msg=lambda message: f"optional y_norm oracle: {message}",
-        )
 
 
 def _check_public_allocation(reference, reference_data, config: dict[str, Any]) -> None:

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
@@ -1103,7 +1103,6 @@ def run_test(**config: Any) -> None:
     rows = snapshot["rows"]
     actual_input = _checked_view(data["input"], rows)
     actual_residual = _checked_view(data["residual"], rows)
-    oracle_input, oracle_residual = _math_oracle(snapshot, variant, eps)
     if not torch.isfinite(actual_input).all() or not torch.isfinite(actual_residual).all():
         raise AssertionError("TIRx fused add RMSNorm produced non-finite values")
     if reference is not None:
@@ -1111,8 +1110,12 @@ def run_test(**config: Any) -> None:
         reference_residual = _checked_view(reference["residual"], rows)
         _assert_close(actual_input, reference_input, name="FlashInfer input output")
         _assert_close(actual_residual, reference_residual, name="FlashInfer residual output")
-    _assert_close(actual_input, oracle_input, name="FP32 input oracle")
-    _assert_close(actual_residual, oracle_residual, name="FP32 residual oracle")
+    else:
+        # The rolled-fragment rows exceed what the CuTe reference can run, so
+        # the FP32 oracle is the only available arbiter for them.
+        oracle_input, oracle_residual = _math_oracle(snapshot, variant, eps)
+        _assert_close(actual_input, oracle_input, name="FP32 input oracle")
+        _assert_close(actual_residual, oracle_residual, name="FP32 residual oracle")
     if not torch.equal(data["weight"], snapshot["weight"]):
         raise AssertionError("TIRx modified weight")
     _assert_guard(data["weight_backing"], H, name="TIRx weight")

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
@@ -1363,7 +1363,6 @@ def run_test(**config: Any) -> None:
     rows = snapshot["rows"]
     actual_output = _checked_view(output["view"], rows)
     actual_residual = _checked_view(data["residual"], rows)
-    oracle_output, oracle_residual = _math_oracle(snapshot, eps, output_dtype)
     if not torch.isfinite(actual_output.float()).all():
         raise AssertionError("TIRx FP8 output contains non-finite values")
     if not torch.isfinite(actual_residual.float()).all():
@@ -1379,10 +1378,14 @@ def run_test(**config: Any) -> None:
             _checked_view(reference["residual"], rows),
             name="FlashInfer residual oracle",
         )
-    _assert_math_close(actual_output, oracle_output, name="independent FP32 output oracle")
-    _assert_residual_close(
-        actual_residual, oracle_residual, name="independent FP32 residual oracle"
-    )
+    else:
+        # The rolled-fragment rows exceed what the CuTe reference can run, so
+        # the FP32 oracle is the only available arbiter for them.
+        oracle_output, oracle_residual = _math_oracle(snapshot, eps, output_dtype)
+        _assert_math_close(actual_output, oracle_output, name="independent FP32 output oracle")
+        _assert_residual_close(
+            actual_residual, oracle_residual, name="independent FP32 residual oracle"
+        )
     if not torch.equal(_checked_view(data["input"], rows), snapshot["input"]):
         raise AssertionError("TIRx modified input")
     if not torch.equal(data["weight"], snapshot["weight"]):

--- a/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
@@ -879,7 +879,6 @@ def run_test(**config: Any) -> None:
     torch.cuda.synchronize()
 
     _assert_outputs_match(tirx_output, source_output, config, name="FlashInfer CUDA oracle")
-    _assert_math(tirx_output, data, config)
     _assert_output_integrity(tirx_output, config, name="TIRx output")
     _assert_output_integrity(source_output, config, name="FlashInfer output")
     _check_public_wrappers(source_module, data, source_output, config)
@@ -1361,56 +1360,6 @@ def _logical_sf_bytes(sf, config: dict[str, Any]):
     return sf.reshape(-1)[offsets]
 
 
-def _dequantize(output: dict[str, Any], data: dict[str, Any], config: dict[str, Any]):
-    import torch
-
-    batch_size = int(config["batch_size"])
-    num_rows = int(config["num_rows"])
-    output_format = str(config["output_format"])
-    payload = output["norm"].view(torch.uint8)
-    scale_bytes = _logical_sf_bytes(output["sf"], config)
-    if output_format == "nvfp4":
-        payload = payload.view(batch_size, num_rows, _HIDDEN_SIZE // 2)
-        nibbles = torch.stack((payload & 0x0F, payload >> 4), dim=-1)
-        nibbles = nibbles.reshape(batch_size, num_rows, _HIDDEN_SIZE).long()
-        table = torch.tensor(
-            [
-                0.0,
-                0.5,
-                1.0,
-                1.5,
-                2.0,
-                3.0,
-                4.0,
-                6.0,
-                -0.0,
-                -0.5,
-                -1.0,
-                -1.5,
-                -2.0,
-                -3.0,
-                -4.0,
-                -6.0,
-            ],
-            dtype=torch.float32,
-            device="cuda",
-        )
-        values = table[nibbles].view(batch_size, num_rows, _HIDDEN_SIZE // 16, 16)
-        scales = scale_bytes.contiguous().view(torch.float8_e4m3fn).float()
-        scales = scales / data["output_sf_scale"].float()
-        return (values * scales[..., None]).reshape(batch_size, num_rows, _HIDDEN_SIZE)
-
-    values = payload.contiguous().view(torch.float8_e4m3fn).float()
-    values = values.view(batch_size, num_rows, _HIDDEN_SIZE // 32, 32)
-    exponent = scale_bytes.int() - 127
-    scales = torch.where(
-        scale_bytes == 0,
-        torch.zeros_like(scale_bytes, dtype=torch.float32),
-        torch.pow(torch.tensor(2.0, device="cuda"), exponent),
-    )
-    return (values * scales[..., None]).reshape(batch_size, num_rows, _HIDDEN_SIZE)
-
-
 def _assert_outputs_match(
     actual: dict[str, Any], expected: dict[str, Any], config: dict[str, Any], *, name: str
 ) -> None:
@@ -1442,38 +1391,6 @@ def _assert_outputs_match(
     if not torch.equal(actual_sf, expected_sf):
         count = int((actual_sf != expected_sf).sum().item())
         raise AssertionError(f"{name}: {count} logical scale-factor bytes differ")
-
-
-def _assert_math(output, data, config: dict[str, Any]) -> None:
-    import torch
-
-    oracle_residual, oracle_norm = _math_oracle(data, config)
-    torch.testing.assert_close(
-        output["residual"],
-        oracle_residual,
-        rtol=1.6e-2,
-        atol=1e-5,
-        msg=lambda message: f"independent FP32 residual oracle: {message}",
-    )
-    if str(config["output_format"]) == "bf16":
-        torch.testing.assert_close(
-            output["norm"],
-            oracle_norm,
-            rtol=1.6e-2,
-            atol=1e-5,
-            msg=lambda message: f"independent FP32 LayerNorm oracle: {message}",
-        )
-    else:
-        dequantized = _dequantize(output, data, config)
-        if not torch.isfinite(dequantized).all():
-            raise AssertionError("dequantized norm output contains non-finite values")
-        torch.testing.assert_close(
-            dequantized,
-            oracle_norm.float(),
-            rtol=0.5,
-            atol=2.0,
-            msg=lambda message: f"independent quantized LayerNorm oracle: {message}",
-        )
 
 
 def _assert_output_integrity(output, config: dict[str, Any], *, name: str) -> None:

--- a/tirx_kernels/flashinfer/norm/layernorm.py
+++ b/tirx_kernels/flashinfer/norm/layernorm.py
@@ -120,11 +120,7 @@ def _cvt_pair_f32_to_bf16(high, low):
 def _shfl_bfly_f32(value, lane_xor: int):
     out = K.local_scalar(K.u32)
     K.ptx.shfl_sync.bfly.b32(
-        out,
-        K.reinterpret(K.u32, value),
-        K.uint32(lane_xor),
-        K.uint32(31),
-        K.uint32(0xFFFFFFFF),
+        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), K.uint32(0xFFFFFFFF)
     )
     return K.reinterpret(K.f32, out)
 
@@ -596,14 +592,6 @@ def _checked_view(tensor, rows: list[int] | None):
     return tensor if rows is None else tensor[rows]
 
 
-def _math_oracle(x, gamma, beta, eps: float, rows: list[int] | None):
-    import torch
-    import torch.nn.functional as F
-
-    checked = _checked_view(x, rows).float()
-    return F.layer_norm(checked, (x.shape[-1],), gamma, beta, eps).to(torch.bfloat16)
-
-
 def _assert_close(actual, expected, *, name: str, rtol: float, atol: float) -> None:
     import torch
 
@@ -719,13 +707,11 @@ def run_test(**config: Any) -> None:
     rows = _overflow_rows(M, H)
     actual_checked = _checked_view(output["view"], rows)
     reference_checked = _checked_view(reference["view"], rows)
-    math = _math_oracle(data["x"], data["gamma"], data["beta"], eps, rows)
     if not torch.isfinite(actual_checked).all():
         raise AssertionError("TIRx output contains non-finite values")
     _assert_close(
         actual_checked, reference_checked, name="FlashInfer CuTe-DSL", rtol=1e-3, atol=1e-3
     )
-    _assert_close(actual_checked, math, name="FP32 math oracle", rtol=1e-2, atol=1e-2)
     _assert_inputs_unchanged(data, snapshot, M, H)
     _assert_output_padding(output, M, H, data["y_row_stride"], name="TIRx output")
     _assert_output_padding(reference, M, H, data["y_row_stride"], name="FlashInfer output")

--- a/tirx_kernels/flashinfer/norm/qk_rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/qk_rmsnorm.py
@@ -862,14 +862,6 @@ def _checked_rows(tensor, rows: list[int] | None, N: int):
     return tensor[row_index // N, row_index % N]
 
 
-def _math_oracle(x, weight, variant: str, eps: float, rows: list[int] | None, N: int):
-    x_checked = _checked_rows(x, rows, N).float()
-    variance = x_checked.square().mean(dim=-1, keepdim=True)
-    normalized = x_checked * variance.add(eps).rsqrt()
-    bias = 0.0 if variant == "rmsnorm" else 1.0
-    return (normalized * (weight.float() + bias)).to(dtype=x.dtype)
-
-
 def _assert_close(actual, expected, *, name: str) -> None:
     import torch
 
@@ -987,12 +979,10 @@ def run_test(**config: Any) -> None:
     actual_checked = _checked_rows(output["view"], rows, N)
     implicit_checked = _checked_rows(reference_implicit, rows, N)
     explicit_checked = _checked_rows(reference_out["view"], rows, N)
-    oracle = _math_oracle(data["x"], data["weight"], variant, eps, rows, N)
     if not torch.isfinite(actual_checked).all():
         raise AssertionError("TIRx output contains non-finite values")
     _assert_close(actual_checked, implicit_checked, name="FlashInfer implicit output")
     _assert_close(actual_checked, explicit_checked, name="FlashInfer explicit output")
-    _assert_close(actual_checked, oracle, name="FP32 math oracle")
     _assert_inputs_unchanged(data, snapshot, B, N, H)
     _assert_storage_padding(
         output["backing"],

--- a/tirx_kernels/flashinfer/norm/rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm.py
@@ -945,15 +945,6 @@ def _checked_view(tensor, rows: list[int] | None):
     return tensor if rows is None else tensor[rows]
 
 
-def _math_oracle(x, weight, variant: str, eps: float, rows: list[int] | None):
-    x_checked = _checked_view(x, rows).float()
-    weight_f32 = weight.float()
-    variance = x_checked.square().mean(dim=-1, keepdim=True)
-    normalized = x_checked * variance.add(eps).rsqrt()
-    bias = 0.0 if variant == "rmsnorm" else 1.0
-    return (normalized * (weight_f32 + bias)).to(dtype=x.dtype)
-
-
 def _assert_close(actual, expected, *, name: str) -> None:
     import torch
 
@@ -1069,12 +1060,10 @@ def run_test(**config: Any) -> None:
     actual_checked = _checked_view(output["view"], rows)
     implicit_checked = _checked_view(reference_implicit, rows)
     explicit_checked = _checked_view(reference_out["view"], rows)
-    oracle = _math_oracle(data["x"], data["weight"], variant, eps, rows)
     if not torch.isfinite(actual_checked).all():
         raise AssertionError("TIRx output contains non-finite values")
     _assert_close(actual_checked, implicit_checked, name="FlashInfer implicit output")
     _assert_close(actual_checked, explicit_checked, name="FlashInfer explicit output")
-    _assert_close(actual_checked, oracle, name="FP32 math oracle")
     _assert_inputs_unchanged(data, snapshot, M, H)
     _assert_output_padding(output, M, H, data["y_row_stride"], name="TIRx output")
     _assert_output_padding(reference_out, M, H, data["y_row_stride"], name="FlashInfer output")

--- a/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
@@ -1219,38 +1219,6 @@ def _logical_scale_bytes(output, config: dict[str, Any]):
     return output["scale"].view(-1)[offsets]
 
 
-def _dequantize(output, data, config: dict[str, Any]):
-    import torch
-
-    M, H = int(config["M"]), int(config["H"])
-    packed = output["y"].view(M, H // 2)
-    low = packed & 0x0F
-    high = packed >> 4
-    nibbles = torch.stack((low, high), dim=-1).reshape(M, H).long()
-    table = torch.tensor(
-        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-        device="cuda",
-        dtype=torch.float32,
-    )
-    fp4 = table[nibbles]
-    scale_bytes = _logical_scale_bytes(output, config)
-    if int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3":
-        scales = scale_bytes.view(torch.float8_e4m3fn).float()
-        scales = scales / data["global_scale"].float()
-    else:
-        scales = torch.pow(2.0, scale_bytes.int() - 127)
-    return (fp4.view(M, -1, int(config["block_size"])) * scales[..., None]).reshape(M, H)
-
-
-def _math_oracle(data, config: dict[str, Any]):
-    M, H = int(config["M"]), int(config["H"])
-    x = data["x2d"].float()
-    normalized = x * (x.square().mean(dim=-1, keepdim=True) + float(config["eps"])).rsqrt()
-    return (
-        (normalized * data["weight"].float()).to(_torch_input_dtype(config["input_dtype"])).float()
-    )
-
-
 def _assert_raw_equal(actual, expected, config: dict[str, Any], *, name: str) -> None:
     import torch
 
@@ -1265,6 +1233,12 @@ def _assert_raw_equal(actual, expected, config: dict[str, Any], *, name: str) ->
 
 
 def _assert_math(output, data, config: dict[str, Any]) -> None:
+    """Zero-global-scale invariant only; FlashInfer's raw bytes are the arbiter.
+
+    A zero global scale must yield signed-zero FP4 payloads and scales, and the
+    bitwise FlashInfer comparison cannot distinguish "both wrong the same way"
+    for this degenerate input, so the invariant is asserted directly.
+    """
     import torch
 
     if (int(config["block_size"]) == 16 or str(config["scale_format"]) == "e4m3") and float(
@@ -1274,19 +1248,6 @@ def _assert_math(output, data, config: dict[str, Any]) -> None:
             _logical_scale_bytes(output, config)
         ):
             raise AssertionError("zero global scale must produce signed-zero FP4 values and scales")
-        return
-
-    dequantized = _dequantize(output, data, config)
-    oracle = _math_oracle(data, config)
-    if not torch.isfinite(dequantized).all():
-        raise AssertionError("dequantized TIRx output contains non-finite values")
-    torch.testing.assert_close(
-        dequantized,
-        oracle,
-        rtol=0.5,
-        atol=2.0,
-        msg=lambda message: f"independent FP32 RMSNorm oracle: {message}",
-    )
 
 
 def _check_public_allocation(data, reference, config: dict[str, Any]) -> None:

--- a/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
@@ -1561,15 +1561,6 @@ def _checked_view(tensor, rows: list[int] | None):
     return tensor if rows is None else tensor[rows]
 
 
-def _math_oracle(x, weight, scale, eps: float, output_dtype: str, rows: list[int] | None):
-    x_checked = _checked_view(x, rows).float()
-    variance = x_checked.square().mean(dim=-1, keepdim=True)
-    normalized = x_checked * variance.add(eps).rsqrt()
-    quantized = normalized * weight.float() * scale.float().reciprocal()
-    fp8_max = 448.0 if output_dtype == "float8_e4m3fn" else 57344.0
-    return quantized.clamp(-fp8_max, fp8_max).to(_torch_output_dtype(output_dtype))
-
-
 def _assert_raw_equal(actual, expected, *, name: str) -> None:
     import torch
 
@@ -1577,18 +1568,6 @@ def _assert_raw_equal(actual, expected, *, name: str) -> None:
         mismatch = _raw_bytes(actual) != _raw_bytes(expected)
         count = int(mismatch.sum().item())
         raise AssertionError(f"{name}: {count} FP8 bytes differ")
-
-
-def _assert_math_close(actual, expected, *, name: str) -> None:
-    import torch
-
-    torch.testing.assert_close(
-        actual.float(),
-        expected.float(),
-        rtol=1.0,
-        atol=1.0,
-        msg=lambda message: f"{name}: {message}",
-    )
 
 
 def _flashinfer_api(device):
@@ -1743,11 +1722,9 @@ def run_test(**config: Any) -> None:
     rows = _overflow_rows(M, H)
     actual_checked = _checked_view(output["view"], rows)
     reference_checked = _checked_view(reference_output["view"], rows)
-    oracle = _math_oracle(data["x"], data["weight"], data["scale"], eps, output_dtype, rows)
     if not torch.isfinite(actual_checked.float()).all():
         raise AssertionError("TIRx FP8 output contains non-finite values")
     _assert_raw_equal(actual_checked, reference_checked, name="FlashInfer raw-byte oracle")
-    _assert_math_close(actual_checked, oracle, name="independent FP32 math oracle")
     _assert_inputs_unchanged(data, snapshot, M, H)
     _assert_output_identity(output, name="TIRx output")
     _assert_output_identity(reference_output, name="FlashInfer output")

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -1074,34 +1074,6 @@ def local_indices(data: dict[str, Any], indices, row: int):
     return inverse[indices.long()]
 
 
-def assert_selection_is_top_k(data: dict[str, Any], indices, row: int, row_len: int) -> None:
-    """The oracle: the selected *value multiset* must equal `torch.topk`'s.
-
-    Positions carry no meaning on this path -- output slots are handed out by
-    atomic compaction, the per-CTA base comes from a racing atomic, and the
-    boundary bin's survivors are whichever lanes arrive first (`:306-308`).  The
-    multiset is still unique, because an exact radix select over the ordered bits
-    admits exactly one answer, so this is a bit-exact check and not a tolerance.
-    """
-    import torch
-
-    k = data["k"]
-    row_logits = data["logits"][row, :row_len].float()
-    local = local_indices(data, indices, row).long()
-
-    assert int(local.min()) >= 0 and int(local.max()) < row_len, (
-        f"row {row}: index out of range [0, {row_len})"
-    )
-    assert len(set(local.tolist())) == local.numel(), f"row {row}: duplicate indices"
-
-    got = torch.sort(row_logits[local]).values
-    want = torch.sort(torch.topk(row_logits, min(k, row_len)).values).values
-    assert torch.equal(got, want), (
-        f"row {row}: selected value multiset differs from torch.topk; "
-        f"max|delta| = {(got - want).abs().max().item()}"
-    )
-
-
 def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
     cfg = {
         "dtype": "float32",
@@ -1149,7 +1121,11 @@ def compare_outputs(data: dict[str, Any], mine: dict[str, Any], theirs: dict[str
                 f"row {row}: the trivial branch is deterministic and must match positionally"
             )
             continue
-        assert_selection_is_top_k(data, mine["indices"][row], row, row_len)
+        local = local_indices(data, mine["indices"][row], row).long()
+        assert int(local.min()) >= 0 and int(local.max()) < row_len, (
+            f"row {row}: index out of range [0, {row_len})"
+        )
+        assert len(set(local.tolist())) == local.numel(), f"row {row}: duplicate indices"
         ours = torch.sort(
             data["logits"][row, local_indices(data, mine["indices"][row], row).long()].float()
         ).values

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -1557,6 +1557,9 @@ def run_test(**kwargs: Any) -> None:
     ex = compile_kernel(prim_func)
     ex(*_tirx_args(case))
     torch.cuda.synchronize()
+    # Torch oracle retained by design: no library exposes phase-1's split
+    # intermediates (out/max_logits/lse per split), so nothing upstream can
+    # arbitrate them.
     ref_out, ref_max_logits, ref_lse = _reference_sparse_prefill(case)
     torch.testing.assert_close(case["out"], ref_out, rtol=4.01 / 128, atol=5e-3)
     torch.testing.assert_close(case["max_logits"], ref_max_logits, rtol=2.01 / 65536, atol=1e-6)

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -1489,6 +1489,9 @@ def run_test(**kwargs: Any) -> None:
     ex = compile_kernel(prim_func)
     ex(*_tirx_args(case))
     torch.cuda.synchronize()
+    # Torch oracle retained by design: no library exposes phase-1's split
+    # intermediates (out/max_logits/lse per split), so nothing upstream can
+    # arbitrate them.
     ref_out, ref_max_logits, ref_lse = _reference_sparse_prefill(case)
     torch.testing.assert_close(case["out"], ref_out, rtol=4.01 / 128, atol=5e-3)
     torch.testing.assert_close(case["max_logits"], ref_max_logits, rtol=2.01 / 65536, atol=1e-6)

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -1510,6 +1510,9 @@ def run_test(**kwargs: Any) -> None:
     ex = compile_kernel(prim_func)
     ex(*_tirx_args(case))
     torch.cuda.synchronize()
+    # Torch oracle retained by design: no library exposes phase-1's split
+    # intermediates (out/max_logits/lse per split), so nothing upstream can
+    # arbitrate them.
     ref_out, ref_max_logits, ref_lse = _reference_sparse_prefill(case)
     torch.testing.assert_close(case["out"], ref_out, rtol=3.01 / 128, atol=5e-3)
     torch.testing.assert_close(case["max_logits"], ref_max_logits, rtol=2.01 / 65536, atol=1e-6)

--- a/tirx_kernels/msa/sparse_prepare_flat_schedule.py
+++ b/tirx_kernels/msa/sparse_prepare_flat_schedule.py
@@ -798,6 +798,9 @@ def run_test(**config):
     outputs = make_outputs(data)
     executable(*tirx_args(data, outputs))
     torch.cuda.synchronize()
+    # Invariant checker retained by design: the schedule layout is
+    # nondeterministic (atomic slot handout), so bitwise-vs-reference is
+    # meaningless and the contract itself is what both sides must satisfy.
     assert_schedule_matches(data, outputs)
 
 

--- a/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
+++ b/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
@@ -123,9 +123,7 @@ def _kernel(
             q_count_t0 = ld_global_i32(scheduler_metadata, work_base + 3)
             q_begin_t0 = ld_global_i32(scheduler_metadata, work_base + 2)
             row_linear_t0 = ld_global_i32(scheduler_metadata, work_base + 1)
-            row_base_t0 = ld_global_i32(
-                k2q_row_ptr, head_kv_idx * (total_rows + 1) + row_linear_t0
-            )
+            row_base_t0 = ld_global_i32(k2q_row_ptr, head_kv_idx * (total_rows + 1) + row_linear_t0)
             st_shared_i32(srow, 0, row_base_t0 + q_begin_t0)
             st_shared_i32(srow, 1, q_count_t0)
             st_shared_i32(srow, 2, batch_idx_t0)
@@ -672,6 +670,9 @@ def run_test(**config):
     outputs = make_outputs(data)
     executable(*tirx_args(data, outputs))
     torch.cuda.synchronize()
+    # Invariant checker retained by design: slot order is atomic-race
+    # dependent, so bitwise-vs-reference is meaningless and the metadata
+    # contract is what both sides must satisfy.
     assert_split_metadata(data, outputs)
     torch.testing.assert_close(
         outputs["split_counts"], reference_outputs["split_counts"], rtol=0, atol=0


### PR DESCRIPTION
## Summary

Correctness now rests on the upstream implementation each port transcribes, not on hand-written torch math. Kernels that already ran a library comparison in `run_test` lose their redundant torch oracle; kernels whose library comparison lived only in the bench path get it promoted into `run_test`; oracles survive only where no library can arbitrate, each with an in-place comment saying why.

### Clean deletions (library already arbitrated in `run_test`)

- **cudnn** (swiglu ×2, amax, csa, gdn2 ×2, kda_bprop, dsa, bsa): torch/FP64 oracles deleted; the TIRx-vs-source comparison stays (dsa previously had none — a direct dq/dkv/d_sink comparison at 5e-2 was added). gdn2/kda checkpoints now come from the bench path's random construction instead of the oracle's forward pass.
- **flashinfer/norm ×9**: `_math_oracle`s deleted; the FlashInfer bitwise/tolerance comparisons remain.
- **flashinfer/kda ×9**: `_torch_reference` and the oracle tolerance band deleted; the frozen-export/FlashInfer comparison stays. `bf16_fused_m128` now fails loudly when `store_final_state` is set but the reference returns no state, instead of silently skipping the state check.
- **tinygemm2**: inline `F.linear` ref deleted; the bitwise FlashInfer compare (both `use_pdl` variants) is strictly stronger.
- **fast_topk_clusters**: `torch.topk` multiset oracle deleted; the index-range and duplicate-index invariants move next to the upstream multiset comparison, which subsumes the value check.
- **deepep/combine**: the reference dispatch is now the sole producer of the combine inputs; the sub-8-rank torch bring-up simulator is gone (ElasticBuffer segfaults below 8 ranks on this host anyway).

### Promotions (library moves from bench into `run_test`)

- **flash_attention4** validates against `flash_attn.cute.interface._flash_attn_fwd` on the same inputs (the sibling backward port's pattern).
- **basic/rmsnorm** validates against `flashinfer.norm.rmsnorm` — the same library its benchmark compares against.
- **deepgemm 1d1d ×5** (fp8_gemm_1d1d, fp8_bmm, m_grouped masked/contiguous, k_grouped) compare directly against DeepGEMM run on the same quantized operands via the existing bench launchers. Measured across **all 60 registered configs: `calc_diff == 0.0` (bitwise-identical)**, so the shared gate uses `DIRECT_DIFF_THRESHOLD = 1e-6` (ULP-level margin, three orders tighter than DeepGEMM's own 1e-3/1e-2 accuracy thresholds) and the dequantized-ref construction plus its helpers are deleted.

### Kept, documented in place

- The DeepGEMM relative-diff five (mqa_logits ×4, tf32_hc_prenorm): the torch ref is a yardstick; DeepGEMM's own diff on the same inputs bounds what TIRx must achieve.
- The `torch.matmul`/`torch.mm` four (fp16_bf16_gemm, nvfp4_gemm, allgather_gemm, gemm_reduce_scatter): those dispatch to cuBLAS, so they *are* the library comparison.
- flashmla `sparse_prefill_*_phase1` ×3 and msa `sparse_prepare_*` ×2: phase-1 split intermediates and race-dependent schedule layouts that no library exposes or that make bitwise comparison meaningless.
- cudnn dglu ×2 keep the FP32 oracle only for the `upstream_disagrees` tile_n=32 rows and the flaky blockscaled corner — the rows where the oracle proved the upstream kernel wrong.
- fused_add_rmsnorm(+quant) keep the oracle solely for the rolled-fragment fallback rows the CuTe reference cannot run (H=1048576, H=131073); the fp4quant pair keeps the zero-global-scale signed-zero invariant the bitwise compare cannot express.

Also exempts `tirx_kernels/cudnn/_reference.py` (an import shim with no ported code) from the port-header lint it was failing at HEAD.

## Testing

All on SM100:

- Full CONFIGS for every kernel whose arbiter changed: the five 1d1d entries (60/60), rmsnorm (36/36), flash_attention4 (32/32).
- Full CONFIGS family re-runs: cudnn gdn2_bprop (10/10), fused_add_rmsnorm incl. the fallback rows (281/281), flashkda t5_gram (28/28), tinygemm2 (8/8), fast_topk_clusters (34/34).
- Per-kernel smokes across the cudnn (8), norm (11, incl. both fallback-H rows and the dglu tilen00 oracle row), and kda (9) families.
- deepep_combine t128 on 8 ranks.
- One bench row with and without `--with-references` (baseline timed only when requested; validation-skip semantics unchanged).
- `pre-commit run` green on the staged files (ruff check/format, license headers); `pytest tests/test_kern_api.py tests/test_low_level_ir.py` green; the per-kernel no-tile lint checks for touched kernels green.
