### PR TITLE
feat(kernel): add cuDNN dense block-scaled GEMM dSReLU

### DIFF
--- a/.agents/sketch/cudnn/sm100_dense_blockscaled_gemm_persistent_dsrelu_quant.md
+++ b/.agents/sketch/cudnn/sm100_dense_blockscaled_gemm_persistent_dsrelu_quant.md
@@ -1,0 +1,727 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 dense block-scaled persistent GEMM + dSReLU quant: coarse WASP pipeline sketch
+
+This is the non-executable execution contract for
+[`tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py`](../../tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py).
+It freezes the seven-warp persistent program, block-scaled A/B mainloop,
+read-only C load pipeline, D store pipeline, row-wise `dprob` reduction,
+optional FP32 amax, and CTA1/CTA2 TMEM lifetime. After the first reviewer PASS
+this file is immutable; the executable module becomes the implementation source
+of truth.
+
+The authority is
+`python/cudnn/gemm/cutedsl/dense/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py`
+at commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`, SHA256
+`eb2b22e69e74f3637eb8f6e86222c83e9349a6e730b64a0fc1d58ba37a57003f`.
+Source citations below refer to that file. The writer export is
+`.porting/dense_blockscaled_gemm_persistent_dsrelu_quant/writer_export/anchor_lineinfo.ptx`,
+SHA256 `9eb4daafa4699d9642cbfd1570cfc41df75ae68919ae152be00c73d1d135edfd`.
+It contains 460 `.loc` records mapping 159 source lines. It was produced by the
+normal cache-disabled CuTeDSL compile path, launched three times with nonempty
+signed production data, and checked for D, dprob, and amax before admission.
+
+The instruction-annotated anchor specialization is:
+
+| axis | anchor value |
+| --- | --- |
+| shape | `M=N=256, K=512, L=2` |
+| A/B | FP4 E2M1, K-major/K-major |
+| SFA/SFB | E8M0, vector size 16 |
+| C/D | BF16/BF16, N-major |
+| MMA tile / cluster | `(256,256)` / `(2,1)` |
+| epilogue | `alpha=2/3`, amax active, SFD absent, `vector_f32=False` |
+| stages | accumulator/AB/C/D = `1/5/2/2` |
+| launch storage | 224 threads, 512 TMEM columns, 229,376 dynamic-SMEM bytes |
+
+The FP32 operation-boundary contract is:
+
+```text
+X[m,n,l] = alpha * blockscaled_gemm(A, B, SFA, SFB)[m,n,l]
+R[m,n,l] = max(X[m,n,l], 0)
+D_fp32[m,n,l] = 2 * R[m,n,l] * (C[m,n,l] * prob[m,l])
+D[m,n,l] = cast(D_fp32[m,n,l], d_dtype)
+dprob[m,l] += sum_n(R[m,n,l] * R[m,n,l] * C[m,n,l])
+amax = max(amax, max_mnl(abs(D_fp32[m,n,l])))       # only when enabled
+```
+
+Operation order is part of the contract: alpha precedes ReLU; C is loaded and
+converted independently; the dSReLU helper performs ReLU, doubling, and
+`C*prob` multiplication; dprob squares the same FP32 ReLU registers, multiplies
+by C, then uses the source scalar ADD reduction order. The global dprob array is
+zeroed by the host before launch because different N tiles atomically accumulate
+into the same `(m,l)` element.
+
+SFD is excluded: the source branch prints `SFD not implemented` instead of
+producing an output. FP8/FP4 D and unproven public-predicate modes are also
+excluded. The target imports only `tirx_kernels.kern as K`; device code uses no
+tile primitive, first-class layout or fragment, multidimensional shared buffer,
+CUDA source/function call, or low-level-IR exemption. Low-level operations are
+spelled only through established `K.ptx[...]` forms in the target module.
+
+## Pipeline at a glance
+
+| warp / role | persistent program | ownership edge |
+| --- | --- | --- |
+| warp 5, AB TMA | prefetch six TensorMaps; issue A/B/SFA/SFB G2S loads for every work item and K tile | AB-empty -> four TMA loads sharing one transaction barrier -> AB-full |
+| warp 4, MMA | retrieve TMEM, copy SFA/SFB S2T, issue block-scaled tcgen05 MMA, release AB and publish accumulator | AB-full -> scale copy/MMA -> AB-empty; ACC-empty -> MMA -> ACC-full |
+| warp 6, C TMA | follow the same persistent work cursor; issue one C G2S load for each 128x32 subtile | C-empty -> one TMA load/expect-tx -> C-full; producer tail drains all C stages |
+| warps 0-3, epilogue | load TMEM, wait/load/release C, compute dSReLU and dprob, optionally reduce amax, stage and TMA-store D | ACC-full + C-full -> FP32 math -> D S2G; C-empty and ACC-empty returned independently |
+| cluster prologue/tail | initialize/publish barriers and TMEM pointer; CTA2 peer release precedes deallocation | cluster init fence/arrive/wait; named barrier 2 publishes TMEM; named barrier 1 synchronizes 128 epilogue threads |
+
+Each role constructs the same static persistent scheduler. There is no scheduler
+warp and no cross-role scheduler handoff: role-local cursors start at
+`block_idx_z`, advance by `grid_dim_z`, and are coupled only by AB, accumulator,
+and C pipeline ownership. Source `906-1202`, `1206-1546`; writer `.loc` evidence
+at source lines 945-1004, 1084-1207, 1299-1475, and 1522-1545.
+
+## Primitive vocabulary
+
+All helpers return scalar integers, scalar state, raw pointers, or raw encoded
+descriptors. They never return a layout, tile, tensor, or fragment object.
+
+```python
+specialize(...); launch(...)
+ceil_div(x, y); align_up(x, y); integer_offset(...)
+byte_ptr(rank1_u8_arena, byte_offset)
+pipeline_state(stages, phase, stage, count); advance(state)
+encode_tensormap(raw_descriptor, dtype, rank, pointer, integer_fields...)
+encode_umma_descriptor(byte_address, ldo, sdo, swizzle, transpose)
+tmem_address(base_column, warp_row, stage_column, subtile_column)
+
+copy_g2s(tensormap, integer_coords, smem_byte_ptr, mbarrier, multicast_mask)
+copy_s2t(raw_smem_descriptor, tmem_u32_address)
+copy_t2r(tmem_u32_address, scalar_registers)
+copy_r2s(scalar_registers, smem_byte_ptr)
+copy_s2g(smem_byte_ptr, tensormap, integer_coords)
+gemm_blockscaled(acc_tmem, a_desc, b_desc, sfa_tmem, sfb_tmem, accumulate)
+
+elect_one(); try_wait(barrier, phase); wait(barrier, phase)
+arrive_expect_tx(barrier, bytes); release(barrier, destination)
+fence_mbarrier_init_cluster(); cluster_arrive_relaxed(); cluster_wait()
+fence_async_shared_cta(); named_barrier(id, thread_count)
+tma_commit_group(); tma_wait_group(pending)
+alloc_tmem(columns); relinquish_tmem(); dealloc_tmem(columns)
+```
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# 1. Static specialization, raw ABI, TensorMaps, and launch
+# source 37-309, 311-600; writer export prologue and source loc 667-672
+# ===========================================================================
+P = specialize(
+    M, N, K, L,
+    ab_dtype, sf_dtype, sf_vec_size, c_dtype, d_dtype,
+    a_major, b_major, c_major,
+    mma_tile_m, mma_tile_n, cluster_m, cluster_n,
+    vector_f32, with_amax,
+)
+assert P in source_capability_manifest.PASS
+assert c_major == "n"
+assert with_sfd is False
+
+CTA_GROUP = 2 if mma_tile_m == 256 else 1
+CTA_M = 128
+N_TILE = mma_tile_n                   # 64, 128, 192, 256
+K_TILE = 256 if ab_dtype is FP4 else 128
+WARPS = 7
+EPI_WARPS = (0, 1, 2, 3)
+MMA_WARP = 4
+AB_TMA_WARP = 5
+C_TMA_WARP = 6
+ACC_STAGES = 1 if N_TILE == 256 else 2
+C_STAGES = 2
+D_STAGES = 2
+AB_STAGES = source_stage_formula(P)
+TMEM_COLUMNS = 512
+
+# Fixed raw pointer ABI. amax remains present even in no-amax specializations;
+# compile-time with_amax guards every access. C is read-only and D is write-only.
+# prob has physical stride (1,M) over (m,l), whereas contiguous source dprob
+# has shape (M,1,L), stride (L,L,1), hence address m*L+l.
+ABI = (A, B, SFA, SFB, C, D, prob, dprob, amax, alpha)
+HOST_DESCRIPTORS = (
+    encode_tensormap(A_MAP, A_DTYPE, 3, A, A_FIELDS),
+    encode_tensormap(B_MAP, B_DTYPE, 3, B, B_FIELDS),
+    encode_tensormap(SFA_MAP, SF_DTYPE, 4, SFA, SFA_FIELDS),
+    encode_tensormap(SFB_MAP, SF_DTYPE, 4, SFB, SFB_FIELDS),
+    encode_tensormap(C_MAP, C_DTYPE, 3, C, C_FIELDS),
+    encode_tensormap(D_MAP, D_DTYPE, 3, D, D_FIELDS),
+)
+
+m_tiles = ceil_div(M, CTA_M)
+n_tiles = ceil_div(N, N_TILE)
+cluster_m_tiles = ceil_div(m_tiles, cluster_m)
+cluster_n_tiles = ceil_div(n_tiles, cluster_n)
+cluster_work = cluster_m_tiles * cluster_n_tiles * L
+resident_clusters = min(cluster_work, source_max_active_clusters(cluster_m * cluster_n))
+launch(
+    grid=(cluster_m, cluster_n, resident_clusters),
+    block=(224, 1, 1),
+    cluster=(cluster_m, cluster_n, 1),
+    arch="sm_100a",
+    dynamic_smem=SHARED_BYTES,
+)
+# instruction_selection: source 121-130 fixes warps 0-3/4/5/6 and 224
+# threads. Anchor export reports dynamic SMEM 229376 and 74 resident clusters.
+# Extent: every admitted specialization.
+
+# ===========================================================================
+# 2. One rank-1 u8 SMEM arena and explicit address arithmetic
+# source 145-309, 471-578, 693-743; writer loc 699/713/726/735
+# ===========================================================================
+ab_bits = dtype_bits(ab_dtype)
+c_bits = dtype_bits(c_dtype)
+d_bits = dtype_bits(d_dtype)
+B_ROWS = N_TILE // CTA_GROUP
+A_STAGE_BYTES = CTA_M * K_TILE * ab_bits // 8
+B_STAGE_BYTES = B_ROWS * K_TILE * ab_bits // 8
+SFA_STAGE_BYTES = CTA_M * K_TILE // sf_vec_size
+SFB_STAGE_BYTES = align_up(N_TILE, 128) * K_TILE // sf_vec_size
+AB_STAGE_BYTES = A_STAGE_BYTES + B_STAGE_BYTES + SFA_STAGE_BYTES + SFB_STAGE_BYTES
+C_STAGE_BYTES = CTA_M * 32 * c_bits // 8
+D_STAGE_BYTES = CTA_M * 32 * d_bits // 8
+AB_STAGES = source_capacity_formula(P, ACC_STAGES, C_STAGES, D_STAGES)
+
+AB_FULL_OFFSET = 0
+AB_EMPTY_OFFSET = AB_FULL_OFFSET + AB_STAGES * 8
+ACC_FULL_OFFSET = AB_EMPTY_OFFSET + AB_STAGES * 8
+ACC_EMPTY_OFFSET = ACC_FULL_OFFSET + ACC_STAGES * 8
+C_FULL_OFFSET = ACC_EMPTY_OFFSET + ACC_STAGES * 8
+C_EMPTY_OFFSET = C_FULL_OFFSET + C_STAGES * 8
+TMEM_DEALLOC_OFFSET = C_EMPTY_OFFSET + C_STAGES * 8
+TMEM_PTR_OFFSET = TMEM_DEALLOC_OFFSET + 8
+
+C_OFFSET = 1024
+D_OFFSET = C_OFFSET + C_STAGES * C_STAGE_BYTES
+A_OFFSET = D_OFFSET + D_STAGES * D_STAGE_BYTES
+B_OFFSET = A_OFFSET + AB_STAGES * A_STAGE_BYTES
+SFA_OFFSET = B_OFFSET + AB_STAGES * B_STAGE_BYTES
+SFB_OFFSET = align_up(SFA_OFFSET + AB_STAGES * SFA_STAGE_BYTES, 1024)
+AMAX_OFFSET = align_up(SFB_OFFSET + AB_STAGES * SFB_STAGE_BYTES, 1024)
+SHARED_BYTES = align_up(AMAX_OFFSET + 4 * 4, 1024)
+assert SHARED_BYTES <= 232448
+smem = K.alloc_buffer((SHARED_BYTES,), K.u8, scope="shared.dyn")
+
+# Anchor byte intervals, recovered from source storage order and PTX addresses:
+#   AB_FULL 0..39; AB_EMPTY 40..79
+#   ACC_FULL 80..87; ACC_EMPTY 88..95
+#   C_FULL 96..111; C_EMPTY 112..127
+#   TMEM_DEALLOC 128..135; TMEM_PTR 136..139; padding through 1023
+#   C 1024..17407; D 17408..33791
+#   A 33792..115711; B 115712..197631
+#   SFA 197632..207871; SFB 207872..228351
+#   amax 228352..228367; arena 229376 bytes.
+# instruction_selection: loc 699 emits ten AB mbarrier.init, loc 713 two ACC,
+# loc 726 four C plus a CTA sync, and loc 735 one TMEM-dealloc barrier.
+
+# Every access expands to explicit scalar byte arithmetic. Swizzle XORs,
+# stage strides, descriptor bits, and TMEM columns never escape as objects.
+a_byte = A_OFFSET + stage*A_STAGE_BYTES + explicit_a_swizzle(row, k, P)
+b_byte = B_OFFSET + stage*B_STAGE_BYTES + explicit_b_swizzle(n, k, P)
+sfa_byte = SFA_OFFSET + stage*SFA_STAGE_BYTES + explicit_sf_offset(m, k, P)
+sfb_byte = SFB_OFFSET + stage*SFB_STAGE_BYTES + explicit_sf_offset(n, k, P)
+c_byte = C_OFFSET + c_stage*C_STAGE_BYTES + explicit_epi_swizzle(row, col, c_bits)
+d_byte = D_OFFSET + d_stage*D_STAGE_BYTES + explicit_epi_swizzle(row, col, d_bits)
+
+a_desc = encode_umma_descriptor(a_byte, A_LDO, A_SDO, A_SWIZZLE, A_TRANSPOSE)
+b_desc = encode_umma_descriptor(b_byte, B_LDO, B_SDO, B_SWIZZLE, B_TRANSPOSE)
+ACC_COLUMNS = ACC_STAGES * N_TILE
+SFA_TMEM_COLUMN = ACC_COLUMNS
+SFA_CHUNKS = SFA_STAGE_BYTES // 512
+SFB_TMEM_COLUMN = SFA_TMEM_COLUMN + 4*SFA_CHUNKS
+SFB_CHUNKS = SFB_STAGE_BYTES // 512
+assert SFB_TMEM_COLUMN + 4*SFB_CHUNKS <= TMEM_COLUMNS
+
+def sfb_tmem_shift(tile_n_idx):
+    if N_TILE == 192:
+        return 2 if tile_n_idx % 2 else 0
+    if N_TILE == 64:
+        return (tile_n_idx % 2) * 2
+    return 0
+
+# ===========================================================================
+# 3. Cluster coordinates, barrier construction, and publication
+# source 641-903; writer loc 667-735
+# ===========================================================================
+tid = thread_idx_x
+warp = uniform(tid >> 5)
+lane = tid & 31
+cluster_rank = block_rank_in_cluster
+cluster_x = cluster_rank % cluster_m
+cluster_y = cluster_rank // cluster_m
+cta_v = cluster_x % CTA_GROUP
+cluster_m_group = cluster_x // CTA_GROUP
+leader_cta = (cta_v == 0)
+
+with warp == AB_TMA_WARP:
+    prefetch(A_MAP); prefetch(B_MAP); prefetch(SFA_MAP); prefetch(SFB_MAP)
+    prefetch(C_MAP); prefetch(D_MAP)
+# instruction_selection: source 667-672 maps one-to-one to six static
+# `prefetch.tensormap` instructions. Extent: warp 5, all its lanes as source.
+
+AB_EMPTY_ARRIVALS = cluster_n + (cluster_m // CTA_GROUP) - 1
+ACC_EMPTY_ARRIVALS = 4 * CTA_GROUP
+C_EMPTY_ARRIVALS = 4
+with warp == 0:
+    with elect_one():
+        for s in range(AB_STAGES): mbarrier_init(AB_FULL[s], 1)
+    with elect_one():
+        for s in range(AB_STAGES): mbarrier_init(AB_EMPTY[s], AB_EMPTY_ARRIVALS)
+    with elect_one():
+        for s in range(ACC_STAGES): mbarrier_init(ACC_FULL[s], 1)
+    with elect_one():
+        for s in range(ACC_STAGES): mbarrier_init(ACC_EMPTY[s], ACC_EMPTY_ARRIVALS)
+    with elect_one():
+        for s in range(C_STAGES): mbarrier_init(C_FULL[s], 1)
+    with elect_one():
+        for s in range(C_STAGES): mbarrier_init(C_EMPTY[s], C_EMPTY_ARRIVALS)
+
+# PipelineTmaAsync publishes the C barriers to every CTA thread. Both operations
+# execute after reconvergence, not inside warp 0.
+fence_mbarrier_init_cluster()
+cta_sync()
+# instruction_selection: source/PTX loc 726 emits
+# `fence.mbarrier_init.release.cluster` followed by `bar.sync 0` once each;
+# execution extent is all 224 CTA threads after four C-ring initializations.
+
+with warp == 0:
+    if CTA_GROUP == 2:
+        with elect_one(): mbarrier_init(TMEM_DEALLOC, 32)
+if CTA_GROUP == 2:
+    fence_mbarrier_init_cluster()
+# instruction_selection: source/PTX loc 735 emits the second
+# `fence.mbarrier_init.release.cluster` after the CTA2 deallocation barrier;
+# the fence executes in all 224 threads and CTA1 omits this allocator edge.
+
+fence_mbarrier_init_cluster()
+if cluster_m * cluster_n > 1:
+    cluster_arrive_relaxed()
+# instruction_selection: source/PTX loc 744 emits the third
+# `fence.mbarrier_init.release.cluster` and one
+# `barrier.cluster.arrive.relaxed` per CTA, in all-thread SPMD form.
+
+# Source performs the scalar shared/TMEM partition and descriptor setup between
+# pipeline_init_arrive and pipeline_init_wait. Those integer-only mappings were
+# frozen in section 2; no memory or async instruction is hidden here.
+if cluster_m * cluster_n > 1:
+    cluster_wait()
+else:
+    cta_sync()
+# instruction_selection: source/PTX loc 901 emits
+# `barrier.cluster.wait` for the anchor. The independent CTA1 guard emits one
+# `bar.sync 0` at the same source loc 901, executed by all 224 CTA threads.
+
+def scheduler_coords(work):
+    cluster_m_idx = work % cluster_m_tiles
+    quotient = work // cluster_m_tiles
+    cluster_n_idx = quotient % cluster_n_tiles
+    batch_idx = quotient // cluster_n_tiles
+    tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+    tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+    return tile_m_idx, tile_n_idx, batch_idx
+
+WORK_STRIDE = grid_dim_z
+
+# ===========================================================================
+# 4. Warp 5: persistent A/B/SFA/SFB TMA producer
+# source 906-1004; writer loc 945-1004
+# ===========================================================================
+with warp == AB_TMA_WARP:
+    work = block_idx_z
+    ab_prod = pipeline_state(AB_STAGES, phase=1, stage=0, count=0)
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        k_tiles = ceil_div(K, K_TILE)
+        speculative = try_wait(AB_EMPTY[ab_prod.stage], ab_prod.phase)
+        for k_count in range(k_tiles):
+            wait_if_needed(AB_EMPTY[ab_prod.stage], ab_prod.phase, speculative)
+            if leader_cta:
+                with elect_one():
+                    arrive_expect_tx(AB_FULL[ab_prod.stage], AB_STAGE_BYTES*CTA_GROUP)
+            with elect_one():
+                copy_g2s(A_MAP, a_coords(tile_m,k_count,batch,cluster_y),
+                         byte_ptr(smem,a_stage_piece(ab_prod.stage,cluster_y)),
+                         AB_FULL[ab_prod.stage], a_multicast_mask)
+            with elect_one():
+                copy_g2s(B_MAP, b_coords(tile_n,k_count,batch,cluster_m_group,cta_v),
+                         byte_ptr(smem,b_stage_piece(ab_prod.stage,cluster_m_group)),
+                         AB_FULL[ab_prod.stage], b_multicast_mask)
+            with elect_one():
+                copy_g2s(SFA_MAP, sfa_coords(tile_m,k_count,batch,cluster_y),
+                         byte_ptr(smem,sfa_stage_piece(ab_prod.stage,cluster_y)),
+                         AB_FULL[ab_prod.stage], sfa_multicast_mask)
+            with elect_one():
+                copy_g2s(SFB_MAP, sfb_coords(tile_n,k_count,batch,cluster_m_group),
+                         byte_ptr(smem,sfb_stage_piece(ab_prod.stage,cluster_m_group)),
+                         AB_FULL[ab_prod.stage], sfb_multicast_mask)
+            advance(ab_prod)
+            speculative = try_wait(AB_EMPTY[ab_prod.stage], ab_prod.phase) if k_count+1 < k_tiles else 1
+        work += WORK_STRIDE
+    for _ in range(AB_STAGES):
+        wait(AB_EMPTY[ab_prod.stage], ab_prod.phase); advance(ab_prod)
+# instruction_selection: loc 945 is
+# `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`; loc 954 contains the
+# blocking `mbarrier.try_wait.parity.shared.b64` spin before the copy. Loc 951
+# emits one `mbarrier.arrive.expect_tx.shared.b64` with 77,824 anchor bytes per
+# K iteration. Loc 954/961 each emit one
+# `cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2`
+# A/B load; loc 968 emits the corresponding 4D SFA form; loc 975 emits the 4D
+# SFB form with `.multicast::cluster`. The anchor runtime loop repeats each
+# family twice for K=512/K_TILE=256. Loc 987 is the next-stage acquire, and loc
+# 1001 emits five ordinary parity waits for the AB producer tail.
+
+# ===========================================================================
+# 5. Warp 4: scale S2T copies and persistent block-scaled tcgen05 MMA
+# source 1007-1207; writer loc 1007-1207
+# ===========================================================================
+with warp == MMA_WARP:
+    named_barrier(2, 160)
+    tmem_base = load_smem_u32(TMEM_PTR)
+    work = block_idx_z
+    ab_cons = pipeline_state(AB_STAGES, phase=0, stage=0, count=0)
+    acc_prod = pipeline_state(ACC_STAGES, phase=1, stage=0, count=0)
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        if leader_cta:
+            speculative = try_wait(AB_FULL[ab_cons.stage], ab_cons.phase)
+            wait(ACC_EMPTY[acc_prod.stage], acc_prod.phase)
+        accumulate = False
+        for k_count in range(ceil_div(K, K_TILE)):
+            if leader_cta:
+                wait_if_needed(AB_FULL[ab_cons.stage], ab_cons.phase, speculative)
+                for chunk in range(SFA_CHUNKS):
+                    with elect_one():
+                        copy_s2t(sfa_smem_desc(ab_cons.stage,chunk),
+                                 tmem_base + SFA_TMEM_COLUMN + 4*chunk)
+                for chunk in range(SFB_CHUNKS):
+                    with elect_one():
+                        copy_s2t(sfb_smem_desc(ab_cons.stage,chunk),
+                                 tmem_base + SFB_TMEM_COLUMN + 4*chunk)
+                for kblock in range(4):
+                    with elect_one():
+                        gemm_blockscaled(
+                            tmem_base + acc_prod.stage*N_TILE,
+                            a_desc_for(ab_cons.stage,kblock),
+                            b_desc_for(ab_cons.stage,kblock),
+                            sfa_tmem_addr(tmem_base,kblock),
+                            sfb_tmem_addr(tmem_base,kblock,sfb_tmem_shift(tile_n)),
+                            accumulate,
+                        )
+                    accumulate = True
+                with elect_one(): release(AB_EMPTY[ab_cons.stage], ab_empty_destination)
+            advance(ab_cons)
+            if leader_cta and k_count+1 < ceil_div(K,K_TILE):
+                speculative = try_wait(AB_FULL[ab_cons.stage], ab_cons.phase)
+        if leader_cta:
+            with elect_one(): tcgen05_commit(ACC_FULL[acc_prod.stage], acc_full_multicast_mask)
+        advance(acc_prod)
+        work += WORK_STRIDE
+    if leader_cta:
+        for _ in range(ACC_STAGES):
+            wait(ACC_EMPTY[acc_prod.stage], acc_prod.phase); advance(acc_prod)
+# instruction_selection: loc 1007 is named barrier 2; loc 1012 loads the TMEM
+# pointer. Loc 1084 is the speculative AB-full
+# `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`; loc 1093 is the
+# blocking ACC-empty `mbarrier.try_wait.parity.shared.b64`; loc 1124 is the
+# blocking AB-full parity wait, and loc 1184 is the next-stage acquire. Loc
+# 1133 emits four and loc 1138 eight
+# `tcgen05.cp.cta_group::2.32x128b.warpx4`; loc 1165 emits four
+# `tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.block16`; loc 1177
+# releases AB and loc 1190 commits the accumulator. Loc 1205 emits the anchor's
+# one ordinary parity wait for the ACC producer tail (two for non-N256 modes).
+
+# ===========================================================================
+# 6. Warp 6: persistent read-only C G2S pipeline
+# source 1478-1546; writer loc 1522-1545
+# ===========================================================================
+with warp == C_TMA_WARP:
+    work = block_idx_z
+    c_prod = pipeline_state(C_STAGES, phase=1, stage=0, count=0)
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        subtile_count = N_TILE // 32
+        for subtile in range(subtile_count):
+            # overlapping_accum is hard-disabled at source line 307, so the
+            # real subtile index is always the forward loop index.
+            wait(C_EMPTY[c_prod.stage], c_prod.phase)
+            with elect_one():
+                arrive_expect_tx(C_FULL[c_prod.stage], C_STAGE_BYTES)
+            with elect_one():
+                copy_g2s(C_MAP, c_coords(tile_m,tile_n,subtile,batch),
+                         byte_ptr(smem,C_OFFSET+c_prod.stage*C_STAGE_BYTES),
+                         C_FULL[c_prod.stage], 0)
+            advance(c_prod)
+        work += WORK_STRIDE
+    for _ in range(C_STAGES):
+        wait(C_EMPTY[c_prod.stage], c_prod.phase); advance(c_prod)
+# instruction_selection: anchor unrolls eight N256 subtiles. Loc 1525 emits
+# eight `mbarrier.try_wait.parity.shared.b64` C-empty waits. Loc 1522 emits
+# eight `mbarrier.arrive.expect_tx.shared.b64` operations with 8,192 bytes
+# each. Loc 1523 emits eight
+# `cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`
+# C loads, with no multicast or CTA-group modifier. Loc 1543 emits the two
+# ordinary parity waits in the producer tail. Extent: warp 6, one elected lane
+# issues each G2S operation.
+
+# ===========================================================================
+# 7. Warps 0-3: C consumption, dSReLU, dprob, optional amax, and D S2G
+# source 1206-1456; writer loc 1210-1456 plus helper loc 309 / driver loc 269
+# ===========================================================================
+with warp in EPI_WARPS:
+    if warp == 0:
+        alloc_tmem(TMEM_COLUMNS)
+    named_barrier(2, 160)
+    tmem_base = load_smem_u32(TMEM_PTR)
+    work = block_idx_z
+    acc_cons = pipeline_state(ACC_STAGES, phase=0, stage=0, count=0)
+    c_cons = pipeline_state(C_STAGES, phase=0, stage=0, count=0)
+    d_store_count = 0
+    while work < cluster_work:
+        tile_m, tile_n, batch = scheduler_coords(work)
+        wait(ACC_FULL[acc_cons.stage], acc_cons.phase)
+        global_row = tile_m*CTA_M + tid
+        row_prob = load_global_f32(prob + global_row + batch*M)
+        row_dprob = f32(0.0)
+        thread_tile_amax = f32(0.0)
+
+        for subtile in range(N_TILE // 32):
+            x = copy_t2r(
+                tmem_base + (warp << 21) + acc_cons.stage*N_TILE + subtile*32,
+                32_scalar_f32_registers,
+            )
+            for pair in 16_packed_pairs(x):
+                pair = mul_f32x2(pair, splat_f32x2(alpha))
+
+            wait(C_FULL[c_cons.stage], c_cons.phase)
+            c_raw = copy_s2r_four_v4(
+                byte_ptr(smem,c_byte_offset(c_cons.stage,warp,lane,P)))
+            c = convert_32_values_to_f32(c_raw, c_dtype)
+            fence_async_shared_cta()
+            with elect_one(): release(C_EMPTY[c_cons.stage], local_barrier)
+            advance(c_cons)
+
+            # Preserve source grouping and packed widths.
+            relu_x = 32_scalar_f32_registers
+            for i in range(32):
+                relu_x[i] = max_f32(x[i], f32(0.0))
+            c_prob = 16_packed_pairs
+            for pair in range(16):
+                c_prob[pair] = mul_f32x2(c.pair[pair], splat_f32x2(row_prob))
+            d_fp32 = 16_packed_pairs
+            for pair in range(16):
+                doubled_relu = add_f32x2(relu_x.pair[pair], relu_x.pair[pair])
+                d_fp32[pair] = mul_f32x2(doubled_relu, c_prob[pair])
+
+            # Source reduction is not reassociated: square and C multiply stay
+            # packed, then their 32 lanes feed the same scalar ADD chain.
+            dprob_terms = 16_packed_pairs
+            for pair in range(16):
+                squared = mul_f32x2(relu_x.pair[pair], relu_x.pair[pair])
+                dprob_terms[pair] = mul_f32x2(squared, c.pair[pair])
+            row_dprob += reduce_add_32_source_order(dprob_terms)
+
+            if with_amax:
+                abs_d = [abs_f32(d_fp32[i]) for i in range(32)]
+                subtile_amax = reduce_max_nan_32(abs_d, instruction_count=17)
+                thread_tile_amax = max_f32(thread_tile_amax, subtile_amax)
+
+            d_stage = d_store_count % D_STAGES
+            d_out = convert_32_f32(d_fp32, d_dtype)
+            copy_r2s_four_v4(d_out,
+                byte_ptr(smem,d_byte_offset(d_stage,warp,lane,P)))
+            fence_async_shared_cta()
+            named_barrier(1, 128)
+            if warp == 0:
+                copy_s2g(byte_ptr(smem,D_OFFSET+d_stage*D_STAGE_BYTES),
+                         D_MAP, d_coords(tile_m,tile_n,subtile,batch))
+                tma_commit_group()
+                tma_wait_group(D_STAGES - 1)
+            named_barrier(1, 128)
+            d_store_count += 1
+
+        if with_amax:
+            warp_amax = warp_reduce_max_nan(thread_tile_amax)
+            if lane == 0: store_smem_f32(AMAX_OFFSET + warp*4, warp_amax)
+            named_barrier(1, 128)
+            if warp == 0 and lane == 0:
+                block_amax = f32(0.0)
+                for slot in range(4):
+                    block_amax = max_f32(block_amax, load_smem_f32(AMAX_OFFSET+slot*4))
+                atomic_max_nonnegative_f32_bits(amax, block_amax)
+
+        # One atomic contribution per output tile and row. Multiple N tiles
+        # complete the global sum without a separate reduction kernel.
+        atomic_add_f32(dprob + global_row*L + batch, row_dprob)
+
+        with elect_one():
+            if CTA_GROUP == 2:
+                release(remote(ACC_EMPTY[acc_cons.stage], even_peer_rank), 1)
+            else:
+                release(ACC_EMPTY[acc_cons.stage], 1)
+        advance(acc_cons)
+        work += WORK_STRIDE
+
+# instruction_selection: loc 1210 is CTA2 TMEM allocation, 1215 named barrier
+# 2, and 1220 pointer load. Loc 1299 waits ACC-full; 1311 loads prob;
+# 1318 emits `tcgen05.ld.sync.aligned.32x32b.x32.b32`; 1329 emits 16 packed
+# alpha multiplies. Loc 1335 emits four `ld.shared.v4.b32`; 1337 waits C-full;
+# 1340 emits `fence.proxy.async.shared::cta`; 1341 releases C-empty with
+# `mbarrier.arrive.shared.b64`.
+# instruction_selection: driver loc 269 emits 32 scalar ReLU max, 16 packed
+# doubling ADDs, and 16 packed D multiplies. Loc 1350 converts 32 BF16 C values
+# and emits 16 packed C*prob multiplies. Loc 1356 emits 32 packed square/C
+# multiplies and the 33-scalar-add dprob chain. Helper loc 309 emits 32
+# `abs.f32` and one `redux.sync.max.NaN.f32`; loc 1372 emits 17
+# `max.NaN.f32`, and loc 1377 one running `max.f32`.
+# instruction_selection: loc 1389 emits 16 BF16x2 D conversions; 1395 four
+# `st.shared.v4.b32`; loc 1401 emits `fence.proxy.async.shared::cta`;
+# 1402/1415 emit `bar.sync 1,128`; loc 1407 emits one
+# `cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint`
+# D S2G per static loop body; loc 1413 emits `cp.async.bulk.commit_group` and
+# loc 1414 `cp.async.bulk.wait_group.read 1`. Loc 1428/1431/1437/1438/1443 is
+# shared store, barrier, one v4 load, four scalar maxima, and global atomic max;
+# the warp redux itself is the helper-loc-309 instruction above.
+# Source helper loc 309 contains `atom.global.add.f32` for dprob. Loc 1455
+# returns accumulator ownership through a cluster barrier arrival.
+
+# ===========================================================================
+# 8. TMEM teardown and D store tail
+# source 1458-1475; writer loc 1468-1475
+# ===========================================================================
+with warp in EPI_WARPS:
+    if warp == 0:
+        relinquish_tmem()
+    named_barrier(1, 128)
+    if warp == 0:
+        if CTA_GROUP == 2:
+            peer_rank = cluster_rank ^ 1
+            arrive(remote(TMEM_DEALLOC, peer_rank), 1)  # all 32 warp lanes
+            wait(TMEM_DEALLOC, phase=0)
+        dealloc_tmem(tmem_base, TMEM_COLUMNS)
+    tma_wait_group(0)
+# instruction_selection: loc 1467 emits
+# `tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned`; loc 1468 is
+# named barrier 1; loc 1469 maps the peer and arrives; loc 1472 waits the
+# deallocation barrier; loc 1473 emits `cp.async.bulk.wait_group.read 0` for
+# the D tail; loc 1475 emits
+# `tcgen05.dealloc.cta_group::2.sync.aligned.b32` for 512 columns.
+```
+
+## Pipeline inventory
+
+| pipeline | stages | producer -> consumer | full event | empty/reuse event |
+| --- | ---: | --- | --- | --- |
+| AB/SF | source formula; anchor 5 | warp 5 -> warp 4 leader | one transaction barrier accounts for A+B+SFA+SFB and CTA-group bytes | tcgen05 multicast commit after scale copies and all K-block MMAs |
+| accumulator | N256: 1; otherwise 2 | warp 4 leader -> warps 0-3, one/two CTAs | tcgen05 commit to ACC-full | one elected arrival per epilogue warp; CTA2 maps eight total arrivals to leader storage |
+| C load | fixed 2 | warp 6 -> warps 0-3 | expect-tx plus one 128x32 G2S TensorMap load | four elected epilogue-warp arrivals return C-empty; producer tail drains both stages |
+| D store | fixed 2 | warps 0-3 -> warp 0 TMA issue | async-shared fence, named barrier 1, TMA commit | wait-group-one before reuse, named barrier 1, final wait-zero tail |
+| dprob | per-thread FP32 scalar | each row thread -> global `(m,l)` | exact ordered reduction across each tile's N values | one `atom.global.add.f32` per tile/row; host initializes zero |
+| amax | optional scalar + four shared FP32 slots | thread -> warp -> CTA -> global | abs/max tree, warp redux, named barrier 1 | one nonnegative-FP32 bitwise atomic max per output tile |
+
+## TensorMap, tails, and persistent scheduling
+
+- A is logically `(M,K,L)`, B `(N,K,L)`, and the MMA computes A times B
+  transposed over K. C and D are `(M,N,L)`. Prob's physical address is
+  `m + l*M`; contiguous source dprob has shape/stride `(M,1,L)/(L,L,1)` and
+  physical address `m*L+l`.
+- TensorMaps use runtime extents and zero-fill A/B/SF/C tail loads. D stores
+  retain source-aligned 128x32 TensorMap boxes; admitted tails respect the
+  source output-alignment predicate.
+- A/SFA multicast across cluster N. B/SFB multicast across the cluster-M group.
+  CTA2 uses a 256-row MMA over two 128-row CTAs; only CTA-v 0 issues tcgen05,
+  while each CTA consumes/stores its own 128 rows of C/D and dprob.
+- N64 divides the SFB TensorMap tile coordinate by two. N64 and odd N192 tiles
+  apply the explicit two-word TMEM shift. N192 retains padded SFB storage in AB
+  transaction bytes.
+- Warp 6 and the epilogue use identical forward subtile order because source
+  `overlapping_accum=False`. Changing that order is a pipeline/control-flow
+  change requiring correctness re-review.
+- M/N/K tails, L=1/2, and long-running CTA1/CTA2 persistent cases were admitted
+  only after three consecutive source launches passed D, dprob, and amax.
+
+## Static specialization boundary
+
+Only rows marked PASS in
+`.porting/dense_blockscaled_gemm_persistent_dsrelu_quant/source_capability_manifest.json`
+may enter `CONFIGS` or `BENCH_CONFIGS`:
+
+- A/B: FP4 E2M1 or same-type FP8 E4M3/E5M2.
+- SF: FP4 admits E8M0/V16, E8M0/V32, and E4M3/V16. FP8 admits E8M0/V32.
+- C/D: FP16, BF16, or FP32 combinations that the manifest compiled and checked.
+- A/B major: FP4 K/K. FP8 admits K/K, K/N, M/K, and M/N. C is N-major.
+- MMA M is 128 (CTA1) or 256 (CTA2); N is 64/128/192/256.
+- CTA1 cluster axes are in `{1,2,4}` with product at most 16. CTA2 cluster M
+  is `{2,4}`, cluster N is `{1,2,4}`, and the same product limit applies.
+- L is 1 or 2 in the admitted matrix. Both amax-on and amax-off are source
+  validated. The current manifest admits `vector_f32=False`; it does not infer
+  the unused source flag's other value.
+- Excluded modes include SFD, FP8/FP4 D, the uint8 FP4 alias, FP4 E4/V32,
+  FP8 with V16/E4 scales, FP4 non-K major, C-major M, invalid cluster shapes,
+  and source-rejected or three-run-oracle-failing alignments.
+
+`CONFIGS` is a deterministic pairwise-token cover of these observed PASS rows,
+with explicit anchor, CTA1/CTA2, N64/N128/N192/N256, L1/L2, cluster, major,
+dtype, amax, persistent, and M/N/K-tail guards. `BENCH_CONFIGS` is a compact
+structure-token cover of validated modes plus square 1024/2048/4096/8192 and
+L1/L2 boundaries. The required performance roster is every `BENCH_CONFIGS`
+entry, not only YAML defaults.
+
+## Writer PTX evidence and five-way instruction check
+
+The preserved analyzer result is
+`.porting/dense_blockscaled_gemm_persistent_dsrelu_quant/writer_export/ptx_evidence.json`.
+The anchor's static opcode inventory includes:
+
+| source operation | anchor instruction evidence |
+| --- | --- |
+| descriptor prefetch | six `prefetch.tensormap` at source 667-672 |
+| barriers | 17 `mbarrier.init`, 7 `bar.sync`, 4 acquire try-waits, 22 ordinary waits |
+| AB/SF G2S | two 3D and two 4D CTA2 TensorMap loads per static K-loop body |
+| scale S2T | twelve `tcgen05.cp.cta_group::2.32x128b.warpx4` |
+| MMA | four `tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.block16` |
+| accumulator | one `tcgen05.ld.sync.aligned.32x32b.x32.b32` per static subtile body |
+| C G2S | eight 3D shared-CTA TensorMap loads and eight expect-tx arrivals |
+| dSReLU | 32 ReLU max, 16 packed doubling ADD, packed C/prob and D multiplies |
+| dprob | packed square/C multiplies, 33 scalar ADDs, one `atom.global.add.f32` |
+| D S2G | four shared v4 stores, one static S2G TensorMap store, wait-group-one |
+| amax | 32 abs, 17 max.NaN, warp redux, shared v4 read, `atom.global.max.s32` |
+| TMEM lifetime | one CTA2 alloc, two commits, peer arrival/wait, one dealloc |
+
+The reviewer must independently export the same specialization and prove both
+directions `source lines <-> sketch operations <-> PTX opcodes`. A structural
+statement without a source and PTX edge is insufficient for instruction
+selection, and an opcode not assigned to a sketch operation is unexplained.
+
+## Executable module and validation contract
+
+The module exposes `KERNEL_META`, deterministic `CONFIGS`, deterministic
+`BENCH_CONFIGS`, `get_kernel`, `prepare_data`, `run_test`, `prepare_bench`,
+`run_gpu`, and `run_bench`. `KERNEL_META["name"]` is
+`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`, category is
+`cudnn`, and compute capability is 10.
+
+`prepare_data` emits deterministic positive and negative A/B/C values,
+nonconstant positive prob, nontrivial scales, runtime alpha, and separately
+allocated D/dprob/amax for TIRx and the pinned source. Source import, compilation,
+reset, synchronization, and validation stay outside timing. Each timed closure
+issues exactly one target or reference kernel launch.
+
+`run_test` compares D, dprob, and enabled amax to the pinned source and a host
+oracle. The source test fixes low-precision output checks at `atol=0.12,
+rtol=0.02`; FP32 paths use their separately recorded FP32 tolerance. Every
+declared config must pass without unexplained skips.
+
+Structural gates reject `TilePrimitiveCall`, `tirx.tile.*`, tile helpers,
+first-class layouts/fragments, non-rank-1 shared buffers, `K.cuda.func_call`,
+embedded CUDA, and low-level-IR exemptions. `inspect_low_level_ir(...).ok` must
+hold with `func_calls == ()`, while `tirx_kernels/kern/` and the exception table
+remain unchanged.

