### PR TITLE
docs(infra): add kernel porting skills

### DIFF
--- a/.agents/skills/tirx-kernel-porting/SKILL.md
+++ b/.agents/skills/tirx-kernel-porting/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: tirx-kernel-porting
+description: "Port performance kernels from CUDA, CuTeDSL, Gluon, and Triton to TIRx through five gated stages: scaffolding, kernel sketch, sketch reviewer, correctness gate, and performance gate. Use when the user asks to port or align an optimized kernel implementation to TIRx while preserving its implementation structure and performance strategy."
+---
+
+# TIRx Kernel Porting
+
+## 1. Goal
+
+### WHAT YOU SHOULD DO
+
+Use this skill to port performance kernels from CUDA, CuTeDSL, Gluon, or Triton to TIRx while preserving the source implementation trace. The goal is to carry over the source kernel's implementation structure, optimization strategy, and low-level techniques, not to replace it with a functional reference kernel.
+
+You are the main writer agent using this skill. Perform the writer-owned work and
+orchestration in the main session so the user can observe it, except for the two
+subagent-owned reviews required below. Your expected on-disk output is the target
+implementation plus the stage artifacts.
+
+There are exactly three agent roles:
+
+- `writer`: the main agent using this skill. Never start a writer subagent.
+- `sketch_reviewer`: one actual subagent that independently verifies the kernel
+  sketch against the source implementation.
+- `correctness_reviewer`: one actual subagent that verifies the concrete TIRx
+  implementation against the reviewer-approved sketch during the correctness gate.
+
+The user explicitly authorizes starting both reviewer subagents. The writer MUST
+start an actual subagent for each review. The writer MUST NOT perform, simulate,
+or self-approve either review in the main-agent session. If the environment cannot
+start a required reviewer, report that review gate as blocked; do not silently
+replace the reviewer with main-agent work and do not claim PASS.
+
+The sketch reviewer is a one-time gate for the initial kernel sketch. Repeat the
+kernel-sketch/reviewer loop only until that initial sketch first passes. After
+the first reviewer PASS, treat the sketch as a completed initial design artifact:
+do not edit it, do not start the sketch reviewer again, and do not return to
+either stage from correctness or performance work. The separate correctness
+reviewer checks whether the initial concrete TIRx implementation realizes the
+approved sketch; it does not reopen or re-review the sketch itself.
+
+You should exactly follow the following stages in order:
+
+1. `scaffolding`: [references/scaffold.md](references/scaffold.md)
+2. `kernel sketch`: [references/kernel_sketch.md](references/kernel_sketch.md)
+3. `sketch reviewer`: [references/sketch_reviewer.md](references/sketch_reviewer.md)
+4. `correctness gate`: [references/correctness_gate.md](references/correctness_gate.md)
+5. `performance gate`: [references/perf_gate.md](references/perf_gate.md)
+
+For kernels under `tirx-kernels`, also use the tirx-kernels conventions skill:
+[../tirx-kernels-kernel-conventions/SKILL.md](../tirx-kernels-kernel-conventions/SKILL.md).
+At the start of the performance gate, read and follow the target checkout's
+repo-local `.agents/skills/tirx-codegen-tuning/SKILL.md`. Treat that checkout as
+authoritative; do not substitute a copied or cached version of the codegen skill.
+
+Before starting agents, identify `TARGET_REPO_ROOT` as the absolute path of the repo that will receive the target implementation. Choose one fixed absolute `PORT_DIR` under that repo root:
+
+- If the user gives a target module path, use `<TARGET_REPO_ROOT>/.porting/<target-file-stem>`.
+- Otherwise use `<TARGET_REPO_ROOT>/.porting/<sanitized-host-entry-or-kernel-name>`.
+
+TBD.
+
+### WHAT YOU MUST NOT DO
+
+WE ARE NOT IMPLEMENTING A MATHEMATICALLY EQUIVALENT KERNEL WHERE THE SAME INPUTS PRODUCE THE SAME OUTPUTS. WE ARE FAITHFULLY AND MECHANICALLY TRANSCOMPILING THE SOURCE IMPLEMENTATION INTO TIRX. THE TARGET KERNEL MUST REPLICATE THE SOURCE KERNEL'S IMPLEMENTATION DETAILS, OPTIMIZATION DETAILS, TECHNICAL TRICKS, AND PERFORMANCE STRUCTURE SO THAT ITS GENERATED PTX/SASS AND PERFORMANCE CAN CONVERGE WITH THE SOURCE KERNEL. EVERY SOURCE OPTIMIZATION DETAIL IS PART OF THE PORTING TARGET AND MUST BE COPIED IN TIRX UNLESS THE SOURCE IMPLEMENTATION ITSELF MAKES IT IRRELEVANT. THAT IS WHY WE BUILD A COMPLETE BIDIRECTIONAL SEMANTIC MAPPING BETWEEN SOURCE REGIONS AND SKETCH OPERATIONS.
+
+- Do not write a scalar, naive, reference, mathematical, or "verifiable first" implementation in place of the CUDA implementation.
+- Do not flatten CUDA CTA/warp/thread roles into a generic output-element loop unless the CUDA source itself does that.
+- Do not replace smem, tmem, TMA, MMA, barrier, pipeline, or inline PTX behavior with ordinary scalar loops or a different algorithm.
+- Do not move work across CTA/warp/thread boundaries, change producer/consumer roles, or change instruction shape merely because tests still pass.
+- Do not use tile primitives: any `TilePrimitiveCall`, `tirx.tile.*` operation,
+  or operation categorized as `tile_primitive` violates the overall porting
+  contract. This is a global implementation constraint, not a correctness-gate
+  metric.
+- Do not use any first-class layout in either the kernel sketch or the final TIRx
+  kernel. A layout object, layout value, layout annotation, or `layout=` argument
+  attached to a tensor, tile, buffer, view, alias, register fragment, TMEM object,
+  or operation is forbidden, regardless of whether it is spelled `Layout`,
+  `T.Layout`, or through another helper API. Source layouts, swizzles, transposes,
+  and fragment mappings must instead be documented and realized with explicit
+  scalar index/byte-offset arithmetic plus the required instruction descriptors,
+  strides, swizzle immediates, or local PTX operands.
+- Every SMEM tensor in the sketch and final TIRx kernel must be a one-dimensional
+  linear allocation with no attached layout or swizzle metadata. Express logical
+  multidimensional coordinates, stage offsets, aliases, and source swizzles as
+  explicit indices into that linear storage. Hardware descriptor fields and
+  instruction immediates are allowed; they are not first-class layouts.
+- For targets in `tirx-kernels`, do not add test files, test modules, or test
+  cases anywhere in the repository, and do not modify existing tests to add
+  coverage. Keep correctness validation in the target kernel module's
+  `run_test` and the repository's existing harness and bench-suite configuration.
+- Workflow-stage terminology belongs only in workflow artifacts. Do not copy
+  stage labels or artifact status into target kernel comments, docstrings, names,
+  or errors. Describe the source implementation and actual kernel semantics
+  directly.
+- Correctness-gate PASS alone is not completion of the whole porting workflow.
+
+## 2. Steps
+
+YOU MUST FOLLOW THESE STAGES EXACTLY IN THE ORDER SHOWN. YOU MUST NOT CHANGE THE
+STAGE ORDER ON YOUR OWN UNDER ANY CIRCUMSTANCES. DO NOT SKIP, REORDER, MERGE, OR
+SUBSTITUTE ANY STAGE, AND DO NOT START WORK FROM A LATER STAGE EARLY. The only
+permitted backward transition is reviewer FAIL returning to kernel sketch before
+the first reviewer PASS.
+
+At the start of every stage, read its corresponding Markdown instructions before
+doing that stage's work. Follow that file exactly for the work, artifacts, gate
+conditions, and transition rules. Do not replace the documented process with your
+own workflow, even if another approach appears faster or equivalent.
+
+DO NOT ADVANCE UNTIL THE CURRENT STAGE'S INSTRUCTIONS SAY ITS GATE HAS PASSED. If
+the initial sketch review does not pass, return to kernel sketch and repeat the
+review. After its first PASS, proceed only forward through correctness and
+performance; neither stage may reopen the kernel-sketch or sketch-reviewer stage.
+
+```mermaid
+flowchart LR
+    A["1. Scaffolding<br/>scaffold.md"] --> B["2. Kernel sketch<br/>kernel_sketch.md"]
+    B --> C["3. Sketch reviewer<br/>sketch_reviewer.md"]
+    C -- FAIL --> B
+    C -- PASS --> D["4. Correctness gate<br/>reviewer PASS + numerical PASS<br/>correctness_gate.md"]
+    D --> E["5. Performance gate<br/>perf_gate.md"]
+```
+
+1. **Scaffolding**: Read and follow
+   [scaffold.md](references/scaffold.md). Create the target-module scaffold and
+   record the source, launch, tensor, and config facts without implementing the kernel.
+2. **Kernel sketch**: Read and follow
+   [kernel_sketch.md](references/kernel_sketch.md). Study the current upstream
+   sketch/kernel pairs, then write a concise copy/compute-dominated execution
+   skeleton with necessary roles, storage, control flow, synchronization, and
+   instruction selection on key copy, compute, and sync/async operations.
+3. **Sketch reviewer**: Start an actual reviewer subagent and require it to read
+   and follow [sketch_reviewer.md](references/sketch_reviewer.md). It validates the
+   sketch against source and line-info PTX; on FAIL, return to kernel sketch and
+   repeat this loop until the initial sketch first passes. That PASS permanently
+   closes both sketch stages; the main writer must not perform or rerun the review.
+4. **Correctness gate**: Read and follow
+   [correctness_gate.md](references/correctness_gate.md). First realize the
+   reviewer-approved sketch as a concrete plain-TIRx/PTX kernel, then start the
+   actual correctness reviewer subagent to check the implementation against that
+   sketch. This gate passes only when both the implementation review and every
+   required numerical correctness case pass. Do not edit or re-review the approved
+   sketch itself.
+5. **Performance gate**: Read and follow
+   [perf_gate.md](references/perf_gate.md). Run its global energy-guided variant
+   search: maintain the global variant ledger, select one eligible parent, select
+   one of the NCU, codegen-database, and free-exploration strategies, and execute
+   that strategy directly in the main writer session to produce one child. A valid
+   parent remains selectable after any number of prior expansions. Measure and
+   register the child before the next expansion. Bench-suite results remain the
+   only performance metric. For a
+   `tirx-kernels` target, first read and follow the checkout's repo-local
+   `.agents/skills/tirx-codegen-tuning/SKILL.md`. The correctness reviewer is
+   closed and must not be rerun during this stage. Only a complete bench-suite run
+   with every shape above `0.99x` source passes.

