### PR TITLE
feat(kernel): port cudnn-frontend gdn_prefill_f16 for sm100

### DIFF
--- a/.agents/sketch/cudnn/sm100_gdn_prefill_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn_prefill_f16.md
@@ -1,0 +1,1179 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 GDN (v1) FP16/BF16 prefill: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch, not Python, a builder API, a new IR,
+or a mathematical reference.  It freezes the source program before device-code
+transcription.  The implementation it describes belongs in
+[`tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py`](../../../tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py).
+
+The frozen source is the standalone `chunk_gdn_sm100` two-launch entry at the
+commit above.  The main anchor is BF16 I/O, FP32 state, final-state enabled,
+`BT=64`, `DK=DV=128`, one CTA per cluster, 384 main threads (12 warps), 1024
+prologue threads, four interleaved K+Q stages, two V stages, three T-inverse
+stages, three A stages, one O stage, three gate/cumprod/beta stages, two
+scheduler stages, 512 TMEM columns, and 232448 bytes of main dynamic shared
+memory.  Checkpoint specializations trim K+Q to three stages and append one
+32768-byte checkpoint staging buffer at the same total.
+
+The accepted capability set is the set the source entry dispatches: BF16 and
+FP16 I/O; FP32 or BF16 state; absent/present initial state; absent/present
+final state; checkpoint cadence 64, 128, or 192 (plus zero for disabled) — a
+positive multiple of the 64-token chunk; grouped Q/K/V heads under
+`HO = max(HQ, HV)` with `k_heads` equal to `q_heads` or `v_heads`;
+ragged/tail/zero-length sequences; gate interpretations raw-alpha,
+natural-log (`log_gate`, the engine's production path), and safe gate with
+per-head `a_log`/`dt_bias`; beta post-sigmoid FP32 or IO-dtype logits with
+in-kernel sigmoid (`use_beta_sigmoid`); static grid-stride or dynamic ticket
+scheduler; generated uncut or caller-staged/sorted work items; i32 or i64
+cumulative sequence lengths; and overlap-recompute split work rows.  Q/K L2
+normalization is NOT part of this kernel: the source engine runs it as a
+separate pre-kernel and the production gdn benchmark runs unfused.
+
+Writer line-info evidence is in `.porting/gdn_prefill_f16/source_export/`:
+`dump_nostate/` holds the BF16 basic anchor (`cutlass_host_GdnCfg...sm_100a.ptx`,
+2652 `.loc` sites, and `cutlass_prologue_...sm_100a.ptx`), `dump_state/` the
+checkpoint + initial-state specialization.  PTX line evidence below refers to
+the nostate anchor unless a branch profile is named.
+
+## Pipeline at a glance
+
+| Warps | Registers | Source-order role | Principal publications |
+| --- | ---: | --- | --- |
+| 0..3 | 224 | CG0 chunk-pair owner: per-pair T-pairwise decay fragments, KK epilogue into the T-inverse buffer, four-level hierarchical pair inverse (8→16→32→64), post-inverse beta column scaling, causal A epilogue | t_inv-ready, a-ready, cg0-acc-done, gate/beta-done |
+| 4..7 | 256 (232 without initial state) | CG1 state owner: initial-state TMEM seed, state repack FP32→IO, checkpoint snapshot, state rescale by chunk cumprod, per-row gate registers, `Y = V − cumprod·(K·S)`, Q·S scale, U repack + decayed-U, O TMEM→SMEM, final-state TMEM→GMEM | state-inp/y-inp/u-inp/decay-u-inp, state-scale-done, o-ready, checkpoint-ready, tmem-done |
+| 8 | 24 (48 w/o initial state) | gate/beta producer: predicated gate loads, log2 transform (raw/log/safe), warp prefix scan → cumsum-log and cumprod SMEM rings, beta cp.async or in-register sigmoid | gate-ready, beta-ready |
+| 9 | 24 (48) | TMA-LDG: per-batch descriptor acquire, interleaved K+Q tile and one-behind V tile TensorMap loads, dynamic-ticket producer | kq-ready (expect-tx), v-ready (expect-tx), sched-ready |
+| 10 | 24 (48) | sole tcgen05 issuer: TMEM alloc/dealloc, fused KK/QK pairs with member-parity lookahead, K·S, Q·S, U, O, state-update chains | cg0/state/o/k-state/u-acc-ready, t_inv/a/kq-done |
+| 11 | 24 (48) | epilogue: one-behind O TensorMap stores and state-checkpoint TensorMap stores | o-done, checkpoint-done |
+
+Dispatch order is exactly source order: warps 0..3, warps 4..7, warp 8,
+warp 10, warp 9, then warp 11.  Every role owns independent pipeline cursors
+that start once per kernel, advance per acquired stage, and are not reset at
+work-item boundaries.  Chunks execute in PAIRS on CG0: warps 0..1 invert the
+pair's member-0 matrix while warps 2..3 invert member 1; an odd tail pair runs
+member 0 only with warps 2..3 idling through the per-warp inverse steps while
+still arriving every group barrier.
+
+## Primitive vocabulary and translation boundary
+
+All storage is one-dimensional.  Names that look like matrices below are only
+logical comments on integer offsets and strides; they are never layout values,
+views, tiles, fragments, or first-class descriptors.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(arena, base, stage, row, col,
+          stage_bytes, row_bytes, elem_bytes, xor128)  # col ^ ((row&7)*8) elems
+tmem_cell(base, row, column)       # base + column + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch)  # (array*B+batch)*128 bytes
+smem_matrix_desc(base_byte, lead_bytes, stride_bytes, swizzle128)  # tcgen05 B/A operand
+```
+
+Directional movements are only `copy_p2g`, `copy_g2s`, `copy_s2g`,
+`copy_g2r`, `copy_r2g`, `copy_s2r`, `copy_r2s`, `copy_t2r`, and `copy_r2t`.
+Computations are only `fill`, `cast`, `add`, `sub`, `mul`, `fma`, `min`,
+`max`, `select`, `exp2`, `log2`, `tanh`, `rcp`, `shuffle`, and `gemm`.
+Barrier init/wait/arrive/expect-tx, commit, fence, synchronization, cursor
+advancement, register-budget changes, TensorMap replacement, and TMEM lifetime
+operations are scheduling actions rather than computation primitives.
+
+The implementation may import device language only as
+`import tirx_kernels.kern as K`.  It may not use `T`, `Tx`, `I`,
+`tirx.tile.*`, a categorized tile primitive, `TilePrimitiveCall`, any
+first-class layout, or rank>1 SMEM.  The single rank-1 `u8` arena is the only
+shared-memory declaration.  `K.smem_pool(base=arena)` allocates only the
+protocol/header prefix; all payload mappings use integer byte arithmetic and
+raw SMEM/TMEM descriptors.
+
+## Complete non-executable sketch
+
+```python
+@specialize(
+    IO_DTYPE={"bf16", "f16"}, STATE_DTYPE={"f32", "bf16"}, ACC_DTYPE="f32",
+    BT=64, DK=128, DV=128,
+    KQ_STAGES=(3 if CHECKPOINTS else 4), V_STAGES=2,
+    TINV_STAGES=3, A_STAGES=3, O_STAGES=1,
+    GATE_STAGES=3, BETA_STAGES=3, CHECKPOINT_STAGES=1,
+    STATE_ACC_STAGES=1, QSTATE_ACC_STAGES=1, STATE_INP_STAGES=1,
+    CG0_ACC_STAGES=2, CG1_ACC_STAGES=1, SCHED_STAGES=2,
+    CLUSTER=(1,1,1),
+    REGS=(224, 256 if USE_INITIAL_STATE else 232,
+          24 if USE_INITIAL_STATE else 48),
+)
+def gdn_prefill_factory(...):
+    return descriptor_order_prologue, persistent_gdn
+
+# ========================================================================
+# Launch 1: source-order work table and five TensorMap descriptor arrays
+# ========================================================================
+
+@kernel(grid=(1,1,1), block=(1024,1,1), warps=32, target="sm_100a")
+def descriptor_order_prologue(
+    base_q, base_k, base_v, base_o, base_checkpoint,
+    descriptor_workspace, cu_seqlens,
+    q, k, v, o, checkpoints_or_dummy,
+    staging_items_or_dummy, work_count, work_items,
+    sched_counter_or_dummy, batch_count,
+    q_row_stride, k_row_stride, v_row_stride,
+    o_row_stride, checkpoint_row_stride, checkpoint_every_n_tokens,
+):
+    tid = thread_id()
+    warp = tid // 32
+
+    # One rank-1 u8 arena: two 4096-i32 order regions plus a two-i32 spread
+    # region; descriptor building needs no SMEM payload.
+    arena = linear_buffer("smem", "u8", 32776, 0, 16, "whole launch")
+    order_key = integer_region(arena, 0, 4096, "i32")
+    order_idx = integer_region(arena, 16384, 4096, "i32")
+    order_spread = integer_region(arena, 32768, 2, "i32")
+
+    if tid == 0 and HAS_DYNAMIC_SCHEDULER:
+        copy_r2g(i32(0), sched_counter[0])
+        # instruction_selection: st.global.u32; extent: one scalar
+
+    # Source LPT order pass (common/split_k.py order_body): generate uncut
+    # rows (batch*HO, chunk-span key from cu_seqlens) or copy caller-staged
+    # rows; above 4096 items copy through unsorted; otherwise spread-detect
+    # via shared atomics and stable bitonic sort descending by span, then
+    # write every eight-i32 row.
+    n = batch_count * HO if GENERATE_UNCUT else copy_g2r(work_count[0])
+    if GENERATE_UNCUT and tid == 0:
+        copy_r2g(n, work_count[0])
+    if n > 4096:
+        for item in range(tid, n, 1024):
+            row = generate_or_load_eight_fields(item)
+            copy_r2g(row, work_items[item,0:8])
+            # instruction_selection: generated rows use two st.global.v4.b32;
+            # scratch rows use eight ld.global.b32 + eight st.global.b32
+    else:
+        if tid == 0:
+            copy_r2s(i32_max, order_spread[0]); copy_r2s(i32_min, order_spread[1])
+        padded_count = next_power_of_two(n)
+        barrier(0,1024)
+        local_min, local_max = i32_max, i32_min
+        for element in range(4):
+            item = tid + element*1024
+            if item < padded_count:
+                key = i32_min
+                if item < n:
+                    row = generate_or_load_eight_fields(item)
+                    key = row_chunk_span(row)
+                    local_min = min(local_min,key); local_max = max(local_max,key)
+                copy_r2s(key, order_key[item]); copy_r2s(item, order_idx[item])
+        shared_atomic_min(order_spread[0], local_min)
+        shared_atomic_max(order_spread[1], local_max)
+        # instruction_selection: atom.shared::cta.min/max.s32; extent: one
+        # pair per thread after four local items
+        barrier(0,1024)
+        stable_lpt_bitonic_sort(order_key, order_idx, n, order_spread)
+        barrier(0,1024)
+        for rank in range(tid, n, 1024):
+            source = copy_s2r(order_idx[rank])
+            row = generate_or_load_eight_fields(source)
+            copy_r2g(row, work_items[rank,0:8])
+            # instruction_selection: two st.global.v4.b32 generated rows /
+            # eight scalar load-store scratch rows
+
+    # Exactly one descriptor array belongs to each warp 0..4.  Its elected
+    # lane walks all batches serially.  Slots are Q,K,V,O,Checkpoint in that
+    # exact warp/array order; warp 4 is compile-time inactive without
+    # checkpoints.  Q/K/V/O base maps carry (channel, head, token) with the
+    # token axis at TMA ordinal 2; the checkpoint map carries
+    # (dv, dk, checkpoint, head) with the checkpoint count at ordinal 2.
+    base_maps = (base_q, base_k, base_v, base_o, base_checkpoint)
+    checkpoint_prefix = 0
+    if warp < 5 and elected_lane() and (warp < 4 or CHECKPOINTS):
+        array = warp
+        for batch in range(batch_count):
+            bos = copy_g2r(cu_seqlens[batch])
+            eos = copy_g2r(cu_seqlens[batch+1])
+            length = eos - bos
+            dst = descriptor_slot(descriptor_workspace, array, batch)
+            copy_p2g(base_maps[array], dst)
+            # instruction_selection: sixteen b64 copies of the 128-byte base
+            # descriptor per slot
+            if array == 4:
+                count = 0 if length == 0 else (length-1)//checkpoint_every_n_tokens + 1
+                replace_global_address(dst,
+                    checkpoints_base + checkpoint_prefix*checkpoint_row_stride)
+                replace_global_dim(dst, ordinal=2, count)
+                checkpoint_prefix += count
+            else:
+                replace_global_address(dst, tensor_base(array) + bos*row_stride(array))
+                replace_global_dim(dst, ordinal=2, length)
+            # instruction_selection: tensormap.replace.tile.global_address /
+            # .global_dim per slot
+        fence("tensormap_generic_release_gpu")
+        # instruction_selection: fence.proxy.tensormap::generic.release.gpu
+
+# ========================================================================
+# Launch 2 ABI, scalar maps, arena and protocol
+# ========================================================================
+
+@kernel(grid=(num_sms,1,1), block=(384,1,1), warps=12,
+        cluster=(1,1,1), min_blocks_per_sm=1, target="sm_100a")
+def persistent_gdn(
+    descriptor_workspace, n_desc,
+    q, k, v, gate, a_log_or_dummy, dt_bias_or_dummy, beta,
+    cu_seqlens, initial_state_or_dummy, o, final_state_or_dummy,
+    work_items, work_count, sched_counter_or_dummy,
+    scale, checkpoint_every_n_tokens,
+):
+    tid = thread_id()
+    warp = warp_uniform(tid // 32)
+    lane = tid & 31
+    cta = block_id_x()
+    grid_x = grid_dim_x()
+    total_tiles = copy_g2r(work_count[0])
+
+    def decode_work(tile):
+        # fields: batch, head, wstart, wend, cstart, cend, bos, eos;
+        # num_chunks_b = ceil_div(eos-bos, 64).  An item computes chunks
+        # [cstart, wend) and writes O/checkpoints only for [wstart, wend).
+        row = copy_g2r(work_items[tile,0:8])
+        return row_with_derived_fields(row)
+        # instruction_selection: role-projected work-row decode, normally
+        # ld.global.v4.b32 plus required scalar loads; it is intentionally
+        # not asserted as two full-vector loads
+
+    def input_head(head, ratio):
+        return head if ratio == 1 else head // ratio
+
+    def descriptor(array, batch):
+        return descriptor_slot(descriptor_workspace, array, batch)
+
+    # One rank-1 u8 declaration, 232448 bytes, 1024-byte aligned.  The first
+    # 3072 bytes are the protocol header plus the three FP32 gate rings; the
+    # payloads follow at 1024-aligned bases.  Checkpoint mode drops one K+Q
+    # stage and inserts the checkpoint staging buffer after O at the same
+    # total footprint.
+    arena = linear_buffer("smem", "u8", 232448, 0, 1024, "whole launch")
+
+    BARRIER_BASE = 0          # 60 x 8-byte mbarriers, declaration-ordered
+    TMEM_MAILBOX = 480        # tcgen05.alloc result, one i32
+    SCHED_BASE = 496          # dynamic-ticket ring, SCHED_STAGES x i32
+    CUMSUMLOG_BASE = 512      # f32 [64 x 3 stages]
+    CUMPROD_BASE = 1280       # f32 [64 x 3 stages]
+    BETA_BASE = 2048          # f32 [64 x 3 stages]
+    O_BASE = 3072             # IO [64 x 128], 1 stage, 16384 B
+    CHECKPOINT_BASE = 19456   # checkpoint mode only: IO [128 x 128], 32768 B
+    KQ_BASE = 19456 + (32768 if CHECKPOINTS else 0)
+                              # IO [2 x 64 x 128] x KQ_STAGES (32768 B/stage)
+    TINV_BASE = KQ_BASE + KQ_STAGES*32768        # IO [64 x 64] x 3, 8192 B/stage
+    A_BASE = TINV_BASE + 3*8192                  # IO [64 x 64] x 3
+    V_BASE = A_BASE + 3*8192                     # IO [64 x 128] x 2, 16384 B/stage
+    # nostate: KQ 19456, TINV 150528, A 175104, V 199680, end 232448.
+
+    # Every IO payload tile is stored 128-byte XOR-swizzled:
+    # phys_col_elems = col ^ ((row & 7) * 8) within each 64-element row
+    # segment; tcgen05 operand descriptors carry lead 16 bytes, stride 1024
+    # bytes, swizzle-128B.  The K^T view of the same K+Q bytes uses lead
+    # 16384 bytes for the state-update GEMM.
+
+    # Protocol table, declaration-ordered physical mbarriers.  Each tuple is
+    # (name, ready, done-or-None, ready stages, done stages,
+    #  ready arrivals, done arrivals).
+    PROTOCOL = (
+      ("kq",           0,  32, KQ_STAGES,KQ_STAGES, 1,1),     # TMA expect-tx / MMA commit
+      ("v",           64,  80, 2,2,   1,128),                 # TMA expect-tx / CG1 threads
+      ("gate",        96, 120, 3,3,  32,256),                 # warp 8 / CG0+CG1
+      ("beta",       144, 168, 3,3,  32,128),                 # warp 8 (cp.async) / CG0
+      ("state_acc",  192, 200, 1,1,   1,128),                 # MMA commit / CG1 scale-done
+      ("o_acc",      208,None, 1,0,   1,None),                # MMA commit (Q*state)
+      ("o_final_acc",216,None, 1,0,   1,None),                # MMA commit (O)
+      ("o_scale_done",224,None,1,0, 128,None),                # CG1 Q*state scale done
+      ("cg0_acc",    232, 248, 2,2,   1,64),                  # MMA commit / half-CG0
+      ("state_inp",  264,None, 1,0, 128,None),                # CG1 packed state
+      ("y_inp",      272,None, 1,0, 128,None),                # CG1 packed Y
+      ("u_inp",      280,None, 1,0, 128,None),                # CG1 packed U
+      ("decay_u_inp",288,None, 1,0, 128,None),                # CG1 packed decayed U
+      ("t_inv",      296, 320, 3,3, 128,1),                   # CG0 / MMA commit
+      ("a",          344, 368, 3,3,  64,1),                   # half-CG0 / MMA commit
+      ("k_state_acc",392,None, 1,0,   1,None),                # MMA commit
+      ("u_acc",      400,None, 1,0,   1,None),                # MMA commit
+      ("o_stage",    408, 416, 1,1, 128,32),                  # CG1 / epilogue warp
+      ("checkpoint", 424, 432, 1,1,   4,32),                  # CG1 warp-elects / epilogue
+      ("tmem_done",  440,None, 1,0, 128,None),                # CG1 -> MMA dealloc
+      ("sched",      448, 464, 2,2,   1,11),                  # warp 9 / 11 consumers
+    )
+
+    pool = smem_pool(base=arena)   # allocates only the header prefix
+    for edge in PROTOCOL:
+        allocate_edge_from_pool(edge)
+
+    # All 60 physical barriers are initialized before the init fence; the
+    # port distributes the init sites across the producer-owning warps.
+    init_protocol_edges(PROTOCOL)
+    # instruction_selection: mbarrier.init.shared.b64; extent: 60 sites
+    fence("mbarrier_init_release_cluster")
+    barrier(0,384)
+    # instruction_selection: fence.mbarrier_init.release.cluster; bar.sync 0
+
+    # TMEM columns (512 total).  Packed IO regions hold two elements per
+    # 32-bit cell; accumulators are FP32.  All row bases are warp-relative
+    # tmem_cell(base, warp_row, col) = base + col + (warp_row << 16).
+    STATE_ACC = 0        # S^T accumulator, 128 rows x cols 0..127
+    QSTATE_ACC = 128     # (Q*S)^T then O^T accumulator, cols 128..191
+    STATE_INP = 192      # packed IO S^T staging (GEMM 3/4 A), cols 192..255
+    CG0_ACC = 256        # fused KK/QK ring, 2 stages x 64, cols 256..383
+    CG1_ACC = 384        # (K*S)^T then U^T accumulator, cols 384..447
+    YU_INP = 448         # packed Y then U (GEMM 5/6 A), cols 448..479
+    DECAY_U_INP = 480    # packed decayed U (GEMM 7 A), cols 480..511
+
+    def wait_edge(name, stage, phase):
+        wait(protocol_ptr(name, stage), phase)
+        # instruction_selection:
+        # mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 in a retry loop
+
+    def arrive_edge(name, stage=0):
+        arrive(protocol_ptr(name, stage))
+        # instruction_selection: mbarrier.arrive.shared.b64
+
+    def expect_edge(name, stage, nbytes):
+        expect_bytes(protocol_ptr(name, stage), nbytes)
+        # instruction_selection: mbarrier.arrive.expect_tx.shared.b64
+
+    def commit_edge(name, stage=0):
+        commit(protocol_ptr(name, stage))
+        # instruction_selection:
+        # tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
+
+    def scheduler_publish(cursor, tile):      # warp 9 side
+        if DYNAMIC:
+            wait_edge("sched_done", cursor.stage, cursor.phase)
+            if elected_lane():
+                ticket = atomic_add(sched_counter[0], 1, scope="gpu", order="relaxed")
+                copy_r2s(grid_x + ticket, arena[SCHED_BASE + 4*cursor.stage])
+                # instruction_selection: atom.global.add.s32 (relaxed, gpu)
+            warp_sync()
+            next_tile = copy_s2r(arena[SCHED_BASE + 4*cursor.stage])
+            if elected_lane(): arrive_edge("sched", cursor.stage)
+            return next_tile, advance(cursor)
+        return tile + grid_x, cursor
+
+    def scheduler_consume(cursor, tile):      # all consumer roles
+        if DYNAMIC:
+            wait_edge("sched", cursor.stage, cursor.phase)
+            next_tile = copy_s2r(arena[SCHED_BASE + 4*cursor.stage])
+            if elected_lane(): arrive_edge("sched_done", cursor.stage)
+            return next_tile, advance(cursor)
+        return tile + grid_x, cursor
+
+    # ====================================================================
+    # Warps 0..3 (CG0): T-pairwise, KK epilogue, pair inverse, A epilogue
+    # ====================================================================
+    if 0 <= warp <= 3:
+        set_register_budget("increase", 224)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32
+        barrier(1, 288)      # TMEM-alloc rendezvous with warps 4..7 and 10
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        gate_cur = consumer_cursor(GATE_STAGES, phase=0)
+        beta_cur = consumer_cursor(BETA_STAGES, phase=0)
+        cg0_cur = consumer_cursor(CG0_ACC_STAGES, phase=0)
+        tinv_cur = producer_cursor(TINV_STAGES, phase=1)
+        a_cur = producer_cursor(A_STAGES, phase=1)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        pair_half = warp // 2          # warps 0..1 = member 0, 2..3 = member 1
+        inv_warp = warp % 2
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            for pair in range(ceil_div(n_local, 2)):
+                # An odd chunk count leaves the last pair with member 0 only;
+                # have_m1 is uniform across CG0 so shared barriers stay aligned.
+                have_m1 = pair*2 + 1 < n_local
+                do_kk = have_m1 or pair_half == 0
+                do_a  = have_m1 or pair_half == 1
+
+                # -- T-pairwise decay fragments for both members ----------
+                # Acquire gate stage 0 (and stage 1 when the pair has two
+                # members); this warp's KK member is stage pair_half, its A
+                # member the opposite one.
+                g0 = acquire(gate_cur); g1 = acquire(gate_cur) if have_m1 else g0
+                wait_edge("gate", g0.stage, g0.phase)
+                if have_m1: wait_edge("gate", g1.stage, g1.phase)
+                kk_g, a_g = (g1, g0) if pair_half == 1 else (g0, g1)
+                # Per accumulator fragment cell (i,j):
+                #   decay[i,j] = exp2(cumsumlog[i] - cumsumlog[j]) if i>=j else 0
+                # built from 4 row reads + 16 column reads of the cumsum ring
+                # for each member; 64 FP32 values per member per thread pair
+                # of chunk = 128 registers.
+                decay_kk = [exp2(sub(cumsumlog_row(kk_g,i), cumsumlog_col(kk_g,j)))
+                            if lower(i,j) else opaque_zero() for (i,j) in acc_frag()]
+                decay_a  = [exp2(sub(cumsumlog_row(a_g,i), cumsumlog_col(a_g,j)))
+                            if lower(i,j) else opaque_zero() for (i,j) in acc_frag()]
+                # instruction_selection: ld.shared.b32 pairs, sub.f32,
+                # ex2.approx.ftz.f32, selp.f32 against an opaque zero;
+                # extent: 128 fused cells per thread
+                arrive_edge("gate_done", g0); arrive_edge("gate_done", g1) if have_m1
+
+                b0 = acquire(beta_cur); b1 = acquire(beta_cur) if have_m1 else b0
+                wait_edge("beta", b0.stage, b0.phase)
+                if have_m1: wait_edge("beta", b1.stage, b1.phase)
+                kk_b = (b1 if pair_half == 1 else b0)
+                kk_beta_rows = copy_s2r(beta_ring_rows(kk_b))
+
+                # -- KK epilogue into the T-inverse buffer ----------------
+                kk_acc = acquire(cg0_cur); a_acc = acquire(cg0_cur) if have_m1 else kk_acc
+                if pair_half == 1: kk_acc, a_acc = a_acc, kk_acc
+                t0 = acquire(tinv_cur); t1 = acquire(tinv_cur) if have_m1 else t0
+                kk_t = (t1 if pair_half == 1 else t0)
+                if do_kk:
+                    wait_edge("cg0_acc", kk_acc.stage, kk_acc.phase)
+                    kk = copy_t2r(tmem_cell(tmem, warp*32, CG0_ACC + kk_acc.stage*64))
+                    # instruction_selection: tcgen05.ld.sync.aligned.16x256b.x8.b32;
+                    # extent: two 16-row halves per warp
+                    wait_edge("t_inv_done", kk_t.stage, kk_t.phase)
+                    m = cast(IO_DTYPE, mul(mul(kk, decay_kk), kk_beta_rows))
+                    # instruction_selection: packed mul.f32 pairs +
+                    # cvt.rn.{bf16x2|f16x2}.f32
+                    copy_r2s(m, smem_byte(arena, TINV_BASE, kk_t.stage,
+                                          row=member_row(warp,lane),
+                                          col=xor128, elem_bytes=2))
+                    # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16;
+                    # extent: 4 fragments x 2 halves
+
+                # -- four-level hierarchical pair inverse -----------------
+                # Warps 0..1 own matrix 0, warps 2..3 matrix 1; without
+                # member 1 all four warps take matrix 0 and the duplicate
+                # band is identical.  Diagonal cells become I via lane
+                # identity injection; result overwrites the same buffer.
+                barrier(2, 128)
+                if have_m1 or warp < 2:
+                    gauss_jordan_8x8(arena, my_tinv_base, d=(inv_warp*32+lane)//8)
+                    # instruction_selection: 1 x ld.shared.v4.b32 8-element
+                    # IO-pair row load, shfl.sync.idx.b32 with clustered
+                    # member mask, rcp-free scaled row elimination in f32,
+                    # 1 x st.shared.v4.b32 row store
+                barrier(2, 128)
+                blockwise_8_to_16(arena, t0.base, d0=warp*16, lane)
+                if have_m1: blockwise_8_to_16(arena, t1.base, d0=warp*16, lane)
+                # instruction_selection per call: 3 x ldmatrix.sync.aligned
+                # .m8n8.x1{,.trans}.shared.b16, 2 x mma.sync.aligned
+                # .m16n8k8.row.col.f32.{bf16|f16}.f32, neg.f32, packed cvt,
+                # 1 x stmatrix.m8n8.x1
+                barrier(2, 128)
+                if have_m1 or warp < 2:
+                    blockwise_16_to_32(arena, my_tinv_base, d0=inv_warp*32, lane)
+                    # instruction_selection: 3 x ldmatrix.x4, 4 x mma.sync
+                    # .m16n8k16, packed cvt, 1 x stmatrix.x4
+                barrier(2, 128)
+                blockwise_32_to_64(arena, my_tail_base, band=inv_warp, lane)
+                # instruction_selection: 10 x ldmatrix.x4, 16 x mma.sync
+                # .m16n8k16, packed cvt, barrier(2,128), 2 x stmatrix.x4
+                barrier(2, 128)
+
+                # -- post-inverse beta column scaling + publish -----------
+                # T_inv[:, j] *= beta[j] for member 0 then member 1:
+                # ldmatrix the finished inverse, multiply by the beta ring
+                # columns, store back, fence, publish.
+                for (t, b) in ((t0, b0),) + (((t1, b1),) if have_m1 else ()):
+                    frag = copy_s2r(smem_byte(arena, TINV_BASE, t.stage, xor128))
+                    # instruction_selection: ldmatrix.m8n8.x4.shared.b16 x4
+                    scaled = cast(IO_DTYPE, mul(cast("f32",frag), beta_cols(b)))
+                    copy_r2s(scaled, smem_byte(arena, TINV_BASE, t.stage, xor128))
+                    # instruction_selection: stmatrix.m8n8.x4 x4
+                    fence("async_shared_cta")
+                    arrive_edge("t_inv", t.stage)
+                    arrive_edge("beta_done", b)
+
+                # -- causal A epilogue (opposite member) ------------------
+                a0 = acquire(a_cur); a1 = acquire(a_cur) if have_m1 else a0
+                my_a = (a0 if pair_half == 1 else a1)
+                if do_a:
+                    av = copy_t2r(tmem_cell(tmem, warp*32, CG0_ACC + a_acc.stage*64))
+                    # instruction_selection: tcgen05.ld.16x256b.x8 x2 halves
+                    wait_tmem_load()
+                    # instruction_selection: tcgen05.wait::ld.sync.aligned
+                    arrive_edge("cg0_acc_done", a_acc.stage)
+                    wait_edge("a_done", my_a.stage, my_a.phase)
+                    ascaled = cast(IO_DTYPE, mul(mul(av, decay_a), scale))
+                    copy_r2s(ascaled, smem_byte(arena, A_BASE, my_a.stage, xor128))
+                    # instruction_selection: packed mul.f32 + cvt +
+                    # stmatrix.m8n8.x4 x4 x 2 halves
+                    fence("async_shared_cta")
+                    arrive_edge("a", my_a.stage)
+            tile, sched = scheduler_consume(sched, tile)
+        drain_producer("t_inv_done", tinv_cur); drain_producer("a_done", a_cur)
+
+    # ====================================================================
+    # Warps 4..7 (CG1): state seed/restage/rescale, Y, Q*S scale, U, O, final
+    # ====================================================================
+    if 4 <= warp <= 7:
+        set_register_budget("increase", 256 if USE_INITIAL_STATE else 232)
+        barrier(1, 288)
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        v_cur = consumer_cursor(V_STAGES, phase=0)
+        gate_cur = consumer_cursor(GATE_STAGES, phase=0)
+        state_cur = consumer_cursor(1, phase=0)      # state_acc ready
+        seed_cur = producer_cursor(1, phase=1)       # state-scale-done reuse
+        oacc_cur = consumer_cursor(1, phase=0)
+        ofin_cur = consumer_cursor(1, phase=0)
+        kst_cur = consumer_cursor(1, phase=0)
+        uacc_cur = consumer_cursor(1, phase=0)
+        o_cur = producer_cursor(O_STAGES, phase=1)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        value_dim = (warp-4)*32 + lane               # 0..127 output row
+        checkpoint_serial = 0
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            ckpt_mod = item.cstart % (checkpoint_every_n_tokens // 64) if CHECKPOINTS
+            if n_local > 0:
+                if USE_INITIAL_STATE:
+                    # -- initial-state seed: GMEM (or zero) -> state TMEM ---
+                    wait_edge("state_scale_done", 0, seed_cur.phase); advance(seed_cur)
+                    if item.cstart == 0:
+                        rows = copy_g2r(initial_state[item.batch, item.head,
+                                                      value_dim, 0:128])
+                        # instruction_selection: 128 scalar ld.global with
+                        # cast for BF16 state
+                    else:
+                        rows = fill(reg_array("f32",128), 0)
+                    copy_r2t(rows, tmem_cell(tmem, value_dim_row, STATE_ACC))
+                    # instruction_selection: tcgen05.st.sync.aligned
+                    # .32x32b.x32.b32 x4 subtiles; tcgen05.wait::st
+                    barrier(4, 128)
+
+                for local in range(n_local):
+                    chunk = item.cstart + local
+                    if CHECKPOINTS:
+                        do_ckpt_now = ckpt_mod == 0
+                        ckpt_mod = 0 if ckpt_mod+1 == ckpt_chunks else ckpt_mod+1
+                    if CHECKPOINTS and not USE_INITIAL_STATE and chunk == 0 and item.wstart == 0:
+                        # explicit zero checkpoint before the first chunk
+                        stage = acquire_checkpoint_done(checkpoint_serial)
+                        copy_r2s(fill(0), arena[CHECKPOINT_BASE + stage_bytes])
+                        # instruction_selection: st.shared.b32 strided zero fill
+                        fence("async_shared_cta")
+                        if elected_lane(): arrive_edge("checkpoint", stage)
+                        checkpoint_serial += 1
+                    have_state = USE_INITIAL_STATE or local > 0
+                    if USE_INITIAL_STATE:
+                        # source line 1708: the seed cursor also advances once
+                        # per chunk so it tracks every scale-done arrival
+                        advance(seed_cur)
+
+                    g = acquire(gate_cur)
+                    wait_edge("gate", g.stage, g.phase)
+                    cumprod_total = copy_s2r(arena[CUMPROD_BASE + g.stage*256 + 63*4])
+
+                    # -- state restage + optional checkpoint + rescale ------
+                    if have_state:
+                        st = acquire(state_cur)
+                        wait_edge("state_acc", st.stage, st.phase)
+                        srows = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: tcgen05.ld.32x32b.x32 x4
+                        packed = cast(IO_DTYPE, srows, packed_pairs)
+                        copy_r2t(packed, tmem_cell(tmem, value_dim_row, STATE_INP))
+                        # instruction_selection: cvt.rn.{bf16x2|f16x2}.f32 x64;
+                        # tcgen05.st.32x32b.x16 x4; tcgen05.wait::st
+                        arrive_edge("state_inp")
+                        if CHECKPOINTS and do_ckpt_now and item.wstart <= chunk < item.wend:
+                            stage = acquire_checkpoint_done(checkpoint_serial)
+                            ck = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                            copy_r2s(cast(IO_DTYPE, ck),
+                                     arena[CHECKPOINT_BASE + xor128_row(value_dim)])
+                            # instruction_selection: tcgen05.ld.32x32b.x32 x4;
+                            # packed cvt; 16-byte st.shared vector stores
+                            fence("async_shared_cta")
+                            if elected_lane(): arrive_edge("checkpoint", stage)
+                            checkpoint_serial += 1
+                        scaled = mul(srows, cumprod_total)
+                        copy_r2t(scaled, tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: packed mul.f32;
+                        # tcgen05.st.32x32b.x32 x4; tcgen05.wait::st
+                        arrive_edge("state_scale_done", st.stage)
+
+                    # -- per-row gate registers -----------------------------
+                    cumprod_cols = copy_s2r(cumprod_ring_cols(g.stage))
+                    last_log = copy_s2r(arena[CUMSUMLOG_BASE + g.stage*256 + 63*4])
+                    decay_scale = exp2(sub(last_log, cumsumlog_ring_cols(g.stage)))
+                    # instruction_selection: ld.shared.b32, add.rn.f32x2 pair
+                    # sums, ex2.approx.ftz.f32; extent: 32 columns
+                    arrive_edge("gate_done", g.stage)
+
+                    # -- Y = V - cumprod * (K*S), packed 16-bit -------------
+                    vv = acquire(v_cur)
+                    wait_edge("v", vv.stage, vv.phase)
+                    vfrag = copy_s2r(smem_byte(arena, V_BASE, vv.stage,
+                                     row=token_row, col=xor128, trans=True))
+                    # instruction_selection: ldmatrix.m8n8.x4.trans.shared.b16
+                    # x8 (two 64-row subtiles x four 16-token bands)
+                    if have_state:
+                        wait_edge("k_state_acc", 0, kst_cur.phase); advance(kst_cur)
+                        ks = copy_t2r(tmem_cell(tmem, value_dim_row, CG1_ACC))
+                        # instruction_selection: tcgen05.ld.16x256b.x8 x2
+                        y = packed_sub(vfrag, cast(IO_DTYPE, mul(ks, cumprod_cols)))
+                        # instruction_selection: packed mul.f32, cvt,
+                        # sub.{bf16x2|f16x2}; extent: 32 packed cells
+                    else:
+                        y = vfrag
+                    copy_r2t(y, tmem_cell(tmem, value_dim_row, YU_INP))
+                    # instruction_selection: tcgen05.st.16x128b.x8 x2;
+                    # tcgen05.wait::st
+                    arrive_edge("y_inp")
+
+                    # -- Q*S epilogue: acc *= cumprod * scale ---------------
+                    if have_state:
+                        qs = acquire(oacc_cur)
+                        wait_edge("o_acc", 0, qs.phase)
+                        qsv = copy_t2r(tmem_cell(tmem, value_dim_row, QSTATE_ACC))
+                        # instruction_selection: tcgen05.ld.16x256b.x8 x2
+                        qsv = mul(mul(qsv, cumprod_cols), scale)
+                        copy_r2t(qsv, tmem_cell(tmem, value_dim_row, QSTATE_ACC))
+                        # instruction_selection: packed mul.f32;
+                        # tcgen05.st.16x256b.x8 x2; tcgen05.wait::st
+                        arrive_edge("o_scale_done", 0)
+
+                    # -- U epilogue + decayed-U publish ---------------------
+                    wait_edge("u_acc", 0, uacc_cur.phase); advance(uacc_cur)
+                    arrive_edge("v_done", vv.stage)
+                    u = copy_t2r(tmem_cell(tmem, value_dim_row, CG1_ACC))
+                    # instruction_selection: tcgen05.ld.16x256b.x8 x2
+                    copy_r2t(cast(IO_DTYPE, u), tmem_cell(tmem, value_dim_row, YU_INP))
+                    # instruction_selection: packed cvt; tcgen05.st.16x128b.x8
+                    # x2; tcgen05.wait::st
+                    arrive_edge("u_inp")
+                    du = cast(IO_DTYPE, mul(u, decay_scale))
+                    copy_r2t(du, tmem_cell(tmem, value_dim_row, DECAY_U_INP))
+                    # instruction_selection: packed mul.f32, cvt;
+                    # tcgen05.st.16x128b.x8 x2; tcgen05.wait::st
+                    arrive_edge("decay_u_inp")
+
+                    # -- O epilogue: acc TMEM -> sO SMEM --------------------
+                    of = acquire(ofin_cur)
+                    wait_edge("o_final_acc", 0, of.phase)
+                    ov = copy_t2r(tmem_cell(tmem, value_dim_row, QSTATE_ACC))
+                    # instruction_selection: tcgen05.ld.16x256b.x8 x2;
+                    # tcgen05.wait::ld
+                    oslot = acquire(o_cur)
+                    wait_edge("o_done", oslot.stage, oslot.phase)
+                    copy_r2s(cast(IO_DTYPE, ov),
+                             smem_byte(arena, O_BASE, oslot.stage, xor128, trans=True))
+                    # instruction_selection: packed cvt +
+                    # stmatrix.m8n8.x4.trans.shared.b16 x8
+                    fence("async_shared_cta")
+                    arrive_edge("o_stage", oslot.stage)
+
+                # -- final state: TMEM -> GMEM after the last chunk ---------
+                st = acquire(state_cur)
+                wait_edge("state_acc", st.stage, st.phase)
+                if STORE_FINAL_STATE and item.wend == item.num_chunks_b:
+                    rows = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                    # instruction_selection: tcgen05.ld.32x32b.x32 x4
+                    copy_r2g(cast(STATE_DTYPE, rows),
+                             final_state[item.batch, item.head, value_dim, 0:128])
+                    # instruction_selection: st.global.v2.b64 vector stores
+                    # (FP32 state) / packed converts then stores (BF16 state)
+                arrive_edge("state_scale_done", st.stage)
+            elif STORE_FINAL_STATE and item.wend == item.num_chunks_b:
+                # Empty sequence: never touches TMEM; passthrough initial
+                # state when present, else state-dtype zero.
+                for key in range(128):
+                    val = (copy_g2r(initial_state[item.batch,item.head,value_dim,key])
+                           if USE_INITIAL_STATE else cast(STATE_DTYPE,0))
+                    copy_r2g(val, final_state[item.batch,item.head,value_dim,key])
+                    # instruction_selection: st.global.v2.b64 vectorized
+                    # zero stores in the FP32 nostate anchor (.loc 1 1977,
+                    # 32 sites); the initial-state profile loads each value
+                    # via ld.global (+ cvt for BF16 state) before the store
+            tile, sched = scheduler_consume(sched, tile)
+        arrive_edge("tmem_done")
+        drain_producer("o_done", o_cur)
+        if CHECKPOINTS: drain_checkpoint_done(checkpoint_serial)
+
+    # ====================================================================
+    # Warp 8: gate/beta producer
+    # ====================================================================
+    elif warp == 8:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32
+        gate_cur = producer_cursor(GATE_STAGES, phase=1)
+        beta_cur = producer_cursor(BETA_STAGES, phase=1)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            if SAFE_GATE and item.wend > item.cstart:
+                a_l2 = mul(neg(exp2(mul(copy_g2r(a_log[item.head]), LOG2_E))), LOG2_E)
+                bias = copy_g2r(dt_bias[item.head])
+                # instruction_selection: ld.global.b32 x2, ex2.approx.ftz.f32
+            for chunk in range(item.cstart, item.wend):
+                # -- gate: predicated GMEM loads, log2 transform, prefix ----
+                # Each lane owns two token columns (lane, lane+32); the OOB
+                # neutral is 0 in log domain, 1 in alpha domain.
+                g = acquire(gate_cur)
+                vals = [copy_g2r(gate[clamped_token(col), item.head])
+                        if token_valid(col) else oob_neutral() for col in (0,1)]
+                # instruction_selection: branch-predicated ld.global.b32 with
+                # min.s32 index clamp and mov-immediate OOB neutral
+                if SAFE_GATE:
+                    vals = [mul(a_l2, softplus(add(vc, bias))) if valid else 0
+                            for vc in vals]
+                    # instruction_selection: ex2/lg2.approx.ftz chain per lane
+                elif LOG_GATE:
+                    vals = mul(vals, RCP_LN2)          # natural log -> log2
+                else:
+                    vals = log2(add(vals, 1e-10))
+                    # instruction_selection: lg2.approx.ftz.f32
+                prefix = warp_inclusive_scan(vals)
+                # instruction_selection: shfl.sync.up.b32 offsets 1,2,4,8,16
+                # per column plus one shfl.sync.idx.b32 lane-31 carry;
+                # extent: 5+5+1 shuffles for the 64-token scan
+                wait_edge("gate_done", g.stage, g.phase)
+                copy_r2s(prefix, arena[CUMSUMLOG_BASE + g.stage*256 + col*4])
+                copy_r2s(exp2(prefix), arena[CUMPROD_BASE + g.stage*256 + col*4])
+                # instruction_selection: st.shared.b32 x2 per column,
+                # ex2.approx.ftz.f32
+                arrive_edge("gate", g.stage)
+
+                # -- beta: cp.async per element or in-register sigmoid ------
+                b = acquire(beta_cur)
+                wait_edge("beta_done", b.stage, b.phase)
+                if BETA_SIGMOID:
+                    for col in (0,1):
+                        bv = 0
+                        if token_valid(col):
+                            bv = cast("f32", cast(IO_DTYPE,
+                                 add(mul(tanh(mul(copy_g2r(beta[token,item.head]),0.5)),0.5),0.5)))
+                        copy_r2s(bv, arena[BETA_BASE + b.stage*256 + col*4])
+                    # instruction_selection: ld.global.b16, tanh.approx.f32,
+                    # round through IO dtype, st.shared.b32
+                    arrive_edge("beta", b.stage)
+                else:
+                    for col in (0,1):
+                        copy_g2s(beta[token, item.head],
+                                 arena[BETA_BASE + b.stage*256 + col*4],
+                                 bytes=4 if token_valid(col) else 0)
+                    # instruction_selection: cp.async.ca.shared.global 4B with
+                    # zero-fill cp-size predication
+                    cp_async_arrive(protocol_ptr("beta", b.stage), noinc=True)
+                    # instruction_selection: cp.async.mbarrier.arrive.noinc
+            tile, sched = scheduler_consume(sched, tile)
+        drain_producer("gate_done", gate_cur); drain_producer("beta_done", beta_cur)
+
+    # ====================================================================
+    # Warp 10: sole tcgen05 issuer and TMEM lifecycle
+    # ====================================================================
+    elif warp == 10:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        allocate_tmem(TMEM_MAILBOX, columns=512, cta_group=1)
+        # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned
+        # .shared::cta.b32
+        barrier(1, 288)
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        kq_cur = consumer_cursor(KQ_STAGES, phase=0)        # per-chunk operand
+        kqf_cur = consumer_cursor(KQ_STAGES, phase=0)       # fused-pair lookahead
+        cg0_cur = consumer_cursor(CG0_ACC_STAGES, phase=1)  # cg0 acc done
+        tinv_cur = consumer_cursor(TINV_STAGES, phase=0)
+        a_cur = consumer_cursor(A_STAGES, phase=0)
+        sinp_cur = consumer_cursor(1, phase=0)
+        y_cur = consumer_cursor(1, phase=0)
+        u_cur = consumer_cursor(1, phase=0)
+        du_cur = consumer_cursor(1, phase=0)
+        oacc_cur = producer_cursor(1, phase=1)              # q_state acc
+        oscale_cur = consumer_cursor(1, phase=0)
+        state_cur = producer_cursor(1, phase=1)             # state acc
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+
+        # SMEM operand descriptors are integer immediates: base>>4 plus
+        # lead 16 B, stride 1024 B, swizzle-128B; the fused pair uses
+        # half-tile offsets KQ_BOX = 64*64*2 B and half-K segment
+        # KQ_SEG = 128*64*2 B >> 4; the state-update B operand re-views the
+        # same K+Q bytes with lead 16384 B.
+        def fused_kk_qk(kqf, acc_stage, same_operand):
+            wait_edge("cg0_acc_done", acc_stage.stage, acc_stage.phase)
+            wait_edge("kq", kqf.stage, kqf.phase)
+            a = smem_matrix_desc(KQ_BASE + kqf.stage*32768)
+            b = a if same_operand else a + KQ_BOX
+            gemm(tmem_cell(tmem, 0, CG0_ACC + acc_stage.stage*64), a, b,
+                 M=128, N=64, K=64, accumulate=False)
+            gemm(tmem_cell(tmem, 0, CG0_ACC + acc_stage.stage*64),
+                 a + KQ_SEG, b + KQ_SEG, M=128, N=64, K=64, accumulate=True)
+            # instruction_selection: tcgen05.mma.cta_group::1.kind::f16 with
+            # SMEM A/B descriptors; extent: 2 x 4 K-phases = 8 instructions
+            if elected_lane(): commit_edge("cg0_acc", acc_stage.stage)
+
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            # fused pair 0 and (when present) pair 1 are issued ahead
+            if n_local > 0: fused_kk_qk(acquire(kqf_cur), acquire(cg0_cur), same=True)
+            if n_local > 1: fused_kk_qk(acquire(kqf_cur), acquire(cg0_cur), same=False)
+            for local in range(n_local):
+                member = local & 1
+                have_state = USE_INITIAL_STATE or local > 0
+                if USE_INITIAL_STATE and local == 0:
+                    if elected_lane(): commit_edge("state_acc", 0)
+                    advance(state_cur)
+                kq = acquire(kq_cur)
+                desc_k = smem_matrix_desc(KQ_BASE + kq.stage*32768) + member*KQ_BOX
+                desc_q = smem_matrix_desc(KQ_BASE + kq.stage*32768) + (KQ_BOX - member*KQ_BOX)
+                desc_kt = smem_matrix_desc(KQ_BASE + kq.stage*32768,
+                                           lead=16384) + member*KQ_BOX
+
+                # member-parity lookahead keeps one fused pair in flight
+                if member == 1 and local+2 < n_local:
+                    fused_kk_qk(acquire(kqf_cur), acquire(cg0_cur), same=False)
+
+                # -- GEMM 3: (K*S)^T = S^T_packed @ K^T ---------------------
+                if have_state:
+                    wait_edge("state_inp", 0, sinp_cur.phase); advance(sinp_cur)
+                    gemm(tmem_cell(tmem, 0, CG1_ACC),
+                         tmem_a(STATE_INP), desc_k, M=128, N=64, K=128,
+                         accumulate=per_k_phase)
+                    # instruction_selection: tcgen05.mma.kind::f16 TMEM-A;
+                    # extent: 2 half-K segments x 4 = 8 instructions
+                    if elected_lane(): commit_edge("k_state_acc", 0)
+
+                # -- GEMM 4: (Q*S)^T = S^T_packed @ Q^T ---------------------
+                qacc = acquire(oacc_cur)
+                if have_state:
+                    gemm(tmem_cell(tmem, 0, QSTATE_ACC),
+                         tmem_a(STATE_INP), desc_q, M=128, N=64, K=128,
+                         accumulate=per_k_phase)
+                    # instruction_selection: 8 x tcgen05.mma TMEM-A
+                    if elected_lane(): commit_edge("o_acc", 0)
+
+                # -- GEMM 5: U^T = Y^T_packed @ T_inv^T ---------------------
+                tv = acquire(tinv_cur)
+                wait_edge("t_inv", tv.stage, tv.phase)
+                wait_edge("y_inp", 0, y_cur.phase); advance(y_cur)
+                gemm(tmem_cell(tmem, 0, CG1_ACC),
+                     tmem_a(YU_INP), smem_matrix_desc(TINV_BASE + tv.stage*8192),
+                     M=128, N=64, K=64, accumulate=per_k_phase_first_false)
+                # instruction_selection: 4 x tcgen05.mma TMEM-A
+                if elected_lane():
+                    commit_edge("u_acc", 0); commit_edge("t_inv_done", tv.stage)
+
+                if member == 0 and local+2 < n_local:
+                    fused_kk_qk(acquire(kqf_cur), acquire(cg0_cur), same=True)
+
+                # -- GEMM 6: O^T += U^T_packed @ A^T ------------------------
+                av = acquire(a_cur)
+                wait_edge("a", av.stage, av.phase)
+                if have_state:
+                    wait_edge("o_scale_done", 0, oscale_cur.phase); advance(oscale_cur)
+                wait_edge("u_inp", 0, u_cur.phase); advance(u_cur)
+                gemm(tmem_cell(tmem, 0, QSTATE_ACC),
+                     tmem_a(YU_INP), smem_matrix_desc(A_BASE + av.stage*8192),
+                     M=128, N=64, K=64, accumulate=have_state_on_first_k)
+                # instruction_selection: 4 x tcgen05.mma TMEM-A
+                if elected_lane():
+                    commit_edge("a_done", av.stage); commit_edge("o_final_acc", 0)
+
+                # -- GEMM 7: S^T += decayedU^T_packed @ K -------------------
+                wait_edge("decay_u_inp", 0, du_cur.phase); advance(du_cur)
+                advance(state_cur)
+                gemm(tmem_cell(tmem, 0, STATE_ACC),
+                     tmem_a(DECAY_U_INP), desc_kt, M=128, N=128, K=64,
+                     accumulate=have_state_on_first_k)
+                # instruction_selection: 4 x tcgen05.mma TMEM-A, B transposed
+                # through the lead-16384 K^T descriptor view
+                if elected_lane():
+                    commit_edge("state_acc", 0); commit_edge("kq_done", kq.stage)
+            tile, sched = scheduler_consume(sched, tile)
+        wait_edge("tmem_done", 0, 0)
+        relinquish_tmem_alloc_permit(cta_group=1)
+        deallocate_tmem(tmem, columns=512, cta_group=1)
+        # instruction_selection: tcgen05.relinquish_alloc_permit /
+        # tcgen05.dealloc.cta_group::1.sync.aligned.b32
+
+    # ====================================================================
+    # Warp 9: TMA-LDG and scheduler producer
+    # ====================================================================
+    elif warp == 9:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        kq_cur = producer_cursor(KQ_STAGES, phase=1)
+        v_cur = producer_cursor(V_STAGES, phase=1)
+        sched = producer_cursor(SCHED_STAGES, phase=1)
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            qh = input_head(item.head, Q_RATIO)
+            kh = input_head(item.head, K_RATIO)
+            vh = input_head(item.head, V_RATIO)
+            if elected_lane():
+                for array in (Q, K, V):
+                    acquire_descriptor(array, item.batch)
+                    # instruction_selection:
+                    # fence.proxy.tensormap::generic.acquire.gpu
+            if item.wend > item.cstart:
+                # first K+Q tile of the item: K in the low half, Q high
+                s = acquire(kq_cur)
+                wait_edge("kq_done", s.stage, s.phase)
+                if elected_lane(): expect_edge("kq", s.stage, 32768)
+                copy_g2s(descriptor(K, item.batch), arena[KQ_BASE + s.stage*32768],
+                         coords=(0, kh, item.cstart*64))
+                copy_g2s(descriptor(Q, item.batch), arena[KQ_BASE + s.stage*32768 + 8192],
+                         coords=(0, qh, item.cstart*64))
+                # instruction_selection: cp.async.bulk.tensor.3d.shared::cta
+                # .global.tile.mbarrier::complete_tx::bytes; extent: each
+                # half-tile is two 8-KB 64-channel boxes at +off and
+                # +off+16384 (interleaved [K_lo, Q_lo, K_hi, Q_hi] stage;
+                # four instructions per 32-KB stage)
+                for chunk in range(item.cstart+1, item.wend):
+                    member = (chunk - item.cstart) & 1
+                    s = acquire(kq_cur)
+                    wait_edge("kq_done", s.stage, s.phase)
+                    if elected_lane(): expect_edge("kq", s.stage, 32768)
+                    first, second = (K, Q) if member == 0 else (Q, K)
+                    copy_g2s(descriptor(first, item.batch),
+                             arena[KQ_BASE + s.stage*32768], (0, head(first), chunk*64))
+                    copy_g2s(descriptor(second, item.batch),
+                             arena[KQ_BASE + s.stage*32768 + 8192],
+                             (0, head(second), chunk*64))
+                    # instruction_selection: same rank-3 TMA pair, two 8-KB
+                    # boxes per half-tile (subtile stride 16384 B); member
+                    # parity swaps which operand owns the +0 half
+                    vs = acquire(v_cur)
+                    wait_edge("v_done", vs.stage, vs.phase)
+                    if elected_lane(): expect_edge("v", vs.stage, 16384)
+                    copy_g2s(descriptor(V, item.batch), arena[V_BASE + vs.stage*16384],
+                             (0, vh, (chunk-1)*64))
+                    # instruction_selection: rank-3 TMA, one-behind V tile
+                vs = acquire(v_cur)
+                wait_edge("v_done", vs.stage, vs.phase)
+                if elected_lane(): expect_edge("v", vs.stage, 16384)
+                copy_g2s(descriptor(V, item.batch), arena[V_BASE + vs.stage*16384],
+                         (0, vh, (item.wend-1)*64))
+            tile, sched = scheduler_publish(sched, tile)
+        drain_producer("kq_done", kq_cur); drain_producer("v_done", v_cur)
+
+    # ====================================================================
+    # Warp 11: epilogue O and checkpoint TensorMap stores
+    # ====================================================================
+    if warp == 11:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        o_cur = consumer_cursor(O_STAGES, phase=0)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        checkpoint_serial = 0
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            if elected_lane():
+                acquire_descriptor(O, item.batch)
+                if CHECKPOINTS: acquire_descriptor(CHECKPOINT, item.batch)
+            if CHECKPOINTS:
+                ckpt_coord = ceil_div(item.wstart, ckpt_chunks)
+                ckpt_mod = (item.cstart + 1) % ckpt_chunks
+            if n_local > 0:
+                if CHECKPOINTS and item.wstart == 0:
+                    stage = checkpoint_serial % CHECKPOINT_STAGES
+                    wait_edge("checkpoint", stage, phase_of(checkpoint_serial))
+                    copy_s2g(arena[CHECKPOINT_BASE + stage*32768],
+                             checkpoint_coord(0, 0, ckpt_coord, item.head))
+                    # instruction_selection: cp.async.bulk.tensor.4d.global
+                    # .shared::cta.tile.bulk_group; extent: two 64-channel
+                    # subtiles
+                    store_commit(); store_wait(0)
+                    # instruction_selection: cp.async.bulk.commit_group;
+                    # cp.async.bulk.wait_group 0
+                    arrive_edge("checkpoint_done", stage)
+                    ckpt_coord += 1; checkpoint_serial += 1
+                for local in range(n_local):
+                    chunk = item.cstart + local
+                    did_o = did_ckpt = False
+                    os = acquire(o_cur)
+                    wait_edge("o_stage", os.stage, os.phase)
+                    if item.wstart <= chunk < item.wend:
+                        copy_s2g(arena[O_BASE + os.stage*16384],
+                                 output_coord(0, item.head, chunk*64))
+                        # instruction_selection: rank-3 TMA S2G, two 8-KB
+                        # subtiles; extent capped by the per-batch sequence dim
+                        store_commit(); did_o = True
+                    if CHECKPOINTS:
+                        stage = checkpoint_serial % CHECKPOINT_STAGES
+                        if item.wstart-1 <= chunk < item.wend-1 and ckpt_mod == 0:
+                            wait_edge("checkpoint", stage, phase_of(checkpoint_serial))
+                            copy_s2g(arena[CHECKPOINT_BASE + stage*32768],
+                                     checkpoint_coord(0,0,ckpt_coord,item.head))
+                            store_commit(); ckpt_coord += 1; did_ckpt = True
+                        ckpt_mod = 0 if ckpt_mod+1 == ckpt_chunks else ckpt_mod+1
+                    # source completion order: O group first, checkpoint after
+                    if CHECKPOINTS and did_o and did_ckpt:
+                        store_wait(1); arrive_edge("o_done", os.stage)
+                        store_wait(0); arrive_edge("checkpoint_done", stage)
+                        checkpoint_serial += 1
+                    elif CHECKPOINTS and did_o:
+                        store_wait(0); arrive_edge("o_done", os.stage)
+                    elif CHECKPOINTS:
+                        if did_ckpt:
+                            store_wait(0); arrive_edge("checkpoint_done", stage)
+                            checkpoint_serial += 1
+                        arrive_edge("o_done", os.stage)
+                    else:
+                        if did_o: store_wait(0)
+                        arrive_edge("o_done", os.stage)
+            tile, sched = scheduler_consume(sched, tile)
+```
+
+## Numerical order frozen by the schedule
+
+For one token, the source recurrence represented by the chunk factorization is:
+
+```text
+S_decayed = alpha_t * S            # alpha = exp(g), gates kept in log2 domain
+erase     = k_t @ S_decayed
+y_t       = v_t - erase
+S         = S_decayed + outer(k_t, beta-folded y)
+o_t       = (scale * q_t) @ S_intra+inter
+```
+
+Within a chunk the exact source order matters: the gate warp converts to log2
+(safe gate through `-exp(a_log·log2e)·softplus(g+bias)·log2e`, natural log
+through `·1/ln2`, raw alpha through `lg2(x+1e-10)`) and prefix-scans with warp
+shuffles; T-pairwise cells are `exp2(cumsumlog_i − cumsumlog_j)` masked by an
+opaque zero; the KK epilogue folds `decay·beta_row` before IO rounding; the
+64×64 inverse runs Gauss-Jordan on 8×8 diagonals then three blockwise
+correction levels in register MMA with IO-dtype rounding at each level; beta
+column scaling rounds through packed IO pairs after the inverse; U, Q·S, and O
+accumulate in FP32 TMEM; `Y = V − cumprod·(K·S)` is computed in packed 16-bit
+subtraction; the decayed U multiplies `exp2(last−prefix)` before IO rounding.
+Tail tokens get log-domain zero gate contribution and TMA OOB zero fill;
+output and checkpoint stores clip in hardware through per-batch descriptor
+sequence extents.
+
+## Logical tcgen05 GEMMs
+
+TMEM accumulators hold transposed results with tokens (or DK for the state)
+in the N dimension.
+
+| # | FP32 TMEM destination | A operand | B operand | logical MxNxK | issues | accumulate |
+| ---: | --- | --- | --- | --- | ---: | --- |
+| 1+2 | fused KK/QK ring col 256/320 | K+Q SMEM stage (SS) | same-stage K SMEM | 128x64x128 | 8 | K-phase only |
+| 3 | (K·S)^T col 384 | packed S^T TMEM | K half of the K+Q stage | 128x64x128 | 8 | K-phase only |
+| 4 | (Q·S)^T col 128 | packed S^T TMEM | Q half of the K+Q stage | 128x64x128 | 8 | K-phase only |
+| 5 | U^T col 384 | packed Y^T TMEM | beta-scaled T_inv SMEM | 128x64x64 | 4 | K-phase only |
+| 6 | O^T col 128 | packed U^T TMEM | causal A SMEM | 128x64x64 | 4 | runtime `have_state` |
+| 7 | S^T cols 0..127 | packed decayed-U^T TMEM | K^T lead-16384 view | 128x128x64 | 4 | runtime `have_state` |
+
+The fused KK/QK op has four static sites (two pre-loop, one per member
+parity), so the BF16 anchor has `4*8 + 8 + 8 + 4 + 4 + 4 = 60` static
+`tcgen05.mma` sites, matching the export.  GEMMs 3 and 5 share the CG1
+accumulator columns sequentially within one chunk; publication follows the
+exact delayed commit sites in warp 10.
+
+## Storage-alias lifetimes
+
+- The T-inverse buffer stage holds, in order: the beta-row-scaled masked KK
+  product `M`, the in-place hierarchical inverse of `I + M` (identity injected
+  by lane predicates), then the beta-column-scaled `T_inv` consumed by GEMM 5.
+- The CG1 TMEM accumulator (col 384) holds `(K·S)^T` until CG1 consumes it
+  into `Y`, then `U^T` from GEMM 5 in the same chunk.
+- The YU input slot (col 448) holds packed `Y^T` for GEMM 5, then packed
+  `U^T` for GEMM 6; the decayed-U slot (col 480) feeds GEMM 7.
+- The Q-state accumulator (col 128) receives GEMM 4, is scaled in place by
+  `cumprod·scale`, then accumulates GEMM 6 before the O epilogue drains it.
+- One K+Q SMEM stage feeds the fused pair, GEMM 3 (K half), GEMM 4 (Q half),
+  and GEMM 7 (K^T view) before `kq_done` releases it.
+
+## Source / PTX / sketch correspondence
+
+`nostate-main`/`nostate-prologue` mean the two files in
+`source_export/dump_nostate`, `state-*` the checkpoint + initial-state files.
+
+| Source action | Source lines | PTX evidence | Sketch section |
+| --- | ---: | --- | --- |
+| mbarrier inventory and arrive counts | 125..231 | nostate-main 60 `mbarrier.init` sites | PROTOCOL table |
+| 8x8 Gauss-Jordan diagonal inverse | 233..263 | `.loc 1 233..263`; shfl.sync.idx with clustered mask, v4.b32 vector row load/stores (`.loc 1 251/262`) | CG0 `gauss_jordan_8x8` |
+| 8→16 blockwise correction | 265..315 | `.loc 1 265..315`; `mma.sync.m16n8k8` x4, ldmatrix.x1 | CG0 `blockwise_8_to_16` |
+| 16→32 blockwise correction | 316..374 | `.loc 1 316..374`; `mma.sync.m16n8k16`, ldmatrix.x4 | CG0 `blockwise_16_to_32` |
+| 32→64 blockwise correction | 375..458 | `.loc 1 375..458`; 16 `mma.sync.m16n8k16`, barrier(2) | CG0 `blockwise_32_to_64` |
+| dynamic ticket publish/consume | 463..488 | dyn-sched profile; `atom.global.add.s32`, sched mbarriers | `scheduler_publish/consume` |
+| O and checkpoint TensorMap stores | 491..629 | `.loc 1 548..628`; 2 rank-3 S2G sites (nostate), rank-4 checkpoint sites in state-main | warp 11 |
+| gate/beta loads, scan, transforms | 631..756 | `.loc 1 662..748`; predicated ld.global, shfl.up x10, ex2, cp.async.ca x2, cp.async.mbarrier.arrive | warp 8 |
+| tcgen05 alloc + GEMM descriptors | 758..903 | `.loc 1 792..900`; tcgen05.alloc, descriptor immediates | warp 10 preamble |
+| fused KK/QK pairs + lookahead | 904..981, 1016..1030 | `.loc 1 908..935`; 32 of 60 `tcgen05.mma` sites | warp 10 `fused_kk_qk` |
+| GEMMs 3..7 chain | 983..1054 | `.loc 1 983..1054`; 28 `tcgen05.mma` sites, commit pairs | warp 10 loop |
+| TMEM teardown | 1058..1064 | relinquish + dealloc pair | warp 10 tail |
+| K+Q interleaved and V TMA loads | 1067..1196 | `.loc 1 1138..1187`; 16 rank-3 G2S sites, expect-tx x4 | warp 9 |
+| T-pairwise decay fragments | 1263..1317 | `.loc 1 1287..1317`; ex2/sub/selp blocks | CG0 pair prologue |
+| KK epilogue | 1332..1388 | `.loc 1 1362..1388`; tcgen05.ld.16x256b, packed mul, stmatrix | CG0 `do_kk` |
+| pair inverse orchestration | 1390..1434 | `.loc 1 1399..1434`; bar.sync id-2 sites | CG0 inverse ladder |
+| beta column scaling + publish | 1436..1507 | `.loc 1 1440..1506`; ldmatrix/stmatrix x4, fence.proxy | CG0 publish |
+| A epilogue | 1509..1552 | `.loc 1 1522..1552`; tcgen05.ld + packed mul + stmatrix | CG0 `do_a` |
+| initial-state seed | 1650..1683 | state-main `.loc 1 1652..1683`; tcgen05.st.32x32b, bar.sync id-4 | CG1 seed |
+| state restage/checkpoint/rescale | 1715..1782 | `.loc 1 1722..1782`; tcgen05.ld/st.32x32b, packed cvt | CG1 state block |
+| per-row gate registers | 1784..1797 | `.loc 1 1785..1796`; add.rn.f32x2, ex2 | CG1 gate regs |
+| Y = V − cumprod·KS | 1799..1842 | `.loc 1 1804..1842`; ldmatrix.trans x8, sub.bf16x2 x32, tcgen05.st.16x128b | CG1 Y |
+| Q·S scale | 1844..1866 | `.loc 1 1850..1866`; tcgen05.ld/st.16x256b | CG1 Q·S |
+| U repack + decayed U | 1868..1908 | `.loc 1 1873..1907`; tcgen05.ld.16x256b, st.16x128b x2 waves | CG1 U |
+| O epilogue | 1910..1942 | `.loc 1 1915..1941`; tcgen05.ld, stmatrix.trans x8 | CG1 O |
+| final state store + passthrough | 1944..1977 | `.loc 1 1950..1977`; st.global.v2.b64 x64 | CG1 tail |
+| descriptor arrays (5) | 1994..2048 | nostate-prologue; b64 copies + tensormap.replace + release fence | launch 1 arrays |
+| order pass | 2051..2130, split_k.py | nostate-prologue; sort/atomics/v4 stores | launch 1 order |
+| base maps and launch | 2133..2228 | host-built descriptors; box (64,1,64) token-ordinal-2 | launch 1 ABI |
+| GQA head folds | 2259..2356 | grouped profile; ratio divisions at issue sites | `input_head` |
+| arena, SmemTile bases, barrier init | 2420..2633 | `.loc 1 2586..2632`; 60 init + fence + bar.sync | arena/protocol |
+| dispatch | 2637..2754 | warp-guard branch structure | role dispatch |
+| cfg stage/offset derivation | 2757..2895 | compile-time constants in both profiles | specialization header |
+
+Reverse lookup is exhaustive at action granularity: each accepted compile-time
+branch, storage family, role, logical GEMM, scheduler operation, descriptor
+operation, and pipeline family has one owner in the table and one concrete
+section above.
+
+## Static instruction evidence for the BF16 nostate anchor
+
+Counts are static sites in the exported main-kernel PTX (instruction lines,
+unpredicated convention).
+
+| Instruction family | Static sites | Owner |
+| --- | ---: | --- |
+| `mbarrier.init.shared.b64` | 60 | protocol init |
+| `mbarrier.try_wait.parity.acquire...` | 58 | role-local waits |
+| `mbarrier.arrive.shared.b64` | 21 | thread publications |
+| `mbarrier.arrive.expect_tx.shared.b64` | 4 | warp-9 TMA transactions |
+| `tcgen05.mma.cta_group::1.kind::f16` | 60 | warp 10 |
+| `tcgen05.commit...mbarrier::arrive::one` | 12 | warp 10 publications |
+| `tcgen05.ld` 16x256b.x8 / 32x32b.x32 | 12 / 8 | CG0 + CG1 |
+| `tcgen05.st` 16x128b.x8 / 32x32b / 16x256b.x8 | 6 / 8 / 2 | CG1 |
+| `mma.sync.m16n8k16` / `m16n8k8` (bf16) | 20 / 4 | CG0 inverse ladder |
+| rank-3 TMA G2S / S2G | 16 / 2 | warp 9 / warp 11 |
+| `cp.async.ca.shared.global` + mbarrier arrive | 2 + 1 | warp 8 beta |
+| `ldmatrix` x4 / x4.trans / x1 / x1.trans | 11 / 18 / 2 / 4 | CG0 + CG1 |
+| `stmatrix` x4 / x4.trans / x1 | 27 / 8 / 2 | CG0 + CG1 |
+| `tcgen05.alloc/relinquish/dealloc` | one each | warp 10 lifecycle |
+| `setmaxnreg` dec / inc | 4 / 2 | role budgets |
+| `ex2.approx.ftz.f32` | 122 | gates and decay fragments |
+| `cvt.rn.bf16x2.f32` | 321 | packed IO rounding |
+| `sub.bf16x2` | 32 | CG1 Y subtraction |
+| `add.rn.f32x2` | 8 | CG1 decay-scale pair sums |
+| `shfl.sync.up/idx.b32` | 10 / 25 | warp-8 scan, inverse ladder |
+| `st.global.v2.b64` | 64 | CG1 final state |
+| `bar.sync` named ids 1,2 | 9 (3 + 6) | TMEM rendezvous, inverse ladder |
+| `barrier.sync 0` CTA-wide | 1 | post-init sync; id 4 appears only in the state profile |
+| `fence.proxy.async.shared::cta` | 4 | SMEM publications |
+| `fence.mbarrier_init.release.cluster` | 1 | protocol init |
+
+## Validation contract
+
+`get_kernel` returns `[descriptor_order_prologue, persistent_gdn]` in launch
+order.  The host adapter gives TIRx and the standalone source the same
+immutable logical inputs but independent work tables, scheduler counters,
+descriptor workspaces, and O/final-state/checkpoint buffers.  Correctness
+compares TIRx against the source kernel on identical inputs with relative RMS
+limits 0.02 for BF16 and 0.01 for FP16 over output, final state, and the
+source-written checkpoint slots, covering every frozen capability profile in
+`CONFIGS`.  Benchmark timing includes both launches for each implementation;
+work-table, TensorMap, reference compilation, and data preparation stay
+outside the timed closure.  `prepare_bench` is CPU-only.  The benchmark suite
+is the only performance authority; PTX/SASS/NCU can explain a candidate but
+cannot select or pass it.

--- a/.agents/skills/tirx-codegen-tuning/references/db/emit-packed-fp32-arithmetic-whatever-the-reference-flag-says.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/emit-packed-fp32-arithmetic-whatever-the-reference-flag-says.md
@@ -33,14 +33,26 @@ def _binary(mnemonic, out, left, right):
 ```
 
 Keep the approximations and comparisons per-element -- `ex2`, `rcp`, `tanh`,
-`setp` have no packed form -- and express a constant-minus-value as a `neg`
-plus a packed `add` rather than reaching back for a scalar `sub`.
+`setp` have no packed form. For a difference, use the packed `sub` directly:
+negating operands ahead of `make_float2` pays one scalar `FADD` per operand,
+because the negation does not fold across the pack.
+
+```python
+# before: two scalar negations per pair survive into SASS.
+K.ptx["add.rn.f32x2"](packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(-b0, -b1))
+# after: the packed sub folds them.
+K.ptx["sub.rn.f32x2"](packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+```
 
 ## Rationale
 
-Each half of `mul.rn.f32x2` / `add.rn.f32x2` rounds exactly as its scalar
-sibling, and `neg` plus packed `add` equals `sub` bit for bit, so the rewrite is
-numerically exact and needs no tolerance argument. In one block-scaled MoE
+Each half of `mul.rn.f32x2` / `add.rn.f32x2` / `sub.rn.f32x2` rounds exactly
+as its scalar sibling, and `sub` equals `neg` plus `add` bit for bit, so the
+rewrite is numerically exact and needs no tolerance argument. Folding the
+negation into the packed `sub` removed about 520K dynamic scalar `FADD` on one
+latency-bound shape; it measured timing-neutral there only because that chain
+sat in stall shadow, and it survived the complete correctness matrix and the
+final performance-matrix winner. In one block-scaled MoE
 grouped GEMM every activation family with real arithmetic depth moved above
 parity at once -- 0.864 to 1.224, 0.987 to 1.120, 0.955 to 1.120 -- and the
 worst row of the whole port stopped being the worst.

--- a/.agents/skills/tirx-codegen-tuning/references/db/hoist-invariant-work-out-of-a-runtime-conditional-region.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/hoist-invariant-work-out-of-a-runtime-conditional-region.md
@@ -1,0 +1,82 @@
+# Hoist invariant work out of a runtime-conditional region
+
+**Symptoms:** `excess_address_math`, `instruction_count_bloat`, `dispatch_specific_deficit`, `branch_in_hot_loop`
+
+## Symptom
+
+One specialization trails the reference while its siblings pass, and the paired
+per-opcode diff shows a large dynamic `IMAD` surplus (1.5x or more) at matched
+protocol and matched tensor-op counts. The surplus sits in a block guarded by a
+runtime predicate inside the persistent loop -- a snapshot, a cadence-gated
+publish -- that in the trailing specialization fires every iteration.
+
+## What to change
+
+Loop-invariant values inside a runtime-guarded block do not get hoisted: the
+compiler will not move them across the branch. Materialize them once in the
+role preamble into a small local array indexed only by compile-time constants,
+and index that array inside the guarded block.
+
+```python
+# before: the swizzled store offsets are iteration-invariant, but the
+# guard stops the compiler from hoisting them.
+with K.If(do_snapshot), K.Then():
+    for sub in range(SUBTILES):
+        for group in range(GROUPS):
+            column = sub * SUB_COLS + group * 8
+            element = (
+                (column // ATOM) * ATOM_STRIDE
+                + row * ROW_ELEMS
+                + _swizzle_xor_128b(row, column % ATOM)
+            )
+            K.ptx.st.shared.v4.b32(arena.ptr_to([BASE + element * 2]), *words)
+
+# after: materialized once per role; the guarded block only indexes.
+snapshot_off = K.alloc_local((SUBTILES * GROUPS,), "int32")
+for sub in range(SUBTILES):
+    for group in range(GROUPS):
+        column = sub * SUB_COLS + group * 8
+        element = (
+            (column // ATOM) * ATOM_STRIDE
+            + row * ROW_ELEMS
+            + _swizzle_xor_128b(row, column % ATOM)
+        )
+        K.assign(snapshot_off[sub * GROUPS + group], BASE + element * 2)
+...
+with K.If(do_snapshot), K.Then():
+    for sub in range(SUBTILES):
+        for group in range(GROUPS):
+            K.ptx.st.shared.v4.b32(
+                arena.ptr_to([snapshot_off[sub * GROUPS + group]]), *words
+            )
+```
+
+Keep every index into the materialized array a compile-time constant: a
+dynamically indexed local array lowers to local memory and inverts the win.
+
+## Rationale
+
+Loop-invariant code motion and CSE stop at runtime branches, so a guarded block
+that fires every iteration re-derives its address chains each time. On the
+specialization where the guard was always true, the paired profile showed
++1.15M dynamic `IMAD` (1.7x the reference) concentrated in the conditional
+region; materializing its sixteen invariant byte offsets moved the focused
+shape from 0.968x to 0.977x with the guard shapes unchanged, and the change
+survived the complete correctness matrix and the final complete
+performance-matrix winner.
+
+## Boundary
+
+Unconditional loop bodies gain nothing: the backend already hoists invariant
+addresses executed on every iteration, and the identical hoist applied to
+always-executed `ldmatrix`/`stmatrix` offsets measured no change on two shapes
+(0.950x/0.971x against 0.953x/0.973x, within run noise). Each materialized
+offset also occupies a register for the role's lifetime; on a warpgroup near
+its budget, hoist only what the guarded block consumes.
+
+## Verification
+
+Diff `IMAD`/`LEA` dynamic counts in the affected region against the reference
+before and after, confirm the guarded block in generated CUDA reads the
+materialized locals rather than rebuilding the chain, then measure the affected
+specialization and its guard shapes.

--- a/.agents/skills/tirx-codegen-tuning/references/db/match-every-kernels-grid-not-only-its-block.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/match-every-kernels-grid-not-only-its-block.md
@@ -36,6 +36,14 @@ reduce epilogue 148, 16 warps each).
 The device SM count is available to CPU-prepare without initializing CUDA, so
 resolving a grid does not require a device query in the wrong stage.
 
+Matching stops where the reference's grid exceeds a persistent kernel's
+work-item count: the surplus CTAs run only launch, barrier-init, and drain
+code, and that fixed cost lands on the shortest shapes. Launching the
+reference's full SM-count grid instead of `min(work_items, sm_count)` measured
+0.976x against a 0.984-0.988x band on a one-item-per-CTA shape and trimmed a
+second from 1.033x to 1.018x; the clamped grid was retained. Match the grid
+when every CTA receives work; clamp it to the work count when it would not.
+
 ## Verification
 
 Compare the realized grid of every kernel in the chain against its own reference

--- a/.agents/skills/tirx-codegen-tuning/references/db/preload-descriptor-images-before-the-prologues-independent-work.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/preload-descriptor-images-before-the-prologues-independent-work.md
@@ -1,0 +1,69 @@
+# Preload descriptor images before the prologue's independent work
+
+**Symptoms:** `serialized_prologue`, `fixed_overhead`, `slow_small_shape`, `long_scoreboard`
+
+## Symptom
+
+A descriptor-publishing prologue runs measurably longer than the reference's
+(a fixed per-launch cost the short shapes cannot amortize), and its publish
+phase reads 128-byte host-encoded TensorMap images through global pointers at
+the point of use. The reference reads the same images from kernel-parameter
+space, which costs nothing.
+
+## What to change
+
+K's PTX surface has no parameter-space load, so a port passes the reference's
+grid-constant descriptors as small global buffers. Do not read them inside the
+publish loop: issue the image loads into registers at kernel entry, on the
+elected lane of the warp that owns each array, run the prologue's unrelated
+phase, then publish and patch from the registers. One load per array serves
+every per-sequence slot.
+
+```python
+# before: each slot's publish re-reads the image through cold global memory.
+with K.If(warp == array_index), K.Then():
+    with K.If(_elected()), K.Then():
+        with K.serial(n_batch) as batch:
+            _copy_image_global_to_slot(base_map, slot(batch))   # 4x ld.global.v4.b64
+            _patch_slot(slot(batch), batch)
+
+# after: the image is register-resident before the ordering phase begins.
+payload = K.alloc_local((16,), "uint64")
+with K.If(warp == array_index), K.Then():
+    with K.If(_elected()), K.Then():
+        for group in range(4):
+            K.ptx.ld.global_.v4.b64(
+                payload[group * 4],
+                payload[group * 4 + 1],
+                payload[group * 4 + 2],
+                payload[group * 4 + 3],
+                _image_ptr(base_map, group * 32),
+            )
+...  # the work-ordering phase, independent of the images
+with K.If(warp == array_index), K.Then():
+    with K.If(_elected()), K.Then():
+        with K.serial(n_batch) as batch:
+            _store_image_from_registers(slot(batch), payload)
+            _patch_slot(slot(batch), batch)
+```
+
+## Rationale
+
+The image buffers are written once by the host and first touched here, so the
+point-of-use reads are cold DRAM chains serialized into the publish phase, and
+a per-slot copy multiplies them by the batch count. Preloading moved the
+measured prologue from 5.4us to 4.6us, into the reference's 4.4-4.9us band, and
+the shortest shape from 0.985x to 0.988x -- margin the complete matrix needed.
+The registers cost thirty-two 32-bit slots on one lane, paid only until the
+publish.
+
+## Boundary
+
+The payload lives in the loading lane's registers, so the same elected lane
+must load and publish. The covering phase must not write the images -- given
+they are host-written inputs, any prologue phase qualifies.
+
+## Verification
+
+Measure the prologue kernel's duration in isolation before and after; the gain
+then appears only on the shortest shapes of the timed two-launch closure.

--- a/.agents/skills/tirx-codegen-tuning/references/db/reuse-register-resident-tmem-values-instead-of-reloading.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/reuse-register-resident-tmem-values-instead-of-reloading.md
@@ -1,0 +1,67 @@
+# Reuse register-resident TMEM values instead of reloading
+
+**Symptoms:** `tmem_wait`, `long_scoreboard`, `exposed_load_latency`, `dispatch_specific_deficit`
+
+## Symptom
+
+A per-iteration path issues a second `tcgen05.ld` of accumulator cells whose
+values are already live in registers from an earlier read in the same
+synchronization window, and the specialization that exercises the path trails
+the reference at matched protocol. The source often carries the same redundant
+read, so instruction parity hides it.
+
+## What to change
+
+When no TMEM store to those cells intervenes between the first read and the
+reuse site -- same acquire, same release -- forward the live registers and
+delete the second load chain. The gate judges time, not fidelity to a
+redundancy the source happens to carry.
+
+```python
+# before: the snapshot path re-reads the cells the repack just read.
+state = K.alloc_local((FRAGMENT,), "float32")
+_tmem_load_fragment(state, STATE_COLUMNS)
+_publish_packed(state)
+with K.If(do_snapshot), K.Then():
+    snapshot = K.alloc_local((FRAGMENT,), "float32")
+    _tmem_load_fragment(snapshot, STATE_COLUMNS)
+    _stage_snapshot(snapshot)
+
+# after: the registers still hold the cells' current value.
+state = K.alloc_local((FRAGMENT,), "float32")
+_tmem_load_fragment(state, STATE_COLUMNS)
+_publish_packed(state)
+with K.If(do_snapshot), K.Then():
+    _stage_snapshot(state)
+```
+
+## Rationale
+
+Inline-PTX TMEM loads are opaque: no backend proves two of them redundant, and
+the second one is a long-latency read sitting on the per-iteration critical
+path, not shadowed arithmetic. Removing four 32-lane-wide loads per iteration
+on a path that fired every iteration moved the focused shape from 0.977x to
+0.991x with the guard shapes at 1.001x-1.034x, and the change survived the
+complete correctness matrix and the final complete performance-matrix winner.
+
+The win is specific to long-latency loads. Pure instruction-count trims in the
+same warpgroup -- folding negations, de-duplicating a replicated register
+array, about 620K dynamic operations together -- measured neutral: that work
+sat in stall shadow.
+
+## Boundary
+
+Valid only inside one synchronization window: any intervening TMEM store to the
+same cells, or a barrier that admits one, makes the registers stale.
+Forwarding must not stretch the fragment's live range into a later region
+either -- keeping a wide fragment alive across an independent load batch pushed
+a warpgroup roughly sixty registers past its budget and spilled, regressing the
+affected shapes to 0.69x and 0.79x. Reuse pays where the fragment was already
+live for another purpose at the reuse site.
+
+## Verification
+
+Confirm the `tcgen05.ld` site count drops in generated code for the affected
+specialization and that registers do not spill, then measure the affected and
+guard shapes; an instruction drop alone is not evidence, since shadowed-work
+removals measure neutral.

--- a/.agents/skills/tirx-codegen-tuning/references/db/tune-pipeline-shape-and-transfer-granularity.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/tune-pipeline-shape-and-transfer-granularity.md
@@ -50,7 +50,13 @@ extra TMA issue instructions often regress short shapes.
 
 ## Boundary
 
-Never reduce a protocol ring below its proven safe depth.
+Never reduce a protocol ring below its proven safe depth. Safe depth is also
+not fast depth, and a sibling specialization's tolerance is no proof: an input
+ring one specialization runs correctly at depth three (its iterations are
+longer) starved a throughput build whose consumer keeps a two-stage lookahead
+in flight when the ring was cut from four to three to fund an extra output
+stage -- two shapes near 0.99x fell to 0.92x and 0.82x, and the cut was
+reverted. Fund new stages from rings whose consumers hold no lookahead.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ list.
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
+  [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
 - **CSA compression:**

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_prefill_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_prefill_f16.yaml
@@ -1,0 +1,22 @@
+# Complete production sweep for the cuDNN Frontend GDN (v1) prefill port.
+kernel: cudnn_sm100_gdn_prefill_f16
+selection_rationale: The selected defaults cover an underfilled single-batch launch, the central four-batch production point, and the longest state/checkpoint workload; the full matrix sweeps production sequence lengths, batch occupancy, and both normal and final-state/checkpoint stage tuples.
+configs:
+  - {config: perf_b4_s2048_h64_nostate, default: false}
+  - {config: perf_b4_s4096_h64_nostate, default: false}
+  - {config: perf_b4_s8192_h64_nostate, default: true, selection_role: medium}
+  - {config: perf_b4_s16384_h64_nostate, default: false}
+  - {config: perf_b4_s32768_h64_nostate, default: false}
+  - {config: perf_b1_s8192_h64_nostate, default: true, selection_role: small}
+  - {config: perf_b2_s8192_h64_nostate, default: false}
+  - {config: perf_b8_s8192_h64_nostate, default: false}
+  - {config: perf_b16_s8192_h64_nostate, default: false}
+  - {config: perf_b4_s2048_h64_state, default: false}
+  - {config: perf_b4_s4096_h64_state, default: false}
+  - {config: perf_b4_s8192_h64_state, default: false}
+  - {config: perf_b4_s16384_h64_state, default: false}
+  - {config: perf_b4_s32768_h64_state, default: true, selection_role: large}
+  - {config: perf_b1_s8192_h64_state, default: false}
+  - {config: perf_b2_s8192_h64_state, default: false}
+  - {config: perf_b8_s8192_h64_state, default: false}
+  - {config: perf_b16_s8192_h64_state, default: false}

--- a/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
@@ -1,0 +1,3404 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell FP16/BF16 Gated DeltaNet (v1) prefill kernels.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_prefill`` entry,
+driven by the ``chunk_gdn_sm100`` THD/varlen host entry).
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {"name": "cudnn_sm100_gdn_prefill_f16", "category": "cudnn", "compute_capability": 10}
+
+# Deterministic pairwise cover of the frozen legal capability set.  Ragged
+# cases include zero- and one-token sequences while retaining a nonzero
+# TensorMap outer dimension.  ``log_gate`` defaults to True (the engine's
+# production path); raw-alpha (log_gate=False) and safe-gate rows cover the
+# other two gate interpretations.  Checkpoint cadences are the validated
+# positive multiples of the 64-token chunk.
+CONFIGS = [
+    {
+        "label": "pairwise_00",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "q_heads": 2,
+        "k_heads": 4,
+        "v_heads": 4,
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_01",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "state_dtype": "bfloat16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 128,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+    },
+    {
+        "label": "pairwise_02",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 192,
+        "log_gate": False,
+    },
+    {
+        "label": "pairwise_03",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "q_heads": 2,
+        "k_heads": 4,
+        "v_heads": 4,
+        "io_dtype": "float16",
+        "state_dtype": "bfloat16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 64,
+        "log_gate": False,
+        "order_generate": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_04",
+        "seq_lens": (192,),
+        "heads": 4,
+        "q_heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_05",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "q_heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "state_dtype": "bfloat16",
+        "checkpoint_every_n_tokens": 192,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_06",
+        "seq_lens": (192,),
+        "heads": 4,
+        "q_heads": 2,
+        "k_heads": 4,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 128,
+        "safe_gate": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_07",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "q_heads": 2,
+        "k_heads": 4,
+        "v_heads": 4,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 192,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_08",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 1,
+        "state_dtype": "bfloat16",
+        "use_initial_state": True,
+        "store_final_state": False,
+        "safe_gate": True,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "pairwise_09",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "q_heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "cu_dtype": "int64",
+        "checkpoint_every_n_tokens": 128,
+        "beta_sigmoid": True,
+        "log_gate": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_10",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "q_heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "state_dtype": "bfloat16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 64,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_11",
+        "seq_lens": (192,),
+        "heads": 1,
+        "state_dtype": "bfloat16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 64,
+        "log_gate": False,
+    },
+    {
+        "label": "pairwise_12",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "q_heads": 2,
+        "k_heads": 4,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "store_final_state": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_13",
+        "seq_lens": (64, 320),
+        "heads": 6,
+        "q_heads": 6,
+        "k_heads": 2,
+        "v_heads": 2,
+        "io_dtype": "float16",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "dynamic_scheduler": True,
+    },
+]
+
+# Production sweep mirroring the upstream gdn benchmark: h64, unfused l2norm
+# (the source runs gdn without in-kernel q/k normalization), natural-log gates.
+# ``state`` adds the per-chunk checkpoint series the backward pass consumes.
+BENCH_CONFIGS = [
+    {
+        "label": f"perf_b{batch}_s{seqlen}_h64_{mode}",
+        "seq_lens": (seqlen,) * batch,
+        "heads": 64,
+        **({"store_final_state": True, "checkpoint_every_n_tokens": 64} if mode == "state" else {}),
+    }
+    for mode in ("nostate", "state")
+    for batch, seqlen in (
+        (4, 2048),
+        (4, 4096),
+        (4, 8192),
+        (4, 16384),
+        (4, 32768),
+        (1, 8192),
+        (2, 8192),
+        (8, 8192),
+        (16, 8192),
+    )
+]
+
+
+_BT = 64
+_DK = 128
+_DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 5  # per-batch runtime TMA descriptors: Q, K, V, O, checkpoints
+_TRY_WAIT_TICKS = 10_000_000
+_RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
+_LN2 = 0.6931471805599453
+_TMA_G2S_3D = "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+
+# Declaration-ordered physical mbarrier header (fixed capacity for the
+# four-stage K+Q ring; checkpoint builds initialize only three).  Each
+# barrier is 8 bytes; ready and done rings of one pipeline are adjacent.
+_BAR_KQ_READY = 0  # 4 stages
+_BAR_KQ_DONE = 32  # 4 stages
+_BAR_V_READY = 64  # 2 stages
+_BAR_V_DONE = 80  # 2 stages
+_BAR_GATE_READY = 96  # 3 stages
+_BAR_GATE_DONE = 120  # 3 stages
+_BAR_BETA_READY = 144  # 3 stages
+_BAR_BETA_DONE = 168  # 3 stages
+_BAR_STATE_ACC_READY = 192
+_BAR_STATE_SCALE_DONE = 200
+_BAR_O_ACC_READY = 208
+_BAR_O_FINAL_READY = 216
+_BAR_O_SCALE_DONE = 224
+_BAR_CG0_ACC_READY = 232  # 2 stages
+_BAR_CG0_ACC_DONE = 248  # 2 stages
+_BAR_STATE_INP_READY = 264
+_BAR_Y_INP_READY = 272
+_BAR_U_INP_READY = 280
+_BAR_DECAY_U_READY = 288
+_BAR_T_INV_READY = 296  # 3 stages
+_BAR_T_INV_DONE = 320  # 3 stages
+_BAR_A_READY = 344  # 3 stages
+_BAR_A_DONE = 368  # 3 stages
+_BAR_K_STATE_READY = 392
+_BAR_U_ACC_READY = 400
+_BAR_O_STG_READY = 408
+_BAR_O_STG_DONE = 416
+_BAR_CKPT_READY = 424
+_BAR_CKPT_DONE = 432
+_BAR_TMEM_DONE = 440
+_BAR_SCHED_READY = 448  # 2 stages
+_BAR_SCHED_DONE = 464  # 2 stages
+_TMEM_MAILBOX = 480
+_SCHED_BASE = 496  # 2 x i32 ticket ring
+_CUMSUMLOG_BASE = 512  # f32 [64 x 3 stages]
+_CUMPROD_BASE = 1280
+_BETA_RING_BASE = 2048
+_O_BASE = 3072  # IO [64 x 128] x 1 stage
+_CKPT_BASE = 19456  # checkpoint builds only: IO [128 x 128] x 1 stage
+_ARENA_BYTES = 232448
+
+# TMEM columns (512 total); packed IO regions hold two elements per cell.
+_TM_STATE = 0
+_TM_QSTATE = 128
+_TM_STATE_INP = 192
+_TM_CG0 = 256  # 2 stages x 64 columns
+_TM_CG1 = 384
+_TM_YU = 448
+_TM_DECAY_U = 480
+
+# tcgen05 instruction descriptors (M=128; N=64 for GEMMs 1-6, N=128 for the
+# state update), extracted from the source export; FP16 clears the BF16
+# dtype fields (delta 0x480).
+_IDESC_N64_BF16 = 135267472
+_IDESC_N128_BF16 = 136381584
+_KQ_BOX = 512  # 8192 B in 16-byte descriptor units: Q-half / member offset
+_KQ_SEG = 1024  # 16384 B in descriptor units: second-K-half subtile offset
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _load_tensormap(payload, src_map):
+    """Load one host-encoded 128-byte TensorMap image into registers.
+
+    The base images use ordinary global pointers because K's PTX instruction
+    surface intentionally has no parameter-space load; issuing the loads
+    before the order pass hides their cold-memory latency, and one load
+    serves every per-sequence slot of the array.
+    """
+    source = K.reinterpret("uint64", src_map.ptr_to([0]))
+    for group in range(4):
+        offset = K.uint64(group * 32)
+        K.ptx.ld.global_.v4.b64(
+            payload[group * 4],
+            payload[group * 4 + 1],
+            payload[group * 4 + 2],
+            payload[group * 4 + 3],
+            K.reinterpret("handle", source + offset),
+        )
+
+
+def _store_tensormap(dst, payload):
+    target = K.reinterpret("uint64", dst)
+    for word in range(16):
+        K.ptx.st.global_.b64(K.reinterpret("handle", target + K.uint64(word * 8)), payload[word])
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + K.cast(stage, "int32") * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready,
+            _barrier_ptr(arena, byte_offset, stage),
+            K.cast(phase, "uint32"),
+            K.uint32(_TRY_WAIT_TICKS),
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0, *, leader):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=leader
+    )
+
+
+def _load_work_item(work_items, tile):
+    values = K.alloc_local((8,), "int32")
+    K.ptx.ld.global_.v4.b32(
+        values[0], values[1], values[2], values[3], work_items.ptr_to([tile * 8])
+    )
+    K.ptx.ld.global_.v4.b32(
+        values[4], values[5], values[6], values[7], work_items.ptr_to([tile * 8 + 4])
+    )
+    return values
+
+
+def _load_cu(cu_seqlens, index, cu_dtype):
+    if cu_dtype == "int64":
+        wide = K.local_scalar("int64")
+        K.ptx.ld.global_.s64(wide, cu_seqlens.ptr_to([index]))
+        return K.cast(wide, "int32")
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, cu_seqlens.ptr_to([index]))
+    return value
+
+
+def _load_state_value(pointer, index, state_dtype):
+    value = K.local_scalar("float32")
+    if state_dtype == "float32":
+        K.ptx.ld.global_.f32(value, pointer.ptr_to([index]))
+    else:
+        bits = K.local_scalar("uint16")
+        K.ptx.ld.global_.b16(bits, pointer.ptr_to([index]))
+        K.ptx.cvt.f32.bf16(value, bits)
+    return value
+
+
+def _store_state_value(pointer, index, value, state_dtype):
+    if state_dtype == "float32":
+        K.ptx.st.global_.f32(pointer.ptr_to([index]), value)
+    else:
+        K.ptx.st.global_.b16(
+            pointer.ptr_to([index]), K.reinterpret("uint16", K.cast(value, "bfloat16"))
+        )
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _pack_io_pair(lo, hi, io_dtype):
+    packed = K.local_scalar("uint32")
+    if io_dtype == "float16":
+        K.ptx.cvt.rn.f16x2.f32(packed, hi, lo)
+    else:
+        K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _unpack_io_pair(packed, lo, hi, io_dtype):
+    low = K.cast(K.bitwise_and(packed, K.uint32(0xFFFF)), "uint16")
+    high = K.cast(K.shift_right(packed, K.uint32(16)), "uint16")
+    if io_dtype == "float16":
+        K.assign(lo, K.cast(K.reinterpret("float16", low), "float32"))
+        K.assign(hi, K.cast(K.reinterpret("float16", high), "float32"))
+    else:
+        K.ptx.cvt.f32.bf16(lo, low)
+        K.ptx.cvt.f32.bf16(hi, high)
+
+
+def _sub_io_pair(dst, lhs, rhs, io_dtype):
+    if io_dtype == "float16":
+        K.ptx.sub.f16x2(dst, lhs, rhs)
+    else:
+        K.ptx["sub.bf16x2"](dst, lhs, rhs)
+
+
+def _fadd2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fsub2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.sub.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fmul2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _exp2(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _lg2(value):
+    result = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(result, value)
+    return result
+
+
+def _tanh(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _softplus(value):
+    # log(1 + exp(x)) with the source's linear tail (x > 20 returns x).
+    grown = _exp2(value * K.float32(_RCP_LN2))
+    smooth = _lg2(K.float32(1.0) + grown) * K.float32(_LN2)
+    return K.if_then_else(value < K.float32(20.0), smooth, value)
+
+
+def _opaque_zero():
+    zero = K.local_scalar("float32")
+    K.ptx.mov.b32(zero, K.uint32(0))
+    return zero
+
+
+def _shfl_idx_f32(value, source_lane, clamp):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.idx.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.cast(source_lane, "uint32"),
+        K.uint32(clamp),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _shfl_up_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.up.b32(
+        shuffled, K.reinterpret("uint32", value), K.uint32(delta), K.uint32(0), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _raw_descriptor(arena, byte_offset, leading_bytes, stride_bytes, layout):
+    shared = K.cuda.cvta_generic_to_shared(arena.ptr_to([byte_offset]))
+    address = K.bitwise_and(K.shift_right(shared, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    desc = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(desc, K.shift_left(K.uint64(layout & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column):
+    # physical column element for the 128-byte XOR swizzle of a bf16/f16 row
+    return K.bitwise_xor(column, (row & 7) * 8)
+
+
+def _swizzle_lin_128b(linear):
+    # 128-byte XOR swizzle over a linear 64-element-row bf16/f16 index
+    return K.bitwise_xor(linear, K.bitwise_and(K.shift_right(linear, K.int32(3)), K.int32(0x38)))
+
+
+def _io_tile_byte(base, stage_bytes, stage, row, column):
+    # byte offset of (row, column) in one 64-column swizzled IO tile stage
+    return base + stage * stage_bytes + (row * 64 + _swizzle_xor_128b(row, column)) * 2
+
+
+def _mma_m16n8k16(acc, acc_base, a, b0, b1, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b0,
+        b1,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _mma_m16n8k8(acc, acc_base, a0, a1, b0, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a0,
+        a1,
+        b0,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _ldmatrix_x4(dst, pointer, *, trans):
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+            dst[0], dst[1], dst[2], dst[3], pointer
+        )
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(dst[0], dst[1], dst[2], dst[3], pointer)
+
+
+def _ldmatrix_x1(pointer, *, trans):
+    frag = K.local_scalar("uint32")
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16(frag, pointer)
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.shared.b16(frag, pointer)
+    return frag
+
+
+def _stmatrix_x4(pointer, words):
+    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(pointer, words[0], words[1], words[2], words[3])
+
+
+def _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group):
+    row_linear = (d * 8 + tidx_in_group) * 64 + d * 8
+    return arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(row_linear) * 2])
+
+
+def _invert_diagonal_8x8(arena, tinv_byte_base, d, tidx_in_group, io_dtype):
+    """Gauss-Jordan inversion of one diagonal 8x8 block in place (IO SMEM)."""
+    row_ptr = _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group)
+    words = K.alloc_local((4,), "uint32")
+    K.ptx.ld.shared.v4.b32(words[0], words[1], words[2], words[3], row_ptr)
+    row = K.alloc_local((8,), "float32")
+    for pair in range(4):
+        _unpack_io_pair(words[pair], row[pair * 2], row[pair * 2 + 1], io_dtype)
+    for i in range(8):
+        K.assign(row[i], K.if_then_else(tidx_in_group == i, K.float32(1.0), row[i]))
+    for src_row in range(7):
+        row_scale = K.local_scalar("float32", init=-row[src_row])
+        for i in range(src_row):
+            shuffled = _shfl_idx_f32(row[i], src_row, 0b1100000011111)
+            K.assign(
+                row[i],
+                K.if_then_else(tidx_in_group > src_row, row[i] + row_scale * shuffled, row[i]),
+            )
+        K.assign(row[src_row], K.if_then_else(tidx_in_group > src_row, row_scale, row[src_row]))
+    for pair in range(4):
+        K.assign(words[pair], _pack_io_pair(row[pair * 2], row[pair * 2 + 1], io_dtype))
+    K.ptx.st.shared.v4.b32(row_ptr, words[0], words[1], words[2], words[3])
+
+
+def _blockwise_8_to_16(arena, tinv_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 8x8 -> 16x16: C <- -(D^-1 C) A^-1."""
+    lane_off = (lane % 8) * 64
+    d_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + 8 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(c_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(c_regs, 0, d_frag, d_frag, c_frag, io_dtype)
+    a_pack = K.alloc_local((2,), "uint32")
+    for pair in range(2):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]), trans=True
+    )
+    o_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(o_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(o_regs, 0, a_pack[0], a_pack[1], ai_frag, io_dtype)
+    o_pack = _pack_io_pair(o_regs[0], o_regs[1], io_dtype)
+    K.ptx.stmatrix.sync.aligned.m8n8.x1.shared.b16(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_16_to_32(arena, tinv_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 16x16 -> 32x32."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    d_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        d_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + 16 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        c_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            c_regs, n_frag * 4, d_frag, c_frag[n_frag * 2], c_frag[n_frag * 2 + 1], io_dtype
+        )
+    a_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        ai_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    o_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            o_regs, n_frag * 4, a_pack, ai_frag[n_frag * 2], ai_frag[n_frag * 2 + 1], io_dtype
+        )
+    o_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    _stmatrix_x4(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
+    """Off-diagonal correction 32x32 -> 64x64 (two warps, one 16-row band each)."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    a_frags = K.alloc_local((8,), "uint32")
+    for vs in range(2):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + band * 16) * 64 + 32 + vs * 16 + lane_off) * 2
+                ]
+            ),
+            trans=False,
+        )
+        for i in range(4):
+            K.assign(a_frags[vs * 4 + i], chunk[i])
+    b_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(b_frags[vs * 4 + i], chunk[i])
+    c_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_frags[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                c_regs,
+                n_frag * 4,
+                a_view,
+                b_frags[k_step * 8 + n_frag * 2],
+                b_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    a_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b(((vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(ai_frags[vs * 4 + i], chunk[i])
+    o_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_pack[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                o_regs,
+                n_frag * 4,
+                a_view,
+                ai_frags[k_step * 8 + n_frag * 2],
+                ai_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    o_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+    _stmatrix_x4(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]),
+        [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
+    )
+    _stmatrix_x4(
+        arena.ptr_to(
+            [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
+        ),
+        [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
+    )
+
+
+def _acc_operand(accumulate):
+    if isinstance(accumulate, bool | int):
+        return K.uint32(int(accumulate))
+    return K.cast(accumulate, "uint32")
+
+
+def _tcgen_mma_ss(dst, a_desc, b_desc, idesc, *, leader, accumulate):
+    """Fused KK/QK half: four K-phases of the SMEM-A x SMEM-B tcgen05 chain."""
+    for step in range(4):
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            a_desc + K.uint64(2 * step),
+            b_desc + K.uint64(2 * step),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _tcgen_mma_ts(dst, tmem_a, b_desc, idesc, *, leader, accumulate, b_step_units=2):
+    """Four K-phases of the TMEM-A x SMEM-B tcgen05 chain (16-wide steps)."""
+    for step in range(4):
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(b_step_units * step),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _make_prologue(
+    *, run_order, order_generate, dynamic_scheduler, n_heads_out, checkpoints, cu_dtype
+):
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_q: K.gptr[K.i64],
+        base_k: K.gptr[K.i64],
+        base_v: K.gptr[K.i64],
+        base_o: K.gptr[K.i64],
+        base_checkpoint: K.gptr[K.i64],
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[cu_t],
+        q: K.gptr[K.u8],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        o: K.gptr[K.u8],
+        checkpoint: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        n_batch: K.i32,
+        q_row_stride_bytes: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        o_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        thread = K.thread_id()
+        warp = K.warp_id()
+        map_payload = K.alloc_local((16,), "uint64")
+        preload_maps = (base_q, base_k, base_v, base_o) + (
+            (base_checkpoint,) if checkpoints else ()
+        )
+        for array_index, base_map in enumerate(preload_maps):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    _load_tensormap(map_payload, base_map)
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+            with K.If(thread == 0), K.Then():
+                if dynamic_scheduler:
+                    K.ptx.st.global_.s32(scheduler.ptr_to([0]), K.int32(0))
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                    end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                    chunks = (end - begin + _BT - 1) // _BT
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]), batch, head, K.int32(0), chunks
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]), K.int32(0), chunks, begin, end
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                                end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](old, order_arena.ptr_to([32_768]), local_min)
+                K.ptx["atom.shared::cta.max.s32"](old, order_arena.ptr_to([32_772]), local_max)
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network <= padded_count):
+                        distance = K.local_scalar("int32", init=network // 2)
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending = ((item // network) % 2) == 0
+                                    swap = K.Or(
+                                        K.And(ascending, key_i < key_j),
+                                        K.And(K.Not(ascending), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network, network * 2)
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+
+        bases = (q, k, v, o)
+        strides = (q_row_stride_bytes, k_row_stride_bytes, v_row_stride_bytes, o_row_stride_bytes)
+        for array_index in range(4):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, array_index, batch)
+                        _store_tensormap(slot, map_payload)
+                        _replace_tensormap_address(
+                            slot,
+                            bases[array_index].ptr_to(
+                                [K.cast(begin, "int64") * strides[array_index]]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, end - begin)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+        if checkpoints:
+            with K.If(warp == 4), K.Then():
+                with K.If(_elected()), K.Then():
+                    checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        length = end - begin
+                        count = K.local_scalar("int32", init=K.int32(0))
+                        with K.If(length > 0), K.Then():
+                            K.assign(count, (length - 1) // checkpoint_every_n + 1)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, 4, batch)
+                        _store_tensormap(slot, map_payload)
+                        _replace_tensormap_address(
+                            slot,
+                            checkpoint.ptr_to(
+                                [K.cast(checkpoint_prefix, "int64") * checkpoint_row_stride_bytes]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, count)
+                        K.assign(checkpoint_prefix, checkpoint_prefix + count)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+def _make_main(
+    *,
+    num_sms,
+    io_dtype,
+    state_dtype,
+    cu_dtype,
+    use_initial_state,
+    store_final_state,
+    checkpoints,
+    log_gate,
+    safe_gate,
+    beta_sigmoid,
+    dynamic_scheduler,
+    q_ratio,
+    k_ratio,
+    v_ratio,
+    n_heads_out,
+    full_tiles,
+):
+    io_t = K.f16 if io_dtype == "float16" else K.bf16
+    state_t = K.bf16 if state_dtype == "bfloat16" else K.f32
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    beta_t = io_t if beta_sigmoid else K.f32
+    kq_stages = 3 if checkpoints else 4
+    kq_base = _CKPT_BASE + (32768 if checkpoints else 0)
+    tinv_base = kq_base + kq_stages * 32768
+    a_base = tinv_base + 3 * 8192
+    v_base = a_base + 3 * 8192
+    idesc_delta = 1152 if io_dtype == "float16" else 0
+    idesc_n64 = _IDESC_N64_BF16 - idesc_delta
+    idesc_n128 = _IDESC_N128_BF16 - idesc_delta
+    cg1_regs = 256 if use_initial_state else 232
+    other_regs = 24 if use_initial_state else 48
+
+    @K.kernel(warps=12, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        q: K.gptr[io_t],
+        k: K.gptr[io_t],
+        v: K.gptr[io_t],
+        gate: K.gptr[K.f32],
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        beta: K.gptr[beta_t],
+        cu_seqlens: K.gptr[cu_t],
+        initial_state: K.gptr[state_t],
+        o: K.gptr[io_t],
+        final_state: K.gptr[state_t],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        scale: K.f32,
+        checkpoint_every_n: K.i32,
+    ):
+        # --- kernel body starts here ---
+        arena = K.alloc_buffer((_ARENA_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        # Declaration-ordered physical mbarrier protocol; each row is
+        # (byte offset, stages, arrive count, initializing warp).
+        protocol = [
+            (_BAR_KQ_READY, kq_stages, 1, 9),
+            (_BAR_KQ_DONE, kq_stages, 1, 9),
+            (_BAR_V_READY, 2, 1, 9),
+            (_BAR_V_DONE, 2, 128, 9),
+            (_BAR_SCHED_READY, 2, 1, 9),
+            (_BAR_SCHED_DONE, 2, 11, 9),
+            (_BAR_GATE_READY, 3, 32, 8),
+            (_BAR_GATE_DONE, 3, 256, 8),
+            (_BAR_BETA_READY, 3, 32, 8),
+            (_BAR_BETA_DONE, 3, 128, 8),
+            (_BAR_STATE_ACC_READY, 1, 1, 10),
+            (_BAR_O_ACC_READY, 1, 1, 10),
+            (_BAR_O_FINAL_READY, 1, 1, 10),
+            (_BAR_CG0_ACC_READY, 2, 1, 10),
+            (_BAR_CG0_ACC_DONE, 2, 64, 10),
+            (_BAR_K_STATE_READY, 1, 1, 10),
+            (_BAR_U_ACC_READY, 1, 1, 10),
+            (_BAR_T_INV_DONE, 3, 1, 10),
+            (_BAR_A_DONE, 3, 1, 10),
+            (_BAR_T_INV_READY, 3, 128, 0),
+            (_BAR_A_READY, 3, 64, 0),
+            (_BAR_STATE_SCALE_DONE, 1, 128, 4),
+            (_BAR_O_SCALE_DONE, 1, 128, 4),
+            (_BAR_STATE_INP_READY, 1, 128, 4),
+            (_BAR_Y_INP_READY, 1, 128, 4),
+            (_BAR_U_INP_READY, 1, 128, 4),
+            (_BAR_DECAY_U_READY, 1, 128, 4),
+            (_BAR_TMEM_DONE, 1, 128, 4),
+            (_BAR_O_STG_READY, 1, 128, 11),
+            (_BAR_O_STG_DONE, 1, 32, 11),
+            (_BAR_CKPT_READY, 1, 4, 11),
+            (_BAR_CKPT_DONE, 1, 32, 11),
+        ]
+        for owner in (9, 8, 10, 0, 4, 11):
+            with K.If(warp == owner), K.Then():
+                with K.If(_elected()), K.Then():
+                    for offset, stages, count, row_owner in protocol:
+                        if row_owner != owner:
+                            continue
+                        for stage in range(stages):
+                            K.ptx.mbarrier.init.shared.b64(
+                                _barrier_ptr(arena, offset, stage), K.uint32(count)
+                            )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 4), regs=224)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=cg1_regs)
+        gate_beta = roles.role("gate_beta", warps=[8], regs=other_regs)
+        mma = roles.role("mma", warps=[10], regs=other_regs)
+        tma = roles.role("tma", warps=[9], regs=other_regs)
+        epilogue = roles.role("epilogue", warps=[11], regs=other_regs)
+
+        def sched_consume(sched_ps, tile):
+            if dynamic_scheduler:
+                _wait_barrier(arena, _BAR_SCHED_READY, sched_ps.stage, sched_ps.phase)
+                K.ptx.ld.shared.s32(tile, arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]))
+                with K.If(_elected()), K.Then():
+                    _arrive_barrier(arena, _BAR_SCHED_DONE, sched_ps.stage)
+                sched_ps.advance()
+            else:
+                K.assign(tile, tile + num_sms)
+
+        # ================================================================
+        # Warps 0..3 (CG0): T-pairwise, KK epilogue, pair inverse, A epilogue
+        # ================================================================
+        with cg0:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_row = tmem_base >> 16
+            cg0_tidx = thread
+            inv_warp = warp % 2
+            pair_half = warp // 2
+            half_row_base = inv_warp * 32
+            tidx_in_group = cg0_tidx % 8
+            gj_d = (inv_warp * 32 + lane) // 8
+            store_row_frag = lane % 16
+            store_col = (lane // 16) * 8
+            beta_scale_row = warp * 16 + lane % 16
+            row_u0_lo = half_row_base + lane // 4
+            mask_zero = _opaque_zero()
+            gate_ps = K.PipelineState(3, phase=0)
+            beta_ps = K.PipelineState(3, phase=0)
+            cg0_ps = K.PipelineState(2, phase=0)
+            tinv_ps = K.PipelineState(3, phase=1)
+            a_ps = K.PipelineState(3, phase=1)
+            sched_ps = K.PipelineState(2, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                n_local = item[3] - item[4]
+                n_pairs = (n_local + 1) // 2
+                with K.serial(n_pairs, unroll=False) as pair_i:
+                    have_m1 = pair_i * 2 + 1 < n_local
+                    do_kk = K.Or(have_m1, pair_half == 0)
+                    do_a = K.Or(have_m1, pair_half == 1)
+
+                    # ---- gate acquires (ready waits per acquired stage) ----
+                    gate0_idx = K.local_scalar("int32", init=gate_ps.stage)
+                    gate0_phase = K.local_scalar("int32", init=gate_ps.phase)
+                    gate_ps.advance()
+                    _wait_barrier(arena, _BAR_GATE_READY, gate0_idx, gate0_phase)
+                    gate1_idx = K.local_scalar("int32", init=gate0_idx)
+                    with K.If(have_m1), K.Then():
+                        K.assign(gate1_idx, gate_ps.stage)
+                        _wait_barrier(arena, _BAR_GATE_READY, gate_ps.stage, gate_ps.phase)
+                        gate_ps.advance()
+                    kk_gate_idx = K.if_then_else(pair_half == 1, gate1_idx, gate0_idx)
+                    a_gate_idx = K.if_then_else(pair_half == 1, gate0_idx, gate1_idx)
+
+                    # ---- T-pairwise decay fragments for both members -------
+                    kk_rows = K.alloc_local((4,), "float32")
+                    a_rows = K.alloc_local((4,), "float32")
+                    row_offsets = [row_u0_lo, row_u0_lo + 8, row_u0_lo + 16, row_u0_lo + 24]
+                    for index in range(4):
+                        K.ptx.ld.shared.f32(
+                            kk_rows[index],
+                            arena.ptr_to(
+                                [_CUMSUMLOG_BASE + kk_gate_idx * 256 + row_offsets[index] * 4]
+                            ),
+                        )
+                        K.ptx.ld.shared.f32(
+                            a_rows[index],
+                            arena.ptr_to(
+                                [_CUMSUMLOG_BASE + a_gate_idx * 256 + row_offsets[index] * 4]
+                            ),
+                        )
+                    kk_cols = K.alloc_local((16,), "float32")
+                    a_cols = K.alloc_local((16,), "float32")
+                    for group in range(8):
+                        col_base = (lane % 4) * 2 + group * 8
+                        K.ptx.ld.shared.v2.f32(
+                            kk_cols[group * 2],
+                            kk_cols[group * 2 + 1],
+                            arena.ptr_to([_CUMSUMLOG_BASE + kk_gate_idx * 256 + col_base * 4]),
+                        )
+                        K.ptx.ld.shared.v2.f32(
+                            a_cols[group * 2],
+                            a_cols[group * 2 + 1],
+                            arena.ptr_to([_CUMSUMLOG_BASE + a_gate_idx * 256 + col_base * 4]),
+                        )
+                    decay_kk = K.alloc_local((64,), "float32")
+                    decay_a = K.alloc_local((64,), "float32")
+                    for member in range(2):
+                        for cell in range(32):
+                            hi_row = ((cell // 2) % 2) == 1
+                            row_index = member * 2 + (1 if hi_row else 0)
+                            col_index = (cell // 4) * 2 + (cell % 2)
+                            crow = row_offsets[row_index]
+                            ccol = (lane % 4) * 2 + ((cell // 4) * 8 + cell % 2)
+                            kk_val = _exp2(kk_rows[row_index] - kk_cols[col_index])
+                            a_val = _exp2(a_rows[row_index] - a_cols[col_index])
+                            K.assign(
+                                decay_kk[member * 32 + cell],
+                                K.if_then_else(crow >= ccol, kk_val, mask_zero),
+                            )
+                            K.assign(
+                                decay_a[member * 32 + cell],
+                                K.if_then_else(crow >= ccol, a_val, mask_zero),
+                            )
+                    _arrive_barrier(arena, _BAR_GATE_DONE, gate0_idx)
+                    with K.If(have_m1), K.Then():
+                        _arrive_barrier(arena, _BAR_GATE_DONE, gate1_idx)
+
+                    # ---- beta acquires (ready waits per acquired stage) ----
+                    beta0_idx = K.local_scalar("int32", init=beta_ps.stage)
+                    beta0_phase = K.local_scalar("int32", init=beta_ps.phase)
+                    beta_ps.advance()
+                    _wait_barrier(arena, _BAR_BETA_READY, beta0_idx, beta0_phase)
+                    beta1_idx = K.local_scalar("int32", init=beta0_idx)
+                    with K.If(have_m1), K.Then():
+                        K.assign(beta1_idx, beta_ps.stage)
+                        _wait_barrier(arena, _BAR_BETA_READY, beta_ps.stage, beta_ps.phase)
+                        beta_ps.advance()
+                    kk_beta_idx = K.if_then_else(pair_half == 1, beta1_idx, beta0_idx)
+                    kk_beta = K.alloc_local((4,), "float32")
+                    for index in range(4):
+                        K.ptx.ld.shared.f32(
+                            kk_beta[index],
+                            arena.ptr_to(
+                                [_BETA_RING_BASE + kk_beta_idx * 256 + row_offsets[index] * 4]
+                            ),
+                        )
+
+                    # ---- accumulator / T-inverse slot pairing --------------
+                    acc0_idx = K.local_scalar("int32", init=cg0_ps.stage)
+                    acc0_phase = K.local_scalar("int32", init=cg0_ps.phase)
+                    cg0_ps.advance()
+                    acc1_idx = K.local_scalar("int32", init=acc0_idx)
+                    acc1_phase = K.local_scalar("int32", init=acc0_phase)
+                    with K.If(have_m1), K.Then():
+                        K.assign(acc1_idx, cg0_ps.stage)
+                        K.assign(acc1_phase, cg0_ps.phase)
+                        cg0_ps.advance()
+                    kk_acc_idx = K.if_then_else(pair_half == 1, acc1_idx, acc0_idx)
+                    kk_acc_phase = K.if_then_else(pair_half == 1, acc1_phase, acc0_phase)
+                    a_acc_idx = K.if_then_else(pair_half == 1, acc0_idx, acc1_idx)
+                    tinv0_idx = K.local_scalar("int32", init=tinv_ps.stage)
+                    tinv0_phase = K.local_scalar("int32", init=tinv_ps.phase)
+                    tinv_ps.advance()
+                    tinv1_idx = K.local_scalar("int32", init=tinv0_idx)
+                    tinv1_phase = K.local_scalar("int32", init=tinv0_phase)
+                    with K.If(have_m1), K.Then():
+                        K.assign(tinv1_idx, tinv_ps.stage)
+                        K.assign(tinv1_phase, tinv_ps.phase)
+                        tinv_ps.advance()
+                    kk_tinv_idx = K.if_then_else(pair_half == 1, tinv1_idx, tinv0_idx)
+                    kk_tinv_phase = K.if_then_else(pair_half == 1, tinv1_phase, tinv0_phase)
+
+                    # ---- KK epilogue into the T-inverse buffer -------------
+                    with K.If(do_kk), K.Then():
+                        _wait_barrier(arena, _BAR_CG0_ACC_READY, kk_acc_idx, kk_acc_phase)
+                        kk_vec0 = K.alloc_local((32,), "float32")
+                        kk_vec1 = K.alloc_local((32,), "float32")
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[kk_vec0[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + kk_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[kk_vec1[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + kk_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32 + 16, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        _wait_barrier(arena, _BAR_T_INV_DONE, kk_tinv_idx, kk_tinv_phase)
+                        for member in range(2):
+                            source_vec = kk_vec1 if member == 1 else kk_vec0
+                            packs = K.alloc_local((16,), "uint32")
+                            for cell in range(16):
+                                beta_row = kk_beta[member * 2 + (cell % 2)]
+                                p0, p1 = _fmul2(
+                                    source_vec[2 * cell],
+                                    source_vec[2 * cell + 1],
+                                    decay_kk[member * 32 + 2 * cell],
+                                    decay_kk[member * 32 + 2 * cell + 1],
+                                )
+                                v0, v1 = _fmul2(p0, p1, beta_row, beta_row)
+                                K.assign(packs[cell], _pack_io_pair(v0, v1, io_dtype))
+                            st_row = half_row_base + member * 16 + store_row_frag
+                            for frag in range(4):
+                                _stmatrix_x4(
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + kk_tinv_idx * 8192
+                                            + (
+                                                st_row * 64
+                                                + _swizzle_xor_128b(st_row, store_col + frag * 16)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    [packs[frag * 4 + j] for j in range(4)],
+                                )
+
+                    # ---- four-level hierarchical pair inverse --------------
+                    inv_tinv_idx = K.local_scalar("int32", init=tinv0_idx)
+                    with K.If(have_m1), K.Then():
+                        with K.If(warp >= 2), K.Then():
+                            K.assign(inv_tinv_idx, tinv1_idx)
+                    do_inv = K.Or(have_m1, warp < 2)
+                    inv_byte_base = tinv_base + inv_tinv_idx * 8192
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(do_inv), K.Then():
+                        _invert_diagonal_8x8(arena, inv_byte_base, gj_d, tidx_in_group, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    _blockwise_8_to_16(
+                        arena, tinv_base + tinv0_idx * 8192, warp * 16, lane, io_dtype
+                    )
+                    with K.If(have_m1), K.Then():
+                        _blockwise_8_to_16(
+                            arena, tinv_base + tinv1_idx * 8192, warp * 16, lane, io_dtype
+                        )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(do_inv), K.Then():
+                        _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    # ---- post-inverse beta column scaling + publish --------
+                    for stage_member in range(2):
+                        publish = K.bool(True) if stage_member == 0 else have_m1
+                        stage_idx = tinv0_idx if stage_member == 0 else tinv1_idx
+                        stage_beta = beta0_idx if stage_member == 0 else beta1_idx
+                        with K.If(publish), K.Then():
+                            beta_col = K.alloc_local((16,), "float32")
+                            for group in range(8):
+                                col_base = (lane % 4) * 2 + group * 8
+                                K.ptx.ld.shared.v2.f32(
+                                    beta_col[group * 2],
+                                    beta_col[group * 2 + 1],
+                                    arena.ptr_to(
+                                        [_BETA_RING_BASE + stage_beta * 256 + col_base * 4]
+                                    ),
+                                )
+                            tinv_words = K.alloc_local((16,), "uint32")
+                            for frag in range(4):
+                                chunk_words = K.alloc_local((4,), "uint32")
+                                _ldmatrix_x4(
+                                    chunk_words,
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + stage_idx * 8192
+                                            + (
+                                                beta_scale_row * 64
+                                                + _swizzle_xor_128b(
+                                                    beta_scale_row, store_col + frag * 16
+                                                )
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    trans=False,
+                                )
+                                for j in range(4):
+                                    K.assign(tinv_words[frag * 4 + j], chunk_words[j])
+                            scaled = K.alloc_local((16,), "uint32")
+                            for j in range(16):
+                                lo = K.local_scalar("float32")
+                                hi = K.local_scalar("float32")
+                                _unpack_io_pair(tinv_words[j], lo, hi, io_dtype)
+                                s0, s1 = _fmul2(
+                                    lo, hi, beta_col[(j // 2) * 2], beta_col[(j // 2) * 2 + 1]
+                                )
+                                K.assign(scaled[j], _pack_io_pair(s0, s1, io_dtype))
+                            for frag in range(4):
+                                _stmatrix_x4(
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + stage_idx * 8192
+                                            + (
+                                                beta_scale_row * 64
+                                                + _swizzle_xor_128b(
+                                                    beta_scale_row, store_col + frag * 16
+                                                )
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    [scaled[frag * 4 + j] for j in range(4)],
+                                )
+                            K.ptx.fence.proxy.async_.shared__cta()
+                            _arrive_barrier(arena, _BAR_T_INV_READY, stage_idx)
+                            _arrive_barrier(arena, _BAR_BETA_DONE, stage_beta)
+
+                    # ---- causal A epilogue (opposite member) ---------------
+                    a0_idx = K.local_scalar("int32", init=a_ps.stage)
+                    a0_phase = K.local_scalar("int32", init=a_ps.phase)
+                    a_ps.advance()
+                    a1_idx = K.local_scalar("int32", init=a0_idx)
+                    a1_phase = K.local_scalar("int32", init=a0_phase)
+                    with K.If(have_m1), K.Then():
+                        K.assign(a1_idx, a_ps.stage)
+                        K.assign(a1_phase, a_ps.phase)
+                        a_ps.advance()
+                    my_a_idx = K.if_then_else(pair_half == 1, a0_idx, a1_idx)
+                    my_a_phase = K.if_then_else(pair_half == 1, a0_phase, a1_phase)
+                    with K.If(do_a), K.Then():
+                        a_vec0 = K.alloc_local((32,), "float32")
+                        a_vec1 = K.alloc_local((32,), "float32")
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[a_vec0[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + a_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[a_vec1[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + a_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32 + 16, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        _arrive_barrier(arena, _BAR_CG0_ACC_DONE, a_acc_idx)
+                        _wait_barrier(arena, _BAR_A_DONE, my_a_idx, my_a_phase)
+                        for member in range(2):
+                            source_vec = a_vec1 if member == 1 else a_vec0
+                            packs = K.alloc_local((16,), "uint32")
+                            for cell in range(16):
+                                p0, p1 = _fmul2(
+                                    source_vec[2 * cell],
+                                    source_vec[2 * cell + 1],
+                                    decay_a[member * 32 + 2 * cell],
+                                    decay_a[member * 32 + 2 * cell + 1],
+                                )
+                                v0, v1 = _fmul2(p0, p1, scale, scale)
+                                K.assign(packs[cell], _pack_io_pair(v0, v1, io_dtype))
+                            st_row = half_row_base + member * 16 + store_row_frag
+                            for frag in range(4):
+                                _stmatrix_x4(
+                                    arena.ptr_to(
+                                        [
+                                            a_base
+                                            + my_a_idx * 8192
+                                            + (
+                                                st_row * 64
+                                                + _swizzle_xor_128b(st_row, store_col + frag * 16)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    [packs[frag * 4 + j] for j in range(4)],
+                                )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_A_READY, my_a_idx)
+                sched_consume(sched_ps, tile)
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_T_INV_DONE, tinv_ps.stage, tinv_ps.phase)
+                tinv_ps.advance()
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_A_DONE, a_ps.stage, a_ps.phase)
+                a_ps.advance()
+
+        # ================================================================
+        # Warps 4..7 (CG1): state seed/restage/rescale, Y, Q*S, U, O, final
+        # ================================================================
+        with cg1:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_row = tmem_base >> 16
+            cg1_tidx = thread - 128
+            value_dim = cg1_tidx
+            row_id = tmem_row + (cg1_tidx // 32) * 32
+            v_o_tok = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+            v_o_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+            v_o_sub_off = (cg1_tidx // 64) * 8192
+            ckpt_elem_off = None
+            if checkpoints:
+                # The snapshot store offsets are chunk-invariant but live under
+                # a runtime branch the compiler will not hoist across.
+                ckpt_elem_off = K.alloc_local((16,), "int32")
+                for sub in range(4):
+                    for group in range(4):
+                        dk = sub * 32 + group * 8
+                        element = (
+                            (dk // 64) * 8192 + cg1_tidx * 64 + _swizzle_xor_128b(cg1_tidx, dk % 64)
+                        )
+                        K.assign(ckpt_elem_off[sub * 4 + group], _CKPT_BASE + element * 2)
+            v_ps = K.PipelineState(2, phase=0)
+            gate_ps = K.PipelineState(3, phase=0)
+            state_ps = K.PipelineState(1, phase=0)
+            seed_ps = K.PipelineState(1, phase=1)
+            oacc_ps = K.PipelineState(1, phase=0)
+            ofin_ps = K.PipelineState(1, phase=0)
+            kst_ps = K.PipelineState(1, phase=0)
+            uacc_ps = K.PipelineState(1, phase=0)
+            o_ps = K.PipelineState(1, phase=1)
+            sched_ps = K.PipelineState(2, phase=0)
+            ckpt_cnt = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                bos = item[6]
+                eos = item[7]
+                num_chunks_b = (eos - bos + _BT - 1) // _BT
+                n_local = wend - cstart
+                state_index = (
+                    (K.cast(batch, "int64") * n_heads_out + head) * 128 + value_dim
+                ) * 128
+                ckpt_chunks = K.local_scalar("int32", init=K.int32(1))
+                ckpt_mod = K.local_scalar("int32", init=K.int32(0))
+                if checkpoints:
+                    K.assign(ckpt_chunks, checkpoint_every_n // _BT)
+                    K.assign(ckpt_mod, cstart % ckpt_chunks)
+                with K.If(n_local > 0), K.Then():
+                    if use_initial_state:
+                        # ---- initial-state seed: GMEM (or zero) -> TMEM ----
+                        _wait_barrier(arena, _BAR_STATE_SCALE_DONE, 0, seed_ps.phase)
+                        seed_ps.advance()
+                        with K.If(cstart == 0), K.Then():
+                            for sub in range(4):
+                                seeded = K.alloc_local((32,), "float32")
+                                for key in range(32):
+                                    K.assign(
+                                        seeded[key],
+                                        _load_state_value(
+                                            initial_state, state_index + sub * 32 + key, state_dtype
+                                        ),
+                                    )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[seeded[i] for i in range(32)],
+                                )
+                        with K.If(cstart != 0), K.Then():
+                            for sub in range(4):
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[K.float32(0.0) for _ in range(32)],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+
+                    def cg1_chunk(local_chunk, have_state, overlap_k_state, overlap_restage):
+                        # ``have_state`` is K.bool(False) for the peeled first
+                        # chunk, K.bool(True) for steady/initial-state chunks;
+                        # constant guards fold out of the generated code.
+                        chunk = cstart + local_chunk
+                        do_ckpt_now = K.local_scalar("int32", init=K.int32(0))
+                        if checkpoints:
+                            K.assign(do_ckpt_now, K.cast(ckpt_mod == 0, "int32"))
+                            K.assign(ckpt_mod, ckpt_mod + 1)
+                            with K.If(ckpt_mod == ckpt_chunks), K.Then():
+                                K.assign(ckpt_mod, K.int32(0))
+                        if checkpoints and not use_initial_state:
+                            with K.If(K.And(chunk == 0, wstart == 0)), K.Then():
+                                _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+                                for zero_step in range(64):
+                                    K.ptx.st.shared.u32(
+                                        arena.ptr_to(
+                                            [_CKPT_BASE + (cg1_tidx + zero_step * 128) * 4]
+                                        ),
+                                        K.uint32(0),
+                                    )
+                                K.ptx.fence.proxy.async_.shared__cta()
+                                with K.If(_elected()), K.Then():
+                                    _arrive_barrier(arena, _BAR_CKPT_READY, 0)
+                                K.assign(ckpt_cnt, ckpt_cnt + 1)
+                        if use_initial_state:
+                            seed_ps.advance()
+
+                        gate_idx = K.local_scalar("int32", init=gate_ps.stage)
+                        gate_phase = K.local_scalar("int32", init=gate_ps.phase)
+                        gate_ps.advance()
+                        _wait_barrier(arena, _BAR_GATE_READY, gate_idx, gate_phase)
+                        cumprod_total = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            cumprod_total, arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + 63 * 4])
+                        )
+
+                        # ---- state restage + checkpoint + rescale ----------
+                        state_vals = K.alloc_local((128,), "float32")
+
+                        def emit_state_load():
+                            _wait_barrier(arena, _BAR_STATE_ACC_READY, 0, state_ps.phase)
+                            state_ps.advance()
+                            for sub in range(4):
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[state_vals[sub * 32 + i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+
+                        def emit_state_rest():
+                            for sub in range(4):
+                                packed = K.alloc_local((16,), "uint32")
+                                for pair in range(16):
+                                    K.assign(
+                                        packed[pair],
+                                        _pack_io_pair(
+                                            state_vals[sub * 32 + 2 * pair],
+                                            state_vals[sub * 32 + 2 * pair + 1],
+                                            io_dtype,
+                                        ),
+                                    )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE_INP
+                                        + sub * 16
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[packed[i] for i in range(16)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, _BAR_STATE_INP_READY, 0)
+                            if checkpoints:
+                                with (
+                                    K.If(
+                                        K.And(
+                                            do_ckpt_now == 1, K.And(chunk >= wstart, chunk < wend)
+                                        )
+                                    ),
+                                    K.Then(),
+                                ):
+                                    _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+                                    for sub in range(4):
+                                        # state_vals still holds this chunk's
+                                        # pre-rescale state from the restage
+                                        # read in the same barrier window.
+                                        for group in range(4):
+                                            words = K.alloc_local((4,), "uint32")
+                                            for pair in range(4):
+                                                K.assign(
+                                                    words[pair],
+                                                    _pack_io_pair(
+                                                        state_vals[sub * 32 + group * 8 + 2 * pair],
+                                                        state_vals[
+                                                            sub * 32 + group * 8 + 2 * pair + 1
+                                                        ],
+                                                        io_dtype,
+                                                    ),
+                                                )
+                                            K.ptx.st.shared.v4.b32(
+                                                arena.ptr_to([ckpt_elem_off[sub * 4 + group]]),
+                                                words[0],
+                                                words[1],
+                                                words[2],
+                                                words[3],
+                                            )
+                                    K.ptx.fence.proxy.async_.shared__cta()
+                                    with K.If(_elected()), K.Then():
+                                        _arrive_barrier(arena, _BAR_CKPT_READY, 0)
+                                    K.assign(ckpt_cnt, ckpt_cnt + 1)
+                            for sub in range(4):
+                                rescaled = K.alloc_local((32,), "float32")
+                                for pair in range(16):
+                                    s0, s1 = _fmul2(
+                                        state_vals[sub * 32 + 2 * pair],
+                                        state_vals[sub * 32 + 2 * pair + 1],
+                                        cumprod_total,
+                                        cumprod_total,
+                                    )
+                                    K.assign(rescaled[2 * pair], s0)
+                                    K.assign(rescaled[2 * pair + 1], s1)
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[rescaled[i] for i in range(32)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, _BAR_STATE_SCALE_DONE, 0)
+
+                        # 16 distinct column values; cell k maps to
+                        # (k // 4) * 2 + (k % 2).
+                        cumprod_vals = K.alloc_local((16,), "float32")
+                        decay_scale = K.alloc_local((16,), "float32")
+
+                        def emit_gate_regs():
+                            # ---- per-row gate registers ------------------------
+                            cumsum_cols = K.alloc_local((16,), "float32")
+                            for group in range(8):
+                                col_base = (lane % 4) * 2 + group * 8
+                                pair_lo = K.local_scalar("float32")
+                                pair_hi = K.local_scalar("float32")
+                                K.ptx.ld.shared.v2.f32(
+                                    pair_lo,
+                                    pair_hi,
+                                    arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + col_base * 4]),
+                                )
+                                K.assign(cumprod_vals[group * 2], pair_lo)
+                                K.assign(cumprod_vals[group * 2 + 1], pair_hi)
+                                K.ptx.ld.shared.v2.f32(
+                                    cumsum_cols[group * 2],
+                                    cumsum_cols[group * 2 + 1],
+                                    arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + col_base * 4]),
+                                )
+                            last_cumsumlog = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                last_cumsumlog,
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + 63 * 4]),
+                            )
+                            for pair in range(8):
+                                d0, d1 = _fsub2(
+                                    last_cumsumlog,
+                                    last_cumsumlog,
+                                    cumsum_cols[pair * 2],
+                                    cumsum_cols[pair * 2 + 1],
+                                )
+                                K.assign(decay_scale[pair * 2], _exp2(d0))
+                                K.assign(decay_scale[pair * 2 + 1], _exp2(d1))
+                            _arrive_barrier(arena, _BAR_GATE_DONE, gate_idx)
+
+                        if overlap_restage:
+                            # Issue the 128-value state TMEM read, cover its latency
+                            # with the independent gate-register shared loads, then
+                            # repack/publish.
+                            with K.If(have_state), K.Then():
+                                emit_state_load()
+                            emit_gate_regs()
+                            with K.If(have_state), K.Then():
+                                emit_state_rest()
+                        else:
+                            with K.If(have_state), K.Then():
+                                emit_state_load()
+                                emit_state_rest()
+                            emit_gate_regs()
+
+                        # ---- Y = V - cumprod * (K*S), packed 16-bit --------
+                        v_idx = K.local_scalar("int32", init=v_ps.stage)
+                        v_phase = K.local_scalar("int32", init=v_ps.phase)
+                        v_ps.advance()
+                        k_state_vals = None
+                        if overlap_k_state:
+                            # Issue the recurrent (K*S)^T TMEM loads before the
+                            # independent V shared-memory batch so the LDSM
+                            # loads cover the TMEM latency.
+                            _wait_barrier(arena, _BAR_K_STATE_READY, 0, kst_ps.phase)
+                            kst_ps.advance()
+                            k_state_vals = K.alloc_local((64,), "float32")
+                            for sub in range(2):
+                                K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                    *[k_state_vals[sub * 32 + i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_CG1
+                                        + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                        _wait_barrier(arena, _BAR_V_READY, v_idx, v_phase)
+                        v_frags = K.alloc_local((32,), "uint32")
+                        for piece in range(8):
+                            m0 = piece % 4
+                            sub = piece // 4
+                            frag = K.alloc_local((4,), "uint32")
+                            _ldmatrix_x4(
+                                frag,
+                                arena.ptr_to(
+                                    [
+                                        v_base
+                                        + v_idx * 16384
+                                        + v_o_sub_off
+                                        + (
+                                            (v_o_tok + m0 * 16) * 64
+                                            + _swizzle_xor_128b(
+                                                v_o_tok + m0 * 16, v_o_col + sub * 16
+                                            )
+                                        )
+                                        * 2
+                                    ]
+                                ),
+                                trans=True,
+                            )
+                            for i in range(4):
+                                K.assign(v_frags[(4 * m0 + i) * 2 + sub], frag[i])
+                        with K.If(have_state), K.Then():
+                            if k_state_vals is None:
+                                _wait_barrier(arena, _BAR_K_STATE_READY, 0, kst_ps.phase)
+                                kst_ps.advance()
+                            for sub in range(2):
+                                if k_state_vals is None:
+                                    k_state_vec = K.alloc_local((32,), "float32")
+                                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                        *[k_state_vec[i] for i in range(32)],
+                                        K.cast(
+                                            tmem_col
+                                            + _TM_CG1
+                                            + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                            "uint32",
+                                        ),
+                                    )
+                                    source_vals = k_state_vec
+                                    source_base = 0
+                                else:
+                                    source_vals = k_state_vals
+                                    source_base = sub * 32
+                                for j in range(16):
+                                    s0, s1 = _fmul2(
+                                        source_vals[source_base + 2 * j],
+                                        source_vals[source_base + 2 * j + 1],
+                                        cumprod_vals[(2 * j // 4) * 2 + (2 * j) % 2],
+                                        cumprod_vals[((2 * j + 1) // 4) * 2 + (2 * j + 1) % 2],
+                                    )
+                                    word = _pack_io_pair(s0, s1, io_dtype)
+                                    _sub_io_pair(
+                                        v_frags[j * 2 + sub], v_frags[j * 2 + sub], word, io_dtype
+                                    )
+                        for sub in range(2):
+                            K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TM_YU
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[v_frags[j * 2 + sub] for j in range(16)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_Y_INP_READY, 0)
+
+                        # ---- Q*S epilogue: acc *= cumprod * scale ----------
+                        with K.If(have_state), K.Then():
+                            _wait_barrier(arena, _BAR_O_ACC_READY, 0, oacc_ps.phase)
+                            oacc_ps.advance()
+                            for sub in range(2):
+                                q_state_vec = K.alloc_local((32,), "float32")
+                                K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                    *[q_state_vec[i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_QSTATE
+                                        + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                scaled = K.alloc_local((32,), "float32")
+                                for j in range(16):
+                                    p0, p1 = _fmul2(
+                                        q_state_vec[2 * j],
+                                        q_state_vec[2 * j + 1],
+                                        cumprod_vals[(2 * j // 4) * 2 + (2 * j) % 2],
+                                        cumprod_vals[((2 * j + 1) // 4) * 2 + (2 * j + 1) % 2],
+                                    )
+                                    s0, s1 = _fmul2(p0, p1, scale, scale)
+                                    K.assign(scaled[2 * j], s0)
+                                    K.assign(scaled[2 * j + 1], s1)
+                                K.ptx["tcgen05.st.sync.aligned.16x256b.x8.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_QSTATE
+                                        + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[scaled[i] for i in range(32)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, _BAR_O_SCALE_DONE, 0)
+
+                        # ---- U epilogue + decayed-U publish ----------------
+                        _wait_barrier(arena, _BAR_U_ACC_READY, 0, uacc_ps.phase)
+                        uacc_ps.advance()
+                        _arrive_barrier(arena, _BAR_V_DONE, v_idx)
+                        u_vals = K.alloc_local((64,), "float32")
+                        for sub in range(2):
+                            K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                *[u_vals[sub * 32 + i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TM_CG1
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                        for sub in range(2):
+                            u_pack = K.alloc_local((16,), "uint32")
+                            for j in range(16):
+                                K.assign(
+                                    u_pack[j],
+                                    _pack_io_pair(
+                                        u_vals[sub * 32 + 2 * j],
+                                        u_vals[sub * 32 + 2 * j + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TM_YU
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[u_pack[i] for i in range(16)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_U_INP_READY, 0)
+                        for sub in range(2):
+                            decay_pack = K.alloc_local((16,), "uint32")
+                            for j in range(16):
+                                d0, d1 = _fmul2(
+                                    u_vals[sub * 32 + 2 * j],
+                                    u_vals[sub * 32 + 2 * j + 1],
+                                    decay_scale[(2 * j // 4) * 2 + (2 * j) % 2],
+                                    decay_scale[((2 * j + 1) // 4) * 2 + (2 * j + 1) % 2],
+                                )
+                                K.assign(decay_pack[j], _pack_io_pair(d0, d1, io_dtype))
+                            K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TM_DECAY_U
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[decay_pack[i] for i in range(16)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_DECAY_U_READY, 0)
+
+                        # ---- O epilogue: acc TMEM -> sO SMEM ---------------
+                        _wait_barrier(arena, _BAR_O_FINAL_READY, 0, ofin_ps.phase)
+                        ofin_ps.advance()
+                        o_vals = K.alloc_local((64,), "float32")
+                        for sub in range(2):
+                            K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                *[o_vals[sub * 32 + i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TM_QSTATE
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                        o_phase = K.local_scalar("int32", init=o_ps.phase)
+                        o_ps.advance()
+                        # The o-ring release is independent of the accumulator
+                        # read; waiting it first covers the TMEM load latency.
+                        _wait_barrier(arena, _BAR_O_STG_DONE, 0, o_phase)
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        for sub in range(2):
+                            for m0 in range(4):
+                                o_pack = K.alloc_local((4,), "uint32")
+                                for j in range(4):
+                                    K.assign(
+                                        o_pack[j],
+                                        _pack_io_pair(
+                                            o_vals[sub * 32 + 8 * m0 + 2 * j],
+                                            o_vals[sub * 32 + 8 * m0 + 2 * j + 1],
+                                            io_dtype,
+                                        ),
+                                    )
+                                K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                                    arena.ptr_to(
+                                        [
+                                            _O_BASE
+                                            + v_o_sub_off
+                                            + (
+                                                (v_o_tok + m0 * 16) * 64
+                                                + _swizzle_xor_128b(
+                                                    v_o_tok + m0 * 16, v_o_col + sub * 16
+                                                )
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    o_pack[0],
+                                    o_pack[1],
+                                    o_pack[2],
+                                    o_pack[3],
+                                )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_O_STG_READY, 0)
+
+                    if use_initial_state:
+                        with K.serial(n_local, unroll=False) as local_chunk:
+                            cg1_chunk(local_chunk, K.bool(True), False, False)
+                    else:
+                        # Peel the first chunk so the recurrent state predicate
+                        # is compile-time in the steady loop, which may then
+                        # overlap the K*S TMEM reads with the V loads.
+                        cg1_chunk(0, K.bool(False), False, False)
+                        with K.serial(n_local - 1, unroll=False) as recurrent_chunk:
+                            # Checkpoint builds keep the source load order: the
+                            # snapshot traffic leaves no room for the overlap's
+                            # extra live fragments.
+                            cg1_chunk(
+                                recurrent_chunk + 1, K.bool(True), not checkpoints, not checkpoints
+                            )
+
+                    # ---- final state: TMEM -> GMEM after the last chunk ----
+                    _wait_barrier(arena, _BAR_STATE_ACC_READY, 0, state_ps.phase)
+                    state_ps.advance()
+                    if store_final_state:
+                        with K.If(wend == num_chunks_b), K.Then():
+                            for sub in range(4):
+                                final_vals = K.alloc_local((32,), "float32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[final_vals[i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                if state_dtype == "float32":
+                                    for group in range(8):
+                                        key = group * 4
+                                        K.ptx.st.global_.v2.b64(
+                                            final_state.ptr_to([state_index + sub * 32 + key]),
+                                            K.cuda.make_float2(
+                                                final_vals[key], final_vals[key + 1]
+                                            ),
+                                            K.cuda.make_float2(
+                                                final_vals[key + 2], final_vals[key + 3]
+                                            ),
+                                        )
+                                else:
+                                    for group in range(4):
+                                        key = group * 8
+                                        words = K.alloc_local((4,), "uint32")
+                                        for pair in range(4):
+                                            K.assign(
+                                                words[pair],
+                                                _pack_io_pair(
+                                                    final_vals[key + pair * 2],
+                                                    final_vals[key + pair * 2 + 1],
+                                                    "bfloat16",
+                                                ),
+                                            )
+                                        K.ptx.st.global_.v4.b32(
+                                            final_state.ptr_to([state_index + sub * 32 + key]),
+                                            words[0],
+                                            words[1],
+                                            words[2],
+                                            words[3],
+                                        )
+                    _arrive_barrier(arena, _BAR_STATE_SCALE_DONE, 0)
+                with K.If(n_local == 0), K.Then():
+                    if store_final_state:
+                        with K.If(wend == num_chunks_b), K.Then():
+                            if state_dtype == "float32":
+                                for group in range(32):
+                                    key = group * 4
+                                    quad = []
+                                    for element in range(4):
+                                        value = K.local_scalar("float32", init=K.float32(0.0))
+                                        if use_initial_state:
+                                            K.assign(
+                                                value,
+                                                _load_state_value(
+                                                    initial_state,
+                                                    state_index + key + element,
+                                                    state_dtype,
+                                                ),
+                                            )
+                                        quad.append(value)
+                                    K.ptx.st.global_.v2.b64(
+                                        final_state.ptr_to([state_index + key]),
+                                        K.cuda.make_float2(quad[0], quad[1]),
+                                        K.cuda.make_float2(quad[2], quad[3]),
+                                    )
+                            else:
+                                for group in range(16):
+                                    key = group * 8
+                                    words = K.alloc_local((4,), "uint32")
+                                    for pair in range(4):
+                                        lo = K.local_scalar("float32", init=K.float32(0.0))
+                                        hi = K.local_scalar("float32", init=K.float32(0.0))
+                                        if use_initial_state:
+                                            K.assign(
+                                                lo,
+                                                _load_state_value(
+                                                    initial_state,
+                                                    state_index + key + pair * 2,
+                                                    state_dtype,
+                                                ),
+                                            )
+                                            K.assign(
+                                                hi,
+                                                _load_state_value(
+                                                    initial_state,
+                                                    state_index + key + pair * 2 + 1,
+                                                    state_dtype,
+                                                ),
+                                            )
+                                        K.assign(words[pair], _pack_io_pair(lo, hi, "bfloat16"))
+                                    K.ptx.st.global_.v4.b32(
+                                        final_state.ptr_to([state_index + key]),
+                                        words[0],
+                                        words[1],
+                                        words[2],
+                                        words[3],
+                                    )
+                sched_consume(sched_ps, tile)
+            _arrive_barrier(arena, _BAR_TMEM_DONE, 0)
+            _wait_barrier(arena, _BAR_O_STG_DONE, 0, o_ps.phase)
+            o_ps.advance()
+            if checkpoints:
+                _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+
+        # ================================================================
+        # Warp 8: gate/beta producer
+        # ================================================================
+        with gate_beta:
+            gate_ps = K.PipelineState(3, phase=1)
+            beta_ps = K.PipelineState(3, phase=1)
+            sched_ps = K.PipelineState(2, phase=0)
+            lidx = lane
+            a_l2 = K.local_scalar("float32", init=K.float32(0.0))
+            bias = K.local_scalar("float32", init=K.float32(0.0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                head = item[1]
+                cstart = item[4]
+                wend = item[3]
+                batch_start = item[6]
+                batch_end = item[7]
+                n_local = wend - cstart
+                if safe_gate:
+                    with K.If(n_local > 0), K.Then():
+                        a_value = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(a_value, a_log.ptr_to([head]))
+                        K.assign(a_l2, -_exp2(a_value * K.float32(_RCP_LN2)) * K.float32(_RCP_LN2))
+                        K.ptx.ld.global_.f32(bias, dt_bias.ptr_to([head]))
+                with K.If(n_local > 0), K.Then():
+                    with K.serial(n_local, unroll=False) as local_idx:
+                        chunk = cstart + local_idx
+                        chunk_offset = batch_start + chunk * _BT
+                        gate_idx = K.local_scalar("int32", init=gate_ps.stage)
+                        gate_phase = K.local_scalar("int32", init=gate_ps.phase)
+                        gate_ps.advance()
+                        oob_neutral = 0.0 if log_gate else 1.0
+                        gate_vals = K.alloc_local((2,), "float32")
+                        for col in range(2):
+                            tok = chunk_offset + lidx + col * 32
+                            K.assign(gate_vals[col], K.float32(oob_neutral))
+                            with K.If(tok < batch_end), K.Then():
+                                clamped = K.if_then_else(tok < batch_end - 1, tok, batch_end - 1)
+                                K.ptx.ld.global_.f32(
+                                    gate_vals[col],
+                                    gate.ptr_to([K.cast(clamped, "int64") * n_heads_out + head]),
+                                )
+                        if safe_gate:
+                            for col in range(2):
+                                tok = chunk_offset + lidx + col * 32
+                                contribution = a_l2 * _softplus(gate_vals[col] + bias)
+                                K.assign(
+                                    gate_vals[col],
+                                    K.if_then_else(tok < batch_end, contribution, K.float32(0.0)),
+                                )
+                        elif log_gate:
+                            for col in range(2):
+                                K.assign(gate_vals[col], gate_vals[col] * K.float32(_RCP_LN2))
+                        else:
+                            for col in range(2):
+                                K.assign(gate_vals[col], _lg2(gate_vals[col] + K.float32(1e-10)))
+                        for offset in (1, 2, 4, 8, 16):
+                            for col in range(2):
+                                neighbor = _shfl_up_f32(gate_vals[col], offset)
+                                K.assign(
+                                    gate_vals[col],
+                                    K.if_then_else(
+                                        lidx >= offset, gate_vals[col] + neighbor, gate_vals[col]
+                                    ),
+                                )
+                        carry = _shfl_idx_f32(gate_vals[0], 31, 31)
+                        K.assign(gate_vals[1], gate_vals[1] + carry)
+                        _wait_barrier(arena, _BAR_GATE_DONE, gate_idx, gate_phase)
+                        for col in range(2):
+                            position = lidx + col * 32
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + position * 4]),
+                                gate_vals[col],
+                            )
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + position * 4]),
+                                _exp2(gate_vals[col]),
+                            )
+                        _arrive_barrier(arena, _BAR_GATE_READY, gate_idx)
+
+                        # ---- beta: cp.async per element or in-register sigmoid
+                        beta_idx = K.local_scalar("int32", init=beta_ps.stage)
+                        _wait_barrier(arena, _BAR_BETA_DONE, beta_ps.stage, beta_ps.phase)
+                        beta_ps.advance()
+                        if beta_sigmoid:
+                            for col in range(2):
+                                position = lidx + col * 32
+                                tok = chunk_offset + position
+                                beta_value = K.local_scalar("float32", init=K.float32(0.0))
+                                with K.If(tok < batch_end), K.Then():
+                                    raw_bits = K.local_scalar("uint16")
+                                    K.ptx.ld.global_.b16(
+                                        raw_bits,
+                                        beta.ptr_to([K.cast(tok, "int64") * n_heads_out + head]),
+                                    )
+                                    raw = K.local_scalar("float32")
+                                    if io_dtype == "float16":
+                                        K.assign(
+                                            raw,
+                                            K.cast(K.reinterpret("float16", raw_bits), "float32"),
+                                        )
+                                    else:
+                                        K.ptx.cvt.f32.bf16(raw, raw_bits)
+                                    half_tanh = _tanh(raw * K.float32(0.5)) * K.float32(0.5)
+                                    rounded_word = _pack_io_pair(
+                                        half_tanh + K.float32(0.5),
+                                        half_tanh + K.float32(0.5),
+                                        io_dtype,
+                                    )
+                                    rounded_lo = K.local_scalar("float32")
+                                    rounded_hi = K.local_scalar("float32")
+                                    _unpack_io_pair(rounded_word, rounded_lo, rounded_hi, io_dtype)
+                                    K.assign(beta_value, rounded_lo)
+                                K.ptx.st.shared.f32(
+                                    arena.ptr_to([_BETA_RING_BASE + beta_idx * 256 + position * 4]),
+                                    beta_value,
+                                )
+                            _arrive_barrier(arena, _BAR_BETA_READY, beta_idx)
+                        else:
+                            for col in range(2):
+                                position = lidx + col * 32
+                                tok = chunk_offset + position
+                                copy_size = K.if_then_else(
+                                    tok < batch_end, K.uint32(4), K.uint32(0)
+                                )
+                                K.ptx["cp.async.ca.shared.global"](
+                                    arena.ptr_to([_BETA_RING_BASE + beta_idx * 256 + position * 4]),
+                                    beta.ptr_to([K.cast(tok, "int64") * n_heads_out + head]),
+                                    K.uint32(4),
+                                    copy_size,
+                                )
+                            K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](
+                                _barrier_ptr(arena, _BAR_BETA_READY, beta_idx)
+                            )
+                sched_consume(sched_ps, tile)
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_GATE_DONE, gate_ps.stage, gate_ps.phase)
+                gate_ps.advance()
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_BETA_DONE, beta_ps.stage, beta_ps.phase)
+                beta_ps.advance()
+
+        # ================================================================
+        # Warp 10: sole tcgen05 issuer and TMEM lifecycle
+        # ================================================================
+        with mma:
+            tcgen_lane = K.local_scalar("uint32")
+            tcgen_leader = K.local_scalar("uint32")
+            K.ptx.elect_sync(tcgen_lane, tcgen_leader, K.uint32(0xFFFFFFFF))
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([_TMEM_MAILBOX]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            oacc_ps = K.PipelineState(1, phase=1)
+            oscale_ps = K.PipelineState(1, phase=0)
+            kvacc_ps = K.PipelineState(1, phase=1)
+            kq_ps = K.PipelineState(kq_stages, phase=0)
+            cg0_ps = K.PipelineState(2, phase=1)
+            kqf_ps = K.PipelineState(kq_stages, phase=0)
+            tinv_ps = K.PipelineState(3, phase=0)
+            a_ps = K.PipelineState(3, phase=0)
+            sinp_ps = K.PipelineState(1, phase=0)
+            y_ps = K.PipelineState(1, phase=0)
+            u_ps = K.PipelineState(1, phase=0)
+            du_ps = K.PipelineState(1, phase=0)
+            sched_ps = K.PipelineState(2, phase=0)
+            leader = tcgen_leader
+
+            def fused_kk_qk(same_operand):
+                fused_idx = K.local_scalar("int32", init=cg0_ps.stage)
+                _wait_barrier(arena, _BAR_CG0_ACC_DONE, cg0_ps.stage, cg0_ps.phase)
+                cg0_ps.advance()
+                kqf_idx = K.local_scalar("int32", init=kqf_ps.stage)
+                _wait_barrier(arena, _BAR_KQ_READY, kqf_ps.stage, kqf_ps.phase)
+                kqf_ps.advance()
+                pair_desc = _raw_descriptor(arena, kq_base + kqf_idx * 32768, 16, 1024, 2)
+                b_desc = pair_desc if same_operand else pair_desc + K.uint64(_KQ_BOX)
+                destination = tmem_base + _TM_CG0 + fused_idx * 64
+                _tcgen_mma_ss(
+                    destination, pair_desc, b_desc, idesc_n64, leader=leader, accumulate=0
+                )
+                _tcgen_mma_ss(
+                    destination,
+                    pair_desc + K.uint64(_KQ_SEG),
+                    b_desc + K.uint64(_KQ_SEG),
+                    idesc_n64,
+                    leader=leader,
+                    accumulate=1,
+                )
+                _tcgen_commit(arena, _BAR_CG0_ACC_READY, fused_idx, leader=leader)
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                n_local = item[3] - item[4]
+                with K.If(n_local > 0), K.Then():
+                    fused_kk_qk(True)
+                with K.If(n_local > 1), K.Then():
+                    fused_kk_qk(False)
+                with K.serial(n_local, unroll=False) as local_idx:
+                    member = local_idx % 2
+                    if use_initial_state:
+                        with K.If(local_idx == 0), K.Then():
+                            _tcgen_commit(arena, _BAR_STATE_ACC_READY, 0, leader=leader)
+                            kvacc_ps.advance()
+                        have_state = K.bool(True)
+                    else:
+                        have_state = local_idx > 0
+                    kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                    kq_ps.advance()
+                    base_desc = _raw_descriptor(arena, kq_base + kq_idx * 32768, 16, 1024, 2)
+                    member_off = K.cast(member * (_KQ_BOX * 16), "int32")
+                    desc_k = base_desc + K.cast(member * _KQ_BOX, "uint64")
+                    desc_q = base_desc + K.cast(_KQ_BOX - member * _KQ_BOX, "uint64")
+                    desc_kt = _raw_descriptor(
+                        arena, kq_base + kq_idx * 32768, 16384, 1024, 2
+                    ) + K.cast(member * _KQ_BOX, "uint64")
+                    del member_off
+
+                    with K.If(member == 1), K.Then():
+                        with K.If(local_idx + 2 < n_local), K.Then():
+                            fused_kk_qk(False)
+
+                    # ---- GEMM 3: (K*S)^T = packed S^T @ K^T ----------------
+                    with K.If(have_state), K.Then():
+                        _wait_barrier(arena, _BAR_STATE_INP_READY, 0, sinp_ps.phase)
+                        sinp_ps.advance()
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_CG1,
+                            tmem_base + _TM_STATE_INP,
+                            desc_k,
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=0,
+                        )
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_CG1,
+                            tmem_base + _TM_STATE_INP + 32,
+                            desc_k + K.uint64(_KQ_SEG),
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=1,
+                        )
+                        _tcgen_commit(arena, _BAR_K_STATE_READY, 0, leader=leader)
+
+                    # ---- GEMM 4: (Q*S)^T = packed S^T @ Q^T ----------------
+                    oacc_ps.advance()
+                    with K.If(have_state), K.Then():
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_QSTATE,
+                            tmem_base + _TM_STATE_INP,
+                            desc_q,
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=0,
+                        )
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_QSTATE,
+                            tmem_base + _TM_STATE_INP + 32,
+                            desc_q + K.uint64(_KQ_SEG),
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=1,
+                        )
+                        _tcgen_commit(arena, _BAR_O_ACC_READY, 0, leader=leader)
+
+                    # ---- GEMM 5: U^T = packed Y^T @ T_inv^T ----------------
+                    tinv_idx = K.local_scalar("int32", init=tinv_ps.stage)
+                    _wait_barrier(arena, _BAR_T_INV_READY, tinv_ps.stage, tinv_ps.phase)
+                    tinv_ps.advance()
+                    _wait_barrier(arena, _BAR_Y_INP_READY, 0, y_ps.phase)
+                    y_ps.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TM_CG1,
+                        tmem_base + _TM_YU,
+                        _raw_descriptor(arena, tinv_base + tinv_idx * 8192, 16, 1024, 2),
+                        idesc_n64,
+                        leader=leader,
+                        accumulate=0,
+                    )
+                    _tcgen_commit(arena, _BAR_U_ACC_READY, 0, leader=leader)
+                    _tcgen_commit(arena, _BAR_T_INV_DONE, tinv_idx, leader=leader)
+
+                    with K.If(member == 0), K.Then():
+                        with K.If(local_idx + 2 < n_local), K.Then():
+                            fused_kk_qk(True)
+
+                    # ---- GEMM 6: O^T += packed U^T @ A^T -------------------
+                    a_idx = K.local_scalar("int32", init=a_ps.stage)
+                    _wait_barrier(arena, _BAR_A_READY, a_ps.stage, a_ps.phase)
+                    a_ps.advance()
+                    with K.If(have_state), K.Then():
+                        _wait_barrier(arena, _BAR_O_SCALE_DONE, 0, oscale_ps.phase)
+                        oscale_ps.advance()
+                    _wait_barrier(arena, _BAR_U_INP_READY, 0, u_ps.phase)
+                    u_ps.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TM_QSTATE,
+                        tmem_base + _TM_YU,
+                        _raw_descriptor(arena, a_base + a_idx * 8192, 16, 1024, 2),
+                        idesc_n64,
+                        leader=leader,
+                        accumulate=have_state,
+                    )
+                    _tcgen_commit(arena, _BAR_A_DONE, a_idx, leader=leader)
+                    _tcgen_commit(arena, _BAR_O_FINAL_READY, 0, leader=leader)
+
+                    # ---- GEMM 7: S^T += packed decayed-U^T @ K -------------
+                    _wait_barrier(arena, _BAR_DECAY_U_READY, 0, du_ps.phase)
+                    du_ps.advance()
+                    kvacc_ps.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TM_STATE,
+                        tmem_base + _TM_DECAY_U,
+                        desc_kt,
+                        idesc_n128,
+                        leader=leader,
+                        accumulate=have_state,
+                        b_step_units=128,
+                    )
+                    _tcgen_commit(arena, _BAR_STATE_ACC_READY, 0, leader=leader)
+                    _tcgen_commit(arena, _BAR_KQ_DONE, kq_idx, leader=leader)
+                sched_consume(sched_ps, tile)
+            _wait_barrier(arena, _BAR_TMEM_DONE, 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+
+        # ================================================================
+        # Warp 9: TMA-LDG and scheduler producer
+        # ================================================================
+        with tma:
+            kq_ps = K.PipelineState(kq_stages, phase=1)
+            v_ps = K.PipelineState(2, phase=1)
+            sched_ps = K.PipelineState(2, phase=1)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wend = item[3]
+                cstart = item[4]
+                head_q = head if q_ratio == 1 else head // q_ratio
+                head_k = head if k_ratio == 1 else head // k_ratio
+                head_v = head if v_ratio == 1 else head // v_ratio
+                desc_q_slot = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_k_slot = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                desc_v_slot = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                with K.If(_elected()), K.Then():
+                    for slot in (desc_q_slot, desc_k_slot, desc_v_slot):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(slot)
+
+                def issue_kq(stage, k_first, tok):
+                    first_slot = desc_k_slot if k_first else desc_q_slot
+                    first_head = head_k if k_first else head_q
+                    second_slot = desc_q_slot if k_first else desc_k_slot
+                    second_head = head_q if k_first else head_k
+                    for d_coord, byte_off in ((0, 0), (64, 16384)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([kq_base + stage * 32768 + byte_off]),
+                            first_slot,
+                            K.int32(d_coord),
+                            first_head,
+                            tok,
+                            _barrier_ptr(arena, _BAR_KQ_READY, stage),
+                        )
+                    for d_coord, byte_off in ((0, 8192), (64, 24576)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([kq_base + stage * 32768 + byte_off]),
+                            second_slot,
+                            K.int32(d_coord),
+                            second_head,
+                            tok,
+                            _barrier_ptr(arena, _BAR_KQ_READY, stage),
+                        )
+
+                def issue_v(stage, tok):
+                    for d_coord, byte_off in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([v_base + stage * 16384 + byte_off]),
+                            desc_v_slot,
+                            K.int32(d_coord),
+                            head_v,
+                            tok,
+                            _barrier_ptr(arena, _BAR_V_READY, stage),
+                        )
+
+                with K.If(wend > cstart), K.Then():
+                    kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                    _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                    kq_ps.advance()
+                    with K.If(_elected()), K.Then():
+                        _expect_tx(arena, _BAR_KQ_READY, kq_idx, 32768)
+                        issue_kq(kq_idx, True, cstart * _BT)
+                    with K.serial(wend - cstart - 1, unroll=False) as ahead:
+                        chunk = cstart + 1 + ahead
+                        member = (chunk - cstart) % 2
+                        loop_kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                        _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                        kq_ps.advance()
+                        with K.If(_elected()), K.Then():
+                            _expect_tx(arena, _BAR_KQ_READY, loop_kq_idx, 32768)
+                            with K.If(member == 0), K.Then():
+                                issue_kq(loop_kq_idx, True, chunk * _BT)
+                            with K.If(member == 1), K.Then():
+                                issue_kq(loop_kq_idx, False, chunk * _BT)
+                        v_idx = K.local_scalar("int32", init=v_ps.stage)
+                        _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                        v_ps.advance()
+                        with K.If(_elected()), K.Then():
+                            _expect_tx(arena, _BAR_V_READY, v_idx, 16384)
+                            issue_v(v_idx, (chunk - 1) * _BT)
+                    tail_v_idx = K.local_scalar("int32", init=v_ps.stage)
+                    _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                    v_ps.advance()
+                    with K.If(_elected()), K.Then():
+                        _expect_tx(arena, _BAR_V_READY, tail_v_idx, 16384)
+                        issue_v(tail_v_idx, (wend - 1) * _BT)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, _BAR_SCHED_DONE, sched_ps.stage, sched_ps.phase)
+                    with K.If(_elected()), K.Then():
+                        ticket = K.local_scalar("uint32")
+                        K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                        K.ptx.st.shared.u32(
+                            arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]),
+                            K.uint32(num_sms) + ticket,
+                        )
+                    K.cuda.warp_sync()
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_READY, sched_ps.stage)
+                    sched_ps.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            for _ in range(kq_stages):
+                _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                kq_ps.advance()
+            for _ in range(2):
+                _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                v_ps.advance()
+
+        # ================================================================
+        # Warp 11: epilogue O and checkpoint TensorMap stores
+        # ================================================================
+        with epilogue:
+            o_ps = K.PipelineState(1, phase=0)
+            sched_ps = K.PipelineState(2, phase=0)
+            ckpt_cnt = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                n_local = wend - cstart
+                desc_o_slot = _descriptor_slot(descriptor_workspace, n_desc, 3, batch)
+                with K.If(_elected()), K.Then():
+                    K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc_o_slot)
+                desc_c_slot = _descriptor_slot(descriptor_workspace, n_desc, 4, batch)
+                ckpt_chunks = K.local_scalar("int32", init=K.int32(1))
+                ckpt_coord = K.local_scalar("int32", init=K.int32(0))
+                ckpt_mod = K.local_scalar("int32", init=K.int32(0))
+                if checkpoints:
+                    K.assign(ckpt_chunks, checkpoint_every_n // _BT)
+                    K.assign(ckpt_coord, (wstart + ckpt_chunks - 1) // ckpt_chunks)
+                    K.assign(ckpt_mod, (cstart + 1) % ckpt_chunks)
+                    with K.If(_elected()), K.Then():
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc_c_slot)
+                with K.If(n_local > 0), K.Then():
+                    if checkpoints:
+                        with K.If(wstart == 0), K.Then():
+                            _wait_barrier(arena, _BAR_CKPT_READY, 0, ckpt_cnt & 1)
+                            for value_coord, byte_off in ((0, 0), (64, 16384)):
+                                K.ptx[_TMA_S2G_4D](
+                                    desc_c_slot,
+                                    K.int32(value_coord),
+                                    K.int32(0),
+                                    ckpt_coord,
+                                    head,
+                                    arena.ptr_to([_CKPT_BASE + byte_off]),
+                                )
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(0)
+                            _arrive_barrier(arena, _BAR_CKPT_DONE, 0)
+                            K.assign(ckpt_coord, ckpt_coord + 1)
+                            K.assign(ckpt_cnt, ckpt_cnt + 1)
+                    with K.serial(n_local, unroll=False) as local_idx:
+                        chunk = cstart + local_idx
+                        did_o = K.local_scalar("int32", init=K.int32(0))
+                        did_ckpt = K.local_scalar("int32", init=K.int32(0))
+                        o_phase = K.local_scalar("int32", init=o_ps.phase)
+                        o_ps.advance()
+                        _wait_barrier(arena, _BAR_O_STG_READY, 0, o_phase)
+                        with K.If(K.And(chunk >= wstart, chunk < wend)), K.Then():
+                            for value_coord, byte_off in ((0, 0), (64, 8192)):
+                                K.ptx[_TMA_S2G_3D](
+                                    desc_o_slot,
+                                    K.int32(value_coord),
+                                    head,
+                                    chunk * _BT,
+                                    arena.ptr_to([_O_BASE + byte_off]),
+                                )
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.assign(did_o, K.int32(1))
+                        if checkpoints:
+                            with (
+                                K.If(
+                                    K.And(
+                                        K.And(chunk >= wstart - 1, chunk < wend - 1), ckpt_mod == 0
+                                    )
+                                ),
+                                K.Then(),
+                            ):
+                                _wait_barrier(arena, _BAR_CKPT_READY, 0, ckpt_cnt & 1)
+                                for value_coord, byte_off in ((0, 0), (64, 16384)):
+                                    K.ptx[_TMA_S2G_4D](
+                                        desc_c_slot,
+                                        K.int32(value_coord),
+                                        K.int32(0),
+                                        ckpt_coord,
+                                        head,
+                                        arena.ptr_to([_CKPT_BASE + byte_off]),
+                                    )
+                                K.ptx.cp.async_.bulk.commit_group()
+                                K.assign(ckpt_coord, ckpt_coord + 1)
+                                K.assign(did_ckpt, K.int32(1))
+                            K.assign(ckpt_mod, ckpt_mod + 1)
+                            with K.If(ckpt_mod == ckpt_chunks), K.Then():
+                                K.assign(ckpt_mod, K.int32(0))
+                        if checkpoints:
+                            with K.If(K.And(did_o == 1, did_ckpt == 1)), K.Then():
+                                K.ptx.cp.async_.bulk.wait_group.read(1)
+                                _arrive_barrier(arena, _BAR_O_STG_DONE, 0)
+                                K.ptx.cp.async_.bulk.wait_group.read(0)
+                                _arrive_barrier(arena, _BAR_CKPT_DONE, 0)
+                                K.assign(ckpt_cnt, ckpt_cnt + 1)
+                            with K.If(K.And(did_o == 1, did_ckpt == 0)), K.Then():
+                                K.ptx.cp.async_.bulk.wait_group.read(0)
+                                _arrive_barrier(arena, _BAR_O_STG_DONE, 0)
+                            with K.If(did_o == 0), K.Then():
+                                with K.If(did_ckpt == 1), K.Then():
+                                    K.ptx.cp.async_.bulk.wait_group.read(0)
+                                    _arrive_barrier(arena, _BAR_CKPT_DONE, 0)
+                                    K.assign(ckpt_cnt, ckpt_cnt + 1)
+                                _arrive_barrier(arena, _BAR_O_STG_DONE, 0)
+                        else:
+                            with K.If(did_o == 1), K.Then():
+                                K.ptx.cp.async_.bulk.wait_group.read(0)
+                            _arrive_barrier(arena, _BAR_O_STG_DONE, 0)
+                sched_consume(sched_ps, tile)
+
+    return main
+
+
+def _normalized_config(config):
+    import math
+
+    config = {key: value for key, value in config.items() if key != "label"}
+    config.setdefault("seq_lens", (64,))
+    config["seq_lens"] = tuple(int(value) for value in config["seq_lens"])
+    config.setdefault("heads", 1)
+    config.setdefault("q_heads", config["heads"])
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("io_dtype", "bfloat16")
+    config.setdefault("state_dtype", "float32")
+    config.setdefault("cu_dtype", "int32")
+    config.setdefault("num_sms", 148)
+    config.setdefault("scale", 1.0 / (_DK**0.5))
+    config.setdefault("checkpoint_every_n_tokens", 0)
+    config.setdefault("use_initial_state", False)
+    config.setdefault("store_final_state", True)
+    config.setdefault("log_gate", True)
+    config.setdefault("safe_gate", False)
+    config.setdefault("beta_sigmoid", False)
+    config.setdefault("dynamic_scheduler", False)
+    config.setdefault("split", False)
+    # The source always executes order_body.  Generated uncut rows are its
+    # default; scratch LPT ordering owns split rows.
+    config.setdefault("run_order", True)
+    config.setdefault("order_generate", not config.get("split", False))
+
+    if config["io_dtype"] not in ("bfloat16", "float16"):
+        raise ValueError("io_dtype must be 'bfloat16' or 'float16'")
+    if config["state_dtype"] not in ("float32", "bfloat16"):
+        raise ValueError("state_dtype must be 'float32' or 'bfloat16'")
+    if config["cu_dtype"] not in ("int32", "int64"):
+        raise ValueError("cu_dtype must be 'int32' or 'int64'")
+    if any(length < 0 for length in config["seq_lens"]):
+        raise ValueError("sequence lengths must be nonnegative")
+    if sum(config["seq_lens"]) == 0:
+        raise ValueError("at least one sequence must be nonempty for CUDA TensorMap encoding")
+    heads = int(config["heads"])
+    for name in ("q_heads", "k_heads", "v_heads"):
+        value = int(config[name])
+        if value <= 0 or heads % value != 0:
+            raise ValueError(f"{name}={value} must be a positive divisor of heads={heads}")
+    if heads != max(int(config["q_heads"]), int(config["v_heads"])):
+        raise ValueError("heads must equal max(q_heads, v_heads), matching the source HO rule")
+    if int(config["k_heads"]) not in (int(config["q_heads"]), int(config["v_heads"])):
+        raise ValueError("k_heads must equal q_heads or v_heads")
+    cadence = int(config["checkpoint_every_n_tokens"])
+    if cadence < 0 or cadence % _BT != 0:
+        raise ValueError("checkpoint cadence must be zero or a positive multiple of 64")
+    if cadence not in (0, 64, 128, 192):
+        raise ValueError("validated checkpoint cadences are 0, 64, 128, and 192")
+    if config["split"] and config["order_generate"]:
+        raise ValueError("split work rows require scratch ordering")
+    if not config["run_order"]:
+        raise ValueError("GDN's frozen two-launch ABI always runs the order prologue")
+    scale = float(config["scale"])
+    if not math.isfinite(scale) or scale == 0.0:
+        raise ValueError("scale must be finite and nonzero")
+    return config
+
+
+def _work_rows(seq_lens, heads, *, split):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            if split and chunks >= 4:
+                midpoint = chunks // 2
+                rows.append((batch, head, 0, midpoint, 0, midpoint, token_begin, token_end))
+                rows.append((batch, head, midpoint, chunks, 0, chunks, token_begin, token_end))
+            else:
+                rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return rows
+
+
+def get_kernel(**config):
+    """Return the source-ordered prologue and persistent main kernels."""
+    config = _normalized_config(config)
+    rows = _work_rows(config["seq_lens"], config["heads"], split=config["split"])
+    num_ctas = min(int(config["num_sms"]), max(len(rows), 1))
+    prologue = _make_prologue(
+        run_order=True,
+        order_generate=bool(config["order_generate"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        n_heads_out=int(config["heads"]),
+        checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
+        cu_dtype=config["cu_dtype"],
+    )
+    main = _make_main(
+        num_sms=num_ctas,
+        io_dtype=config["io_dtype"],
+        state_dtype=config["state_dtype"],
+        cu_dtype=config["cu_dtype"],
+        use_initial_state=bool(config["use_initial_state"]),
+        store_final_state=bool(config["store_final_state"]),
+        checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
+        log_gate=bool(config["log_gate"]),
+        safe_gate=bool(config["safe_gate"]),
+        beta_sigmoid=bool(config["beta_sigmoid"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        q_ratio=int(config["heads"]) // int(config["q_heads"]),
+        k_ratio=int(config["heads"]) // int(config["k_heads"]),
+        v_ratio=int(config["heads"]) // int(config["v_heads"]),
+        n_heads_out=int(config["heads"]),
+        full_tiles=all(length % _BT == 0 for length in config["seq_lens"]),
+    )
+    return [prologue.func, main.func]
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _checkpoint_count(seq_lens, cadence):
+    # Matches the packed per-batch layout of the source's
+    # emit_checkpoint_seq_descs: count_b = (len - 1) // cadence + 1 per
+    # nonempty sequence, running-prefix-summed.
+    if not cadence:
+        return 0
+    return sum(0 if length == 0 else (length - 1) // cadence + 1 for length in seq_lens)
+
+
+def _prepare_work_tables(torch, config):
+    base = torch.tensor(
+        _work_rows(config["seq_lens"], config["heads"], split=config["split"]),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    def one_side():
+        work_items = torch.empty_like(base)
+        staging = None if config["order_generate"] else base.clone()
+        return {
+            "work_items": work_items,
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": staging,
+            "scheduler": (
+                torch.zeros(1, dtype=torch.int32, device="cuda")
+                if config["dynamic_scheduler"]
+                else None
+            ),
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _new_outputs(torch, config, total_tokens):
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    result = {
+        "output": torch.full(
+            (total_tokens, config["heads"], _DV), float("nan"), dtype=io_t, device="cuda"
+        )
+    }
+    if config["store_final_state"]:
+        result["final_state"] = torch.full(
+            (len(config["seq_lens"]), config["heads"], _DV, _DK),
+            float("nan"),
+            dtype=state_t,
+            device="cuda",
+        )
+    checkpoint_count = _checkpoint_count(config["seq_lens"], config["checkpoint_every_n_tokens"])
+    if checkpoint_count:
+        result["checkpoints"] = torch.full(
+            (checkpoint_count, config["heads"], _DV, _DK), float("nan"), dtype=io_t, device="cuda"
+        )
+    return result
+
+
+def _prepare_data(config):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260827)
+    total_tokens = sum(config["seq_lens"])
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    q = (0.2 * torch.randn(total_tokens, config["q_heads"], _DK, device="cuda")).to(io_t)
+    k = (0.2 * torch.randn(total_tokens, config["k_heads"], _DK, device="cuda")).to(io_t)
+    v = (0.2 * torch.randn(total_tokens, config["v_heads"], _DV, device="cuda")).to(io_t)
+    # The scalar forget gate: raw logits under safe_gate, natural-log decay
+    # under log_gate, raw linear alpha otherwise.
+    gate = torch.empty(total_tokens, config["heads"], dtype=torch.float32, device="cuda")
+    if config["safe_gate"]:
+        gate.normal_(std=0.2)
+    elif config["log_gate"]:
+        gate.uniform_(-0.9, -0.01)
+    else:
+        gate.uniform_(0.4, 0.99)
+    # The scalar update gate: fp32 post-sigmoid, or io-dtype logits when the
+    # kernel applies the sigmoid.
+    if config["beta_sigmoid"]:
+        beta = (0.3 * torch.randn(total_tokens, config["heads"], device="cuda")).to(io_t)
+    else:
+        beta = torch.sigmoid(0.3 * torch.randn(total_tokens, config["heads"], device="cuda"))
+    cu_t = torch.int64 if config["cu_dtype"] == "int64" else torch.int32
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(config["seq_lens"]).cumsum(0).tolist()], dtype=cu_t, device="cuda"
+    )
+    a_log = (
+        0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        (0.01 * torch.randn(len(config["seq_lens"]), config["heads"], _DV, _DK, device="cuda")).to(
+            state_t
+        )
+        if config["use_initial_state"]
+        else None
+    )
+    outputs = {
+        "tirx": _new_outputs(torch, config, total_tokens),
+        "source": _new_outputs(torch, config, total_tokens),
+    }
+    workspace_bytes = _TENSOR_MAP_BYTES * (_TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 1)
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+
+    return {
+        "config": config,
+        "q": q,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "initial_state": initial_state,
+        "tirx": outputs["tirx"],
+        "source": outputs["source"],
+        "work": _prepare_work_tables(torch, config),
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "_workspace_owners": (tirx_owner, source_owner),
+    }
+
+
+def prepare_data(**config):
+    """Allocate the shared input set plus source/TIRx output buffers."""
+    return _prepare_data(config)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype == torch.float16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT16
+    elif tensor.dtype == torch.bfloat16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif tensor.dtype == torch.float32:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return (
+        torch.tensor([int(word) for word in tensor_map.opaque], dtype=torch.uint64)
+        .view(torch.int64)
+        .to(device=tensor.device)
+    )
+
+
+def _base_tensor_maps(data, side):
+    config = data["config"]
+    total_tokens = data["q"].shape[0]
+
+    def headed(tensor, channels, heads, box_channels):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (box_channels, 1, _BT),
+        )
+
+    output = data[side]
+    maps = [
+        headed(data["q"], _DK, config["q_heads"], 64),
+        headed(data["k"], _DK, config["k_heads"], 64),
+        headed(data["v"], _DV, config["v_heads"], 64),
+        headed(output["output"], _DV, config["heads"], 64),
+    ]
+    checkpoints = output.get("checkpoints")
+    if checkpoints is None:
+        maps.append(maps[-1])
+    else:
+        maps.append(
+            _encode_tiled_map(
+                checkpoints,
+                (_DK, _DV, checkpoints.shape[0], config["heads"]),
+                (
+                    checkpoints.stride(2) * checkpoints.element_size(),
+                    checkpoints.stride(0) * checkpoints.element_size(),
+                    checkpoints.stride(1) * checkpoints.element_size(),
+                ),
+                (64, _DV, 1, 1),
+            )
+        )
+    return maps
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data, "tirx")
+    work = data["work"]["tirx"]
+    output = data["tirx"]
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    beta_t = io_t if config["beta_sigmoid"] else torch.float32
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_io = torch.zeros(1, dtype=io_t, device="cuda")
+    dummy_state = torch.zeros(1, dtype=state_t, device="cuda")
+    dummy_f32 = torch.zeros(config["heads"], dtype=torch.float32, device="cuda")
+    checkpoint = output.get("checkpoints", dummy_io)
+    beta = data["beta"].to(beta_t)
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *maps,
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["q"].view(torch.uint8).reshape(-1),
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            output["output"].view(torch.uint8).reshape(-1),
+            checkpoint.view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["scheduler"] if work["scheduler"] is not None else dummy_i32,
+            len(config["seq_lens"]),
+            data["q"].stride(0) * data["q"].element_size(),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            output["output"].stride(0) * output["output"].element_size(),
+            checkpoint.stride(0) * checkpoint.element_size() if checkpoint.ndim > 1 else 0,
+            int(config["checkpoint_every_n_tokens"]),
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["q"].reshape(-1),
+            data["k"].reshape(-1),
+            data["v"].reshape(-1),
+            data["gate"].reshape(-1),
+            data["a_log"] if data["a_log"] is not None else dummy_f32,
+            data["dt_bias"] if data["dt_bias"] is not None else dummy_f32,
+            beta.reshape(-1),
+            data["cu_seqlens"],
+            (
+                data["initial_state"].reshape(-1)
+                if data["initial_state"] is not None
+                else dummy_state
+            ),
+            output["output"].reshape(-1),
+            output.get("final_state", dummy_state).reshape(-1),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["scheduler"] if work["scheduler"] is not None else dummy_i32,
+            float(config["scale"]),
+            int(config["checkpoint_every_n_tokens"]),
+        )
+
+    launch._keep_alive = (maps, beta, dummy_i32, dummy_io, dummy_state, dummy_f32)
+    return launch
+
+
+def _load_reference_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn_prefill_f16")
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    beta = data["beta"].to(io_t) if config["beta_sigmoid"] else data["beta"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_gdn_sm100(
+            data["q"],
+            data["k"],
+            data["v"],
+            data["gate"],
+            beta,
+            output["output"],
+            data["cu_seqlens"],
+            data["initial_state"],
+            output.get("final_state"),
+            float(config["scale"]),
+            checkpoint_every_n_tokens=int(config["checkpoint_every_n_tokens"]),
+            output_state_checkpoints=output.get("checkpoints"),
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["scheduler"],
+            log_gate=bool(config["log_gate"]),
+            safe_gate=bool(config["safe_gate"]),
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=bool(config["beta_sigmoid"]),
+            work_item_scratch=work["staging"],
+            workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    launch._keep_alive = (beta,)
+    return launch
+
+
+def _rms_ratio(torch, actual, expected):
+    if actual.shape != expected.shape:
+        raise ValueError(
+            f"RMS operands must have the same shape: {actual.shape} != {expected.shape}"
+        )
+    actual = actual.detach().reshape(-1)
+    expected = expected.detach().reshape(-1)
+    elements = actual.numel()
+    if elements == 0:
+        return 0.0
+    difference_square_sum = torch.zeros((), dtype=torch.float64, device=actual.device)
+    expected_square_sum = torch.zeros((), dtype=torch.float64, device=actual.device)
+    chunk_elements = 1 << 24
+    for begin in range(0, elements, chunk_elements):
+        end = min(begin + chunk_elements, elements)
+        actual_chunk = actual[begin:end].double()
+        expected_chunk = expected[begin:end].double()
+        difference = actual_chunk - expected_chunk
+        difference_square_sum.add_(difference.square().sum())
+        expected_square_sum.add_(expected_chunk.square().sum())
+    denominator = (expected_square_sum / elements).sqrt().clamp_min(1e-12)
+    return float(((difference_square_sum / elements).sqrt() / denominator).item())
+
+
+def _validate_outputs(data, *, sources):
+    import math
+
+    import torch
+
+    limit = 0.01 if data["config"]["io_dtype"] == "float16" else 0.02
+    failures = {}
+    if "tirx" in sources and "source" in sources:
+        for name in data["tirx"]:
+            actual = data["tirx"][name]
+            expected = data["source"][name]
+            if name == "checkpoints":
+                # The source clips checkpoint stores in hardware; compare only
+                # the entries the source actually wrote and require the TIRx
+                # side to leave the same tail untouched.
+                written = ~torch.isnan(expected.float())
+                if bool(torch.isnan(actual.float())[written].any()):
+                    failures["tirx_vs_source.checkpoints.missing"] = float("nan")
+                    continue
+                actual = torch.where(written, actual, torch.zeros_like(actual))
+                expected = torch.where(written, expected, torch.zeros_like(expected))
+            ratio = _rms_ratio(torch, actual, expected)
+            if not math.isfinite(ratio) or ratio >= limit:
+                failures[f"tirx_vs_source.{name}"] = ratio
+    if failures:
+        raise AssertionError(
+            f"GDN prefill validation failed for {data['config']}: {failures}; limit={limit}"
+        )
+
+
+def run_test(**config):
+    """Compare TIRx with the upstream kernel on identical inputs."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = _normalized_config(config)
+    data = _prepare_data(config)
+    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"))
+    return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
+
+
+def prepare_bench(**config):
+    """Compile both TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config = _normalized_config(config)
+    state = {
+        "config": config,
+        "executables": [compile_kernel(func) for func in get_kernel(**config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then expose the exact two-launch paths to bench_suite."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _validate_outputs(data, sources=("tirx", "source"))
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
Ports the cuDNN frontend frost **GDN v1 prefill** kernel
(`cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py`, commit `aded9909`)
to a TIRx kernel using the `tirx_kernels.kern` API, following the porting
workflow (scaffold → sketch → sketch review → correctness gate → perf gate).

## What's included

- `tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py` — the port:
  prologue kernel (LPT work ordering + runtime TensorMap publication) plus a
  persistent main kernel with 12 warps / 384 threads, chunked delta rule
  (BT=64, DK=DV=128), 7 tcgen05 GEMMs with TMEM-resident state,
  33-mbarrier ring protocol, hierarchical block lower-triangular inverse.
  `K.ptx.*` / pure `K.cuda.*` only; no `allowed_func_calls` exemptions and
  no changes under `kern/`.
- Reviewed kernel sketch at `.agents/sketch/cudnn/sm100_gdn_prefill_f16.md`.
- bench_suite workload config and README port row.
- Codegen-tuning DB (second commit): 3 new entries and 3 measured boundary
  updates distilled from the port's perf search.

## Validation

- **Correctness**: `python -m tirx_kernels.test --kernel cudnn_sm100_gdn_prefill_f16`
  — all 14 pairwise configs pass against the frost source outputs
  (rms-ratio ≤ 0.01 fp16 / 0.02 bf16 on O, final state, and checkpoints),
  covering io/state dtypes, GQA folds, initial/final state, checkpoint
  cadences, l2norm, safe_gate, beta_sigmoid, dyn_sched, and ragged/0-token
  sequences.
- **Performance** (bench_suite with `--with-references`, B200): all 18
  workloads above the 0.99× gate against the cuDNN frontend reference —
  min 0.9988, mean 1.0242, max 1.0861.