--- a/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/sweep-register-budgets-by-role-and-shape.md
@@ -59,6 +59,19 @@ elapsed cycles from 23,294 to 22,896 and executed instructions from 11,406 to
 11,377. It subsequently passed complete targeted and full matrices at 0.995x
 and 1.002x minimum ratios.
 
+Instruction count can point at the same role-budget problem from the opposite
+direction. One seven-warp persistent pipeline already executed 5,276 fewer
+basic-opcode thread instructions than its reference, yet used 72 registers per
+thread against 89 and executed 9,269 more synchronization try-wait warp events;
+the accumulator-empty wait alone ran 12,926 times against 6,532. Giving only
+the four-warp epilogue role an 88-register temporal target moved the directly
+affected ratio from 0.9804x to 1.0134x. All 35 correctness configurations and
+seven affected or guard configurations passed, and the complete 28-row matrix
+cleared at a 0.9908x minimum; an equivalent final build repeated the complete
+matrix at a 0.9932x minimum. Once the target already has the shorter instruction
+stream, a register deficit plus excess consumer-release polling is a reason to
+sweep the consumer role rather than keep deleting arithmetic.
+
 ## Boundary
 
 An occupancy proof only shows that a larger budget is affordable; it does not
@@ -92,9 +105,19 @@ shape-scoped rebalance removed six shared-spilling requests, yet its two
 critical benchmark ratios were only 0.981x and 0.989x. Continue through the
 performance matrix after the generated-code symptom is repaired.
 
