### PR TITLE
feat(kernel): port cuDNN block-scaled sReLU GEMM

### DIFF
--- a/.agents/sketch/cudnn/sm100_dense_blockscaled_gemm_persistent_srelu_quant.md
+++ b/.agents/sketch/cudnn/sm100_dense_blockscaled_gemm_persistent_srelu_quant.md
@@ -1,0 +1,689 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 dense block-scaled persistent GEMM + sReLU quant: coarse WASP pipeline sketch
+
+This is the non-executable execution sketch for
+[`tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py`](../../tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py).
+It freezes the six-warp persistent program, the A/B/SFA/SFB block-scaled
+mainloop, the independent C and D store pipelines, `relu(C)^2 * prob`, mandatory
+FP32 amax, and one-/two-CTA TMEM lifetime. After the first reviewer PASS this
+file is immutable; the module becomes the executable source of truth.
+
+The source is
+`python/cudnn/gemm/cutedsl/dense/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py`
+at commit `7b5327b32907b9dd21d85a393d62f9573d7f0116`, SHA256
+`63aaee0a2acdd94c16c261157c9befb1a4265ca514b9f83dec1e5f5679508b4c`.
+Source citations below refer to that file. Writer exports are under
+`.porting/dense_blockscaled_gemm_persistent_srelu_quant/writer_export/`; the
+primary PTX is `ptx/anchor.ptx`, 1,643 lines, SHA256
+`4ab8daa4e85649c89e14f7ad76505bab356615d100d35c628f1e184c3aac6bc6`.
+Every export was compiled through the public source class, launched three
+consecutive times, and checked against a dequantized FP32 oracle before its PTX
+was admitted as evidence.
+
+The instruction-annotated body uses this primary specialization:
+
+| axis | anchor value |
+| --- | --- |
+| shape | `M=N=256, K=512, L=2` |
+| A/B | FP4 E2M1, K-major/K-major |
+| SFA/SFB | E8M0, vector size 16 |
+| C/D | BF16/BF16, N-major |
+| MMA tile / cluster | `(256,256)` / `(2,1)` |
+| fixed epilogue | `alpha=2/3`, sReLU active, amax active, SFD absent |
+| stage tuple | accumulator/AB/C/D = `1/5/2/2` |
+| storage | 512 TMEM columns, 229,376 bytes dynamic SMEM |
+
+The mathematical contract is exact at the FP32 operation boundary:
+
+```text
+C_fp32 = alpha * (dequant(A,SFA) @ dequant(B,SFB)^T)
+C       = cast(C_fp32, c_dtype)
+D_fp32 = prob * max(C_fp32, 0)^2
+D       = cast(D_fp32, d_dtype)
+amax    = max_over_all_elements(abs(D_fp32))       # FP32 global result
+```
+
+The source only applies sReLU and `prob` inside `generate_amax`; therefore this
+port fixes `generate_amax=True` and `generate_sfd=False`. The SFD branch only
+prints `SFD not implemented` and cannot produce valid D. `vector_f32` remains a
+public specialization key for compatibility, but source lines 139-140 only
+store it and never read it. Independent `true`/`false` anchor exports are
+byte-identical.
+
+No first-class layout, tile, or fragment object may appear in device code.
+The implementation imports only `tirx_kernels.kern as K`. Shared memory is one
+rank-1 `u8` arena. Stages, swizzles, TensorMap coordinates, UMMA descriptors,
+register fragments, and TMEM rows/columns are scalar integer expressions.
+
+## Pipeline at a glance
+
+| warp / role | persistent program | ownership edge |
+| --- | --- | --- |
+| warp 5, TMA | prefetch six TensorMaps; for every output work item and K tile, wait for AB-empty and issue A/B/SFA/SFB TMA loads | AB-empty -> four TMA loads sharing one transaction barrier -> AB-full; producer tail drains every AB stage |
+| warp 4, MMA | wait for TMEM publication; leader CTA waits for AB-full and accumulator-empty, copies SFA/SFB SMEM to TMEM, performs block-scaled tcgen05 MMA, releases AB, publishes accumulator | AB-full -> `tcgen05.cp`/MMA -> AB-empty; ACC-empty -> MMA -> ACC-full |
+| warps 0-3, epilogue | warp 0 allocates 512 TMEM columns; all four warps load 128x32 subtiles, apply alpha, store C, compute sReLU/prob and amax, store D, then release accumulator | ACC-full -> TMEM load -> independent C/D TMA rings -> ACC-empty; named barrier 1 brackets every SMEM/TMA reuse and the CTA amax reduction |
+| CTA/cluster prologue/tail | initialize and publish barriers, derive cluster coordinates and raw descriptors, then synchronize; epilogue relinquishes allocation and frees after all work | cluster init fence/arrive/wait; named barrier 2 publishes TMEM pointer; CTA2 uses peer deallocation arrival/wait before `tcgen05.dealloc` |
+
+All three role-local schedulers start from the same cluster work id and advance
+by the persistent grid's number of resident clusters. There is no scheduler
+handoff: only the AB and accumulator barriers transfer ownership. Source
+`873-1171`, `1173-1459`; anchor PTX `311-1020`, `1023-1636`.
+
+## Primitive vocabulary
+
+Every structural helper below returns an integer, scalar state, raw pointer, or
+raw descriptor; none returns a first-class mapping value.
+
+```python
+specialize(...); launch(...)
+ceil_div(x, y); align_up(x, y); integer_offset(...)
+byte_ptr(rank1_u8_arena, byte_offset)
+pipeline_state(stages, phase, stage, count)
+encode_tensormap(raw_descriptor, dtype, rank, pointer, integer_fields...)
+encode_umma_descriptor(smem_byte_address, ldo, sdo, swizzle, transpose)
+tmem_address(base_column, warp_row, stage_column, subtile_column)
+
+copy_g2s(tensormap, integer_coords, smem_byte_ptr, mbarrier, multicast_mask)
+copy_s2t(raw_smem_descriptor, tmem_u32_address)
+copy_t2r(tmem_u32_address, scalar_registers)
+copy_r2s(scalar_registers, smem_byte_ptr)
+copy_s2g(smem_byte_ptr, tensormap, integer_coords)
+
+gemm_blockscaled(acc_tmem, a_desc, b_desc, sfa_tmem, sfb_tmem, accumulate)
+cast(value, dtype); mul(a, b); max(a, b); abs(value)
+warp_reduce_max_nan(value); atomic_max_nonnegative_f32_bits(pointer, value)
+
+elect_one(); try_wait(barrier, phase); wait(barrier, phase)
+arrive_expect_tx(barrier, bytes); release(barrier, mask)
+advance(stage, phase, count); fence_mbarrier_init_cluster()
+cluster_arrive_relaxed(); cluster_wait(); fence_async_shared_cta()
+named_barrier(id, thread_count); tma_commit_group(); tma_wait_group(pending)
+alloc_tmem(columns); relinquish_tmem(); dealloc_tmem(columns)
+```
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# 1. Static specialization, raw ABI, host descriptors, and launch
+# source 37-140, 145-299, 301-600; anchor PTX 12-119
+# ===========================================================================
+P = specialize(
+    M, N, K, L,
+    ab_dtype, sf_dtype, sf_vec_size, c_dtype, d_dtype,
+    a_major, b_major, c_major,
+    mma_tile_m, mma_tile_n, cluster_m, cluster_n,
+    vector_f32,
+)
+assert P in source_validated_capability_manifest
+assert c_major == "n"                 # M-major produced incorrect D in source
+assert generate_amax is True
+assert generate_sfd is False
+
+CTA_GROUP = 2 if mma_tile_m == 256 else 1
+CTA_M = 128
+N_TILE = mma_tile_n                    # 64, 128, 192, or 256
+K_TILE = 256 if ab_dtype is FP4 else 128
+WARPS = 6
+EPI_WARPS = (0, 1, 2, 3)
+MMA_WARP = 4
+TMA_WARP = 5
+ACC_STAGES = 1 if N_TILE == 256 else 2
+C_STAGES = 2
+D_STAGES = 2
+AB_STAGES = source_stage_formula(P)
+TMEM_COLUMNS = 512
+
+# Fixed pointer ABI. The host prelude creates raw TensorMaps for A/B/SFA/SFB
+# loads and C/D stores, preserving dtype, major, strides, tail fill, tile box,
+# and multicast pieces. prob and amax remain ordinary global pointers.
+ABI = (A, B, SFA, SFB, C, D, prob, amax, alpha)
+HOST_DESCRIPTORS = (
+    encode_tensormap(A_MAP, A_DTYPE, 3, A, A_INTEGER_FIELDS),
+    encode_tensormap(B_MAP, B_DTYPE, 3, B, B_INTEGER_FIELDS),
+    encode_tensormap(SFA_MAP, SF_DTYPE, 4, SFA, SFA_INTEGER_FIELDS),
+    encode_tensormap(SFB_MAP, SF_DTYPE, 4, SFB, SFB_INTEGER_FIELDS),
+    encode_tensormap(C_MAP, C_DTYPE, 3, C, C_INTEGER_FIELDS),
+    encode_tensormap(D_MAP, D_DTYPE, 3, D, D_INTEGER_FIELDS),
+)
+
+m_tiles = ceil_div(M, CTA_M)
+n_tiles = ceil_div(N, N_TILE)
+cluster_m_tiles = ceil_div(m_tiles, cluster_m)
+cluster_n_tiles = ceil_div(n_tiles, cluster_n)
+cluster_work = cluster_m_tiles * cluster_n_tiles * L
+resident_clusters = min(cluster_work, source_max_active_clusters(cluster_m * cluster_n))
+launch(
+    grid=(cluster_m, cluster_n, resident_clusters),
+    block=(192, 1, 1),
+    cluster=(cluster_m, cluster_n, 1),
+    arch="sm_100a",
+    dynamic_smem=SHARED_BYTES,
+)
+# instruction_selection: source `595-600`; anchor `.reqntid 192,1,1` at PTX
+#   `40`, `.extern .shared .align 1024` at `12`. Extent: all specializations.
+
+# ===========================================================================
+# 2. One rank-1 SMEM arena and explicit byte/descriptor/TMEM arithmetic
+# source 170-299, 471-559, 670-743, 1636-1750; anchor PTX 138-210
+# ===========================================================================
+ab_bits = dtype_bits(ab_dtype)
+c_bits = dtype_bits(c_dtype)
+d_bits = dtype_bits(d_dtype)
+B_ROWS = N_TILE // CTA_GROUP
+A_STAGE_BYTES = CTA_M * K_TILE * ab_bits // 8
+B_STAGE_BYTES = B_ROWS * K_TILE * ab_bits // 8
+SFA_STAGE_BYTES = CTA_M * K_TILE // sf_vec_size
+SFB_STAGE_BYTES = align_up(N_TILE, 128) * K_TILE // sf_vec_size
+AB_STAGE_BYTES = A_STAGE_BYTES + B_STAGE_BYTES + SFA_STAGE_BYTES + SFB_STAGE_BYTES
+C_STAGE_BYTES = CTA_M * 32 * c_bits // 8
+D_STAGE_BYTES = CTA_M * 32 * d_bits // 8
+AB_STAGES = (232448 - (1024 + 2*C_STAGE_BYTES + 2*D_STAGE_BYTES + 16)) // AB_STAGE_BYTES
+
+AB_FULL_OFFSET = 0
+AB_EMPTY_OFFSET = AB_FULL_OFFSET + AB_STAGES * 8
+ACC_FULL_OFFSET = AB_EMPTY_OFFSET + AB_STAGES * 8
+ACC_EMPTY_OFFSET = ACC_FULL_OFFSET + ACC_STAGES * 8
+TMEM_DEALLOC_OFFSET = ACC_EMPTY_OFFSET + ACC_STAGES * 8
+TMEM_PTR_OFFSET = TMEM_DEALLOC_OFFSET + 8
+C_OFFSET = 1024
+D_OFFSET = C_OFFSET + C_STAGES * C_STAGE_BYTES
+A_OFFSET = D_OFFSET + D_STAGES * D_STAGE_BYTES
+B_OFFSET = A_OFFSET + AB_STAGES * A_STAGE_BYTES
+SFA_OFFSET = B_OFFSET + AB_STAGES * B_STAGE_BYTES
+SFB_OFFSET = align_up(SFA_OFFSET + AB_STAGES * SFA_STAGE_BYTES, 1024)
+AMAX_OFFSET = align_up(SFB_OFFSET + AB_STAGES * SFB_STAGE_BYTES, 1024)
+SHARED_BYTES = align_up(AMAX_OFFSET + 16, 1024)
+assert SHARED_BYTES <= 232448
+smem = K.alloc_buffer((SHARED_BYTES,), K.u8, scope="shared.dyn")
+
+# Anchor byte intervals, directly observed in anchor TMA addresses:
+#   AB_FULL 0..39; AB_EMPTY 40..79; ACC_FULL 80..87; ACC_EMPTY 88..95
+#   TMEM_DEALLOC 96..103; TMEM_PTR 104..107; protocol padding to 1024
+#   C    1024..17407      (2 * 8192)
+#   D   17408..33791      (2 * 8192)
+#   A   33792..115711     (5 * 16384)
+#   B  115712..197631     (5 * 16384)
+#   SFA 197632..207871    (5 * 2048)
+#   SFB 207872..228351    (5 * 4096)
+#   amax 228352..228367; whole arena rounds to 229376 bytes.
+# instruction_selection: anchor A/B/SFA/SFB TMA destinations are PTX
+#   `383`, `392`, `408`, `423`; C/D store sources are `1300`, `1497`; amax
+#   shared writes/reads are `1525`, `1535-1547`.
+
+# All accessors below expand to scalar byte arithmetic, including stage and
+# swizzle XORs. They are functions of integer row/column/major/dtype fields,
+# never stored or passed as first-class layouts.
+a_byte = A_OFFSET + stage*A_STAGE_BYTES + explicit_a_swizzle(row, k, P)
+b_byte = B_OFFSET + stage*B_STAGE_BYTES + explicit_b_swizzle(n, k, P)
+sfa_byte = SFA_OFFSET + stage*SFA_STAGE_BYTES + explicit_sf_offset(m, k, P)
+sfb_byte = SFB_OFFSET + stage*SFB_STAGE_BYTES + explicit_sf_offset(n, k, P)
+c_byte = C_OFFSET + c_stage*C_STAGE_BYTES + explicit_epi_swizzle(row, col, c_bits)
+d_byte = D_OFFSET + d_stage*D_STAGE_BYTES + explicit_epi_swizzle(row, col, d_bits)
+
+# Raw 64-bit UMMA descriptors encode the shared byte base/16, leading offset,
+# stride offset, transpose bit, and swizzle enum. K-major FP4 anchor uses
+# `ldo=1, sdo=64, swizzle=3`; MN-major variants select the source's 32/64/128B
+# swizzle integers and split copies without constructing a mapping value.
+a_desc = encode_umma_descriptor(a_byte, A_LDO, A_SDO, A_SWIZZLE, A_TRANSPOSE)
+b_desc = encode_umma_descriptor(b_byte, B_LDO, B_SDO, B_SWIZZLE, B_TRANSPOSE)
+sf_desc = encode_umma_descriptor(sfa_byte, 1, 8, 0, 0)
+
+ACC_COLUMNS = ACC_STAGES * N_TILE
+SFA_TMEM_COLUMN = ACC_COLUMNS
+SFA_CHUNKS = SFA_STAGE_BYTES // 512
+SFB_TMEM_COLUMN = SFA_TMEM_COLUMN + SFA_CHUNKS * 4
+SFB_CHUNKS = SFB_STAGE_BYTES // 512
+assert SFB_TMEM_COLUMN + SFB_CHUNKS * 4 <= 512
+
+def sfb_tmem_shift(tile_n_idx):
+    # Source `1061-1077`: N192 odd tiles and N64 alternating half-tiles skip
+    # the first 64 scale columns by shifting two TMEM words.
+    if N_TILE == 192:
+        return 2 if tile_n_idx % 2 else 0
+    if N_TILE == 64:
+        return (tile_n_idx % 2) * 2
+    return 0
+
+# ===========================================================================
+# 3. Cluster coordinates, barriers, descriptor prefetch, and publication
+# source 641-870; anchor PTX 119-274
+# ===========================================================================
+tid = thread_idx_x
+warp = uniform(tid >> 5)
+lane = tid & 31
+cluster_rank = block_rank_in_cluster
+cluster_x = cluster_rank % cluster_m
+cluster_y = cluster_rank // cluster_m
+cta_v = cluster_x % CTA_GROUP
+cluster_m_group = cluster_x // CTA_GROUP
+leader_cta = (cta_v == 0)
+
+with warp == TMA_WARP:
+    prefetch(A_MAP); prefetch(B_MAP); prefetch(SFA_MAP); prefetch(SFB_MAP)
+    prefetch(C_MAP); prefetch(D_MAP)
+# instruction_selection: source `647-653`; six `prefetch.tensormap` operations
+#   begin at anchor PTX `104`. Extent: all 32 lanes of warp 5; there is no
+#   `elect.sync` predicate around descriptor prefetch.
+
+AB_EMPTY_ARRIVALS = cluster_n + (cluster_m // CTA_GROUP) - 1
+ACC_EMPTY_ARRIVALS = 4 * CTA_GROUP
+with warp == 0:
+    # Each constructor performs its own election. Source construction order is
+    # also the physical barrier/election order.
+    with elect_one():
+        for s in range(AB_STAGES):
+            mbarrier_init(AB_FULL[s], 1)
+    with elect_one():
+        for s in range(AB_STAGES):
+            mbarrier_init(AB_EMPTY[s], AB_EMPTY_ARRIVALS)
+    with elect_one():
+        for s in range(ACC_STAGES):
+            mbarrier_init(ACC_FULL[s], 1)
+    with elect_one():
+        for s in range(ACC_STAGES):
+            mbarrier_init(ACC_EMPTY[s], ACC_EMPTY_ARRIVALS)
+    if CTA_GROUP == 2:
+        with elect_one():
+            mbarrier_init(TMEM_DEALLOC, 32)
+if CTA_GROUP == 2:
+    # TmemAllocator publishes its two-CTA deallocation barrier independently.
+    fence_mbarrier_init_cluster()
+# `pipeline_init_arrive` always supplies the second publication fence; the
+# AB/ACC constructors use `defer_sync=True` and emit no construction fence.
+fence_mbarrier_init_cluster()
+if cluster_m * cluster_n > 1:
+    cluster_arrive_relaxed()
+    cluster_wait()
+else:
+    cta_sync()
+# instruction_selection: anchor PTX `145-163`, `177`, `190`, `203` contains
+#   the 5/5/1/1/dealloc `mbarrier.init`; publication and cluster arrival are
+#   `208-211`. CTA1 evidence is in `cta1_n64.ptx`.
+
+def scheduler_coords(work):
+    # Default source scheduler is M-raster: cluster M changes fastest.
+    cluster_m_idx = work % cluster_m_tiles
+    quotient = work // cluster_m_tiles
+    cluster_n_idx = quotient % cluster_n_tiles
+    batch_idx = quotient // cluster_n_tiles
+    tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+    tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+    return tile_m_idx, tile_n_idx, batch_idx
+
+work = block_idx_z
+WORK_STRIDE = grid_dim_z
+
+# ===========================================================================
+# 4. Warp 5: persistent A/B/SFA/SFB TMA producer
+# source 873-967; anchor PTX 311-594
+# ===========================================================================
+with warp == TMA_WARP:
+    ab_prod = pipeline_state(AB_STAGES, phase=1, stage=0, count=0)
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        k_count = 0
+        speculative = try_wait(AB_EMPTY[ab_prod.stage], ab_prod.phase)
+        while k_count < ceil_div(K, K_TILE):
+            wait_if_needed(AB_EMPTY[ab_prod.stage], ab_prod.phase, speculative)
+            # The pipeline arrival and four copy atoms each perform their own
+            # source election. They are five distinct synchronization points.
+            if leader_cta:
+                with elect_one():
+                    arrive_expect_tx(AB_FULL[ab_prod.stage], AB_STAGE_BYTES * CTA_GROUP)
+
+            # Integer coordinates include cluster pieces and zero-fill tails.
+            # A/SFA multicast across cluster N; B/SFB multicast across the
+            # cluster-M group. CTA2 addresses the leader's cluster SMEM.
+            with elect_one():
+                copy_g2s(A_MAP, a_coords(tile_m,k_count,batch,cluster_y),
+                         byte_ptr(smem, a_stage_piece(ab_prod.stage,cluster_y)),
+                         AB_FULL[ab_prod.stage], a_multicast_mask)
+            with elect_one():
+                copy_g2s(B_MAP, b_coords(tile_n,k_count,batch,cluster_m_group,cta_v),
+                         byte_ptr(smem, b_stage_piece(ab_prod.stage,cluster_m_group)),
+                         AB_FULL[ab_prod.stage], b_multicast_mask)
+            with elect_one():
+                copy_g2s(SFA_MAP, sfa_coords(tile_m,k_count,batch,cluster_y),
+                         byte_ptr(smem, sfa_stage_piece(ab_prod.stage,cluster_y)),
+                         AB_FULL[ab_prod.stage], sfa_multicast_mask)
+            with elect_one():
+                copy_g2s(SFB_MAP, sfb_coords(tile_n,k_count,batch,cluster_m_group),
+                         byte_ptr(smem, sfb_stage_piece(ab_prod.stage,cluster_m_group)),
+                         AB_FULL[ab_prod.stage], sfb_multicast_mask)
+            advance(ab_prod)
+            k_count += 1
+            speculative = try_wait(AB_EMPTY[ab_prod.stage], ab_prod.phase) if k_count < k_tiles else 1
+        work += WORK_STRIDE
+
+    # Producer tail: revisit each AB stage and wait until MMA has released it.
+    for _ in range(AB_STAGES):
+        wait(AB_EMPTY[ab_prod.stage], ab_prod.phase)
+        advance(ab_prod)
+# instruction_selection: source `910-967`; anchor PTX `321`, `349`, `368`
+#   implement try/wait/expect-tx. Anchor TMA instructions are 3D CTA-group-2
+#   A/B at `383`, `392` and 4D SFA/SFB at `408`, `423`. CTA1, multicast,
+#   FP8, and alternate-major opcodes are covered by the writer variants.
+
+# ===========================================================================
+# 5. Warp 4: persistent SMEM->TMEM scale copies and block-scaled tcgen05 MMA
+# source 970-1171; anchor PTX 603-1020
+# ===========================================================================
+with warp == MMA_WARP:
+    named_barrier(2, 160)               # wait for TMEM pointer publication
+    tmem_base = load_smem_u32(TMEM_PTR)
+    ab_cons = pipeline_state(AB_STAGES, phase=0, stage=0, count=0)
+    acc_prod = pipeline_state(ACC_STAGES, phase=1, stage=0, count=0)
+    work = block_idx_z
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        if leader_cta:
+            speculative = try_wait(AB_FULL[ab_cons.stage], ab_cons.phase)
+            wait(ACC_EMPTY[acc_prod.stage], acc_prod.phase)
+        accumulate = False
+        for k_count in range(ceil_div(K, K_TILE)):
+            if leader_cta:
+                wait_if_needed(AB_FULL[ab_cons.stage], ab_cons.phase, speculative)
+
+                # Copy compact scale blocks. Each tcgen05.cp consumes one raw
+                # SMEM descriptor and one scalar TMEM address.
+                for chunk in range(SFA_CHUNKS):
+                    with elect_one():
+                        copy_s2t(sf_smem_desc(SFA_OFFSET, ab_cons.stage, chunk),
+                                 tmem_base + SFA_TMEM_COLUMN + 4*chunk)
+                for chunk in range(SFB_CHUNKS):
+                    with elect_one():
+                        copy_s2t(sf_smem_desc(SFB_OFFSET, ab_cons.stage, chunk),
+                                 tmem_base + SFB_TMEM_COLUMN + 4*chunk)
+
+                for kblock in range(4):
+                    sfa_addr = integer_sfa_tmem_address(tmem_base, kblock)
+                    sfb_addr = integer_sfb_tmem_address(
+                        tmem_base, kblock, sfb_tmem_shift(tile_n)
+                    )
+                    with elect_one():
+                        gemm_blockscaled(
+                            acc=tmem_base + acc_prod.stage*N_TILE,
+                            a=a_desc_for_stage_kblock(ab_cons.stage,kblock),
+                            b=b_desc_for_stage_kblock(ab_cons.stage,kblock),
+                            sfa=sfa_addr,
+                            sfb=sfb_addr,
+                            accumulate=accumulate,
+                        )
+                    accumulate = True
+                with elect_one():
+                    release(AB_EMPTY[ab_cons.stage], ab_empty_multicast_mask)
+            advance(ab_cons)
+            if k_count + 1 < k_tiles and leader_cta:
+                speculative = try_wait(AB_FULL[ab_cons.stage], ab_cons.phase)
+
+        if leader_cta:
+            with elect_one():
+                tcgen05_commit(ACC_FULL[acc_prod.stage], acc_full_multicast_mask)
+        advance(acc_prod)
+        work += WORK_STRIDE
+
+    if leader_cta:
+        for _ in range(ACC_STAGES):
+            wait(ACC_EMPTY[acc_prod.stage], acc_prod.phase)
+            advance(acc_prod)
+# instruction_selection: source `1092-1146`; anchor PTX has twelve CTA2
+#   `tcgen05.cp.cta_group::2.32x128b.warpx4` operations at `768-861`, four
+#   `tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.block16` at
+#   `884-938`, AB release commit at `949`, and accumulator commit at `986`.
+#   CTA1 and MXF8 instruction forms are in `cta1_n64.ptx` and
+#   `cta1_n128_f8_f32_f16_c4x4.ptx`.
+
+# ===========================================================================
+# 6. Warps 0-3: C store, FP32 sReLU/prob/amax, and independent D store
+# source 1173-1447; anchor PTX 1023-1595
+# ===========================================================================
+with warp in EPI_WARPS:
+    if warp == 0:
+        alloc_tmem(TMEM_COLUMNS)
+    named_barrier(2, 160)
+    tmem_base = load_smem_u32(TMEM_PTR)
+    acc_cons = pipeline_state(ACC_STAGES, phase=0, stage=0, count=0)
+    c_store_count = 0
+    d_store_count = 0
+    work = block_idx_z
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        wait(ACC_FULL[acc_cons.stage], acc_cons.phase)
+        thread_tile_amax = f32(0.0)
+
+        # Each epilogue warp owns one 32-row slice of every 128x32 subtile.
+        # `prob` is one FP32 per output row and batch, reused across N subtiles.
+        global_row = tile_m * CTA_M + tid
+        row_prob = load_global_f32(prob + global_row + batch*M)
+        for subtile in range(N_TILE // 32):
+            regs = copy_t2r(
+                tmem_base + (warp << 21) + acc_cons.stage*N_TILE + subtile*32,
+                scalar_f32_registers_for_32x32(),
+            )
+            # Source order and issue widths are mandatory. The x32 TMEM load
+            # yields 32 scalar FP32 registers; alpha is applied as 16 packed
+            # FP32-pair multiplies before C conversion.
+            for pair in packed_f32_pairs(regs, count=16):
+                pair = mul_f32x2(pair, splat_f32x2(alpha))
+
+            c_stage = c_store_count % C_STAGES
+            c_regs = convert_32_f32(regs, c_dtype)       # distinct conversion
+            copy_r2s(c_regs,                             # four vector SMEM stores
+                     byte_ptr(smem, c_byte_offset(c_stage,warp,lane,subtile,P)))
+            fence_async_shared_cta()
+            named_barrier(1, 128)
+            if warp == 0:
+                copy_s2g(byte_ptr(smem, C_OFFSET + c_stage*C_STAGE_BYTES),
+                         C_MAP, c_coords(tile_m,tile_n,subtile,batch))
+                tma_commit_group()
+                tma_wait_group(C_STAGES - 1)
+            named_barrier(1, 128)
+            c_store_count += 1
+
+            # Active source branch, entirely FP32 and independent of rounded C:
+            # 32 scalar ReLU instructions, 16 packed squares, then 16 packed
+            # probability multiplies. Do not fold these instruction families.
+            relu_regs = scalar_f32_registers_for_32x32()
+            for i in range(32):
+                relu_regs[i] = max_f32(regs[i], f32(0.0))
+            d_regs = scalar_f32_registers_for_32x32()
+            for pair in range(16):
+                d_regs.pair[pair] = mul_f32x2(relu_regs.pair[pair], relu_regs.pair[pair])
+            for pair in range(16):
+                d_regs.pair[pair] = mul_f32x2(d_regs.pair[pair], splat_f32x2(row_prob))
+
+            abs_d_regs = scalar_f32_registers_for_32x32()
+            for i in range(32):
+                abs_d_regs[i] = abs_f32(d_regs[i])
+            # The source vector reduction lowers to a fixed 17-instruction
+            # max.NaN tree over these 32 values, then one ordinary running fmax.
+            subtile_amax = reduce_max_nan_32(abs_d_regs, instruction_count=17)
+            thread_tile_amax = max_f32(thread_tile_amax, subtile_amax)
+
+            d_stage = d_store_count % D_STAGES
+            d_output_regs = convert_32_f32(d_regs, d_dtype)  # distinct conversion
+            copy_r2s(d_output_regs,                          # four vector SMEM stores
+                     byte_ptr(smem, d_byte_offset(d_stage,warp,lane,subtile,P)))
+            fence_async_shared_cta()
+            named_barrier(1, 128)
+            if warp == 0:
+                copy_s2g(byte_ptr(smem, D_OFFSET + d_stage*D_STAGE_BYTES),
+                         D_MAP, d_coords(tile_m,tile_n,subtile,batch))
+                tma_commit_group()
+                tma_wait_group(D_STAGES - 1)
+            named_barrier(1, 128)
+            d_store_count += 1
+
+        warp_amax = warp_reduce_max_nan(thread_tile_amax)
+        if lane == 0:
+            store_smem_f32(AMAX_OFFSET + warp*4, warp_amax)
+        named_barrier(1, 128)
+        if warp == 0 and lane == 0:
+            block_amax = f32(0.0)
+            for slot in range(4):
+                block_amax = max(block_amax, load_smem_f32(AMAX_OFFSET + slot*4))
+            atomic_max_nonnegative_f32_bits(amax, block_amax)
+
+        with elect_one():
+            if CTA_GROUP == 2:
+                # AsyncThread arrival targets the even leader CTA's physical
+                # ACC-empty barrier; this is a rank mapping, not multicast.
+                acc_empty_destination_rank = (cluster_rank // 2) * 2
+                arrive(remote(ACC_EMPTY[acc_cons.stage], acc_empty_destination_rank), 1)
+            else:
+                arrive(ACC_EMPTY[acc_cons.stage], 1)
+        advance(acc_cons)
+        work += WORK_STRIDE
+
+# instruction_selection: source `1298-1305`; anchor PTX loads prob at `1191-1197`
+#   and accumulator with `tcgen05.ld.sync.aligned.32x32b.x32.b32` at `1205`.
+# instruction_selection: source `1315-1349`; anchor PTX applies alpha with
+#   packed FP32 multiplies `1223-1238`, converts C `1245-1276`, uses
+#   `st.shared.v4.b32` `1282-1288`, `fence.proxy.async.shared::cta`/barrier
+#   `1290-1292`, and C TMA commit/wait-one `1300-1304`.
+# instruction_selection: source `1354-1368`; anchor PTX uses `max.f32` ReLU
+#   `1309-1356`, `mul.f32x2` square `1357-1372`, prob multiply `1376-1391`,
+#   `abs.f32` `1394-1440`, and `max.NaN.f32` `1442-1458`.
+# instruction_selection: source `1379-1406`; anchor PTX converts D at
+#   `1462-1477`, stores it at `1481-1487`, and issues the distinct D TMA
+#   commit/wait-one at `1497-1501` after its own fence/barriers.
+# instruction_selection: source `1408-1434`; anchor PTX emits
+#   `redux.sync.max.NaN.f32` at `1517`, four shared values `1525-1547`, and
+#   `atom.global.max.s32` at `1551`. Because values are nonnegative FP32,
+#   signed integer bit ordering implements atomic fmax without a CAS loop.
+
+# ===========================================================================
+# 7. TMEM teardown and store tails
+# source 1449-1459; anchor PTX 1596-1636
+# ===========================================================================
+with warp in EPI_WARPS:
+    if warp == 0:
+        relinquish_tmem()
+    named_barrier(1, 128)
+    if warp == 0:
+        if CTA_GROUP == 2:
+            peer_rank = cluster_rank ^ 1
+            # SPMD extent: each of warp 0's 32 lanes sends exactly one arrival.
+            arrive(remote(TMEM_DEALLOC, peer_rank), 1)
+            wait(TMEM_DEALLOC, phase=0)
+        dealloc_tmem(tmem_base, TMEM_COLUMNS)
+    # After the warp-0 free branch rejoins, all 128 epilogue threads execute
+    # both independent store tails in source order.
+    tma_wait_group(0)                    # C pipeline tail
+    tma_wait_group(0)                    # D pipeline tail
+# instruction_selection: source `1452-1459`; anchor PTX emits CTA2 relinquish
+#   `1602`, 128-thread barrier `1607`, peer `mapa`/arrival `1611-1614`, wait
+#   `1621`, 512-column deallocation `1631`, and two independent wait-zero tails
+#   `1634`, `1636`. CTA1 omits only the peer protocol.
+```
+
+## Pipeline inventory
+
+| pipeline | stages | producer -> consumer | full event | empty/reuse event |
+| --- | ---: | --- | --- | --- |
+| AB/SF | source formula; anchor 5 | warp 5 -> warp 4 leader CTA | one transaction mbarrier accounts for A+B+SFA+SFB and CTA group bytes | tcgen05 multicast commit after all scale copies and four K-block MMAs |
+| accumulator | 1 for N256, otherwise 2 | warp 4 leader -> warps 0-3 in one or two CTAs | tcgen05 commit to ACC_FULL | one elected arrival per epilogue warp; CTA1 targets local ACC-empty, CTA2 maps all eight arrivals to the even leader CTA's count-8 barrier |
+| C store | fixed 2 | warps 0-3 -> warp 0 TMA issue | async shared fence + named barrier 1 + TMA commit | `wait_group.read 1` before ring reuse, final `read 0` |
+| D store | fixed 2 | warps 0-3 -> warp 0 TMA issue | independent async shared fence + named barrier 1 + TMA commit | independent `wait_group.read 1`, final `read 0` |
+| amax | tile-local scalar + 4 shared FP32 slots | thread -> warp -> CTA -> global | scalar max, `redux.sync.max.NaN.f32`, named barrier 1 | one nonnegative FP32 bitwise atomic max per output tile |
+
+The source stage formula is part of the specialization and SMEM ABI. The
+validated capability matrix observed twelve stage/storage tuples, including
+anchor `1/5/2/2`, N64 `2/6/2/2`, N192 `2/5/2/2`, FP8 N128
+`2/5/2/2`, FP8 N256 `1/4/2/2`, and FP4 V32 N128 `2/7/2/2`.
+
+## TensorMap, tail, and persistent-scheduler contract
+
+- A is logically `(M,K,L)`, B `(N,K,L)`, and the MMA computes A times B
+  transposed over K. SFA/SFB use the source block-scale atom packing.
+- Host TensorMaps carry the exact runtime extents and zero-fill out-of-bounds
+  A/B/SF loads. C/D stores are 128x32 subtiles and keep predicate/tail
+  semantics in the raw descriptor coordinates.
+- The N64 SFB TensorMap divides the tile coordinate by two; N64 and N192 then
+  apply the explicit two-word TMEM shift shown above. N192's padded 256-column
+  SFB storage participates in AB transaction bytes.
+- CTA2 uses a 256-row MMA instruction over two 128-row CTAs. Only CTA-v 0 owns
+  tcgen05 scale-copy/MMA/commit instructions; output coordinates remain per
+  128-row CTA. Cluster M must therefore be divisible by two.
+- The role-local work cursor is persistent and advances by resident cluster
+  count. Tail shapes and `L=2` were admitted only after three consecutive
+  source launches matched C, D, and amax.
+
+## Static specialization boundary
+
+Only capability-manifest PASS modes may enter `CONFIGS` or `BENCH_CONFIGS`:
+
+- A/B: FP4 E2M1 or same-type FP8 E4M3/E5M2.
+- SF: FP4 accepts E8M0/V16, E8M0/V32, or E4M3/V16; FP8 accepts E8M0/V32.
+- C: FP16, BF16, FP32, FP8 E4M3, or FP8 E5M2. D: FP16, BF16, or FP32.
+- A/B major: FP4 K/K; FP8 A K/M and B K/N. C and D are N-major only.
+- MMA M: 128 (CTA1) or 256 (CTA2); N: 64/128/192/256.
+- CTA1 clusters use axes in `{1,2,4}`. CTA2 cluster M is `{2,4}` and cluster N
+  is `{1,2,4}`. Cluster axes and product still obey the source public checks.
+- L is 1 or 2 in the port matrix. `vector_f32` accepts both values but does not
+  change generated code; benchmark coverage keeps one representative.
+- amax is always active and FP32; SFD, D=FP8, D=FP4, the `uint8` FP4 alias, and
+  source-rejected or three-run-oracle-failing combinations are excluded.
+
+The single parameterized kernel must preserve the source stage formula,
+descriptor form, instruction family, store conversion path, and CTA topology
+for every admitted mode. `CONFIGS` will be the deterministic pairwise-token
+cover plus CTA1/CTA2, N64/N192, L2, M/N/K tails, stage, vector flag, and cluster
+boundary guards. Performance representatives are a separate deterministic
+minimal cover.
+
+## Writer PTX evidence
+
+`analyze_writer_exports.py` tokenized each `.loc file:line | PTX opcode` pair.
+Greedy selection maximized newly covered branch tokens and broke ties by label;
+reverse redundancy pruning retained seven exports covering all 581 tokens.
+
+| label | tile / cluster | dtype and output path | stages | PTX SHA256 |
+| --- | --- | --- | --- | --- |
+| `anchor` | 256x256 / 2x1 | FP4 E8V16, BF16/BF16, K/K/N | 1/5/2/2 | `4ab8daa4e85649c89e14f7ad76505bab356615d100d35c628f1e184c3aac6bc6` |
+| `cta1_n64` | 128x64 / 1x1 | FP4 E8V16, BF16/BF16, tail | 2/6/2/2 | `353615e53ade976ad302cf75696a5634d857e135a22407c6ef4a791440fad5bb` |
+| `cta2_n128_f4v32_e4_f32_c4x2` | 256x128 / 4x2 | FP4 E8V32, FP8E4/FP32 | 2/7/2/2 | `249bde96666be193f61083cb933f4e6c5083d607c49609fb83877bc00d392d56` |
+| `cta2_n192` | 256x192 / 2x1 | FP4 E8V16, BF16/BF16, tail | 2/5/2/2 | `97275a36a62d03cc5580c2a4824cee237fa95fc9fcd76835f5dfebdffef13429` |
+| `cta1_n128_f8_f32_f16_c4x4` | 128x128 / 4x4 | FP8E5 E8V32, FP32/FP16, M/N/N | 2/5/2/2 | `4d3e40a0ac7bd491af7723c6b01bad906283bbd2e0b08ecadbd3b917ab853648` |
+| `cta1_n256_f8_e5_bf16_c1x4` | 128x256 / 1x4 | FP8E4 E8V32, FP8E5/BF16 | 1/4/2/2 | `fbe0c7e62667bf6b1264f5fa1c67890d0721d99a7e87c9fccb2dcaf43f3613eb` |
+| `cta2_n256_f4e4_f16_bf16_c2x4` | 256x256 / 2x4 | FP4 E4V16, FP16/BF16 | 1/5/2/2 | `0ff652711857f2be85cb3cc1bc9460a297a3ac1d52313d6f563950d2185f9fc6` |
+
+`anchor_scalar` is a separately compiled and validated `vector_f32=False`
+specialization. Its SHA256 equals `anchor` exactly, so it adds no PTX branch
+token. Raw results, generated intermediates, and the complete token ledger are
+preserved beneath `writer_export/`.
+
+## Executable module and validation contract
+
+The executable module exposes `KERNEL_META`, deterministic `CONFIGS`,
+deterministic `BENCH_CONFIGS`, `get_kernel`, `prepare_data`, `run_test`,
+`prepare_bench`, `run_gpu`, and `run_bench`. It must use a lazy importlib source
+reference, not `cudnn._compiled_module`.
+
+`prepare_data` generates deterministic signed FP4/FP8 patterns, nontrivial
+per-row `prob`, `alpha=2/3`, and representable K-dependent scales. TIRx and
+source get identical logical inputs but separate C/D/amax outputs. `run_test`
+checks TIRx against the independently compiled source and both against the
+dequantized FP32 oracle for C, D, and mandatory FP32 amax. FP32 uses
+`atol=rtol=1e-4`; FP16/BF16 and amax use `atol=0.12, rtol=0.02`; FP8 C compares
+against an oracle converted to the same FP8 dtype.
+
+`prepare_bench` compiles TIRx. The GPU child lazily builds the source reference,
+keeps source JIT, allocation, validation, reset, and synchronization outside
+the timed closure, and registers it as `cudnn_frontend`. Every timed closure
+contains exactly one launch and forwards timer/warmup/repeat/rounds/cooldown to
+the central benchmark API unchanged.
+
+Structural gates reject `TilePrimitiveCall`, `tirx.tile.*`, `tile_primitive`,
+any first-class layout, non-rank-1 shared buffers, or imports other than the
+normal Python/runtime dependencies plus `tirx_kernels.kern as K` for device
+construction. Generated PTX must retain the instruction-selection and protocol
+edges cited above.

--- a/.agents/skills/tirx-codegen-tuning/references/db/fold-disjoint-address-fields-into-one-lop3.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/fold-disjoint-address-fields-into-one-lop3.md
@@ -45,6 +45,15 @@ between a barrier wait and the shared load that depends on it. The lane-field
 fold added a second effect -- eleven per-thread operations moved onto the
 uniform datapath, which issues on a separate scalar pipe.
 
+In another measured block-scaled epilogue, replacing only a proven-disjoint
+row-plus-vector shared-memory offset with OR reduced allocation from 66 to 55
+registers and static SASS from 960 to 952 instructions, with zero spill. All 41
+correctness configurations passed. Its 136-row targeted minimum improved by
+0.00450 and its geometric mean by 0.00344; a subsequent 184-row matrix improved
+to a 0.98292 minimum and 1.01575 geometric mean but retained five strict-gate
+failures. This confirms the address rewrite as a real code-generation lever,
+not as a guarantee that every affected shape will improve enough.
+
 ## Boundary
 
 The disjointness is arithmetic, not a heuristic. Every caller has to pass a base
@@ -52,6 +61,13 @@ aligned to the field width, and the twisted field has to fit inside that
 alignment; verify both before rewriting, because an unaligned caller silently
 reads the wrong bytes. The payoff also scales with how many terms share one
 base: a row wide enough for eight chunks shows it and a two-chunk row does not.
+
+OR and XOR are arithmetically interchangeable only under the same disjointness
+proof, but they need not schedule identically. In the measured epilogue, a
+dtype-specific OR path and an XOR path had the same 56-register, 952-instruction
+resource summary while producing different executable code and different
+timings. Keep the operation as a specialization choice when the output width
+changes how often the address combine executes.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-launch-bounds.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-launch-bounds.md
@@ -30,6 +30,25 @@ if ILP_ROWS == 4 and SEQ_LEN == 8:
         T.attr({"tirx.launch_bounds_min_blocks_per_sm": 8})
 ```
 
+For a persistent kernel whose launch grid is already capped by measured
+concurrent residency, also test omitting the minimum-block contract instead of
+assuming that a value of one is neutral.
+
+```python
+# before: a second launch constraint duplicates the persistent grid cap.
+return K.kernel(
+    warps=WARPS,
+    min_blocks_per_sm=1,
+    grid=[CLUSTER_M, CLUSTER_N, active_clusters],
+)(kernel)
+
+# after: the grid still limits concurrency; ptxas chooses allocation freely.
+return K.kernel(
+    warps=WARPS,
+    grid=[CLUSTER_M, CLUSTER_N, active_clusters],
+)(kernel)
+```
+
 ## Rationale
 
 The value becomes the second CUDA `__launch_bounds__` argument and imposes a
@@ -50,6 +69,15 @@ one moved the allocation from 63 to 90 registers, reduced static SASS from 664
 to 656 instructions, and introduced no spill. Two non-protocol paths reached
 1.016x and 1.005x, while the dependency-protocol path improved from about
 0.945x to 0.959x.
+
+In one measured six-warp persistent kernel whose grid already capped active
+clusters, removing only a minimum-block count of one changed allocation from 56
+to 54 registers and static SASS from 944 to 928 instructions, with zero spill.
+All 41 correctness configurations passed. The four affected performance rows
+moved from one strict failure at a 0.98973 minimum to zero failures at a 0.99928
+minimum; the complete 30-row matrix then passed at a 0.99766 minimum and
+1.00986 geometric mean. A minimum-block count of one can therefore alter ptxas
+code selection even when it does not appear to demand additional residency.
 
 ## Boundary
 
@@ -84,7 +112,13 @@ Use `tirx.max_registers` when an exact per-specialization ceiling, rather than a
 minimum resident-block target, is the demonstrated lever. The two contracts are
 mutually exclusive.
 
+Removing the bound is only justified when another proven launch rule already
+enforces the intended concurrency. Without that cap, the change can alter
+residency as well as register allocation and must be evaluated as a different
+launch policy.
+
 ## Verification
 
 Compare resource usage, achieved occupancy, and dynamic local-memory traffic on
-both sides; do not infer success from the declared launch bound alone.
+both sides, including the no-bound case when concurrency is capped elsewhere;
+do not infer success from the declared launch bound alone.

--- a/.agents/skills/tirx-codegen-tuning/references/db/materialize-and-forward-reused-values.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/materialize-and-forward-reused-values.md
@@ -144,6 +144,24 @@ unchanged at 0.979-0.980x. A broader address-base materialization removed 16
 static instructions and reduced registers from 92 to 88 with no spill, yet the
 affected path still regressed to 0.985x. Both changes were reverted.
 
+Shared-memory swizzles can benefit from materializing an arena-relative row
+offset rather than repeatedly forming and canceling the absolute shared base.
+In one block-scaled epilogue this changed 69 registers / 984 static
+instructions into 66 / 960, improved a frozen 136-row targeted minimum from
+0.974556 to 0.976191, and raised its geometric mean from 0.998707 to 1.005177.
+The subsequent 184-row validation still had five strict-gate failures and a
+0.974381 minimum. Keep the relative-offset form only when its alignment proof
+holds, and treat the resource reduction as mechanism evidence rather than a
+full-matrix performance verdict.
+
+Composing the same relative-offset rewrite with a source-shaped native
+accumulator wait preserved the 66-register / 960-instruction program. A
+worktree-isolated 136-row run improved the geometric mean from 1.001507 to
+1.005664, but raised the minimum by only 0.000999, from 0.973880 to 0.974879,
+and left six strict-gate failures in the FP32-output path. Do not infer
+composition safety from resource counts or an aggregate: require the minimum
+and every affected path to clear the targeted trigger before full validation.
+
 ## Verification
 
 Count instructions in the corresponding PTX/SASS basic block and inspect ptxas

--- a/.agents/skills/tirx-codegen-tuning/references/db/select-address-lowering-by-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/select-address-lowering-by-shape.md
@@ -56,6 +56,17 @@ point, copy, or store counts. It still measured only 0.980x, so the shorter
 instruction stream did not translate to a shorter timed path and the rewrite
 was reverted.
 
+A measured block-scaled epilogue showed the same choice within one store helper.
+Hoisting every output base across the epilogue produced 69 registers and 976
+static instructions. Forming the complete row, swizzle, and stage offset at the
+use site only for the wider FP32 output reduced that specialization to 64
+registers and 960 instructions with zero spill, while narrower outputs retained
+the hoisted form. All 41 correctness configurations passed. The 136-row
+targeted result reached a 0.97877 minimum and 1.00850 geometric mean, but the
+30-row validation still had four failures at a 0.97928 minimum. The reusable
+result is the shape-selective live-range reduction; the static improvement alone
+is not a performance verdict.
+
 ## Boundary
 
 Native offsets, explicit arithmetic, and cursor induction are alternative

--- a/.agents/skills/tirx-codegen-tuning/references/db/spin-an-mbarrier-without-a-suspend-hint.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/spin-an-mbarrier-without-a-suspend-hint.md
@@ -55,6 +55,17 @@ consumer warp in that design always has producer warps to run. A large static
 divergence with a clean mechanism is not a timing result; keep the change if it
 matches the reference, but do not spend expansions on it.
 
+A dense SM100 block-scaled GEMM exposed a related boundary: replacing a TIRx
+`While` around the hinted `try_wait` with the native `K.cuda.mbarrier_wait`
+helper kept the same 10,000,000-tick hint but moved the slow retry loop out of
+line, matching the reference's hot `TRYWAIT; @!P BRA` control-flow shape. The
+change was unique, correctness-clean, spill-free, and preserved 69 registers
+and 968 static instructions, yet its 136-row targeted result regressed from
+`(min=0.973880, geomean=1.001507)` to `(min=0.971149,
+geomean=0.998895)`. Treat cold-loop placement as an instruction-selection
+check, not a sufficient performance hypothesis; measure the complete fixed
+roster even when the hot-path SASS becomes reference-shaped.
+
 ## Verification
 
 Count `NANOSLEEP` sites in the SASS before and after, and confirm the wait

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ list.
 - **Persistent GEMM:**
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py),
   [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py),
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py),
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
 - **Grouped GEMM:**
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)