--- a/.agents/skills/tirx-kernel-porting/agents/openai.yaml
+++ b/.agents/skills/tirx-kernel-porting/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TIRx Kernel Porting"
+  short_description: "Port optimized CUDA kernels to TIRx faithfully"
+  default_prompt: "Use $tirx-kernel-porting to port this optimized CUDA kernel to TIRx while preserving its implementation and performance structure."

--- a/.agents/skills/tirx-kernel-porting/references/correctness_gate.md
+++ b/.agents/skills/tirx-kernel-porting/references/correctness_gate.md
@@ -1,0 +1,112 @@
+# Writer Phase: Correctness Gate
+
+## Goal And Two Required Gates
+
+Implement the reviewer-approved sketch as a concrete TIRx kernel, verify that
+implementation against the sketch, then make it numerically correct.
+
+The correctness stage has exactly two required gates:
+
+1. `implementation review`: the concrete kernel faithfully realizes the approved
+   sketch's resources, warp roles, pipeline, control flow, tile data flow, and
+   key-operation instruction selections in plain TIRx or local PTX;
+2. `numerical correctness`: the target compiles, launches safely, and produces
+   correct outputs for every required case.
+
+Both must pass before entering the performance gate. Performance, profiler
+artifacts, and auxiliary documents are not criteria for this stage.
+
+The initial sketch review is already complete. Use the approved sketch as a
+binding implementation plan and the source implementation as the final authority.
+Do not edit the sketch or return to the sketch-reviewer stage.
+
+## Procedure
+
+1. Realize the approved sketch as a concrete TIRx kernel while retaining its
+   resource allocation, warp-role split, pipeline, control flow, and tile-based
+   data-flow structure. For every key copy, compute, and sync/async operation,
+   implement the sketch's `instruction_selection` with plain TIRx or exact local
+   PTX as needed. Use no first-class layouts. Allocate every SMEM tensor as
+   one-dimensional linear storage and implement all logical coordinates,
+   swizzles, transposes, stages, and aliases through explicit scalar offsets.
+2. Start an actual `correctness_reviewer` subagent and require it to follow the
+   reviewer instructions below. If it returns FAIL, fix all scoped findings and
+   rerun that reviewer until it passes. The writer must not self-review.
+3. Start with the smallest deterministic target config.
+4. Compile and run against the trusted source implementation or reference.
+5. Fix compile, launch, synchronization, memory-safety, and numerical failures
+   directly in the TIRx implementation.
+6. Rerun the failing case after each fix.
+7. Run every required `CONFIGS` case, specialization branch, boundary case,
+   tail case, and relevant correctness test.
+8. Remove temporary correctness instrumentation.
+9. If correctness work changed any reviewer-scoped resource, role, pipeline,
+   control-flow, tile-data-flow, or key instruction-selection decision, the old
+   reviewer PASS is invalid. Rerun the same correctness reviewer until both gates
+   pass on the same implementation. Incidental address arithmetic and local
+   scalar plumbing do not invalidate the review.
+
+Complete the target module according to `tirx-kernels-kernel-conventions`,
+including the kernel, local helpers, launch metadata, `prepare_data`, `run_test`,
+`run_bench`, `CONFIGS`, and optional `BENCH_CONFIGS` required by the target.
+
+## Correctness Reviewer Subagent
+
+The reviewer reads the approved sketch and the concrete TIRx kernel. It may inspect
+the source and generated line-info PTX only as needed to resolve ambiguity or
+verify a key instruction selection. It must not edit any file or debug numerical
+correctness.
+
+Review only these points:
+
+1. resources: smem, registers, barriers, and other explicitly sketched storage
+   are represented consistently;
+2. task split: warp/lane/producer/consumer roles match the sketch;
+3. pipeline and synchronization structure match the sketch;
+4. control flow and per-task tile data flow broadly match the sketch, with no
+   missing, invented, reordered, or collapsed key copy/compute/sync operation;
+5. every key operation's sketched `instruction_selection` is concretely realized
+   by plain TIRx or local PTX, and generated PTX confirms the selection where
+   compilation is available;
+6. the implementation contains no `TilePrimitiveCall`, `tirx.tile.*`, or
+   operation categorized as `tile_primitive`;
+7. neither the sketch nor implementation uses a first-class layout object,
+   value, annotation, or layout-bearing helper, and every implementation SMEM
+   allocation is one-dimensional and linear with explicit offset arithmetic.
+
+Ignore incidental address calculations, pointer arithmetic, descriptor assembly,
+temporary scalar plumbing, routine casts, and other details below the sketch's
+abstraction level unless they change one of the seven points above.
+
+Return exactly `PASS`, `FAIL`, or `BLOCKED`, followed by concise scoped findings.
+PASS requires all seven points to pass. BLOCKED is not PASS.
+
+## PASS
+
+This gate passes only when both conditions hold on the same implementation:
+
+- the actual correctness reviewer has returned PASS;
+- every required case compiles and launches successfully;
+- synchronization and memory behavior are valid;
+- every checked output matches the trusted source/reference under the target
+  tolerances;
+- no known correctness failure remains.
+
+After this PASS, enter the performance gate and permanently stop using the
+correctness reviewer. Performance changes do not require reviewer revalidation.
+
+## Must Not
+
+- Do not edit or re-review the approved sketch.
+- Do not simulate the correctness reviewer in the writer session.
+- Do not use tile primitives; use plain TIRx and exact local PTX when needed.
+- Do not introduce a first-class layout or a non-linear/multidimensional SMEM
+  tensor. Use one-dimensional linear SMEM and explicit scalar offset arithmetic.
+- Workflow-stage terminology belongs only in workflow artifacts. Do not copy
+  stage labels or artifact status into target code. Kernel comments and docstrings
+  must describe source provenance, implementation structure, and runtime semantics
+  directly.
+- Do not perform performance alignment in this stage.
+- Do not claim PASS without both a current reviewer PASS and complete numerical
+  correctness. Do not pass while any required case is failing, skipped without
+  justification, or untested.