+A source register count is only a seed for the sweep. In the seven-warp case,
+88 was the nearest legal target below the reference's observed 89, but adjacent
+budgets were not measured and the child was not re-profiled. The timings prove
+that the scoped register intervention repaired the deficit; they do not prove
+that 88 is optimal or that the measured try-wait count itself fell. Do not copy
+the value or claim the counter mechanism without the corresponding sweep and
+post-change profile.
+
 ## Verification
 
 Record realized allocation and dynamic local traffic, not only the requested
 cap. Compile every specialization touched by the selector so allocator cliffs
 cannot hide outside the timing set, then measure the beneficiary and guard
-paths at adjacent budgets.
+paths at adjacent budgets. When excess pipeline polling motivated the sweep,
+re-profile the retained child and compare the same barrier waits before
+attributing the gain to faster stage release.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ list.
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py),
   [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py),
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py),
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py),
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
 - **Grouped GEMM:**
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)

--- a/tirx_kernels/bench_suite/config/cudnn/dsrelu/cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/dsrelu/cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant.yaml
@@ -1,0 +1,33 @@
+# Complete deterministic compact performance-path covering matrix for the
+# parameterized cuDNN Frontend dense block-scaled GEMM+dSReLU port.
+kernel: cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant
+selection_rationale: The 28-row matrix preserves one representative for every source-verified structural token across AB/SF/C/D dtype and major modes, CTA1/CTA2, N tiles 64/128/192/256, cluster shapes, L=1/2, amax guards, and 1024/2048/4096/8192 square boundaries. Only the anchor structure's 1024, 4096, and 8192 rows are defaults.
+configs:
+  - {config: anchor_m1024_n1024_k1024_l1, default: true, selection_role: small}
+  - {config: anchor_m2048_n2048_k2048_l2, default: false}
+  - {config: anchor_m4096_n4096_k4096_l1, default: true, selection_role: medium}
+  - {config: anchor_m8192_n8192_k8192_l2, default: true, selection_role: large}
+  - {config: cover00_m1024_n1024_k1024_anchor, default: false}
+  - {config: cover01_m2048_n2048_k2048_major_float8_e4m3fn_kn, default: false}
+  - {config: cover02_m4096_n4096_k4096_cluster_cta1_1x1, default: false}
+  - {config: cover03_m8192_n8192_k8192_explicit_amax_fp8, default: false}
+  - {config: cover04_m1024_n1024_k1024_c_bf16_d_f32, default: false}
+  - {config: cover05_m2048_n2048_k2048_c_f16_d_bf16, default: false}
+  - {config: cover06_m4096_n4096_k4096_c_f16_d_f32, default: false}
+  - {config: cover07_m8192_n8192_k8192_c_f32_d_f16, default: false}
+  - {config: cover08_m1024_n1024_k1024_cluster_cta1_1x2, default: false}
+  - {config: cover09_m2048_n2048_k2048_cluster_cta1_1x4, default: false}
+  - {config: cover10_m4096_n4096_k4096_cluster_cta1_2x2, default: false}
+  - {config: cover11_m8192_n8192_k8192_cluster_cta1_2x4, default: false}
+  - {config: cover12_m1024_n1024_k1024_cluster_cta1_4x1, default: false}
+  - {config: cover13_m2048_n2048_k2048_cluster_cta1_4x2, default: false}
+  - {config: cover14_m4096_n4096_k4096_cluster_cta1_4x4, default: false}
+  - {config: cover15_m8192_n8192_k8192_fp4_e4v16, default: false}
+  - {config: cover16_m1024_n1024_k1024_l1, default: false}
+  - {config: cover17_m2048_n2048_k2048_major_float8_e4m3fn_mk, default: false}
+  - {config: cover18_m4096_n4096_k4096_persistent_cta1, default: false}
+  - {config: cover19_m8192_n8192_k8192_persistent_cta2, default: false}
+  - {config: cover20_m1024_n1024_k1024_tail_cta1_n64, default: false}
+  - {config: cover21_m2048_n2048_k2048_tail_cta2_n192, default: false}
+  - {config: cover22_m4096_n4096_k4096_tile_128x192, default: false}
+  - {config: cover23_m8192_n8192_k8192_tile_256x64, default: false}

