### PR TITLE
Remove redundant tcgen05 load waits

### DIFF
--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -993,7 +993,6 @@ def make_kernel(
                     with K.If(warp_id == 0), K.Then():
                         K.cuda.iket.mark("softmax-phase-2")
                     K.ptx.tcgen05.wait__st.sync.aligned()
-                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_ready_2.arrive(wg_id)
                     with K.If(warp_id == 0), K.Then():
                         K.cuda.iket.mark("softmax-phase-3")

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -3140,7 +3140,6 @@ def _make_prefill(spec):
                                 )
                                 K.ptx.mov.b32(fragment[pair * 2], K.cuda.float2_x(mul[0]))
                                 K.ptx.mov.b32(fragment[pair * 2 + 1], K.cuda.float2_y(mul[0]))
-                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_cg1.empty.arrive(st_shared.stage)
                     st_shared.advance()
                     with K.unroll(32) as pair:
@@ -3195,7 +3194,6 @@ def _make_prefill(spec):
                             nv_words[pair],
                             _mn_opt_pack_iox2(fragment[pair * 2], fragment[pair * 2 + 1], io_dtype),
                         )
-                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     p_cg1.empty.arrive(st_shared.stage)
                     st_shared.advance()
                     with K.unroll(2) as row_half:
@@ -3253,7 +3251,6 @@ def _make_prefill(spec):
                             _mn_opt_pack_iox2(fragment[pair * 2], fragment[pair * 2 + 1], io_dtype),
                         )
                     _prefill_opt_store_o_fragment(s_o, st_o.stage, cg1_thread, o_words)
-                    K.ptx.tcgen05.wait__ld.sync.aligned()
                     K.ptx.fence.proxy.async_.shared__cta()
                     p_qstate.empty.arrive(st_qstate_c.stage)
                     st_qstate_c.advance()

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -934,7 +934,6 @@ def make_kernel(HQ: int, HV: int):
                             sub[vec * 4 + 2],
                             sub[vec * 4 + 3],
                         )
-                K.ptx[WAIT_LD]()
                 p_kv.empty.arrive(st_kvc.stage)
                 st_kvc.advance()
 
@@ -1035,7 +1034,6 @@ def make_kernel(HQ: int, HV: int):
                                         scale_pair(
                                             fr, p, f2(cumprod_f[2 * g], cumprod_f[2 * g + 1])
                                         )
-                            K.ptx[WAIT_LD]()
                             p_cg1.empty.arrive(st_cg1c.stage)  # release KS
                             st_cg1c.advance()
                             for p in range(32):  # orig:L1998-2002
@@ -1078,7 +1076,6 @@ def make_kernel(HQ: int, HV: int):
                             cg1_acc_ld(fr, TM_CG1)
                             for p in range(32):
                                 pack_f16x2(nvw[p], fr[2 * p], fr[2 * p + 1])
-                            K.ptx[WAIT_LD]()
                             p_cg1.empty.arrive(st_cg1c.stage)  # release NV
                             st_cg1c.advance()
                             for h in range(2):
@@ -1103,7 +1100,6 @@ def make_kernel(HQ: int, HV: int):
                             for p in range(32):
                                 pack_f16x2(nvw[p], fr[2 * p], fr[2 * p + 1])
                             store_o_frag(nvw, s_o[st_op.stage])
-                            K.ptx[WAIT_LD]()
                             K.ptx[FENCE_ASYNC]()
                             p_qs.empty.arrive(st_qsc.stage)  # release QKV
                             st_qsc.advance()


### PR DESCRIPTION
Summary:
- remove the eight tcgen05.wait::ld instructions added by PR #114 in FlashAttention-4 and the two GDN prefill kernels
- rely on the existing true register-dependency chains before the corresponding TMEM reuse publications

Validation:
- targeted Racecheck: review only, no error or incomplete
- targeted Synccheck: clean with complete bounded coverage
- GPU correctness: FlashAttention-4, GDN prefill, and CP-GDN prefill all passed