--- a/tirx_kernels/bench_suite/config/cudnn/srelu/cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/srelu/cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant.yaml
@@ -1,0 +1,35 @@
+# Complete deterministic compact performance-path covering matrix for the
+# parameterized cuDNN Frontend dense block-scaled GEMM+sReLU port.
+kernel: cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant
+selection_rationale: The 30-row matrix retains all 23 independently source-verified structural representatives and seven size/L boundary guards, including every admitted AB/SF/C/D dtype and major, CTA1/CTA2, N tiles 64/128/192/256, cluster shapes, TMA/MMA/store paths, seven stage tuples, mandatory amax, and the single vector_f32 representative whose true/false source PTX is byte-identical.
+configs:
+  - {config: perf00_m4096_n4096_k4096_l1_e4_e8v32_bf16_bf16_mn_n_t256x256_c2x1_vf32_l1, default: true, selection_role: medium}
+  - {config: perf00_m8192_n8192_k8192_l1_e4_e8v32_bf16_bf16_mn_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf01_m8192_n8192_k8192_l1_f4_e8v16_f32_f16_kk_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf02_m1024_n1024_k1024_l1_f4_e8v16_bf16_bf16_kk_n_t128x128_c1x1_vf32_l1, default: true, selection_role: small}
+  - {config: perf02_m8192_n8192_k8192_l1_f4_e8v16_bf16_bf16_kk_n_t128x128_c1x1_vf32_l1, default: false}
+  - {config: perf03_m1024_n1024_k1024_l1_f4_e8v16_e4_f32_kk_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf03_m2048_n2048_k2048_l2_f4_e8v16_e4_f32_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf03_m4096_n4096_k4096_l1_f4_e8v16_e4_f32_kk_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf03_m4096_n4096_k4096_l2_f4_e8v16_e4_f32_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf03_m8192_n8192_k8192_l2_f4_e8v16_e4_f32_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf04_m8192_n8192_k8192_l1_f4_e8v16_f16_bf16_kk_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf05_m4096_n4096_k4096_l2_f4_e8v16_e5_bf16_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf06_m4096_n4096_k4096_l1_f4_e8v16_bf16_bf16_kk_n_t128x256_c1x2_vf32_l1, default: false}
+  - {config: perf07_m1024_n1024_k1024_l2_f4_e4v16_bf16_bf16_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf08_m4096_n4096_k4096_l2_e5_e8v32_bf16_bf16_mn_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf09_m8192_n8192_k8192_l1_f4_e8v16_bf16_bf16_kk_n_t128x192_c1x1_vf32_l1, default: false}
+  - {config: perf10_m8192_n8192_k8192_l2_f4_e8v16_bf16_bf16_kk_n_t128x64_c1x1_vf32_l2, default: false}
+  - {config: perf11_m8192_n8192_k8192_l2_f4_e8v16_f32_bf16_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf12_m4096_n4096_k4096_l2_f4_e8v16_e4_bf16_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf13_m4096_n4096_k4096_l1_f4_e8v16_bf16_bf16_kk_n_t128x256_c1x4_vf32_l1, default: false}
+  - {config: perf14_m8192_n8192_k8192_l2_f4_e8v16_bf16_bf16_kk_n_t128x256_c2x2_vf32_l2, default: false}
+  - {config: perf15_m4096_n4096_k4096_l2_f4_e8v16_bf16_bf16_kk_n_t128x256_c2x4_vf32_l2, default: false}
+  - {config: perf16_m4096_n4096_k4096_l2_f4_e8v16_bf16_bf16_kk_n_t128x256_c4x1_vf32_l2, default: false}
+  - {config: perf17_m2048_n2048_k2048_l2_f4_e8v16_bf16_bf16_kk_n_t128x256_c4x2_vf32_l2, default: false}
+  - {config: perf18_m4096_n4096_k4096_l1_f4_e8v16_bf16_bf16_kk_n_t128x256_c4x4_vf32_l1, default: false}
+  - {config: perf19_m4096_n4096_k4096_l1_f4_e8v16_bf16_f16_kk_n_t256x256_c2x1_vf32_l1, default: false}
+  - {config: perf20_m4096_n4096_k4096_l2_f4_e8v16_bf16_f32_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf21_m4096_n4096_k4096_l2_f4_e8v32_bf16_bf16_kk_n_t256x256_c2x1_vf32_l2, default: false}
+  - {config: perf22_m4096_n4096_k4096_l1_f4_e8v16_bf16_bf16_kk_n_t256x64_c2x1_vf32_l1, default: false}
+  - {config: perf22_m8192_n8192_k8192_l2_f4_e8v16_bf16_bf16_kk_n_t256x64_c2x1_vf32_l2, default: true, selection_role: large}