--- a/tirx_kernels/cudnn/dsrelu/__init__.py
+++ b/tirx_kernels/cudnn/dsrelu/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
+++ b/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
@@ -1,0 +1,2397 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Persistent SM100 block-scaled GEMM with dSReLU and probability reduction.
+
+Upstream source:
+python/cudnn/gemm/cutedsl/dense/dsrelu/
+dense_blockscaled_gemm_persistent_dsrelu_quant.py.
+"""
+
+import tirx_kernels.kern as K
+
+_TRY_WAIT_TICKS = 10_000_000
+_SMEM_CAPACITY = 232_448
+_MAX_ACTIVE_CLUSTERS = {1: 148, 2: 74, 4: 33, 8: 15, 16: 7}
+_SF_MODES = (("float8_e8m0fnu", 16), ("float8_e8m0fnu", 32), ("float8_e4m3fn", 16))
+_C_DTYPES = ("float32", "float16", "bfloat16")
+_D_DTYPES = ("float32", "float16", "bfloat16")
+_MODE_KEYS = (
+    "ab_dtype",
+    "sf_dtype",
+    "sf_vec_size",
+    "c_dtype",
+    "d_dtype",
+    "a_major",
+    "b_major",
+    "c_major",
+    "mma_tiler_mn",
+    "cluster_shape_mn",
+    "vector_f32",
+    "L",
+)
+_SHORT_DTYPE = {
+    "float4_e2m1fn": "f4",
+    "bfloat16": "bf16",
+    "float16": "f16",
+    "float32": "f32",
+    "float8_e4m3fn": "e4",
+    "float8_e5m2": "e5",
+    "float8_e8m0fnu": "e8",
+}
+
+
+def _ceil_div(value, divisor):
+    return (value + divisor - 1) // divisor
+
+
+def _align_up(value, alignment):
+    return _ceil_div(value, alignment) * alignment
+
+
+def _next_power_of_two(value):
+    return 1 << (value - 1).bit_length()
+
+
+def _dtype_bits(dtype):
+    return {
+        "float4_e2m1fn": 4,
+        "float8_e4m3fn": 8,
+        "float8_e5m2": 8,
+        "float8_e8m0fnu": 8,
+        "bfloat16": 16,
+        "float16": 16,
+        "float32": 32,
+    }[dtype]
+
+
+def _descriptor_base(ldo, sdo, swizzle):
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _instruction_descriptor(M, N, ab_dtype, sf_dtype, a_major, b_major):
+    """Fold the source SM100 block-scaled MMA descriptor fields."""
+    if M not in (128, 256) or N not in (64, 128, 192, 256):
+        raise ValueError(f"unsupported instruction shape {(M, N)}")
+    sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1}[sf_dtype]
+    value = 0
+    if ab_dtype in {"float4_e2m1fn", "float8_e5m2"}:
+        value |= 1 << 7
+        value |= 1 << 10
+    if a_major == "m":
+        value |= 1 << 15
+    if b_major == "n":
+        value |= 1 << 16
+    value |= ((N >> 3) & 0x3F) << 17
+    value |= (sf_format & 1) << 23
+    value |= ((M >> 4) & 0x1F) << 24
+    return value & 0xFFFFFFFF
+
+
+def _descriptor_with_address(base, shared_address):
+    base_value = K.bitwise_or(
+        K.shift_left(K.uint64(base >> 32), K.uint64(32)), K.uint64(base & 0xFFFFFFFF)
+    )
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(base_value, address_field)
+
+
+def _advance(state):
+    state.advance()
+
+
+def _try_wait_acquire(dst, barrier, phase):
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready):
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _issue_ptx_if(predicate, mnemonic, *args):
+    with K.If(predicate):
+        with K.Then():
+            K.ptx[mnemonic](*args)
+
+
+def _swizzled(row_offset, chunk, row_bytes):
+    """Return one 16-byte chunk offset under the epilogue TensorMap swizzle."""
+    chunks = row_bytes // 16
+    if chunks == 1:
+        return row_offset + K.int32(chunk * 16)
+    twist = K.local_scalar(
+        "int32", init=((row_offset // K.int32(128)) % K.int32(chunks)) * K.int32(16)
+    )
+    return K.local_scalar("int32", init=row_offset | (K.int32(chunk * 16) ^ twist))
+
+
+def _unpack_input(values, words, dtype, bits):
+    """Expand one thread's 32-element C row to FP32 registers."""
+    if bits == 16:
+        if dtype == "bfloat16":
+            for word in range(16):
+                low_bits = K.local_scalar("uint32")
+                high_bits = K.local_scalar("uint32")
+                K.ptx.shl.b32(low_bits, words[word], K.uint32(16))
+                K.ptx.and_.b32(high_bits, words[word], K.uint32(0xFFFF0000))
+                K.assign(values[2 * word], K.reinterpret("float32", low_bits))
+                K.assign(values[2 * word + 1], K.reinterpret("float32", high_bits))
+            return
+        for word in range(16):
+            low = K.local_scalar("uint16")
+            high = K.local_scalar("uint16")
+            K.ptx.mov.b32(low, high, words[word])
+            K.ptx.cvt.f32.f16(values[2 * word], low)
+            K.ptx.cvt.f32.f16(values[2 * word + 1], high)
+    else:
+        for word in range(32):
+            K.ptx.mov.b32(values[word], words[word])
+
+
+def _valid_mode(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    if tile_m not in (128, 256) or tile_n not in (64, 128, 192, 256):
+        return False
+    if cluster_m not in (1, 2, 4) or cluster_n not in (1, 2, 4):
+        return False
+    if cluster_m * cluster_n > 16 or (tile_m == 256 and cluster_m % 2):
+        return False
+    if mode["ab_dtype"] == "float4_e2m1fn":
+        if mode["a_major"] != "k" or mode["b_major"] != "k":
+            return False
+        if (mode["sf_dtype"], mode["sf_vec_size"]) not in _SF_MODES:
+            return False
+    else:
+        if mode["a_major"] not in ("k", "m") or mode["b_major"] not in ("k", "n"):
+            return False
+        if (mode["sf_dtype"], mode["sf_vec_size"]) != ("float8_e8m0fnu", 32):
+            return False
+    return (
+        mode["c_dtype"] in _C_DTYPES
+        and mode["d_dtype"] in _D_DTYPES
+        and mode["c_major"] == "n"
+        and mode["L"] in (1, 2)
+        and mode["with_sfd"] is False
+    )
+
+
+def _mode_label(mode):
+    tile_m, tile_n = mode["mma_tiler_mn"]
+    cluster_m, cluster_n = mode["cluster_shape_mn"]
+    return (
+        f"{_SHORT_DTYPE[mode['ab_dtype']]}_{_SHORT_DTYPE[mode['sf_dtype']]}v{mode['sf_vec_size']}_"
+        f"{_SHORT_DTYPE[mode['c_dtype']]}_{_SHORT_DTYPE[mode['d_dtype']]}_"
+        f"{mode['a_major']}{mode['b_major']}_{mode['c_major']}_"
+        f"t{tile_m}x{tile_n}_c{cluster_m}x{cluster_n}_"
+        f"{'v' if mode['vector_f32'] else 's'}f32_l{mode['L']}"
+    )
+
+
+# Every base record below corresponds to a PASS row in the preserved source
+# capability manifest. Shapes may be replaced by BENCH_CONFIGS only after the
+# structure itself has passed the source compile/run/oracle probe.
+def _base_config(label="anchor", **updates):
+    config = {
+        "label": label,
+        "M": 256,
+        "N": 256,
+        "K": 512,
+        "L": 2,
+        "ab_dtype": "float4_e2m1fn",
+        "sf_dtype": "float8_e8m0fnu",
+        "sf_vec_size": 16,
+        "c_dtype": "bfloat16",
+        "d_dtype": "bfloat16",
+        "a_major": "k",
+        "b_major": "k",
+        "c_major": "n",
+        "mma_tiler_mn": (256, 256),
+        "cluster_shape_mn": (2, 1),
+        "vector_f32": False,
+        "with_amax": True,
+        "with_sfd": False,
+        "alpha": 2.0 / 3.0,
+    }
+    config.update(updates)
+    return config
+
+
+def _source_probe_configs():
+    probes = [_base_config()]
+    probes.extend(
+        [
+            _base_config("fp4_e8v32", sf_vec_size=32),
+            _base_config("fp4_e4v16", sf_dtype="float8_e4m3fn"),
+            _base_config(
+                "fp8e4_e8v32_mn", ab_dtype="float8_e4m3fn", sf_vec_size=32, a_major="m", b_major="n"
+            ),
+            _base_config(
+                "fp8e5_e8v32_mn", ab_dtype="float8_e5m2", sf_vec_size=32, a_major="m", b_major="n"
+            ),
+            _base_config("c_f16_d_bf16", c_dtype="float16"),
+            _base_config("c_f32_d_f16", c_dtype="float32", d_dtype="float16"),
+            _base_config("c_bf16_d_f32", d_dtype="float32"),
+            _base_config("c_f16_d_f32", c_dtype="float16", d_dtype="float32"),
+            _base_config("l1", L=1),
+            _base_config("no_amax_fp4", with_amax=False),
+            _base_config(
+                "no_amax_fp8",
+                ab_dtype="float8_e4m3fn",
+                sf_vec_size=32,
+                a_major="m",
+                b_major="n",
+                with_amax=False,
+            ),
+            _base_config(
+                "explicit_amax_fp8",
+                ab_dtype="float8_e5m2",
+                sf_vec_size=32,
+                a_major="m",
+                b_major="n",
+            ),
+        ]
+    )
+    for dtype in ("float8_e4m3fn", "float8_e5m2"):
+        for a_major in ("k", "m"):
+            for b_major in ("k", "n"):
+                probes.append(
+                    _base_config(
+                        f"major_{dtype}_{a_major}{b_major}",
+                        ab_dtype=dtype,
+                        sf_vec_size=32,
+                        a_major=a_major,
+                        b_major=b_major,
+                        with_amax=False,
+                    )
+                )
+    for tile_m in (128, 256):
+        for tile_n in (64, 128, 192, 256):
+            probes.append(
+                _base_config(
+                    f"tile_{tile_m}x{tile_n}",
+                    N=192 if tile_n == 192 else 256,
+                    mma_tiler_mn=(tile_m, tile_n),
+                    cluster_shape_mn=(1, 1) if tile_m == 128 else (2, 1),
+                )
+            )
+    for cluster_m in (1, 2, 4):
+        for cluster_n in (1, 2, 4):
+            probes.append(
+                _base_config(
+                    f"cluster_cta1_{cluster_m}x{cluster_n}",
+                    mma_tiler_mn=(128, 256),
+                    cluster_shape_mn=(cluster_m, cluster_n),
+                )
+            )
+    for cluster_m in (2, 4):
+        for cluster_n in (1, 2, 4):
+            probes.append(
+                _base_config(
+                    f"cluster_cta2_{cluster_m}x{cluster_n}", cluster_shape_mn=(cluster_m, cluster_n)
+                )
+            )
+    probes.extend(
+        [
+            _base_config("tail_m", M=272),
+            _base_config("tail_n", N=272),
+            _base_config("tail_k", K=544),
+            _base_config("tail_mnk", M=272, N=272, K=544),
+            _base_config(
+                "tail_cta1_n64",
+                M=272,
+                N=208,
+                K=544,
+                mma_tiler_mn=(128, 64),
+                cluster_shape_mn=(1, 1),
+            ),
+            _base_config("tail_cta2_n192", M=272, N=208, K=544, mma_tiler_mn=(256, 192)),
+            _base_config(
+                "persistent_cta1", M=4096, N=512, mma_tiler_mn=(128, 128), cluster_shape_mn=(1, 1)
+            ),
+            _base_config("persistent_cta2", M=4096, N=512, mma_tiler_mn=(256, 128)),
+        ]
+    )
+    by_label = {}
+    for probe in probes:
+        by_label[probe["label"]] = probe
+    return [by_label[label] for label in sorted(by_label)]
+
+
+_STRUCTURE_KEYS = (
+    "ab_dtype",
+    "sf_dtype",
+    "sf_vec_size",
+    "c_dtype",
+    "d_dtype",
+    "a_major",
+    "b_major",
+    "c_major",
+    "mma_tiler_mn",
+    "cluster_shape_mn",
+    "vector_f32",
+    "with_amax",
+    "with_sfd",
+    "L",
+)
+
+
+def _verified_structure(mode):
+    for probe in _source_probe_configs():
+        if all(probe[key] == mode[key] for key in _STRUCTURE_KEYS):
+            return True
+    return False
+
+
+def _pair_tokens(config):
+    tokens = set()
+    for left in range(len(_STRUCTURE_KEYS)):
+        for right in range(left + 1, len(_STRUCTURE_KEYS)):
+            key_a = _STRUCTURE_KEYS[left]
+            key_b = _STRUCTURE_KEYS[right]
+            tokens.add((key_a, repr(config[key_a]), key_b, repr(config[key_b])))
+    return tokens
+
+
+def _minimal_pairwise_cover(candidates, forced_labels):
+    uncovered = set()
+    for candidate in candidates:
+        uncovered.update(_pair_tokens(candidate))
+    selected = []
+    remaining = list(candidates)
+    for label in forced_labels:
+        for candidate in tuple(remaining):
+            if candidate["label"] == label:
+                selected.append(candidate)
+                remaining.remove(candidate)
+                uncovered.difference_update(_pair_tokens(candidate))
+                break
+    while uncovered:
+        best = max(
+            remaining,
+            key=lambda candidate: (
+                len(_pair_tokens(candidate) & uncovered),
+                tuple(-ord(char) for char in candidate["label"]),
+            ),
+        )
+        selected.append(best)
+        remaining.remove(best)
+        uncovered.difference_update(_pair_tokens(best))
+    return selected
+
+
+def _correctness_configs():
+    forced = (
+        "anchor",
+        "l1",
+        "no_amax_fp4",
+        "tail_mnk",
+        "tail_cta1_n64",
+        "tail_cta2_n192",
+        "persistent_cta1",
+        "persistent_cta2",
+        "cluster_cta1_4x4",
+        "cluster_cta2_4x4",
+    )
+    return _minimal_pairwise_cover(_source_probe_configs(), forced)
+
+
+def _structure_tokens(config):
+    return {
+        ("ab", config["ab_dtype"]),
+        ("sf", config["sf_dtype"], config["sf_vec_size"]),
+        ("cd", config["c_dtype"], config["d_dtype"]),
+        ("major", config["a_major"], config["b_major"]),
+        ("tile", config["mma_tiler_mn"]),
+        ("cluster", config["cluster_shape_mn"]),
+        ("amax", config["with_amax"]),
+        ("batch", config["L"]),
+    }
+
+
+def _benchmark_configs():
+    probes = _source_probe_configs()
+    uncovered = set()
+    for probe in probes:
+        uncovered.update(_structure_tokens(probe))
+    representatives = []
+    while uncovered:
+        best = max(
+            probes,
+            key=lambda probe: (
+                len(_structure_tokens(probe) & uncovered),
+                tuple(-ord(char) for char in probe["label"]),
+            ),
+        )
+        representatives.append(best)
+        probes.remove(best)
+        uncovered.difference_update(_structure_tokens(best))
+
+    configs = []
+    anchor = _base_config()
+    for size, batch in ((1024, 1), (2048, 2), (4096, 1), (8192, 2)):
+        config = dict(anchor)
+        config.update(
+            label=f"anchor_m{size}_n{size}_k{size}_l{batch}", M=size, N=size, K=size, L=batch
+        )
+        configs.append(config)
+    for index, base in enumerate(representatives):
+        size = (1024, 2048, 4096, 8192)[index % 4]
+        config = dict(base)
+        config.update(
+            label=f"cover{index:02d}_m{size}_n{size}_k{size}_{base['label']}",
+            M=size,
+            N=size,
+            K=size,
+        )
+        configs.append(config)
+    by_label = {}
+    for config in configs:
+        by_label[config["label"]] = config
+    return [by_label[label] for label in sorted(by_label)]
+
+
+KERNEL_META = {
+    "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _correctness_configs()
+BENCH_CONFIGS = _benchmark_configs()
+
+
+def _make_kernel(
+    M,
+    N,
+    K_dim,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    d_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    vector_f32,
+    with_amax,
+    with_sfd,
+):
+    if ab_dtype == "uint8":
+        raise ValueError("the non-running uint8 packed-FP4 alias is not supported")
+    if sf_dtype == "int8":
+        sf_dtype = "float8_e8m0fnu"
+    mma_tiler_mn = tuple(mma_tiler_mn)
+    cluster_shape_mn = tuple(cluster_shape_mn)
+    mode = {
+        "ab_dtype": ab_dtype,
+        "sf_dtype": sf_dtype,
+        "sf_vec_size": sf_vec_size,
+        "c_dtype": c_dtype,
+        "d_dtype": d_dtype,
+        "a_major": a_major,
+        "b_major": b_major,
+        "c_major": c_major,
+        "mma_tiler_mn": mma_tiler_mn,
+        "cluster_shape_mn": cluster_shape_mn,
+        "vector_f32": vector_f32,
+        "with_amax": with_amax,
+        "with_sfd": with_sfd,
+        "L": L,
+    }
+    if min(M, N, K_dim, L) <= 0:
+        raise ValueError("M/N/K/L must be positive")
+    if not _valid_mode(mode):
+        raise ValueError(f"unsupported source specialization: {_mode_label(mode)}")
+    if not _verified_structure(mode):
+        raise ValueError(
+            f"source specialization was not independently verified: {_mode_label(mode)}"
+        )
+    ab_bits = _dtype_bits(ab_dtype)
+    c_bits = _dtype_bits(c_dtype)
+    d_bits = _dtype_bits(d_dtype)
+    if (M if a_major == "m" else K_dim) % (128 // ab_bits):
+        raise ValueError("A's contiguous dimension must be 16-byte aligned")
+    if (N if b_major == "n" else K_dim) % (128 // ab_bits):
+        raise ValueError("B's contiguous dimension must be 16-byte aligned")
+    if (M if c_major == "m" else N) % (128 // c_bits):
+        raise ValueError("C's contiguous dimension must be 16-byte aligned")
+    if (M if c_major == "m" else N) % (128 // d_bits):
+        raise ValueError("D's contiguous dimension must be 16-byte aligned")
+
+    tile_m, n_tile = mma_tiler_mn
+    cta_group = tile_m // 128
+    cta_m = 128
+    b_rows = n_tile // cta_group
+    cluster_m, cluster_n = cluster_shape_mn
+    cluster_size = cluster_m * cluster_n
+    cluster_m_groups = cluster_m // cta_group
+    k_tile = 256 if ab_dtype == "float4_e2m1fn" else 128
+    k_tiles = _ceil_div(K_dim, k_tile)
+    m_tiles = _ceil_div(M, cta_m)
+    n_tiles = _ceil_div(N, n_tile)
+    cluster_m_tiles = _ceil_div(m_tiles, cluster_m)
+    cluster_n_tiles = _ceil_div(n_tiles, cluster_n)
+    cluster_work = cluster_m_tiles * cluster_n_tiles * L
+    num_clusters = min(cluster_work, _MAX_ACTIVE_CLUSTERS[cluster_size])
+    acc_stages = 1 if n_tile == 256 else 2
+    c_stages = 2
+    d_stages = 2
+    epi_n = 32
+    epilogue_subtiles = n_tile // epi_n
+    a_stage_bytes = cta_m * k_tile * ab_bits // 8
+    b_stage_bytes = b_rows * k_tile * ab_bits // 8
+    sfa_stage_bytes = cta_m * k_tile // sf_vec_size
+    # The source SFB layout is padded to a whole 128-column scale tile.
+    # This padding participates in both SMEM allocation and mbarrier bytes.
+    sfb_stage_bytes = _align_up(n_tile, 128) * k_tile // sf_vec_size
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes + sfa_stage_bytes + sfb_stage_bytes
+    c_stage_bytes = cta_m * epi_n * c_bits // 8
+    d_stage_bytes = cta_m * epi_n * d_bits // 8
+    ab_stages = (
+        _SMEM_CAPACITY - (1024 + c_stages * c_stage_bytes + d_stages * d_stage_bytes + 16)
+    ) // ab_stage_bytes
+    if ab_stages <= 0:
+        raise ValueError("source stage heuristic exceeds SM100 shared-memory capacity")
+
+    ab_full_offset = 0
+    ab_empty_offset = ab_full_offset + ab_stages * 8
+    acc_full_offset = ab_empty_offset + ab_stages * 8
+    acc_empty_offset = acc_full_offset + acc_stages * 8
+    c_full_offset = acc_empty_offset + acc_stages * 8
+    c_empty_offset = c_full_offset + c_stages * 8
+    tmem_dealloc_offset = c_empty_offset + c_stages * 8
+    tmem_ptr_offset = tmem_dealloc_offset + 8
+    c_offset = 1024
+    d_offset = c_offset + c_stages * c_stage_bytes
+    a_offset = d_offset + d_stages * d_stage_bytes
+    b_offset = a_offset + ab_stages * a_stage_bytes
+    sfa_offset = b_offset + ab_stages * b_stage_bytes
+    sfb_offset = _align_up(sfa_offset + ab_stages * sfa_stage_bytes, 1024)
+    sfb_storage_stage_bytes = sfb_stage_bytes
+    amax_offset = _align_up(sfb_offset + ab_stages * sfb_storage_stage_bytes, 1024)
+    shared_bytes = _align_up(amax_offset + 16, 1024)
+    if shared_bytes > _SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {_SMEM_CAPACITY}")
+
+    ab_empty_arrivals = cluster_n + cluster_m_groups - 1
+    acc_empty_arrivals = 4 * cta_group
+    tmem_columns = 512
+    tma_cache_hint = 0
+    entry_max_registers = None
+
+    def mn_smem_parameters(major_size):
+        major_bits = major_size * ab_bits
+        if ab_bits == 32 and major_bits % 1024 == 0:
+            # MN_SW128_32B: S<2, 5, 2>, exposed to TMA as the
+            # 128-byte-atom/32-byte-base swizzle.
+            swizzle, chunk, sdo = 4, 32, 32
+        elif major_bits % 1024 == 0:
+            swizzle, chunk, sdo = 3, 1024 // ab_bits, 64
+        elif major_bits % 512 == 0:
+            swizzle, chunk, sdo = 2, 512 // ab_bits, 32
+        elif major_bits % 256 == 0:
+            swizzle, chunk, sdo = 1, 256 // ab_bits, 16
+        else:
+            raise ValueError("MN-major input tile must contain a 32-byte swizzle atom")
+        copies = major_size // chunk
+        ldo = 0 if copies == 1 else chunk * k_tile * (ab_bits // 8) // 16
+        return swizzle, chunk, copies, ldo, sdo
+
+    if a_major == "m":
+        a_swizzle, a_chunk, a_copies, a_ldo, a_sdo = mn_smem_parameters(cta_m)
+    else:
+        a_swizzle, a_chunk, a_copies, a_ldo, a_sdo = 3, cta_m, 1, 1, 64
+    if b_major == "n":
+        b_swizzle, b_chunk, b_copies, b_ldo, b_sdo = mn_smem_parameters(b_rows)
+    else:
+        b_swizzle, b_chunk, b_copies, b_ldo, b_sdo = 3, b_rows, 1, 1, 64
+    a_cluster_piece = (k_tile if a_major == "m" else cta_m) // cluster_n
+    b_cluster_piece = (k_tile if b_major == "n" else b_rows) // cluster_m_groups
+    a_piece_bytes = a_stage_bytes // (a_copies * cluster_n)
+    b_piece_bytes = b_stage_bytes // (b_copies * cluster_m_groups)
+    num_tma_load_bytes = ab_stage_bytes * cta_group
+
+    a_desc_base = _descriptor_base(ldo=a_ldo, sdo=a_sdo, swizzle=a_swizzle)
+    b_desc_base = _descriptor_base(ldo=b_ldo, sdo=b_sdo, swizzle=b_swizzle)
+    sf_desc_base = _descriptor_base(ldo=1, sdo=8, swizzle=0)
+    instr_desc = _instruction_descriptor(tile_m, n_tile, ab_dtype, sf_dtype, a_major, b_major)
+    acc_columns = acc_stages * n_tile
+    sfa_tmem_column = acc_columns
+    sfa_chunks = sfa_stage_bytes // 512
+    sfb_chunks = sfb_stage_bytes // 512
+    sfb_tmem_column = sfa_tmem_column + sfa_chunks * 4
+    if sfb_tmem_column + sfb_chunks * 4 > 512:
+        raise ValueError("source TMEM scale regions exceed 512 columns")
+    sf_k_box = k_tile // (4 * sf_vec_size)
+    sfa_piece_values = 256 * sf_k_box // cluster_n
+    sfb_n_box = _ceil_div(n_tile, 128)
+    sfb_piece_values = 256 * sf_k_box * sfb_n_box // cluster_m_groups
+
+    def host_prelude(params):
+        a = params["a"]
+        b = params["b"]
+        sfa = params["sfa"]
+        sfb = params["sfb"]
+        c = params["c"]
+        d = params["d"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        sfa_map = K.stack_alloca("tensormap", 1)
+        sfb_map = K.stack_alloca("tensormap", 1)
+        c_map = K.stack_alloca("tensormap", 1)
+        d_map = K.stack_alloca("tensormap", 1)
+
+        def encode(descriptor, dtype, rank, data, *fields):
+            K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+        a_contiguous_bytes = (M if a_major == "m" else K_dim) * ab_bits // 8
+        b_contiguous_bytes = (N if b_major == "n" else K_dim) * ab_bits // 8
+        if a_major == "m":
+            a_fields = (
+                M,
+                K_dim,
+                L,
+                a_contiguous_bytes,
+                M * K_dim * ab_bits // 8,
+                a_chunk,
+                a_cluster_piece,
+                1,
+            )
+        else:
+            a_fields = (
+                K_dim,
+                M,
+                L,
+                a_contiguous_bytes,
+                M * K_dim * ab_bits // 8,
+                k_tile,
+                a_cluster_piece,
+                1,
+            )
+        if b_major == "n":
+            b_fields = (
+                N,
+                K_dim,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                b_chunk,
+                b_cluster_piece,
+                1,
+            )
+        else:
+            b_fields = (
+                K_dim,
+                N,
+                L,
+                b_contiguous_bytes,
+                N * K_dim * ab_bits // 8,
+                k_tile,
+                b_cluster_piece,
+                1,
+            )
+        tensor_tail = (1, 1, 1, 0, a_swizzle, 2, 0)
+        if ab_dtype == "float4_e2m1fn":
+            tensor_tail += (13,)
+        encode(a_map, ab_dtype, 3, a.data, *a_fields, *tensor_tail)
+        tensor_tail = (1, 1, 1, 0, b_swizzle, 2, 0)
+        if ab_dtype == "float4_e2m1fn":
+            tensor_tail += (13,)
+        encode(b_map, ab_dtype, 3, b.data, *b_fields, *tensor_tail)
+
+        sf_k_groups = _ceil_div(K_dim, 4 * sf_vec_size)
+        sf_m_groups = _ceil_div(M, 128)
+        sf_n_groups = _ceil_div(N, 128)
+        sfa_box_0 = min(256, sfa_piece_values)
+        sfa_box_1 = sfa_piece_values // sfa_box_0
+        encode(
+            sfa_map,
+            "uint16",
+            4,
+            sfa.data,
+            256,
+            sf_k_groups,
+            sf_m_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_m_groups * sf_k_groups * 512,
+            sfa_box_0,
+            sfa_box_1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        sfb_box_0 = min(256, sfb_piece_values)
+        sfb_remaining = sfb_piece_values // sfb_box_0
+        sfb_box_1 = min(sf_k_box, sfb_remaining)
+        sfb_box_2 = sfb_remaining // sfb_box_1
+        encode(
+            sfb_map,
+            "uint16",
+            4,
+            sfb.data,
+            256,
+            sf_k_groups,
+            sf_n_groups,
+            L,
+            512,
+            sf_k_groups * 512,
+            sf_n_groups * sf_k_groups * 512,
+            sfb_box_0,
+            sfb_box_1,
+            sfb_box_2,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+
+        def encode_output(descriptor, tensor, dtype, bits):
+            element_bytes = bits // 8
+            contiguous_bytes = N * element_bytes
+            batch_bytes = M * N * element_bytes
+            fields = (N, M, L, contiguous_bytes, batch_bytes, epi_n, cta_m, 1)
+            row_bytes = epi_n * element_bytes
+            swizzle = 3 if row_bytes >= 128 else 2 if row_bytes >= 64 else 1
+            encode(descriptor, dtype, 3, tensor.data, *fields, 1, 1, 1, 0, swizzle, 2, 0)
+
+        encode_output(c_map, c, c_dtype, c_bits)
+        encode_output(d_map, d, d_dtype, d_bits)
+        return a_map, b_map, sfa_map, sfb_map, c_map, d_map
+
+    def kernel(a, b, sfa, sfb, c, d, prob, dprob, amax, alpha, *, host):
+        del a, b, sfa, sfb, c, d
+        a_map, b_map, sfa_map, sfb_map, c_map, d_map = host
+        if entry_max_registers is None:
+            _block_x, _block_y, cluster_work_id = K.cta_id()
+        else:
+            with K.attr({"tirx.max_registers": entry_max_registers}):
+                _block_x, _block_y, cluster_work_id = K.cta_id()
+        cluster_x_scope, cluster_y_scope = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        del _block_x, _block_y, cluster_x_scope, cluster_y_scope
+        cluster_rank = K.local_scalar("int32", init=K.cuda.mov_sreg(32, "cluster_ctarank"))
+        cluster_x = K.local_scalar("int32", init=cluster_rank & (cluster_m - 1))
+        cluster_y = K.local_scalar("int32", init=cluster_rank >> (cluster_m.bit_length() - 1))
+        cta_v = cluster_x % cta_group
+        leader_cta = cta_v == 0
+        cluster_m_group = cluster_x // cta_group
+        pair_leader_x = cluster_m_group * cta_group
+        leader_rank = pair_leader_x + cluster_m * cluster_y
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3], regs=88, direction="inc")
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+        c_role = roles.role("c_load", warps=[6])
+
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool,
+            ab_stages,
+            full="tma",
+            empty="tcgen05",
+            init_empty=ab_empty_arrivals,
+            leader=K.bool(False),
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=acc_empty_arrivals,
+            leader=K.bool(False),
+        )
+        if protocol_pool.bytes != c_full_offset:
+            raise AssertionError("protocol storage changed before the C pipeline")
+        c_pipe = K.Pipeline(
+            protocol_pool, c_stages, full="tma", empty="mbar", init_empty=4, leader=K.bool(False)
+        )
+        if protocol_pool.bytes != tmem_dealloc_offset:
+            raise AssertionError("protocol storage offsets changed")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.bytes != tmem_ptr_offset + 4:
+            raise AssertionError("protocol storage header changed")
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfa_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfb_map))
+            K.ptx.prefetch.tensormap(K.address_of(c_map))
+            K.ptx.prefetch.tensormap(K.address_of(d_map))
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(ab_empty_arrivals)
+                            )
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(acc_empty_arrivals)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, c_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(c_pipe.full.ptr_to([stage]), K.uint32(1))
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, c_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                c_pipe.empty.ptr_to([stage]), K.uint32(4)
+                            )
+
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.sync(K.uint32(0), K.uint32(224))
+
+        if cta_group == 2:
+            with K.If(warp == 0):
+                with K.Then():
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.init.shared.b64(tmem_dealloc.ptr_to([0]), K.uint32(32))
+            K.ptx.fence.mbarrier_init.release.cluster()
+
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.arrive.relaxed()
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        tmem_slot_addr = K.uniform(smem_base + K.uint32(tmem_ptr_offset))
+        cluster_smem_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_u64, smem.ptr_to([0]))
+        cluster_smem = K.local_scalar("uint32", init=K.cast(cluster_smem_u64, "uint32"))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, smem_base + a_offset)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, smem_base + b_offset)
+        )
+        sfa_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfa_offset)
+        )
+        sfb_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfb_offset)
+        )
+
+        a_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_n in range(cluster_n):
+            K.assign(
+                a_mcast_mask,
+                K.bitwise_or(
+                    a_mcast_mask, K.uint32(1) << K.cast(cluster_x + cluster_m * peer_n, "uint32")
+                ),
+            )
+        b_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_group in range(cluster_m_groups):
+            peer_x = cta_v + cta_group * peer_group
+            K.assign(
+                b_mcast_mask,
+                K.bitwise_or(
+                    b_mcast_mask, K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        ab_consumer_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for pair_v in range(cta_group):
+            for peer_n in range(cluster_n):
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1)
+                        << K.cast(pair_leader_x + pair_v + cluster_m * peer_n, "uint32"),
+                    ),
+                )
+            for peer_group in range(cluster_m_groups):
+                peer_x = pair_v + cta_group * peer_group
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32"),
+                    ),
+                )
+        acc_producer_mask = K.local_scalar(
+            "uint32", init=K.uint32((1 << cta_group) - 1) << K.cast(leader_rank, "uint32")
+        )
+        ab_full_leader = ab_pipe.full.remote_view(leader_rank)
+        acc_empty_leader = acc_pipe.empty.remote_view(leader_rank)
+
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.wait()
+        else:
+            K.ptx.bar.sync(K.uint32(0), K.uint32(224))
+
+        def scheduler_coords(work):
+            cluster_m_idx = work % cluster_m_tiles
+            quotient = work // cluster_m_tiles
+            cluster_n_idx = quotient % cluster_n_tiles
+            batch_idx = quotient // cluster_n_tiles
+            tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+            tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+            return tile_m_idx, tile_n_idx, batch_idx
+
+        def advance_work(work):
+            K.assign(work, work + num_clusters)
+
+        # TMEM allocation is published through one physical 160-thread
+        # barrier instruction shared by the four epilogue warps and the MMA
+        # warp.  Keeping the arrival at one PC is required by synccheck and is
+        # equivalent to the source's named-barrier-2 rendezvous.
+        with K.If(warp < K.uint32(5)):
+            with K.Then():
+                with K.If(warp == 0):
+                    with K.Then():
+                        K.ptx[
+                            "tcgen05.alloc.cta_group::"
+                            + str(cta_group)
+                            + ".sync.aligned.shared::cta.b32"
+                        ](tmem_slot_addr, K.uint32(tmem_columns))
+                K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+
+        with tma_role:
+            tma_state = K.PipelineState(ab_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase
+                        )
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
+                    )
+                    if k_tiles:
+                        if ab_stages:
+                            with K.If(leader_cta):
+                                with K.Then():
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                                ab_pipe.full.ptr_to([tma_state.stage]),
+                                                K.uint32(num_tma_load_bytes),
+                                            )
+
+                            a_elected = _elected()
+                            for copy in range(a_copies):
+                                a_coord_m = tile_m_idx * cta_m
+                                a_coord_k = count * k_tile
+                                if a_major == "m":
+                                    a_coord_m = a_coord_m + copy * a_chunk
+                                    a_coord_k = a_coord_k + cluster_y * a_cluster_piece
+                                else:
+                                    a_coord_m = a_coord_m + cluster_y * a_cluster_piece
+                                a_coord_0 = a_coord_m if a_major == "m" else a_coord_k
+                                a_coord_1 = a_coord_k if a_major == "m" else a_coord_m
+                                a_smem_offset = (
+                                    a_offset
+                                    + tma_state.stage * a_stage_bytes
+                                    + copy * (a_stage_bytes // a_copies)
+                                    + cluster_y * a_piece_bytes
+                                )
+                                if cta_group == 1 and cluster_n == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                        smem.ptr_to([a_smem_offset]),
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cta_group == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cluster_n == 1:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    _issue_ptx_if(
+                                        a_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2",
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_0, "int32"),
+                                        K.cast(a_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+
+                            b_elected = _elected()
+                            for copy in range(b_copies):
+                                b_coord_n = tile_n_idx * n_tile + cta_v * b_rows
+                                b_coord_k = count * k_tile
+                                if b_major == "n":
+                                    b_coord_n = b_coord_n + copy * b_chunk
+                                    b_coord_k = b_coord_k + cluster_m_group * b_cluster_piece
+                                else:
+                                    b_coord_n = b_coord_n + cluster_m_group * b_cluster_piece
+                                b_coord_0 = b_coord_n if b_major == "n" else b_coord_k
+                                b_coord_1 = b_coord_k if b_major == "n" else b_coord_n
+                                b_smem_offset = (
+                                    b_offset
+                                    + tma_state.stage * b_stage_bytes
+                                    + copy * (b_stage_bytes // b_copies)
+                                    + cluster_m_group * b_piece_bytes
+                                )
+                                if cta_group == 1 and cluster_m_groups == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                        smem.ptr_to([b_smem_offset]),
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cta_group == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                elif cluster_m_groups == 1:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    _issue_ptx_if(
+                                        b_elected,
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2",
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_0, "int32"),
+                                        K.cast(b_coord_1, "int32"),
+                                        K.cast(batch_idx, "int32"),
+                                        ab_full_leader.ptr_to([tma_state.stage]),
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+
+                            sfa_linear = cluster_y * sfa_piece_values
+                            sfa_coord_0 = sfa_linear % 256
+                            sfa_coord_1 = count * sf_k_box + sfa_linear // 256
+                            sfa_smem_offset = (
+                                sfa_offset
+                                + tma_state.stage * sfa_stage_bytes
+                                + cluster_y * (sfa_stage_bytes // cluster_n)
+                            )
+                            sfa_elected = _elected()
+                            if cta_group == 1 and cluster_n == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                    smem.ptr_to([sfa_smem_offset]),
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cta_group == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cluster_n == 1:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                _issue_ptx_if(
+                                    sfa_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+
+                            sfb_linear = cluster_m_group * sfb_piece_values
+                            sfb_coord_0 = sfb_linear % 256
+                            sfb_quotient = sfb_linear // 256
+                            sfb_coord_1 = count * sf_k_box + sfb_quotient % sf_k_box
+                            # SFB is globally blocked in 128-column units.  N64
+                            # and N192 tiles can start halfway through a scale
+                            # block; the TMEM shift below selects that half.
+                            sfb_global_block = tile_n_idx * n_tile // 128
+                            sfb_coord_2 = sfb_global_block + sfb_quotient // sf_k_box
+                            sfb_smem_offset = (
+                                sfb_offset
+                                + tma_state.stage * sfb_stage_bytes
+                                + cluster_m_group * (sfb_stage_bytes // cluster_m_groups)
+                            )
+                            sfb_elected = _elected()
+                            if cta_group == 1 and cluster_m_groups == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint",
+                                    smem.ptr_to([sfb_smem_offset]),
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cta_group == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cluster_m_groups == 1:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                _issue_ptx_if(
+                                    sfb_elected,
+                                    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2",
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    _advance(tma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative,
+                                ab_pipe.empty.ptr_to([tma_state.stage]),
+                                tma_state.phase,
+                            )
+                advance_work(work)
+            with K.unroll(0, ab_stages) as unused_stage:
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+            del unused_stage
+
+        with mma_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            mma_state = K.PipelineState(ab_stages, phase=0)
+            acc_state = K.PipelineState(acc_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            accumulate = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                _tile_m_idx, tile_n_idx, _batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If((count < k_tiles) & leader_cta):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                        )
+                with K.If(leader_cta):
+                    with K.Then():
+                        _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(accumulate, K.uint32(0))
+                with K.While(count < k_tiles):
+                    with K.If(leader_cta):
+                        with K.Then():
+                            _wait_plain_if_needed(
+                                ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase, speculative
+                            )
+                            for sf_chunk in range(sfa_chunks):
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        K.ptx[
+                                            "tcgen05.cp.cta_group::"
+                                            + str(cta_group)
+                                            + ".32x128b.warpx4"
+                                        ](
+                                            K.cast(
+                                                tmem_base + sfa_tmem_column + sf_chunk * 4, "uint32"
+                                            ),
+                                            sfa_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (sfa_stage_bytes // 16)
+                                                + sf_chunk * 32,
+                                                "uint64",
+                                            ),
+                                        )
+                            for sf_chunk in range(sfb_chunks):
+                                sfb_shared_chunk = (
+                                    sf_chunk % sfb_n_box
+                                ) * sf_k_box + sf_chunk // sfb_n_box
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        K.ptx[
+                                            "tcgen05.cp.cta_group::"
+                                            + str(cta_group)
+                                            + ".32x128b.warpx4"
+                                        ](
+                                            K.cast(
+                                                tmem_base + sfb_tmem_column + sf_chunk * 4, "uint32"
+                                            ),
+                                            sfb_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (sfb_stage_bytes // 16)
+                                                + sfb_shared_chunk * 32,
+                                                "uint64",
+                                            ),
+                                        )
+                            for kblock in range(4):
+                                if sf_vec_size == 16:
+                                    sfa_scale_offset = kblock * 4
+                                    sfb_scale_offset = kblock * 4 * sfb_n_box
+                                    sf_selector = 0
+                                elif ab_dtype == "float4_e2m1fn":
+                                    sfa_scale_offset = (kblock // 2) * 4
+                                    sfb_scale_offset = (kblock // 2) * 4 * sfb_n_box
+                                    sf_selector = (kblock % 2) * 0x80000000
+                                else:
+                                    sfa_scale_offset = 0
+                                    sfb_scale_offset = 0
+                                    sf_selector = kblock * 0x40000000
+                                sfb_tile_shift = 0
+                                if n_tile in (64, 192):
+                                    sfb_tile_shift = (tile_n_idx % 2) * 2
+                                sfa_tmem_addr = K.cast(
+                                    tmem_base
+                                    + sfa_tmem_column
+                                    + sfa_scale_offset
+                                    + K.uint32(sf_selector),
+                                    "uint32",
+                                )
+                                sfb_tmem_addr = K.cast(
+                                    tmem_base
+                                    + sfb_tmem_column
+                                    + sfb_tile_shift
+                                    + sfb_scale_offset
+                                    + K.uint32(sf_selector),
+                                    "uint32",
+                                )
+                                runtime_instr_desc = K.bitwise_and(
+                                    K.uint32(instr_desc), K.uint32(0x9FFFFFCF)
+                                )
+                                runtime_instr_desc = K.bitwise_or(
+                                    runtime_instr_desc,
+                                    K.bitwise_and(
+                                        K.shift_right(sfa_tmem_addr, K.uint32(1)),
+                                        K.uint32(0x60000000),
+                                    ),
+                                )
+                                runtime_instr_desc = K.bitwise_or(
+                                    runtime_instr_desc,
+                                    K.bitwise_and(
+                                        K.shift_right(sfb_tmem_addr, K.uint32(26)), K.uint32(0x30)
+                                    ),
+                                )
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        mma_kind = (
+                                            "mxf4nvf4"
+                                            if ab_dtype == "float4_e2m1fn"
+                                            else "mxf8f6f4"
+                                        )
+                                        a_kblock = (
+                                            2 if a_major == "k" else a_chunk * 32 * ab_bits // 128
+                                        )
+                                        b_kblock = (
+                                            2 if b_major == "k" else b_chunk * 32 * ab_bits // 128
+                                        )
+                                        K.ptx[
+                                            "tcgen05.mma.cta_group::"
+                                            + str(cta_group)
+                                            + ".kind::"
+                                            + mma_kind
+                                            + ".block_scale.block"
+                                            + str(sf_vec_size)
+                                        ](
+                                            K.cast(tmem_base + acc_state.stage * n_tile, "uint32"),
+                                            a_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (a_stage_bytes // 16)
+                                                + kblock * a_kblock,
+                                                "uint64",
+                                            ),
+                                            b_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (b_stage_bytes // 16)
+                                                + kblock * b_kblock,
+                                                "uint64",
+                                            ),
+                                            runtime_instr_desc,
+                                            sfa_tmem_addr,
+                                            sfb_tmem_addr,
+                                            K.ptx.pred(K.cast(accumulate, "bool")),
+                                        )
+                                K.assign(accumulate, K.uint32(1))
+                            with K.If(_elected()):
+                                with K.Then():
+                                    if cta_group == 2:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                            ".shared::cluster.multicast::cluster.b64"
+                                        ](
+                                            ab_pipe.empty.ptr_to([mma_state.stage]),
+                                            K.cast(ab_consumer_mask, "uint16"),
+                                        )
+                                    elif cluster_size > 1:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                            ".shared::cluster.multicast::cluster.b64"
+                                        ](
+                                            ab_pipe.empty.ptr_to([mma_state.stage]),
+                                            K.cast(ab_consumer_mask, "uint16"),
+                                        )
+                                    else:
+                                        K.ptx[
+                                            "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                            ".shared::cluster.b64"
+                                        ](ab_pipe.empty.ptr_to([mma_state.stage]))
+                    _advance(mma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If((count < k_tiles) & leader_cta):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                            )
+                with K.If(leader_cta):
+                    with K.Then():
+                        with K.If(_elected()):
+                            with K.Then():
+                                if cta_group == 2:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                        ".shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        acc_pipe.full.ptr_to([acc_state.stage]),
+                                        K.cast(acc_producer_mask, "uint16"),
+                                    )
+                                elif cluster_size > 1:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                        ".shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        acc_pipe.full.ptr_to([acc_state.stage]),
+                                        K.cast(acc_producer_mask, "uint16"),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+                                        ".shared::cluster.b64"
+                                    ](acc_pipe.full.ptr_to([acc_state.stage]))
+                _advance(acc_state)
+                advance_work(work)
+            with K.If(leader_cta):
+                with K.Then():
+                    for _ in range(acc_stages - 1):
+                        _advance(acc_state)
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        # Warp 6 follows the same persistent cursor and produces read-only C
+        # subtiles into the two-stage mbarrier ring.
+        with c_role:
+            c_state = K.PipelineState(c_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    _wait_plain(c_pipe.empty.ptr_to([c_state.stage]), c_state.phase)
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                c_pipe.full.ptr_to([c_state.stage]), K.uint32(c_stage_bytes)
+                            )
+                            K.ptx[
+                                "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                            ](
+                                smem.ptr_to([c_offset + c_state.stage * c_stage_bytes]),
+                                K.address_of(c_map),
+                                K.cast(tile_n_idx * n_tile + subtile * epi_n, "int32"),
+                                K.cast(tile_m_idx * cta_m, "int32"),
+                                K.cast(batch_idx, "int32"),
+                                c_pipe.full.ptr_to([c_state.stage]),
+                                K.uint64(tma_cache_hint),
+                            )
+                    _advance(c_state)
+                    K.assign(subtile, subtile + 1)
+                advance_work(work)
+            with K.unroll(0, c_stages):
+                _wait_plain(c_pipe.empty.ptr_to([c_state.stage]), c_state.phase)
+                _advance(c_state)
+
+        with epilogue_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            acc_state = K.PipelineState(acc_stages, phase=0)
+            c_state = K.PipelineState(c_stages, phase=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            executed_tiles = K.local_scalar("int32", init=0)
+
+            values = K.alloc_local((32,), "float32")
+            c_values = K.alloc_local((32,), "float32")
+            d_values = K.alloc_local((32,), "float32")
+            dprob_terms = K.alloc_local((32,), "float32")
+            c_words = K.alloc_local((32,), "uint32")
+            d_words = K.alloc_local((32,), "uint32")
+            d_pairs = K.alloc_local((16,), "uint16")
+            d_wide = K.alloc_local((16,), "uint64")
+            d_offsets = K.alloc_local((8,), "int32")
+            absolute_values = K.alloc_local((32,), "float32")
+            maxima = K.alloc_local((11,), "float32")
+            tile_amax = K.local_scalar("float32")
+            warp_amax = K.local_scalar("float32")
+            prob_value = K.local_scalar("float32")
+            dprob_value = K.local_scalar("float32")
+
+            def load_accumulator(subtile):
+                tmem_load_addr = K.local_scalar(
+                    "uint32",
+                    init=tmem_base + (warp << 21) + acc_state.stage * n_tile + subtile * epi_n,
+                )
+                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                    *[values[index] for index in range(32)], tmem_load_addr
+                )
+
+            def multiply_pair(dst0, dst1, left0, left1, right0, right1):
+                packed = K.local_scalar("uint64")
+                K.ptx.mul.rn.f32x2(
+                    packed, K.cuda.make_float2(left0, left1), K.cuda.make_float2(right0, right1)
+                )
+                K.ptx.mov.b64(dst0, dst1, packed)
+
+            def add_pair(dst0, dst1, left0, left1, right0, right1):
+                packed = K.local_scalar("uint64")
+                K.ptx.add.rn.f32x2(
+                    packed, K.cuda.make_float2(left0, left1), K.cuda.make_float2(right0, right1)
+                )
+                K.ptx.mov.b64(dst0, dst1, packed)
+
+            def apply_alpha():
+                for index in range(0, 32, 2):
+                    multiply_pair(
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                        alpha,
+                        alpha,
+                    )
+
+            def load_c():
+                row_bytes = epi_n * c_bits // 8
+                word_count = epi_n * c_bits // 32
+                c_slot = c_offset + c_state.stage * c_stage_bytes
+                row_offset = (warp * 32 + lane) * row_bytes
+                for word in range(0, word_count, 4):
+                    K.ptx.ld.shared.v4.b32(
+                        c_words[word],
+                        c_words[word + 1],
+                        c_words[word + 2],
+                        c_words[word + 3],
+                        smem.ptr_to([c_slot + _swizzled(row_offset, word // 4, row_bytes)]),
+                    )
+                K.ptx.fence.proxy.async_.shared__cta()
+                with K.If(lane == 0):
+                    with K.Then():
+                        K.ptx.mbarrier.arrive.shared.b64(c_pipe.empty.ptr_to([c_state.stage]))
+                _advance(c_state)
+                _unpack_input(c_values, c_words, c_dtype, c_bits)
+
+            def pack_output(dtype, source_values, words, pairs, wide):
+                if dtype == "float32":
+                    for index in range(16):
+                        K.assign(
+                            wide[index],
+                            K.cuda.make_float2(
+                                source_values[index * 2], source_values[index * 2 + 1]
+                            ),
+                        )
+                else:
+                    for index in range(16):
+                        if dtype == "float16":
+                            K.ptx.cvt.rn.f16x2.f32(
+                                words[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[index], source_values[index * 2 + 1], source_values[index * 2]
+                            )
+
+            def stage_output(dtype, bits, words, wide, offsets, stage):
+                row_bytes = epi_n * bits // 8
+                word_count = epi_n * bits // 32
+                vector_count = row_bytes // 16
+                row_offset = K.local_scalar(
+                    "int32",
+                    init=d_offset
+                    + stage * d_stage_bytes
+                    + warp * (32 * row_bytes)
+                    + lane * row_bytes,
+                )
+                for vector in range(vector_count):
+                    K.assign(
+                        offsets[vector],
+                        d_offset
+                        + stage * d_stage_bytes
+                        + _swizzled((warp * 32 + lane) * row_bytes, vector, row_bytes),
+                    )
+                if dtype == "float32":
+                    for vector in range(vector_count):
+                        K.ptx["st.shared.v2.b64"](
+                            smem.ptr_to([offsets[vector]]), wide[vector * 2], wide[vector * 2 + 1]
+                        )
+                else:
+                    for vector in range(word_count // 4):
+                        K.ptx.st.shared.v4.b32(
+                            smem.ptr_to([offsets[vector]]),
+                            words[vector * 4],
+                            words[vector * 4 + 1],
+                            words[vector * 4 + 2],
+                            words[vector * 4 + 3],
+                        )
+                del row_offset
+
+            def tma_store_d(stage, subtile):
+                K.ptx["cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"](
+                    K.address_of(d_map),
+                    K.cast(tile_n_idx * n_tile + subtile * epi_n, "int32"),
+                    K.cast(tile_m_idx * cta_m, "int32"),
+                    K.cast(batch_idx, "int32"),
+                    smem.ptr_to([d_offset + stage * d_stage_bytes]),
+                    K.uint64(tma_cache_hint),
+                )
+
+            def apply_dsrelu_and_dprob():
+                for index in range(32):
+                    K.ptx.max.f32(values[index], values[index], K.float32(0.0))
+                for index in range(0, 32, 2):
+                    c_prob_0 = K.local_scalar("float32")
+                    c_prob_1 = K.local_scalar("float32")
+                    doubled_0 = K.local_scalar("float32")
+                    doubled_1 = K.local_scalar("float32")
+                    squared_0 = K.local_scalar("float32")
+                    squared_1 = K.local_scalar("float32")
+                    multiply_pair(
+                        c_prob_0,
+                        c_prob_1,
+                        c_values[index],
+                        c_values[index + 1],
+                        prob_value,
+                        prob_value,
+                    )
+                    add_pair(
+                        doubled_0,
+                        doubled_1,
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                    )
+                    multiply_pair(
+                        d_values[index],
+                        d_values[index + 1],
+                        doubled_0,
+                        doubled_1,
+                        c_prob_0,
+                        c_prob_1,
+                    )
+                    multiply_pair(
+                        squared_0,
+                        squared_1,
+                        values[index],
+                        values[index + 1],
+                        values[index],
+                        values[index + 1],
+                    )
+                    multiply_pair(
+                        dprob_terms[index],
+                        dprob_terms[index + 1],
+                        squared_0,
+                        squared_1,
+                        c_values[index],
+                        c_values[index + 1],
+                    )
+
+                subtile_sum = K.local_scalar("float32", init=K.float32(0.0))
+                for index in range(31, -1, -1):
+                    K.ptx.add.f32(subtile_sum, subtile_sum, dprob_terms[index])
+                K.ptx.add.f32(dprob_value, dprob_value, subtile_sum)
+
+            def update_amax():
+                for index in range(32):
+                    K.ptx.abs.f32(absolute_values[index], d_values[index])
+                for index in range(10):
+                    K.ptx.max.NaN.f32(
+                        maxima[index],
+                        absolute_values[index * 3],
+                        absolute_values[index * 3 + 1],
+                        absolute_values[index * 3 + 2],
+                    )
+                K.ptx.max.NaN.f32(
+                    maxima[10], absolute_values[30], absolute_values[31], K.float32(0.0)
+                )
+                for index in range(3):
+                    K.ptx.max.NaN.f32(
+                        maxima[index],
+                        maxima[index * 3],
+                        maxima[index * 3 + 1],
+                        maxima[index * 3 + 2],
+                    )
+                K.ptx.max.NaN.f32(maxima[3], maxima[9], maxima[10], K.float32(0.0))
+                K.ptx.max.NaN.f32(maxima[0], maxima[0], maxima[1], maxima[2])
+                subtile_amax = K.local_scalar("float32")
+                K.ptx.max.NaN.f32(subtile_amax, maxima[0], maxima[3], K.float32(0.0))
+                K.ptx.max.f32(tile_amax, tile_amax, subtile_amax)
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                _wait_plain(acc_pipe.full.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(tile_amax, K.float32(0.0))
+                K.assign(dprob_value, K.float32(0.0))
+                K.assign(prob_value, K.float32(0.0))
+                global_row = tile_m_idx * cta_m + warp * 32 + lane
+                with K.If(global_row < M):
+                    with K.Then():
+                        prob_offset = batch_idx * (m_tiles * cta_m) + global_row
+                        K.ptx.ld.global_.b32(prob_value, prob.ptr_to([prob_offset]))
+
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    linear_subtile = executed_tiles * epilogue_subtiles + subtile
+                    d_stage = K.bitwise_and(linear_subtile, K.int32(1))
+                    load_accumulator(subtile)
+                    apply_alpha()
+                    _wait_plain(c_pipe.full.ptr_to([c_state.stage]), c_state.phase)
+                    load_c()
+                    apply_dsrelu_and_dprob()
+                    if with_amax:
+                        update_amax()
+
+                    pack_output(d_dtype, d_values, d_words, d_pairs, d_wide)
+                    stage_output(d_dtype, d_bits, d_words, d_wide, d_offsets, d_stage)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If(warp == 0):
+                        with K.Then():
+                            tma_store_d(d_stage, subtile)
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(d_stages - 1)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    K.assign(subtile, subtile + 1)
+
+                if with_amax:
+                    K.ptx.redux_sync.max.NaN.f32(warp_amax, tile_amax, K.uint32(0xFFFFFFFF))
+                    with K.If(lane == 0):
+                        with K.Then():
+                            K.ptx.st.shared.b32(smem.ptr_to([amax_offset + warp * 4]), warp_amax)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If((warp == 0) & (lane == 0)):
+                        with K.Then():
+                            block_amax = K.local_scalar("float32")
+                            next_amax = K.local_scalar("float32")
+                            K.ptx.ld.shared.b32(block_amax, smem.ptr_to([amax_offset]))
+                            K.ptx.max.f32(block_amax, block_amax, K.float32(0.0))
+                            for slot in range(1, 4):
+                                K.ptx.ld.shared.b32(
+                                    next_amax, smem.ptr_to([amax_offset + slot * 4])
+                                )
+                                K.ptx.max.f32(block_amax, block_amax, next_amax)
+                            atomic_old = K.local_scalar("int32")
+                            K.ptx.atom.global_.max.s32(
+                                atomic_old, amax.ptr_to([0]), K.reinterpret("int32", block_amax)
+                            )
+
+                with K.If(global_row < M):
+                    with K.Then():
+                        atomic_old = K.local_scalar("float32")
+                        K.ptx.atom.global_.add.f32(
+                            atomic_old, dprob.ptr_to([global_row * L + batch_idx]), dprob_value
+                        )
+
+                with K.If(_elected()):
+                    with K.Then():
+                        if cta_group == 2:
+                            K.ptx.mbarrier.arrive.shared__cluster.b64(
+                                acc_empty_leader.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                        else:
+                            K.ptx.mbarrier.arrive.shared.b64(
+                                acc_pipe.empty.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                _advance(acc_state)
+                K.assign(executed_tiles, executed_tiles + 1)
+                advance_work(work)
+
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx[
+                        "tcgen05.relinquish_alloc_permit.cta_group::"
+                        + str(cta_group)
+                        + ".sync.aligned"
+                    ]()
+            K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+            with K.If(warp == 0):
+                with K.Then():
+                    if cta_group == 2:
+                        remote_dealloc = K.local_scalar("uint32")
+                        K.ptx.mapa.shared__cluster.u32(
+                            remote_dealloc,
+                            K.cuda.cvta_generic_to_shared(tmem_dealloc.ptr_to([0])),
+                            K.cast(cluster_rank ^ 1, "uint32"),
+                        )
+                        K.ptx.mbarrier.arrive.shared__cluster.b64(remote_dealloc, K.uint32(1))
+                        _wait_plain(tmem_dealloc.ptr_to([0]), K.uint32(0))
+                    K.ptx["tcgen05.dealloc.cta_group::" + str(cta_group) + ".sync.aligned.b32"](
+                        tmem_base, K.uint32(tmem_columns)
+                    )
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+
+    kernel.__annotations__ = {
+        "a": K.gptr[K.u8, (M * K_dim * L * ab_bits // 8,)],
+        "b": K.gptr[K.u8, (N * K_dim * L * ab_bits // 8,)],
+        "sfa": K.gptr[K.u8, (L * _ceil_div(M, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "sfb": K.gptr[K.u8, (L * _ceil_div(N, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "c": K.gptr[K.u8, (M * N * L * c_bits // 8,)],
+        "d": K.gptr[K.u8, (M * N * L * d_bits // 8,)],
+        "prob": K.gptr[K.f32, (m_tiles * cta_m * L,)],
+        "dprob": K.gptr[K.f32, (M * L,)],
+        "amax": K.gptr[K.f32, (1,)],
+        "alpha": K.f32,
+    }
+    return K.kernel(
+        warps=7,
+        arch="sm_100a",
+        grid=[cluster_m, cluster_n, num_clusters],
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(
+    M,
+    N,
+    K,
+    L,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    c_dtype,
+    d_dtype,
+    a_major,
+    b_major,
+    c_major,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    vector_f32,
+    with_amax=True,
+    with_sfd=False,
+    alpha=None,
+):
+    del alpha
+    if with_sfd:
+        raise ValueError("the source SFD branch is not implemented")
+    return _make_kernel(
+        M,
+        N,
+        K,
+        L,
+        ab_dtype,
+        sf_dtype,
+        sf_vec_size,
+        c_dtype,
+        d_dtype,
+        a_major,
+        b_major,
+        c_major,
+        tuple(mma_tiler_mn),
+        tuple(cluster_shape_mn),
+        vector_f32,
+        with_amax,
+        with_sfd,
+    ).func
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _torch_dtype(torch, dtype):
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e5m2": torch.float8_e5m2,
+        "float8_e8m0fnu": torch.float8_e8m0fnu,
+    }[dtype]
+
+
+def _regular_tensor(torch, rows, columns, batch, dtype, first_major):
+    bits = _dtype_bits(dtype)
+    raw = torch.empty(rows * columns * batch * bits // 8, dtype=torch.uint8, device="cuda")
+    storage = raw.view(_torch_dtype(torch, dtype))
+    strides = (1, rows, rows * columns) if first_major else (columns, 1, rows * columns)
+    logical = torch.as_strided(storage, (rows, columns, batch), strides)
+    return raw, logical
+
+
+def _signed_row_factors(torch, rows, batch, offset):
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None]
+    batch_index = torch.arange(batch, device="cuda", dtype=torch.int64)[None, :]
+    selector = ((row // 32) + batch_index + offset) % 4
+    values = torch.tensor((-1.0, -0.5, 0.5, 1.0), dtype=torch.float32, device="cuda")
+    return values[selector]
+
+
+def _input_tensor(torch, rows, K_dim, batch, dtype, major, offset):
+    factors = _signed_row_factors(torch, rows, batch, offset)
+    if dtype == "float4_e2m1fn":
+        if K_dim % 2:
+            raise ValueError("packed FP4 K must be even")
+        codes = (factors.abs() * 2.0).to(torch.uint8)
+        codes = codes | ((factors < 0).to(torch.uint8) << 3)
+        packed = codes | (codes << 4)
+        physical = packed.transpose(0, 1)[:, :, None].expand(batch, rows, K_dim // 2).contiguous()
+        logical = physical.view(torch.float4_e2m1fn_x2).permute(1, 2, 0)
+        return {"raw": physical.reshape(-1), "source": logical, "factors": factors}
+    raw, logical = _regular_tensor(torch, rows, K_dim, batch, dtype, first_major=major != "k")
+    logical.copy_(factors[:, None, :].expand(rows, K_dim, batch).to(logical.dtype))
+    return {"raw": raw, "source": logical, "factors": factors}
+
+
+def _output_tensor(torch, rows, columns, batch, dtype, major):
+    raw, logical = _regular_tensor(torch, rows, columns, batch, dtype, first_major=major == "m")
+    logical.zero_()
+    return {"raw": raw, "source": logical}
+
+
+def _sf_storage(torch, rows, columns, batch, vec_size, dtype, fill):
+    shape = (batch, _ceil_div(rows, 128), _ceil_div(columns, 4 * vec_size), 32, 4, 4)
+    return torch.full(shape, fill, dtype=torch.float32, device="cuda").to(
+        _torch_dtype(torch, dtype)
+    )
+
+
+def _prob_storage(torch, rows, padded_rows, batch, a_major):
+    raw = torch.zeros(batch * padded_rows, dtype=torch.float32, device="cuda")
+    strides = (1, padded_rows, padded_rows) if a_major == "m" else (1, 1, padded_rows)
+    logical = torch.as_strided(raw, (rows, 1, batch), strides)
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None]
+    batch_index = torch.arange(batch, device="cuda", dtype=torch.int64)[None, :]
+    values = ((((row // 16) + batch_index) % 3).float() + 1.0) * 0.125
+    logical.copy_(values[:, None, :])
+    return {"raw": raw, "source": logical, "values": values}
+
+
+def _c_input_tensor(torch, rows, columns, batch, dtype, major):
+    raw, logical = _regular_tensor(torch, rows, columns, batch, dtype, first_major=major == "m")
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)[:, None, None]
+    column = torch.arange(columns, device="cuda", dtype=torch.int64)[None, :, None]
+    batch_index = torch.arange(batch, device="cuda", dtype=torch.int64)[None, None, :]
+    # Keep both signs and seven deterministic levels while leaving headroom for
+    # the source and target's different inter-CTA FP32 atomic reduction order.
+    values = (((row // 17 + column // 13 + batch_index) % 7).float() - 3.0) * 0.0625
+    logical.copy_(values.to(logical.dtype))
+    return {"raw": raw, "source": logical}
+
+
+def prepare_data(**config):
+    """Allocate deterministic signed inputs and independent target/source outputs."""
+    import math
+
+    import torch
+
+    config = _without_label(config)
+    M, N, K_dim, L = (config[key] for key in ("M", "N", "K", "L"))
+    sf_dtype = "float8_e8m0fnu" if config["sf_dtype"] == "int8" else config["sf_dtype"]
+    a_data = _input_tensor(torch, M, K_dim, L, config["ab_dtype"], config["a_major"], 0)
+    b_data = _input_tensor(torch, N, K_dim, L, config["ab_dtype"], config["b_major"], 1)
+
+    scale_exponent = math.ceil(math.log2(max(1.0, K_dim / 512.0)))
+    sfa = _sf_storage(torch, M, K_dim, L, config["sf_vec_size"], sf_dtype, 2.0 ** (-scale_exponent))
+    sfb = _sf_storage(torch, N, K_dim, L, config["sf_vec_size"], sf_dtype, 0.5)
+    c = _c_input_tensor(torch, M, N, L, config["c_dtype"], config["c_major"])
+    tirx_d = _output_tensor(torch, M, N, L, config["d_dtype"], config["c_major"])
+    source_d = _output_tensor(torch, M, N, L, config["d_dtype"], config["c_major"])
+
+    padded_m = _ceil_div(M, 128) * 128
+    prob = _prob_storage(torch, M, padded_m, L, config["a_major"])
+    tirx_dprob = torch.zeros((M, 1, L), dtype=torch.float32, device="cuda")
+    source_dprob = torch.zeros((M, 1, L), dtype=torch.float32, device="cuda")
+    tirx_amax = torch.full((1,), float("-inf"), dtype=torch.float32, device="cuda")
+    source_amax = torch.full((1,), float("-inf"), dtype=torch.float32, device="cuda")
+
+    return {
+        "a": a_data,
+        "b": b_data,
+        "sfa": sfa,
+        "sfb": sfb,
+        "c": c,
+        "prob": prob,
+        "tirx_d": tirx_d,
+        "source_d": source_d,
+        "tirx_dprob": tirx_dprob,
+        "source_dprob": source_dprob,
+        "tirx_amax": tirx_amax,
+        "source_amax": source_amax,
+    }
+
+
+def _load_reference_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module(
+        "cudnn.gemm.cutedsl.dense.dsrelu.dense_blockscaled_gemm_persistent_dsrelu_quant"
+    )
+
+
+def _compile_reference(data, config):
+    from tirx_kernels.cudnn._reference import import_cutlass_reference
+
+    cutlass = import_cutlass_reference()
+    import cutlass.cute as cute
+    import torch
+    from cuda.bindings import driver as cuda
+    from cutlass.cute.runtime import from_dlpack, make_fake_stream
+
+    module = _load_reference_source()
+    config = _without_label(config)
+    a = data["a"]["source"]
+    b = data["b"]["source"]
+    sfa = data["sfa"]
+    sfb = data["sfb"]
+    c = data["c"]["source"]
+    d = data["source_d"]["source"]
+    prob = data["prob"]["source"]
+    dprob = data["source_dprob"]
+    amax = data["source_amax"] if config["with_amax"] else None
+
+    torch.cuda.set_device(a.device)
+
+    def dynamic(tensor, leading_dim):
+        return from_dlpack(tensor, assumed_align=16).mark_layout_dynamic(leading_dim=leading_dim)
+
+    a_cute = dynamic(a, 0 if config["a_major"] == "m" else 1)
+    b_cute = dynamic(b, 0 if config["b_major"] == "n" else 1)
+    sfa_cute = from_dlpack(sfa, assumed_align=16)
+    sfb_cute = from_dlpack(sfb, assumed_align=16)
+    c_cute = dynamic(c, 0 if config["c_major"] == "m" else 1)
+    d_cute = dynamic(d, 0 if config["c_major"] == "m" else 1)
+    prob_cute = dynamic(prob, 0 if config["a_major"] == "m" else 1)
+    dprob_cute = from_dlpack(dprob, assumed_align=16)
+    amax_cute = from_dlpack(amax, assumed_align=16) if amax is not None else None
+
+    kernel = module.Sm100BlockScaledPersistentDenseGemmKernel(
+        sf_vec_size=config["sf_vec_size"],
+        mma_tiler_mn=tuple(config["mma_tiler_mn"]),
+        cluster_shape_mn=tuple(config["cluster_shape_mn"]),
+        vector_f32=config["vector_f32"],
+    )
+    cluster_size = config["cluster_shape_mn"][0] * config["cluster_shape_mn"][1]
+    max_active_clusters = cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size)
+
+    def epilogue_op(x, y):
+        return cute.where(x > 0, x, cute.full_like(x, 0)) * 2 * y
+
+    executable = cute.compile(
+        kernel,
+        a_tensor=a_cute,
+        b_tensor=b_cute,
+        sfa_tensor=sfa_cute,
+        sfb_tensor=sfb_cute,
+        c_tensor=c_cute,
+        d_tensor=d_cute,
+        prob_tensor=prob_cute,
+        dprob_tensor=dprob_cute,
+        amax_tensor=amax_cute,
+        sfd_tensor=None,
+        norm_const_tensor=None,
+        alpha=config["alpha"],
+        max_active_clusters=max_active_clusters,
+        stream=make_fake_stream(use_tvm_ffi_env_stream=False),
+        epilogue_op=epilogue_op,
+        options="--enable-tvm-ffi",
+    )
+    torch.cuda.set_device(a.device)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        executable(a, b, sfa, sfb, c, d, prob, dprob, amax, None, None, config["alpha"], stream)
+
+    launch._keep_alive = (executable, a, b, sfa, sfb, c, d, prob, dprob, amax, stream)
+    return launch
+
+
+def _tirx_launch(executable, data, alpha):
+    import torch
+
+    a = data["a"]["raw"]
+    b = data["b"]["raw"]
+    sfa = data["sfa"].view(torch.uint8).reshape(-1)
+    sfb = data["sfb"].view(torch.uint8).reshape(-1)
+    c = data["c"]["raw"]
+    d = data["tirx_d"]["raw"]
+    prob = data["prob"]["raw"]
+    dprob = data["tirx_dprob"].reshape(-1)
+    amax = data["tirx_amax"]
+
+    def launch():
+        executable(a, b, sfa, sfb, c, d, prob, dprob, amax, alpha)
+
+    launch._keep_alive = (a, b, sfa, sfb, c, d, prob, dprob, amax)
+    return launch
+
+
+def _reset_outputs(data, prefix):
+    data[f"{prefix}_d"]["source"].zero_()
+    data[f"{prefix}_dprob"].zero_()
+    data[f"{prefix}_amax"].fill_(float("-inf"))
+
+
+def _assert_close(torch, actual, expected, *, atol, rtol, label):
+    actual_f32 = actual.float()
+    expected_f32 = expected.float()
+    if actual_f32.shape != expected_f32.shape:
+        raise AssertionError(f"{label} shape mismatch: {actual_f32.shape} != {expected_f32.shape}")
+    close = torch.isclose(actual_f32, expected_f32, atol=atol, rtol=rtol)
+    if bool(torch.all(close).item()):
+        return
+    absolute_error = torch.abs(actual_f32 - expected_f32)
+    allowed_error = atol + rtol * torch.abs(expected_f32)
+    excess = absolute_error - allowed_error
+    worst_index = int(torch.argmax(excess).item())
+    raise AssertionError(
+        f"{label} mismatch: value={float(actual_f32.reshape(-1)[worst_index].item())}, "
+        f"expected={float(expected_f32.reshape(-1)[worst_index].item())}, "
+        f"absolute_error={float(absolute_error.reshape(-1)[worst_index].item())}"
+    )
+
+
+# Exact tolerances used by the pinned dense dSReLU source test.
+_LOW_PRECISION_TOLERANCE = (0.12, 0.02)
+_FP32_TOLERANCE = (0.12, 0.02)
+
+
+def _validate_outputs(data, config, *, with_source):
+    """Hold D, dprob, and enabled amax to the pinned source on identical bytes."""
+    if not with_source:
+        return
+    import torch
+
+    d_atol, d_rtol = _FP32_TOLERANCE if config["d_dtype"] == "float32" else _LOW_PRECISION_TOLERANCE
+    _assert_close(
+        torch,
+        data["tirx_d"]["source"],
+        data["source_d"]["source"],
+        atol=d_atol,
+        rtol=d_rtol,
+        label="TIRx D versus pinned source",
+    )
+    _assert_close(
+        torch,
+        data["tirx_dprob"],
+        data["source_dprob"],
+        atol=_FP32_TOLERANCE[0],
+        rtol=_FP32_TOLERANCE[1],
+        label="TIRx dprob versus pinned source",
+    )
+    if config["with_amax"]:
+        _assert_close(
+            torch,
+            data["tirx_amax"],
+            data["source_amax"],
+            atol=_FP32_TOLERANCE[0],
+            rtol=_FP32_TOLERANCE[1],
+            label="TIRx amax versus pinned source",
+        )
+
+
+def run_test(**config):
+    """Compare TIRx with the cuDNN Frontend kernel on identical inputs."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executable = compile_kernel(get_kernel(**kernel_config))
+    tirx_launch = _tirx_launch(executable, data, kernel_config["alpha"])
+    source_launch = _compile_reference(data, kernel_config)
+    _reset_outputs(data, "tirx")
+    tirx_launch()
+    _reset_outputs(data, "source")
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, kernel_config, with_source=True)
+    return {"amax": float(data["source_amax"].item())}
+
+
+def prepare_bench(**config):
+    """Compile TIRx before entering the GPU benchmark child."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {"config": kernel_config, "executable": compile_kernel(get_kernel(**kernel_config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then time closures containing exactly one kernel launch."""
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = {**prepared["config"], **kwargs}
+    kernel_config = _without_label(config)
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**kernel_config)
+        tirx_launch = _tirx_launch(prepared["executable"], data, kernel_config["alpha"])
+        gpu_state = {
+            "data": data,
+            "tirx_launch": tirx_launch,
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    source_launch = gpu_state["source_launch"]
+    if not gpu_state["validated"]:
+        _reset_outputs(data, "tirx")
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                if source_launch is None:
+                    source_launch = _compile_reference(data, kernel_config)
+                    gpu_state["source_launch"] = source_launch
+                _reset_outputs(data, "source")
+                source_launch()
+                torch.cuda.synchronize()
+        _validate_outputs(data, kernel_config, with_source=with_source)
+        gpu_state["validated"] = True
+    references = {"cudnn_frontend": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- Port the cuDNN Frontend SM100 persistent dense block-scaled GEMM dSReLU quant kernel to the pure K API.
- Add deterministic correctness and benchmark configurations, the canonical implementation sketch, package exports, and README registration.
- Record the measured epilogue warpgroup register-budget result in the codegen-tuning database.

The source implementation is pinned to NVIDIA/cudnn-frontend commit aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.

## Validation

- python -m tirx_kernels.bench_suite --check-imports
- python tests/lint/check_license_headers.py
- python tests/lint/check_license_headers.py --self-test
- pre-commit run --files <changed files>
- 35/35 correctness configurations passed against the pinned source reference.
- memcheck and synccheck completed with zero errors on the anchor, CTA1, CTA2, and tail guards.
- The low-level IR contract passed for all configurations with no function calls.
- The complete 28-row reference performance matrix passed strictly above 0.99x; the final minimum ratio was 0.993190x.