--- a/.agents/skills/tirx-kernel-porting/references/kernel_sketch.md
+++ b/.agents/skills/tirx-kernel-porting/references/kernel_sketch.md
@@ -1,0 +1,216 @@
+# Writer Phase: Kernel Sketch
+
+## Goal
+
+Write a non-executable kernel sketch in the style of the current examples under
+[tirx-kernels `.agents/sketch/`](https://github.com/mlc-ai/tirx-kernels/tree/main/.agents/sketch).
+
+Current canonical upstream sketch/kernel pairs:
+
+| sketch | corresponding TIRx kernel source |
+| --- | --- |
+| `.agents/sketch/flashkda_bf16_m128.md` | `tirx_kernels/flashkda/bf16_fused_m128.py` |
+| `.agents/sketch/gdn_prefill_sm100.md` | `tirx_kernels/attention/gdn_prefill_sm100.py` |
+
+Only files under the canonical upstream `.agents/sketch/` directory belong in
+this list. Do not treat kernel-local design notes or files named `*_sketch.md`
+elsewhere in the repository as sketch examples for this workflow.
+
+This list will grow. Before every use, enumerate the current upstream sketch
+directory, identify any newly added sketch/kernel pairs, and study them too. Do
+not treat this table as a closed or exhaustive list.
+
+Before writing, read every sketch in that directory and the corresponding TIRx
+kernel linked by each sketch. Learn the style from the sketch/kernel pairs, not
+from one example or from this file alone.
+
+Treat the FlashKDA and GDN prefill sketches as the target abstraction level and
+detail density. A sketch is the kernel's semantic execution skeleton, not a
+source-level transcription or an expanded derivation of every implementation
+expression.
+
+**Kernel sketch = resource allocation (SMEM/registers/mbarriers) + task split
+(warps/roles) + per-task tile-based dataflow.**
+
+## Linear Storage Constraint
+
+The sketch must not use any first-class layout. Do not attach a layout object,
+layout value, layout annotation, or `layout=` argument to a tensor, tile, buffer,
+view, alias, register fragment, TMEM object, or operation. This prohibition applies
+even when the source framework represents its mapping with CuTe, CuTeDSL, Gluon,
+Triton, or another layout abstraction.
+
+Every SMEM declaration must be a one-dimensional linear allocation. Represent
+logical dimensions, pipeline stages, aliases, swizzles, transposes, and operand
+mappings with named scalar offset/index functions over that linear allocation.
+Keep routine address arithmetic summarized, but show every mapping that changes
+the selected bytes, instruction descriptor, role ownership, or dataflow. Hardware
+descriptor fields, strides, swizzle immediates, and PTX operands may be written
+explicitly because they select instructions; they are not first-class layouts.
+
+Examples of forbidden sketch forms include `tile(..., layout=...)`,
+`view(..., layout=...)`, `alias(..., layout=...)`, layout-bearing register/TMEM
+fragments, and declarations that model SMEM as a multidimensional layout object.
+Use a linear SMEM base plus explicit offsets instead.
+
+Write the result to:
+
+```text
+${TARGET_REPO_ROOT}/.agents/sketch/<target-kernel-name>.md
+```
+
+## Sketch File Contents
+
+The two current sketches share this overall structure:
+
+1. **Title and scope**
+   - `<kernel>: coarse WASP pipeline sketch`
+   - state that the sketch is non-executable
+   - link the corresponding TIRx kernel module as the source of truth
+   - state the fixed specialization and out-of-scope variants
+2. **Pipeline at a glance**
+   - a table of warp/warpgroup/CTA roles
+   - each role's tile program and publication/reuse edges
+3. **Primitive vocabulary**
+   - structural ops: linear storage, explicit offset/index functions, slices,
+     and register storage without first-class layouts
+   - directional copy ops between GMEM, SMEM, TMEM, and registers
+   - basic compute ops such as `gemm`, `fill`, `cast`, `exp`, `add`, and `mul`
+   - explicit schedule ops for pipes, barriers, waits, commits, releases, fences,
+     stages, and phases
+4. **Complete sketch**
+   - static specialization, runtime ABI, and launch
+   - necessary SMEM, TMEM, register, and mbarrier declarations, explicit physical
+     mappings, aliases, and lifetimes
+   - pipeline and synchronization construction
+   - source-order role selection and complete role bodies
+   - necessary scheduler/phase scalar state, loops, branches, tails, and output
+     stores
+   - instruction selection for key copy, compute, and sync/async operations
+5. **Kernel-specific tables when needed**
+   - logical GEMM shapes and owners
+   - descriptor or TensorMap fields
+   - storage-alias lifetimes
+   - TIRx module and benchmark contract
+   - static specialization boundary
+6. **Instruction-selection summary**
+   - summarize how placement, explicit physical mapping, shape, and schedule
+     select PTX/SASS
+   - keep opcode names and counts as evidence, not as hidden computation
+
+Use this as the file outline, but include only kernel-specific sections supported
+by the target implementation.
+
+## Required Abstraction
+
+The sketch body must be dominated by the two operation classes that carry the
+kernel's semantics:
+
+1. **Data movement**: explicit directional copies between GMEM, SMEM, TMEM, and
+   registers.
+2. **Data computation**: explicit basic compute ops such as `gemm`, `fill`,
+   `cast`, `exp`, `add`, and `mul`. Do not replace these with a generic
+   `compute` op.
+
+Include only the supporting structure needed to explain how those operations
+execute:
+
+- warp/lane/warpgroup/CTA roles and their control-flow branches;
+- loops, `while` loops, tails, and predicates that change executed work;
+- pipe, mbarrier, fence, wait, commit, release, and other sync/async operations;
+- necessary SMEM, TMEM, register, and mbarrier declarations;
+- necessary scalar control state such as phase, stage, tile scheduler, loop
+  counters, and bounds.
+
+Do not expand incidental address arithmetic, pointer arithmetic, descriptor bit
+assembly, constant folding, temporary scalar plumbing, or equivalent mechanical
+setup. Retain such a detail only when it changes the selected tile or memory
+region, mask/bounds behavior, role ownership, storage alias/lifetime,
+synchronization protocol, control flow, or instruction selection. Express the
+resulting logical tile/region directly at the copy or compute operation.
+
+The sketch must explicitly show:
+
+- warp, warpgroup, CTA, producer, and consumer roles used by the kernel;
+- pipes, stages, phases, publication/reuse edges, and asynchronous synchronization;
+- storage placement, linear buffers, explicit physical mappings, aliases, and
+  lifetimes;
+- source-order control flow, loops, branches, tails, and output paths.
+
+Express data movement and computation with basic ops such as `copy`, `gemm`,
+`fill`, `cast`, `exp`, `add`, and `mul`.
+
+Each key copy, compute, or sync/async op may represent only:
+
+- one PTX instruction;
+- one tile of the same PTX instruction family; or
+- one explicit loop of the same PTX instruction family.
+
+An op must not contain work more complex than that. It must not hide another
+algorithmic phase, role, branch, pipe transition, synchronization, epilogue, or
+output path.
+
+Every key copy, compute, and sync/async op occurrence must be followed by its
+instruction selection:
+
+```python
+op(...)
+# instruction_selection: <PTX instruction or family>; extent: <scalar/vector/tile/loop>
+```
+
+Storage declarations, structural views, control-flow syntax, and scalar
+bookkeeping for phase/stage/scheduling do not need instruction-selection
+annotations unless they themselves emit a key operation. Do not annotate omitted
+address derivations merely to make the sketch look line-by-line complete.
+
+## Steps
+
+1. Read the scaffold artifacts and target source implementation.
+2. **Export the source specialization's line-info PTX before writing anything.**
+   Build it through its normal path with line information enabled, preserve the
+   export under `${PORT_DIR}`, and preserve the generated intermediate source
+   when the input is CuTeDSL, Gluon, Triton, or another code generator. See
+   [source_export.md](source_export.md) for per-source-kind recipes.
+3. Read all current upstream `.agents/sketch/*.md` files and each linked TIRx
+   kernel.
+4. Identify the target kernel's roles, storage, pipes, synchronization, control
+   flow, and primitive PTX-level dataflow. Read the export for every fact the
+   source text cannot settle, and reconcile the scaffold's provisional launch and
+   tensor claims against it; record any correction, because a wrong claim there
+   propagates into the sketch and then into the implementation.
+5. Write a same-style sketch under `${TARGET_REPO_ROOT}/.agents/sketch/`.
+6. Check that every key copy, compute, and sync/async op stays within the allowed
+   abstraction bound and has an instruction-selection annotation **derived from
+   the export**.
+7. Continue to the sketch-reviewer gate. The sketch reviewer must be a subagent.
+   It produces its own independent export; yours does not replace it, and having
+   yours is what changes the review from "did the writer guess the lowering" to
+   "did the writer read it correctly".
+
+## Must Not
+
+- Do not write a mathematical reference or high-level algorithm summary.
+- Do not define compound ops such as `attention`, `softmax`, `normalize`,
+  `inverse`, `update_state`, `run_pipeline`, or `load_and_gemm`.
+- Do not hide warp roles, pipes, async synchronization, or control flow inside an
+  op.
+- Do not omit or defer instruction selection for key copy, compute, or
+  sync/async operations.
+- Do not annotate instruction selection from the source text. The source
+  systematically misrepresents at least these, and each one changes what the
+  port must transcribe, so look each up in the export rather than inferring it:
+  - **storage class** -- a declaration that reads like a static shared struct may
+    be allocated from the dynamic pool, which selects a different TIRx form;
+  - **which threads execute an operation** -- the compiler sinks a load into a
+    predicated block, or hoists one out, so a value the source reads on every
+    thread may in fact be read by one, which decides whether a broadcast is
+    load-bearing or redundant;
+  - **whether a loop-invariant load is hoisted** -- a memory clobber, such as an
+    atomic in the loop body, can keep it re-issued every iteration;
+  - **operand form and width** -- immediate versus register, and sign-extending
+    versus plain loads, follow from how the value is consumed downstream;
+  - **whether a loop is unrolled** -- an explicit `unroll=1` in the source, or its
+    absence, is not the same as what the backend emits.
+- Do not bury the semantic execution skeleton under address calculations or
+  other mechanical source details.
+- Do not implement or debug the target TIRx kernel in this stage.

--- a/.agents/skills/tirx-kernel-porting/references/perf_gate.md
+++ b/.agents/skills/tirx-kernel-porting/references/perf_gate.md
@@ -1,0 +1,317 @@
+# Writer Phase: Performance Gate
+
+## Goal
+
+Improve TIRx performance as measured by the `tirx-kernels` bench-suite on the
+required shapes. Bench-suite timing is the only performance metric in this gate.
+Generated code, NCU counters, opcode tables, memory tables, lineinfo, and static
+instruction counts are diagnostic evidence only; none of them can accept or
+reject a performance change.
+
+The gate is:
+
+```text
+source_time / tirx_time > 0.99 for every required shape
+```
+
+The writer may create a goal for this stage. Do not complete the goal or claim
+PASS while any required shape is at or below `0.99`.
+
+## Required Repo-Local Skill
+
+For a target under `tirx-kernels`, read and follow
+`<TARGET_REPO_ROOT>/.agents/skills/tirx-codegen-tuning/SKILL.md` at the start of
+this gate. Use the skill from the target checkout so its guidance stays aligned
+with that checkout. Before changing emitted instructions, issue order,
+predication, uniformity, register lifetimes, address lowering, memory width or
+cache hints, pipeline depth, or synchronization for performance, apply that
+skill's symptom-indexed workflow.
+
+If the target is not a `tirx-kernels` checkout or does not contain that skill,
+continue with the diagnostics below; do not silently substitute an unrelated
+cached copy.
+
+## Hard Acceptance Gate
+
+Every final threshold decision MUST use the `tirx-kernels` bench-suite tool:
+
+```bash
+python -m tirx_kernels.bench_suite
+```
+
+Ensure the selected workload set contains every required target shape. Final
+evidence must come from the latest complete bench-suite run. Do not use
+`python -m tirx_kernels.bench`, an ad hoc timer, a partial run, selected shapes,
+or an average ratio as final acceptance evidence.
+
+Follow `tirx-kernels-kernel-conventions` for benchmark scope, references,
+rounds, artifacts, and invalid-run handling.
+
+Use bench-suite measurements to decide whether a candidate improved performance
+and should be retained. Targeted bench-suite workloads may be used during an
+iteration, but final PASS requires the latest complete required-shape matrix.
+
+## Read Once and Freeze Validation Commands
+
+Read this file and the repo-local codegen-tuning skill once when entering the
+performance stage. Do not reread this file, `correctness_gate.md`, or the root
+porting skill during each search expansion. Do not restart either reviewer.
+
+At stage entry, write one validation manifest under:
+
+```text
+${PORT_DIR}/perf_gate/validation_manifest.json
+```
+
+Record the exact source/reference identity, required and guard shapes,
+correctness commands, tolerances, targeted bench-suite commands, complete-matrix
+command, and measurement protocol. Search iterations execute this frozen manifest;
+they do not rediscover or reinterpret the gates. Update the manifest only when the
+user changes the task or an actual code-interface change makes a recorded command
+invalid. A timing value is not frozen: paired source/TIRx timings may still be
+remeasured under the fixed protocol.
+
+## Global Variant Ledger
+
+Maintain one append-only global ledger for the complete performance search:
+
+```text
+${PORT_DIR}/perf_gate/variant_ledger.jsonl
+```
+
+Initialize it with the correctness-gate implementation as the root variant.
+Every explored result must receive a stable `variant_id` and a ledger row,
+including variants that fail to compile, fail correctness, regress performance,
+duplicate an existing program, or produce no useful change. Preserve each unique
+program under `${PORT_DIR}/perf_gate/variants/<variant_id>/` as an immutable commit,
+tree hash, or complete reproducible patch plus its parent identity. The ledger is
+the search history, not a list containing only winners.
+
+Each row must record at least:
+
+- `variant_id`, `parent_id`, lineage depth, selected strategy, and code/tree hash;
+- strategy-selection policy, selection reason or probability, and random seed
+  when selection is stochastic;
+- expansion ID and the parent's expansion count at selection time;
+- exact hypothesis and focused code change;
+- compile and correctness status plus validation level: `provisional` or
+  `fully_validated`;
+- targeted and full bench-suite commands, artifacts, per-shape times and ratios;
+- diagnostic artifact paths and a short evidence summary;
+- energy value and the exact energy-function version/parameters;
+- eligibility state: `eligible`, `ineligible`, or `duplicate`;
+- failure, rejection, or duplicate reason when applicable.
+
+Only the main writer performs the search, writes strategy-local artifacts,
+produces candidate patches/commits, appends canonical ledger rows, and changes
+eligibility state.
+
+## Global Energy-Guided Search
+
+The candidate pool contains every quick-validation-passing, reproducible,
+nonduplicate variant, regardless of lineage depth, validation level, or how many
+times it has already been expanded. Select the parent from this complete eligible
+pool. Expansion does not consume or retire a parent: the same parent may be
+selected and expanded again any number of times, including repeatedly with the
+same strategy, as long as each expansion records a concrete new hypothesis or
+attempt.
+
+Before the first selection, run the complete required-shape bench-suite matrix
+for the root variant and store it in the root ledger row. If the root already
+passes the hard gate, no expansion is needed. Otherwise use its failing shapes
+and measurements to initialize the candidate-pool energy values.
+
+Selection may be greedy or stochastic. Define and record an energy function from
+measured bench-suite results and optional novelty/complexity terms. A suitable
+policy is:
+
+```text
+with probability p_greedy:
+    choose argmax energy(eligible_pool)
+otherwise:
+    sample eligible_pool with probability softmax(energy / temperature)
+```
+
+Use nonzero exploration probability so a performance-average variant can still
+be selected. The energy function ranks search candidates only; it must not replace
+the per-shape hard acceptance gate. Do not use profiler counters as if they were
+performance scores. Record the random seed whenever stochastic selection is used.
+The energy function may include an expansion-count or novelty term to avoid
+starvation, but it must not make a previously expanded valid parent ineligible.
+
+After selecting the parent, select exactly one of the three strategies below for
+this expansion. The strategy choice may be deterministic from current evidence or
+sampled from an adaptive probability distribution. Record the chosen strategy,
+the reason or probability assigned to it, and the random seed when sampled. Do
+not run the other two strategies during the same expansion and do not silently
+switch strategies after work on the selected strategy starts.
+
+For each selected parent:
+
+1. Select one strategy and materialize one isolated working copy at exactly the
+   selected parent program.
+2. In the main writer session, execute that strategy using the parent ID, exact
+   target/guard shapes, source baseline, approved sketch, and relevant
+   generated-code paths.
+3. Produce one focused candidate. A blocked or no-change result is still recorded;
+   do not silently substitute work from another strategy.
+4. Do not run GPU measurements that overlap contaminating work. Serialize
+   NCU and bench-suite commands through the environment's shared GPU lock and
+   reject measurements with intruding work according to repository conventions.
+5. Materialize the child and run only the quick validation recorded in the
+   manifest: compile, affected/target correctness, guard correctness, and targeted
+   target/guard bench-suite measurements.
+6. Register the outcome in the global ledger. Add a unique, quick-validation-
+   passing, reproducible child to the eligible pool as `provisional` even when it
+   is not faster than the parent; mark an invalid or duplicate child ineligible
+   while retaining its ledger row. Keep the parent eligible.
+7. Increment the parent's expansion count, then perform the next global selection.
+   Periodically run the complete required-shape matrix for the best current variant.
+
+Continue expanding the candidate pool until one variant passes the latest complete
+required-shape matrix or the search is genuinely blocked. Do not overwrite the
+main target implementation on every experiment. Promote a selected candidate to
+the main working tree only after its immutable variant and measurements are in
+the ledger.
+
+## Performance Strategies
+
+### Strategy 1: Paired NCU and lineinfo
+
+Profile the source and selected parent on the same representative failing shape,
+input regime, timing scope, launch boundaries, and kernel instance. Export paired
+reports with at least:
+
+```bash
+ncu \
+  --section InstructionStats \
+  --section MemoryWorkloadAnalysis_Tables \
+  --section SourceCounters \
+  --import-sass yes \
+  --import-source yes \
+  --source-folders <source-roots-and-generated-code-dump> \
+  --export <source-or-tirx-report> \
+  <equivalent-single-shape-command>
+```
+
+Compare the complete union of:
+
+- dynamic warp-level `sass__inst_executed_per_opcode`;
+- predicated-on thread-level
+  `sass__thread_inst_executed_true_per_opcode`;
+- shared-memory, L1/TEX, L2, and device-memory rows from
+  `MemoryWorkloadAnalysis_Tables`.
+
+Choose one actionable metric where TIRx is demonstrably behind the source. Do not
+equate a large difference with a regression without establishing the harmful
+direction. Trace that metric through its contributing SASS PCs and lineinfo:
+
+```text
+dynamic NCU or memory difference
+  -> contributing SASS PC(s) and instruction(s)
+  -> generated/source file:line
+  -> originating TIRx operation and source-kernel operation
+  -> one focused candidate change
+```
+
+Build with line information and retain generated TIRx, CUDA, PTX, and SASS needed
+for the trace. `TVM_KERNEL_DUMP=<absolute-directory>` may be used for this. Make
+one change intended to close the selected metric, then return the candidate and
+the paired reports, exported tables, source map, and hypothesis. `SYNC` and
+`NANOSLEEP` commonly originate from `mbarrier.wait` busy-wait loops and are not
+standalone targets unless evidence shows a controllable protocol difference.
+
+### Strategy 2: Codegen database
+
+Follow the target checkout's repo-local `tirx-codegen-tuning` skill. Search only
+the `**Symptoms:**` rows in its `references/db/`, match the selected parent's
+observed symptom, and read every matching entry in full. Select one applicable
+codegen-database intervention, state why its preconditions match, and make one
+focused candidate change. Return the candidate, selected database entry, observed
+symptom, expected generated-code effect, and resulting generated-code evidence.
+If no entry applies, return a recorded no-change result instead of inventing a
+database rule or silently switching strategies.
+
+### Strategy 3: Free exploration
+
+Independently inspect the parent implementation, source, generated code, benchmark
+shape behavior, and existing evidence. Form one concrete performance hypothesis
+and make one focused change. This strategy is not required to use NCU or the codegen
+database, but it must preserve correctness and return a reproducible candidate,
+the hypothesis, and the expected mechanism. Do not combine several unrelated
+optimizations into one child.
+
+## Candidate Evaluation
+
+Diagnostic evidence explains a child; bench-suite timing judges it. Validation
+has exactly two levels.
+
+### Quick validation for every child
+
+Run only the commands frozen in the manifest for:
+
+1. compilation;
+2. correctness on the affected or target config plus predefined guard configs;
+3. targeted bench-suite workloads for the target and guard shapes;
+4. contamination and timing-scope checks.
+
+A unique child that passes this level is `provisional` and may enter the eligible
+pool or become a parent. Retain slower provisional children so the energy policy
+can explore through a temporary regression. Do not run all correctness configs or
+the complete performance matrix merely to register an ordinary child.
+
+### Full validation for selected candidates
+
+Run the manifest's complete correctness set and complete required-shape
+bench-suite matrix only when:
+
+- a provisional child is being promoted to replace the current champion;
+- the recorded periodic checkpoint is due; or
+- the writer is preparing to claim final PASS.
+
+A candidate that passes both becomes `fully_validated`. If it fails, record the
+failure and mark that variant ineligible; continue the search. Full validation
+means executing the frozen commands, not rereading gate documents, rescanning the
+repository for validation scope, or starting a reviewer.
+
+A diagnostic improvement without a bench-suite improvement is not a performance
+win, but the child remains part of the ledger. Final PASS still requires the
+latest complete required-shape matrix, not a strategy-local or targeted
+measurement.
+
+## Stage Boundary
+
+The initial sketch review is complete before this stage. Treat that sketch as a
+completed initial design artifact. Do not edit it, return to the sketch stage,
+or start another reviewer. Correctness was established by the preceding gate
+and remains a prerequisite for retaining implementation changes, but it is not
+an additional performance metric.
+
+## Must Not
+
+- Do not use `tirx_kernels.bench` for final performance acceptance.
+- Do not stop on a partial matrix or an average above `0.99`.
+- Do not pass when even one required shape is `<= 0.99x` source.
+- Do not compare timings from different scopes or setup boundaries.
+- Do not edit the approved sketch or start another sketch reviewer.
+- Do not introduce any first-class layout or any non-linear/multidimensional SMEM
+  tensor in a performance variant. Every variant must retain one-dimensional
+  linear SMEM and explicit scalar offset/index arithmetic.
+- Do not reread correctness/performance gate documents or rescan validation scope
+  during each expansion; execute the frozen validation manifest.
+- Do not run full correctness and the complete performance matrix for every
+  ordinary child.
+- Do not call a generated-code or profiler difference a performance improvement
+  unless bench-suite measurements improve.
+
+## PASS Checklist
+
+The performance gate is PASS only when all are true:
+
+- the latest complete `tirx_kernels.bench_suite` matrix contains every required
+  shape;
+- every required shape has `source_time / tirx_time > 0.99`;
+- the winning variant and its complete matrix are present in the global ledger;
+- the winning variant is marked `fully_validated`;
+- the target implementation in the main working tree is byte-identical to the
+  recorded winning variant and still passes required correctness checks.

--- a/.agents/skills/tirx-kernel-porting/references/scaffold.md
+++ b/.agents/skills/tirx-kernel-porting/references/scaffold.md
@@ -1,0 +1,156 @@
+# Writer Phase: Scaffold
+
+## 1. Goal
+
+This is the scaffold stage.
+
+Create the integration scaffold once. The expected on-disk outputs are:
+
+- target TIRx module
+- `${PORT_DIR}/source_overview.md`
+- `${PORT_DIR}/launch_config.md`
+- `${PORT_DIR}/tensor_overview.md`
+- `${PORT_DIR}/scaffold_manifest.yaml`
+
+The target TIRx module must include:
+
+- `KERNEL_META`
+- `CONFIGS`
+- `BENCH_CONFIGS` when benchmark-only cases are useful
+- `prepare_data`
+- `run_test`
+- `run_bench`
+- an `@T.primfunc` target entry with an empty body and a visible start marker for
+  the kernel-sketch stage
+
+### File Format
+
+`${PORT_DIR}/source_overview.md` must use this Markdown structure:
+
+```markdown
+# Source Overview
+
+## Primary Source
+- source_kind: <cuda|cutedsl|gluon|triton|other>
+- source_path: <path>
+- expected_source_entry: <symbol>
+
+## Files Inspected
+| path | relevant symbols | reason |
+| --- | --- | --- |
+
+## Call Graph
+- <public/host entry> -> <dispatched kernel or program> -> <helpers>
+
+## Specialization And Launch Facts
+- <template/JIT/runtime facts needed later>
+
+## Supported Modes And Branches
+- <mode/dtype/layout/compression branch and condition>
+
+## Source-Order Algorithm Phases
+- <ordered list of major source regions, for orientation only>
+
+## Unresolved Items
+- <missing file/helper or none>
+
+## Risks
+- <DSL/codegen/runtime risks or none>
+```
+
+`${PORT_DIR}/launch_config.md` must use this Markdown structure:
+
+```markdown
+# Launch Config
+
+## Logical Inputs And Outputs
+- <name>: <shape/dtype/role>
+
+## Runtime Parameters
+- <parameter>: <meaning and source>
+
+## Launch Topology
+- grid_or_program_shape: <expression>
+- block_or_program_shape: <expression or none>
+- threads_or_warps: <expression or none>
+- cta_group: <mode>
+- cluster: <shape or none>
+
+## Memory Resources And Launch Attributes
+- shared_memory_bytes: <expression or none>
+- pipeline_stages: <expression or none>
+- attributes: <list>
+
+## Compile-Time Or JIT Parameters
+- <parameter>: <value/source>
+
+## Source To TIRx Correspondence
+| source launch value | TIRx value | notes |
+| --- | --- | --- |
+```
+
+`${PORT_DIR}/tensor_overview.md` must use this Markdown structure:
+
+```markdown
+# Tensor Overview
+
+| tensor | storage | dtype | logical shape | size | alignment | offset/start | source physical mapping/swizzle (documentation only) | lifetime | source location |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+```
+
+`${PORT_DIR}/scaffold_manifest.yaml` is an entry index, not an edit contract. It must include only these fields:
+
+```yaml
+port_dir: "<PORT_DIR>"
+target_repo_root: "<TARGET_REPO_ROOT>"
+source_entry:
+  kind: "<cuda|cutedsl|gluon|triton|other>"
+  source: "<absolute source path>"
+  symbol: "<source kernel, program, or host entry symbol where tracing starts>"
+target_entry:
+  module: "tirx_kernels/.../<kernel>.py"
+  symbol: "<TIRx primfunc symbol where implementation starts>"
+  start_marker: "<optional exact marker string or null>"
+```
+
+The start marker is only a visual anchor for where the kernel-sketch stage should
+begin writing. It is not an edit boundary.
+
+The overview documents are mandatory orientation notes for later phases. They are
+not edit permissions, not an implementation spec, and not a substitute for reading
+the source implementation and TIRx source.
+
+## 2. Steps
+
+Step 1: Read the user task, repo-local instructions, and nearby TIRx kernel modules needed to match local style.
+
+Step 2: Read only enough source dispatch/API/test/benchmark code to identify the
+source entry point, the target TIRx entry point, and the shape/config coverage
+needed for `prepare_data`, `run_test`, and `run_bench`.
+
+Step 3: Create the target TIRx module scaffold.
+
+Step 4: Write `${PORT_DIR}/source_overview.md`, `${PORT_DIR}/launch_config.md`, `${PORT_DIR}/tensor_overview.md`, and `${PORT_DIR}/scaffold_manifest.yaml` using the File Format above.
+
+Step 5: Continue to the kernel-sketch stage in the main session.
+
+## 3. What You Must Follow
+
+- Do not implement source-kernel behavior inside the `@T.primfunc`.
+- Do not create or edit `line_by_line_mapping.yaml` or `partial_line_by_line_mapping.yaml`.
+- Do not claim correctness passes.
+- Do not run expensive benchmarks.
+- Keep the scaffold consistent with `tirx-kernels-kernel-conventions`.
+- Include existing source test or benchmark shape/config coverage when it is discoverable.
+- Keep `source_overview.md`, `launch_config.md`, and `tensor_overview.md` useful enough to orient later phases.
+- Treat their storage-class, launch, and per-thread claims as **provisional**.
+  They are written from the source text, which misrepresents exactly those: a
+  declaration that reads static may be allocated dynamically, and a value the
+  source reads on every thread may be read by one after the compiler sinks it.
+  The kernel-sketch stage exports line-info PTX and reconciles these documents
+  against it. Do not let a claim that the export later overturns stay in them --
+  a stale overview propagates into the sketch and then into the implementation.
+- Do not turn scaffold facts into edit permissions. The manifest tells the
+  kernel-sketch stage where source tracing starts and where to start in TIRx; it
+  does not restrict required target-module edits.
+- Do not stop in scaffold because entry or coverage information is incomplete. Resolve it by reading more local source, using the user-provided entry, or recording an explicit assumption in the overview documents.

--- a/.agents/skills/tirx-kernel-porting/references/sketch_reviewer.md
+++ b/.agents/skills/tirx-kernel-porting/references/sketch_reviewer.md
@@ -1,0 +1,201 @@
+# Sketch Reviewer Gate
+
+## Role
+
+You are the reviewer subagent. Independently verify the kernel sketch against the
+source implementation. Do not edit the sketch, source, scaffold, or target kernel.
+
+Read the user task, scaffold artifacts, target sketch, source entry, dispatch and
+launch code, and every reachable helper needed by the selected specialization.
+
+Use the FlashKDA and GDN prefill sketches as the target abstraction level. Review
+for faithful semantic coverage and the same concise execution-skeleton style;
+do not demand a source-level transcription of incidental implementation detail.
+
+Build a complete bidirectional semantic line mapping between the source kernel
+and the sketch while reviewing. Every relevant source region must map to sketch
+lines, and every sketch role, storage object, control-flow region, key copy,
+compute, and sync/async operation must map back to source lines. One sketch row
+may cover a source line range whose address or temporary-scalar mechanics only
+realize that semantic operation. Do not require a separate sketch operation for
+each such source statement. For instruction selection, extend key-operation
+evidence to PTX line info:
+
+```text
+source lines <-> sketch lines <-> PTX .file/.loc and instructions
+```
+
+The review passes only when all five checks below pass.
+
+## 1. Pipeline and Warp Roles
+
+Verify that the sketch exactly preserves the source implementation's:
+
+- warp, warpgroup, CTA, producer, consumer, scheduler, and epilogue roles;
+- role-selection branches and source-order execution structure;
+- pipe topology, stage count, phase/index movement, and publication/reuse edges.
+
+Fail for any missing, extra, merged, split, reordered, or reassigned role or edge.
+
+## 2. Tensor and Mbarrier Placement
+
+Verify every relevant tensor, tile, view, alias, and mbarrier against the source.
+
+First enforce the representation contract: the sketch must contain no first-class
+layout object, value, annotation, or `layout=` argument on any tensor, tile,
+buffer, view, alias, register fragment, TMEM object, or operation. Every SMEM
+tensor must be a one-dimensional linear allocation without attached layout or
+swizzle metadata. Any violation is an immediate FAIL even if the represented
+mapping matches the source.
+
+For tensors, check storage class, dtype, logical shape, alignment, semantically
+relevant placement/offset, stage stride, aliasing, lifetime, and the explicit
+scalar index/byte-offset mapping from logical coordinates into storage. Verify
+that these explicit mappings preserve every source layout, swizzle, transpose,
+and fragment mapping that affects selected bytes or instruction descriptors. Do
+not require routine arithmetic expansion beyond the named mapping functions.
+Hardware descriptor fields, strides, swizzle immediates, and PTX operands are
+allowed and must be checked as instruction-selection details; they are not
+first-class layouts.
+
+For mbarriers, check physical position/index, stage count, initial phase, arrival
+count, expected transaction bytes, producer/consumer ownership, and reuse.
+
+Fail for any mismatch, omitted object, invented object, or overlapping lifetime
+that the source does not permit.
+
+## 3. Synchronization Protocol
+
+Verify that synchronous and asynchronous protocols exactly match the source:
+
+- acquire, wait, arrive, expect-bytes, commit, release, and tail order;
+- stage/phase transitions and cursor movement;
+- CTA, warpgroup, cluster, named-barrier, and mbarrier synchronization;
+- fences, proxy scopes, memory ordering, async-copy groups, and completion edges;
+- the point where storage may be consumed or reused.
+
+Fail if the sketch omits, adds, reorders, broadens, narrows, or hides any protocol
+operation.
+
+## 4. Operation Dataflow
+
+Walk the source and sketch in source order. Verify that its dominant body is the
+complete data-movement and data-computation flow, supported only by necessary
+storage declarations, scheduler/phase scalar state, synchronization, role
+control flow, loops, predicates, tails, and output paths.
+
+Check that no semantic source operation is missing, no sketch operation is
+invented, and no key copy, compute, or sync/async operation is skipped,
+duplicated, reordered, or folded into a compound op. Each key op must stay within
+the allowed abstraction bound: one PTX instruction, one tile of one PTX
+instruction family, or one explicit loop of one PTX instruction family.
+
+Use the bidirectional source/sketch line mapping as the coverage proof. Unmapped
+semantic source regions indicate missing sketch behavior; unmapped sketch lines
+indicate invented or unsupported behavior. Incidental address calculation,
+pointer arithmetic, descriptor bit assembly, constant folding, and temporary
+scalar plumbing may be covered by the containing semantic mapping row and omitted
+from the sketch body. Fail an over-detailed sketch that buries the copy/compute
+execution skeleton under those mechanics.
+
+## 5. Instruction Selection
+
+Do not validate instruction selection from intuition or op names.
+
+Compile the exact source specialization through its normal build path with line
+information enabled, then export its PTX. Preserve the generated source when the
+input is CuTeDSL, Gluon, Triton, or another code generator. Use PTX `.file`/`.loc`
+line information to connect source operations to emitted PTX.
+
+For every key copy, compute, and sync/async op in the sketch, verify that its
+inline `instruction_selection` and extent match the line-associated source PTX:
+
+- exact instruction or instruction family;
+- scalar, vector, tile, or loop extent;
+- operand dtype and shape;
+- relevant modifiers, predicates, scopes, cache or memory-order qualifiers;
+- issue count or K-phase repetition when the op represents a tile or loop.
+
+Storage declarations, structural views, control-flow syntax, and phase/stage/
+scheduler bookkeeping do not require instruction selection unless they emit a
+key operation. Missing line information, missing exported PTX, an unannotated key
+operation, or an annotation that cannot be proven from PTX cannot pass this
+check.
+
+## Procedure
+
+1. Identify the exact source entry and specialization selected by the user task.
+2. Read the complete source path and target sketch.
+3. Build the source specialization with line information and export PTX.
+4. Build the complete semantic source-lines-to-sketch-lines mapping and attach
+   PTX `.loc` evidence to key copy, compute, and sync/async rows.
+5. Audit all five checks. Continue after finding a problem so the writer receives
+   the complete batch of findings for this review run.
+6. Return `PASS`, `FAIL`, or `BLOCKED` using the format below.
+
+Use `BLOCKED` only when required source, toolchain, hardware, or line-info PTX
+cannot be obtained. A blocked review is not a pass and must not advance the
+workflow.
+
+The writer now exports line-info PTX during the kernel-sketch stage and cites it
+from the sketch. Generate your own regardless and review against that; the
+writer's copy is something to diff against, never a substitute. If the two
+differ, say so -- it means one of the two exports does not describe the
+specialization under review.
+
+Separately, report any scaffold artifact the sketch now contradicts, as an
+observation rather than a finding. A stale `launch_config.md` or
+`tensor_overview.md` does not make the sketch wrong and must not gate it, but it
+will mislead the implementation stage if nobody says so.
+
+## Result Format
+
+```markdown
+Reviewer result: PASS | FAIL | BLOCKED
+
+Source specialization: <entry and config>
+Sketch: <path>
+Line-info PTX: <path or blocked reason>
+
+Line mapping:
+| source lines | sketch lines | role/storage/sync/op | PTX .loc/instruction |
+| --- | --- | --- | --- |
+
+Checks:
+1. Pipeline and warp roles: PASS | FAIL | BLOCKED
+2. Tensor and mbarrier placement: PASS | FAIL | BLOCKED
+3. Synchronization protocol: PASS | FAIL | BLOCKED
+4. Operation dataflow: PASS | FAIL | BLOCKED
+5. Instruction selection: PASS | FAIL | BLOCKED
+
+Findings:
+- category: <1-5>
+  source: <path:lines>
+  sketch: <path:lines>
+  ptx: <PTX path and .loc/instruction evidence when relevant>
+  expected: <source behavior>
+  observed: <sketch behavior>
+  required_fix: <specific sketch correction>
+```
+
+Use `n/a` in the PTX column for supporting storage, control-flow, or scalar
+bookkeeping rows that do not require instruction-selection evidence.
+
+Return `PASS` only when every check passes and `Findings` is empty.
+The semantic line mapping must cover both directions completely; a partial
+mapping cannot pass. This completeness requirement does not turn omitted
+mechanical address derivations into standalone sketch operations.
+
+## Must Not
+
+- Do not perform this review in the main writer agent.
+- Do not edit files or fix findings yourself.
+- Do not substitute mathematical correctness for source fidelity.
+- Do not infer PTX instruction selection without a fresh line-info PTX export.
+- Do not demand standalone sketch lines for incidental address or temporary
+  scalar mechanics that are already covered by a semantic operation.
+- Do not pass with unmapped semantic source behavior or unmapped sketch behavior.
+- Do not stop at the first failure; report all findings found in the review run.
+- Do not pass a sketch with missing, extra, skipped, reordered, or unproven work.
+- Do not pass an over-detailed sketch whose core copy/compute flow is obscured by
+  mechanical implementation detail.

--- a/.agents/skills/tirx-kernel-porting/references/source_export.md
+++ b/.agents/skills/tirx-kernel-porting/references/source_export.md
@@ -1,0 +1,96 @@
+# Exporting the source's line-info PTX
+
+Both the kernel-sketch stage and the sketch reviewer need a line-info PTX export
+of the exact source specialization. The writer's export grounds the sketch's
+`instruction_selection` annotations; the reviewer's is independent and does not
+reuse the writer's. This file exists so the mechanics are looked up once instead
+of rediscovered every port.
+
+Preserve the export under `${PORT_DIR}` and cite its path from the sketch, so the
+reviewer can diff its own export against it.
+
+## What a usable export looks like
+
+- `.file` directives naming the source file, and `.loc` directives through the
+  body. An export with zero `.loc` is not usable for check 5 -- line info was not
+  enabled.
+- For a code generator (CuTeDSL, Gluon, Triton), the generated intermediate
+  source preserved alongside, since `.loc` may point into it rather than into the
+  code you read.
+
+## CuTeDSL
+
+```bash
+mkdir -p "$DUMP"          # the directory must already exist; the DSL will not create it
+MM_SPARSE_ATTN_AOT_DISABLE=1 \
+CUTE_DSL_NO_CACHE=1 \
+CUTE_DSL_KEEP=ptx \
+CUTE_DSL_LINEINFO=1 \
+CUTE_DSL_DUMP_DIR="$DUMP" \
+python <driver>
+```
+
+- `CUTE_DSL_LINEINFO=1` is what adds `.loc`; `CUTE_DSL_KEEP=ptx` alone gives an
+  export with none.
+- Disable both caches or a previously compiled binary is returned and nothing is
+  dumped: the DSL's own JIT cache (`CUTE_DSL_NO_CACHE=1`) and any project-level
+  AOT cache (above, MSA's is `MM_SPARSE_ATTN_AOT_DISABLE=1`).
+- Keep `CUTE_DSL_KEEP=ptx`. Adding `ir-debug` or `cubin` has been observed to
+  segfault the compiler.
+- `CUTE_DSL_KEEP=ir` also dumps MLIR, but the "clean" MLIR is post-canonicalize
+  and carries no `loc`, so it does not substitute for the PTX.
+
+**The driver matters.** A kernel that consumes another kernel's output, or that
+needs real payload data, cannot be exported by calling it with empty tensors --
+it will not run, or will run a degenerate path. Drive the source's own host
+wrapper with data shaped like production, and assert something about the result
+so a silently wrong run is caught. Doing so doubles as a semantic check: one such
+run confirmed a per-group degree bound that the correctness oracle then depended
+on. If the wrapper runs an upstream kernel first, the dump directory will hold
+more than one `.ptx`; take the one whose name carries the target symbol.
+
+## Triton
+
+```bash
+TRITON_CACHE_DIR="$DUMP" python <driver>
+```
+
+The cache holds `.ttir`, `.ttgir`, `.ptx` and `.cubin` per compiled kernel.
+Preserve the `.ttgir` as the generated intermediate source. Line info requires
+the kernel to be compiled with debug info enabled (`TRITON_DEBUG=1`, or
+`@triton.jit(debug=True)` depending on version).
+
+## CUDA C++
+
+```bash
+nvcc -arch=<sm_xx> -ptx -lineinfo <source> -o "$DUMP/kernel.ptx"
+```
+
+When the source is JIT-built by the project (torch `cpp_extension`, a project
+JIT), add `-lineinfo` to that build's flag list rather than compiling by hand, so
+the export matches the specialization the project actually runs.
+
+## Reading the export
+
+Two commands cover most of what the sketch needs:
+
+```bash
+# key operations mapped to source lines
+awk '/\.loc/{loc=$0} /ld\.global|st\.global|ld\.shared|st\.shared|atom\.|bar\.|shfl\.|mbarrier|cp\.async/ \
+     {gsub(/^[ \t]+/,"",$0); gsub(/^[ \t]+/,"",loc); print loc" ||| "$0}' "$PTX" \
+  | sed 's/\[[^]]*\]/[addr]/' | sort | uniq -c | sort -rn
+
+# static opcode histogram, for the sketch's evidence table
+grep -oE "^\s+[a-z][a-z0-9_.]+" "$PTX" | sed 's/^[ \t]*//' \
+  | grep -v "^ld.param\|^\." | sort | uniq -c | sort -rn
+```
+
+Read the loop bodies, not only the totals. A port can match the reference's
+static opcode counts exactly and still carry a fatter loop body, which is where
+the time goes.
+
+## Counting convention
+
+Sketches in this corpus report instruction counts as instruction lines minus
+predicated lines. State the convention if you report a figure, so a reviewer
+recounting it does not read a mismatch as an error.

--- a/.agents/skills/tirx-kernels-kernel-conventions/SKILL.md
+++ b/.agents/skills/tirx-kernels-kernel-conventions/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: tirx-kernels-kernel-conventions
+description: Follow the current tirx-kernels module, registry, licensing, correctness, benchmark, and bench-suite conventions. Use when adding, porting, testing, benchmarking, or reviewing kernels in tirx-kernels, including source attribution, SPDX headers, CONFIGS, BENCH_CONFIGS, run_test, run_bench, tvm.tirx.bench, references, distributed timing, and baseline integration.
+---
+
+# tirx-kernels Kernel Conventions
+
+Use this skill for repository integration around a TIRx kernel. Use
+`tirx-kernel-porting` separately when the task requires implementation-trace-
+preserving transcription from CUDA, CuTeDSL, Gluon, Triton, or another source.
+
+## 1. Confirm the Live Contract
+
+Before editing a kernel, inspect the current versions of:
+
+- `tirx_kernels/runner.py`
+- `tirx_kernels/registry.py`
+- `tirx_kernels/bench/__main__.py`
+- `tirx_kernels/test/__main__.py`
+- `tirx_kernels/bench_suite/README.md` and the relevant file under
+  `tirx_kernels/bench_suite/config/`
+- `LICENSE`, `NOTICE`, `licenses/`, and the License section of `README.md`
+- `tests/lint/check_license_headers.py` and the license hook in
+  `.pre-commit-config.yaml`
+- the `license` and `license-files` fields in `pyproject.toml`
+- `tvm.tirx.bench.bench` in the paired TVM worktree
+- tests covering the affected CLI or protocol
+- one recently maintained module with similar runtime and reference behavior
+
+Also inspect `tirx_kernels/_protocol.py`, but do not treat it as authoritative when
+it lags the executable code. If sources conflict, follow this order:
+
+1. runner, CLI, and tests
+2. recently maintained kernel modules
+3. `_protocol.py`
+4. this skill
+
+The paired worktrees matter: the host `~/tvm` or `~/tirx-kernels` checkout may not
+match the branch under development. If live code differs from this skill, follow
+the live code and update the skill.
+
+## 2. Standard Module Shape
+
+A discoverable module under `tirx_kernels/<category>/` should normally expose:
+
+```python
+KERNEL_META = {
+    "name": "kernel_name",
+    "category": "gemm",
+    "compute_capability": 10,
+}
+
+CONFIGS = [
+    {"label": "m1024_n1024_k1024", "M": 1024, "N": 1024, "K": 1024},
+]
+
+# Optional when the performance sweep intentionally differs from CONFIGS.
+BENCH_CONFIGS = [
+    {"label": "m4096_n4096_k4096", "M": 4096, "N": 4096, "K": 4096},
+]
+
+
+def get_kernel(...):
+    ...
+
+
+def prepare_data(...):
+    ...
+
+
+def run_test(...):
+    ...
+
+
+def run_bench(
+    ..., *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0
+):
+    ...
+```
+
+Important:
+
+- `compute_capability=10` means SM100. Do not write `100`.
+- `KERNEL_META["name"]` must be globally unique and is the CLI kernel name.
+- `category` is discovered from package directories. A new category needs an
+  `__init__.py`; registry infrastructure directories are intentionally skipped.
+- `get_kernel` returns the TIRx `PrimFunc`, or a list for a multi-kernel workload.
+- `run_test` is the correctness entry point used by the runner.
+- `run_bench` is optional and is the benchmark entry point used by the runner.
+- `check_correctness` may be a useful internal helper, but current execution uses
+  `run_test`; do not add a second abstraction only to satisfy a stale protocol.
+- Keep `__all__` synchronized when the surrounding package uses it.
+
+## 3. License and Provenance
+
+Treat a mechanically transcribed or substantially copied kernel as a port, not
+as native TIRx code. Determine provenance and applicable terms before writing the
+implementation. Inspect the upstream repository license, file-local header,
+`NOTICE` or authors files, and the exact source commit. Do not infer a license
+from the project name or from another checkout revision. If the source has no
+clear redistributable license, has conflicting terms, or requires a compatibility
+decision that is not already represented by repository policy, stop and report
+the issue instead of copying the implementation.
+
+Current repository organization is:
+
+- `LICENSE` contains Apache-2.0 plus a third-party component-to-license map.
+- `NOTICE` carries project notices and upstream notices that must propagate.
+- `licenses/` contains verbatim upstream license and required authors texts.
+- `pyproject.toml` currently declares
+  `Apache-2.0 AND BSD-3-Clause AND MIT` and includes `LICENSE`, `NOTICE`, and
+  `licenses/*.txt` in distributions.
+- `tests/lint/check_license_headers.py` binds source-project buckets and exceptional
+  files to their required citations and SPDX expressions.
+
+The current path-to-license map is:
+
+- native TIRx code, including `tirx_kernels/basic/`: `Apache-2.0`
+- `tirx_kernels/deepgemm/`: `Apache-2.0 AND MIT`
+- `tirx_kernels/flashmla/`: `Apache-2.0 AND MIT`
+- `tirx_kernels/flashattention/`: `Apache-2.0 AND BSD-3-Clause`
+- `tirx_kernels/flashinfer/`: normally `Apache-2.0`
+- `tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py`:
+  `Apache-2.0 AND BSD-3-Clause`, with the upstream BSD conditions and disclaimer
+  retained verbatim in the file header
+
+Every tracked Python source file must have exactly one SPDX license expression and
+the TIRx copyright line. Native files use exactly:
+
+```python
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+```
+
+A ported file must instead name the upstream project, cite the canonical URL and
+exact source commit, retain the relevant upstream copyright notice, and declare
+both the TIRx and upstream terms. Follow the live checker for exact spelling:
+
+```python
+# This file is a TIRx port of code from <Project>
+# (<canonical URL> @ <commit>), <upstream copyright notice>
+# SPDX-License-Identifier: Apache-2.0 AND <upstream SPDX license>
+# SPDX-FileCopyrightText: Copyright TIRx authors
+```
+
+Also put the exact upstream source path or paths in the module docstring. Derived
+helpers carry the port header too; package markers and genuinely native harnesses
+use the native header only when the checker classifies them as exceptions. Never
+run the checker's `--fix` mode on a port: it intentionally synthesizes only the
+native Apache header and cannot determine upstream terms.
+
+For a source project already represented in the repository, use its existing
+bucket, license text, citation shape, and checker rule. A file with terms different
+from its bucket needs a narrow file override. Preserve any file-local conditions
+or disclaimer that the upstream license requires to travel with the source; SPDX
+tags do not replace required text.
+
+For a new source project or license family, update all applicable surfaces in the
+same change:
+
+1. Add the verbatim upstream license under `licenses/`, plus required `AUTHORS` or
+   notice text.
+2. Add the component or precise file exception to the third-party map in `LICENSE`.
+3. Propagate relevant upstream `NOTICE` attribution when required.
+4. Extend the `pyproject.toml` license expression if it introduces a new license;
+   keep every license/notice file included by `license-files`.
+5. Add the path-bound project, URL, and SPDX expectation to
+   `tests/lint/check_license_headers.py`, using a file override for exceptional
+   terms and an exception only for genuinely native files.
+6. Extend the checker's self-tests so a wrong license, URL, missing copyright, or
+   missing required text cannot pass.
+7. Update the README License section when the documented source-project set or
+   packaging description changes.
+
+Do not remove or rewrite verbatim files under `licenses/`, strip an upstream
+header, label a port as plain Apache-2.0, or choose `AND`/`OR` expressions from
+memory. Match the inspected source terms and the repository's live policy.
+
+Validate with:
+
+```bash
+python tests/lint/check_license_headers.py
+python tests/lint/check_license_headers.py --self-test
+pre-commit run --all-files
+```
+
+## 4. Configuration Layers
+
+There are three distinct configuration layers. Do not collapse their roles:
+
+1. `CONFIGS` is the labeled correctness/default module matrix.
+2. Optional `BENCH_CONFIGS` is the module benchmark matrix. The benchmark CLI
+   prefers it and falls back to `CONFIGS` when it is absent.
+3. `tirx_kernels/bench_suite/config/<kernel>.yaml` selects the curated regression
+   sweep and marks each benchmark config `default: true|false`.
+
+Every module config must have a stable, meaningful `label`; the runner removes
+`label` and passes the remaining keys as keyword arguments. A bench-suite `config`
+value must match a label accepted by the module benchmark matrix.
+
+Keep every config in the implementation's real dispatch domain. For a port of a
+specific source specialization, record and enforce the source dispatch predicates;
+do not add nearby shapes that dispatch to a different implementation.
+
+Use labels that expose meaningful dimensions or modes. Avoid labels such as
+`small` or `fast` when a parameter-encoded label is practical.
+
+## 5. Imports and Data Preparation
+
+Kernel discovery must work without optional reference packages. Import FlashInfer,
+FlashMLA, FlashAttention, SGLang, DeepGEMM, FlashKDA, and similar dependencies only
+inside the preparation, execution, or lazy reference-builder path that needs them.
+Do not import optional packages at module import time.
+
+`prepare_data` should make logical inputs and implementation-specific state explicit.
+
+- Use deterministic seeds for correctness data.
+- Allocate inputs before timed closures are created.
+- Give TIRx and references equivalent logical values.
+- Give implementations independent mutable outputs and workspaces unless sharing
+  is required by the actual API.
+- Prefer torch tensors when the compiled module accepts them directly.
+- Do not add torch -> NumPy -> TVM copies without a runtime requirement.
+- Keep quantization, packing, scaling, layout conversion, metadata generation,
+  JIT compilation, autotuning, workspace setup, and validation outside the timed
+  launch unless the production operation intentionally includes them.
+- For debugging, record shape, dtype, seed, device, and derived launch values.
+
+For distributed kernels, make rank-local tensors, process-group assumptions,
+required GPU count, communication state, and timing stream explicit. Do not reuse
+a stale free-GPU decision.
+
+## 6. Correctness
+
+`run_test(**config)` must compile, launch, and validate one config internally.
+
+- Raise `AssertionError` on mismatch.
+- Raise `unittest.SkipTest` when hardware, GPU count, a reference package, or a
+  runtime dependency is unavailable.
+- Start with a debugger-friendly case, but also cover predicates and boundary
+  conditions that distinguish the target implementation.
+- Compare against the source implementation or another trusted reference when
+  doing a port. A scalar mathematical implementation is useful only as an
+  additional oracle; it does not establish implementation alignment.
+- Fold stable regression coverage into `run_test`, `CONFIGS`, or repository tests
+  rather than leaving it only in scratch scripts.
+
+Run one config with:
+
+```bash
+python -m tirx_kernels.test --kernel <name> --config <label>
+```
+
+Run the default-sweep import gate with:
+
+```bash
+python -m tirx_kernels.bench_suite --check-imports
+```
+
+## 7. Benchmark Entry Point
+
+Use the paired TVM worktree's `tvm.tirx.bench.bench` as the standard timing API.
+The local benchmark API takes our no-argument launch closures and optional lazy
+reference builders:
+
+```python
+from tvm.tirx.bench import bench
+
+
+def run_bench(
+    ..., *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0
+):
+    data = prepare_data(...)
+    tirx_launch = build_tirx_launch(data)
+
+    def build_reference():
+        # Heavy import, JIT, tuning, setup, and validation happen here.
+        return build_reference_launch(data)
+
+    return bench(
+        {"tirx": tirx_launch},
+        references={"reference": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+```
+
+Rules:
+
+- `funcs` contains only our implementations. External implementations belong in
+  `references`.
+- Launch closures are no-argument callables. Inputs, compilation, and setup are
+  outside the timed closure unless intentionally part of the measured operation.
+- `references` maps a name to a no-argument builder; the builder returns the
+  no-argument launch closure.
+- A reference-builder failure is returned by `bench` as a `BASELINE_ERROR` while
+  preserving our result. The bench suite treats that error as a failed workload;
+  it is not valid regression evidence.
+- Pass `timer=None`, `warmup=None`, and `repeat=None` to inherit central defaults
+  unless the module has a justified override. `warmup` and `repeat` are millisecond
+  budgets, not iteration counts.
+- `rounds` is the number of independent measurement rounds.
+- `cooldown_s` is applied before each implementation in each round.
+- Return the complete `bench` result instead of legacy `*_ms` fields.
+
+Use `tirx` for a new single implementation and `tirx_<variant>` for multiple TIRx
+variants. The bench suite also recognizes legacy `tir` and `tir_<variant>` names.
+All other implementation names are treated as references.
+
+Result values under `impls` and `round_samples` are microseconds:
+
+```python
+{
+    "impls": {"tirx": tirx_us, "reference": reference_us},
+    "round_samples": {"tirx": [tirx_us, ...]},
+    "errors": {},
+    "timer": "proton",
+    "benchmark_protocol": {...},
+}
+```
+
+## 8. Timer Semantics
+
+Local timers:
+
+- `timer=None` resolves to `proton`.
+- `proton` attributes per-kernel GPU time and excludes host dispatch overhead.
+- `event` measures CUDA-event wall time for the launch closure.
+- `cudagraph_proton` uses CUDA Graph replay plus Proton attribution. It uses
+  `cudagraph_rep`, not `warmup` or `repeat`, and should be used only when every
+  implementation captures and attributes correctly.
+
+Distributed timing:
+
+- Supplying a `DistributedBenchContext` makes `timer=None` resolve to `kineto`.
+- Distributed benchmarking supports only `kineto`.
+- Kineto uses fixed iteration counts and rejects `warmup`, `repeat`, and
+  `cudagraph_rep` overrides.
+- A distributed `prepare={name: callback}` resets implementation-specific state
+  outside the measured span. Local benchmarks reject `prepare`.
+- Auxiliary streams must synchronize correctly with the context's timing stream.
+
+`megamoe` is a specialized CLI/module protocol for the DeepGEMM MegaMoE path, not
+a general `tvm.tirx.bench.bench` timer. It fixes its own schedule; do not pass
+`warmup` or `repeat` overrides to it.
+
+Do not mix values from different timers in one unlabeled comparison. Do not claim
+drop-in latency from a kernel-only Proton result.
+
+Run a local benchmark with:
+
+```bash
+python -m tirx_kernels.bench \
+  --kernel <name> --config <label> \
+  --timer proton --rounds 5 --cooldown 1
+```
+
+The runner forwards `warmup`, `repeat`, and `timer` only when explicitly supplied.
+The CLI and bench suite normally forward their defaults of `rounds=5` and
+`cooldown_s=1.0`; a direct module call normally defaults to one round.
+
+## 9. Kernel-Only and End-to-End
+
+Keep these as separate measurements:
+
+- Kernel-only times only the target launch or intended one-to-one kernel sequence.
+- Drop-in/end-to-end times the real repeated operation, including required setup
+  kernels, metadata work, communication, and wrapper overhead.
+
+For an implementation-trace-preserving port, kernel-only is the direct generated-
+code comparison. End-to-end answers whether replacing the production call path
+helps. State exactly which one each result represents.
+
+## 10. Bench Suite
+
+The curated sweep is defined by one file per kernel:
+
+```yaml
+kernel: kernel_name
+defaults:
+  num_gpus: 1
+configs:
+  - {config: m1024_n1024_k1024, default: true}
+  - {config: m4096_n4096_k4096, default: false}
+```
+
+Each entry requires `config` and `default`. Optional file-level defaults and
+per-entry overrides include `timer`, `warmup`, `repeat`, and `num_gpus`. A custom
+file passed through `--workloads` instead uses a flat `workloads:` list where every
+entry includes its own `kernel`.
+
+Run the default sweep with:
+
+```bash
+python -m tirx_kernels.bench_suite
+```
+
+Suite rules:
+
+- Do not set `CUDA_VISIBLE_DEVICES`; the suite acquires and monitors GPUs atomically.
+- The default is five independent rounds with arithmetic-mean aggregation.
+- A workload benchmarks our implementation and every declared reference.
+- The first real `FAIL`, including a missing/failing reference, fail-fasts the sweep.
+- `INTERFERED` is requeued. `SKIP` is accepted without retry.
+- Run JSON, logs, and reports live under `.bench-suite/` and are not committed.
+- Reference adapters may use the absolute `TIRX_BENCH_CACHE_DIR` supplied by the
+  suite for version- and GPU-qualified caches.
+- A report ratio is `fastest non-ours reference / ours`; values greater than one
+  mean our implementation is faster.
+
+Promote a complete default sweep by replacing the baseline:
+
+```bash
+python tirx_kernels/bench_suite/promote_baseline.py \
+  .bench-suite/runs/<id>.json
+```
+
+Promote a targeted run without dropping unrelated rows:
+
+```bash
+python tirx_kernels/bench_suite/promote_baseline.py \
+  .bench-suite/runs/<id>.json --merge
+```
+
+Both forms regenerate `baseline.md`. Never copy a run JSON over `baseline.json`.
+
+## 11. Review Checklist
+
+- Does registry discovery find a unique `KERNEL_META["name"]`?
+- Does every Python file have the correct native or port SPDX header?
+- Does each port cite the canonical upstream URL, exact commit, copyright, and
+  source path without dropping required file-local license text?
+- For a new source family, are `LICENSE`, `NOTICE` when applicable, `licenses/`,
+  `pyproject.toml`, README, and the path-bound license checker synchronized?
+- Do the license checker, its self-test, and the pre-commit license hook pass?
+- Is `compute_capability` encoded as `10` for SM100 rather than `100`?
+- Do optional dependencies remain lazy so import discovery succeeds?
+- Are `CONFIGS` and optional `BENCH_CONFIGS` serving their distinct purposes?
+- Does the bench-suite config reference valid labels and set `default` deliberately?
+- Does every test and benchmark config dispatch to the intended implementation?
+- Does `run_test` validate useful boundary cases and raise on mismatch?
+- Are logical inputs equivalent and mutable workspaces independent?
+- Does `run_bench` forward timer, rounds, and cooldown semantics correctly?
+- Are setup, JIT, tuning, validation, and allocations outside timed closures?
+- Are external implementations supplied as lazy reference builders?
+- Are implementation names classified correctly as ours versus references?
+- Are benchmark values treated as microseconds and timer semantics labeled?
+- Are distributed context, prepare callbacks, streams, and GPU count explicit?
+- Are kernel-only and end-to-end claims kept separate?
+- Does the bench suite pass its import gate, and is baseline promotion mode correct?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kern kernels on TIRx
+# TIRx kernels
 
 High-performance GPU kernels authored in
 [Kern](tirx_kernels/kern/README.md) and compiled through


### PR DESCRIPTION
## Summary

- add the repo-local kernel porting workflow with staged scaffold, sketch review, correctness, and performance gates
- add the TIRx kernel integration skill used by the porting workflow
- organize the remaining root-level cuDNN sketches under `.agents/sketch/cudnn/`
- restore the root README title to "TIRx kernels" while preserving the Kern authoring description

## Validation

- quick_validate.py for both skills
- pre-commit run