--- a/tirx_kernels/cudnn/srelu/__init__.py
+++ b/tirx_kernels/cudnn/srelu/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -1,0 +1,3399 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ 7b5327b32907b9dd21d85a393d62f9573d7f0116), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Persistent SM100 block-scaled GEMM with sReLU, probability, and amax.
+
+Upstream source:
+``python/cudnn/gemm/cutedsl/dense/srelu/``
+``dense_blockscaled_gemm_persistent_srelu_quant.py``.
+"""
+
+import heapq
+import importlib.util
+import os
+from functools import cache
+from itertools import combinations
+
+import tirx_kernels.kern as K
+
+_TRY_WAIT_TICKS = 10_000_000
+_SMEM_CAPACITY = 232_448
+_MAX_ACTIVE_CLUSTERS = {1: 148, 2: 74, 4: 33, 8: 15, 16: 7}
+_SF_MODES = (("float8_e8m0fnu", 16), ("float8_e8m0fnu", 32), ("float8_e4m3fn", 16))
+_C_DTYPES = ("float32", "float16", "bfloat16", "float8_e4m3fn", "float8_e5m2")
+_D_DTYPES = ("float32", "float16", "bfloat16")
+_MODE_KEYS = (
+    "ab_dtype",
+    "sf_dtype",
+    "sf_vec_size",
+    "c_dtype",
+    "d_dtype",
+    "a_major",
+    "b_major",
+    "c_major",
+    "mma_tiler_mn",
+    "cluster_shape_mn",
+    "vector_f32",
+    "L",
+)
+_SHORT_DTYPE = {
+    "float4_e2m1fn": "f4",
+    "bfloat16": "bf16",
+    "float16": "f16",
+    "float32": "f32",
+    "float8_e4m3fn": "e4",
+    "float8_e5m2": "e5",
+    "float8_e8m0fnu": "e8",
+}
+
+
+def _ceil_div(value, divisor):
+    return (value + divisor - 1) // divisor
+
+
+def _align_up(value, alignment):
+    return _ceil_div(value, alignment) * alignment
+
+
+def _next_power_of_two(value):
+    return 1 << (value - 1).bit_length()
+
+
+def _dtype_bits(dtype):
+    return {
+        "float4_e2m1fn": 4,
+        "float8_e4m3fn": 8,
+        "float8_e5m2": 8,
+        "float8_e8m0fnu": 8,
+        "bfloat16": 16,
+        "float16": 16,
+        "float32": 32,
+    }[dtype]
+
+
+def _descriptor_base(ldo, sdo, swizzle):
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _instruction_descriptor(M, N, ab_dtype, sf_dtype, a_major, b_major):
+    """Fold the source SM100 block-scaled MMA descriptor fields."""
+    if M not in (128, 256) or N not in (64, 128, 192, 256):
+        raise ValueError(f"unsupported instruction shape {(M, N)}")
+    sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1}[sf_dtype]
+    value = 0
+    if ab_dtype in {"float4_e2m1fn", "float8_e5m2"}:
+        value |= 1 << 7
+        value |= 1 << 10
+    if a_major == "m":
+        value |= 1 << 15
+    if b_major == "n":
+        value |= 1 << 16
+    value |= ((N >> 3) & 0x3F) << 17
+    value |= (sf_format & 1) << 23
+    value |= ((M >> 4) & 0x1F) << 24
+    return value & 0xFFFFFFFF
+
+
+def _descriptor_with_address(base, shared_address):
+    base_value = K.bitwise_or(
+        K.shift_left(K.uint64(base >> 32), K.uint64(32)), K.uint64(base & 0xFFFFFFFF)
+    )
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(base_value, address_field)
+
+
+def _advance(state):
+    state.advance()
+
+
+def _try_wait_acquire(dst, barrier, phase):
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready):
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _issue_ptx_if(predicate, mnemonic, *args):
+    with K.If(predicate):
+        with K.Then():
+            K.ptx[mnemonic](*args)
+
+
+def _valid_mode(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    if tile_m not in (128, 256) or tile_n not in (64, 128, 192, 256):
+        return False
+    if cluster_m not in (1, 2, 4) or cluster_n not in (1, 2, 4):
+        return False
+    if cluster_m * cluster_n > 16 or (tile_m == 256 and cluster_m % 2):
+        return False
+    if mode["ab_dtype"] == "float4_e2m1fn":
+        if mode["a_major"] != "k" or mode["b_major"] != "k":
+            return False
+        if (mode["sf_dtype"], mode["sf_vec_size"]) not in _SF_MODES:
+            return False
+    else:
+        if mode["a_major"] not in ("k", "m") or mode["b_major"] not in ("k", "n"):
+            return False
+        if (mode["sf_dtype"], mode["sf_vec_size"]) != ("float8_e8m0fnu", 32):
+            return False
+    return (
+        mode["c_dtype"] in _C_DTYPES
+        and mode["d_dtype"] in _D_DTYPES
+        and mode["c_major"] == "n"
+        and mode["L"] in (1, 2)
+    )
+
+
+def _mode_label(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    return (
+        f"{_SHORT_DTYPE[mode['ab_dtype']]}_{_SHORT_DTYPE[mode['sf_dtype']]}v{mode['sf_vec_size']}_"
+        f"{_SHORT_DTYPE[mode['c_dtype']]}_{_SHORT_DTYPE[mode['d_dtype']]}_"
+        f"{mode['a_major']}{mode['b_major']}_{mode['c_major']}_"
+        f"t{tile_m}x{tile_n}_c{cluster_m}x{cluster_n}_"
+        f"{'v' if mode['vector_f32'] else 's'}f32_l{mode['L']}"
+    )
+
+
+# Exact PASS rows from ``source_results/capability_matrix.json``.  Each row was
+# compiled in an isolated process and matched the FP32 oracle on three launches.
+# Keeping this frozen roster here prevents single-axis source probes from being
+# accidentally expanded into an unverified Cartesian product.
+_VERIFIED_PROBES = (
+    (
+        "anchor",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "input_float4_e2m1fn_float8_e8m0fnu_v16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "input_float4_e2m1fn_float8_e8m0fnu_v32",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "input_float4_e2m1fn_float8_e4m3fn_v16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e4m3fn",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "input_float8_e4m3fn_float8_e8m0fnu_v32",
+        256,
+        256,
+        512,
+        2,
+        "float8_e4m3fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "input_float8_e5m2_float8_e8m0fnu_v32",
+        256,
+        256,
+        512,
+        2,
+        "float8_e5m2",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_float16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_float32",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float32",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_float8_e4m3fn",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float8_e4m3fn",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_float8_e5m2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float8_e5m2",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "d_float16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "float16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "d_float32",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "float32",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_fp8e4_d_f32",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float8_e4m3fn",
+        "float32",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_f32_d_f16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float32",
+        "float16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "c_f16_d_bf16",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "float16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "vector_f32_false",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        False,
+    ),
+    (
+        "batch_l1",
+        256,
+        256,
+        512,
+        1,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e4m3fn_kk",
+        256,
+        256,
+        512,
+        2,
+        "float8_e4m3fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e4m3fn_kn",
+        256,
+        256,
+        512,
+        2,
+        "float8_e4m3fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e4m3fn_mk",
+        256,
+        256,
+        512,
+        2,
+        "float8_e4m3fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e4m3fn_mn_c_n",
+        256,
+        256,
+        512,
+        2,
+        "float8_e4m3fn",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e5m2_kk",
+        256,
+        256,
+        512,
+        2,
+        "float8_e5m2",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e5m2_kn",
+        256,
+        256,
+        512,
+        2,
+        "float8_e5m2",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e5m2_mk",
+        256,
+        256,
+        512,
+        2,
+        "float8_e5m2",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "major_float8_e5m2_mn_c_n",
+        256,
+        256,
+        512,
+        2,
+        "float8_e5m2",
+        "float8_e8m0fnu",
+        32,
+        "bfloat16",
+        "bfloat16",
+        "m",
+        "n",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tile_128x64",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        64,
+        1,
+        1,
+        True,
+    ),
+    (
+        "tile_128x128",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        128,
+        1,
+        1,
+        True,
+    ),
+    (
+        "tile_128x192",
+        256,
+        192,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        192,
+        1,
+        1,
+        True,
+    ),
+    (
+        "tile_128x256",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        1,
+        1,
+        True,
+    ),
+    (
+        "tile_256x64",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        64,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tile_256x128",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        128,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tile_256x192",
+        256,
+        192,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        192,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tile_256x256",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta1_1x1",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        1,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta1_1x2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        1,
+        2,
+        True,
+    ),
+    (
+        "cluster_cta1_1x4",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        1,
+        4,
+        True,
+    ),
+    (
+        "cluster_cta1_2x1",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta1_2x2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        2,
+        2,
+        True,
+    ),
+    (
+        "cluster_cta1_2x4",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        2,
+        4,
+        True,
+    ),
+    (
+        "cluster_cta1_4x1",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        4,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta1_4x2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        4,
+        2,
+        True,
+    ),
+    (
+        "cluster_cta1_4x4",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        256,
+        4,
+        4,
+        True,
+    ),
+    (
+        "cluster_cta2_2x1",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta2_2x2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        2,
+        True,
+    ),
+    (
+        "cluster_cta2_2x4",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        4,
+        True,
+    ),
+    (
+        "cluster_cta2_4x1",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        4,
+        1,
+        True,
+    ),
+    (
+        "cluster_cta2_4x2",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        4,
+        2,
+        True,
+    ),
+    (
+        "cluster_cta2_4x4",
+        256,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        4,
+        4,
+        True,
+    ),
+    (
+        "tail_m",
+        272,
+        256,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tail_n",
+        256,
+        272,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tail_k",
+        256,
+        256,
+        544,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tail_mnk_l2",
+        272,
+        272,
+        544,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        256,
+        2,
+        1,
+        True,
+    ),
+    (
+        "tail_cta1_n64",
+        272,
+        208,
+        544,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        64,
+        1,
+        1,
+        True,
+    ),
+    (
+        "tail_cta2_n192",
+        272,
+        208,
+        544,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        192,
+        2,
+        1,
+        True,
+    ),
+    (
+        "persistent_cta1",
+        4096,
+        512,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        128,
+        128,
+        1,
+        1,
+        True,
+    ),
+    (
+        "persistent_cta2",
+        4096,
+        512,
+        512,
+        2,
+        "float4_e2m1fn",
+        "float8_e8m0fnu",
+        16,
+        "bfloat16",
+        "bfloat16",
+        "k",
+        "k",
+        "n",
+        256,
+        128,
+        2,
+        1,
+        True,
+    ),
+)
+
+
+def _probe_config(probe):
+    (
+        label,
+        M,
+        N,
+        K_dim,
+        L,
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        d_dtype,
+        a_major,
+        b_major,
+        c_major,
+        tile_m,
+        tile_n,
+        cluster_m,
+        cluster_n,
+        vector_f32,
+    ) = probe
+    return {
+        "label": f"source_{label}",
+        "source_probe": label,
+        "M": M,
+        "N": N,
+        "K": K_dim,
+        "L": L,
+        "alpha": 2.0 / 3.0,
+        "ab_dtype": ab_dtype,
+        "sf_dtype": sf_dtype,
+        "sf_vec_size": sf_vec_size,
+        "c_dtype": c_dtype,
+        "d_dtype": d_dtype,
+        "a_major": a_major,
+        "b_major": b_major,
+        "c_major": c_major,
+        "mma_tiler_mn": (tile_m, tile_n),
+        "cluster_shape_mn": (cluster_m, cluster_n),
+        "vector_f32": vector_f32,
+    }
+
+
+@cache
+def _verified_configs():
+    return tuple(_probe_config(probe) for probe in _VERIFIED_PROBES)
+
+
+def _verified_structure(mode):
+    structural_keys = tuple(key for key in _MODE_KEYS if key != "L")
+    return any(
+        all(mode[key] == verified[key] for key in structural_keys)
+        for verified in _verified_configs()
+    )
+
+
+def _pair_tokens(config):
+    encoded = {key: repr(config[key]) for key in _MODE_KEYS}
+    return frozenset(
+        (left, encoded[left], right, encoded[right]) for left, right in combinations(_MODE_KEYS, 2)
+    )
+
+
+def _minimal_cover(candidates, token_fn):
+    covers = [token_fn(mode) for mode in candidates]
+    token_users = {}
+    for index, tokens in enumerate(covers):
+        for token in tokens:
+            token_users.setdefault(token, []).append(index)
+    uncovered = set(token_users)
+    scores = [len(tokens) for tokens in covers]
+    labels = [mode.get("label", _mode_label(mode)) for mode in candidates]
+    heap = [(-score, labels[index], index) for index, score in enumerate(scores)]
+    heapq.heapify(heap)
+    selected = []
+    while uncovered:
+        while True:
+            neg_score, _label, best = heapq.heappop(heap)
+            if -neg_score == scores[best]:
+                break
+        if scores[best] == 0:
+            raise AssertionError("structural coverage did not converge")
+        selected.append(best)
+        newly_covered = covers[best] & uncovered
+        uncovered.difference_update(newly_covered)
+        for token in newly_covered:
+            for index in token_users[token]:
+                scores[index] -= 1
+                heapq.heappush(heap, (-scores[index], labels[index], index))
+    counts = {}
+    for index in selected:
+        for token in covers[index]:
+            counts[token] = counts.get(token, 0) + 1
+    kept = []
+    for index in reversed(selected):
+        if all(counts[token] > 1 for token in covers[index]):
+            for token in covers[index]:
+                counts[token] -= 1
+        else:
+            kept.append(index)
+    return [candidates[index] for index in reversed(kept)]
+
+
+def _stage_parameters(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cta_group = tile_m // 128
+    ab_bits = _dtype_bits(mode["ab_dtype"])
+    c_bits = _dtype_bits(mode["c_dtype"])
+    d_bits = _dtype_bits(mode["d_dtype"])
+    k_tile = 256 if ab_bits == 4 else 128
+    acc_stages = 1 if tile_n == 256 else 2
+    a_stage = 128 * k_tile * ab_bits // 8
+    b_stage = (tile_n // cta_group) * k_tile * ab_bits // 8
+    sfa_stage = 128 * k_tile // mode["sf_vec_size"]
+    sfb_stage = _align_up(tile_n, 128) * k_tile // mode["sf_vec_size"]
+    c_stage = 128 * 32 * c_bits // 8
+    d_stage = 128 * 32 * d_bits // 8
+    ab_stage = a_stage + b_stage + sfa_stage + sfb_stage
+    ab_stages = (_SMEM_CAPACITY - (1024 + 2 * c_stage + 2 * d_stage + 16)) // ab_stage
+    c_offset = 1024
+    d_offset = c_offset + 2 * c_stage
+    a_offset = d_offset + 2 * d_stage
+    b_offset = a_offset + ab_stages * a_stage
+    sfa_offset = b_offset + ab_stages * b_stage
+    sfb_offset = _align_up(sfa_offset + ab_stages * sfa_stage, 1024)
+    amax_offset = _align_up(sfb_offset + ab_stages * sfb_stage, 1024)
+    shared_bytes = _align_up(amax_offset + 16, 1024)
+    return {
+        "cta_group": cta_group,
+        "k_tile": k_tile,
+        "acc_stages": acc_stages,
+        "ab_stages": ab_stages,
+        "c_stages": 2,
+        "d_stages": 2,
+        "shared_bytes": shared_bytes,
+    }
+
+
+def _correctness_tokens(config):
+    stages = _stage_parameters(config)
+    tokens = set(_pair_tokens(config))
+    tokens.add(
+        (
+            "stage_tuple",
+            stages["acc_stages"],
+            stages["ab_stages"],
+            stages["c_stages"],
+            stages["d_stages"],
+            stages["shared_bytes"],
+        )
+    )
+    source_probe = config["source_probe"]
+    if source_probe == "anchor" or source_probe.startswith(("tail_", "persistent_")):
+        tokens.add(("required_guard", source_probe))
+    return frozenset(tokens)
+
+
+def _correctness_configs():
+    # Pairwise values, every stage tuple, and the frozen anchor/tail/persistent
+    # guards are selected together, followed by reverse redundancy pruning.
+    selected = _minimal_cover(_verified_configs(), _correctness_tokens)
+    configs = []
+    for selected_config in selected:
+        config = dict(selected_config)
+        config.pop("source_probe")
+        configs.append(config)
+    return sorted(configs, key=lambda config: config["label"])
+
+
+def _performance_tokens(mode):
+    stages = _stage_parameters(mode)
+    return frozenset(
+        {
+            ("ab", mode["ab_dtype"]),
+            ("sf", mode["sf_dtype"], mode["sf_vec_size"]),
+            ("c", mode["c_dtype"]),
+            ("d", mode["d_dtype"]),
+            ("a_major", mode["a_major"]),
+            ("b_major", mode["b_major"]),
+            ("c_major", mode["c_major"]),
+            ("cta_group", stages["cta_group"]),
+            ("tile_n", mode["mma_tiler_mn"][1]),
+            ("cluster", mode["cluster_shape_mn"]),
+            ("mma", mode["ab_dtype"], mode["sf_dtype"], mode["sf_vec_size"]),
+            ("store", mode["c_dtype"], mode["d_dtype"]),
+            (
+                "stages",
+                stages["acc_stages"],
+                stages["ab_stages"],
+                stages["c_stages"],
+                stages["d_stages"],
+            ),
+            ("amax", True),
+        }
+    )
+
+
+def _benchmark_configs():
+    # The independent PTX export proved vector_f32=true/false byte-identical,
+    # so performance coverage keeps one representative (true) while CONFIGS
+    # retain both correctness probes.
+    unique_modes = {}
+    for config in _verified_configs():
+        if not config["vector_f32"]:
+            continue
+        key = tuple(config[name] for name in _MODE_KEYS if name != "L")
+        unique_modes.setdefault(key, config)
+    base_modes = tuple(sorted(unique_modes.values(), key=lambda config: config["label"]))
+    representatives = _minimal_cover(base_modes, _performance_tokens)
+    # Freeze one compact, deterministic instance roster after structural
+    # representative selection. Every one of the 23 representatives remains
+    # present, while seven extra rows cover small/large and L=1/L=2 boundaries.
+    instances = {
+        0: ((4096, 1), (8192, 1)),
+        1: ((8192, 1),),
+        2: ((1024, 1), (8192, 1)),
+        3: ((1024, 1), (2048, 2), (4096, 1), (4096, 2), (8192, 2)),
+        4: ((8192, 1),),
+        5: ((4096, 2),),
+        6: ((4096, 1),),
+        7: ((1024, 2),),
+        8: ((4096, 2),),
+        9: ((8192, 1),),
+        10: ((8192, 2),),
+        11: ((8192, 2),),
+        12: ((4096, 2),),
+        13: ((4096, 1),),
+        14: ((8192, 2),),
+        15: ((4096, 2),),
+        16: ((4096, 2),),
+        17: ((2048, 2),),
+        18: ((4096, 1),),
+        19: ((4096, 1),),
+        20: ((4096, 2),),
+        21: ((4096, 2),),
+        22: ((4096, 1), (8192, 2)),
+    }
+    assert len(representatives) == len(instances) == 23
+    configs = []
+    for index, base_mode in enumerate(representatives):
+        for size, batch in instances[index]:
+            mode = {**base_mode, "M": size, "N": size, "K": size, "L": batch}
+            mode["label"] = f"perf{index:02d}_m{size}_n{size}_k{size}_l{batch}_{_mode_label(mode)}"
+            mode.pop("source_probe")
+            configs.append(mode)
+    assert len(configs) == 30
+    return sorted(configs, key=lambda config: config["label"])
+
+
+KERNEL_META = {
+    "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _correctness_configs()
+BENCH_CONFIGS = _benchmark_configs()
+
+
+@cache
+def _make_kernel(
+    M,
+    N,
+    K_dim,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    d_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    vector_f32,
+):
+    if ab_dtype == "uint8":
+        raise ValueError("the non-running uint8 packed-FP4 alias is not supported")
+    if sf_dtype == "int8":
+        sf_dtype = "float8_e8m0fnu"
+    mma_tiler_mn = tuple(mma_tiler_mn)
+    cluster_shape_mn = tuple(cluster_shape_mn)
+    mode = {
+        "ab_dtype": ab_dtype,
+        "sf_dtype": sf_dtype,
+        "sf_vec_size": sf_vec_size,
+        "c_dtype": c_dtype,
+        "d_dtype": d_dtype,
+        "a_major": a_major,
+        "b_major": b_major,
+        "c_major": c_major,
+        "mma_tiler_mn": mma_tiler_mn,
+        "cluster_shape_mn": cluster_shape_mn,
+        "vector_f32": vector_f32,
+        "L": L,
+    }
+    if min(M, N, K_dim, L) <= 0:
+        raise ValueError("M/N/K/L must be positive")
+    if not _valid_mode(mode):
+        raise ValueError(f"unsupported source specialization: {_mode_label(mode)}")
+    if not _verified_structure(mode):
+        raise ValueError(
+            f"source specialization was not independently verified: {_mode_label(mode)}"
+        )
+    ab_bits = _dtype_bits(ab_dtype)
+    c_bits = _dtype_bits(c_dtype)
+    d_bits = _dtype_bits(d_dtype)
+    if (M if a_major == "m" else K_dim) % (128 // ab_bits):
+        raise ValueError("A's contiguous dimension must be 16-byte aligned")
+    if (N if b_major == "n" else K_dim) % (128 // ab_bits):
+        raise ValueError("B's contiguous dimension must be 16-byte aligned")
+    if (M if c_major == "m" else N) % (128 // c_bits):
+        raise ValueError("C's contiguous dimension must be 16-byte aligned")
+    if (M if c_major == "m" else N) % (128 // d_bits):
+        raise ValueError("D's contiguous dimension must be 16-byte aligned")
+
+    tile_m, n_tile = mma_tiler_mn
+    cta_group = tile_m // 128
+    cta_m = 128
+    b_rows = n_tile // cta_group
+    cluster_m, cluster_n = cluster_shape_mn
+    cluster_size = cluster_m * cluster_n
+    cluster_m_groups = cluster_m // cta_group
+    k_tile = 256 if ab_dtype == "float4_e2m1fn" else 128
+    k_tiles = _ceil_div(K_dim, k_tile)
+    m_tiles = _ceil_div(M, cta_m)
+    n_tiles = _ceil_div(N, n_tile)
+    cluster_m_tiles = _ceil_div(m_tiles, cluster_m)
+    cluster_n_tiles = _ceil_div(n_tiles, cluster_n)
+    cluster_work = cluster_m_tiles * cluster_n_tiles * L
+    num_clusters = min(cluster_work, _MAX_ACTIVE_CLUSTERS[cluster_size])
+    acc_stages = 1 if n_tile == 256 else 2
+    c_stages = 2
+    d_stages = 2
+    epi_n = 32
+    epilogue_subtiles = n_tile // epi_n
+    a_stage_bytes = cta_m * k_tile * ab_bits // 8
+    b_stage_bytes = b_rows * k_tile * ab_bits // 8
+    sfa_stage_bytes = cta_m * k_tile // sf_vec_size
+    # The source SFB layout is padded to a whole 128-column scale tile.
+    # This padding participates in both SMEM allocation and mbarrier bytes.
+    sfb_stage_bytes = _align_up(n_tile, 128) * k_tile // sf_vec_size
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes + sfa_stage_bytes + sfb_stage_bytes
+    c_stage_bytes = cta_m * epi_n * c_bits // 8
+    d_stage_bytes = cta_m * epi_n * d_bits // 8
+    ab_stages = (
+        _SMEM_CAPACITY - (1024 + c_stages * c_stage_bytes + d_stages * d_stage_bytes + 16)
+    ) // ab_stage_bytes
+    if ab_stages <= 0:
+        raise ValueError("source stage heuristic exceeds SM100 shared-memory capacity")
+
+    ab_full_offset = 0
+    ab_empty_offset = ab_full_offset + ab_stages * 8
+    acc_full_offset = ab_empty_offset + ab_stages * 8
+    acc_empty_offset = acc_full_offset + acc_stages * 8
+    tmem_dealloc_offset = acc_empty_offset + acc_stages * 8
+    tmem_ptr_offset = tmem_dealloc_offset + 8
+    c_offset = 1024
+    d_offset = c_offset + c_stages * c_stage_bytes
+    a_offset = d_offset + d_stages * d_stage_bytes
+    b_offset = a_offset + ab_stages * a_stage_bytes
+    sfa_offset = b_offset + ab_stages * b_stage_bytes
+    sfb_offset = _align_up(sfa_offset + ab_stages * sfa_stage_bytes, 1024)
+    sfb_storage_stage_bytes = sfb_stage_bytes
+    amax_offset = _align_up(sfb_offset + ab_stages * sfb_storage_stage_bytes, 1024)
+    shared_bytes = _align_up(amax_offset + 16, 1024)
+    if shared_bytes > _SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {_SMEM_CAPACITY}")
+
+    ab_empty_arrivals = cluster_n + cluster_m_groups - 1
+    acc_empty_arrivals = 4 * cta_group
+    tmem_columns = 512
+    tma_cache_hint = 0
+    entry_max_registers = None
+
+    def mn_smem_parameters(major_size):
+        major_bits = major_size * ab_bits
+        if ab_bits == 32 and major_bits % 1024 == 0:
+            # MN_SW128_32B: S<2, 5, 2>, exposed to TMA as the
+            # 128-byte-atom/32-byte-base swizzle.
+            swizzle, chunk, sdo = 4, 32, 32
+        elif major_bits % 1024 == 0:
+            swizzle, chunk, sdo = 3, 1024 // ab_bits, 64
+        elif major_bits % 512 == 0:
+            swizzle, chunk, sdo = 2, 512 // ab_bits, 32
+        elif major_bits % 256 == 0:
+            swizzle, chunk, sdo = 1, 256 // ab_bits, 16
+        else:
+            raise ValueError("MN-major input tile must contain a 32-byte swizzle atom")
+        copies = major_size // chunk
+        ldo = 0 if copies == 1 else chunk * k_tile * (ab_bits // 8) // 16
+        return swizzle, chunk, copies, ldo, sdo
+
+    if a_major == "m":
+        a_swizzle, a_chunk, a_copies, a_ldo, a_sdo = mn_smem_parameters(cta_m)
+    else:
+        a_swizzle, a_chunk, a_copies, a_ldo, a_sdo = 3, cta_m, 1, 1, 64
+    if b_major == "n":
+        b_swizzle, b_chunk, b_copies, b_ldo, b_sdo = mn_smem_parameters(b_rows)
+    else:
+        b_swizzle, b_chunk, b_copies, b_ldo, b_sdo = 3, b_rows, 1, 1, 64
+    a_cluster_piece = (k_tile if a_major == "m" else cta_m) // cluster_n
+    b_cluster_piece = (k_tile if b_major == "n" else b_rows) // cluster_m_groups
+    a_piece_bytes = a_stage_bytes // (a_copies * cluster_n)
+    b_piece_bytes = b_stage_bytes // (b_copies * cluster_m_groups)
+    num_tma_load_bytes = ab_stage_bytes * cta_group
+
+    a_desc_base = _descriptor_base(ldo=a_ldo, sdo=a_sdo, swizzle=a_swizzle)
+    b_desc_base = _descriptor_base(ldo=b_ldo, sdo=b_sdo, swizzle=b_swizzle)
+    sf_desc_base = _descriptor_base(ldo=1, sdo=8, swizzle=0)
+    instr_desc = _instruction_descriptor(tile_m, n_tile, ab_dtype, sf_dtype, a_major, b_major)
+    acc_columns = acc_stages * n_tile
+    sfa_tmem_column = acc_columns
+    sfa_chunks = sfa_stage_bytes // 512
+    sfb_chunks = sfb_stage_bytes // 512
+    sfb_tmem_column = sfa_tmem_column + sfa_chunks * 4
+    if sfb_tmem_column + sfb_chunks * 4 > 512:
+        raise ValueError("source TMEM scale regions exceed 512 columns")
+    sf_k_box = k_tile // (4 * sf_vec_size)
+    sfa_piece_values = 256 * sf_k_box // cluster_n
+    sfb_n_box = _ceil_div(n_tile, 128)
+    sfb_piece_values = 256 * sf_k_box * sfb_n_box // cluster_m_groups
+
+    def host_prelude(params):
+        a = params["a"]
+        b = params["b"]
+        sfa = params["sfa"]
+        sfb = params["sfb"]
+        c = params["c"]
+        d = params["d"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        sfa_map = K.stack_alloca("tensormap", 1)
+        sfb_map = K.stack_alloca("tensormap", 1)
+        c_map = K.stack_alloca("tensormap", 1)
+        d_map = K.stack_alloca("tensormap", 1)
+
+        def encode(descriptor, dtype, rank, data, *fields):
+            K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+        a_contiguous_bytes = (M if a_major == "m" else K_dim) * ab_bits // 8
+        b_contiguous_bytes = (N if b_major == "n" else K_dim) * ab_bits // 8
+        if a_major == "m":
+            a_fields = (
+                M,
+                K_dim,
+                L,
+                a_contiguous_bytes,
+                M * K_dim * ab_bits // 8,
+                a_chunk,
+                a_cluster_piece,
+                1,
+            )
+        else:
+            a_fields = (
+                K_dim,
+                M,
+                L,
+                a_contiguous_bytes,
+                M * K_dim * ab_bits // 8,
+                k_tile,
+                a_cluster_piece,
+                1,
+            )
+        if b_major == "n":
+            b_fields = (
+                N,
+                K_dim,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                b_chunk,
+                b_cluster_piece,
+                1,
+            )
+        else:
+            b_fields = (
+                K_dim,
+                N,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                k_tile,
+                b_cluster_piece,
+                1,
+            )
+        tensor_tail = (1, 1, 1, 0, a_swizzle, 2, 0)
+        if ab_dtype == "float4_e2m1fn":
+            tensor_tail += (13,)
+        encode(a_map, ab_dtype, 3, a.data, *a_fields, *tensor_tail)
+        tensor_tail = (1, 1, 1, 0, b_swizzle, 2, 0)
+        if ab_dtype == "float4_e2m1fn":
+            tensor_tail += (13,)
+        encode(b_map, ab_dtype, 3, b.data, *b_fields, *tensor_tail)
+
+        sf_k_groups = _ceil_div(K_dim, 4 * sf_vec_size)
+        sf_m_groups = _ceil_div(M, 128)
+        sf_n_groups = _ceil_div(N, 128)
+        sfa_box_0 = min(256, sfa_piece_values)
+        sfa_box_1 = sfa_piece_values // sfa_box_0
+        encode(
+            sfa_map,
+            "uint16",
+            4,
+            sfa.data,
+            256,
+            sf_k_groups,
+            sf_m_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_m_groups * sf_k_groups * 512,
+            sfa_box_0,
+            sfa_box_1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        sfb_box_0 = min(256, sfb_piece_values)
+        sfb_remaining = sfb_piece_values // sfb_box_0
+        sfb_box_1 = min(sf_k_box, sfb_remaining)
+        sfb_box_2 = sfb_remaining // sfb_box_1
+        encode(
+            sfb_map,
+            "uint16",
+            4,
+            sfb.data,
+            256,
+            sf_k_groups,
+            sf_n_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_n_groups * sf_k_groups * 512,
+            sfb_box_0,
+            sfb_box_1,
+            sfb_box_2,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+
+        def encode_output(descriptor, tensor, dtype, bits):
+            element_bytes = bits // 8
+            contiguous_bytes = N * element_bytes
+            batch_bytes = M * N * element_bytes
+            fields = (N, M, L, contiguous_bytes, batch_bytes, epi_n, cta_m, 1)
+            row_bytes = epi_n * element_bytes
+            swizzle = 3 if row_bytes >= 128 else 2 if row_bytes >= 64 else 1
+            encode(descriptor, dtype, 3, tensor.data, *fields, 1, 1, 1, 0, swizzle, 2, 0)
+
+        encode_output(c_map, c, c_dtype, c_bits)
+        encode_output(d_map, d, d_dtype, d_bits)
+        return a_map, b_map, sfa_map, sfb_map, c_map, d_map
+
+    def kernel(a, b, sfa, sfb, c, d, prob, amax, alpha, *, host):
+        del a, b, sfa, sfb, c, d
+        a_map, b_map, sfa_map, sfb_map, c_map, d_map = host
+        if entry_max_registers is None:
+            _block_x, _block_y, cluster_work_id = K.cta_id()
+        else:
+            with K.attr({"tirx.max_registers": entry_max_registers}):
+                _block_x, _block_y, cluster_work_id = K.cta_id()
+        cluster_x_scope, cluster_y_scope = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        del _block_x, _block_y, cluster_x_scope, cluster_y_scope
+        cluster_rank = K.local_scalar("int32", init=K.cuda.mov_sreg(32, "cluster_ctarank"))
+        cluster_x = K.local_scalar("int32", init=cluster_rank & (cluster_m - 1))
+        cluster_y = K.local_scalar("int32", init=cluster_rank >> (cluster_m.bit_length() - 1))
+        cta_v = cluster_x % cta_group
+        leader_cta = cta_v == 0
+        cluster_m_group = cluster_x // cta_group
+        pair_leader_x = cluster_m_group * cta_group
+        leader_rank = pair_leader_x + cluster_m * cluster_y
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool,
+            ab_stages,
+            full="tma",
+            empty="tcgen05",
+            init_empty=ab_empty_arrivals,
+            leader=K.bool(False),
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=acc_empty_arrivals,
+            leader=K.bool(False),
+        )
+        if protocol_pool.bytes != tmem_dealloc_offset:
+            raise AssertionError("protocol storage offsets changed")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.bytes != tmem_ptr_offset + 4:
+            raise AssertionError("protocol storage header changed")
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfa_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfb_map))
+            K.ptx.prefetch.tensormap(K.address_of(c_map))
+            K.ptx.prefetch.tensormap(K.address_of(d_map))
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(ab_empty_arrivals)
+                            )
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(acc_empty_arrivals)
+                            )
+        if cta_group == 2:
+            with K.If(warp == 0):
+                with K.Then():
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.init.shared.b64(tmem_dealloc.ptr_to([0]), K.uint32(32))
+            K.ptx.fence.mbarrier_init.release.cluster()
+
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.arrive.relaxed()
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        tmem_slot_addr = K.uniform(smem_base + K.uint32(tmem_ptr_offset))
+        cluster_smem_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_u64, smem.ptr_to([0]))
+        cluster_smem = K.local_scalar("uint32", init=K.cast(cluster_smem_u64, "uint32"))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, smem_base + a_offset)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, smem_base + b_offset)
+        )
+        sfa_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfa_offset)
+        )
+        sfb_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfb_offset)
+        )
+
+        a_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_n in range(cluster_n):
+            K.assign(
+                a_mcast_mask,
+                K.bitwise_or(
+                    a_mcast_mask, K.uint32(1) << K.cast(cluster_x + cluster_m * peer_n, "uint32")
+                ),
+            )
+        b_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_group in range(cluster_m_groups):
+            peer_x = cta_v + cta_group * peer_group
+            K.assign(
+                b_mcast_mask,
+                K.bitwise_or(
+                    b_mcast_mask, K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        ab_consumer_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for pair_v in range(cta_group):
+            for peer_n in range(cluster_n):
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1)
+                        << K.cast(pair_leader_x + pair_v + cluster_m * peer_n, "uint32"),
+                    ),
+                )
+            for peer_group in range(cluster_m_groups):
+                peer_x = pair_v + cta_group * peer_group
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32"),
+                    ),
+                )
+        acc_producer_mask = K.local_scalar(
+            "uint32", init=K.uint32((1 << cta_group) - 1) << K.cast(leader_rank, "uint32")
+        )
+        ab_full_leader = ab_pipe.full.remote_view(leader_rank)
+        acc_empty_leader = acc_pipe.empty.remote_view(leader_rank)
+
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.wait()
+        else:
+            K.ptx.bar.sync(K.uint32(0), K.uint32(192))
+
+        def scheduler_coords(work):
+            cluster_m_idx = work % cluster_m_tiles
+            quotient = work // cluster_m_tiles
+            cluster_n_idx = quotient % cluster_n_tiles
+            batch_idx = quotient // cluster_n_tiles
+            tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+            tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+            return tile_m_idx, tile_n_idx, batch_idx
+
+        def advance_work(work):
+            K.assign(work, work + num_clusters)
+
+        # TMEM allocation is published through one physical 160-thread
+        # barrier instruction shared by the four epilogue warps and the MMA
+        # warp.  Keeping the arrival at one PC is required by synccheck and is
+        # equivalent to the source's named-barrier-2 rendezvous.
+        with K.If(warp < K.uint32(5)):
+            with K.Then():
+                with K.If(warp == 0):
+                    with K.Then():
+                        K.ptx[
+                            "tcgen05.alloc.cta_group::"
+                            + str(cta_group)
+                            + ".sync.aligned.shared::cta.b32"
+                        ](tmem_slot_addr, K.uint32(tmem_columns))
+                K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+
+        with tma_role:
+            tma_state = K.PipelineState(ab_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase
+                        )
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
+                    )
+                    if k_tiles:
+                        if ab_stages:
+                            with K.If(leader_cta):
+                                with K.Then():
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                                ab_pipe.full.ptr_to([tma_state.stage]),
+                                                K.uint32(num_tma_load_bytes),
+                                            )
+
+                            a_elected = _elected()
+                            for copy in range(a_copies):
+                                a_coord_m = tile_m_idx * cta_m
+                                a_coord_k = count * k_tile
+                                if a_major == "m":
+                                    a_coord_m = a_coord_m + copy * a_chunk
+                                    a_coord_k = a_coord_k + cluster_y * a_cluster_piece
+                                else:
+                                    a_coord_m = a_coord_m + cluster_y * a_cluster_piece
+                                a_coord_0 = a_coord_m if a_major == "m" else a_coord_k
+                                a_coord_1 = a_coord_k if a_major == "m" else a_coord_m
+                                a_smem_offset = (
+                                    a_offset
+                                    + tma_state.stage * a_stage_bytes
+                                    + copy * (a_stage_bytes // a_copies)
+                                    + cluster_y * a_piece_bytes
+                                )
+                                if cta_group == 1 and cluster_n == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                        smem.ptr_to([a_smem_offset]),
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cta_group == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cluster_n == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+
+                            b_elected = _elected()
+                            for copy in range(b_copies):
+                                b_coord_n = tile_n_idx * n_tile + cta_v * b_rows
+                                b_coord_k = count * k_tile
+                                if b_major == "n":
+                                    b_coord_n = b_coord_n + copy * b_chunk
+                                    b_coord_k = b_coord_k + cluster_m_group * b_cluster_piece
+                                else:
+                                    b_coord_n = b_coord_n + cluster_m_group * b_cluster_piece
+                                b_coord_0 = b_coord_n if b_major == "n" else b_coord_k
+                                b_coord_1 = b_coord_k if b_major == "n" else b_coord_n
+                                b_smem_offset = (
+                                    b_offset
+                                    + tma_state.stage * b_stage_bytes
+                                    + copy * (b_stage_bytes // b_copies)
+                                    + cluster_m_group * b_piece_bytes
+                                )
+                                if cta_group == 1 and cluster_m_groups == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                        smem.ptr_to([b_smem_offset]),
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cta_group == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cluster_m_groups == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+
+                            sfa_linear = cluster_y * sfa_piece_values
+                            sfa_coord_0 = sfa_linear % 256
+                            sfa_coord_1 = count * sf_k_box + sfa_linear // 256
+                            sfa_smem_offset = (
+                                sfa_offset
+                                + tma_state.stage * sfa_stage_bytes
+                                + cluster_y * (sfa_stage_bytes // cluster_n)
+                            )
+                            sfa_elected = _elected()
+                            if cta_group == 1 and cluster_n == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                    smem.ptr_to([sfa_smem_offset]),
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cta_group == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cluster_n == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+
+                            sfb_linear = cluster_m_group * sfb_piece_values
+                            sfb_coord_0 = sfb_linear % 256
+                            sfb_quotient = sfb_linear // 256
+                            sfb_coord_1 = count * sf_k_box + sfb_quotient % sf_k_box
+                            # SFB is globally blocked in 128-column units.  N64
+                            # and N192 tiles can start halfway through a scale
+                            # block; the TMEM shift below selects that half.
+                            sfb_global_block = tile_n_idx * n_tile // 128
+                            sfb_coord_2 = sfb_global_block + sfb_quotient // sf_k_box
+                            sfb_smem_offset = (
+                                sfb_offset
+                                + tma_state.stage * sfb_stage_bytes
+                                + cluster_m_group * (sfb_stage_bytes // cluster_m_groups)
+                            )
+                            sfb_elected = _elected()
+                            if cta_group == 1 and cluster_m_groups == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                    smem.ptr_to([sfb_smem_offset]),
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cta_group == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cluster_m_groups == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    _advance(tma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative,
+                                ab_pipe.empty.ptr_to([tma_state.stage]),
+                                tma_state.phase,
+                            )
+                advance_work(work)
+            with K.unroll(0, ab_stages) as unused_stage:
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+            del unused_stage
+
+        with mma_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            mma_state = K.PipelineState(ab_stages, phase=0)
+            acc_state = K.PipelineState(acc_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            accumulate = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                _tile_m_idx, tile_n_idx, _batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If((count < k_tiles) & leader_cta):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                        )
+                with K.If(leader_cta):
+                    with K.Then():
+                        _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(accumulate, K.uint32(0))
+                with K.While(count < k_tiles):
+                    with K.If(leader_cta):
+                        with K.Then():
+                            _wait_plain_if_needed(
+                                ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase, speculative
+                            )
+                            for sf_chunk in range(sfa_chunks):
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        K.ptx[
+                                            "tcgen05.cp.cta_group::"
+                                            + str(cta_group)
+                                            + ".32x128b.warpx4"
+                                        ](
+                                            K.cast(
+                                                tmem_base + sfa_tmem_column + sf_chunk * 4, "uint32"
+                                            ),
+                                            sfa_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (sfa_stage_bytes // 16)
+                                                + sf_chunk * 32,
+                                                "uint64",
+                                            ),
+                                        )
+                            for sf_chunk in range(sfb_chunks):
+                                sfb_shared_chunk = (
+                                    sf_chunk % sfb_n_box
+                                ) * sf_k_box + sf_chunk // sfb_n_box
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        K.ptx[
+                                            "tcgen05.cp.cta_group::"
+                                            + str(cta_group)
+                                            + ".32x128b.warpx4"
+                                        ](
+                                            K.cast(
+                                                tmem_base + sfb_tmem_column + sf_chunk * 4, "uint32"
+                                            ),
+                                            sfb_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (sfb_stage_bytes // 16)
+                                                + sfb_shared_chunk * 32,
+                                                "uint64",
+                                            ),
+                                        )
+                            for kblock in range(4):
+                                if sf_vec_size == 16:
+                                    sfa_scale_offset = kblock * 4
+                                    sfb_scale_offset = kblock * 4 * sfb_n_box
+                                    sf_selector = 0
+                                elif ab_dtype == "float4_e2m1fn":
+                                    sfa_scale_offset = (kblock // 2) * 4
+                                    sfb_scale_offset = (kblock // 2) * 4 * sfb_n_box
+                                    sf_selector = (kblock % 2) * 0x80000000
+                                else:
+                                    sfa_scale_offset = 0
+                                    sfb_scale_offset = 0
+                                    sf_selector = kblock * 0x40000000
+                                sfb_tile_shift = 0
+                                if n_tile in (64, 192):
+                                    sfb_tile_shift = (tile_n_idx % 2) * 2
+                                sfa_tmem_addr = K.cast(
+                                    tmem_base
+                                    + sfa_tmem_column
+                                    + sfa_scale_offset
+                                    + K.uint32(sf_selector),
+                                    "uint32",
+                                )
+                                sfb_tmem_addr = K.cast(
+                                    tmem_base
+                                    + sfb_tmem_column
+                                    + sfb_tile_shift
+                                    + sfb_scale_offset
+                                    + K.uint32(sf_selector),
+                                    "uint32",
+                                )
+                                runtime_instr_desc = K.bitwise_and(
+                                    K.uint32(instr_desc), K.uint32(0x9FFFFFCF)
+                                )
+                                runtime_instr_desc = K.bitwise_or(
+                                    runtime_instr_desc,
+                                    K.bitwise_and(
+                                        K.shift_right(sfa_tmem_addr, K.uint32(1)),
+                                        K.uint32(0x60000000),
+                                    ),
+                                )
+                                runtime_instr_desc = K.bitwise_or(
+                                    runtime_instr_desc,
+                                    K.bitwise_and(
+                                        K.shift_right(sfb_tmem_addr, K.uint32(26)), K.uint32(0x30)
+                                    ),
+                                )
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        mma_kind = (
+                                            "mxf4nvf4"
+                                            if ab_dtype == "float4_e2m1fn"
+                                            else "mxf8f6f4"
+                                        )
+                                        a_kblock = (
+                                            2 if a_major == "k" else a_chunk * 32 * ab_bits // 128
+                                        )
+                                        b_kblock = (
+                                            2 if b_major == "k" else b_chunk * 32 * ab_bits // 128
+                                        )
+                                        K.ptx[
+                                            "tcgen05.mma.cta_group::"
+                                            + str(cta_group)
+                                            + ".kind::"
+                                            + mma_kind
+                                            + ".block_scale.block"
+                                            + str(sf_vec_size)
+                                        ](
+                                            K.cast(tmem_base + acc_state.stage * n_tile, "uint32"),
+                                            a_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (a_stage_bytes // 16)
+                                                + kblock * a_kblock,
+                                                "uint64",
+                                            ),
+                                            b_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (b_stage_bytes // 16)
+                                                + kblock * b_kblock,
+                                                "uint64",
+                                            ),
+                                            runtime_instr_desc,
+                                            sfa_tmem_addr,
+                                            sfb_tmem_addr,
+                                            K.ptx.pred(K.cast(accumulate, "bool")),
+                                        )
+                                K.assign(accumulate, K.uint32(1))
+                            with K.If(_elected()):
+                                with K.Then():
+                                    if cta_group == 2:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                            ".shared::cluster.multicast::cluster.b64"
+                                        ](
+                                            ab_pipe.empty.ptr_to([mma_state.stage]),
+                                            K.cast(ab_consumer_mask, "uint16"),
+                                        )
+                                    elif cluster_size > 1:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                            ".shared::cluster.multicast::cluster.b64"
+                                        ](
+                                            ab_pipe.empty.ptr_to([mma_state.stage]),
+                                            K.cast(ab_consumer_mask, "uint16"),
+                                        )
+                                    else:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                            ".shared::cluster.b64"
+                                        ](ab_pipe.empty.ptr_to([mma_state.stage]))
+                    _advance(mma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If((count < k_tiles) & leader_cta):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                            )
+                with K.If(leader_cta):
+                    with K.Then():
+                        with K.If(_elected()):
+                            with K.Then():
+                                if cta_group == 2:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                        ".shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        acc_pipe.full.ptr_to([acc_state.stage]),
+                                        K.cast(acc_producer_mask, "uint16"),
+                                    )
+                                elif cluster_size > 1:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                        ".shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        acc_pipe.full.ptr_to([acc_state.stage]),
+                                        K.cast(acc_producer_mask, "uint16"),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                        ".shared::cluster.b64"
+                                    ](acc_pipe.full.ptr_to([acc_state.stage]))
+                _advance(acc_state)
+                advance_work(work)
+            with K.If(leader_cta):
+                with K.Then():
+                    for _ in range(acc_stages - 1):
+                        _advance(acc_state)
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        with epilogue_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            acc_state = K.PipelineState(acc_stages, phase=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            executed_tiles = K.local_scalar("int32", init=0)
+
+            values = K.alloc_local((32,), "float32")
+            absolute_values = K.alloc_local((32,), "float32")
+            maxima = K.alloc_local((11,), "float32")
+            c_words = K.alloc_local((32,), "uint32")
+            d_words = K.alloc_local((32,), "uint32")
+            c_pairs = K.alloc_local((16,), "uint16")
+            d_pairs = K.alloc_local((16,), "uint16")
+            c_wide = K.alloc_local((16,), "uint64")
+            d_wide = K.alloc_local((16,), "uint64")
+            c_offsets = K.alloc_local((8,), "int32")
+            d_offsets = K.alloc_local((8,), "int32")
+            tile_amax = K.local_scalar("float32")
+            warp_amax = K.local_scalar("float32")
+            prob_value = K.local_scalar("float32")
+
+            def load_accumulator(subtile):
+                tmem_load_addr = K.local_scalar(
+                    "uint32",
+                    init=tmem_base + (warp << 21) + acc_state.stage * n_tile + subtile * epi_n,
+                )
+                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                    *[values[index] for index in range(32)], tmem_load_addr
+                )
+
+            def multiply_pair(dst0, dst1, left0, left1, right0, right1):
+                packed = K.local_scalar("uint64")
+                K.ptx.mul.rn.f32x2(
+                    packed, K.cuda.make_float2(left0, left1), K.cuda.make_float2(right0, right1)
+                )
+                K.ptx.mov.b64(dst0, dst1, packed)
+
+            def apply_alpha():
+                for index in range(0, 32, 2):
+                    multiply_pair(
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                        alpha,
+                        alpha,
+                    )
+
+            def pack_output(dtype, source_values, words, pairs, wide):
+                if dtype == "float32":
+                    for index in range(16):
+                        K.assign(
+                            wide[index],
+                            K.cuda.make_float2(
+                                source_values[index * 2], source_values[index * 2 + 1]
+                            ),
+                        )
+                elif dtype in {"float16", "bfloat16"}:
+                    for index in range(16):
+                        if dtype == "float16":
+                            K.ptx.cvt.rn.f16x2.f32(
+                                words[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+                else:
+                    for index in range(16):
+                        if dtype == "float8_e4m3fn":
+                            K.ptx.cvt.rn.satfinite.e4m3x2.f32(
+                                pairs[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.satfinite.e5m2x2.f32(
+                                pairs[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+                    for index in range(8):
+                        K.assign(
+                            words[index],
+                            K.bitwise_or(
+                                K.cast(pairs[index * 2], "uint32"),
+                                K.shift_left(K.cast(pairs[index * 2 + 1], "uint32"), K.uint32(16)),
+                            ),
+                        )
+
+            def stage_output(dtype, bits, words, wide, offsets, region_offset, stage, stage_bytes):
+                row_bytes = epi_n * bits // 8
+                word_count = epi_n * bits // 32
+                vector_count = row_bytes // 16
+                # The dynamic arena's fixed base preserves every admitted row
+                # alignment, so apply the vector swizzle directly to the
+                # arena-relative row offset.
+                row_offset = K.local_scalar(
+                    "uint32",
+                    init=region_offset
+                    + stage * stage_bytes
+                    + warp * (32 * row_bytes)
+                    + lane * row_bytes,
+                )
+                swizzle_vector = K.local_scalar(
+                    "uint32",
+                    init=K.bitwise_and(
+                        K.shift_right(row_offset, K.uint32(7)), K.uint32(vector_count - 1)
+                    ),
+                )
+                for vector in range(vector_count):
+                    vector_offset = K.shift_left(
+                        K.bitwise_xor(K.uint32(vector), swizzle_vector), K.uint32(4)
+                    )
+                    if dtype == "float32":
+                        K.assign(
+                            offsets[vector],
+                            K.cast(K.bitwise_or(row_offset, vector_offset), "int32"),
+                        )
+                    else:
+                        K.assign(
+                            offsets[vector],
+                            K.cast(K.bitwise_xor(row_offset, vector_offset), "int32"),
+                        )
+                if dtype == "float32":
+                    for vector in range(vector_count):
+                        K.ptx["st.shared.v2.b64"](
+                            smem.ptr_to([offsets[vector]]), wide[vector * 2], wide[vector * 2 + 1]
+                        )
+                else:
+                    for vector in range(word_count // 4):
+                        K.ptx.st.shared.v4.b32(
+                            smem.ptr_to([offsets[vector]]),
+                            words[vector * 4],
+                            words[vector * 4 + 1],
+                            words[vector * 4 + 2],
+                            words[vector * 4 + 3],
+                        )
+
+            def tma_store_output(map_ptr, region_offset, stage, stage_bytes, subtile):
+                K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"](
+                    K.address_of(map_ptr),
+                    K.cast(tile_n_idx * n_tile + subtile * epi_n, "int32"),
+                    K.cast(tile_m_idx * cta_m, "int32"),
+                    K.cast(batch_idx, "int32"),
+                    smem.ptr_to([region_offset + stage * stage_bytes]),
+                    K.uint64(tma_cache_hint),
+                )
+
+            def apply_srelu_and_amax():
+                for index in range(32):
+                    K.ptx.max.f32(values[index], values[index], K.float32(0.0))
+                for index in range(0, 32, 2):
+                    multiply_pair(
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                    )
+                for index in range(0, 32, 2):
+                    multiply_pair(
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                        prob_value,
+                        prob_value,
+                    )
+                for index in range(32):
+                    K.ptx.abs.f32(absolute_values[index], values[index])
+
+                # Fixed 17-instruction max.NaN tree for the source's 32-value
+                # vector reduction, followed by one non-NaN running fmax.
+                for index in range(10):
+                    K.ptx.max.NaN.f32(
+                        maxima[index],
+                        absolute_values[index * 3],
+                        absolute_values[index * 3 + 1],
+                        absolute_values[index * 3 + 2],
+                    )
+                K.ptx.max.NaN.f32(
+                    maxima[10], absolute_values[30], absolute_values[31], K.float32(0.0)
+                )
+                for index in range(3):
+                    K.ptx.max.NaN.f32(
+                        maxima[index],
+                        maxima[index * 3],
+                        maxima[index * 3 + 1],
+                        maxima[index * 3 + 2],
+                    )
+                K.ptx.max.NaN.f32(maxima[3], maxima[9], maxima[10], K.float32(0.0))
+                K.ptx.max.NaN.f32(maxima[0], maxima[0], maxima[1], maxima[2])
+                K.ptx.max.NaN.f32(tile_amax, maxima[0], maxima[3], tile_amax)
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                K.cuda.mbarrier_wait(acc_pipe.full.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(tile_amax, K.float32(0.0))
+                global_row = tile_m_idx * cta_m + warp * 32 + lane
+                prob_offset = batch_idx * (m_tiles * cta_m) + global_row
+                K.ptx.ld.global_.b32(prob_value, prob.ptr_to([prob_offset]))
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    linear_subtile = executed_tiles * epilogue_subtiles + subtile
+                    c_stage = K.bitwise_and(linear_subtile, K.int32(1))
+                    d_stage = K.bitwise_and(linear_subtile, K.int32(1))
+
+                    load_accumulator(subtile)
+                    apply_alpha()
+
+                    # C is converted and stored before sReLU; the FP32 values
+                    # remain live and are the sole input to D.
+                    pack_output(c_dtype, values, c_words, c_pairs, c_wide)
+                    stage_output(
+                        c_dtype,
+                        c_bits,
+                        c_words,
+                        c_wide,
+                        c_offsets,
+                        c_offset,
+                        c_stage,
+                        c_stage_bytes,
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If(warp == 0):
+                        with K.Then():
+                            tma_store_output(c_map, c_offset, c_stage, c_stage_bytes, subtile)
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(c_stages - 1)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+
+                    apply_srelu_and_amax()
+                    pack_output(d_dtype, values, d_words, d_pairs, d_wide)
+                    stage_output(
+                        d_dtype,
+                        d_bits,
+                        d_words,
+                        d_wide,
+                        d_offsets,
+                        d_offset,
+                        d_stage,
+                        d_stage_bytes,
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If(warp == 0):
+                        with K.Then():
+                            tma_store_output(d_map, d_offset, d_stage, d_stage_bytes, subtile)
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(d_stages - 1)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    K.assign(subtile, subtile + 1)
+
+                K.ptx.redux_sync.max.NaN.f32(warp_amax, tile_amax, K.uint32(0xFFFFFFFF))
+                with K.If(lane == 0):
+                    with K.Then():
+                        K.ptx.st.shared.b32(smem.ptr_to([amax_offset + warp * 4]), warp_amax)
+                K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                with K.If((warp == 0) & (lane == 0)):
+                    with K.Then():
+                        amax_words = K.alloc_local((4,), "uint32", align=16)
+                        K.ptx.ld.shared.v4.b32(
+                            amax_words[0],
+                            amax_words[1],
+                            amax_words[2],
+                            amax_words[3],
+                            smem.ptr_to([amax_offset]),
+                        )
+                        block_amax = K.local_scalar("float32")
+                        K.ptx.max.f32(
+                            block_amax, K.reinterpret("float32", amax_words[0]), K.float32(0.0)
+                        )
+                        for slot in range(1, 4):
+                            K.ptx.max.f32(
+                                block_amax, block_amax, K.reinterpret("float32", amax_words[slot])
+                            )
+                        K.ptx["red.global.max.s32"](
+                            amax.ptr_to([0]), K.reinterpret("int32", block_amax)
+                        )
+                with K.If(_elected()):
+                    with K.Then():
+                        if cta_group == 2:
+                            K.ptx.mbarrier.arrive.shared__cluster.b64(
+                                acc_empty_leader.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                        else:
+                            K.ptx.mbarrier.arrive.shared.b64(
+                                acc_pipe.empty.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                _advance(acc_state)
+                K.assign(executed_tiles, executed_tiles + 1)
+                advance_work(work)
+
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx[
+                        "tcgen05.relinquish_alloc_permit.cta_group::"
+                        + str(cta_group)
+                        + ".sync.aligned"
+                    ]()
+            K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+            with K.If(warp == 0):
+                with K.Then():
+                    if cta_group == 2:
+                        remote_dealloc = K.local_scalar("uint32")
+                        K.ptx.mapa.shared__cluster.u32(
+                            remote_dealloc,
+                            K.cuda.cvta_generic_to_shared(tmem_dealloc.ptr_to([0])),
+                            K.cast(cluster_rank ^ 1, "uint32"),
+                        )
+                        K.ptx.mbarrier.arrive.shared__cluster.b64(remote_dealloc, K.uint32(1))
+                        _wait_plain(tmem_dealloc.ptr_to([0]), K.uint32(0))
+                    K.ptx["tcgen05.dealloc.cta_group::" + str(cta_group) + ".sync.aligned.b32"](
+                        tmem_base, K.uint32(tmem_columns)
+                    )
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+
+    kernel.__annotations__ = {
+        "a": K.gptr[K.u8, (M * K_dim * L * ab_bits // 8,)],
+        "b": K.gptr[K.u8, (N * K_dim * L * ab_bits // 8,)],
+        "sfa": K.gptr[K.u8, (L * _ceil_div(M, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "sfb": K.gptr[K.u8, (L * _ceil_div(N, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "c": K.gptr[K.u8, (M * N * L * c_bits // 8,)],
+        "d": K.gptr[K.u8, (M * N * L * d_bits // 8,)],
+        "prob": K.gptr[K.f32, (m_tiles * cta_m * L,)],
+        "amax": K.gptr[K.f32, (1,)],
+        "alpha": K.f32,
+    }
+    return K.kernel(
+        warps=6,
+        arch="sm_100a",
+        grid=[cluster_m, cluster_n, num_clusters],
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(
+    M,
+    N,
+    K,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    d_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    vector_f32,
+    alpha=None,
+):
+    del alpha
+    return _make_kernel(
+        M,
+        N,
+        K,
+        L,
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        d_dtype,
+        a_major,
+        b_major,
+        c_major,
+        tuple(mma_tiler_mn),
+        tuple(cluster_shape_mn),
+        vector_f32,
+    ).func
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _torch_dtype(torch, dtype):
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e5m2": torch.float8_e5m2,
+        "float8_e8m0fnu": torch.float8_e8m0fnu,
+    }[dtype]
+
+
+def _regular_tensor(torch, rows, columns, batch, dtype, first_major):
+    bits = _dtype_bits(dtype)
+    raw = torch.empty(rows * columns * batch * bits // 8, dtype=torch.uint8, device="cuda")
+    storage = raw.view(_torch_dtype(torch, dtype))
+    strides = (1, rows, rows * columns) if first_major else (columns, 1, rows * columns)
+    logical = torch.as_strided(storage, (rows, columns, batch), strides)
+    return raw, logical
+
+
+def _signed_row_factors(torch, rows, batch, offset):
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None]
+    batch_index = torch.arange(batch, device="cuda", dtype=torch.int64)[None, :]
+    selector = ((row // 32) + batch_index + offset) % 4
+    values = torch.tensor((-1.0, -0.5, 0.5, 1.0), dtype=torch.float32, device="cuda")
+    return values[selector]
+
+
+def _input_tensor(torch, rows, K_dim, batch, dtype, major, offset):
+    factors = _signed_row_factors(torch, rows, batch, offset)
+    if dtype == "float4_e2m1fn":
+        if K_dim % 2:
+            raise ValueError("packed FP4 K must be even")
+        codes = (factors.abs() * 2.0).to(torch.uint8)
+        codes = codes | ((factors < 0).to(torch.uint8) << 3)
+        packed = codes | (codes << 4)
+        physical = packed.transpose(0, 1)[:, :, None].expand(batch, rows, K_dim // 2).contiguous()
+        logical = physical.view(torch.float4_e2m1fn_x2).permute(1, 2, 0)
+        return {"raw": physical.reshape(-1), "source": logical, "factors": factors}
+    raw, logical = _regular_tensor(torch, rows, K_dim, batch, dtype, first_major=major != "k")
+    logical.copy_(factors[:, None, :].expand(rows, K_dim, batch).to(logical.dtype))
+    return {"raw": raw, "source": logical, "factors": factors}
+
+
+def _output_tensor(torch, rows, columns, batch, dtype, major):
+    raw, logical = _regular_tensor(torch, rows, columns, batch, dtype, first_major=major == "m")
+    logical.zero_()
+    return {"raw": raw, "source": logical}
+
+
+def _sf_storage(torch, rows, columns, batch, vec_size, dtype, fill):
+    shape = (batch, _ceil_div(rows, 128), _ceil_div(columns, 4 * vec_size), 32, 4, 4)
+    return torch.full(shape, fill, dtype=torch.float32, device="cuda").to(
+        _torch_dtype(torch, dtype)
+    )
+
+
+def _prob_storage(torch, rows, padded_rows, batch, a_major):
+    raw = torch.zeros(batch * padded_rows, dtype=torch.float32, device="cuda")
+    strides = (1, padded_rows, padded_rows) if a_major == "m" else (1, 1, padded_rows)
+    logical = torch.as_strided(raw, (rows, 1, batch), strides)
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None]
+    batch_index = torch.arange(batch, device="cuda", dtype=torch.int64)[None, :]
+    values = ((((row // 16) + batch_index) % 3).float() + 1.0) * 0.125
+    logical.copy_(values[:, None, :])
+    return {"raw": raw, "source": logical, "values": values}
+
+
+def prepare_data(**config):
+    """Allocate deterministic signed inputs and independent target/source outputs."""
+    import math
+
+    import torch
+
+    config = _without_label(config)
+    M, N, K_dim, L = (config[key] for key in ("M", "N", "K", "L"))
+    sf_dtype = "float8_e8m0fnu" if config["sf_dtype"] == "int8" else config["sf_dtype"]
+    a_data = _input_tensor(torch, M, K_dim, L, config["ab_dtype"], config["a_major"], 0)
+    b_data = _input_tensor(torch, N, K_dim, L, config["ab_dtype"], config["b_major"], 1)
+
+    scale_exponent = math.ceil(math.log2(max(1.0, K_dim / 512.0)))
+    sfa_fill = 2.0 ** (-scale_exponent)
+    sfb_fill = 0.5
+    sfa = _sf_storage(torch, M, K_dim, L, config["sf_vec_size"], sf_dtype, sfa_fill)
+    sfb = _sf_storage(torch, N, K_dim, L, config["sf_vec_size"], sf_dtype, sfb_fill)
+
+    tirx_c = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
+    source_c = _output_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
+    tirx_d = _output_tensor(torch, M, N, L, config["d_dtype"], config["c_major"])
+    source_d = _output_tensor(torch, M, N, L, config["d_dtype"], config["c_major"])
+    padded_m = _ceil_div(M, 128) * 128
+    prob = _prob_storage(torch, M, padded_m, L, config["a_major"])
+    tirx_amax = torch.full((1,), float("-inf"), dtype=torch.float32, device="cuda")
+    source_amax = torch.full((1,), float("-inf"), dtype=torch.float32, device="cuda")
+
+    return {
+        "a": a_data,
+        "b": b_data,
+        "sfa": sfa,
+        "sfb": sfb,
+        "prob": prob,
+        "tirx_c": tirx_c,
+        "source_c": source_c,
+        "tirx_d": tirx_d,
+        "source_d": source_d,
+        "tirx_amax": tirx_amax,
+        "source_amax": source_amax,
+    }
+
+
+@cache
+def _load_reference_source():
+    root = os.environ.get("CUDNN_FRONTEND_PATH")
+    if root is None:
+        root = os.path.join(os.path.dirname(__file__), "../../../.reference-deps/cudnn-frontend")
+    source_path = os.path.abspath(
+        os.path.join(
+            root,
+            "python/cudnn/gemm/cutedsl/dense/srelu/"
+            "dense_blockscaled_gemm_persistent_srelu_quant.py",
+        )
+    )
+    spec = importlib.util.spec_from_file_location("tirx_cudnn_frontend_srelu_source", source_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load cuDNN Frontend source: {source_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _compile_reference(data, config):
+    from tirx_kernels.cudnn._reference import import_cutlass_reference
+
+    cutlass = import_cutlass_reference()
+    import cutlass.cute as cute
+    import torch
+    from cuda.bindings import driver as cuda
+    from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+    module = _load_reference_source()
+    config = _without_label(config)
+    a = data["a"]["source"]
+    b = data["b"]["source"]
+    sfa = data["sfa"]
+    sfb = data["sfb"]
+    c = data["source_c"]["source"]
+    d = data["source_d"]["source"]
+    prob = data["prob"]["source"]
+    amax = data["source_amax"]
+
+    def dynamic(tensor, leading_dim):
+        return from_dlpack(tensor, assumed_align=16).mark_layout_dynamic(leading_dim=leading_dim)
+
+    a_cute = dynamic(a, 0 if config["a_major"] == "m" else 1)
+    b_cute = dynamic(b, 0 if config["b_major"] == "n" else 1)
+    sfa_cute = from_dlpack(sfa, assumed_align=16)
+    sfb_cute = from_dlpack(sfb, assumed_align=16)
+    c_cute = dynamic(c, 0 if config["c_major"] == "m" else 1)
+    d_cute = dynamic(d, 0 if config["c_major"] == "m" else 1)
+    prob_cute = dynamic(prob, 0 if config["a_major"] == "m" else 1)
+    amax_cute = from_dlpack(amax, assumed_align=16)
+
+    kernel = module.Sm100BlockScaledPersistentDenseGemmKernel(
+        sf_vec_size=config["sf_vec_size"],
+        mma_tiler_mn=tuple(config["mma_tiler_mn"]),
+        cluster_shape_mn=tuple(config["cluster_shape_mn"]),
+        vector_f32=config["vector_f32"],
+    )
+    cluster_size = config["cluster_shape_mn"][0] * config["cluster_shape_mn"][1]
+    max_active_clusters = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size)
+
+    def epilogue_op(x):
+        return cute.where(x > 0, x, cute.full_like(x, 0)) ** 2
+
+    executable = cute.compile(
+        kernel,
+        a_tensor=a_cute,
+        b_tensor=b_cute,
+        sfa_tensor=sfa_cute,
+        sfb_tensor=sfb_cute,
+        c_tensor=c_cute,
+        d_tensor=d_cute,
+        prob_tensor=prob_cute,
+        amax_tensor=amax_cute,
+        sfd_tensor=None,
+        norm_const_tensor=None,
+        alpha=config["alpha"],
+        max_active_clusters=max_active_clusters,
+        stream=make_fake_stream(use_tvm_ffi_env_stream=False),
+        epilogue_op=epilogue_op,
+        options="--enable-tvm-ffi",
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        executable(a, b, sfa, sfb, c, d, prob, amax, None, None, config["alpha"], stream)
+
+    launch._keep_alive = (executable, a, b, sfa, sfb, c, d, prob, amax, stream)
+    return launch
+
+
+def _tirx_launch(executable, data, alpha):
+    import torch
+
+    a = data["a"]["raw"]
+    b = data["b"]["raw"]
+    sfa = data["sfa"].view(torch.uint8).reshape(-1)
+    sfb = data["sfb"].view(torch.uint8).reshape(-1)
+    c = data["tirx_c"]["raw"]
+    d = data["tirx_d"]["raw"]
+    prob = data["prob"]["raw"]
+    amax = data["tirx_amax"]
+
+    def launch():
+        executable(a, b, sfa, sfb, c, d, prob, amax, alpha)
+
+    launch._keep_alive = (a, b, sfa, sfb, c, d, prob, amax)
+    return launch
+
+
+def _reset_outputs(data, prefix):
+    data[f"{prefix}_c"]["source"].zero_()
+    data[f"{prefix}_d"]["source"].zero_()
+    data[f"{prefix}_amax"].fill_(float("-inf"))
+
+
+def _assert_close(torch, actual, expected, *, atol, rtol, label):
+    actual_f32 = actual.float()
+    expected_f32 = expected.float()
+    if actual_f32.shape != expected_f32.shape:
+        raise AssertionError(f"{label} shape mismatch: {actual_f32.shape} != {expected_f32.shape}")
+    close = torch.isclose(actual_f32, expected_f32, atol=atol, rtol=rtol)
+    if bool(torch.all(close).item()):
+        return
+    absolute_error = torch.abs(actual_f32 - expected_f32)
+    allowed_error = atol + rtol * torch.abs(expected_f32)
+    excess = absolute_error - allowed_error
+    worst_index = int(torch.argmax(excess).item())
+    raise AssertionError(
+        f"{label} mismatch: value={float(actual_f32.reshape(-1)[worst_index].item())}, "
+        f"expected={float(expected_f32.reshape(-1)[worst_index].item())}, "
+        f"absolute_error={float(absolute_error.reshape(-1)[worst_index].item())}"
+    )
+
+
+def _output_tolerance(dtype):
+    return (1.0e-4, 1.0e-4) if dtype == "float32" else (0.12, 0.02)
+
+
+def _validate_outputs(data, config, *, with_source):
+    """Hold TIRx to the upstream kernel's outputs on the same bytes."""
+    if not with_source:
+        return
+    import torch
+
+    c_atol, c_rtol = _output_tolerance(config["c_dtype"])
+    d_atol, d_rtol = _output_tolerance(config["d_dtype"])
+    _assert_close(
+        torch,
+        data["tirx_c"]["source"],
+        data["source_c"]["source"],
+        atol=c_atol,
+        rtol=c_rtol,
+        label="TIRx C versus standalone source",
+    )
+    _assert_close(
+        torch,
+        data["tirx_d"]["source"],
+        data["source_d"]["source"],
+        atol=d_atol,
+        rtol=d_rtol,
+        label="TIRx D versus standalone source",
+    )
+    _assert_close(
+        torch,
+        data["tirx_amax"],
+        data["source_amax"],
+        atol=0.12,
+        rtol=0.02,
+        label="TIRx amax versus standalone source",
+    )
+
+
+def run_test(**config):
+    """Compare TIRx with the cuDNN Frontend kernel on identical inputs."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executable = compile_kernel(get_kernel(**kernel_config))
+    tirx_launch = _tirx_launch(executable, data, kernel_config["alpha"])
+    source_launch = _compile_reference(data, kernel_config)
+    _reset_outputs(data, "tirx")
+    tirx_launch()
+    _reset_outputs(data, "source")
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, kernel_config, with_source=True)
+    return {"amax": float(data["source_amax"].item())}
+
+
+def prepare_bench(**config):
+    """Compile TIRx before entering the GPU benchmark child."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {"config": kernel_config, "executable": compile_kernel(get_kernel(**kernel_config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then time closures containing exactly one kernel launch."""
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = {**prepared["config"], **kwargs}
+    kernel_config = _without_label(config)
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**kernel_config)
+        tirx_launch = _tirx_launch(prepared["executable"], data, kernel_config["alpha"])
+        gpu_state = {
+            "data": data,
+            "tirx_launch": tirx_launch,
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    source_launch = gpu_state["source_launch"]
+    if not gpu_state["validated"]:
+        _reset_outputs(data, "tirx")
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                if source_launch is None:
+                    source_launch = _compile_reference(data, kernel_config)
+                    gpu_state["source_launch"] = source_launch
+                _reset_outputs(data, "source")
+                source_launch()
+                torch.cuda.synchronize()
+        _validate_outputs(data, kernel_config, with_source=with_source)
+        gpu_state["validated"] = True
+    references = {"cudnn_frontend": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- Port the SM100 persistent dense block-scaled GEMM with sReLU, per-row probability scaling, and mandatory FP32 amax from cuDNN Frontend.
- Keep shared memory as a linear byte arena and express TensorMap, TMEM, pipeline, swizzle, descriptor, and fragment coordinates with explicit integer offsets through tirx_kernels.kern.
- Cover FP4/FP8 inputs, E8M0/E4M3 scales, FP16/BF16/FP32/FP8 C, FP16/BF16/FP32 D, CTA1/CTA2 clusters, N tiles 64/128/192/256, L=1/2, tails, and stage variants.
- Add 41 correctness configurations and a compact 30-row benchmark matrix with small, medium, and large defaults.

## Source

- cuDNN Frontend commit: 7b5327b32907b9dd21d85a393d62f9573d7f0116
- Source file SHA256: 63aaee0a2acdd94c16c261157c9befb1a4265ca514b9f83dec1e5f5679508b4c
- The target source file remains byte-identical in the repository's current pinned cuDNN Frontend revision.

## Validation

- Single smallest correctness configuration: 1 passed
- Full correctness matrix: 41 passed, 0 failed, 0 skipped
- Bench-suite import check: passed
- License checker and 22-case self-test: passed
- Changed-file pre-commit: passed
- Compute Sanitizer memcheck and synccheck guards: zero errors
- Five-round 30-row kernel-only sweep: minimum cuDNN Frontend / TIRx ratio 0.997285; geometric mean 1.008921; every row strictly above 0.99
- Post-rebase nvdisasm code-section SHA256: 5ed326325869a34af0fd3eeeca940f3e8b30e8c4a1fdfd5e6da4b3c093ccda6d, byte-identical to the measured executable
