### PR TITLE
feat(kernel): port cudnn-frontend gdn_recompute_f16 for sm100

### DIFF
--- a/.agents/sketch/cudnn/sm100_gdn_recompute_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn_recompute_f16.md
@@ -1,0 +1,1219 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 GDN (v1) FP16/BF16 state recompute: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch, not Python, a builder API, a new IR,
+or a mathematical reference.  It freezes the source program before device-code
+transcription.  The implementation it describes belongs in
+[`tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py`](../../../tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py).
+
+The frozen source is the standalone `chunk_gdn_recompute_sm100` two-launch entry
+at the commit above.  The kernel re-runs the chunked delta-rule forward
+recurrence for its recurrent state alone and publishes the per-chunk state
+checkpoint series a backward pass consumes; it carries no query tensor, no
+attention output, and no attention scale.  The main anchor is BF16 I/O, FP32
+state, checkpoints enabled at the per-chunk cadence, no initial state, no final
+state, dynamic ticket scheduler, order pass owned by this prologue, `BT=64`,
+`DK=DV=128`, one CTA per cluster, 384 main threads (12 warps), 1024 prologue
+threads, three K stages, two V stages, three T-inverse stages, one checkpoint
+staging stage, three gate/cumprod/beta stages, two scheduler stages, 512
+allocated TMEM columns of which 448 are used, and 191488 bytes of main dynamic
+shared memory.  Specializations without checkpoints carry four K stages and no
+staging buffer at exactly the same total.
+
+The accepted capability set is the set the source entry dispatches: BF16 and
+FP16 I/O; FP32 or BF16 state (FP32 when neither state tensor is present);
+absent/present initial state; absent/present final state; checkpoint cadence
+64, 128, or 192 — a positive multiple of the 64-token chunk — with the source
+requiring at least one of the checkpoint series and the final state; grouped
+K/V heads under `HO = gate.shape[1]` with `k_ratio = HO//HK` and
+`v_ratio = HO//HV`; ragged/tail/zero-length sequences; gate interpretations
+raw-alpha, natural-log (`log_gate`, the backward plan's production path), and
+safe gate with per-head `a_log`/`dt_bias`; beta post-sigmoid FP32 or IO-dtype
+logits with in-kernel sigmoid (`use_beta_sigmoid`); static grid-stride or
+dynamic ticket scheduler; the prologue order pass owned or not owned by this
+kernel (`run_order`); generated uncut or caller-staged/sorted work items; i32 or
+i64 cumulative sequence lengths; and overlap-recompute split work rows.  Q/K L2
+normalization is not part of this kernel.
+
+Writer line-info evidence is in `.porting/gdn_recompute_f16/source_export/`:
+`dump_nostate/` holds the BF16 checkpoint-only anchor
+(`cutlass_host_GdnRecomputeCfg...sm_100a.ptx`, 2259 `.loc` sites, and
+`cutlass_prologue_...sm_100a.ptx`, 309 `.loc` sites), `dump_state/` the
+initial-state + final-state specialization (2649 `.loc`).  PTX line evidence
+below refers to the nostate anchor unless a branch profile is named.  Both were
+produced by `driver_gdn_recompute.py`, which validates every produced checkpoint
+row against the repository's FP64 per-token recurrence over the matching token
+prefix before the dump is kept.
+
+## Pipeline at a glance
+
+| Warps | Registers | Source-order role | Principal publications |
+| --- | ---: | --- | --- |
+| 0..3 | 224 | CG0 chunk-pair owner: per-pair T-pairwise decay fragments for its KK member, KK epilogue into the T-inverse buffer, four-level hierarchical pair inverse (8→16→32→64), post-inverse beta column scaling for both members | t_inv-ready, cg0-acc-done, gate/beta-done |
+| 4..7 | 256 (232 without initial state) | CG1 state owner: initial-state TMEM seed, state repack FP32→IO, pre-rescale checkpoint snapshot, state rescale by chunk cumprod, per-row gate registers, `Y = V − cumprod·(K·S)`, decayed-U repack, final-state TMEM→GMEM | state-inp/y-inp/decay-u-inp, state-scale-done, checkpoint-ready, tmem-done |
+| 8 | 24 (48 w/o initial state) | gate/beta producer: predicated gate loads, log2 transform (raw/log/safe), warp prefix scan → cumsum-log and cumprod SMEM rings, beta cp.async or in-register sigmoid | gate-ready, beta-ready |
+| 9 | 24 (48) | TMA-LDG: per-batch K/V descriptor acquire, one K box per chunk into the alternating pair stage, one-behind V tile, dynamic-ticket producer | kq-ready (expect-tx), v-ready (expect-tx), sched-ready |
+| 10 | 24 (48) | sole tcgen05 issuer: TMEM alloc/dealloc, fused M=128 KK pairs with member-parity lookahead, K·S, U, state-update chains | cg0/state/k-state/u-acc-ready, t_inv/kq-done |
+| 11 | 24 (48) | epilogue: state-checkpoint TensorMap stores | checkpoint-done |
+
+Dispatch order is exactly source order: warps 0..3, warps 4..7, warp 8,
+warp 10, warp 9, then warp 11.  Every role owns independent pipeline cursors
+that start once per kernel, advance per acquired stage, and are not reset at
+work-item boundaries.  Chunks execute in PAIRS on CG0: warps 0..1 invert the
+pair's member-0 matrix while warps 2..3 invert member 1; an odd tail pair runs
+member 0 only with warps 2..3 idling through the per-warp inverse steps while
+still arriving every group barrier.
+
+## Primitive vocabulary and translation boundary
+
+All storage is one-dimensional.  Names that look like matrices below are only
+logical comments on integer offsets and strides; they are never layout values,
+views, tiles, fragments, or first-class descriptors.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(arena, base, stage, row, col,
+          stage_bytes, row_bytes, elem_bytes, xor128)  # col ^ ((row&7)*8) elems
+tmem_cell(base, row, column)       # base + column + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch)  # (array*B+batch)*128 bytes
+smem_matrix_desc(base_byte, lead_bytes, stride_bytes, swizzle128)  # tcgen05 B/A operand
+```
+
+Directional movements are only `copy_p2g`, `copy_g2s`, `copy_s2g`,
+`copy_g2r`, `copy_r2g`, `copy_s2r`, `copy_r2s`, `copy_t2r`, and `copy_r2t`.
+Computations are only `fill`, `cast`, `add`, `sub`, `mul`, `fma`, `min`,
+`max`, `select`, `exp2`, `log2`, `tanh`, `shuffle`, and `gemm`.
+Barrier init/wait/arrive/expect-tx, commit, fence, synchronization, cursor
+advancement, register-budget changes, TensorMap replacement, and TMEM lifetime
+operations are scheduling actions rather than computation primitives.
+
+The implementation may import device language only as
+`import tirx_kernels.kern as K`.  It may not use `T`, `Tx`, `I`,
+`tirx.tile.*`, a categorized tile primitive, `TilePrimitiveCall`, any
+first-class layout, or rank>1 SMEM.  The single rank-1 `u8` arena is the only
+shared-memory declaration.  `K.smem_pool(base=arena)` allocates only the
+protocol/header prefix; all payload mappings use integer byte arithmetic and
+raw SMEM/TMEM descriptors.
+
+## Complete non-executable sketch
+
+```python
+@specialize(
+    IO_DTYPE={"bf16", "f16"}, STATE_DTYPE={"f32", "bf16"}, ACC_DTYPE="f32",
+    BT=64, DK=128, DV=128,
+    KQ_STAGES=(3 if CHECKPOINTS else 4), V_STAGES=2,
+    TINV_STAGES=3, GATE_STAGES=3, BETA_STAGES=3, CHECKPOINT_STAGES=1,
+    STATE_ACC_STAGES=1, STATE_INP_STAGES=1,
+    CG0_ACC_STAGES=2, CG1_ACC_STAGES=1, SCHED_STAGES=2,
+    CLUSTER=(1,1,1),
+    REGS=(224, 256 if USE_INITIAL_STATE else 232,
+          24 if USE_INITIAL_STATE else 48),
+)
+def gdn_recompute_factory(...):
+    return descriptor_order_prologue, persistent_gdn_recompute
+
+# ========================================================================
+# Launch 1: optional work table order pass and three TensorMap arrays
+# ========================================================================
+
+@kernel(grid=(1,1,1), block=(1024,1,1), warps=32, target="sm_100a")
+def descriptor_order_prologue(
+    base_k, base_v, base_checkpoint,
+    descriptor_workspace, cu_seqlens,
+    k, v, checkpoints_or_dummy,
+    staging_items_or_dummy, work_count, work_items,
+    sched_ring_or_dummy, batch_count,
+    k_row_stride, v_row_stride,
+    checkpoint_row_stride, checkpoint_every_n_tokens,
+):
+    tid = thread_id()
+    warp = tid // 32
+
+    # One rank-1 u8 arena: two 4096-i32 order regions plus a two-i32 spread
+    # region; descriptor building needs no SMEM payload.  The arena exists
+    # only under RUN_ORDER.
+    arena = linear_buffer("smem", "u8", 32776, 0, 16, "whole launch")
+    order_key = integer_region(arena, 0, 4096, "i32")
+    order_idx = integer_region(arena, 16384, 4096, "i32")
+    order_spread = integer_region(arena, 32768, 2, "i32")
+
+    if RUN_ORDER:
+        # Source LPT order pass (common/split_k.py order_body): this kernel is
+        # the backward pair's first table consumer, so it zeroes EVERY cell of
+        # the shared sched region, then generates uncut rows (batch*HO,
+        # chunk-span key from cu_seqlens) or copies caller-staged rows; above
+        # 4096 items it copies through unsorted; otherwise it spread-detects
+        # via shared atomics and stable bitonic sorts descending by span.
+        if tid == 0:
+            for cell in range(sched_ring_cells):
+                copy_r2g(i32(0), sched_ring[cell])
+                # instruction_selection: st.global.b32 (.loc 2 635); extent: a
+                # serial thread-0 loop over the ring, unrolled to 29 sites
+        n = batch_count * HO if GENERATE_UNCUT else copy_g2r(work_count[0])
+        if GENERATE_UNCUT and tid == 0:
+            copy_r2g(n, work_count[0])
+        if n > 4096:
+            for item in range(tid, n, 1024):
+                row = generate_or_load_eight_fields(item)
+                copy_r2g(row, work_items[item,0:8])
+                # instruction_selection: generated rows use two st.global.v4.b32;
+                # scratch rows use eight ld.global.b32 + eight st.global.b32
+        else:
+            if tid == 0:
+                copy_r2s(i32_max, order_spread[0]); copy_r2s(i32_min, order_spread[1])
+            padded_count = next_power_of_two(n)
+            barrier(0,1024)
+            local_min, local_max = i32_max, i32_min
+            for element in range(4):
+                item = tid + element*1024
+                if item < padded_count:
+                    key = i32_min
+                    if item < n:
+                        row = generate_or_load_eight_fields(item)
+                        key = row_chunk_span(row)
+                        local_min = min(local_min,key); local_max = max(local_max,key)
+                    copy_r2s(key, order_key[item]); copy_r2s(item, order_idx[item])
+            shared_atomic_min(order_spread[0], local_min)
+            shared_atomic_max(order_spread[1], local_max)
+            # instruction_selection: atom.shared::cta.min/max.s32; extent: one
+            # pair per thread after four local items
+            barrier(0,1024)
+            stable_lpt_bitonic_sort(order_key, order_idx, n, order_spread)
+            barrier(0,1024)
+            for rank in range(tid, n, 1024):
+                source = copy_s2r(order_idx[rank])
+                row = generate_or_load_eight_fields(source)
+                copy_r2g(row, work_items[rank,0:8])
+                # instruction_selection: two st.global.v4.b32 generated rows /
+                # eight scalar load-store scratch rows
+
+    # Exactly one descriptor array belongs to each warp 0..2.  Its elected lane
+    # walks all batches serially.  Slots are K,V,Checkpoint in that exact
+    # warp/array order; warp 2 is compile-time inactive without checkpoints.
+    # K and V base maps carry (channel, head, token) with the token axis at TMA
+    # ordinal 2; the checkpoint map carries (dv, dk, checkpoint, head) with the
+    # checkpoint count at ordinal 2.  Without the series the source aliases the
+    # checkpoint base map onto V's.
+    base_maps = (base_k, base_v, base_checkpoint)
+    checkpoint_prefix = 0
+    if warp < 3 and elected_lane() and (warp < 2 or CHECKPOINTS):
+        array = warp
+        for batch in range(batch_count):
+            bos = copy_g2r(cu_seqlens[batch])
+            eos = copy_g2r(cu_seqlens[batch+1])
+            length = eos - bos
+            dst = descriptor_slot(descriptor_workspace, array, batch)
+            copy_p2g(base_maps[array], dst)
+            # instruction_selection: st.global.b64; extent: sixteen b64 copies
+            # of the 128-byte base descriptor per slot, 48 sites across the
+            # three arrays, imprecisely attributed to `.loc 1 1813`
+            if array == 2:
+                count = 0 if length == 0 else (length-1)//checkpoint_every_n_tokens + 1
+                replace_global_address(dst,
+                    checkpoints_base + checkpoint_prefix*checkpoint_row_stride)
+                replace_global_dim(dst, ordinal=2, count)
+                checkpoint_prefix += count
+            else:
+                replace_global_address(dst, tensor_base(array) + bos*row_stride(array))
+                replace_global_dim(dst, ordinal=2, length)
+            # instruction_selection: tensormap.replace.tile.global_address /
+            # .global_dim per slot
+        fence("tensormap_generic_release_gpu")
+        # instruction_selection: fence.proxy.tensormap::generic.release.gpu;
+        # extent: 3 static sites, one per array warp
+        # (.loc 1 1726 / 1730 / 1737)
+
+# ========================================================================
+# Launch 2 ABI, scalar maps, arena and protocol
+# ========================================================================
+
+@kernel(grid=(num_sms,1,1), block=(384,1,1), warps=12,
+        cluster=(1,1,1), min_blocks_per_sm=1, target="sm_100a")
+def persistent_gdn_recompute(
+    descriptor_workspace, n_desc,
+    k, v, gate, a_log_or_dummy, dt_bias_or_dummy, beta,
+    cu_seqlens, initial_state_or_dummy, final_state_or_dummy,
+    work_items, work_count, sched_counter_or_dummy,
+    checkpoint_every_n_tokens,
+):
+    # k and v are carried for source ABI parity only: the source kernel takes
+    # mK/mV and never reads them, because every K/V byte arrives through the
+    # prologue-built TMA descriptors.
+    tid = thread_id()
+    warp = warp_uniform(tid // 32)
+    lane = tid & 31
+    cta = block_id_x()
+    grid_x = grid_dim_x()
+    total_tiles = copy_g2r(work_count[0])
+    # instruction_selection: ld.global.b32 (.loc 1 2077)
+
+    def decode_work(tile):
+        # fields: batch, head, wstart, wend, cstart, cend, bos, eos;
+        # num_chunks_b = ceil_div(eos-bos, 64).  An item computes chunks
+        # [cstart, wend) and writes checkpoints only for [wstart, wend).
+        row = copy_g2r(work_items[tile,0:8])
+        return row_with_derived_fields(row)
+        # instruction_selection: role-projected work-row decode, normally
+        # ld.global.v4.b32 plus required scalar loads (.loc 5 144..148)
+
+    def input_head(head, ratio):
+        return head if ratio == 1 else head // ratio
+
+    def descriptor(array, batch):
+        return descriptor_slot(descriptor_workspace, array, batch)
+
+    # One rank-1 u8 declaration, 191488 bytes, 1024-byte aligned.  The first
+    # 3072 bytes are the protocol header plus the three FP32 gate rings; the
+    # payloads follow at 1024-aligned bases.  Checkpoint mode drops one K stage
+    # and inserts the checkpoint staging buffer at the same total footprint.
+    arena = linear_buffer("smem", "u8", 191488, 0, 1024, "whole launch")
+
+    BARRIER_BASE = 0          # 48 x 8-byte mbarriers, declaration-ordered
+    TMEM_MAILBOX = 384        # tcgen05.alloc result, one i32
+    SCHED_BASE = 400          # dynamic-ticket ring, SCHED_STAGES x i32
+    CUMSUMLOG_BASE = 512      # f32 [64 x 3 stages]
+    CUMPROD_BASE = 1280       # f32 [64 x 3 stages]
+    BETA_BASE = 2048          # f32 [64 x 3 stages]
+    CHECKPOINT_BASE = 3072    # checkpoint mode only: IO [128 x 128], 32768 B
+    KQ_BASE = 3072 + (32768 if CHECKPOINTS else 0)
+                              # IO [2 boxes x 64 x 128] x KQ_STAGES (32768 B/stage)
+    TINV_BASE = KQ_BASE + KQ_STAGES*32768        # IO [64 x 64] x 3, 8192 B/stage
+    V_BASE = TINV_BASE + 3*8192                  # IO [128 x 64] x 2, 16384 B/stage
+    # checkpoints: KQ 35840, TINV 134144, V 158720, end 191488.
+    # nostate:     KQ  3072, TINV 134144, V 158720, end 191488.
+
+    # Every IO payload tile is stored 128-byte XOR-swizzled:
+    # phys_col_elems = col ^ ((row & 7) * 8) within each 64-element row
+    # segment; tcgen05 operand descriptors carry lead 16 bytes, stride 1024
+    # bytes, swizzle-128B.  The K^T view of the same K stage bytes uses lead
+    # 16384 bytes for the state-update GEMM; the V descriptor uses lead 8192.
+    #
+    # One K stage holds the pair's two chunks as four 8192-byte boxes:
+    #   +0     K(even chunk) channels 0..63     <- TMA subtile 0 of box 0
+    #   +8192  K(odd  chunk) channels 0..63     <- TMA subtile 0 of box 1
+    #   +16384 K(even chunk) channels 64..127   <- TMA subtile 1 of box 0
+    #   +24576 K(odd  chunk) channels 64..127   <- TMA subtile 1 of box 1
+    # so the member offset is KQ_BOX = 8192 B and the high-channel segment
+    # offset is KQ_SEG = 16384 B.
+
+    # Protocol table, declaration-ordered physical mbarriers.  Each tuple is
+    # (name, ready, done-or-None, ready stages, done stages,
+    #  ready arrivals, done arrivals).
+    PROTOCOL = (
+      ("kq",           0,  32, KQ_STAGES,KQ_STAGES, 1,1),   # TMA expect-tx / MMA commit
+      ("v",           64,  80, 2,2,   1,128),               # TMA expect-tx / CG1 threads
+      ("gate",        96, 120, 3,3,  32,256),               # warp 8 / CG0+CG1
+      ("beta",       144, 168, 3,3,  32,128),               # warp 8 (cp.async) / CG0
+      ("state_acc",  192, 200, 1,1,   1,128),               # MMA commit / CG1 scale-done
+      ("cg0_acc",    208, 224, 2,2,   1,64),                # MMA commit / half-CG0
+      ("k_state_acc",240,None, 1,0,   1,None),              # MMA commit
+      ("u_acc",      248,None, 1,0,   1,None),              # MMA commit
+      ("t_inv",      256, 280, 3,3, 128,1),                 # CG0 / MMA commit
+      ("state_inp",  304,None, 1,0, 128,None),              # CG1 packed state
+      ("y_inp",      312,None, 1,0, 128,None),              # CG1 packed Y
+      ("decay_u_inp",320,None, 1,0, 128,None),              # CG1 packed decayed U
+      ("checkpoint", 328, 336, 1,1,   4,32),                # CG1 warp-elects / epilogue
+      ("tmem_done",  344,None, 1,0, 128,None),              # CG1 -> MMA dealloc
+      ("sched",      352, 368, 2,2,   1,11),                # warp 9 / 11 consumers
+    )
+
+    pool = smem_pool(base=arena)   # allocates only the header prefix
+    for edge in PROTOCOL:
+        allocate_edge_from_pool(edge)
+
+    # All 46 physical barriers are initialized before the init fence (48 when
+    # the K ring keeps four stages); the port distributes the init sites across
+    # the producer-owning warps.
+    init_protocol_edges(PROTOCOL)
+    # instruction_selection: mbarrier.init.shared.b64; extent: 46 sites
+    fence("mbarrier_init_release_cluster")
+    barrier(0,384)
+    # instruction_selection: fence.mbarrier_init.release.cluster (.loc 1 2219);
+    # barrier.sync 0 (.loc 1 2220)
+
+    # TMEM columns: 512 allocated, 448 used.  Packed IO regions hold two
+    # elements per 32-bit cell; accumulators are FP32.  All row bases are
+    # warp-relative tmem_cell(base, warp_row, col) = base + col + (warp_row<<16).
+    STATE_ACC = 0        # S^T accumulator, 128 rows x cols 0..127
+    STATE_INP = 128      # packed IO S^T staging (GEMM 3 A), cols 128..191
+    CG0_ACC = 192        # KK ring, 2 stages x 64, cols 192..319
+    CG1_ACC = 320        # (K*S)^T then U^T accumulator, cols 320..383
+    Y_INP = 384          # packed Y^T (GEMM 5 A), cols 384..415
+    DECAY_U_INP = 416    # packed decayed U^T (GEMM 7 A), cols 416..447
+
+    def wait_edge(name, stage, phase):
+        wait(protocol_ptr(name, stage), phase)
+        # instruction_selection:
+        # mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 in a retry loop
+        # (.loc 2 39; 55 static sites)
+
+    def arrive_edge(name, stage=0):
+        arrive(protocol_ptr(name, stage))
+        # instruction_selection: mbarrier.arrive.shared.b64 (.loc 2 45)
+
+    def expect_edge(name, stage, nbytes):
+        expect_bytes(protocol_ptr(name, stage), nbytes)
+        # instruction_selection: mbarrier.arrive.expect_tx.shared.b64 (.loc 2 51)
+
+    def commit_edge(name, stage=0):
+        commit(protocol_ptr(name, stage))
+        # instruction_selection:
+        # tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
+        # (.loc 2 118; 9 static sites, 10 with the initial-state seed)
+
+    def scheduler_publish(cursor, tile):      # warp 9 side
+        if DYNAMIC:
+            wait_edge("sched_done", cursor.stage, cursor.phase)
+            if elected_lane():
+                ticket = atomic_add(sched_counter[0], 1, scope="gpu", order="relaxed")
+                # instruction_selection: atom.global.add.u32 (.loc 1 419)
+                copy_r2s(grid_x + ticket, arena[SCHED_BASE + 4*cursor.stage])
+                # instruction_selection: st.shared.b32 (attributed .loc 1 1896)
+            warp_sync()
+            next_tile = copy_s2r(arena[SCHED_BASE + 4*cursor.stage])
+            # instruction_selection: ld.shared.b32 (.loc 1 422)
+            if elected_lane(): arrive_edge("sched", cursor.stage)
+            return next_tile, advance(cursor)
+        return tile + grid_x, cursor
+
+    def scheduler_consume(cursor, tile):      # all consumer roles
+        if DYNAMIC:
+            wait_edge("sched", cursor.stage, cursor.phase)
+            next_tile = copy_s2r(arena[SCHED_BASE + 4*cursor.stage])
+            # instruction_selection: ld.shared.b32 (.loc 1 434; 5 role sites)
+            if elected_lane(): arrive_edge("sched_done", cursor.stage)
+            return next_tile, advance(cursor)
+        return tile + grid_x, cursor
+
+    # ====================================================================
+    # Warps 0..3 (CG0): T-pairwise, KK epilogue, pair inverse, beta scaling
+    # ====================================================================
+    if 0 <= warp <= 3:
+        set_register_budget("increase", 224)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 (.loc 1 1064)
+        barrier(1, 288)      # TMEM-alloc rendezvous with warps 4..7 and 10
+        # instruction_selection: bar.sync 1 (.loc 1 1070)
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        # instruction_selection: ld.shared.b32 (.loc 1 1074)
+        gate_cur = consumer_cursor(GATE_STAGES, phase=0)
+        beta_cur = consumer_cursor(BETA_STAGES, phase=0)
+        cg0_cur = consumer_cursor(CG0_ACC_STAGES, phase=0)
+        tinv_cur = producer_cursor(TINV_STAGES, phase=1)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        pair_half = warp // 2          # warps 0..1 = member 0, 2..3 = member 1
+        inv_warp = warp % 2
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            for pair in range(ceil_div(n_local, 2)):
+                # An odd chunk count leaves the last pair with member 0 only;
+                # have_m1 is uniform across CG0 so shared barriers stay aligned.
+                have_m1 = pair*2 + 1 < n_local
+                do_kk = have_m1 or pair_half == 0
+
+                # -- T-pairwise decay fragments for this warp's KK member --
+                # Acquire gate stage 0 (and stage 1 when the pair has two
+                # members); this warp's KK member is stage pair_half.  Unlike
+                # the prefill sibling only ONE decay fragment set is built,
+                # because there is no A epilogue.
+                g0 = acquire(gate_cur); g1 = acquire(gate_cur) if have_m1 else g0
+                wait_edge("gate", g0.stage, g0.phase)
+                if have_m1: wait_edge("gate", g1.stage, g1.phase)
+                kk_g = g1 if pair_half == 1 else g0
+                rows = copy_s2r(cumsumlog_rows(kk_g))       # 4 row reads
+                # instruction_selection: ld.shared.b32 x4 (.loc 1 1128)
+                cols = copy_s2r(cumsumlog_cols(kk_g))       # 16 column reads
+                # instruction_selection: ld.shared.v2.b32 x8 (.loc 1 1133)
+                # Per accumulator fragment cell (i,j):
+                #   decay[i,j] = exp2(cumsumlog[i] - cumsumlog[j]) if i>=j else 0
+                decay_kk = [exp2(sub(rows[r(i)], cols[c(j)])) if lower(i,j)
+                            else opaque_zero() for (i,j) in acc_frag()]
+                # instruction_selection: sub.f32, ex2.approx.ftz.f32 (52 sites,
+                # .loc 1 1146), selp.f32 against an opaque zero; extent: 64
+                # cells per thread over two 32-value halves
+                arrive_edge("gate_done", g0); arrive_edge("gate_done", g1) if have_m1
+
+                b0 = acquire(beta_cur); b1 = acquire(beta_cur) if have_m1 else b0
+                wait_edge("beta", b0.stage, b0.phase)
+                if have_m1: wait_edge("beta", b1.stage, b1.phase)
+                kk_b = (b1 if pair_half == 1 else b0)
+                kk_beta_rows = copy_s2r(beta_ring_rows(kk_b))
+                # instruction_selection: ld.shared.b32 x4 (.loc 1 1162)
+
+                # -- KK epilogue into the T-inverse buffer ----------------
+                kk_acc = acquire(cg0_cur); a_acc = acquire(cg0_cur) if have_m1 else kk_acc
+                if pair_half == 1: kk_acc = a_acc
+                t0 = acquire(tinv_cur); t1 = acquire(tinv_cur) if have_m1 else t0
+                kk_t = (t1 if pair_half == 1 else t0)
+                if do_kk:
+                    wait_edge("cg0_acc", kk_acc.stage, kk_acc.phase)
+                    # Only the 64-row half matching this warp's member is read
+                    # out of the M=128 accumulator; the other half multiplies
+                    # the stage box this member does not own and is dropped.
+                    kk = copy_t2r(tmem_cell(tmem, warp*32, CG0_ACC + kk_acc.stage*64))
+                    # instruction_selection: tcgen05.ld.sync.aligned.16x256b
+                    # .x8.b32; extent: two 16-row halves per warp
+                    # (.loc 1 1194, 1197)
+                    wait_tmem_load()
+                    # instruction_selection: tcgen05.wait::ld.sync.aligned
+                    # (.loc 1 1200; the only load wait in the kernel)
+                    arrive_edge("cg0_acc_done", kk_acc.stage)
+                    wait_edge("t_inv_done", kk_t.stage, kk_t.phase)
+                    m = cast(IO_DTYPE, mul(mul(kk, decay_kk), kk_beta_rows))
+                    # instruction_selection: 2 x mul.f32x2 (.loc 3 244) +
+                    # 1 x cvt.rn.{bf16x2|f16x2}.f32 (.loc 3 120) per
+                    # (half, pair) = 64 + 32 over the two 16-row halves
+                    copy_r2s(m, smem_byte(arena, TINV_BASE, kk_t.stage,
+                                          row=member_row(warp,lane),
+                                          col=xor128, elem_bytes=2))
+                    # instruction_selection: stmatrix.sync.aligned.m8n8.x4
+                    # .shared.b16; extent: 4 fragments x 2 halves = 8 sites
+                    # (.loc 1 1213)
+
+                # -- four-level hierarchical pair inverse -----------------
+                # Warps 0..1 own matrix 0, warps 2..3 matrix 1; without
+                # member 1 all four warps take matrix 0 and the duplicate
+                # band is identical.  Diagonal cells become I via lane
+                # identity injection; result overwrites the same buffer.
+                barrier(2, 128)
+                if have_m1 or warp < 2:
+                    gauss_jordan_8x8(arena, my_tinv_base, d=(inv_warp*32+lane)//8)
+                    # instruction_selection: 1 x ld.shared.v4.b32 8-element
+                    # IO-pair row load (.loc 1 217), 21 x shfl.sync.idx.b32
+                    # (.loc 1 223), scaled row elimination in f32,
+                    # 1 x st.shared.v4.b32 (.loc 1 228)
+                barrier(2, 128)
+                blockwise_8_to_16(arena, t0.base, d0=warp*16, lane)
+                if have_m1: blockwise_8_to_16(arena, t1.base, d0=warp*16, lane)
+                # instruction_selection per call: ldmatrix.m8n8.x1{,.trans}
+                # .shared.b16 (.loc 1 236/241/257), 2 x mma.sync.aligned
+                # .m16n8k8.row.col.f32.bf16.bf16.f32 (.loc 7 488), neg.f32,
+                # packed cvt, 1 x stmatrix.m8n8.x1 (.loc 1 269)
+                barrier(2, 128)
+                if have_m1 or warp < 2:
+                    blockwise_16_to_32(arena, my_tinv_base, d0=inv_warp*32, lane)
+                    # instruction_selection: 3 x ldmatrix.x4{,.trans}
+                    # (.loc 1 282/291/309), 4 x mma.sync.m16n8k16 (.loc 7 436),
+                    # packed cvt, 1 x stmatrix.x4 (.loc 1 322)
+                barrier(2, 128)
+                blockwise_32_to_64(arena, my_tail_base, band=inv_warp, lane)
+                # instruction_selection: 10 x ldmatrix.x4{,.trans}
+                # (.loc 1 338/351/376), 16 x mma.sync.m16n8k16 (.loc 7 436),
+                # packed cvt, bar.sync 2 (.loc 1 394), 2 x stmatrix.x4
+                # (.loc 1 398/403)
+                barrier(2, 128)
+                # instruction_selection: bar.sync 2; extent: 5 ladder sites
+                # (.loc 1 1232, 1238, 1247, 1255, 1264)
+
+                # -- post-inverse beta column scaling + publish -----------
+                # T_inv[:, j] *= beta[j] for member 0 then member 1, both
+                # performed by all four warps: ldmatrix the finished inverse,
+                # multiply by the beta ring columns, store back, fence, publish.
+                for (t, b) in ((t0, b0),) + (((t1, b1),) if have_m1 else ()):
+                    beta_cols = copy_s2r(beta_ring_cols(b))
+                    # instruction_selection: ld.shared.v2.b32 x8
+                    # (.loc 1 1272 / 1309)
+                    frag = copy_s2r(smem_byte(arena, TINV_BASE, t.stage, xor128))
+                    # instruction_selection: ldmatrix.m8n8.x4.shared.b16 x4
+                    # (.loc 1 1276 / 1313)
+                    scaled = cast(IO_DTYPE, mul(cast("f32",frag), beta_cols))
+                    # instruction_selection: f16x2_to_f32 unpack x16,
+                    # mul.f32x2 x16 (.loc 3 244), cvt.rn.bf16x2.f32 x16
+                    # (.loc 3 120) per member block, over 2 blocks
+                    copy_r2s(scaled, smem_byte(arena, TINV_BASE, t.stage, xor128))
+                    # instruction_selection: stmatrix.m8n8.x4 x4
+                    # (.loc 1 1292 / 1329)
+                    fence("async_shared_cta")
+                    # instruction_selection: fence.proxy.async.shared::cta
+                    # (.loc 1 1301 / 1338)
+                    arrive_edge("t_inv", t.stage)
+                    arrive_edge("beta_done", b)
+            tile, sched = scheduler_consume(sched, tile)
+        drain_producer("t_inv_done", tinv_cur)
+
+    # ====================================================================
+    # Warps 4..7 (CG1): state seed/restage/checkpoint/rescale, Y, U, final
+    # ====================================================================
+    if 4 <= warp <= 7:
+        set_register_budget("increase", 256 if USE_INITIAL_STATE else 232)
+        # instruction_selection: setmaxnreg.inc.sync.aligned.u32 (.loc 1 1383)
+        barrier(1, 288)
+        # instruction_selection: bar.sync 1 (.loc 1 1384)
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        # instruction_selection: ld.shared.b32 (.loc 1 1388)
+        v_cur = consumer_cursor(V_STAGES, phase=0)
+        gate_cur = consumer_cursor(GATE_STAGES, phase=0)
+        state_cur = consumer_cursor(1, phase=0)      # state_acc ready
+        seed_cur = producer_cursor(1, phase=1)       # state-scale-done reuse
+        kst_cur = consumer_cursor(1, phase=0)
+        uacc_cur = consumer_cursor(1, phase=0)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        value_dim = (warp-4)*32 + lane               # 0..127 state row
+        checkpoint_serial = 0
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            ckpt_mod = item.cstart % (checkpoint_every_n_tokens // 64) if CHECKPOINTS
+            if n_local > 0:
+                if USE_INITIAL_STATE:
+                    # -- initial-state seed: GMEM (or zero) -> state TMEM ---
+                    wait_edge("state_scale_done", 0, seed_cur.phase); advance(seed_cur)
+                    if item.cstart == 0:
+                        rows = copy_g2r(initial_state[item.batch, item.head,
+                                                      value_dim, 0:128])
+                        # instruction_selection: ld.global.v2.b64 x32, each
+                        # moving four FP32 of the row (state-main .loc 1 1437);
+                        # BF16 state routes through packed converts first
+                        copy_r2t(rows, tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: tcgen05.st.32x32b.x32.b32 x4
+                        # (state-main .loc 1 1441)
+                    else:
+                        copy_r2t(fill(reg_array("f32",128), 0),
+                                 tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: tcgen05.st.32x32b.x32.b32 x4
+                        # (state-main .loc 1 1448)
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st (state .loc 1 1453)
+                    barrier(4, 128)
+                    # instruction_selection: bar.sync 4 (state .loc 1 1455);
+                    # this named barrier appears only in the seeded profile
+
+                for local in range(n_local):
+                    chunk = item.cstart + local
+                    if CHECKPOINTS:
+                        do_ckpt_now = ckpt_mod == 0
+                        ckpt_mod = 0 if ckpt_mod+1 == ckpt_chunks else ckpt_mod+1
+                    if CHECKPOINTS and not USE_INITIAL_STATE and chunk == 0 and item.wstart == 0:
+                        # Explicit zero checkpoint before the first chunk: the
+                        # entering state of an unseeded sequence is zero and no
+                        # TMEM read can supply it.
+                        stage = acquire_checkpoint_done(checkpoint_serial)
+                        fill_zero(arena[CHECKPOINT_BASE + stage*32768], per_thread=64)
+                        # instruction_selection: st.shared.b32; extent: 64
+                        # strided stores per thread (attributed .loc 1 1896)
+                        fence("async_shared_cta")
+                        # instruction_selection: fence.proxy.async.shared::cta
+                        # (.loc 1 1476)
+                        if elected_lane(): arrive_edge("checkpoint", stage)
+                        checkpoint_serial += 1
+                    have_state = USE_INITIAL_STATE or local > 0
+                    if USE_INITIAL_STATE:
+                        # the seed cursor also advances once per chunk so it
+                        # tracks every scale-done arrival
+                        advance(seed_cur)
+
+                    g = acquire(gate_cur)
+                    wait_edge("gate", g.stage, g.phase)
+                    cumprod_total = copy_s2r(arena[CUMPROD_BASE + g.stage*256 + 63*4])
+                    # instruction_selection: ld.shared.b32 (.loc 1 1488)
+
+                    # -- state restage + checkpoint + rescale ---------------
+                    if have_state:
+                        st = acquire(state_cur)
+                        wait_edge("state_acc", st.stage, st.phase)
+                        srows = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: tcgen05.ld.32x32b.x32.b32 x4
+                        # (.loc 1 1502)
+                        packed = cast(IO_DTYPE, srows, packed_pairs)
+                        copy_r2t(packed, tmem_cell(tmem, value_dim_row, STATE_INP))
+                        # instruction_selection: cvt.rn.{bf16x2|f16x2}.f32 x64;
+                        # tcgen05.st.32x32b.x16.b32 x4 (.loc 1 1508);
+                        # tcgen05.wait::st (.loc 1 1513)
+                        arrive_edge("state_inp")
+                        if CHECKPOINTS and do_ckpt_now and item.wstart <= chunk < item.wend:
+                            # The snapshot is taken BEFORE the rescale, so row j
+                            # of the series is the state ENTERING token j*N.
+                            # The source re-reads the same TMEM cells here even
+                            # though `srows` still holds them.
+                            stage = acquire_checkpoint_done(checkpoint_serial)
+                            ck = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                            # instruction_selection: tcgen05.ld.32x32b.x32.b32
+                            # x4, a second read of the cells already in
+                            # registers (.loc 1 1527)
+                            copy_r2s(cast(IO_DTYPE, ck),
+                                     arena[CHECKPOINT_BASE + xor128_row(value_dim)])
+                            # instruction_selection: packed cvt; 16 x
+                            # st.shared.v4.b32 16-byte vector stores
+                            # (attributed .loc 1 1896)
+                            fence("async_shared_cta")
+                            # instruction_selection: fence.proxy.async
+                            # .shared::cta (.loc 1 1541)
+                            if elected_lane(): arrive_edge("checkpoint", stage)
+                            checkpoint_serial += 1
+                        scaled = mul(srows, cumprod_total)
+                        copy_r2t(scaled, tmem_cell(tmem, value_dim_row, STATE_ACC))
+                        # instruction_selection: mul.f32x2 x64 (.loc 3 244),
+                        # four subs x sixteen pairs;
+                        # tcgen05.st.32x32b.x32.b32 x4 (.loc 1 1551);
+                        # tcgen05.wait::st (.loc 1 1556)
+                        arrive_edge("state_scale_done", st.stage)
+
+                    # -- per-row gate registers -----------------------------
+                    cumprod_cols = copy_s2r(cumprod_ring_cols(g.stage))
+                    # instruction_selection: ld.shared.v2.b32 x8 (.loc 1 1562)
+                    last_log = copy_s2r(arena[CUMSUMLOG_BASE + g.stage*256 + 63*4])
+                    # instruction_selection: ld.shared.b32 (.loc 1 1563)
+                    decay_scale = exp2(sub(last_log, cumsumlog_ring_cols(g.stage)))
+                    # instruction_selection: ld.shared.v2.b32 x8 (.loc 1 1566);
+                    # neg.f32 x16 (.loc 1 1569); add.rn.f32x2 x8 pair sums
+                    # against those negated columns (attributed .loc 1 1896);
+                    # ex2.approx.ftz.f32 x16 (.loc 1 1570/1571)
+                    arrive_edge("gate_done", g.stage)
+
+                    # -- Y = V - cumprod * (K*S), packed 16-bit -------------
+                    vv = acquire(v_cur)
+                    wait_edge("v", vv.stage, vv.phase)
+                    vfrag = copy_s2r(smem_byte(arena, V_BASE, vv.stage,
+                                     row=token_row, col=xor128, trans=True))
+                    # instruction_selection: ldmatrix.m8n8.x4.trans.shared.b16
+                    # x8 (two 64-channel subtiles x four 16-token bands)
+                    # (.loc 1 1583)
+                    if have_state:
+                        wait_edge("k_state_acc", 0, kst_cur.phase); advance(kst_cur)
+                        ks = copy_t2r(tmem_cell(tmem, value_dim_row, CG1_ACC))
+                        # instruction_selection: tcgen05.ld.16x256b.x8.b32 x2
+                        # (.loc 1 1601)
+                        y = packed_sub(vfrag, cast(IO_DTYPE, mul(ks, cumprod_cols)))
+                        # instruction_selection: mul.f32x2 x32 (.loc 3 244),
+                        # cvt.rn.bf16x2.f32 x32 (.loc 3 120),
+                        # sub.{bf16x2|f16x2} x32 (.loc 3 297)
+                    else:
+                        y = vfrag
+                    copy_r2t(y, tmem_cell(tmem, value_dim_row, Y_INP))
+                    # instruction_selection: tcgen05.st.16x128b.x8.b32 x2
+                    # (.loc 1 1611); tcgen05.wait::st (.loc 1 1616)
+                    arrive_edge("y_inp")
+
+                    # -- U epilogue: decayed-U publish ----------------------
+                    wait_edge("u_acc", 0, uacc_cur.phase); advance(uacc_cur)
+                    arrive_edge("v_done", vv.stage)
+                    u = copy_t2r(tmem_cell(tmem, value_dim_row, CG1_ACC))
+                    # instruction_selection: tcgen05.ld.16x256b.x8.b32 x2
+                    # (.loc 1 1628)
+                    du = cast(IO_DTYPE, mul(u, decay_scale))
+                    copy_r2t(du, tmem_cell(tmem, value_dim_row, DECAY_U_INP))
+                    # instruction_selection: mul.f32x2 x32 (.loc 3 244),
+                    # cvt.rn.bf16x2.f32 x32 (.loc 3 120);
+                    # tcgen05.st.16x128b.x8.b32 x2 (.loc 1 1644);
+                    # tcgen05.wait::st (.loc 1 1649)
+                    # Unlike the prefill sibling there is no undecayed U
+                    # republish: nothing consumes U except the state update.
+                    arrive_edge("decay_u_inp")
+
+                # -- final state: TMEM -> GMEM after the last chunk ---------
+                # The wait/arrive pair runs whether or not the final state is
+                # stored, because it also closes the last chunk's state edge.
+                st = acquire(state_cur)
+                wait_edge("state_acc", st.stage, st.phase)
+                if STORE_FINAL_STATE and item.wend == item.num_chunks_b:
+                    rows = copy_t2r(tmem_cell(tmem, value_dim_row, STATE_ACC))
+                    # instruction_selection: tcgen05.ld.32x32b.x32.b32 x4
+                    # (state-main .loc 1 1661)
+                    copy_r2g(cast(STATE_DTYPE, rows),
+                             final_state[item.batch, item.head, value_dim, 0:128])
+                    # instruction_selection: st.global.v2.b64 x32, 16 B per
+                    # access (FP32 state) / packed converts then stores for
+                    # BF16 state (state-main .loc 1 1668)
+                arrive_edge("state_scale_done", st.stage)
+            elif STORE_FINAL_STATE and item.wend == item.num_chunks_b:
+                # Empty sequence: never touches TMEM; passthrough initial
+                # state when present, else state-dtype zero.
+                for key in range(128):
+                    val = (copy_g2r(initial_state[item.batch,item.head,value_dim,key])
+                           if USE_INITIAL_STATE else cast(STATE_DTYPE,0))
+                    copy_r2g(val, final_state[item.batch,item.head,value_dim,key])
+                    # instruction_selection: ld.global + st.global pairs in the
+                    # seeded profile (state-main .loc 1 1680); plain st.global
+                    # zero stores otherwise
+            tile, sched = scheduler_consume(sched, tile)
+        arrive_edge("tmem_done")
+        if CHECKPOINTS: drain_checkpoint_done(checkpoint_serial)
+
+    # ====================================================================
+    # Warp 8: gate/beta producer
+    # ====================================================================
+    elif warp == 8:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (.loc 1 544)
+        gate_cur = producer_cursor(GATE_STAGES, phase=1)
+        beta_cur = producer_cursor(BETA_STAGES, phase=1)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            if SAFE_GATE and item.wend > item.cstart:
+                a_l2 = mul(neg(exp2(mul(copy_g2r(a_log[item.head]), LOG2_E))), LOG2_E)
+                bias = copy_g2r(dt_bias[item.head])
+                # instruction_selection: ld.global.b32 x2, ex2.approx.ftz.f32
+            for chunk in range(item.cstart, item.wend):
+                # -- gate: predicated GMEM loads, log2 transform, prefix ----
+                # Each lane owns two token columns (lane, lane+32); the OOB
+                # neutral is 0 in log domain, 1 in alpha domain.
+                g = acquire(gate_cur)
+                vals = [copy_g2r(gate[clamped_token(col), item.head])
+                        if token_valid(col) else oob_neutral() for col in (0,1)]
+                # instruction_selection: branch-predicated ld.global.b32 x2 with
+                # min.s32 index clamp and mov-immediate OOB neutral (.loc 1 581)
+                if SAFE_GATE:
+                    vals = [mul(a_l2, softplus(add(vc, bias))) if valid else 0
+                            for vc in vals]
+                    # instruction_selection: ex2/lg2.approx.ftz chain per lane
+                elif LOG_GATE:
+                    vals = mul(vals, RCP_LN2)          # natural log -> log2
+                    # instruction_selection: mul.f32 x2, one per owned token
+                    # column (.loc 1 590)
+                else:
+                    vals = log2(add(vals, 1e-10))
+                    # instruction_selection: lg2.approx.ftz.f32
+                prefix = warp_inclusive_scan(vals)
+                # instruction_selection: shfl.sync.up.b32 offsets 1,2,4,8,16 per
+                # column (10 sites, .loc 1 596) plus one shfl.sync.idx.b32
+                # lane-31 carry (.loc 1 600)
+                wait_edge("gate_done", g.stage, g.phase)
+                copy_r2s(prefix, arena[CUMSUMLOG_BASE + g.stage*256 + col*4])
+                copy_r2s(exp2(prefix), arena[CUMPROD_BASE + g.stage*256 + col*4])
+                # instruction_selection: st.shared.b32 x2 each (.loc 1 612/613),
+                # ex2.approx.ftz.f32 x2 (.loc 1 613)
+                arrive_edge("gate", g.stage)
+
+                # -- beta: cp.async per element or in-register sigmoid ------
+                b = acquire(beta_cur)
+                wait_edge("beta_done", b.stage, b.phase)
+                if BETA_SIGMOID:
+                    for col in (0,1):
+                        bv = 0
+                        if token_valid(col):
+                            bv = cast("f32", cast(IO_DTYPE,
+                                 add(mul(tanh(mul(copy_g2r(beta[token,item.head]),0.5)),0.5),0.5)))
+                        copy_r2s(bv, arena[BETA_BASE + b.stage*256 + col*4])
+                    # instruction_selection: ld.global.b16, tanh.approx.f32,
+                    # round through IO dtype, st.shared.b32
+                    arrive_edge("beta", b.stage)
+                else:
+                    for col in (0,1):
+                        copy_g2s(beta[token, item.head],
+                                 arena[BETA_BASE + b.stage*256 + col*4],
+                                 bytes=4 if token_valid(col) else 0)
+                    # instruction_selection: cp.async.ca.shared.global 4B with
+                    # zero-fill cp-size predication x2 (.loc 1 638)
+                    cp_async_arrive(protocol_ptr("beta", b.stage), noinc=True)
+                    # instruction_selection: cp.async.mbarrier.arrive.noinc
+                    # .shared.b64 (.loc 1 639)
+            tile, sched = scheduler_consume(sched, tile)
+        drain_producer("gate_done", gate_cur); drain_producer("beta_done", beta_cur)
+
+    # ====================================================================
+    # Warp 10: sole tcgen05 issuer and TMEM lifecycle
+    # ====================================================================
+    elif warp == 10:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (.loc 1 669)
+        allocate_tmem(TMEM_MAILBOX, columns=512, cta_group=1)
+        # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned
+        # .shared::cta.b32 (.loc 1 679)
+        barrier(1, 288)
+        # instruction_selection: bar.sync 1 (.loc 1 680)
+        tmem = copy_s2r(arena[TMEM_MAILBOX])
+        # instruction_selection: ld.shared.b32 (.loc 1 776)
+        kq_cur = consumer_cursor(KQ_STAGES, phase=0)        # per-chunk operand
+        kqf_cur = consumer_cursor(KQ_STAGES, phase=0)       # fused-pair lookahead
+        cg0_cur = consumer_cursor(CG0_ACC_STAGES, phase=1)  # cg0 acc done
+        tinv_cur = consumer_cursor(TINV_STAGES, phase=0)
+        sinp_cur = consumer_cursor(1, phase=0)
+        y_cur = consumer_cursor(1, phase=0)
+        du_cur = consumer_cursor(1, phase=0)
+        state_cur = producer_cursor(1, phase=1)             # state acc
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+
+        # SMEM operand descriptors are integer immediates: base>>4 plus lead
+        # 16 B, stride 1024 B, swizzle-128B; the member box offset is
+        # KQ_BOX = 64*64*2 B >> 4 and the high-channel segment offset is
+        # KQ_SEG = 2*64*64*2 B >> 4; the state-update B operand re-views the
+        # same K stage bytes with lead 16384 B.
+        def fused_kk(kqf, acc_stage, member_one):
+            # M = 128 spans BOTH pair boxes of the stage, N = 64 spans only the
+            # box of the member being computed, so exactly half of each
+            # accumulator is consumed by CG0 and the other half is dead work
+            # the source keeps.
+            wait_edge("cg0_acc_done", acc_stage.stage, acc_stage.phase)
+            wait_edge("kq", kqf.stage, kqf.phase)
+            a = smem_matrix_desc(KQ_BASE + kqf.stage*32768)
+            b = a + KQ_BOX if member_one else a
+            gemm(tmem_cell(tmem, 0, CG0_ACC + acc_stage.stage*64), a, b,
+                 M=128, N=64, K=64, accumulate=False)
+            gemm(tmem_cell(tmem, 0, CG0_ACC + acc_stage.stage*64),
+                 a + KQ_SEG, b + KQ_SEG, M=128, N=64, K=64, accumulate=True)
+            # instruction_selection: tcgen05.mma.cta_group::1.kind::f16 with
+            # SMEM A/B descriptors; extent: 2 x 4 K-phases = 8 instructions
+            # (.loc 7 143; 4 static sites x 8 = 32 of the 48 total)
+            if elected_lane(): commit_edge("cg0_acc", acc_stage.stage)
+
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            # pair member 0 and (when present) member 1 are issued ahead
+            if n_local > 0: fused_kk(acquire(kqf_cur), acquire(cg0_cur), member_one=False)
+            if n_local > 1: fused_kk(acquire(kqf_cur), acquire(cg0_cur), member_one=True)
+            for local in range(n_local):
+                member = local & 1
+                have_state = USE_INITIAL_STATE or local > 0
+                if USE_INITIAL_STATE and local == 0:
+                    # the seeded state is already in TMEM; publish it so CG1's
+                    # first restage can proceed without an MMA
+                    if elected_lane(): commit_edge("state_acc", 0)
+                    advance(state_cur)
+                kq = acquire(kq_cur)
+                desc_k = smem_matrix_desc(KQ_BASE + kq.stage*32768) + member*KQ_BOX
+                desc_kt = smem_matrix_desc(KQ_BASE + kq.stage*32768,
+                                           lead=16384) + member*KQ_BOX
+
+                # member-parity lookahead keeps one fused pair in flight
+                if member == 1 and local+2 < n_local:
+                    fused_kk(acquire(kqf_cur), acquire(cg0_cur), member_one=True)
+
+                # -- GEMM 3: (K*S)^T = S^T_packed @ K^T ---------------------
+                if have_state:
+                    wait_edge("state_inp", 0, sinp_cur.phase); advance(sinp_cur)
+                    gemm(tmem_cell(tmem, 0, CG1_ACC),
+                         tmem_a(STATE_INP), desc_k, M=128, N=64, K=128,
+                         accumulate=per_k_phase)
+                    # instruction_selection: tcgen05.mma.kind::f16 TMEM-A;
+                    # extent: 2 half-K segments x 4 = 8 instructions
+                    # (.loc 7 223), the second segment advancing the TMEM A
+                    # pointer by 32 columns and the B descriptor by KQ_SEG
+                    if elected_lane(): commit_edge("k_state_acc", 0)
+
+                # -- GEMM 5: U^T = Y^T_packed @ T_inv -----------------------
+                tv = acquire(tinv_cur)
+                wait_edge("t_inv", tv.stage, tv.phase)
+                wait_edge("y_inp", 0, y_cur.phase); advance(y_cur)
+                gemm(tmem_cell(tmem, 0, CG1_ACC),
+                     tmem_a(Y_INP), smem_matrix_desc(TINV_BASE + tv.stage*8192),
+                     M=128, N=64, K=64, accumulate=per_k_phase)
+                # instruction_selection: 4 x tcgen05.mma TMEM-A (.loc 7 223)
+                if elected_lane():
+                    commit_edge("u_acc", 0); commit_edge("t_inv_done", tv.stage)
+
+                if member == 0 and local+2 < n_local:
+                    fused_kk(acquire(kqf_cur), acquire(cg0_cur), member_one=False)
+
+                # -- GEMM 7: S^T += decayedU^T_packed @ K -------------------
+                wait_edge("decay_u_inp", 0, du_cur.phase); advance(du_cur)
+                advance(state_cur)
+                gemm(tmem_cell(tmem, 0, STATE_ACC),
+                     tmem_a(DECAY_U_INP), desc_kt, M=128, N=128, K=64,
+                     accumulate=have_state_on_first_k)
+                # instruction_selection: 4 x tcgen05.mma TMEM-A (.loc 7 223),
+                # B transposed through the lead-16384 K^T descriptor view and
+                # the b_major instruction-descriptor field
+                if elected_lane():
+                    commit_edge("state_acc", 0); commit_edge("kq_done", kq.stage)
+            tile, sched = scheduler_consume(sched, tile)
+        wait_edge("tmem_done", 0, 0)
+        relinquish_tmem_alloc_permit(cta_group=1)
+        deallocate_tmem(tmem, columns=512, cta_group=1)
+        # instruction_selection: tcgen05.relinquish_alloc_permit (.loc 1 912) /
+        # tcgen05.dealloc.cta_group::1.sync.aligned.b32 (.loc 1 913)
+
+    # ====================================================================
+    # Warp 9: TMA-LDG and scheduler producer
+    # ====================================================================
+    elif warp == 9:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (.loc 1 939)
+        kq_cur = producer_cursor(KQ_STAGES, phase=1)
+        v_cur = producer_cursor(V_STAGES, phase=1)
+        sched = producer_cursor(SCHED_STAGES, phase=1)
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            kh = input_head(item.head, K_RATIO)
+            vh = input_head(item.head, V_RATIO)
+            if elected_lane():
+                for array in (K, V):
+                    acquire_descriptor(array, item.batch)
+                    # instruction_selection:
+                    # fence.proxy.tensormap::generic.acquire.gpu (.loc 8 272)
+            if item.wend > item.cstart:
+                # first chunk of the item always lands in box 0 of its stage
+                s = acquire(kq_cur)
+                wait_edge("kq_done", s.stage, s.phase)
+                if elected_lane(): expect_edge("kq", s.stage, 16384)
+                copy_g2s(descriptor(K, item.batch), arena[KQ_BASE + s.stage*32768],
+                         coords=(0, kh, item.cstart*64))
+                # instruction_selection: cp.async.bulk.tensor.3d.shared::cta
+                # .global.tile.mbarrier::complete_tx::bytes; extent: two
+                # 8-KB 64-channel boxes at +0 and +16384 (.loc 8 77)
+                for chunk in range(item.cstart+1, item.wend):
+                    member = (chunk - item.cstart) & 1
+                    s = acquire(kq_cur)
+                    wait_edge("kq_done", s.stage, s.phase)
+                    if elected_lane(): expect_edge("kq", s.stage, 16384)
+                    if member == 0:
+                        copy_g2s(descriptor(K, item.batch),
+                                 arena[KQ_BASE + s.stage*32768],
+                                 (0, kh, chunk*64))
+                    else:
+                        copy_g2s(descriptor(K, item.batch),
+                                 arena[KQ_BASE + s.stage*32768 + 8192],
+                                 (0, kh, chunk*64))
+                    # instruction_selection: cp.async.bulk.tensor.3d...; extent:
+                    # 2 static sites x two 8-KB subtiles 16384 B apart; 4 of the
+                    # 10 rank-3 `.loc 8 77` instructions.  Member parity selects
+                    # box 0 or box 1 of the stage at compile time, not through a
+                    # runtime byte offset.
+                    vs = acquire(v_cur)
+                    wait_edge("v_done", vs.stage, vs.phase)
+                    if elected_lane(): expect_edge("v", vs.stage, 16384)
+                    copy_g2s(descriptor(V, item.batch), arena[V_BASE + vs.stage*16384],
+                             (0, vh, (chunk-1)*64))
+                    # instruction_selection: rank-3 TMA, one-behind V tile, two
+                    # 8-KB subtiles 8192 B apart (.loc 8 77)
+                vs = acquire(v_cur)
+                wait_edge("v_done", vs.stage, vs.phase)
+                if elected_lane(): expect_edge("v", vs.stage, 16384)
+                copy_g2s(descriptor(V, item.batch), arena[V_BASE + vs.stage*16384],
+                         (0, vh, (item.wend-1)*64))
+            tile, sched = scheduler_publish(sched, tile)
+        drain_producer("kq_done", kq_cur); drain_producer("v_done", v_cur)
+
+    # ====================================================================
+    # Warp 11: epilogue checkpoint TensorMap stores
+    # ====================================================================
+    if warp == 11:
+        set_register_budget("decrease", 24 if USE_INITIAL_STATE else 48)
+        # instruction_selection: setmaxnreg.dec.sync.aligned.u32 (.loc 1 459)
+        sched = consumer_cursor(SCHED_STAGES, phase=0)
+        checkpoint_serial = 0
+        tile = cta
+        while tile < total_tiles:
+            item = decode_work(tile)
+            n_local = item.wend - item.cstart
+            if CHECKPOINTS:
+                if elected_lane(): acquire_descriptor(CHECKPOINT, item.batch)
+                # instruction_selection:
+                # fence.proxy.tensormap::generic.acquire.gpu (.loc 8 272)
+                ckpt_coord = ceil_div(item.wstart, ckpt_chunks)
+                ckpt_mod = item.cstart % ckpt_chunks
+            if n_local > 0:
+                for local in range(n_local):
+                    chunk = item.cstart + local
+                    did_ckpt = False
+                    if CHECKPOINTS:
+                        stage = checkpoint_serial % CHECKPOINT_STAGES
+                        if item.wstart <= chunk < item.wend and ckpt_mod == 0:
+                            wait_edge("checkpoint", stage, phase_of(checkpoint_serial))
+                            copy_s2g(arena[CHECKPOINT_BASE + stage*32768],
+                                     checkpoint_coord(0, 0, ckpt_coord, item.head))
+                            # instruction_selection: cp.async.bulk.tensor.4d
+                            # .global.shared::cta.tile.bulk_group; extent: two
+                            # 64-channel subtiles (.loc 8 119)
+                            store_commit()
+                            # instruction_selection: cp.async.bulk.commit_group
+                            # (.loc 8 152)
+                            ckpt_coord += 1; did_ckpt = True
+                        ckpt_mod = 0 if ckpt_mod+1 == ckpt_chunks else ckpt_mod+1
+                        if did_ckpt:
+                            store_wait(0)
+                            # instruction_selection: cp.async.bulk.wait_group
+                            # .read 0 (.loc 8 157)
+                            arrive_edge("checkpoint_done", stage)
+                            checkpoint_serial += 1
+            tile, sched = scheduler_consume(sched, tile)
+```
+
+## Numerical order frozen by the schedule
+
+For one token, the source recurrence represented by the chunk factorization is:
+
+```text
+S_decayed = alpha_t * S            # alpha = exp(g), gates kept in log2 domain
+erase     = k_t @ S_decayed
+y_t       = v_t - erase
+S         = S_decayed + outer(k_t, beta-folded y)
+```
+
+Within a chunk the exact source order matters: the gate warp converts to log2
+(safe gate through `-exp(a_log·log2e)·softplus(g+bias)·log2e`, natural log
+through `·1/ln2`, raw alpha through `lg2(x+1e-10)`) and prefix-scans with warp
+shuffles; T-pairwise cells are `exp2(cumsumlog_i − cumsumlog_j)` masked by an
+opaque zero; the KK epilogue folds `decay·beta_row` before IO rounding; the
+64×64 inverse runs Gauss-Jordan on 8×8 diagonals then three blockwise
+correction levels in register MMA with IO-dtype rounding at each level; beta
+column scaling rounds through packed IO pairs after the inverse; U accumulates
+in FP32 TMEM; `Y = V − cumprod·(K·S)` is computed in packed 16-bit subtraction;
+the decayed U multiplies `exp2(last−prefix)` before IO rounding; the checkpoint
+snapshot rounds the pre-rescale FP32 state to IO dtype.  Tail tokens get
+log-domain zero gate contribution and TMA OOB zero fill; checkpoint stores clip
+in hardware through the per-batch descriptor's checkpoint-count extent.
+
+## Logical tcgen05 GEMMs
+
+TMEM accumulators hold transposed results with tokens (or DK for the state) in
+the N dimension.
+
+| # | FP32 TMEM destination | A operand | B operand | logical MxNxK | issues | accumulate |
+| ---: | --- | --- | --- | --- | ---: | --- |
+| 1 | KK ring col 192/256 | K stage, both boxes (SS) | the member's box of the same stage | 128x64x128 | 8 | K-phase only |
+| 3 | (K·S)^T col 320 | packed S^T TMEM | the member's K box | 128x64x128 | 8 | K-phase only |
+| 5 | U^T col 320 | packed Y^T TMEM | beta-scaled T_inv SMEM | 128x64x64 | 4 | K-phase only |
+| 7 | S^T cols 0..127 | packed decayed-U^T TMEM | K^T lead-16384 view of the member's box | 128x128x64 | 4 | runtime `have_state` |
+
+GEMM 1 has four static sites (two pre-loop, one per member parity), so the BF16
+anchor has `4*8 + 8 + 4 + 4 = 48` static `tcgen05.mma` sites, matching the
+export exactly.  GEMMs 3 and 5 share the CG1 accumulator columns sequentially
+within one chunk; publication follows the exact delayed commit sites in warp 10.
+The M=128 shape of GEMM 1 makes half of every KK accumulator dead: the source
+keeps it because the shape is inherited from the prefill kernel's genuinely
+fused KK/QK pair, and the port keeps it because dropping it would change the
+issue count and the accumulator ring geometry.
+
+## Storage-alias lifetimes
+
+- The T-inverse buffer stage holds, in order: the beta-row-scaled masked KK
+  product `M`, the in-place hierarchical inverse of `I + M` (identity injected
+  by lane predicates), then the beta-column-scaled `T_inv` consumed by GEMM 5.
+- The CG1 TMEM accumulator (col 320) holds `(K·S)^T` until CG1 consumes it into
+  `Y`, then `U^T` from GEMM 5 in the same chunk.
+- The Y input slot (col 384) feeds GEMM 5; the decayed-U slot (col 416) feeds
+  GEMM 7.  Unlike the prefill sibling the Y slot is never rewritten with an
+  undecayed U, because no second consumer exists.
+- One K SMEM stage carries two chunks: box 0 the pair's even member, box 1 the
+  odd member.  It feeds the fused KK issue for both members, GEMM 3, and GEMM 7
+  (K^T view) before `kq_done` releases it.
+- The checkpoint staging buffer holds one 128x128 IO snapshot between the CG1
+  publish and the warp-11 TMA store; its single stage serializes CG1 against the
+  store, which is why the CG1 side waits `checkpoint_done` before filling.
+
+## Source / PTX / sketch correspondence
+
+`nostate-main`/`nostate-prologue` mean the two files in
+`source_export/dump_nostate`, `state-*` the initial-state + final-state files.
+
+| Source action | Source lines | PTX evidence | Sketch section |
+| --- | ---: | --- | --- |
+| mbarrier inventory and arrive counts | 115..196 | nostate-main 46 `mbarrier.init` sites (`.loc 2 183`) | PROTOCOL table |
+| 8x8 Gauss-Jordan diagonal inverse | 199..228 | `.loc 1 217/223/228`; ld.shared.v4.b32, 21 shfl.sync.idx.b32, st.shared.v4.b32 | CG0 `gauss_jordan_8x8` |
+| 8→16 blockwise correction | 231..273 | `.loc 1 236/241/257/269`, `.loc 7 488`; 4 `mma.sync.m16n8k8`, ldmatrix.x1, stmatrix.x1 | CG0 `blockwise_8_to_16` |
+| 16→32 blockwise correction | 276..326 | `.loc 1 282/291/309/322`, `.loc 7 436`; ldmatrix.x4, stmatrix.x4 | CG0 `blockwise_16_to_32` |
+| 32→64 blockwise correction | 329..407 | `.loc 1 338/351/376/394/398/403`; 16 `mma.sync.m16n8k16`, internal bar.sync 2 | CG0 `blockwise_32_to_64` |
+| dynamic ticket publish/consume | 413..438 | `.loc 1 419` atom.global.add.u32, `.loc 1 422/434` ld.shared.b32 | `scheduler_publish/consume` |
+| checkpoint TensorMap stores | 441..519 | `.loc 8 119/152/157/272`; 2 rank-4 S2G sites, commit, wait_group, descriptor acquire | warp 11 |
+| gate/beta loads, scan, transforms | 522..647 | `.loc 1 581/596/600/612/613/638/639`; predicated ld.global, shfl.up x10, ex2, cp.async.ca x2, cp.async.mbarrier.arrive | warp 8 |
+| tcgen05 alloc + GEMM descriptors | 650..787 | `.loc 1 679/776`; tcgen05.alloc, descriptor immediates | warp 10 preamble |
+| fused KK pairs + lookahead | 792..819, 843..858, 883..897 | `.loc 7 143`; 32 of 48 `tcgen05.mma` sites | warp 10 `fused_kk` |
+| GEMMs 3, 5, 7 chain | 860..907 | `.loc 7 223`; 16 `tcgen05.mma` sites, commit pairs (`.loc 2 118`) | warp 10 loop |
+| TMEM teardown | 911..917 | `.loc 1 912/913`; relinquish + dealloc pair | warp 10 tail |
+| K and V TMA loads | 920..1040 | `.loc 8 77`; 10 rank-3 G2S sites, expect-tx x4 (`.loc 2 51`) | warp 9 |
+| T-pairwise decay fragments | 1104..1149 | `.loc 1 1128/1133/1146`; ld.shared.b32 x4 + v2.b32 x8, 52 ex2 sites | CG0 pair prologue |
+| KK epilogue | 1151..1221 | `.loc 1 1162/1194/1197/1200/1213`, `.loc 3 244/120`; tcgen05.ld.16x256b x2, tcgen05.wait::ld, 64 mul.f32x2 + 32 cvt.rn.bf16x2.f32, 8 stmatrix.x4 | CG0 `do_kk` |
+| pair inverse orchestration | 1223..1267 | `.loc 1 1232/1238/1247/1255/1264`; 5 bar.sync id-2 sites | CG0 inverse ladder |
+| beta column scaling + publish | 1269..1340 | `.loc 1 1272/1276/1292/1301` and 1309/1313/1329/1338; ldmatrix/stmatrix x4 each, fence.proxy | CG0 publish |
+| initial-state seed | 1426..1458 | state-main `.loc 1 1437/1441/1448/1453/1455`; ld.global.v2.b64 x32, tcgen05.st.32x32b x8, bar.sync id-4 | CG1 seed |
+| zero checkpoint before chunk 0 | 1466..1479 | `.loc 1 1476` fence; 64 st.shared.b32 (attributed `.loc 1 1896`) | CG1 zero checkpoint |
+| state restage | 1491..1515 | `.loc 1 1502/1508/1513`; tcgen05.ld.32x32b x4, tcgen05.st.32x32b.x16 x4, wait::st | CG1 restage |
+| pre-rescale checkpoint snapshot | 1517..1544 | `.loc 1 1527/1541`; tcgen05.ld.32x32b x4 (a redundant second read), 16 st.shared.v4.b32 (attributed `.loc 1 1896`), fence.proxy | CG1 checkpoint |
+| state rescale | 1546..1557 | `.loc 1 1551/1556`, `.loc 3 244`; mul.f32x2 x64, tcgen05.st.32x32b x4, wait::st | CG1 rescale |
+| per-row gate registers | 1559..1572 | `.loc 1 1562/1563/1566/1570/1571`; ld.shared.v2.b32 x16, neg.f32 x16 (`.loc 1 1569`), add.rn.f32x2 x8 (attributed `.loc 1 1896`), 16 ex2 | CG1 gate regs |
+| Y = V − cumprod·KS | 1574..1617 | `.loc 1 1583/1601/1611/1616`, `.loc 3 297`; ldmatrix.trans x8, tcgen05.ld.16x256b x2, 32 sub.bf16x2, tcgen05.st.16x128b x2 | CG1 Y |
+| U epilogue + decayed U | 1619..1650 | `.loc 1 1628/1644/1649`, `.loc 3 244/120`; tcgen05.ld.16x256b x2, mul.f32x2 x32, cvt x32, tcgen05.st.16x128b x2 | CG1 U |
+| final state store + passthrough | 1652..1684 | state-main `.loc 1 1661/1668/1680`; tcgen05.ld.32x32b x4, st.global.v2.b64 x32, passthrough ld.global.b32/st.global.b32 x16 | CG1 tail |
+| checkpoint drain | 1690..1695 | `.loc 2 39` try_wait sites | CG1 drain |
+| descriptor arrays (3) | 1698..1737 | nostate-prologue; 48 st.global.b64 base copies (imprecisely attributed `.loc 1 1813`), tensormap.replace at `.loc 3 56/61/103/108`, 3 release fences at `.loc 1 1726/1730/1737` | launch 1 arrays |
+| order pass and its sched zeroing | 1740..1794, split_k.py 602..660 | nostate-prologue; thread-0 serial ring zeroing `st.global.b32` (`.loc 2 635`), row synth/copy (`.loc 2 567/568/591/595`), shared min/max atomics, bitonic sort; `run_order` gates the whole block | launch 1 order |
+| base maps and prologue launch | 1813..1893 | host-built descriptors; K/V box (64,1,64) token-ordinal-2, checkpoint box (64,128,1,1) | launch 1 ABI |
+| GQA head folds and cfg stamping | 1915..2015 | ratio divisions at the TMA coordinate sites (`.loc 1 978/979`, elided at ratio 1, so the anchor emits nothing here) | `input_head` |
+| arena, SmemTile bases, barrier init | 2050..2220 | `.loc 1 2219/2220`; 46 init + fence + barrier.sync 0 | arena/protocol |
+| dispatch | 2222..2333 | warp-guard branch structure (`.loc 1 2073` warp_uniform) | role dispatch |
+| cfg stage/offset derivation | 2336..2469 | compile-time constants in both profiles | specialization header |
+| host entry, cache key, validation | 2475..2823 | n/a | validation contract |
+| `run_recompute` replay: prologue launch then main launch | 2825..2881 | n/a | launch order, validation contract |
+
+Reverse lookup is exhaustive at action granularity: each accepted compile-time
+branch, storage family, role, logical GEMM, scheduler operation, descriptor
+operation, and pipeline family has one owner in the table and one concrete
+section above.
+
+Four unrelated operations carry imprecise line attribution in the export and are
+recorded as such rather than silently mapped: the checkpoint zero fill (source
+1475, 64 `st.shared.b32`), the dynamic-scheduler ring publish (source 420, 1
+`st.shared.b32`), the checkpoint snapshot's SMEM vector stores (source 1538, 16
+`st.shared.v4.b32`), and the CG1 decay-scale pair sums (source 1569, 8
+`add.rn.f32x2`) all surface under `.loc 1 1896`, the `@cute.jit` decorator line
+of `host`.  Their counts (64, 1, 16, 8) and their operand widths identify them
+unambiguously; the 64/1 split is confirmed by the store addresses, the zero fill
+walking the 32768-byte checkpoint buffer at a 512-byte stride and the scheduler
+publish landing on the `sSched` base.
+
+## Static instruction evidence for the BF16 checkpoint-only anchor
+
+Counts are static sites in the exported main-kernel PTX (instruction lines,
+unpredicated convention).  `fmul2` in `pointwise.py` is emitted as a braced
+inline-PTX block, so its `mul.f32x2` -- and the `mov.b64` register-pair packs
+around it, which dominate the raw opcode histogram and usually fold away in
+SASS -- sit mid-line and a line-anchored grep returns zero for them; the 224
+below is a per-mnemonic occurrence count.  The other packed mnemonics
+(`add.rn.f32x2` 8, `sub.bf16x2` 32, `cvt.rn.bf16x2.f32` 289) are one-per-line
+and count normally.
+
+| Instruction family | Static sites | Owner |
+| --- | ---: | --- |
+| `mbarrier.init.shared.b64` | 46 | protocol init |
+| `mbarrier.try_wait.parity.acquire...` | 55 | role-local waits |
+| `mbarrier.arrive.shared.b64` | 25 | thread publications |
+| `mbarrier.arrive.expect_tx.shared.b64` | 4 | warp-9 TMA transactions |
+| `tcgen05.mma.cta_group::1.kind::f16` | 48 | warp 10 |
+| `tcgen05.commit...mbarrier::arrive::one` | 9 (10 seeded) | warp 10 publications |
+| `tcgen05.ld` 16x256b.x8 / 32x32b.x32 | 6 / 8 (12 seeded) | CG0 + CG1 |
+| `tcgen05.st` 32x32b.x32 / 32x32b.x16 / 16x128b.x8 | 4 / 4 / 4 (12 / 4 / 4 seeded) | CG1 |
+| `tcgen05.wait::st` / `tcgen05.wait::ld` | 4 / 1 (5 / 1 seeded) | CG1 / CG0 |
+| `mma.sync.m16n8k16` / `m16n8k8` (bf16) | 20 / 4 | CG0 inverse ladder |
+| rank-3 TMA G2S / rank-4 TMA S2G | 10 / 2 | warp 9 / warp 11 |
+| `cp.async.bulk.commit_group` / `.wait_group.read` | 1 / 1 | warp 11 |
+| `cp.async.ca.shared.global` + mbarrier arrive | 2 + 1 | warp 8 beta |
+| `ldmatrix` x4 / x4.trans / x1 / x1.trans | 11 / 18 / 2 / 4 | CG0 + CG1 |
+| `stmatrix` x4 / x1 | 19 / 2 | CG0 |
+| `tcgen05.alloc/relinquish/dealloc` | one each | warp 10 lifecycle |
+| `setmaxnreg` dec / inc | 4 / 2 | role budgets |
+| `ex2.approx.ftz.f32` | 70 | gates and decay fragments |
+| `cvt.rn.bf16x2.f32` | 289 | packed IO rounding |
+| `mul.f32x2` (inline PTX, `.loc 3 244`) | 224 | every packed FP32 multiply |
+| `sub.bf16x2` | 32 | CG1 Y subtraction |
+| `add.rn.f32x2` | 8 | CG1 decay-scale pair sums |
+| `shfl.sync.up/idx.b32` | 10 / 25 | warp-8 scan, 8x8 inverse |
+| `st.shared.b32` / `st.shared.v4.b32` | 69 / 17 | gate rings, checkpoint staging |
+| `ld.shared.b32` / `.v2.b32` / `.v4.b32` | 19 / 40 / 1 | rings, TMEM mailbox, inverse |
+| `bar.sync` named ids 1,2 | 9 (3 + 6) | TMEM rendezvous, inverse ladder |
+| `barrier.sync 0` CTA-wide | 1 | post-init sync; id 4 appears only in the seeded profile |
+| `fence.proxy.async.shared::cta` | 4 | SMEM publications |
+| `fence.proxy.tensormap::generic.acquire.gpu` | 3 | K, V, checkpoint descriptors |
+| `fence.mbarrier_init.release.cluster` | 1 | protocol init |
+| `atom.global.add.u32` | 1 | dynamic ticket |
+
+## Validation contract
+
+`get_kernel` returns `[descriptor_order_prologue, persistent_gdn_recompute]` in
+launch order.  The host adapter gives TIRx and the standalone source the same
+immutable logical inputs but independent work tables, scheduler rings,
+descriptor workspaces, and checkpoint/final-state buffers.  Correctness compares
+TIRx against the source kernel on identical inputs with relative RMS limits 0.02
+for BF16 and 0.01 for FP16 over the source-written checkpoint slots and the
+final state, covering every frozen capability profile in `CONFIGS`.  Benchmark
+timing includes both launches for each implementation; work-table, TensorMap,
+reference compilation, and data preparation stay outside the timed closure.
+`prepare_bench` is CPU-only.  The benchmark suite is the only performance
+authority; PTX/SASS/NCU can explain a candidate but cannot select or pass it.

--- a/.agents/skills/tirx-codegen-tuning/references/db/keep-trace-time-loops-at-trace-time.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/keep-trace-time-loops-at-trace-time.md
@@ -69,6 +69,17 @@ code size, so it is not a general replacement for runtime iteration. Explicit
 device unrolling is best reserved for small fixed trip counts where preserving
 the source order and scalar indexing is important.
 
+The code-size clause has teeth in the other direction too. A cold path guarded
+by a runtime predicate still occupies the loop body that encloses it, so
+expanding one at trace time costs the hot iterations even though it never
+executes. A tail fixup that a reference writes as a runtime loop over a row, and
+that a port expanded into a Python loop, put 256 unreachable global accesses
+inside a persistent kernel's per-work-item body; restoring the runtime loop took
+the port's excess over the reference from +112 sites per direction to below zero
+and moved three near-gate shapes up by 0.004 to 0.016 with correctness
+unchanged. Match the reference's staging boundary in both directions: expand
+what it expands, and leave as a device loop what it leaves as one.
+
 ## Verification
 
 Compare PTX for `.local`, `ld.local`, `st.local`, and an unexpected loop

--- a/.agents/skills/tirx-codegen-tuning/references/db/move-whole-rows-with-vector-global-accesses.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/move-whole-rows-with-vector-global-accesses.md
@@ -1,0 +1,67 @@
+# Move whole rows with vector global accesses
+
+**Symptoms:** `fixed_overhead`, `slow_small_shape`, `dispatch_specific_deficit`, `instruction_count_gap`
+
+## Symptom
+
+A persistent kernel seeds or drains a per-thread row of state through global
+memory once per work item, and the port issues one scalar access per element
+where the reference moves the row 128 bits at a time. The specialization that
+carries the row trails the reference, and the deficit shrinks monotonically as
+the per-item iteration count grows -- the signature of a fixed per-work-item
+cost rather than a steady-state throughput gap.
+
+## What to change
+
+Move the row in 16-byte accesses. A row whose length is a power-of-two multiple
+of the element size starts at least that far aligned, so every group is in
+bounds and the width is structural rather than something ptxas may or may not
+fuse.
+
+```python
+# before: one access per element, 128 per row.
+for key in range(ROW):
+    K.assign(values[key], _load_scalar(src, base + key))
+
+# after: 16 bytes per access.
+for group in range(ROW // 4):          # f32 rows
+    K.ptx["ld.global.v4.f32"](
+        values[group * 4], values[group * 4 + 1],
+        values[group * 4 + 2], values[group * 4 + 3],
+        src.ptr_to([base + group * 4]),
+    )
+```
+
+For a narrower element type, load the same 16 bytes as `ld.global.v4.b32` and
+unpack the pairs; the access count falls by the packing factor again.
+
+## Rationale
+
+Both directions matter: the seed reads the row and the drain writes it, and each
+was one access per element. Widening them took the shortest affected shape from
+0.858x to 0.998x while the guard dispatch that compiles the row moves out
+measured unchanged (0.0001). The gain tracked the per-item iteration count
+inversely, as a fixed per-item cost must: +0.14 where an item covered 32
+iterations, +0.004 where it covered 512.
+
+The reason this survives into a mature port is worth naming. A sibling kernel
+sharing the same helper had its benchmark dispatch compile the row moves out
+entirely, so the scalar form was never on a measured path there and carried over
+looking proven. A dispatch that no benchmark covers can hide an arbitrarily
+large fixed cost; when a new port puts that dispatch on the gate, check its
+access widths against the reference before trusting the inheritance.
+
+## Boundary
+
+Only for contiguous runs whose base alignment follows from the row length, not
+from a runtime offset that happens to be aligned. Where a cold path moves the
+same row but never executes on the measured shapes, widening it is not the
+lever -- keeping it a runtime loop is, because the cost there is the code it
+adds to the enclosing loop body rather than the accesses it issues.
+
+## Verification
+
+Compare the state-carrying and state-free builds of the same kernel: take the
+difference in `ld.global`/`st.global` sites on each side and require the port's
+delta to match the reference's. Absolute counts across two compilers are not
+comparable; the delta between two builds of the same program is.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ list.
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
   [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
+  [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
 - **CSA compression:**

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_recompute_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_recompute_f16.yaml
@@ -1,0 +1,22 @@
+# Complete production sweep for the cuDNN Frontend GDN (v1) state-recompute port.
+kernel: cudnn_sm100_gdn_recompute_f16
+selection_rationale: The selected defaults cover an underfilled single-batch launch, the central four-batch production point, and the longest seeded-state workload; the full matrix sweeps production sequence lengths, batch occupancy, and both the checkpoint-only regen specialization the backward pass runs and the seeded initial-state one.
+configs:
+  - {config: perf_b4_s2048_h64_nostate, default: false}
+  - {config: perf_b4_s4096_h64_nostate, default: false}
+  - {config: perf_b4_s8192_h64_nostate, default: true, selection_role: medium}
+  - {config: perf_b4_s16384_h64_nostate, default: false}
+  - {config: perf_b4_s32768_h64_nostate, default: false}
+  - {config: perf_b1_s8192_h64_nostate, default: true, selection_role: small}
+  - {config: perf_b2_s8192_h64_nostate, default: false}
+  - {config: perf_b8_s8192_h64_nostate, default: false}
+  - {config: perf_b16_s8192_h64_nostate, default: false}
+  - {config: perf_b4_s2048_h64_state, default: false}
+  - {config: perf_b4_s4096_h64_state, default: false}
+  - {config: perf_b4_s8192_h64_state, default: false}
+  - {config: perf_b4_s16384_h64_state, default: false}
+  - {config: perf_b4_s32768_h64_state, default: true, selection_role: large}
+  - {config: perf_b1_s8192_h64_state, default: false}
+  - {config: perf_b2_s8192_h64_state, default: false}
+  - {config: perf_b8_s8192_h64_state, default: false}
+  - {config: perf_b16_s8192_h64_state, default: false}

--- a/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
@@ -1,0 +1,2967 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell FP16/BF16 Gated DeltaNet (v1) state-recompute kernels.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_recompute`` entry,
+driven by the ``chunk_gdn_recompute_sm100`` THD/varlen host entry).
+
+The kernel re-runs the chunked delta-rule forward recurrence to regenerate the
+per-chunk recurrent-state checkpoint series a backward pass consumes; the query
+and output paths of the prefill kernel are absent.
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cudnn_sm100_gdn_recompute_f16",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+# Deterministic pairwise cover of the frozen legal capability set.  Ragged
+# cases include zero- and one-token sequences while retaining a nonzero
+# TensorMap outer dimension.  ``log_gate`` defaults to True (the backward
+# plan's production path); raw-alpha (log_gate=False) and safe-gate rows cover
+# the other two gate interpretations.  Checkpoint cadences are the validated
+# positive multiples of the 64-token chunk; a zero cadence requires the final
+# state, which is the source's "checkpoints or final state" precondition.
+CONFIGS = [
+    {
+        "label": "pairwise_00",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_01",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "state_dtype": "bfloat16",
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 128,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+    },
+    {
+        "label": "pairwise_02",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 192,
+        "log_gate": False,
+    },
+    {
+        "label": "pairwise_03",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "k_heads": 2,
+        "v_heads": 4,
+        "io_dtype": "float16",
+        "state_dtype": "bfloat16",
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "log_gate": False,
+        "order_generate": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_04",
+        "seq_lens": (192,),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_05",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "k_heads": 2,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "use_initial_state": True,
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 192,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_06",
+        "seq_lens": (192,),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "state_dtype": "bfloat16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 128,
+        "safe_gate": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_07",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 2,
+        "v_heads": 4,
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 192,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_08",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 1,
+        "state_dtype": "bfloat16",
+        "use_initial_state": True,
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 0,
+        "safe_gate": True,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "pairwise_09",
+        "seq_lens": (63, 0, 129, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "cu_dtype": "int64",
+        "checkpoint_every_n_tokens": 128,
+        "beta_sigmoid": True,
+        "log_gate": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_10",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "state_dtype": "bfloat16",
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_11",
+        "seq_lens": (192,),
+        "heads": 1,
+        "checkpoint_every_n_tokens": 64,
+        "log_gate": False,
+        "run_order": False,
+        "order_generate": False,
+    },
+    {
+        "label": "pairwise_12",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 2,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "store_final_state": True,
+        "checkpoint_every_n_tokens": 0,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_13",
+        "seq_lens": (64, 320),
+        "heads": 6,
+        "k_heads": 6,
+        "v_heads": 2,
+        "io_dtype": "float16",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 64,
+        "dynamic_scheduler": True,
+    },
+]
+
+# Production sweep mirroring the upstream gdn benchmark's backward pass: h64,
+# natural-log gates, the per-chunk cadence the backward consumes, and the
+# device-side dynamic scheduler the engine always enables for this kernel.
+# ``nostate`` is the regen path exactly as the backward plan runs it
+# (checkpoints only); ``state`` seeds the recurrence and also stores the final
+# state, which is a separate compiled specialization (wider register split).
+BENCH_CONFIGS = [
+    {
+        "label": f"perf_b{batch}_s{seqlen}_h64_{mode}",
+        "seq_lens": (seqlen,) * batch,
+        "heads": 64,
+        "checkpoint_every_n_tokens": 64,
+        "dynamic_scheduler": True,
+        **({"use_initial_state": True, "store_final_state": True} if mode == "state" else {}),
+    }
+    for mode in ("nostate", "state")
+    for batch, seqlen in (
+        (4, 2048),
+        (4, 4096),
+        (4, 8192),
+        (4, 16384),
+        (4, 32768),
+        (1, 8192),
+        (2, 8192),
+        (8, 8192),
+        (16, 8192),
+    )
+]
+
+
+_BT = 64
+_DK = 128
+_DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 3  # per-batch runtime TMA descriptors: K, V, checkpoints
+_TRY_WAIT_TICKS = 10_000_000
+_SCHED_ALL_CELLS = 4  # the engine's shared sched block: both consumers' ticket rings
+_RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
+_LN2 = 0.6931471805599453
+_TMA_G2S_3D = "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+
+# Declaration-ordered physical mbarrier header (fixed capacity for the
+# four-stage K ring; checkpoint builds initialize only three).  Each barrier
+# is 8 bytes; ready and done rings of one pipeline are adjacent.
+_BAR_KQ_READY = 0  # 4 stages
+_BAR_KQ_DONE = 32  # 4 stages
+_BAR_V_READY = 64  # 2 stages
+_BAR_V_DONE = 80  # 2 stages
+_BAR_GATE_READY = 96  # 3 stages
+_BAR_GATE_DONE = 120  # 3 stages
+_BAR_BETA_READY = 144  # 3 stages
+_BAR_BETA_DONE = 168  # 3 stages
+_BAR_STATE_ACC_READY = 192
+_BAR_STATE_SCALE_DONE = 200
+_BAR_CG0_ACC_READY = 208  # 2 stages
+_BAR_CG0_ACC_DONE = 224  # 2 stages
+_BAR_K_STATE_READY = 240
+_BAR_U_ACC_READY = 248
+_BAR_T_INV_READY = 256  # 3 stages
+_BAR_T_INV_DONE = 280  # 3 stages
+_BAR_STATE_INP_READY = 304
+_BAR_Y_INP_READY = 312
+_BAR_DECAY_U_READY = 320
+_BAR_CKPT_READY = 328
+_BAR_CKPT_DONE = 336
+_BAR_TMEM_DONE = 344
+_BAR_SCHED_READY = 352  # 2 stages
+_BAR_SCHED_DONE = 368  # 2 stages
+_TMEM_MAILBOX = 384
+_SCHED_BASE = 400  # 2 x i32 ticket ring
+_CUMSUMLOG_BASE = 512  # f32 [64 x 3 stages]
+_CUMPROD_BASE = 1280
+_BETA_RING_BASE = 2048
+_CKPT_BASE = 3072  # checkpoint builds only: IO [128 x 128] x 1 stage
+_ARENA_BYTES = 191488
+
+# TMEM columns (512 allocated, 448 used); packed IO regions hold two elements
+# per cell.
+_TM_STATE = 0
+_TM_STATE_INP = 128
+_TM_CG0 = 192  # 2 stages x 64 columns
+_TM_CG1 = 320  # K*state accumulator, then the U accumulator in the same cells
+_TM_Y = 384
+_TM_DECAY_U = 416
+
+# tcgen05 instruction descriptors (M=128; N=64 for the KK/K-state/U GEMMs,
+# N=128 for the state update), extracted from the source export; FP16 clears
+# the BF16 dtype fields (delta 0x480).
+_IDESC_N64_BF16 = 135267472
+_IDESC_N128_BF16 = 136381584
+_KQ_BOX = 512  # 8192 B in 16-byte descriptor units: pair-member box offset
+_KQ_SEG = 1024  # 16384 B in descriptor units: second-K-half subtile offset
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _load_tensormap(payload, src_map):
+    """Load one host-encoded 128-byte TensorMap image into registers.
+
+    The base images use ordinary global pointers because K's PTX instruction
+    surface intentionally has no parameter-space load.  One load serves every
+    per-sequence slot of the array; it is issued at the point of use, inside
+    the owning warp's guard.
+    """
+    source = K.reinterpret("uint64", src_map.ptr_to([0]))
+    for group in range(4):
+        offset = K.uint64(group * 32)
+        K.ptx.ld.global_.v4.b64(
+            payload[group * 4],
+            payload[group * 4 + 1],
+            payload[group * 4 + 2],
+            payload[group * 4 + 3],
+            K.reinterpret("handle", source + offset),
+        )
+
+
+def _store_tensormap(dst, payload):
+    target = K.reinterpret("uint64", dst)
+    for word in range(16):
+        K.ptx.st.global_.b64(K.reinterpret("handle", target + K.uint64(word * 8)), payload[word])
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + K.cast(stage, "int32") * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready,
+            _barrier_ptr(arena, byte_offset, stage),
+            K.cast(phase, "uint32"),
+            K.uint32(_TRY_WAIT_TICKS),
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0, *, leader):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=leader
+    )
+
+
+def _load_work_item(work_items, tile):
+    values = K.alloc_local((8,), "int32")
+    K.ptx.ld.global_.v4.b32(
+        values[0], values[1], values[2], values[3], work_items.ptr_to([tile * 8])
+    )
+    K.ptx.ld.global_.v4.b32(
+        values[4], values[5], values[6], values[7], work_items.ptr_to([tile * 8 + 4])
+    )
+    return values
+
+
+def _load_cu(cu_seqlens, index, cu_dtype):
+    if cu_dtype == "int64":
+        wide = K.local_scalar("int64")
+        K.ptx.ld.global_.s64(wide, cu_seqlens.ptr_to([index]))
+        return K.cast(wide, "int32")
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, cu_seqlens.ptr_to([index]))
+    return value
+
+
+def _load_state_value(pointer, index, state_dtype):
+    value = K.local_scalar("float32")
+    if state_dtype == "float32":
+        K.ptx.ld.global_.f32(value, pointer.ptr_to([index]))
+    else:
+        bits = K.local_scalar("uint16")
+        K.ptx.ld.global_.b16(bits, pointer.ptr_to([index]))
+        K.ptx.cvt.f32.bf16(value, bits)
+    return value
+
+
+def _store_state_value(pointer, index, value, state_dtype):
+    if state_dtype == "float32":
+        K.ptx.st.global_.f32(pointer.ptr_to([index]), value)
+    else:
+        K.ptx.st.global_.b16(
+            pointer.ptr_to([index]), K.reinterpret("uint16", K.cast(value, "bfloat16"))
+        )
+
+
+def _load_state_row(pointer, index, count, state_dtype):
+    """Load ``count`` state values starting at ``index`` in 16-byte accesses.
+
+    A state row is 128 contiguous elements, so its start is at least 256-byte
+    aligned and every 16-byte group is in bounds.  The source moves this row
+    with 128-bit accesses; one scalar load per element would add a per-work-item
+    fixed cost to the seed path.
+    """
+    values = K.alloc_local((count,), "float32")
+    if state_dtype == "float32":
+        for group in range(count // 4):
+            K.ptx["ld.global.v4.f32"](
+                values[group * 4],
+                values[group * 4 + 1],
+                values[group * 4 + 2],
+                values[group * 4 + 3],
+                pointer.ptr_to([index + group * 4]),
+            )
+    else:
+        for group in range(count // 8):
+            words = K.alloc_local((4,), "uint32")
+            K.ptx["ld.global.v4.b32"](
+                words[0], words[1], words[2], words[3], pointer.ptr_to([index + group * 8])
+            )
+            for pair in range(4):
+                _unpack_io_pair(
+                    words[pair],
+                    values[group * 8 + pair * 2],
+                    values[group * 8 + pair * 2 + 1],
+                    state_dtype,
+                )
+    return values
+
+
+def _store_state_row(pointer, index, values, count, state_dtype):
+    """Store ``count`` state values starting at ``index`` in 16-byte accesses."""
+    if state_dtype == "float32":
+        for group in range(count // 4):
+            K.ptx["st.global.v4.f32"](
+                pointer.ptr_to([index + group * 4]),
+                values[group * 4],
+                values[group * 4 + 1],
+                values[group * 4 + 2],
+                values[group * 4 + 3],
+            )
+    else:
+        for group in range(count // 8):
+            words = K.alloc_local((4,), "uint32")
+            for pair in range(4):
+                K.assign(
+                    words[pair],
+                    _pack_io_pair(
+                        values[group * 8 + pair * 2], values[group * 8 + pair * 2 + 1], state_dtype
+                    ),
+                )
+            K.ptx["st.global.v4.b32"](
+                pointer.ptr_to([index + group * 8]), words[0], words[1], words[2], words[3]
+            )
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _pack_io_pair(lo, hi, io_dtype):
+    packed = K.local_scalar("uint32")
+    if io_dtype == "float16":
+        K.ptx.cvt.rn.f16x2.f32(packed, hi, lo)
+    else:
+        K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _unpack_io_pair(packed, lo, hi, io_dtype):
+    low = K.cast(K.bitwise_and(packed, K.uint32(0xFFFF)), "uint16")
+    high = K.cast(K.shift_right(packed, K.uint32(16)), "uint16")
+    if io_dtype == "float16":
+        K.assign(lo, K.cast(K.reinterpret("float16", low), "float32"))
+        K.assign(hi, K.cast(K.reinterpret("float16", high), "float32"))
+    else:
+        K.ptx.cvt.f32.bf16(lo, low)
+        K.ptx.cvt.f32.bf16(hi, high)
+
+
+def _sub_io_pair(dst, lhs, rhs, io_dtype):
+    if io_dtype == "float16":
+        K.ptx.sub.f16x2(dst, lhs, rhs)
+    else:
+        K.ptx["sub.bf16x2"](dst, lhs, rhs)
+
+
+def _fsub2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.sub.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fmul2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _exp2(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _lg2(value):
+    result = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(result, value)
+    return result
+
+
+def _tanh(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _softplus(value):
+    # log(1 + exp(x)) with the source's linear tail (x > 20 returns x).
+    grown = _exp2(value * K.float32(_RCP_LN2))
+    smooth = _lg2(K.float32(1.0) + grown) * K.float32(_LN2)
+    return K.if_then_else(value < K.float32(20.0), smooth, value)
+
+
+def _opaque_zero():
+    zero = K.local_scalar("float32")
+    K.ptx.mov.b32(zero, K.uint32(0))
+    return zero
+
+
+def _shfl_idx_f32(value, source_lane, clamp):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.idx.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.cast(source_lane, "uint32"),
+        K.uint32(clamp),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _shfl_up_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.up.b32(
+        shuffled, K.reinterpret("uint32", value), K.uint32(delta), K.uint32(0), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _raw_descriptor(arena, byte_offset, leading_bytes, stride_bytes, layout):
+    shared = K.cuda.cvta_generic_to_shared(arena.ptr_to([byte_offset]))
+    address = K.bitwise_and(K.shift_right(shared, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    desc = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(desc, K.shift_left(K.uint64(layout & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column):
+    # physical column element for the 128-byte XOR swizzle of a bf16/f16 row
+    return K.bitwise_xor(column, (row & 7) * 8)
+
+
+def _swizzle_lin_128b(linear):
+    # 128-byte XOR swizzle over a linear 64-element-row bf16/f16 index
+    return K.bitwise_xor(linear, K.bitwise_and(K.shift_right(linear, K.int32(3)), K.int32(0x38)))
+
+
+def _io_tile_byte(base, stage_bytes, stage, row, column):
+    # byte offset of (row, column) in one 64-column swizzled IO tile stage
+    return base + stage * stage_bytes + (row * 64 + _swizzle_xor_128b(row, column)) * 2
+
+
+def _mma_m16n8k16(acc, acc_base, a, b0, b1, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b0,
+        b1,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _mma_m16n8k8(acc, acc_base, a0, a1, b0, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a0,
+        a1,
+        b0,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _ldmatrix_x4(dst, pointer, *, trans):
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+            dst[0], dst[1], dst[2], dst[3], pointer
+        )
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(dst[0], dst[1], dst[2], dst[3], pointer)
+
+
+def _ldmatrix_x1(pointer, *, trans):
+    frag = K.local_scalar("uint32")
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16(frag, pointer)
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.shared.b16(frag, pointer)
+    return frag
+
+
+def _stmatrix_x4(pointer, words):
+    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(pointer, words[0], words[1], words[2], words[3])
+
+
+def _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group):
+    row_linear = (d * 8 + tidx_in_group) * 64 + d * 8
+    return arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(row_linear) * 2])
+
+
+def _invert_diagonal_8x8(arena, tinv_byte_base, d, tidx_in_group, io_dtype):
+    """Gauss-Jordan inversion of one diagonal 8x8 block in place (IO SMEM)."""
+    row_ptr = _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group)
+    words = K.alloc_local((4,), "uint32")
+    K.ptx.ld.shared.v4.b32(words[0], words[1], words[2], words[3], row_ptr)
+    row = K.alloc_local((8,), "float32")
+    for pair in range(4):
+        _unpack_io_pair(words[pair], row[pair * 2], row[pair * 2 + 1], io_dtype)
+    for i in range(8):
+        K.assign(row[i], K.if_then_else(tidx_in_group == i, K.float32(1.0), row[i]))
+    for src_row in range(7):
+        row_scale = K.local_scalar("float32", init=-row[src_row])
+        for i in range(src_row):
+            shuffled = _shfl_idx_f32(row[i], src_row, 0b1100000011111)
+            K.assign(
+                row[i],
+                K.if_then_else(tidx_in_group > src_row, row[i] + row_scale * shuffled, row[i]),
+            )
+        K.assign(row[src_row], K.if_then_else(tidx_in_group > src_row, row_scale, row[src_row]))
+    for pair in range(4):
+        K.assign(words[pair], _pack_io_pair(row[pair * 2], row[pair * 2 + 1], io_dtype))
+    K.ptx.st.shared.v4.b32(row_ptr, words[0], words[1], words[2], words[3])
+
+
+def _blockwise_8_to_16(arena, tinv_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 8x8 -> 16x16: C <- -(D^-1 C) A^-1."""
+    lane_off = (lane % 8) * 64
+    d_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + 8 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(c_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(c_regs, 0, d_frag, d_frag, c_frag, io_dtype)
+    a_pack = K.alloc_local((2,), "uint32")
+    for pair in range(2):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]), trans=True
+    )
+    o_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(o_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(o_regs, 0, a_pack[0], a_pack[1], ai_frag, io_dtype)
+    o_pack = _pack_io_pair(o_regs[0], o_regs[1], io_dtype)
+    K.ptx.stmatrix.sync.aligned.m8n8.x1.shared.b16(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_16_to_32(arena, tinv_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 16x16 -> 32x32."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    d_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        d_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + 16 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        c_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            c_regs, n_frag * 4, d_frag, c_frag[n_frag * 2], c_frag[n_frag * 2 + 1], io_dtype
+        )
+    a_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        ai_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    o_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            o_regs, n_frag * 4, a_pack, ai_frag[n_frag * 2], ai_frag[n_frag * 2 + 1], io_dtype
+        )
+    o_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    _stmatrix_x4(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
+    """Off-diagonal correction 32x32 -> 64x64 (two warps, one 16-row band each)."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    a_frags = K.alloc_local((8,), "uint32")
+    for vs in range(2):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + band * 16) * 64 + 32 + vs * 16 + lane_off) * 2
+                ]
+            ),
+            trans=False,
+        )
+        for i in range(4):
+            K.assign(a_frags[vs * 4 + i], chunk[i])
+    b_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(b_frags[vs * 4 + i], chunk[i])
+    c_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_frags[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                c_regs,
+                n_frag * 4,
+                a_view,
+                b_frags[k_step * 8 + n_frag * 2],
+                b_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    a_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b(((vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(ai_frags[vs * 4 + i], chunk[i])
+    o_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_pack[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                o_regs,
+                n_frag * 4,
+                a_view,
+                ai_frags[k_step * 8 + n_frag * 2],
+                ai_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    o_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+    _stmatrix_x4(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]),
+        [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
+    )
+    _stmatrix_x4(
+        arena.ptr_to(
+            [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
+        ),
+        [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
+    )
+
+
+def _acc_operand(accumulate):
+    if isinstance(accumulate, bool | int):
+        return K.uint32(int(accumulate))
+    return K.cast(accumulate, "uint32")
+
+
+def _tcgen_mma_ss(dst, a_desc, b_desc, idesc, *, leader, accumulate):
+    """Fused KK/QK half: four K-phases of the SMEM-A x SMEM-B tcgen05 chain."""
+    for step in range(4):
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            a_desc + K.uint64(2 * step),
+            b_desc + K.uint64(2 * step),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _tcgen_mma_ts(dst, tmem_a, b_desc, idesc, *, leader, accumulate, b_step_units=2):
+    """Four K-phases of the TMEM-A x SMEM-B tcgen05 chain (16-wide steps)."""
+    for step in range(4):
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(b_step_units * step),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _make_prologue(*, run_order, order_generate, n_heads_out, checkpoints, cu_dtype):
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_k: K.gptr[K.i64],
+        base_v: K.gptr[K.i64],
+        base_checkpoint: K.gptr[K.i64],
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[cu_t],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        checkpoint: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        n_batch: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        # --- kernel body starts here ---
+        thread = K.thread_id()
+        warp = K.warp_id()
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+            # The order pass owns both consumers' ticket rings: thread 0 walks
+            # every cell serially, as the source's order_body does.
+            with K.If(thread == 0), K.Then():
+                for cell in range(_SCHED_ALL_CELLS):
+                    K.ptx.st.global_.s32(scheduler.ptr_to([cell]), K.int32(0))
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                    end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                    chunks = (end - begin + _BT - 1) // _BT
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]), batch, head, K.int32(0), chunks
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]), K.int32(0), chunks, begin, end
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                                end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](old, order_arena.ptr_to([32_768]), local_min)
+                K.ptx["atom.shared::cta.max.s32"](old, order_arena.ptr_to([32_772]), local_max)
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network <= padded_count):
+                        distance = K.local_scalar("int32", init=network // 2)
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending = ((item // network) % 2) == 0
+                                    swap = K.Or(
+                                        K.And(ascending, key_i < key_j),
+                                        K.And(K.Not(ascending), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network, network * 2)
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+
+        # One descriptor array per warp: K, V, then the checkpoint series.
+        # The elected lane reads the 128-byte base image once for the array and
+        # replays it into every per-sequence slot, patching the global address
+        # and the sequence extent.
+        bases = (k, v)
+        strides = (k_row_stride_bytes, v_row_stride_bytes)
+        base_maps = (base_k, base_v)
+        for array_index in range(2):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    map_payload = K.alloc_local((16,), "uint64")
+                    _load_tensormap(map_payload, base_maps[array_index])
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, array_index, batch)
+                        _store_tensormap(slot, map_payload)
+                        _replace_tensormap_address(
+                            slot,
+                            bases[array_index].ptr_to(
+                                [K.cast(begin, "int64") * strides[array_index]]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, end - begin)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+        if checkpoints:
+            # The checkpoint array's outer extent is the per-sequence entry
+            # count, running-prefix-summed, matching emit_checkpoint_seq_descs.
+            with K.If(warp == 2), K.Then():
+                with K.If(_elected()), K.Then():
+                    map_payload = K.alloc_local((16,), "uint64")
+                    _load_tensormap(map_payload, base_checkpoint)
+                    checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        length = end - begin
+                        count = K.local_scalar("int32", init=K.int32(0))
+                        with K.If(length > 0), K.Then():
+                            K.assign(count, (length - 1) // checkpoint_every_n + 1)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, 2, batch)
+                        _store_tensormap(slot, map_payload)
+                        _replace_tensormap_address(
+                            slot,
+                            checkpoint.ptr_to(
+                                [K.cast(checkpoint_prefix, "int64") * checkpoint_row_stride_bytes]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, count)
+                        K.assign(checkpoint_prefix, checkpoint_prefix + count)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+def _make_main(
+    *,
+    num_sms,
+    io_dtype,
+    state_dtype,
+    cu_dtype,
+    use_initial_state,
+    store_final_state,
+    checkpoints,
+    log_gate,
+    safe_gate,
+    beta_sigmoid,
+    dynamic_scheduler,
+    k_ratio,
+    v_ratio,
+    n_heads_out,
+):
+    io_t = K.f16 if io_dtype == "float16" else K.bf16
+    state_t = K.bf16 if state_dtype == "bfloat16" else K.f32
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    beta_t = io_t if beta_sigmoid else K.f32
+    # The checkpoint build trades one K stage for the staging buffer, so both
+    # builds allocate the same arena.
+    kq_stages = 3 if checkpoints else 4
+    kq_base = _CKPT_BASE + (32768 if checkpoints else 0)
+    tinv_base = kq_base + kq_stages * 32768
+    v_base = tinv_base + 3 * 8192
+    idesc_delta = 1152 if io_dtype == "float16" else 0
+    idesc_n64 = _IDESC_N64_BF16 - idesc_delta
+    idesc_n128 = _IDESC_N128_BF16 - idesc_delta
+    cg1_regs = 256 if use_initial_state else 232
+    other_regs = 24 if use_initial_state else 48
+
+    @K.kernel(warps=12, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        k: K.gptr[io_t],
+        v: K.gptr[io_t],
+        gate: K.gptr[K.f32],
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        beta: K.gptr[beta_t],
+        cu_seqlens: K.gptr[cu_t],
+        initial_state: K.gptr[state_t],
+        final_state: K.gptr[state_t],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        checkpoint_every_n: K.i32,
+    ):
+        # --- kernel body starts here ---
+        arena = K.alloc_buffer((_ARENA_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        # Declaration-ordered physical mbarrier protocol; each row is
+        # (byte offset, stages, arrive count, initializing warp).
+        protocol = [
+            (_BAR_KQ_READY, kq_stages, 1, 9),
+            (_BAR_KQ_DONE, kq_stages, 1, 9),
+            (_BAR_V_READY, 2, 1, 9),
+            (_BAR_V_DONE, 2, 128, 9),
+            (_BAR_SCHED_READY, 2, 1, 9),
+            (_BAR_SCHED_DONE, 2, 11, 9),
+            (_BAR_GATE_READY, 3, 32, 8),
+            (_BAR_GATE_DONE, 3, 256, 8),
+            (_BAR_BETA_READY, 3, 32, 8),
+            (_BAR_BETA_DONE, 3, 128, 8),
+            (_BAR_STATE_ACC_READY, 1, 1, 10),
+            (_BAR_CG0_ACC_READY, 2, 1, 10),
+            (_BAR_CG0_ACC_DONE, 2, 64, 10),
+            (_BAR_K_STATE_READY, 1, 1, 10),
+            (_BAR_U_ACC_READY, 1, 1, 10),
+            (_BAR_T_INV_DONE, 3, 1, 10),
+            (_BAR_T_INV_READY, 3, 128, 0),
+            (_BAR_STATE_SCALE_DONE, 1, 128, 4),
+            (_BAR_STATE_INP_READY, 1, 128, 4),
+            (_BAR_Y_INP_READY, 1, 128, 4),
+            (_BAR_DECAY_U_READY, 1, 128, 4),
+            (_BAR_TMEM_DONE, 1, 128, 4),
+            (_BAR_CKPT_READY, 1, 4, 11),
+            (_BAR_CKPT_DONE, 1, 32, 11),
+        ]
+        for owner in (9, 8, 10, 0, 4, 11):
+            with K.If(warp == owner), K.Then():
+                with K.If(_elected()), K.Then():
+                    for offset, stages, count, row_owner in protocol:
+                        if row_owner != owner:
+                            continue
+                        for stage in range(stages):
+                            K.ptx.mbarrier.init.shared.b64(
+                                _barrier_ptr(arena, offset, stage), K.uint32(count)
+                            )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 4), regs=224)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=cg1_regs)
+        gate_beta = roles.role("gate_beta", warps=[8], regs=other_regs)
+        mma = roles.role("mma", warps=[10], regs=other_regs)
+        tma = roles.role("tma", warps=[9], regs=other_regs)
+        epilogue = roles.role("epilogue", warps=[11], regs=other_regs)
+
+        def sched_consume(sched_ps, tile):
+            if dynamic_scheduler:
+                _wait_barrier(arena, _BAR_SCHED_READY, sched_ps.stage, sched_ps.phase)
+                K.ptx.ld.shared.s32(tile, arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]))
+                with K.If(_elected()), K.Then():
+                    _arrive_barrier(arena, _BAR_SCHED_DONE, sched_ps.stage)
+                sched_ps.advance()
+            else:
+                K.assign(tile, tile + num_sms)
+
+        with cg0:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_row = tmem_base >> 16
+            cg0_tidx = thread
+            inv_warp = warp % 2
+            pair_half = warp // 2
+            half_row_base = inv_warp * 32
+            tidx_in_group = cg0_tidx % 8
+            gj_d = (inv_warp * 32 + lane) // 8
+            store_row_frag = lane % 16
+            store_col = (lane // 16) * 8
+            beta_scale_row = warp * 16 + lane % 16
+            row_u0_lo = half_row_base + lane // 4
+            mask_zero = _opaque_zero()
+            gate_ps = K.PipelineState(3, phase=0)
+            beta_ps = K.PipelineState(3, phase=0)
+            cg0_ps = K.PipelineState(2, phase=0)
+            tinv_ps = K.PipelineState(3, phase=1)
+            sched_ps = K.PipelineState(2, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                n_local = item[3] - item[4]
+                n_pairs = (n_local + 1) // 2
+                with K.serial(n_pairs, unroll=False) as pair_i:
+                    have_m1 = pair_i * 2 + 1 < n_local
+                    do_kk = K.Or(have_m1, pair_half == 0)
+
+                    # ---- gate acquires (ready waits per acquired stage) ----
+                    gate0_idx = K.local_scalar("int32", init=gate_ps.stage)
+                    gate0_phase = K.local_scalar("int32", init=gate_ps.phase)
+                    gate_ps.advance()
+                    _wait_barrier(arena, _BAR_GATE_READY, gate0_idx, gate0_phase)
+                    gate1_idx = K.local_scalar("int32", init=gate0_idx)
+                    with K.If(have_m1), K.Then():
+                        K.assign(gate1_idx, gate_ps.stage)
+                        _wait_barrier(arena, _BAR_GATE_READY, gate_ps.stage, gate_ps.phase)
+                        gate_ps.advance()
+                    kk_gate_idx = K.if_then_else(pair_half == 1, gate1_idx, gate0_idx)
+
+                    # ---- T-pairwise decay fragments for both members -------
+                    kk_rows = K.alloc_local((4,), "float32")
+                    row_offsets = [row_u0_lo, row_u0_lo + 8, row_u0_lo + 16, row_u0_lo + 24]
+                    for index in range(4):
+                        K.ptx.ld.shared.f32(
+                            kk_rows[index],
+                            arena.ptr_to(
+                                [_CUMSUMLOG_BASE + kk_gate_idx * 256 + row_offsets[index] * 4]
+                            ),
+                        )
+                    kk_cols = K.alloc_local((16,), "float32")
+                    for group in range(8):
+                        col_base = (lane % 4) * 2 + group * 8
+                        K.ptx.ld.shared.v2.f32(
+                            kk_cols[group * 2],
+                            kk_cols[group * 2 + 1],
+                            arena.ptr_to([_CUMSUMLOG_BASE + kk_gate_idx * 256 + col_base * 4]),
+                        )
+                    decay_kk = K.alloc_local((64,), "float32")
+                    for member in range(2):
+                        for cell in range(32):
+                            hi_row = ((cell // 2) % 2) == 1
+                            row_index = member * 2 + (1 if hi_row else 0)
+                            col_index = (cell // 4) * 2 + (cell % 2)
+                            crow = row_offsets[row_index]
+                            ccol = (lane % 4) * 2 + ((cell // 4) * 8 + cell % 2)
+                            kk_val = _exp2(kk_rows[row_index] - kk_cols[col_index])
+                            K.assign(
+                                decay_kk[member * 32 + cell],
+                                K.if_then_else(crow >= ccol, kk_val, mask_zero),
+                            )
+                    _arrive_barrier(arena, _BAR_GATE_DONE, gate0_idx)
+                    with K.If(have_m1), K.Then():
+                        _arrive_barrier(arena, _BAR_GATE_DONE, gate1_idx)
+
+                    # ---- beta acquires (ready waits per acquired stage) ----
+                    beta0_idx = K.local_scalar("int32", init=beta_ps.stage)
+                    beta0_phase = K.local_scalar("int32", init=beta_ps.phase)
+                    beta_ps.advance()
+                    _wait_barrier(arena, _BAR_BETA_READY, beta0_idx, beta0_phase)
+                    beta1_idx = K.local_scalar("int32", init=beta0_idx)
+                    with K.If(have_m1), K.Then():
+                        K.assign(beta1_idx, beta_ps.stage)
+                        _wait_barrier(arena, _BAR_BETA_READY, beta_ps.stage, beta_ps.phase)
+                        beta_ps.advance()
+                    kk_beta_idx = K.if_then_else(pair_half == 1, beta1_idx, beta0_idx)
+                    kk_beta = K.alloc_local((4,), "float32")
+                    for index in range(4):
+                        K.ptx.ld.shared.f32(
+                            kk_beta[index],
+                            arena.ptr_to(
+                                [_BETA_RING_BASE + kk_beta_idx * 256 + row_offsets[index] * 4]
+                            ),
+                        )
+
+                    # ---- accumulator / T-inverse slot pairing --------------
+                    acc0_idx = K.local_scalar("int32", init=cg0_ps.stage)
+                    acc0_phase = K.local_scalar("int32", init=cg0_ps.phase)
+                    cg0_ps.advance()
+                    acc1_idx = K.local_scalar("int32", init=acc0_idx)
+                    acc1_phase = K.local_scalar("int32", init=acc0_phase)
+                    with K.If(have_m1), K.Then():
+                        K.assign(acc1_idx, cg0_ps.stage)
+                        K.assign(acc1_phase, cg0_ps.phase)
+                        cg0_ps.advance()
+                    kk_acc_idx = K.if_then_else(pair_half == 1, acc1_idx, acc0_idx)
+                    kk_acc_phase = K.if_then_else(pair_half == 1, acc1_phase, acc0_phase)
+                    tinv0_idx = K.local_scalar("int32", init=tinv_ps.stage)
+                    tinv0_phase = K.local_scalar("int32", init=tinv_ps.phase)
+                    tinv_ps.advance()
+                    tinv1_idx = K.local_scalar("int32", init=tinv0_idx)
+                    tinv1_phase = K.local_scalar("int32", init=tinv0_phase)
+                    with K.If(have_m1), K.Then():
+                        K.assign(tinv1_idx, tinv_ps.stage)
+                        K.assign(tinv1_phase, tinv_ps.phase)
+                        tinv_ps.advance()
+                    kk_tinv_idx = K.if_then_else(pair_half == 1, tinv1_idx, tinv0_idx)
+                    kk_tinv_phase = K.if_then_else(pair_half == 1, tinv1_phase, tinv0_phase)
+
+                    # ---- KK epilogue into the T-inverse buffer -------------
+                    with K.If(do_kk), K.Then():
+                        _wait_barrier(arena, _BAR_CG0_ACC_READY, kk_acc_idx, kk_acc_phase)
+                        kk_vec0 = K.alloc_local((32,), "float32")
+                        kk_vec1 = K.alloc_local((32,), "float32")
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[kk_vec0[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + kk_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                            *[kk_vec1[i] for i in range(32)],
+                            K.cast(
+                                tmem_col
+                                + _TM_CG0
+                                + kk_acc_idx * 64
+                                + K.shift_left(tmem_row + warp * 32 + 16, K.int32(16)),
+                                "uint32",
+                            ),
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        _arrive_barrier(arena, _BAR_CG0_ACC_DONE, kk_acc_idx)
+                        _wait_barrier(arena, _BAR_T_INV_DONE, kk_tinv_idx, kk_tinv_phase)
+                        for member in range(2):
+                            source_vec = kk_vec1 if member == 1 else kk_vec0
+                            packs = K.alloc_local((16,), "uint32")
+                            for cell in range(16):
+                                beta_row = kk_beta[member * 2 + (cell % 2)]
+                                p0, p1 = _fmul2(
+                                    source_vec[2 * cell],
+                                    source_vec[2 * cell + 1],
+                                    decay_kk[member * 32 + 2 * cell],
+                                    decay_kk[member * 32 + 2 * cell + 1],
+                                )
+                                v0, v1 = _fmul2(p0, p1, beta_row, beta_row)
+                                K.assign(packs[cell], _pack_io_pair(v0, v1, io_dtype))
+                            st_row = half_row_base + member * 16 + store_row_frag
+                            for frag in range(4):
+                                _stmatrix_x4(
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + kk_tinv_idx * 8192
+                                            + (
+                                                st_row * 64
+                                                + _swizzle_xor_128b(st_row, store_col + frag * 16)
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    [packs[frag * 4 + j] for j in range(4)],
+                                )
+
+                    # ---- four-level hierarchical pair inverse --------------
+                    inv_tinv_idx = K.local_scalar("int32", init=tinv0_idx)
+                    with K.If(have_m1), K.Then():
+                        with K.If(warp >= 2), K.Then():
+                            K.assign(inv_tinv_idx, tinv1_idx)
+                    do_inv = K.Or(have_m1, warp < 2)
+                    inv_byte_base = tinv_base + inv_tinv_idx * 8192
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(do_inv), K.Then():
+                        _invert_diagonal_8x8(arena, inv_byte_base, gj_d, tidx_in_group, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    _blockwise_8_to_16(
+                        arena, tinv_base + tinv0_idx * 8192, warp * 16, lane, io_dtype
+                    )
+                    with K.If(have_m1), K.Then():
+                        _blockwise_8_to_16(
+                            arena, tinv_base + tinv1_idx * 8192, warp * 16, lane, io_dtype
+                        )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(do_inv), K.Then():
+                        _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype)
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    # ---- post-inverse beta column scaling + publish --------
+                    for stage_member in range(2):
+                        publish = K.bool(True) if stage_member == 0 else have_m1
+                        stage_idx = tinv0_idx if stage_member == 0 else tinv1_idx
+                        stage_beta = beta0_idx if stage_member == 0 else beta1_idx
+                        with K.If(publish), K.Then():
+                            beta_col = K.alloc_local((16,), "float32")
+                            for group in range(8):
+                                col_base = (lane % 4) * 2 + group * 8
+                                K.ptx.ld.shared.v2.f32(
+                                    beta_col[group * 2],
+                                    beta_col[group * 2 + 1],
+                                    arena.ptr_to(
+                                        [_BETA_RING_BASE + stage_beta * 256 + col_base * 4]
+                                    ),
+                                )
+                            tinv_words = K.alloc_local((16,), "uint32")
+                            for frag in range(4):
+                                chunk_words = K.alloc_local((4,), "uint32")
+                                _ldmatrix_x4(
+                                    chunk_words,
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + stage_idx * 8192
+                                            + (
+                                                beta_scale_row * 64
+                                                + _swizzle_xor_128b(
+                                                    beta_scale_row, store_col + frag * 16
+                                                )
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    trans=False,
+                                )
+                                for j in range(4):
+                                    K.assign(tinv_words[frag * 4 + j], chunk_words[j])
+                            scaled = K.alloc_local((16,), "uint32")
+                            for j in range(16):
+                                lo = K.local_scalar("float32")
+                                hi = K.local_scalar("float32")
+                                _unpack_io_pair(tinv_words[j], lo, hi, io_dtype)
+                                s0, s1 = _fmul2(
+                                    lo, hi, beta_col[(j // 2) * 2], beta_col[(j // 2) * 2 + 1]
+                                )
+                                K.assign(scaled[j], _pack_io_pair(s0, s1, io_dtype))
+                            for frag in range(4):
+                                _stmatrix_x4(
+                                    arena.ptr_to(
+                                        [
+                                            tinv_base
+                                            + stage_idx * 8192
+                                            + (
+                                                beta_scale_row * 64
+                                                + _swizzle_xor_128b(
+                                                    beta_scale_row, store_col + frag * 16
+                                                )
+                                            )
+                                            * 2
+                                        ]
+                                    ),
+                                    [scaled[frag * 4 + j] for j in range(4)],
+                                )
+                            K.ptx.fence.proxy.async_.shared__cta()
+                            _arrive_barrier(arena, _BAR_T_INV_READY, stage_idx)
+                            _arrive_barrier(arena, _BAR_BETA_DONE, stage_beta)
+
+                sched_consume(sched_ps, tile)
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_T_INV_DONE, tinv_ps.stage, tinv_ps.phase)
+                tinv_ps.advance()
+
+        # ================================================================
+        # Warps 4..7 (CG1): state seed/restage/checkpoint/rescale, Y, U, final
+        # ================================================================
+        with cg1:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_row = tmem_base >> 16
+            cg1_tidx = thread - 128
+            value_dim = cg1_tidx
+            row_id = tmem_row + (cg1_tidx // 32) * 32
+            v_tok = cg1_tidx % 8 + (cg1_tidx // 16 % 2) * 8
+            v_col = (cg1_tidx // 8 % 2) * 8 + (cg1_tidx // 32 % 2) * 32
+            v_sub_off = (cg1_tidx // 64) * 8192
+            v_ps = K.PipelineState(2, phase=0)
+            gate_ps = K.PipelineState(3, phase=0)
+            state_ps = K.PipelineState(1, phase=0)
+            seed_ps = K.PipelineState(1, phase=1)
+            kst_ps = K.PipelineState(1, phase=0)
+            uacc_ps = K.PipelineState(1, phase=0)
+            sched_ps = K.PipelineState(2, phase=0)
+            ckpt_cnt = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                bos = item[6]
+                eos = item[7]
+                num_chunks_b = (eos - bos + _BT - 1) // _BT
+                n_local = wend - cstart
+                state_index = (
+                    (K.cast(batch, "int64") * n_heads_out + head) * 128 + value_dim
+                ) * 128
+                ckpt_chunks = K.local_scalar("int32", init=K.int32(1))
+                ckpt_mod = K.local_scalar("int32", init=K.int32(0))
+                if checkpoints:
+                    K.assign(ckpt_chunks, checkpoint_every_n // _BT)
+                    K.assign(ckpt_mod, cstart % ckpt_chunks)
+                with K.If(n_local > 0), K.Then():
+                    if use_initial_state:
+                        # ---- initial-state seed: GMEM (or zero) -> TMEM ----
+                        _wait_barrier(arena, _BAR_STATE_SCALE_DONE, 0, seed_ps.phase)
+                        seed_ps.advance()
+                        with K.If(cstart == 0), K.Then():
+                            for sub in range(4):
+                                seeded = _load_state_row(
+                                    initial_state, state_index + sub * 32, 32, state_dtype
+                                )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[seeded[i] for i in range(32)],
+                                )
+                        with K.If(cstart != 0), K.Then():
+                            for sub in range(4):
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[K.float32(0.0) for _ in range(32)],
+                                )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        K.ptx.bar.sync(K.uint32(4), K.uint32(128))
+
+                    with K.serial(n_local, unroll=False) as local_idx:
+                        chunk = cstart + local_idx
+                        do_ckpt_now = K.local_scalar("int32", init=K.int32(0))
+                        if checkpoints:
+                            K.assign(do_ckpt_now, K.cast(ckpt_mod == 0, "int32"))
+                            K.assign(ckpt_mod, ckpt_mod + 1)
+                            with K.If(ckpt_mod == ckpt_chunks), K.Then():
+                                K.assign(ckpt_mod, K.int32(0))
+                        if checkpoints and not use_initial_state:
+                            # The entering state of an unseeded sequence is zero
+                            # and no TMEM read can supply it.
+                            with K.If(K.And(chunk == 0, wstart == 0)), K.Then():
+                                _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+                                for zero_step in range(64):
+                                    K.ptx.st.shared.u32(
+                                        arena.ptr_to(
+                                            [_CKPT_BASE + (cg1_tidx + zero_step * 128) * 4]
+                                        ),
+                                        K.uint32(0),
+                                    )
+                                K.ptx.fence.proxy.async_.shared__cta()
+                                with K.If(_elected()), K.Then():
+                                    _arrive_barrier(arena, _BAR_CKPT_READY, 0)
+                                K.assign(ckpt_cnt, ckpt_cnt + 1)
+                        if use_initial_state:
+                            have_state = K.bool(True)
+                            seed_ps.advance()
+                        else:
+                            have_state = local_idx > 0
+
+                        gate_idx = K.local_scalar("int32", init=gate_ps.stage)
+                        gate_phase = K.local_scalar("int32", init=gate_ps.phase)
+                        gate_ps.advance()
+                        _wait_barrier(arena, _BAR_GATE_READY, gate_idx, gate_phase)
+                        cumprod_total = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            cumprod_total, arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + 63 * 4])
+                        )
+
+                        # ---- state restage + checkpoint + rescale ----------
+                        state_vals = K.alloc_local((128,), "float32")
+                        with K.If(have_state), K.Then():
+                            _wait_barrier(arena, _BAR_STATE_ACC_READY, 0, state_ps.phase)
+                            state_ps.advance()
+                            for sub in range(4):
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[state_vals[sub * 32 + i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                            for sub in range(4):
+                                packed = K.alloc_local((16,), "uint32")
+                                for pair in range(16):
+                                    K.assign(
+                                        packed[pair],
+                                        _pack_io_pair(
+                                            state_vals[sub * 32 + 2 * pair],
+                                            state_vals[sub * 32 + 2 * pair + 1],
+                                            io_dtype,
+                                        ),
+                                    )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE_INP
+                                        + sub * 16
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[packed[i] for i in range(16)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, _BAR_STATE_INP_READY, 0)
+                            if checkpoints:
+                                # The snapshot is taken before the rescale, so
+                                # row j of the series is the state entering
+                                # token j*N.  The source re-reads the cells the
+                                # restage already holds; transcribed as-is.
+                                with (
+                                    K.If(
+                                        K.And(
+                                            do_ckpt_now == 1, K.And(chunk >= wstart, chunk < wend)
+                                        )
+                                    ),
+                                    K.Then(),
+                                ):
+                                    _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+                                    # ``state_vals`` still holds these cells:
+                                    # the restage read them in this same
+                                    # acquire window and nothing has stored to
+                                    # them since, so the source's second read is
+                                    # pure redundancy on the per-chunk critical
+                                    # path.  The fragment stays live past this
+                                    # point for the rescale, so forwarding it
+                                    # costs no extra live range.
+                                    for sub in range(4):
+                                        for group in range(4):
+                                            dk = sub * 32 + group * 8
+                                            element = (
+                                                (dk // 64) * 8192
+                                                + cg1_tidx * 64
+                                                + _swizzle_xor_128b(cg1_tidx, dk % 64)
+                                            )
+                                            words = K.alloc_local((4,), "uint32")
+                                            for pair in range(4):
+                                                K.assign(
+                                                    words[pair],
+                                                    _pack_io_pair(
+                                                        state_vals[sub * 32 + group * 8 + 2 * pair],
+                                                        state_vals[
+                                                            sub * 32 + group * 8 + 2 * pair + 1
+                                                        ],
+                                                        io_dtype,
+                                                    ),
+                                                )
+                                            K.ptx.st.shared.v4.b32(
+                                                arena.ptr_to([_CKPT_BASE + element * 2]),
+                                                words[0],
+                                                words[1],
+                                                words[2],
+                                                words[3],
+                                            )
+                                    K.ptx.fence.proxy.async_.shared__cta()
+                                    with K.If(_elected()), K.Then():
+                                        _arrive_barrier(arena, _BAR_CKPT_READY, 0)
+                                    K.assign(ckpt_cnt, ckpt_cnt + 1)
+                            for sub in range(4):
+                                rescaled = K.alloc_local((32,), "float32")
+                                for pair in range(16):
+                                    s0, s1 = _fmul2(
+                                        state_vals[sub * 32 + 2 * pair],
+                                        state_vals[sub * 32 + 2 * pair + 1],
+                                        cumprod_total,
+                                        cumprod_total,
+                                    )
+                                    K.assign(rescaled[2 * pair], s0)
+                                    K.assign(rescaled[2 * pair + 1], s1)
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[rescaled[i] for i in range(32)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, _BAR_STATE_SCALE_DONE, 0)
+
+                        # ---- per-row gate registers ------------------------
+                        cumprod_vals = K.alloc_local((16,), "float32")
+                        decay_scale = K.alloc_local((16,), "float32")
+                        cumsum_cols = K.alloc_local((16,), "float32")
+                        for group in range(8):
+                            col_base = (lane % 4) * 2 + group * 8
+                            pair_lo = K.local_scalar("float32")
+                            pair_hi = K.local_scalar("float32")
+                            K.ptx.ld.shared.v2.f32(
+                                pair_lo,
+                                pair_hi,
+                                arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + col_base * 4]),
+                            )
+                            K.assign(cumprod_vals[group * 2], pair_lo)
+                            K.assign(cumprod_vals[group * 2 + 1], pair_hi)
+                            K.ptx.ld.shared.v2.f32(
+                                cumsum_cols[group * 2],
+                                cumsum_cols[group * 2 + 1],
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + col_base * 4]),
+                            )
+                        last_cumsumlog = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            last_cumsumlog,
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + 63 * 4]),
+                        )
+                        for pair in range(8):
+                            d0, d1 = _fsub2(
+                                last_cumsumlog,
+                                last_cumsumlog,
+                                cumsum_cols[pair * 2],
+                                cumsum_cols[pair * 2 + 1],
+                            )
+                            K.assign(decay_scale[pair * 2], _exp2(d0))
+                            K.assign(decay_scale[pair * 2 + 1], _exp2(d1))
+                        _arrive_barrier(arena, _BAR_GATE_DONE, gate_idx)
+
+                        # ---- Y = V - cumprod * (K*S), packed 16-bit --------
+                        v_idx = K.local_scalar("int32", init=v_ps.stage)
+                        v_phase = K.local_scalar("int32", init=v_ps.phase)
+                        v_ps.advance()
+                        _wait_barrier(arena, _BAR_V_READY, v_idx, v_phase)
+                        v_frags = K.alloc_local((32,), "uint32")
+                        for piece in range(8):
+                            m0 = piece % 4
+                            sub = piece // 4
+                            frag = K.alloc_local((4,), "uint32")
+                            _ldmatrix_x4(
+                                frag,
+                                arena.ptr_to(
+                                    [
+                                        v_base
+                                        + v_idx * 16384
+                                        + v_sub_off
+                                        + (
+                                            (v_tok + m0 * 16) * 64
+                                            + _swizzle_xor_128b(v_tok + m0 * 16, v_col + sub * 16)
+                                        )
+                                        * 2
+                                    ]
+                                ),
+                                trans=True,
+                            )
+                            for i in range(4):
+                                K.assign(v_frags[(4 * m0 + i) * 2 + sub], frag[i])
+                        with K.If(have_state), K.Then():
+                            _wait_barrier(arena, _BAR_K_STATE_READY, 0, kst_ps.phase)
+                            kst_ps.advance()
+                            for sub in range(2):
+                                k_state_vec = K.alloc_local((32,), "float32")
+                                K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                    *[k_state_vec[i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_CG1
+                                        + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                for j in range(16):
+                                    s0, s1 = _fmul2(
+                                        k_state_vec[2 * j],
+                                        k_state_vec[2 * j + 1],
+                                        cumprod_vals[(2 * j // 4) * 2 + (2 * j) % 2],
+                                        cumprod_vals[((2 * j + 1) // 4) * 2 + (2 * j + 1) % 2],
+                                    )
+                                    word = _pack_io_pair(s0, s1, io_dtype)
+                                    _sub_io_pair(
+                                        v_frags[j * 2 + sub], v_frags[j * 2 + sub], word, io_dtype
+                                    )
+                        for sub in range(2):
+                            K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+                                K.cast(
+                                    tmem_col + _TM_Y + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[v_frags[j * 2 + sub] for j in range(16)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_Y_INP_READY, 0)
+
+                        # ---- U epilogue: decayed-U publish -----------------
+                        # Nothing consumes the undecayed U, so unlike the
+                        # prefill sibling there is no second republish.
+                        _wait_barrier(arena, _BAR_U_ACC_READY, 0, uacc_ps.phase)
+                        uacc_ps.advance()
+                        _arrive_barrier(arena, _BAR_V_DONE, v_idx)
+                        u_vals = K.alloc_local((64,), "float32")
+                        for sub in range(2):
+                            K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+                                *[u_vals[sub * 32 + i] for i in range(32)],
+                                K.cast(
+                                    tmem_col
+                                    + _TM_CG1
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                        for sub in range(2):
+                            decay_pack = K.alloc_local((16,), "uint32")
+                            for j in range(16):
+                                d0, d1 = _fmul2(
+                                    u_vals[sub * 32 + 2 * j],
+                                    u_vals[sub * 32 + 2 * j + 1],
+                                    decay_scale[(2 * j // 4) * 2 + (2 * j) % 2],
+                                    decay_scale[((2 * j + 1) // 4) * 2 + (2 * j + 1) % 2],
+                                )
+                                K.assign(decay_pack[j], _pack_io_pair(d0, d1, io_dtype))
+                            K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + _TM_DECAY_U
+                                    + K.shift_left(row_id + sub * 16, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[decay_pack[i] for i in range(16)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, _BAR_DECAY_U_READY, 0)
+
+                    # ---- final state: TMEM -> GMEM after the last chunk ----
+                    # The wait/arrive pair runs whether or not the final state
+                    # is stored; it also closes the last chunk's state edge.
+                    _wait_barrier(arena, _BAR_STATE_ACC_READY, 0, state_ps.phase)
+                    state_ps.advance()
+                    if store_final_state:
+                        with K.If(wend == num_chunks_b), K.Then():
+                            for sub in range(4):
+                                final_vals = K.alloc_local((32,), "float32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[final_vals[i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + _TM_STATE
+                                        + sub * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                _store_state_row(
+                                    final_state, state_index + sub * 32, final_vals, 32, state_dtype
+                                )
+                    _arrive_barrier(arena, _BAR_STATE_SCALE_DONE, 0)
+                if store_final_state:
+                    with K.If(n_local <= 0), K.Then():
+                        # Empty sequence: never touches TMEM; pass the initial
+                        # state through when present, else store state zero.
+                        with K.If(wend == num_chunks_b), K.Then():
+                            # A runtime loop, as the source writes it: this path
+                            # runs only for empty sequences, and unrolling it
+                            # would leave 256 unreachable global accesses inside
+                            # CG1's persistent loop body.
+                            with K.serial(128, unroll=False) as key:
+                                if use_initial_state:
+                                    value = _load_state_value(
+                                        initial_state, state_index + key, state_dtype
+                                    )
+                                else:
+                                    value = K.float32(0.0)
+                                _store_state_value(
+                                    final_state, state_index + key, value, state_dtype
+                                )
+                sched_consume(sched_ps, tile)
+            _arrive_barrier(arena, _BAR_TMEM_DONE, 0)
+            if checkpoints:
+                _wait_barrier(arena, _BAR_CKPT_DONE, 0, 1 - (ckpt_cnt & 1))
+
+        with gate_beta:
+            gate_ps = K.PipelineState(3, phase=1)
+            beta_ps = K.PipelineState(3, phase=1)
+            sched_ps = K.PipelineState(2, phase=0)
+            lidx = lane
+            a_l2 = K.local_scalar("float32", init=K.float32(0.0))
+            bias = K.local_scalar("float32", init=K.float32(0.0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                head = item[1]
+                cstart = item[4]
+                wend = item[3]
+                batch_start = item[6]
+                batch_end = item[7]
+                n_local = wend - cstart
+                if safe_gate:
+                    with K.If(n_local > 0), K.Then():
+                        a_value = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(a_value, a_log.ptr_to([head]))
+                        K.assign(a_l2, -_exp2(a_value * K.float32(_RCP_LN2)) * K.float32(_RCP_LN2))
+                        K.ptx.ld.global_.f32(bias, dt_bias.ptr_to([head]))
+                with K.If(n_local > 0), K.Then():
+                    with K.serial(n_local, unroll=False) as local_idx:
+                        chunk = cstart + local_idx
+                        chunk_offset = batch_start + chunk * _BT
+                        gate_idx = K.local_scalar("int32", init=gate_ps.stage)
+                        gate_phase = K.local_scalar("int32", init=gate_ps.phase)
+                        gate_ps.advance()
+                        oob_neutral = 0.0 if log_gate else 1.0
+                        gate_vals = K.alloc_local((2,), "float32")
+                        for col in range(2):
+                            tok = chunk_offset + lidx + col * 32
+                            K.assign(gate_vals[col], K.float32(oob_neutral))
+                            with K.If(tok < batch_end), K.Then():
+                                clamped = K.if_then_else(tok < batch_end - 1, tok, batch_end - 1)
+                                K.ptx.ld.global_.f32(
+                                    gate_vals[col],
+                                    gate.ptr_to([K.cast(clamped, "int64") * n_heads_out + head]),
+                                )
+                        if safe_gate:
+                            for col in range(2):
+                                tok = chunk_offset + lidx + col * 32
+                                contribution = a_l2 * _softplus(gate_vals[col] + bias)
+                                K.assign(
+                                    gate_vals[col],
+                                    K.if_then_else(tok < batch_end, contribution, K.float32(0.0)),
+                                )
+                        elif log_gate:
+                            for col in range(2):
+                                K.assign(gate_vals[col], gate_vals[col] * K.float32(_RCP_LN2))
+                        else:
+                            for col in range(2):
+                                K.assign(gate_vals[col], _lg2(gate_vals[col] + K.float32(1e-10)))
+                        for offset in (1, 2, 4, 8, 16):
+                            for col in range(2):
+                                neighbor = _shfl_up_f32(gate_vals[col], offset)
+                                K.assign(
+                                    gate_vals[col],
+                                    K.if_then_else(
+                                        lidx >= offset, gate_vals[col] + neighbor, gate_vals[col]
+                                    ),
+                                )
+                        carry = _shfl_idx_f32(gate_vals[0], 31, 31)
+                        K.assign(gate_vals[1], gate_vals[1] + carry)
+                        _wait_barrier(arena, _BAR_GATE_DONE, gate_idx, gate_phase)
+                        for col in range(2):
+                            position = lidx + col * 32
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_idx * 256 + position * 4]),
+                                gate_vals[col],
+                            )
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMPROD_BASE + gate_idx * 256 + position * 4]),
+                                _exp2(gate_vals[col]),
+                            )
+                        _arrive_barrier(arena, _BAR_GATE_READY, gate_idx)
+
+                        # ---- beta: cp.async per element or in-register sigmoid
+                        beta_idx = K.local_scalar("int32", init=beta_ps.stage)
+                        _wait_barrier(arena, _BAR_BETA_DONE, beta_ps.stage, beta_ps.phase)
+                        beta_ps.advance()
+                        if beta_sigmoid:
+                            for col in range(2):
+                                position = lidx + col * 32
+                                tok = chunk_offset + position
+                                beta_value = K.local_scalar("float32", init=K.float32(0.0))
+                                with K.If(tok < batch_end), K.Then():
+                                    raw_bits = K.local_scalar("uint16")
+                                    K.ptx.ld.global_.b16(
+                                        raw_bits,
+                                        beta.ptr_to([K.cast(tok, "int64") * n_heads_out + head]),
+                                    )
+                                    raw = K.local_scalar("float32")
+                                    if io_dtype == "float16":
+                                        K.assign(
+                                            raw,
+                                            K.cast(K.reinterpret("float16", raw_bits), "float32"),
+                                        )
+                                    else:
+                                        K.ptx.cvt.f32.bf16(raw, raw_bits)
+                                    half_tanh = _tanh(raw * K.float32(0.5)) * K.float32(0.5)
+                                    rounded_word = _pack_io_pair(
+                                        half_tanh + K.float32(0.5),
+                                        half_tanh + K.float32(0.5),
+                                        io_dtype,
+                                    )
+                                    rounded_lo = K.local_scalar("float32")
+                                    rounded_hi = K.local_scalar("float32")
+                                    _unpack_io_pair(rounded_word, rounded_lo, rounded_hi, io_dtype)
+                                    K.assign(beta_value, rounded_lo)
+                                K.ptx.st.shared.f32(
+                                    arena.ptr_to([_BETA_RING_BASE + beta_idx * 256 + position * 4]),
+                                    beta_value,
+                                )
+                            _arrive_barrier(arena, _BAR_BETA_READY, beta_idx)
+                        else:
+                            for col in range(2):
+                                position = lidx + col * 32
+                                tok = chunk_offset + position
+                                copy_size = K.if_then_else(
+                                    tok < batch_end, K.uint32(4), K.uint32(0)
+                                )
+                                K.ptx["cp.async.ca.shared.global"](
+                                    arena.ptr_to([_BETA_RING_BASE + beta_idx * 256 + position * 4]),
+                                    beta.ptr_to([K.cast(tok, "int64") * n_heads_out + head]),
+                                    K.uint32(4),
+                                    copy_size,
+                                )
+                            K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](
+                                _barrier_ptr(arena, _BAR_BETA_READY, beta_idx)
+                            )
+                sched_consume(sched_ps, tile)
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_GATE_DONE, gate_ps.stage, gate_ps.phase)
+                gate_ps.advance()
+            for _ in range(3):
+                _wait_barrier(arena, _BAR_BETA_DONE, beta_ps.stage, beta_ps.phase)
+                beta_ps.advance()
+
+        # ================================================================
+        # Warp 10: sole tcgen05 issuer and TMEM lifecycle
+        # ================================================================
+        with mma:
+            tcgen_lane = K.local_scalar("uint32")
+            tcgen_leader = K.local_scalar("uint32")
+            K.ptx.elect_sync(tcgen_lane, tcgen_leader, K.uint32(0xFFFFFFFF))
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([_TMEM_MAILBOX]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            kvacc_ps = K.PipelineState(1, phase=1)
+            kq_ps = K.PipelineState(kq_stages, phase=0)
+            cg0_ps = K.PipelineState(2, phase=1)
+            kqf_ps = K.PipelineState(kq_stages, phase=0)
+            tinv_ps = K.PipelineState(3, phase=0)
+            sinp_ps = K.PipelineState(1, phase=0)
+            y_ps = K.PipelineState(1, phase=0)
+            du_ps = K.PipelineState(1, phase=0)
+            sched_ps = K.PipelineState(2, phase=0)
+            leader = tcgen_leader
+
+            def fused_kk(member_one):
+                # M=128 spans both pair boxes of the stage while N=64 spans only
+                # the member's box, so half of each accumulator is never read.
+                # The shape is inherited from the prefill kernel's genuinely
+                # fused KK/QK pair and is kept: dropping it would change the
+                # issue count and the accumulator ring geometry.
+                fused_idx = K.local_scalar("int32", init=cg0_ps.stage)
+                _wait_barrier(arena, _BAR_CG0_ACC_DONE, cg0_ps.stage, cg0_ps.phase)
+                cg0_ps.advance()
+                kqf_idx = K.local_scalar("int32", init=kqf_ps.stage)
+                _wait_barrier(arena, _BAR_KQ_READY, kqf_ps.stage, kqf_ps.phase)
+                kqf_ps.advance()
+                pair_desc = _raw_descriptor(arena, kq_base + kqf_idx * 32768, 16, 1024, 2)
+                b_desc = pair_desc + K.uint64(_KQ_BOX) if member_one else pair_desc
+                destination = tmem_base + _TM_CG0 + fused_idx * 64
+                _tcgen_mma_ss(
+                    destination, pair_desc, b_desc, idesc_n64, leader=leader, accumulate=0
+                )
+                _tcgen_mma_ss(
+                    destination,
+                    pair_desc + K.uint64(_KQ_SEG),
+                    b_desc + K.uint64(_KQ_SEG),
+                    idesc_n64,
+                    leader=leader,
+                    accumulate=1,
+                )
+                _tcgen_commit(arena, _BAR_CG0_ACC_READY, fused_idx, leader=leader)
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                n_local = item[3] - item[4]
+                with K.If(n_local > 0), K.Then():
+                    fused_kk(False)
+                with K.If(n_local > 1), K.Then():
+                    fused_kk(True)
+                with K.serial(n_local, unroll=False) as local_idx:
+                    member = local_idx % 2
+                    if use_initial_state:
+                        with K.If(local_idx == 0), K.Then():
+                            _tcgen_commit(arena, _BAR_STATE_ACC_READY, 0, leader=leader)
+                            kvacc_ps.advance()
+                        have_state = K.bool(True)
+                    else:
+                        have_state = local_idx > 0
+                    kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                    kq_ps.advance()
+                    base_desc = _raw_descriptor(arena, kq_base + kq_idx * 32768, 16, 1024, 2)
+                    desc_k = base_desc + K.cast(member * _KQ_BOX, "uint64")
+                    desc_kt = _raw_descriptor(
+                        arena, kq_base + kq_idx * 32768, 16384, 1024, 2
+                    ) + K.cast(member * _KQ_BOX, "uint64")
+
+                    with K.If(member == 1), K.Then():
+                        with K.If(local_idx + 2 < n_local), K.Then():
+                            fused_kk(True)
+
+                    # ---- GEMM 3: (K*S)^T = packed S^T @ K^T ----------------
+                    with K.If(have_state), K.Then():
+                        _wait_barrier(arena, _BAR_STATE_INP_READY, 0, sinp_ps.phase)
+                        sinp_ps.advance()
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_CG1,
+                            tmem_base + _TM_STATE_INP,
+                            desc_k,
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=0,
+                        )
+                        _tcgen_mma_ts(
+                            tmem_base + _TM_CG1,
+                            tmem_base + _TM_STATE_INP + 32,
+                            desc_k + K.uint64(_KQ_SEG),
+                            idesc_n64,
+                            leader=leader,
+                            accumulate=1,
+                        )
+                        _tcgen_commit(arena, _BAR_K_STATE_READY, 0, leader=leader)
+
+                    # ---- GEMM 5: U^T = packed Y^T @ T_inv ------------------
+                    tinv_idx = K.local_scalar("int32", init=tinv_ps.stage)
+                    _wait_barrier(arena, _BAR_T_INV_READY, tinv_ps.stage, tinv_ps.phase)
+                    tinv_ps.advance()
+                    _wait_barrier(arena, _BAR_Y_INP_READY, 0, y_ps.phase)
+                    y_ps.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TM_CG1,
+                        tmem_base + _TM_Y,
+                        _raw_descriptor(arena, tinv_base + tinv_idx * 8192, 16, 1024, 2),
+                        idesc_n64,
+                        leader=leader,
+                        accumulate=0,
+                    )
+                    _tcgen_commit(arena, _BAR_U_ACC_READY, 0, leader=leader)
+                    _tcgen_commit(arena, _BAR_T_INV_DONE, tinv_idx, leader=leader)
+
+                    with K.If(member == 0), K.Then():
+                        with K.If(local_idx + 2 < n_local), K.Then():
+                            fused_kk(False)
+
+                    # ---- GEMM 7: S^T += packed decayed-U^T @ K -------------
+                    _wait_barrier(arena, _BAR_DECAY_U_READY, 0, du_ps.phase)
+                    du_ps.advance()
+                    kvacc_ps.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + _TM_STATE,
+                        tmem_base + _TM_DECAY_U,
+                        desc_kt,
+                        idesc_n128,
+                        leader=leader,
+                        accumulate=have_state,
+                        b_step_units=128,
+                    )
+                    _tcgen_commit(arena, _BAR_STATE_ACC_READY, 0, leader=leader)
+                    _tcgen_commit(arena, _BAR_KQ_DONE, kq_idx, leader=leader)
+                sched_consume(sched_ps, tile)
+            _wait_barrier(arena, _BAR_TMEM_DONE, 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+
+        # ================================================================
+        # Warp 9: TMA-LDG and scheduler producer
+        # ================================================================
+        with tma:
+            kq_ps = K.PipelineState(kq_stages, phase=1)
+            v_ps = K.PipelineState(2, phase=1)
+            sched_ps = K.PipelineState(2, phase=1)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wend = item[3]
+                cstart = item[4]
+                head_k = head if k_ratio == 1 else head // k_ratio
+                head_v = head if v_ratio == 1 else head // v_ratio
+                desc_k_slot = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_v_slot = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                with K.If(_elected()), K.Then():
+                    for slot in (desc_k_slot, desc_v_slot):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(slot)
+
+                def issue_k(stage, box, tok):
+                    # One chunk's K tile: two 8-KB 64-channel subtiles 16384 B
+                    # apart inside the box the pair member owns.
+                    for d_coord, byte_off in ((0, 0), (64, 16384)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([kq_base + stage * 32768 + box * 8192 + byte_off]),
+                            desc_k_slot,
+                            K.int32(d_coord),
+                            head_k,
+                            tok,
+                            _barrier_ptr(arena, _BAR_KQ_READY, stage),
+                        )
+
+                def issue_v(stage, tok):
+                    for d_coord, byte_off in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([v_base + stage * 16384 + byte_off]),
+                            desc_v_slot,
+                            K.int32(d_coord),
+                            head_v,
+                            tok,
+                            _barrier_ptr(arena, _BAR_V_READY, stage),
+                        )
+
+                with K.If(wend > cstart), K.Then():
+                    # The item's first chunk always lands in box 0 of its stage.
+                    kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                    _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                    kq_ps.advance()
+                    with K.If(_elected()), K.Then():
+                        _expect_tx(arena, _BAR_KQ_READY, kq_idx, 16384)
+                        issue_k(kq_idx, 0, cstart * _BT)
+                    with K.serial(wend - cstart - 1, unroll=False) as ahead:
+                        chunk = cstart + 1 + ahead
+                        member = (chunk - cstart) % 2
+                        loop_kq_idx = K.local_scalar("int32", init=kq_ps.stage)
+                        _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                        kq_ps.advance()
+                        with K.If(_elected()), K.Then():
+                            _expect_tx(arena, _BAR_KQ_READY, loop_kq_idx, 16384)
+                            # Member parity selects the box through two static
+                            # sites, not one site with a runtime byte offset.
+                            with K.If(member == 0), K.Then():
+                                issue_k(loop_kq_idx, 0, chunk * _BT)
+                            with K.If(member == 1), K.Then():
+                                issue_k(loop_kq_idx, 1, chunk * _BT)
+                        v_idx = K.local_scalar("int32", init=v_ps.stage)
+                        _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                        v_ps.advance()
+                        with K.If(_elected()), K.Then():
+                            _expect_tx(arena, _BAR_V_READY, v_idx, 16384)
+                            issue_v(v_idx, (chunk - 1) * _BT)
+                    tail_v_idx = K.local_scalar("int32", init=v_ps.stage)
+                    _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                    v_ps.advance()
+                    with K.If(_elected()), K.Then():
+                        _expect_tx(arena, _BAR_V_READY, tail_v_idx, 16384)
+                        issue_v(tail_v_idx, (wend - 1) * _BT)
+                if dynamic_scheduler:
+                    _wait_barrier(arena, _BAR_SCHED_DONE, sched_ps.stage, sched_ps.phase)
+                    with K.If(_elected()), K.Then():
+                        ticket = K.local_scalar("uint32")
+                        K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                        K.ptx.st.shared.u32(
+                            arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]),
+                            K.uint32(num_sms) + ticket,
+                        )
+                    K.cuda.warp_sync()
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([_SCHED_BASE + sched_ps.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, _BAR_SCHED_READY, sched_ps.stage)
+                    sched_ps.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            for _ in range(kq_stages):
+                _wait_barrier(arena, _BAR_KQ_DONE, kq_ps.stage, kq_ps.phase)
+                kq_ps.advance()
+            for _ in range(2):
+                _wait_barrier(arena, _BAR_V_DONE, v_ps.stage, v_ps.phase)
+                v_ps.advance()
+
+        # ================================================================
+        # Warp 11: epilogue checkpoint TensorMap stores
+        # ================================================================
+        with epilogue:
+            sched_ps = K.PipelineState(2, phase=0)
+            ckpt_cnt = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                n_local = wend - cstart
+                if checkpoints:
+                    desc_c_slot = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                    ckpt_chunks = K.local_scalar("int32", init=checkpoint_every_n // _BT)
+                    # Pre-chunk indexing: the snapshot CG1 stages is the state
+                    # entering the chunk, so the window is [wstart, wend) and
+                    # the running modulus starts at cstart, with no pre-loop
+                    # store.
+                    ckpt_coord = K.local_scalar(
+                        "int32", init=(wstart + ckpt_chunks - 1) // ckpt_chunks
+                    )
+                    ckpt_mod = K.local_scalar("int32", init=cstart % ckpt_chunks)
+                    with K.If(_elected()), K.Then():
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc_c_slot)
+                    with K.If(n_local > 0), K.Then():
+                        with K.serial(n_local, unroll=False) as local_idx:
+                            chunk = cstart + local_idx
+                            did_ckpt = K.local_scalar("int32", init=K.int32(0))
+                            with (
+                                K.If(K.And(K.And(chunk >= wstart, chunk < wend), ckpt_mod == 0)),
+                                K.Then(),
+                            ):
+                                _wait_barrier(arena, _BAR_CKPT_READY, 0, ckpt_cnt & 1)
+                                for value_coord, byte_off in ((0, 0), (64, 16384)):
+                                    K.ptx[_TMA_S2G_4D](
+                                        desc_c_slot,
+                                        K.int32(value_coord),
+                                        K.int32(0),
+                                        ckpt_coord,
+                                        head,
+                                        arena.ptr_to([_CKPT_BASE + byte_off]),
+                                    )
+                                K.ptx.cp.async_.bulk.commit_group()
+                                K.assign(ckpt_coord, ckpt_coord + 1)
+                                K.assign(did_ckpt, K.int32(1))
+                            K.assign(ckpt_mod, ckpt_mod + 1)
+                            with K.If(ckpt_mod == ckpt_chunks), K.Then():
+                                K.assign(ckpt_mod, K.int32(0))
+                            with K.If(did_ckpt == 1), K.Then():
+                                K.ptx.cp.async_.bulk.wait_group.read(0)
+                                _arrive_barrier(arena, _BAR_CKPT_DONE, 0)
+                                K.assign(ckpt_cnt, ckpt_cnt + 1)
+                sched_consume(sched_ps, tile)
+
+    return main
+
+
+def _normalized_config(config):
+    config = {key: value for key, value in config.items() if key != "label"}
+    config.setdefault("seq_lens", (64,))
+    config["seq_lens"] = tuple(int(value) for value in config["seq_lens"])
+    config.setdefault("heads", 1)
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("io_dtype", "bfloat16")
+    config.setdefault("state_dtype", "float32")
+    config.setdefault("cu_dtype", "int32")
+    config.setdefault("num_sms", 148)
+    # The backward plan's regen call: per-chunk checkpoints, no final state.
+    config.setdefault("checkpoint_every_n_tokens", 64)
+    config.setdefault("use_initial_state", False)
+    config.setdefault("store_final_state", False)
+    config.setdefault("log_gate", True)
+    config.setdefault("safe_gate", False)
+    config.setdefault("beta_sigmoid", False)
+    config.setdefault("dynamic_scheduler", False)
+    config.setdefault("split", False)
+    # This kernel's prologue runs the order pass only when it is the backward
+    # pair's first work-table consumer.  Generated uncut rows are the default;
+    # scratch LPT ordering owns split rows.
+    config.setdefault("run_order", True)
+    config.setdefault("order_generate", not config.get("split", False))
+
+    if config["io_dtype"] not in ("bfloat16", "float16"):
+        raise ValueError("io_dtype must be 'bfloat16' or 'float16'")
+    if config["state_dtype"] not in ("float32", "bfloat16"):
+        raise ValueError("state_dtype must be 'float32' or 'bfloat16'")
+    if config["cu_dtype"] not in ("int32", "int64"):
+        raise ValueError("cu_dtype must be 'int32' or 'int64'")
+    if any(length < 0 for length in config["seq_lens"]):
+        raise ValueError("sequence lengths must be nonnegative")
+    if sum(config["seq_lens"]) == 0:
+        raise ValueError("at least one sequence must be nonempty for CUDA TensorMap encoding")
+    heads = int(config["heads"])
+    for name in ("k_heads", "v_heads"):
+        value = int(config[name])
+        if value <= 0 or heads % value != 0:
+            raise ValueError(f"{name}={value} must be a positive divisor of heads={heads}")
+    if heads != max(int(config["k_heads"]), int(config["v_heads"])):
+        raise ValueError("heads must equal max(k_heads, v_heads), matching the source HO rule")
+    cadence = int(config["checkpoint_every_n_tokens"])
+    if cadence < 0 or cadence % _BT != 0:
+        raise ValueError("checkpoint cadence must be zero or a positive multiple of 64")
+    if cadence not in (0, 64, 128, 192):
+        raise ValueError("validated checkpoint cadences are 0, 64, 128, and 192")
+    if not (cadence or config["store_final_state"]):
+        raise ValueError("the checkpoint series or the final state is required")
+    if not (config["use_initial_state"] or config["store_final_state"]) and (
+        config["state_dtype"] != "float32"
+    ):
+        raise ValueError("state_dtype is float32 when neither state tensor is present")
+    if config["split"] and config["order_generate"]:
+        raise ValueError("split work rows require scratch ordering")
+    if not config["run_order"] and config["dynamic_scheduler"]:
+        raise ValueError("the dynamic scheduler needs the order pass to zero its ticket ring")
+    return config
+
+
+def _work_rows(seq_lens, heads, *, split):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            if split and chunks >= 4:
+                midpoint = chunks // 2
+                rows.append((batch, head, 0, midpoint, 0, midpoint, token_begin, token_end))
+                rows.append((batch, head, midpoint, chunks, 0, chunks, token_begin, token_end))
+            else:
+                rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return rows
+
+
+def get_kernel(**config):
+    """Return the source-ordered prologue and persistent main kernels."""
+    config = _normalized_config(config)
+    rows = _work_rows(config["seq_lens"], config["heads"], split=config["split"])
+    num_ctas = min(int(config["num_sms"]), max(len(rows), 1))
+    prologue = _make_prologue(
+        run_order=bool(config["run_order"]),
+        order_generate=bool(config["order_generate"]),
+        n_heads_out=int(config["heads"]),
+        checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
+        cu_dtype=config["cu_dtype"],
+    )
+    main = _make_main(
+        num_sms=num_ctas,
+        io_dtype=config["io_dtype"],
+        state_dtype=config["state_dtype"],
+        cu_dtype=config["cu_dtype"],
+        use_initial_state=bool(config["use_initial_state"]),
+        store_final_state=bool(config["store_final_state"]),
+        checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
+        log_gate=bool(config["log_gate"]),
+        safe_gate=bool(config["safe_gate"]),
+        beta_sigmoid=bool(config["beta_sigmoid"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        k_ratio=int(config["heads"]) // int(config["k_heads"]),
+        v_ratio=int(config["heads"]) // int(config["v_heads"]),
+        n_heads_out=int(config["heads"]),
+    )
+    return [prologue.func, main.func]
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _checkpoint_count(seq_lens, cadence):
+    # Matches the packed per-batch layout of the source's
+    # emit_checkpoint_seq_descs: count_b = (len - 1) // cadence + 1 per
+    # nonempty sequence, running-prefix-summed.
+    if not cadence:
+        return 0
+    return sum(0 if length == 0 else (length - 1) // cadence + 1 for length in seq_lens)
+
+
+def _prepare_work_tables(torch, config):
+    base = torch.tensor(
+        _work_rows(config["seq_lens"], config["heads"], split=config["split"]),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    def one_side():
+        # Without the order pass the caller owns an already-ordered table.
+        work_items = torch.empty_like(base) if config["run_order"] else base.clone()
+        staging = None if config["order_generate"] else base.clone()
+        # The order pass zeroes every cell of this region; the ticket counter
+        # is its first cell, matching the engine's shared sched block.
+        sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+        return {
+            "work_items": work_items,
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": staging,
+            "sched_all": sched_all,
+            "scheduler": sched_all[:1] if config["dynamic_scheduler"] else None,
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _new_outputs(torch, config):
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    result = {}
+    if config["store_final_state"]:
+        result["final_state"] = torch.full(
+            (len(config["seq_lens"]), config["heads"], _DV, _DK),
+            float("nan"),
+            dtype=state_t,
+            device="cuda",
+        )
+    checkpoint_count = _checkpoint_count(config["seq_lens"], config["checkpoint_every_n_tokens"])
+    if checkpoint_count:
+        result["checkpoints"] = torch.full(
+            (checkpoint_count, config["heads"], _DV, _DK), float("nan"), dtype=io_t, device="cuda"
+        )
+    return result
+
+
+def _prepare_data(config):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260827)
+    total_tokens = sum(config["seq_lens"])
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    k = (0.2 * torch.randn(total_tokens, config["k_heads"], _DK, device="cuda")).to(io_t)
+    v = (0.2 * torch.randn(total_tokens, config["v_heads"], _DV, device="cuda")).to(io_t)
+    # The scalar forget gate: raw logits under safe_gate, natural-log decay
+    # under log_gate, raw linear alpha otherwise.
+    gate = torch.empty(total_tokens, config["heads"], dtype=torch.float32, device="cuda")
+    if config["safe_gate"]:
+        gate.normal_(std=0.2)
+    elif config["log_gate"]:
+        gate.uniform_(-0.9, -0.01)
+    else:
+        gate.uniform_(0.4, 0.99)
+    # The scalar update gate: fp32 post-sigmoid, or io-dtype logits when the
+    # kernel applies the sigmoid.
+    if config["beta_sigmoid"]:
+        beta = (0.3 * torch.randn(total_tokens, config["heads"], device="cuda")).to(io_t)
+    else:
+        beta = torch.sigmoid(0.3 * torch.randn(total_tokens, config["heads"], device="cuda"))
+    cu_t = torch.int64 if config["cu_dtype"] == "int64" else torch.int32
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(config["seq_lens"]).cumsum(0).tolist()], dtype=cu_t, device="cuda"
+    )
+    a_log = (
+        0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        (0.01 * torch.randn(len(config["seq_lens"]), config["heads"], _DV, _DK, device="cuda")).to(
+            state_t
+        )
+        if config["use_initial_state"]
+        else None
+    )
+    outputs = {"tirx": _new_outputs(torch, config), "source": _new_outputs(torch, config)}
+    workspace_bytes = _TENSOR_MAP_BYTES * (_TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 1)
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+
+    return {
+        "config": config,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "initial_state": initial_state,
+        "tirx": outputs["tirx"],
+        "source": outputs["source"],
+        "work": _prepare_work_tables(torch, config),
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "_workspace_owners": (tirx_owner, source_owner),
+    }
+
+
+def prepare_data(**config):
+    """Allocate the shared input set plus source/TIRx output buffers."""
+    return _prepare_data(config)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype == torch.float16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT16
+    elif tensor.dtype == torch.bfloat16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif tensor.dtype == torch.float32:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return (
+        torch.tensor([int(word) for word in tensor_map.opaque], dtype=torch.uint64)
+        .view(torch.int64)
+        .to(device=tensor.device)
+    )
+
+
+def _base_tensor_maps(data, side):
+    config = data["config"]
+    total_tokens = data["k"].shape[0]
+
+    def headed(tensor, channels, heads, box_channels):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (box_channels, 1, _BT),
+        )
+
+    output = data[side]
+    maps = [
+        headed(data["k"], _DK, config["k_heads"], 64),
+        headed(data["v"], _DV, config["v_heads"], 64),
+    ]
+    checkpoints = output.get("checkpoints")
+    if checkpoints is None:
+        # The source aliases the checkpoint descriptor onto V's when the
+        # series is absent.
+        maps.append(maps[-1])
+    else:
+        maps.append(
+            _encode_tiled_map(
+                checkpoints,
+                (_DK, _DV, checkpoints.shape[0], config["heads"]),
+                (
+                    checkpoints.stride(2) * checkpoints.element_size(),
+                    checkpoints.stride(0) * checkpoints.element_size(),
+                    checkpoints.stride(1) * checkpoints.element_size(),
+                ),
+                (64, _DV, 1, 1),
+            )
+        )
+    return maps
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data, "tirx")
+    work = data["work"]["tirx"]
+    output = data["tirx"]
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    beta_t = io_t if config["beta_sigmoid"] else torch.float32
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_io = torch.zeros(1, dtype=io_t, device="cuda")
+    dummy_state = torch.zeros(1, dtype=state_t, device="cuda")
+    dummy_f32 = torch.zeros(config["heads"], dtype=torch.float32, device="cuda")
+    checkpoint = output.get("checkpoints", dummy_io)
+    beta = data["beta"].to(beta_t)
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *maps,
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            checkpoint.view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["sched_all"],
+            len(config["seq_lens"]),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            checkpoint.stride(0) * checkpoint.element_size() if checkpoint.ndim > 1 else 0,
+            int(config["checkpoint_every_n_tokens"]),
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["k"].reshape(-1),
+            data["v"].reshape(-1),
+            data["gate"].reshape(-1),
+            data["a_log"] if data["a_log"] is not None else dummy_f32,
+            data["dt_bias"] if data["dt_bias"] is not None else dummy_f32,
+            beta.reshape(-1),
+            data["cu_seqlens"],
+            (
+                data["initial_state"].reshape(-1)
+                if data["initial_state"] is not None
+                else dummy_state
+            ),
+            output.get("final_state", dummy_state).reshape(-1),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["scheduler"] if work["scheduler"] is not None else dummy_i32,
+            int(config["checkpoint_every_n_tokens"]),
+        )
+
+    launch._keep_alive = (maps, beta, dummy_i32, dummy_io, dummy_state, dummy_f32)
+    return launch
+
+
+def _load_reference_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn_recompute_f16")
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    beta = data["beta"].to(io_t) if config["beta_sigmoid"] else data["beta"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_gdn_recompute_sm100(
+            data["k"],
+            data["v"],
+            data["gate"],
+            beta,
+            data["cu_seqlens"],
+            data["initial_state"],
+            output.get("final_state"),
+            checkpoint_every_n_tokens=int(config["checkpoint_every_n_tokens"]),
+            output_state_checkpoints=output.get("checkpoints"),
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["scheduler"],
+            sched_all=work["sched_all"] if config["run_order"] else None,
+            work_item_scratch=work["staging"],
+            order_in_prologue=bool(config["run_order"]),
+            log_gate=bool(config["log_gate"]),
+            safe_gate=bool(config["safe_gate"]),
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=bool(config["beta_sigmoid"]),
+            workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    launch._keep_alive = (beta,)
+    return launch
+
+
+def _rms_ratio(torch, actual, expected):
+    if actual.shape != expected.shape:
+        raise ValueError(
+            f"RMS operands must have the same shape: {actual.shape} != {expected.shape}"
+        )
+    actual = actual.detach().reshape(-1)
+    expected = expected.detach().reshape(-1)
+    elements = actual.numel()
+    if elements == 0:
+        return 0.0
+    difference_square_sum = torch.zeros((), dtype=torch.float64, device=actual.device)
+    expected_square_sum = torch.zeros((), dtype=torch.float64, device=actual.device)
+    chunk_elements = 1 << 24
+    for begin in range(0, elements, chunk_elements):
+        end = min(begin + chunk_elements, elements)
+        actual_chunk = actual[begin:end].double()
+        expected_chunk = expected[begin:end].double()
+        difference = actual_chunk - expected_chunk
+        difference_square_sum.add_(difference.square().sum())
+        expected_square_sum.add_(expected_chunk.square().sum())
+    denominator = (expected_square_sum / elements).sqrt().clamp_min(1e-12)
+    return float(((difference_square_sum / elements).sqrt() / denominator).item())
+
+
+def _validate_outputs(data, *, sources):
+    import math
+
+    import torch
+
+    limit = 0.01 if data["config"]["io_dtype"] == "float16" else 0.02
+    failures = {}
+    if "tirx" in sources and "source" in sources:
+        for name in data["tirx"]:
+            actual = data["tirx"][name]
+            expected = data["source"][name]
+            if name == "checkpoints":
+                # The source clips checkpoint stores in hardware; compare only
+                # the entries the source actually wrote and require the TIRx
+                # side to leave the same tail untouched.
+                written = ~torch.isnan(expected.float())
+                if bool(torch.isnan(actual.float())[written].any()):
+                    failures["tirx_vs_source.checkpoints.missing"] = float("nan")
+                    continue
+                actual = torch.where(written, actual, torch.zeros_like(actual))
+                expected = torch.where(written, expected, torch.zeros_like(expected))
+            ratio = _rms_ratio(torch, actual, expected)
+            if not math.isfinite(ratio) or ratio >= limit:
+                failures[f"tirx_vs_source.{name}"] = ratio
+    if failures:
+        raise AssertionError(
+            f"GDN recompute validation failed for {data['config']}: {failures}; limit={limit}"
+        )
+
+
+def run_test(**config):
+    """Compare TIRx with the upstream kernel on identical inputs."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = _normalized_config(config)
+    data = _prepare_data(config)
+    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"))
+    return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
+
+
+def prepare_bench(**config):
+    """Compile both TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config = _normalized_config(config)
+    state = {
+        "config": config,
+        "executables": [compile_kernel(func) for func in get_kernel(**config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then expose the exact two-launch paths to bench_suite."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _validate_outputs(data, sources=("tirx", "source"))
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
Ports the cuDNN frontend frost **GDN v1 state-recompute** kernel
(`cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py`, commit `aded9909`)
to a TIRx kernel using the `tirx_kernels.kern` API, following the porting
workflow (scaffold → sketch → sketch review → correctness gate → perf gate).

This kernel is the GDN backward plan's regeneration pass: when the forward did
not save the per-chunk state checkpoint series, the backward recomputes it here
and feeds it to `gdn_bprop`. It is the prefill pipeline with the query and
output paths removed — four tcgen05 GEMMs instead of seven, 24 mbarrier
families, 448 of 512 TMEM columns.

## What's included

- `tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py` — the port:
  a single-CTA prologue (optional LPT work ordering plus three runtime
  TensorMap descriptor arrays) and a persistent 12-warp / 384-thread main
  kernel. `K.ptx.*` and pure `K.cuda.*` only; no `allowed_func_calls`
  exemption and no changes under `kern/`.
- Reviewed kernel sketch at `.agents/sketch/cudnn/sm100_gdn_recompute_f16.md`.
- bench_suite workload config and README port row.
- Codegen-tuning DB (second commit): one new entry plus one boundary
  refinement, both distilled from the perf search.

## Notes on the port

- The K SMEM stage carries the chunk **pair**: box 0 the even member, box 1
  the odd one. Member parity selects the box through two static TMA sites.
- The fused KK issue is M=128/N=64, so half of every accumulator is unread.
  That shape is inherited from the prefill kernel's genuinely fused KK/QK
  pair; it is kept because dropping it would change the issue count and the
  accumulator ring geometry.
- Checkpoints are snapshotted **before** the state rescale, so entry `j` is the
  state *entering* token `j*N` and row 0 is the incoming state. (The upstream
  docstring says "after `(j+1)*N`"; the code, the tests and the fp64 reference
  all say otherwise.)

## Validation

- **Correctness**: `python -m tirx_kernels.test --kernel cudnn_sm100_gdn_recompute_f16`
  — all 14 pairwise configs pass against the frost source outputs
  (rms-ratio ≤ 0.01 fp16 / 0.02 bf16 over the written checkpoint slots and the
  final state), covering both io dtypes, fp32/bf16 state, int32/int64
  cu_seqlens, GQA in both directions, seeded and unseeded state, checkpoint
  cadences 0/64/128/192, safe-gate, beta-sigmoid, dynamic and static
  scheduling, split work rows, and ragged sequences with zero- and one-token
  entries.
- **Performance** (bench_suite with `--with-references`, B200): all 18
  workloads at or above parity with the cuDNN frontend reference —
  min 1.0001, mean 1.0161, max 1.0458.
