### PR TITLE
fix(kernel): stabilize cuDNN correctness on multi-GPU runs

### DIFF
--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/kernel.py
@@ -373,18 +373,22 @@ def _bwd_load(
             )
 
     # LSE and sum_OdO: 32 lanes x 2 f32 = the 64 rows of this head block. The
-    # workspace planes are head-contiguous, so a head block is 64 consecutive
-    # f32 only when it starts at head 0; index each row explicitly instead.
+    # d576 geometry has only 32 heads, so lanes 16-31 must zero-fill instead of
+    # reading beyond the last query's workspace. cp.async's ignore-src form
+    # preserves the 32-lane pipeline arrival while suppressing that global
+    # access. The workspace planes are head-contiguous, so index each row
+    # explicitly instead of treating the head block as a contiguous vector.
     slot = token * num_head + head_block * block
+    ignore_src = K.ptx.pred(lane * 2 >= K.int32(num_head))
     p_lse.empty.wait(0, 1)
     K.ptx["cp.async.ca.shared.global"](
-        smem.ptr_to([off_lse + lane * 8]), ws.ptr_to([plane + slot + lane * 2]), 8, 8
+        smem.ptr_to([off_lse + lane * 8]), ws.ptr_to([plane + slot + lane * 2]), 8, ignore_src
     )
     K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](p_lse.full.buf.ptr_to([0]))
 
     p_sum.empty.wait(0, 1)
     K.ptx["cp.async.ca.shared.global"](
-        smem.ptr_to([off_sum + lane * 8]), ws.ptr_to([slot + lane * 2]), 8, 8
+        smem.ptr_to([off_sum + lane * 8]), ws.ptr_to([slot + lane * 2]), 8, ignore_src
     )
     K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](p_sum.full.buf.ptr_to([0]))
 

--- a/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -3165,6 +3165,11 @@ def _compile_reference(data, config):
     prob = data["prob"]["source"]
     amax = data["source_amax"]
 
+    # Loading the reference can release stale TVM resources from an earlier
+    # test, and CUDA resource cleanup is allowed to change the thread's current
+    # device. DLPack requires it to match the tensor being exported.
+    torch.cuda.set_device(a.device)
+
     def dynamic(tensor, leading_dim):
         return from_dlpack(tensor, assumed_align=16).mark_layout_dynamic(leading_dim=leading_dim)
 
@@ -3207,6 +3212,7 @@ def _compile_reference(data, config):
         epilogue_op=epilogue_op,
         options="--enable-tvm-ffi",
     )
+    torch.cuda.set_device(a.device)
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     def launch():


### PR DESCRIPTION
## Summary

- zero-fill the inactive half of the DSA d576 LSE and sum_OdO head tile instead of reading past the workspace
- bind the sReLU CuTeDSL reference to the input tensor device before DLPack export and stream capture

## Testing

- all 12 DSA correctness configurations passed
- Compute Sanitizer memcheck on the reproducing DSA sequence: 3 passed, 0 errors
- sReLU perf00, perf02, and perf22 passed on logical GPU 2
- forced current-device mismatch before sReLU reference compilation passed
- pre-commit run on both changed files
- full TVM TIRx suite: 2845 passed, 91 skipped, 3 xpassed