### PR TITLE
feat(kernel): add SM100 MXFP8 projection RoPE

### DIFF
--- a/.agents/sketch/cudnn/sm100_gemm_proj_rope_mxfp8_mxfp8in.md
+++ b/.agents/sketch/cudnn/sm100_gemm_proj_rope_mxfp8_mxfp8in.md
@@ -1,0 +1,735 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 MXFP8-input projection GEMM + YARN RoPE sketch
+
+This is the non-executable execution sketch for
+[`tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py`](../../tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py).
+It freezes the direct TE-native ABI, block-scaled MXFP8 mainloop, 14-warp
+split, static persistent scheduler, dual pipeline, FP32-TMEM-to-BF16-SMEM
+drain, YARN RoPE, dual-direction MXFP8 quantization, and TMEM teardown. Once
+the independent sketch reviewer returns PASS, this file is immutable.
+
+The authoritative source is
+`python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py`
+at commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`. Its SHA256 is
+`c2754a908368055f0fcbc9f044f06808b204e730ea94723888493b594198c34e`.
+Source citations below refer to that file. The writer's independent,
+cache-disabled line-info exports are under
+`.porting/gemm_proj_rope_mxfp8_mxfp8in/writer_export/`:
+
+- `tokens128`: PTX SHA256
+  `44b54abc473ebea981da2c241973dd60a7fdf3689a1d05a1bd639fbfcf3ca159`;
+  `PTX-128 n` means physical line `n` of the 7309-line PTX.
+- `tokens2048`: PTX SHA256
+  `5c08f06fdd9bf8bbee9b5902c73f6215a295f1180674a0c840461d04129d904a`;
+  `PTX-2048 n` means physical line `n` of the 7560-line PTX.
+
+Both use `K=1536`, `num_heads=128`, execute once, and match all four
+upstream outputs with row and column match fractions 1.0. The first export
+covers the non-persistent x32 T2R branch; the second covers persistent x8.
+
+## No first-class layout invariant
+
+The executable device body imports only `tirx_kernels.kern as K`. It may not
+construct, pass, return, or store a first-class layout, invoke a tile
+primitive, allocate multidimensional shared memory, call `K.cuda.func_call`,
+embed CUDA source, or rely on a low-level-IR exemption. All shared storage is
+one rank-1 dynamic `u8` arena. TensorMap fields, swizzles, descriptor fields,
+scheduler coordinates, TMEM addresses, and fragment placement are explicit
+integer arithmetic. “Tile” below names an algorithmic rectangle only.
+
+## Frozen roles and publication edges
+
+| role | warps | responsibility |
+| --- | --- | --- |
+| epilogue | 0-11 | warp 0 allocates 512 TMEM columns; warps 0-3 drain one 32-row accumulator band each; all 12 own one 32-token by 64-feature cell, apply the optional RoPE cell, and quantize row/column outputs |
+| MMA | 12 | copies staged compact SFA/SFB into TMEM, issues block-scaled E4M3 MMA, releases AB stages, and publishes accumulator stages |
+| TMA | 13 | relays 128 SFA rows and paired 256 SFB rows, publishes them to async-shared view, then issues A/B TensorMap loads |
+
+AB has three full/empty stages with one arrival on each side. ACC has two
+full/empty stages: one MMA full arrival and four T2R empty arrivals. Named
+barrier 2 joins MMA plus all epilogue warps (416 threads); named barrier 1
+joins all epilogue warps (384 threads) twice per work tile.
+
+## Scalar primitive vocabulary
+
+The pseudocode uses only scalar values, raw pointers, opaque host-created
+TensorMaps, and explicit byte/TMEM-column offsets:
+
+```python
+encode_tensormap(base, dtype, extents, byte_stride, box, swizzle)
+arena_ptr(byte_offset)
+raw_umma_descriptor(base_bits, shared_byte_address)
+pipeline_state(stage_count, initial_phase)
+wait_mbarrier(barrier_byte, phase)
+arrive_expect_tx(barrier_byte, byte_count)
+tma_load_2d_cta(map, coord0, coord1, arena_byte, barrier_byte)
+scale_s2t(tmem_column, shared_descriptor)
+blockscaled_mma(acc_column, a_desc, b_desc, instruction_desc,
+                sfa_column, sfb_column, accumulate)
+umma_commit(barrier_byte)
+tmem_load_x32_or_x8(register_words, tmem_address)
+packed_f32x2_mul_or_fma(...)
+convert_e8m0_or_e4m3x2(...)
+global_load_or_store(...)
+```
+
+## Complete sketch
+
+```python
+# S1 =======================================================================
+# Fixed specialization, direct ABI, TensorMaps, and launch
+# source 18-71, 557-649; PTX-128/PTX-2048 14-42
+# ==========================================================================
+TILE_M = 128
+TILE_N = HEAD_DIM = 192
+K_TILE = 128
+K_DIM = 1536
+NUM_HEADS = 128
+QK_NOPE = 128
+QK_ROPE = 64
+BLOCK = SF_VEC = 32
+AB_STAGES = 3
+ACC_STAGES = 2
+NUM_K_TILES = 12
+NUM_EPI_WARPS = 12
+T2R_WARPS = 4
+MMA_WARP = 12
+TMA_WARP = 13
+TMEM_COLUMNS = 512
+SACC_STRIDE_BF16 = 196
+assert tokens in (128, 256, 2048, 4096)
+
+# This is the only supported device ABI. Codes and scales are physically
+# bytes; cos/sin and the staging conversion are BF16.
+ABI = (
+    x_code_u8_ptr, x_scale_u8_ptr,
+    w_code_u8_ptr, w_scale_u8_ptr,
+    cos_bf16_ptr, sin_bf16_ptr,
+    qrow_u8_ptr, srow_u8_ptr,
+    qcol_u8_ptr, scol_u8_ptr,
+)
+
+# x_code is [tokens,K] and w_code is [heads*192,K], both row-major. TensorMap
+# coordinate 0 is contiguous K. No wrapper weight-transpose orientation exists.
+map_A = encode_tensormap(
+    x_code_u8_ptr, dtype=e4m3, extents=(K_DIM, tokens),
+    byte_stride=K_DIM, box=(128, 128), swizzle=SW128,
+)
+map_B = encode_tensormap(
+    w_code_u8_ptr, dtype=e4m3, extents=(K_DIM, NUM_HEADS * HEAD_DIM),
+    byte_stride=K_DIM, box=(128, 192), swizzle=SW128,
+)
+
+M_TILES = tokens // 128
+TOTAL_WORK = M_TILES * NUM_HEADS
+NUM_CLUSTERS = min(TOTAL_WORK, 148)
+SWIZZLE = {128: 4, 256: 4, 2048: 16, 4096: 32}[tokens]
+T2R_X8 = tokens >= 2048
+launch(
+    grid=(1, 1, NUM_CLUSTERS), block_threads=448,
+    cluster=(1, 1, 1), dynamic_smem_bytes=177792, arch="sm_100a",
+)
+# instruction_selection: `.reqntid 448,1,1`, singleton CTA/cluster, one
+#   `.extern .shared .align 1024`; extent: every specialization. The B200
+#   residency query caps the z grid at 148. Source 596-649; both PTX 14-42.
+
+# S2 =======================================================================
+# One rank-1 u8 shared arena, raw descriptors, and TMEM partition
+# source 43-54, 74-80, 222-228, 325-366; both PTX 93-119
+# ==========================================================================
+smem = rank1_dynamic_u8(177792, alignment=1024)
+
+AB_FULL = 0                  # three u64 barriers: [0,24)
+AB_EMPTY = 24                # three u64 barriers: [24,48)
+ACC_FULL = 48                # two u64 barriers: [48,64)
+ACC_EMPTY = 64               # two u64 barriers: [64,80)
+TMEM_DEALLOC = 80            # one u64: [80,88)
+TMEM_PTR = 88                # one u32, header padded through 128
+A_BASE = 128                 # 3 * 16384 bytes; ends 49280
+B_BASE = 49280               # 3 * 24576 bytes; ends 123008
+SFA_BASE = 123008            # 3 * 512 bytes; ends 124544
+SFB_BASE = 124544            # 3 * 1024 bytes; ends 127616
+SACC_BASE = 127616           # 128 * 196 BF16; ends 177792
+
+def barrier(base, stage):
+    return arena_ptr(base + 8 * stage)
+
+def a_stage_byte(stage):
+    return A_BASE + stage * 16384
+
+def b_stage_byte(stage):
+    return B_BASE + stage * 24576
+
+def sfa_stage_byte(stage):
+    return SFA_BASE + stage * 512
+
+def sfb_stage_byte(stage):
+    return SFB_BASE + stage * 1024
+
+def sacc_byte(row, feature):
+    return SACC_BASE + 2 * (row * 196 + feature)
+
+def desc_address(base_bits, byte_address):
+    return uint64(base_bits) | uint64((shared_address(byte_address) >> 4) & 0x3fff)
+
+AB_DESC_BASE = 0x4000404000010000
+SF_DESC_BASE = 0x400800010000
+MMA_INSTR_BASE = 0x08B00000
+A_DESC = desc_address(AB_DESC_BASE, A_BASE)
+B_DESC = desc_address(AB_DESC_BASE, B_BASE)
+SFA_DESC = desc_address(SF_DESC_BASE, SFA_BASE)
+SFB_DESC = desc_address(SF_DESC_BASE, SFB_BASE)
+
+def a_desc(stage, kphase):
+    return A_DESC + stage * 1024 + 2 * kphase
+
+def b_desc(stage, kphase):
+    return B_DESC + stage * 1536 + 2 * kphase
+
+def sf_desc_sfa(stage):
+    return SFA_DESC + stage * 32
+
+def sf_desc_sfb(stage, half):
+    return SFB_DESC + stage * 64 + half * 32
+
+# TMEM columns are scalar integer addresses: ACC 0-383, SFA 384-399, and
+# SFB 400-431. Odd heads shift the SFB MMA view by exactly two columns.
+ACC_COL = 0
+SFA_COL = 384
+SFB_COL = 400
+
+def mma_instruction_desc(sfa_column, sfb_column):
+    return ((MMA_INSTR_BASE & 0x9fffffcf)
+            | ((sfa_column >> 1) & 0x60000000)
+            | ((sfb_column >> 26) & 0x30))
+
+# instruction_selection: A/B operands are raw 64-bit shared descriptors,
+#   scale-copy operands use raw SF descriptors, the accumulator and scale
+#   destinations are raw TMEM columns, and the MMA descriptor is the patched
+#   integer above. Extent: four K phases x 12 K tiles for every work tile.
+#   Source 327-374; PTX-128 433-725, PTX-2048 450-751.
+
+# S3 =======================================================================
+# Warp roles, barrier initialization, scheduler coordinate lowering
+# source 213-220, 230-254, 275-300
+# ==========================================================================
+warp = warp_uniform(warp_id())
+lane = lane_id()
+roles = chain_dispatch(
+    epilogue=warps(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+    mma=warps(12),
+    tma=warps(13),
+)
+
+if warp == TMA_WARP:
+    prefetch_tensormap(map_A)
+    prefetch_tensormap(map_B)
+# instruction_selection: two `prefetch.tensormap`; extent: one per input map
+#   by the active TMA warp. Source 230-232; both PTX 89,92.
+
+if warp == 0 and elect_one():
+    for stage in unroll(3):
+        mbarrier_init(barrier(AB_FULL, stage), arrivals=1)
+if warp == 0 and elect_one():
+    for stage in unroll(3):
+        mbarrier_init(barrier(AB_EMPTY, stage), arrivals=1)
+fence_mbarrier_init_release_cluster()
+cta_barrier_all()
+if warp == 0 and elect_one():
+    for stage in unroll(2):
+        mbarrier_init(barrier(ACC_FULL, stage), arrivals=1)
+if warp == 0 and elect_one():
+    for stage in unroll(2):
+        mbarrier_init(barrier(ACC_EMPTY, stage), arrivals=4)
+fence_mbarrier_init_release_cluster()
+cta_barrier_all()
+# instruction_selection: exactly ten `mbarrier.init.shared.b64`, two
+#   `fence.mbarrier_init.release.cluster`, and two `bar.sync 0`; arrivals are
+#   1/1/1/4 for AB-full/AB-empty/ACC-full/ACC-empty. Source 275-294; both PTX
+#   126-173. Each barrier family has an independent warp election.
+
+def scheduler_coord(work):
+    s = SWIZZLE
+    head_minor = work % s
+    m_idx = (work // s) % M_TILES
+    head = (work // (s * M_TILES)) * s + head_minor
+    return m_idx, head
+
+def advance_work(work):
+    return work + NUM_CLUSTERS
+
+# instruction_selection: only integer shifts/masks/division express the
+#   scheduler. For tokens=2048, `m=(work>>4)&15` and
+#   `head=((work>>4)&112)|(work&15)`; extent: independent cursors in all three
+#   roles. Source 298-305,316-317,377-378,550-551; PTX-2048 178-241 and tail.
+
+# S4 =======================================================================
+# Warp 13: compact-scale relay followed by three-stage A/B TMA
+# source 147-183, 301-318; PTX-128 249-412, PTX-2048 251-429
+# ==========================================================================
+with role("tma"):
+    state = pipeline_state(stages=3, phase=1)
+    work = cta_id_z()
+    while work < TOTAL_WORK:
+        m_idx, head = scheduler_coord(work)
+        for ktile in serial(12):
+            handle = acquire_and_advance(state)
+            if elect_one():
+                arrive_expect_tx(handle.full_barrier, 40960)
+
+            # Every lane relays four SFA rows as one v4 b32 store.
+            sfa_row0 = m_idx * 128 + lane
+            sfa_word = ktile * 4
+            sfa4 = [
+                global_load_u32(x_scale_u8_ptr,
+                    (sfa_row0 + row_block * 32) * 48 + sfa_word)
+                for row_block in unroll(4)
+            ]
+            store_shared_v4_u32(
+                arena_ptr(sfa_stage_byte(handle.stage) + lane * 16), sfa4
+            )
+
+            # The paired SFB relay starts 64 rows earlier for odd heads.
+            sfb_row0 = head * 192 - (head & 1) * 64 + lane
+            sfb8 = [
+                global_load_u32(w_scale_u8_ptr,
+                    (sfb_row0 + row_block * 32) * 48 + sfa_word)
+                for row_block in unroll(8)
+            ]
+            store_shared_v4_u32(
+                arena_ptr(sfb_stage_byte(handle.stage) + lane * 16), sfb8[0:4]
+            )
+            store_shared_v4_u32(
+                arena_ptr(sfb_stage_byte(handle.stage) + 512 + lane * 16),
+                sfb8[4:8],
+            )
+
+            sync_warp()
+            fence_proxy_async_shared_cta()
+            if elect_one():
+                tma_load_2d_cta(
+                    map_A, coord0=ktile * 128, coord1=m_idx * 128,
+                    arena_byte=a_stage_byte(handle.stage),
+                    barrier_byte=handle.full_barrier,
+                )
+            if elect_one():
+                tma_load_2d_cta(
+                    map_B, coord0=ktile * 128, coord1=head * 192,
+                    arena_byte=b_stage_byte(handle.stage),
+                    barrier_byte=handle.full_barrier,
+                )
+        work = advance_work(work)
+    for unused in unroll(3):
+        wait_mbarrier(barrier(AB_EMPTY, state.stage), state.phase)
+        state.advance()
+
+# protocol_order: `acquire_and_advance` clones the current stage/phase, waits
+#   AB-empty, and advances the live cursor before relay/TMA; every subsequent
+#   operation uses the cloned handle. The three tail waits use the live cursor.
+# instruction_selection: AB acquire and all three tail waits use
+#   `mbarrier.try_wait.parity.shared.b64`; extent: 12 acquires/work and three
+#   tail waits. `mbarrier.arrive.expect_tx.shared.b64` arms exactly 40960
+#   bytes. Source 309-318; first PTX wait/expect 249/264 (128) and 251/266
+#   (2048).
+# instruction_selection: scale relay is twelve `ld.global.b32` plus three
+#   `st.shared.v4.b32` static sites, dynamically four SFA and eight SFB words
+#   per lane/stage. It is followed in order by `bar.warp.sync -1` and
+#   `fence.proxy.async.shared::cta`. Source 147-183,311-313; PTX-128 276-307,
+#   PTX-2048 278-309.
+# instruction_selection: each map copy has its own `elect.sync` predicate and
+#   emits
+#   `cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`.
+#   Extent: one A plus one B copy per K tile, 12 K tiles/work. Source 314-315;
+#   PTX-128 317,327; PTX-2048 319,329.
+
+# S5 =======================================================================
+# Warp 12: scale S2T, block-scaled E4M3 MMA, ACC publication
+# source 320-379; PTX-128 433-725, PTX-2048 450-751
+# ==========================================================================
+with role("mma"):
+    named_barrier(id=2, threads=416)
+    tmem_base = load_shared_u32(TMEM_PTR)
+    ab = pipeline_state(stages=3, phase=0)
+    acc = pipeline_state(stages=2, phase=1)
+    work = cta_id_z()
+    while work < TOTAL_WORK:
+        acc_handle = acquire_and_advance(acc)
+        m_idx, head = scheduler_coord(work)
+        sfb_mma_column = tmem_base + SFB_COL + 2 * (head & 1)
+        accumulate = False
+        for ktile in serial(12):
+            ab_handle = wait_and_advance(ab)
+            if elect_one():
+                scale_s2t(tmem_base + SFA_COL, sf_desc_sfa(ab_handle.stage))
+            if elect_one():
+                scale_s2t(tmem_base + SFB_COL, sf_desc_sfb(ab_handle.stage, 0))
+            if elect_one():
+                scale_s2t(tmem_base + SFB_COL + 4, sf_desc_sfb(ab_handle.stage, 1))
+            for kphase in unroll(4):
+                sfa_phase_column = tmem_base + SFA_COL + kphase * 0x40000000
+                sfb_phase_column = sfb_mma_column + kphase * 0x40000000
+                phase_instruction = mma_instruction_desc(
+                    sfa_phase_column, sfb_phase_column
+                )
+                if elect_one():
+                    blockscaled_mma(
+                        acc_column=tmem_base + acc_handle.stage * 192,
+                        a_desc=a_desc(ab_handle.stage, kphase),
+                        b_desc=b_desc(ab_handle.stage, kphase),
+                        instruction_desc=phase_instruction,
+                        sfa_column=sfa_phase_column,
+                        sfb_column=sfb_phase_column,
+                        accumulate=accumulate,
+                    )
+                accumulate = True
+            if elect_one():
+                umma_commit(ab_handle.empty_barrier)
+        if elect_one():
+            umma_commit(acc_handle.full_barrier)
+        work = advance_work(work)
+    acc.advance()
+    wait_mbarrier(barrier(ACC_EMPTY, acc.stage), acc.phase)
+
+# protocol_order: ACC `acquire_and_advance` and AB `wait_and_advance` both
+#   advance their live cursors immediately after cloning/waiting; S2T, MMA,
+#   and commits use only the cloned handle. Source 356-376.
+# instruction_selection: MMA entry uses `bar.sync 2,416` and `ld.shared.b32`;
+#   ACC-empty and AB-full acquire plus the one-stage producer tail use
+#   `mbarrier.try_wait.parity.shared.b64`. Extent: 1+12 waits/work and one tail
+#   wait. Source 322-379; PTX-128 433,499,555 and PTX-2048 450,516,572.
+# instruction_selection: three elected
+#   `tcgen05.cp.cta_group::1.32x128b.warpx4` sites copy one SFA and two SFB
+#   atoms per K tile to TMEM columns 384,400,404. Source 345-371; PTX-128
+#   579,590,598; PTX-2048 596,607,615.
+# instruction_selection: four elected
+#   `tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32` sites execute
+#   per K tile. Every phase recomputes descriptor selector bits from its shifted
+#   SFA/SFB TMEM addresses. Only the first phase of the first K tile has
+#   accumulate false; all other 47 dynamic MMAs accumulate. Source 361-375;
+#   PTX-128 620,633,
+#   646,659; PTX-2048 637,650,663,676.
+# instruction_selection: elected
+#   `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`
+#   releases AB-empty after every K tile and publishes ACC-full after all 12.
+#   Source 375-376; PTX-128 666,678; PTX-2048 683,695.
+
+# S6 =======================================================================
+# Epilogue entry and warps 0-3 FP32 TMEM -> BF16 sACC drain
+# source 381-427; PTX-128 744-1237, PTX-2048 770-1259
+# ==========================================================================
+with role("epilogue"):
+    if warp == 0:
+        tmem_alloc_cta_group_one(shared_u32=TMEM_PTR, columns=512)
+    named_barrier(id=2, threads=416)
+    tmem_base = load_shared_u32(TMEM_PTR)
+    acc = pipeline_state(stages=2, phase=0)
+    work = cta_id_z()
+    while work < TOTAL_WORK:
+        if warp < 4:
+            acc_handle = wait_and_advance(acc)
+            row = warp * 32 + lane
+            if not T2R_X8:
+                for group in unroll(6):
+                    words_f32[0:32] = tmem_load_x32(
+                        tmem_base + (warp << 21) + acc_handle.stage * 192 + group * 32
+                    )
+                    for pair in unroll(16):
+                        packed_bf16[pair] = convert_bf16x2(
+                            words_f32[2 * pair + 1], words_f32[2 * pair]
+                        )
+                    for vec in unroll(8):
+                        store_shared_v2_u32(
+                            arena_ptr(sacc_byte(row, group * 32 + vec * 4)),
+                            packed_bf16[2 * vec], packed_bf16[2 * vec + 1],
+                        )
+            else:
+                for group in unroll(6):
+                    for chunk in unroll(4):
+                        words_f32[0:8] = tmem_load_x8(
+                            tmem_base + (warp << 21) + acc_handle.stage * 192
+                            + group * 32 + chunk * 8
+                        )
+                        for pair in unroll(4):
+                            packed_bf16[pair] = convert_bf16x2(
+                                words_f32[2 * pair + 1], words_f32[2 * pair]
+                            )
+                        for vec in unroll(2):
+                            store_shared_v2_u32(
+                                arena_ptr(sacc_byte(
+                                    row, group * 32 + chunk * 8 + vec * 4
+                                )),
+                                packed_bf16[2 * vec], packed_bf16[2 * vec + 1],
+                            )
+            if elect_one():
+                arrive_mbarrier(acc_handle.empty_barrier, count=1)
+        named_barrier(id=1, threads=384)
+
+# instruction_selection: warp 0 issues
+#   `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32` with immediate
+#   512; all 13 participating warps execute `bar.sync 2,416` and retrieve the
+#   shared TMEM pointer with `ld.shared.b32`. Source 251-254,383-385; PTX-128
+#   744,749,751; PTX-2048 770,775,777.
+# instruction_selection: tokens 128/256 emit six static
+#   `tcgen05.ld.sync.aligned.32x32b.x32.b32`; tokens 2048/4096 emit 24 static
+#   `...x8.b32`. Each specialization has 96 static
+#   `cvt.rn.bf16x2.f32` sites and 48 `st.shared.v2.b32` sites; dynamically each
+#   32-column group performs 16 conversions and eight vector stores. Extent:
+#   four T2R warps x six groups per work tile. Source 388-423; PTX-128
+#   849-1223, PTX-2048 835-1245.
+# protocol_order: `wait_and_advance` clones the ACC-full handle and advances
+#   the T2R cursor before all loads; its cloned empty barrier receives release.
+# instruction_selection: each T2R warp has one elected
+#   `mbarrier.arrive.shared.b64`, totaling four ACC-empty arrivals, followed by
+#   the first `bar.sync 1,384`. Source 424-427; PTX-128 1232,1237,
+#   PTX-2048 1254,1259.
+
+# S7 =======================================================================
+# Twelve epilogue cells: BF16 load, branch-uniform YARN RoPE, column amax
+# source 429-499; PTX-128 1243-4296, PTX-2048 1265-4355
+# ==========================================================================
+        m_idx, head = scheduler_coord(work)
+        token_base = m_idx * 128
+        cell = warp
+        cb = cell // 3                 # token block 0..3
+        fc = cell % 3                  # feature cell 0..2
+        tok0 = cb * 32
+        f0 = fc * 64 + 2 * lane
+        f1 = f0 + 1
+        scale_block = fc * 2 + lane // 16
+        col_amax0 = 0.0f
+        col_amax1 = 0.0f
+
+        if fc == 2:
+            lib = lane & 15
+            side = lane >> 4
+            pcol0 = 128 + 4 * lib
+            pcol1 = pcol0 + 2
+            trig_col = 2 * lib + 32 * side
+            if side == 1:             # uniform half-warp branch
+                for r in unroll(32):
+                    p0,q0,p1,q1 = load_and_convert_shared_v4_bf16(
+                        arena_ptr(sacc_byte(tok0 + r, pcol0))
+                    )
+                    c0,c1 = load_and_convert_global_v2_bf16(
+                        cos_bf16_ptr, token_base + tok0 + r, trig_col
+                    )
+                    s0,s1 = load_and_convert_global_v2_bf16(
+                        sin_bf16_ptr, token_base + tok0 + r, trig_col
+                    )
+                    ps0,ps1 = packed_mul_f32x2((p0,p1), (s0,s1))
+                    v0,v1 = packed_fma_f32x2((q0,q1), (c0,c1), (ps0,ps1))
+                    buf0[r],buf1[r] = v0,v1
+                    col_amax0 = max(col_amax0, abs(v0))
+                    col_amax1 = max(col_amax1, abs(v1))
+            else:
+                for r in unroll(32):
+                    p0,q0,p1,q1 = load_and_convert_shared_v4_bf16(
+                        arena_ptr(sacc_byte(tok0 + r, pcol0))
+                    )
+                    c0,c1 = load_and_convert_global_v2_bf16(
+                        cos_bf16_ptr, token_base + tok0 + r, trig_col
+                    )
+                    s0,s1 = load_and_convert_global_v2_bf16(
+                        sin_bf16_ptr, token_base + tok0 + r, trig_col
+                    )
+                    pc0,pc1 = packed_mul_f32x2((p0,p1), (c0,c1))
+                    qs0,qs1 = packed_mul_f32x2((q0,q1), (s0,s1))
+                    v0,v1 = packed_fma_f32x2(
+                        (qs0,qs1), (-1.0,-1.0), (pc0,pc1)
+                    )
+                    buf0[r],buf1[r] = v0,v1
+                    col_amax0 = max(col_amax0, abs(v0))
+                    col_amax1 = max(col_amax1, abs(v1))
+        else:
+            for r in unroll(32):
+                v0,v1 = load_and_convert_shared_v2_bf16(
+                    arena_ptr(sacc_byte(tok0 + r, f0))
+                )
+                buf0[r],buf1[r] = v0,v1
+                col_amax0 = max(col_amax0, abs(v0))
+                col_amax1 = max(col_amax1, abs(v1))
+
+# instruction_selection: the two half-warp RoPE branches contribute 64 static
+#   `ld.shared.v4.b16` sites; each dynamic RoPE cell executes 32. The compiler
+#   scalarizes the two cos and two sin values into 256 static `ld.global.b16`
+#   sites (128 dynamic loads per RoPE cell), not vector global loads. The plain
+#   path has 32 static/dynamic `ld.shared.v2.b16` sites. Across both static
+#   RoPE branches and the plain path there are 576 `cvt.f32.bf16` sites. Each
+#   RoPE row then uses packed `mul.rn.f32x2` plus
+#   `fma.rn.f32x2`. Lanes 16-31 compute `p*s+q*c`; lanes 0-15 compute
+#   `p*c-q*s` with two packed multiplies and one packed FMA. Extent: 32 rows
+#   only for fc=2. Non-RoPE cells load two BF16 values per row. All paths use
+#   `abs.f32`/`max.f32` for both columns. Source 441-499; PTX-128 1250-4296,
+#   PTX-2048 1272-4355. The static export contains 160 packed multiplies and
+#   64 packed FMAs.
+
+# S8 =======================================================================
+# Column E8M0 scale and two byte stores
+# source 82-129, 500-503; PTX-128 4300-4346, PTX-2048 4359-4410
+# ==========================================================================
+        packed_col_scale = cvt_rp_satfinite_ue8m0x2_f32(
+            col_amax0 / 448.0, col_amax1 / 448.0
+        )
+        scol0 = (packed_col_scale >> 8) & 0xff
+        scol1 = packed_col_scale & 0xff
+        inv_col0 = reinterpret_f32((254 - scol0) << 23)
+        inv_col1 = reinterpret_f32((254 - scol1) << 23)
+        scol_row = m_idx * 4 + cb
+        global_store_u8(scol_u8_ptr,
+            (scol_row * NUM_HEADS + head) * 192 + f0, scol0)
+        global_store_u8(scol_u8_ptr,
+            (scol_row * NUM_HEADS + head) * 192 + f1, scol1)
+# instruction_selection: one `cvt.rp.satfinite.ue8m0x2.f32`, exact inverse
+#   bit construction using `sub.s32`/`shl.b32 23`/`mov.b32`, and two
+#   `st.global.b8`. Extent: one conversion and two column-scale stores per
+#   epilogue warp/work tile. Source 82-129,500-503; PTX ranges above.
+
+# S9 =======================================================================
+# Two-pass row scale, dual E4M3x2 packs, four outputs
+# source 82-110,132-143,504-546; PTX-128 4347-7267, PTX-2048 4411-7503
+# ==========================================================================
+        leader = (lane & 15) == 0
+        # Pass one freezes all 32 row scales before any output-code pass.
+        for r in unroll(32):
+            v0,v1 = buf0[r],buf1[r]
+            row_amax = max(abs(v0), abs(v1))
+            for delta in (8,4,2,1):
+                row_amax = max(row_amax, shfl_xor(row_amax, delta))
+            packed_row_scale = cvt_rp_satfinite_ue8m0x2_f32(
+                0.0, row_amax / 448.0
+            )
+            srow_buf[r] = packed_row_scale & 0xff
+            inv_row_buf[r] = reinterpret_f32((254 - srow_buf[r]) << 23)
+
+        # Pass two writes the leader-owned row scale and both quantizations.
+        for r in unroll(32):
+            token = token_base + tok0 + r
+            v0,v1 = buf0[r],buf1[r]
+            if leader:
+                global_store_u8(srow_u8_ptr,
+                    (token * NUM_HEADS + head) * 6 + scale_block,
+                    srow_buf[r])
+            vr0,vr1 = packed_mul_f32x2(
+                (v0,v1), (inv_row_buf[r],inv_row_buf[r]))
+            vc0,vc1 = packed_mul_f32x2(
+                (v0,v1), (inv_col0,inv_col1))
+            row_pair = cvt_rn_satfinite_e4m3x2_f32(vr1,vr0)
+            col_pair = cvt_rn_satfinite_e4m3x2_f32(vc1,vc0)
+            output_byte = (token * NUM_HEADS + head) * 192 + f0
+            global_store_u16(qrow_u8_ptr, output_byte, row_pair)
+            global_store_u16(qcol_u8_ptr, output_byte, col_pair)
+
+# instruction_selection: pass one uses `abs.f32`/`max.f32`, four
+#   `shfl.sync.bfly.b32` deltas 8/4/2/1, one E8M0 conversion, and exact inverse
+#   bits for each of 32 rows. Pass two uses leader-predicated `st.global.b8`,
+#   two packed `mul.rn.f32x2`, two
+#   `cvt.rn.satfinite.e4m3x2.f32`, and two `st.global.b16` per row. Extent: 32
+#   rows per epilogue warp/work tile; static totals are 128 shuffles, 64 E4M3
+#   conversions, 34 byte stores, and 64 u16 stores. Source 510-546;
+#   complete phase PTX-128 4347-7267; PTX-2048 4411-7503.
+
+# S10 ======================================================================
+# sACC protection, persistent advance, and TMEM release
+# source 548-554; PTX-128 7269-7303, PTX-2048 7505-7554
+# ==========================================================================
+        named_barrier(id=1, threads=384)
+        work = advance_work(work)
+
+    if warp == 0:
+        tmem_relinquish_alloc_permit_cta_group_one()
+    if warp == 0:
+        tmem_dealloc_cta_group_one(tmem_base, columns=512)
+
+# instruction_selection: the second `bar.sync 1,384` protects sACC reuse and
+#   precedes every role-local work advance. Warp 0 then issues
+#   `tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned` followed by
+#   `tcgen05.dealloc.cta_group::1.sync.aligned.b32` immediate 512. Extent: two
+#   named-barrier-1 rendezvous per work tile and one teardown per CTA. Source
+#   548-554; PTX-128 7269,7300,7303; PTX-2048 7505,7551,7554.
+```
+
+## Resource and storage summary
+
+| resource | frozen value | evidence |
+| --- | ---: | --- |
+| threads / warps | 448 / 14 | source 51-53,218-220,646; PTX `.reqntid` |
+| cluster / CTA group | `(1,1,1)` / one | source 596-600,644-648 |
+| AB / ACC stages | 3 / 2 | source 45-46,275-294 |
+| dynamic SMEM | 177792 bytes | both exports; exact bases 128/49280/123008/124544/127616 |
+| TMEM | 512 columns | source 47-50,325-366; PTX teardown immediate 512 |
+| named barrier 1 | 384 epilogue threads | PTX-128 1237,7269; PTX-2048 1259,7505 |
+| named barrier 2 | 416 MMA+epilogue threads | PTX-128 433,749; PTX-2048 450,775 |
+| TMA transaction | 40960 bytes | A 16384 + B 24576; source 271-284 |
+| T2R | four warps x six 32-column groups | source 405-423; x32 or x8 emission branch |
+| cell ownership | 12 x `(32 tokens,64 features)` | source 429-440 |
+
+No protocol interval overlaps A/B/SFA/SFB/sACC. The 196-BF16 sACC stride
+includes four padding values per row; that padding is not reusable storage.
+
+## Static module contract
+
+- The module admits only the direct E4M3/E8M0 input ABI with `K=1536`, 128
+  heads, head geometry `128+64`, and tokens 128/256/2048/4096. The wrapper
+  weight-transpose ABI is explicitly absent.
+- Correctness covers all four token counts. Required performance rows are
+  2048 and 4096, both measured against the pinned source with bench-suite.
+- `prepare_data` produces deterministic signed BF16 values, then applies the
+  upstream rowwise MXFP8 quantizer. TIRx and source share read-only inputs but
+  own independent four-output buffers. Row and column dequantized match
+  fractions must each be at least 0.95 under
+  `abs(diff) <= 0.1 + 0.1*abs(source)`.
+- The public API is `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`, `get_kernel`,
+  `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, and `run_bench`.
+  Reference import, support check, compile, and correctness are outside timing;
+  each timed closure launches the target kernel exactly once.
+
+## Instruction-selection summary
+
+| operation | required generated instruction |
+| --- | --- |
+| map warmup | `prefetch.tensormap` |
+| scale relay | `ld.global.b32`, `st.shared.v4.b32`, `bar.warp.sync`, async-shared fence |
+| AB publication | `mbarrier.arrive.expect_tx.shared.b64` with 40960 bytes |
+| A/B G2S | CTA-scope 2D TensorMap `cp.async.bulk...L2::cache_hint` |
+| scale S2T | `tcgen05.cp.cta_group::1.32x128b.warpx4` |
+| GEMM | `tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32` |
+| pipeline commit | `tcgen05.commit...mbarrier::arrive::one.shared::cluster.b64` |
+| FP32 TMEM drain | x32 below 2048 tokens, x8 at and above 2048 |
+| BF16 staging | `cvt.rn.bf16x2.f32` plus `st.shared.v2.b32` |
+| RoPE | packed `.f32x2` multiply and FMA |
+| row reduction | `shfl.sync.bfly.b32` deltas 8/4/2/1 |
+| E8M0 / E4M3 | `cvt.rp.satfinite.ue8m0x2.f32` / `cvt.rn.satfinite.e4m3x2.f32` |
+| output stores | `st.global.b8` scales and `st.global.b16` adjacent code pairs |
+| TMEM lifecycle | CTA-group-one alloc/relinquish/dealloc, 512 columns |
+
+Any implementation requiring a multidimensional shared buffer, first-class
+layout, tile primitive, embedded CUDA, `K.cuda.func_call`, change under
+`tirx_kernels/kern/`, or low-level-IR exemption violates this frozen design.
+
+## Bidirectional source / sketch / PTX map
+
+The physical sketch ranges below are stable because this table is appended
+after the complete sketch. Reading left-to-right proves every source phase has
+an explicit scalar sketch phase and an emitted anchor; reading right-to-left
+proves every critical emitted family has a source and sketch owner.
+
+| phase | source lines | sketch lines | PTX-128 | PTX-2048 |
+| --- | --- | --- | --- | --- |
+| direct ABI and E8M0 scale reinterpret | `api.py:272-419`; 186-212,652-657 | 100-117,676-691 | parameter list 14-42 | parameter list 14-42 |
+| fixed geometry, ABI, host launch | 18-71,557-649 | 86-142 | 14-42 | 14-42 |
+| arena, descriptors, TMEM | 43-54,74-80,222-228,325-366 | 143-218 | 93-119,579-678 | 93-119,596-695 |
+| roles, initialization, scheduler | 213-220,230-300 | 219-272 | 89-239 | 89-241 |
+| scale relay and A/B TMA | 147-183,301-318 | 273-351 | 249-412 | 251-429 |
+| scale S2T and block-scaled MMA | 320-379 | 352-422 | 433-725 | 450-751 |
+| TMEM allocation and T2R drain | 381-427 | 423-492 | 744-1237 | 770-1259 |
+| RoPE/plain staging and column amax | 429-499 | 493-572 | 1243-4296 | 1265-4355 |
+| column E8M0 quantization | 82-129,500-503 | 573-593 | 4300-4346 | 4359-4410 |
+| two-pass row quantization and E4M3 helpers | 82-110,132-143,504-546 | 594-637 | 4347-7267 | 4411-7503 |
+| second rendezvous and teardown | 548-554 | 638-657 | 7269-7303 | 7505-7554 |

--- a/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/bound-hoisting-by-live-range-cost.md
@@ -50,6 +50,27 @@ for chunk in T.unroll(CHUNKS):
     _publish_chunk(fragment[chunk])
 ```
 
+Likewise, when one pass produces public metadata and a derived value used by a
+single output, consume that derived value at its production point instead of
+retaining a second wide array for a later pass.
+
+```python
+# before: every derived value remains live until the second pass.
+derived = T.alloc_local((ROWS,), "float32")
+for row in T.unroll(ROWS):
+    metadata = _compute_metadata(row)
+    _publish_metadata(row, metadata)
+    derived[row] = _derive(metadata)
+for row in T.unroll(ROWS):
+    _produce_output(row, derived[row])
+
+# after: metadata publication and its dependent output share one lifetime.
+for row in T.unroll(ROWS):
+    metadata = _compute_metadata(row)
+    _publish_metadata(row, metadata)
+    _produce_output(row, _derive(metadata))
+```
+
 ## Rationale
 
 One measured FP32 bias hoist regressed 6.6%; by contrast, staging a larger load
@@ -69,6 +90,14 @@ executed instructions from 11,495 to 11,406. The two critical benchmark ratios
 moved from 0.981x/0.989x to 0.987x/0.997x; a later role-budget adjustment supplied
 the remaining margin without undoing the shorter fragment lifetime.
 
+In a multi-output epilogue, publishing a 32-element metadata array at production
+reduced stack use from 72 to 8 bytes and static local-memory instructions from 34
+to 2; two production workloads improved by 4.75% and 4.91%. Consuming the
+remaining 32-element derived array at production then reduced registers from 128
+to 102, eliminated the stack and static local-memory instructions, and improved
+the same workloads by another 1.12% and 0.88%. Correctness passed for both output
+orientations after each rewrite.
+
 ## Boundary
 
 Do not shorten a fragment lifetime across an ordering that belongs to the
@@ -82,6 +111,12 @@ State hoisted across persistent work also creates a dependency between work
 items that were previously independent. Measure both one-work CTAs, where the
 hoist can only add lifetime, and high-trip-count CTAs, where removing repeated
 tail operations has a chance to repay it.
+
+Lower resource counts do not guarantee a win on short work. The derived-array
+rewrite above made a one-work guard 24.0% slower even though it removed the
+remaining stack traffic, while the persistent production workloads improved.
+Keep short and persistent shapes in the validation matrix when changing phase
+boundaries.
 
 Do not publish earlier than the chunk's own correctness and scheduling boundary.
 Moving publication and release ahead of the chunk-local reduction reduced one

--- a/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-tuning/references/db/expose-predication-and-uniform-control.md
@@ -101,6 +101,27 @@ no spill.
   _issue_transfer(..., pred=leader)
   ```
 
+- When complementary lane groups choose between two pure arithmetic results,
+  and both results are defined for every lane, match a reference that uses
+  exact zero/one weights instead of duplicating a long unrolled body under a
+  divergent branch.
+
+  ```python
+  # before: both unrolled arithmetic bodies survive behind half-warp control.
+  with K.If(lane < HALF), K.Then():
+      result = _left_path(inputs)
+  with K.Else():
+      result = _right_path(inputs)
+
+  # after: one straight-line body selects with exact arithmetic identities.
+  right_weight = K.cast(lane // HALF, "float32")
+  left_weight = K.float32(1.0) - right_weight
+  left = _left_path(inputs)
+  right = _right_path(inputs)
+  scaled_left = _packed_mul(left, left_weight)
+  result = _packed_fma(right, right_weight, scaled_left)
+  ```
+
 ## Rationale
 
 - Replacing repeated pad checks with the `T.constexpr` specialization removed
@@ -149,6 +170,14 @@ no spill.
   copies, eight loads, and eight stores were unchanged. Two affected ratios
   moved from 0.9794 to 0.9895 and from 0.9869 to 0.9955; a neighboring multi-row
   shape stayed flat at 0.9836 to 0.9834.
+
+- A half-warp arithmetic branch around two 32-step unrolled bodies measured
+  94.53% branch efficiency against the reference's 99.96%. Replacing it with
+  the reference's exact zero/one packed blend kept 102 registers and zero stack
+  use, while static SASS fell from 2775 to 2352 instructions. Two production
+  workloads moved from 97.32/191.57 us to 92.72/186.00 us, and a one-work guard
+  moved from 21.62 to 16.77 us; all output orientations retained full numerical
+  agreement.
 
 The reference's source text does not reveal whether it wants this. nvcc
 routinely duplicates a loop around a store predicate the reference wrote per
@@ -218,9 +247,16 @@ never diverged in the first place. Check that the guard actually varies across
 the warp before rewriting it; divergent-branch counters separate the two cases
 where branch counts do not.
 
+An identity-weighted arithmetic blend is legal only when both arms are pure and
+defined for every lane. It cannot replace guarded memory accesses, barriers, or
+other side effects, and inactive-arm NaNs or infinities can defeat the zero
+weight. Preserve the reference's rounding sequence and test both lane groups.
+
 ## Verification
 
 Confirm predicate polarity and inactive-lane memory behavior, then compare BRA,
 BSYNC, reconvergence, code size, registers, and both control-flow outcomes. For
 the `T.constexpr` specialization, test both copies and compare code size,
-registers, and every affected workload.
+registers, and every affected workload. For identity-weighted arithmetic,
+confirm the long body is no longer duplicated in SASS and validate both lane
+groups with asymmetric finite inputs.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ list.
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py),
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py),
   [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py),
-  [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
+  [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py),
+  [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
 - **Grouped GEMM:**
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)

--- a/tirx_kernels/bench_suite/config/cudnn/proj_rope_mxfp8/cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/proj_rope_mxfp8/cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in.yaml
@@ -1,0 +1,6 @@
+# Complete production matrix for the cuDNN Frontend MXFP8-input projection
+# GEMM + YARN RoPE + dual-direction MXFP8 port.
+kernel: cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in
+configs:
+  - {config: t2048_k1536_h128, default: true}
+  - {config: t4096_k1536_h128, default: true}

--- a/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -1,0 +1,1041 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""MXFP8 projection GEMM with YARN RoPE and dual-direction MXFP8 outputs.
+
+Upstream source:
+``python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py``
+(``gemm_proj_rope_mxfp8_kernel`` and ``gemm_proj_rope_mxfp8_host``), reached
+through ``GemmProjRopeMxfp8Mxfp8InSm100`` in ``api.py``.
+"""
+
+import tirx_kernels.kern as K
+
+_TILE_M = 128
+_HEAD_DIM = 192
+_QK_ROPE = 64
+_BLOCK = 32
+_K_DIM = 1536
+_NUM_HEADS = 128
+_MAX_ACTIVE_CLUSTERS = 148
+_TRY_WAIT_TICKS = 10_000_000
+
+_K_TILE = 128
+_AB_STAGES = 3
+_ACC_STAGES = 2
+_SHARED_BYTES = 177_792
+_A_OFFSET = 128
+_A_STAGE_BYTES = 16_384
+_B_OFFSET = 49_280
+_B_STAGE_BYTES = 24_576
+_SFA_OFFSET = 123_008
+_SFA_STAGE_BYTES = 512
+_SFB_OFFSET = 124_544
+_SFB_STAGE_BYTES = 1_024
+_SACC_OFFSET = 127_616
+_SACC_STRIDE = 196
+_TMEM_DEALLOC_OFFSET = 80
+_TMEM_PTR_OFFSET = 88
+_TMEM_COLUMNS = 512
+_SFA_TMEM_COLUMN = 384
+_SFB_TMEM_COLUMN = 400
+_AB_DESC_BASE = 0x4000404000010000
+_SF_DESC_BASE = 0x400800010000
+_MMA_INSTR_BASE = 0x08B00000
+_TMA_G2S_2D = (
+    "cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_MMA_MXFP8 = "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32"
+
+
+def _descriptor_with_address(base, shared_address):
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), address_field)
+
+
+def _advance(state):
+    state.advance()
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _fadd2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fmul2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _ffma2(a0, a1, b0, b1, c0, c1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.fma.rn.f32x2(
+        packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1), K.cuda.make_float2(c0, c1)
+    )
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _e8m0_inverse(scale_byte):
+    bits = K.local_scalar("int32")
+    result = K.local_scalar("float32")
+    K.ptx.sub.s32(bits, K.int32(254), K.cast(scale_byte, "int32"))
+    K.ptx.shl.b32(bits, bits, K.uint32(23))
+    K.ptx.mov.b32(result, bits)
+    return result
+
+
+def _absmax(lhs, rhs):
+    absolute = K.local_scalar("float32")
+    result = K.local_scalar("float32")
+    K.ptx.abs.f32(absolute, rhs)
+    K.ptx.max.f32(result, lhs, absolute)
+    return result
+
+
+def _shuffle_xor_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(delta),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _config(label, tokens):
+    return {"label": label, "tokens": tokens, "k_dim": _K_DIM, "num_heads": _NUM_HEADS}
+
+
+KERNEL_META = {
+    "name": "cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = [
+    _config("t128_k1536_h128", 128),
+    _config("t256_k1536_h128", 256),
+    _config("t2048_k1536_h128", 2048),
+    _config("t4096_k1536_h128", 4096),
+]
+
+BENCH_CONFIGS = [dict(config) for config in CONFIGS if config["tokens"] in (2048, 4096)]
+
+
+def _validate_config(tokens, k_dim, num_heads):
+    if tokens <= 0 or tokens % _TILE_M:
+        raise ValueError(f"tokens must be a positive multiple of {_TILE_M}, got {tokens}")
+    if k_dim != _K_DIM:
+        raise ValueError(f"the verified MXFP8 projection specialization requires k_dim={_K_DIM}")
+    if num_heads != _NUM_HEADS:
+        raise ValueError(
+            f"the verified MXFP8 projection specialization requires num_heads={_NUM_HEADS}"
+        )
+
+
+def _make_kernel(tokens, k_dim, num_heads):
+    _validate_config(tokens, k_dim, num_heads)
+    total_work = (tokens // _TILE_M) * num_heads
+    num_clusters = min(total_work, _MAX_ACTIVE_CLUSTERS)
+    m_tiles = tokens // _TILE_M
+    swizzle = {128: 4, 256: 4, 2048: 16, 4096: 32}[tokens]
+    t2r_x8 = tokens >= 2048
+
+    def host_prelude(params):
+        x_code = params["x_code"]
+        w_code = params["w_code"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            a_map,
+            "float8_e4m3fn",
+            2,
+            x_code.data,
+            k_dim,
+            tokens,
+            k_dim,
+            _K_TILE,
+            _TILE_M,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            b_map,
+            "float8_e4m3fn",
+            2,
+            w_code.data,
+            k_dim,
+            num_heads * _HEAD_DIM,
+            k_dim,
+            _K_TILE,
+            _HEAD_DIM,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+        )
+        return a_map, b_map
+
+    def kernel(
+        x_code,
+        x_scale,
+        w_code,
+        w_scale,
+        cos,
+        sin,
+        out_fp8_row,
+        out_scales_row,
+        out_fp8_col,
+        out_scales_col,
+        *,
+        host,
+    ):
+        # TIRX_PORT_START: gemm_proj_rope_mxfp8_mxfp8in_kernel
+        del x_code, w_code
+        a_map, b_map = host
+        _block_x, _block_y, cluster_work_id = K.cta_id()
+        del _block_x, _block_y
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=list(range(12)))
+        mma_role = roles.role("mma", warps=[12])
+        tma_role = roles.role("tma", warps=[13])
+
+        smem = K.alloc_buffer((_SHARED_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool,
+            _AB_STAGES,
+            full="tma",
+            empty="tcgen05",
+            init_empty=1,
+            leader=K.bool(False),
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            _ACC_STAGES,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=4,
+            leader=K.bool(False),
+        )
+        if protocol_pool.bytes != _TMEM_DEALLOC_OFFSET:
+            raise AssertionError("pipeline protocol layout changed")
+        protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.bytes != _TMEM_PTR_OFFSET + 4:
+            raise AssertionError("TMEM protocol layout changed")
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+
+        # Initialize AB then ACC exactly at the two source publication edges.
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, _AB_STAGES) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, _AB_STAGES) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(1)
+                            )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.sync(K.uint32(0), K.uint32(448))
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, _ACC_STAGES) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, _ACC_STAGES) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(4)
+                            )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.sync(K.uint32(0), K.uint32(448))
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(_AB_DESC_BASE, smem_base + _A_OFFSET)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(_AB_DESC_BASE, smem_base + _B_OFFSET)
+        )
+        sfa_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(_SF_DESC_BASE, smem_base + _SFA_OFFSET)
+        )
+        sfb_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(_SF_DESC_BASE, smem_base + _SFB_OFFSET)
+        )
+
+        def scheduler_coords(work):
+            head_minor = work % swizzle
+            quotient = work // swizzle
+            m_idx = quotient % m_tiles
+            head_major = quotient // m_tiles
+            return m_idx, head_major * swizzle + head_minor
+
+        def advance_work(work):
+            K.assign(work, work + num_clusters)
+
+        # CuTe expresses the same 13-warp TMEM allocation rendezvous at two
+        # branch-local PCs. One physical PC preserves its participants/count and
+        # avoids divergent named-barrier diagnostics under synccheck.
+        with K.If(warp < K.uint32(13)):
+            with K.Then():
+                with K.If(warp == 0):
+                    with K.Then():
+                        K.ptx["tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"](
+                            tmem_slot.ptr_to([0]), K.uint32(_TMEM_COLUMNS)
+                        )
+                K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+
+        with tma_role:
+            tma_state = K.PipelineState(_AB_STAGES, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            sfa_words = K.alloc_local((4,), "uint32")
+            sfb_words = K.alloc_local((8,), "uint32")
+            with K.While(work < total_work):
+                m_idx, head = scheduler_coords(work)
+                with K.serial(k_dim // _K_TILE) as k_tile:
+                    handle_stage = K.local_scalar("int32", init=tma_state.stage)
+                    handle_phase = K.local_scalar("int32", init=tma_state.phase)
+                    _wait_plain(ab_pipe.empty.ptr_to([handle_stage]), handle_phase)
+                    _advance(tma_state)
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                ab_pipe.full.ptr_to([handle_stage]), K.uint32(40_960)
+                            )
+
+                    scale_word = k_tile * 4
+                    sfa_row = m_idx * _TILE_M + lane
+                    for row_block in range(4):
+                        scale_offset = (sfa_row + row_block * 32) * (k_dim // _BLOCK)
+                        K.ptx.ld.global_.b32(
+                            sfa_words[row_block], x_scale.ptr_to([scale_offset + scale_word])
+                        )
+                    K.ptx.st.shared.v4.b32(
+                        smem.ptr_to([_SFA_OFFSET + handle_stage * _SFA_STAGE_BYTES + lane * 16]),
+                        sfa_words[0],
+                        sfa_words[1],
+                        sfa_words[2],
+                        sfa_words[3],
+                    )
+
+                    sfb_row = head * _HEAD_DIM - (head % 2) * _QK_ROPE + lane
+                    for row_block in range(8):
+                        scale_offset = (sfb_row + row_block * 32) * (k_dim // _BLOCK)
+                        K.ptx.ld.global_.b32(
+                            sfb_words[row_block], w_scale.ptr_to([scale_offset + scale_word])
+                        )
+                    K.ptx.st.shared.v4.b32(
+                        smem.ptr_to([_SFB_OFFSET + handle_stage * _SFB_STAGE_BYTES + lane * 16]),
+                        sfb_words[0],
+                        sfb_words[1],
+                        sfb_words[2],
+                        sfb_words[3],
+                    )
+                    K.ptx.st.shared.v4.b32(
+                        smem.ptr_to(
+                            [_SFB_OFFSET + handle_stage * _SFB_STAGE_BYTES + 512 + lane * 16]
+                        ),
+                        sfb_words[4],
+                        sfb_words[5],
+                        sfb_words[6],
+                        sfb_words[7],
+                    )
+                    K.ptx.bar.warp.sync(K.uint32(0xFFFFFFFF))
+                    K.ptx["fence.proxy.async.shared::cta"]()
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx[_TMA_G2S_2D](
+                                smem_base + _A_OFFSET + handle_stage * _A_STAGE_BYTES,
+                                K.address_of(a_map),
+                                K.cast(k_tile * _K_TILE, "int32"),
+                                K.cast(m_idx * _TILE_M, "int32"),
+                                ab_pipe.full.ptr_to([handle_stage]),
+                                K.uint64(0),
+                            )
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx[_TMA_G2S_2D](
+                                smem_base + _B_OFFSET + handle_stage * _B_STAGE_BYTES,
+                                K.address_of(b_map),
+                                K.cast(k_tile * _K_TILE, "int32"),
+                                K.cast(head * _HEAD_DIM, "int32"),
+                                ab_pipe.full.ptr_to([handle_stage]),
+                                K.uint64(0),
+                            )
+                advance_work(work)
+            for _ in range(_AB_STAGES):
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+
+        with mma_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            mma_state = K.PipelineState(_AB_STAGES, phase=0)
+            acc_state = K.PipelineState(_ACC_STAGES, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            accumulate = K.local_scalar("uint32")
+            with K.While(work < total_work):
+                acc_stage = K.local_scalar("int32", init=acc_state.stage)
+                acc_phase = K.local_scalar("int32", init=acc_state.phase)
+                _wait_plain(acc_pipe.empty.ptr_to([acc_stage]), acc_phase)
+                _advance(acc_state)
+                _m_idx, head = scheduler_coords(work)
+                del _m_idx
+                sfb_mma_base = K.local_scalar(
+                    "uint32", init=tmem_base + _SFB_TMEM_COLUMN + (head % 2) * 2
+                )
+                K.assign(accumulate, K.uint32(0))
+                with K.serial(k_dim // _K_TILE) as _k_tile:
+                    handle_stage = K.local_scalar("int32", init=mma_state.stage)
+                    handle_phase = K.local_scalar("int32", init=mma_state.phase)
+                    _wait_plain(ab_pipe.full.ptr_to([handle_stage]), handle_phase)
+                    _advance(mma_state)
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](
+                                K.cast(tmem_base + _SFA_TMEM_COLUMN, "uint32"),
+                                sfa_descriptor
+                                + K.cast(handle_stage * (_SFA_STAGE_BYTES // 16), "uint64"),
+                            )
+                    for half in range(2):
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx["tcgen05.cp.cta_group::1.32x128b.warpx4"](
+                                    K.cast(tmem_base + _SFB_TMEM_COLUMN + half * 4, "uint32"),
+                                    sfb_descriptor
+                                    + K.cast(
+                                        handle_stage * (_SFB_STAGE_BYTES // 16) + half * 32,
+                                        "uint64",
+                                    ),
+                                )
+                    for kphase in range(4):
+                        selector = K.uint32(kphase * 0x40000000)
+                        sfa_tmem_addr = K.cast(tmem_base + _SFA_TMEM_COLUMN + selector, "uint32")
+                        sfb_tmem_addr = K.cast(sfb_mma_base + selector, "uint32")
+                        runtime_instr_desc = K.bitwise_and(
+                            K.uint32(_MMA_INSTR_BASE), K.uint32(0x9FFFFFCF)
+                        )
+                        runtime_instr_desc = K.bitwise_or(
+                            runtime_instr_desc,
+                            K.bitwise_and(
+                                K.shift_right(sfa_tmem_addr, K.uint32(1)), K.uint32(0x60000000)
+                            ),
+                        )
+                        runtime_instr_desc = K.bitwise_or(
+                            runtime_instr_desc,
+                            K.bitwise_and(
+                                K.shift_right(sfb_tmem_addr, K.uint32(26)), K.uint32(0x30)
+                            ),
+                        )
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx[_MMA_MXFP8](
+                                    K.cast(tmem_base + acc_stage * _HEAD_DIM, "uint32"),
+                                    a_descriptor
+                                    + K.cast(
+                                        handle_stage * (_A_STAGE_BYTES // 16) + kphase * 2, "uint64"
+                                    ),
+                                    b_descriptor
+                                    + K.cast(
+                                        handle_stage * (_B_STAGE_BYTES // 16) + kphase * 2, "uint64"
+                                    ),
+                                    runtime_instr_desc,
+                                    sfa_tmem_addr,
+                                    sfb_tmem_addr,
+                                    K.ptx.pred(K.cast(accumulate, "bool")),
+                                )
+                        K.assign(accumulate, K.uint32(1))
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx[
+                                "tcgen05.commit.cta_group::1.mbarrier::arrive::one."
+                                "shared::cluster.b64"
+                            ](ab_pipe.empty.ptr_to([handle_stage]))
+                with K.If(_elected()):
+                    with K.Then():
+                        K.ptx[
+                            "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+                        ](acc_pipe.full.ptr_to([acc_stage]))
+                advance_work(work)
+            _advance(acc_state)
+            _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        with epilogue_role:
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            acc_state = K.PipelineState(_ACC_STAGES, phase=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            values0 = K.alloc_local((_BLOCK,), "float32")
+            values1 = K.alloc_local((_BLOCK,), "float32")
+            drain_count = 8 if t2r_x8 else 32
+            drain = K.alloc_local((drain_count,), "float32")
+            staged_words = K.alloc_local((drain_count // 2,), "uint32")
+
+            with K.While(work < total_work):
+                m_idx, head = scheduler_coords(work)
+                token_base = m_idx * _TILE_M
+                with K.If(warp < 4):
+                    with K.Then():
+                        acc_stage = K.local_scalar("int32", init=acc_state.stage)
+                        acc_phase = K.local_scalar("int32", init=acc_state.phase)
+                        _wait_plain(acc_pipe.full.ptr_to([acc_stage]), acc_phase)
+                        _advance(acc_state)
+                        row = warp * 32 + lane
+                        if t2r_x8:
+                            for group in range(6):
+                                for chunk in range(4):
+                                    tmem_address = K.cast(
+                                        tmem_base
+                                        + (warp << 21)
+                                        + acc_stage * _HEAD_DIM
+                                        + group * 32
+                                        + chunk * 8,
+                                        "uint32",
+                                    )
+                                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x8.b32"](
+                                        *[drain[index] for index in range(8)], tmem_address
+                                    )
+                                    for pair in range(4):
+                                        K.ptx.cvt.rn.bf16x2.f32(
+                                            staged_words[pair], drain[pair * 2 + 1], drain[pair * 2]
+                                        )
+                                    row_byte = _SACC_OFFSET + 2 * (
+                                        row * _SACC_STRIDE + group * 32 + chunk * 8
+                                    )
+                                    for vector in range(2):
+                                        K.ptx.st.shared.v2.b32(
+                                            smem.ptr_to([row_byte + vector * 8]),
+                                            staged_words[vector * 2],
+                                            staged_words[vector * 2 + 1],
+                                        )
+                        else:
+                            for group in range(6):
+                                tmem_address = K.cast(
+                                    tmem_base + (warp << 21) + acc_stage * _HEAD_DIM + group * 32,
+                                    "uint32",
+                                )
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[drain[index] for index in range(32)], tmem_address
+                                )
+                                for pair in range(16):
+                                    K.ptx.cvt.rn.bf16x2.f32(
+                                        staged_words[pair], drain[pair * 2 + 1], drain[pair * 2]
+                                    )
+                                row_byte = _SACC_OFFSET + 2 * (row * _SACC_STRIDE + group * 32)
+                                for vector in range(8):
+                                    K.ptx.st.shared.v2.b32(
+                                        smem.ptr_to([row_byte + vector * 8]),
+                                        staged_words[vector * 2],
+                                        staged_words[vector * 2 + 1],
+                                    )
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx.mbarrier.arrive.shared.b64(
+                                    acc_pipe.empty.ptr_to([acc_stage]), K.uint32(1)
+                                )
+
+                K.ptx.bar.sync(K.uint32(1), K.uint32(384))
+                cb = warp // 3
+                fc = warp % 3
+                tok0 = cb * _BLOCK
+                f0 = fc * 64 + lane * 2
+                col_amax0 = K.local_scalar("float32", init=K.float32(0.0))
+                col_amax1 = K.local_scalar("float32", init=K.float32(0.0))
+
+                with K.If(fc == 2):
+                    with K.Then():
+                        lib = lane % 16
+                        pcol0 = 128 + 4 * lib
+                        roff = 32 * (lane // 16)
+                        rf = K.cast(lane // 16, "float32")
+                        lf = K.float32(1.0) - rf
+                        cidx0 = 2 * lib + roff
+                        for row_index in range(_BLOCK):
+                            shared_byte = _SACC_OFFSET + 2 * (
+                                (tok0 + row_index) * _SACC_STRIDE + pcol0
+                            )
+                            p0_b16 = K.local_scalar("uint16")
+                            q0_b16 = K.local_scalar("uint16")
+                            p1_b16 = K.local_scalar("uint16")
+                            q1_b16 = K.local_scalar("uint16")
+                            K.ptx.ld.shared.v4.b16(
+                                p0_b16, q0_b16, p1_b16, q1_b16, smem.ptr_to([shared_byte])
+                            )
+                            p0 = K.local_scalar("float32")
+                            q0 = K.local_scalar("float32")
+                            p1 = K.local_scalar("float32")
+                            q1 = K.local_scalar("float32")
+                            K.ptx.cvt.f32.bf16(p0, p0_b16)
+                            K.ptx.cvt.f32.bf16(q0, q0_b16)
+                            K.ptx.cvt.f32.bf16(p1, p1_b16)
+                            K.ptx.cvt.f32.bf16(q1, q1_b16)
+                            cos0_b16 = K.local_scalar("uint16")
+                            cos1_b16 = K.local_scalar("uint16")
+                            sin0_b16 = K.local_scalar("uint16")
+                            sin1_b16 = K.local_scalar("uint16")
+                            trig_offset = (token_base + tok0 + row_index) * _QK_ROPE + cidx0
+                            K.ptx.ld.global_.b16(cos0_b16, cos.ptr_to([trig_offset]))
+                            K.ptx.ld.global_.b16(cos1_b16, cos.ptr_to([trig_offset + 1]))
+                            K.ptx.ld.global_.b16(sin0_b16, sin.ptr_to([trig_offset]))
+                            K.ptx.ld.global_.b16(sin1_b16, sin.ptr_to([trig_offset + 1]))
+                            c0 = K.local_scalar("float32")
+                            c1 = K.local_scalar("float32")
+                            s0 = K.local_scalar("float32")
+                            s1 = K.local_scalar("float32")
+                            K.ptx.cvt.f32.bf16(c0, cos0_b16)
+                            K.ptx.cvt.f32.bf16(c1, cos1_b16)
+                            K.ptx.cvt.f32.bf16(s0, sin0_b16)
+                            K.ptx.cvt.f32.bf16(s1, sin1_b16)
+                            pc0, pc1 = _fmul2(p0, p1, c0, c1)
+                            qs0, qs1 = _fmul2(q0, q1, s0, s1)
+                            lft0, lft1 = _ffma2(
+                                qs0, qs1, K.float32(-1.0), K.float32(-1.0), pc0, pc1
+                            )
+                            ps0, ps1 = _fmul2(p0, p1, s0, s1)
+                            qc0, qc1 = _fmul2(q0, q1, c0, c1)
+                            rgt0, rgt1 = _fadd2(ps0, ps1, qc0, qc1)
+                            ll0, ll1 = _fmul2(lft0, lft1, lf, lf)
+                            v0, v1 = _ffma2(rgt0, rgt1, rf, rf, ll0, ll1)
+                            K.assign(values0[row_index], v0)
+                            K.assign(values1[row_index], v1)
+                            K.assign(col_amax0, _absmax(col_amax0, v0))
+                            K.assign(col_amax1, _absmax(col_amax1, v1))
+                    with K.Else():
+                        for row_index in range(_BLOCK):
+                            shared_byte = _SACC_OFFSET + 2 * (
+                                (tok0 + row_index) * _SACC_STRIDE + f0
+                            )
+                            v0_b16 = K.local_scalar("uint16")
+                            v1_b16 = K.local_scalar("uint16")
+                            K.ptx.ld.shared.v2.b16(v0_b16, v1_b16, smem.ptr_to([shared_byte]))
+                            v0 = K.local_scalar("float32")
+                            v1 = K.local_scalar("float32")
+                            K.ptx.cvt.f32.bf16(v0, v0_b16)
+                            K.ptx.cvt.f32.bf16(v1, v1_b16)
+                            K.assign(values0[row_index], v0)
+                            K.assign(values1[row_index], v1)
+                            K.assign(col_amax0, _absmax(col_amax0, v0))
+                            K.assign(col_amax1, _absmax(col_amax1, v1))
+
+                col_scale_pair = K.local_scalar("uint16")
+                K.ptx.cvt.rp.satfinite.ue8m0x2.f32(
+                    col_scale_pair,
+                    col_amax0 * K.float32(1.0 / 448.0),
+                    col_amax1 * K.float32(1.0 / 448.0),
+                )
+                col_scale0 = K.cast(
+                    K.shift_right(K.cast(col_scale_pair, "uint32"), K.uint32(8)), "uint8"
+                )
+                col_scale1 = K.cast(
+                    K.bitwise_and(K.cast(col_scale_pair, "uint32"), K.uint32(0xFF)), "uint8"
+                )
+                inv_col0 = _e8m0_inverse(col_scale0)
+                inv_col1 = _e8m0_inverse(col_scale1)
+                col_scale_base = ((m_idx * 4 + cb) * num_heads + head) * _HEAD_DIM + f0
+                K.ptx.st.global_.b8(out_scales_col.ptr_to([col_scale_base]), col_scale0)
+                K.ptx.st.global_.b8(out_scales_col.ptr_to([col_scale_base + 1]), col_scale1)
+
+                row_block = fc * 2 + lane // 16
+                for row_index in range(_BLOCK):
+                    v0 = values0[row_index]
+                    v1 = values1[row_index]
+                    absolute0 = K.local_scalar("float32")
+                    absolute1 = K.local_scalar("float32")
+                    row_amax = K.local_scalar("float32")
+                    K.ptx.abs.f32(absolute0, v0)
+                    K.ptx.abs.f32(absolute1, v1)
+                    K.ptx.max.f32(row_amax, absolute0, absolute1)
+                    for delta in (8, 4, 2, 1):
+                        other = _shuffle_xor_f32(row_amax, delta)
+                        K.ptx.max.f32(row_amax, row_amax, other)
+                    row_scale_pair = K.local_scalar("uint16")
+                    K.ptx.cvt.rp.satfinite.ue8m0x2.f32(
+                        row_scale_pair, K.float32(0.0), row_amax * K.float32(1.0 / 448.0)
+                    )
+                    row_scale = K.cast(
+                        K.bitwise_and(K.cast(row_scale_pair, "uint32"), K.uint32(0xFF)), "uint32"
+                    )
+                    token = token_base + tok0 + row_index
+                    with K.If((lane % 16) == 0):
+                        with K.Then():
+                            row_scale_offset = (token * num_heads + head) * (
+                                _HEAD_DIM // _BLOCK
+                            ) + row_block
+                            K.ptx.st.global_.b8(
+                                out_scales_row.ptr_to([row_scale_offset]),
+                                K.cast(row_scale, "uint8"),
+                            )
+                    inv_row = _e8m0_inverse(row_scale)
+                    vr0, vr1 = _fmul2(v0, v1, inv_row, inv_row)
+                    row_pair = K.local_scalar("uint16")
+                    K.ptx.cvt.rn.satfinite.e4m3x2.f32(row_pair, vr1, vr0)
+                    output_offset = (token * num_heads + head) * _HEAD_DIM + f0
+                    K.ptx.st.global_.b16(out_fp8_row.ptr_to([output_offset]), row_pair)
+
+                for row_index in range(_BLOCK):
+                    token = token_base + tok0 + row_index
+                    v0 = values0[row_index]
+                    v1 = values1[row_index]
+                    vc0, vc1 = _fmul2(v0, v1, inv_col0, inv_col1)
+                    col_pair = K.local_scalar("uint16")
+                    K.ptx.cvt.rn.satfinite.e4m3x2.f32(col_pair, vc1, vc0)
+                    output_offset = (token * num_heads + head) * _HEAD_DIM + f0
+                    K.ptx.st.global_.b16(out_fp8_col.ptr_to([output_offset]), col_pair)
+
+                K.ptx.bar.sync(K.uint32(1), K.uint32(384))
+                advance_work(work)
+
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx["tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"]()
+                    K.ptx["tcgen05.dealloc.cta_group::1.sync.aligned.b32"](
+                        tmem_base, K.uint32(_TMEM_COLUMNS)
+                    )
+
+    kernel.__annotations__ = {
+        "x_code": K.gptr[K.u8, (tokens * k_dim,)],
+        "x_scale": K.gptr[K.u8, (tokens * (k_dim // _BLOCK),)],
+        "w_code": K.gptr[K.u8, (num_heads * _HEAD_DIM * k_dim,)],
+        "w_scale": K.gptr[K.u8, (num_heads * _HEAD_DIM * (k_dim // _BLOCK),)],
+        "cos": K.gptr[K.bf16, (tokens * _QK_ROPE,)],
+        "sin": K.gptr[K.bf16, (tokens * _QK_ROPE,)],
+        "out_fp8_row": K.gptr[K.u8, (tokens * num_heads * _HEAD_DIM,)],
+        "out_scales_row": K.gptr[K.u8, (tokens * num_heads * (_HEAD_DIM // _BLOCK),)],
+        "out_fp8_col": K.gptr[K.u8, (tokens * num_heads * _HEAD_DIM,)],
+        "out_scales_col": K.gptr[K.u8, ((tokens // _BLOCK) * num_heads * _HEAD_DIM,)],
+    }
+    return K.kernel(warps=14, arch="sm_100a", grid=[1, 1, num_clusters], host_prelude=host_prelude)(
+        kernel
+    )
+
+
+def get_kernel(tokens, k_dim, num_heads):
+    return _make_kernel(tokens, k_dim, num_heads).func
+
+
+def _quantize_mxfp8(torch, values):
+    rows, k_dim = values.shape
+    blocks = values.float().reshape(rows, k_dim // _BLOCK, _BLOCK)
+    amax = blocks.abs().amax(dim=-1, keepdim=True).clamp(min=1e-30)
+    exponent = torch.ceil(torch.log2(amax / 448.0)).clamp(-127.0, 127.0)
+    code = (
+        (blocks * torch.pow(2.0, -exponent))
+        .clamp(-448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+        .reshape(rows, k_dim)
+    )
+    scale = (exponent.squeeze(-1) + 127.0).to(torch.uint8)
+    return code, scale
+
+
+def _dequantize_input(torch, code, scale):
+    rows, k_dim = code.shape
+    decoded = torch.pow(2.0, scale.float() - 127.0).unsqueeze(-1)
+    return (code.float().reshape(rows, k_dim // _BLOCK, _BLOCK) * decoded).reshape(rows, k_dim)
+
+
+def prepare_data(tokens, k_dim, num_heads):
+    """Allocate deterministic MXFP8 inputs and independent mutable outputs."""
+    _validate_config(tokens, k_dim, num_heads)
+    import torch
+
+    torch.manual_seed(0)
+    x_bf16 = torch.randn(tokens, k_dim, dtype=torch.bfloat16, device="cuda") * 0.5
+    w_bf16 = torch.randn(num_heads * _HEAD_DIM, k_dim, dtype=torch.bfloat16, device="cuda") * 0.02
+    x_code, x_scale = _quantize_mxfp8(torch, x_bf16)
+    w_code, w_scale = _quantize_mxfp8(torch, w_bf16)
+    cos = torch.randn(tokens, _QK_ROPE, dtype=torch.bfloat16, device="cuda")
+    sin = torch.randn(tokens, _QK_ROPE, dtype=torch.bfloat16, device="cuda")
+
+    def outputs():
+        return {
+            "out_fp8_row": torch.empty(
+                tokens, num_heads, _HEAD_DIM, dtype=torch.float8_e4m3fn, device="cuda"
+            ),
+            "out_scales_row": torch.empty(
+                tokens, num_heads, _HEAD_DIM // _BLOCK, dtype=torch.uint8, device="cuda"
+            ),
+            "out_fp8_col": torch.empty(
+                tokens, num_heads, _HEAD_DIM, dtype=torch.float8_e4m3fn, device="cuda"
+            ),
+            "out_scales_col": torch.empty(
+                tokens // _BLOCK, num_heads, _HEAD_DIM, dtype=torch.uint8, device="cuda"
+            ),
+        }
+
+    return {
+        "x_code": x_code,
+        "x_scale": x_scale,
+        "w_code": w_code,
+        "w_scale": w_scale,
+        "x_dequant_bf16": _dequantize_input(torch, x_code, x_scale).to(torch.bfloat16),
+        "w_dequant_bf16": _dequantize_input(torch, w_code, w_scale).to(torch.bfloat16),
+        "cos": cos,
+        "sin": sin,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _tirx_launch(executable, data):
+    import torch
+
+    output = data["tirx"]
+    arguments = (
+        data["x_code"].view(torch.uint8).reshape(-1),
+        data["x_scale"].reshape(-1),
+        data["w_code"].view(torch.uint8).reshape(-1),
+        data["w_scale"].reshape(-1),
+        data["cos"].reshape(-1),
+        data["sin"].reshape(-1),
+        output["out_fp8_row"].view(torch.uint8).reshape(-1),
+        output["out_scales_row"].reshape(-1),
+        output["out_fp8_col"].view(torch.uint8).reshape(-1),
+        output["out_scales_col"].reshape(-1),
+    )
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _compile_reference(data, config):
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    module = load_reference_module("cudnn.gemm.cutedsl.dense.proj_rope_mxfp8.api")
+    output = data["source"]
+    op = module.GemmProjRopeMxfp8Mxfp8InSm100(
+        data["x_code"],
+        data["x_scale"],
+        data["w_code"],
+        data["w_scale"],
+        data["cos"],
+        data["sin"],
+        output["out_fp8_row"],
+        output["out_scales_row"],
+        output["out_fp8_col"],
+        output["out_scales_col"],
+    )
+    if not op.check_support():
+        raise RuntimeError(f"pinned source rejected {config}")
+    op.compile()
+
+    def launch():
+        op.execute(
+            data["x_code"],
+            data["x_scale"],
+            data["w_code"],
+            data["w_scale"],
+            data["cos"],
+            data["sin"],
+            output["out_fp8_row"],
+            output["out_scales_row"],
+            output["out_fp8_col"],
+            output["out_scales_col"],
+        )
+
+    launch._keep_alive = (op, output)
+    return launch
+
+
+def _dequantize_row(torch, data, scale):
+    tokens, num_heads, _ = data.shape
+    decoded = torch.pow(2.0, scale.float() - 127.0).unsqueeze(-1)
+    return (data.float().reshape(tokens, num_heads, _HEAD_DIM // _BLOCK, _BLOCK) * decoded).reshape(
+        tokens, num_heads, _HEAD_DIM
+    )
+
+
+def _dequantize_col(torch, data, scale):
+    tokens, num_heads, _ = data.shape
+    decoded = torch.pow(2.0, scale.float() - 127.0).reshape(
+        tokens // _BLOCK, 1, num_heads, _HEAD_DIM
+    )
+    return (data.float().reshape(tokens // _BLOCK, _BLOCK, num_heads, _HEAD_DIM) * decoded).reshape(
+        tokens, num_heads, _HEAD_DIM
+    )
+
+
+def _match_fraction(torch, actual, expected):
+    difference = (actual.float() - expected.float()).abs()
+    return float((difference <= 0.1 + 0.1 * expected.float().abs()).float().mean().item())
+
+
+def _validate_outputs(data):
+    import torch
+
+    tirx = data["tirx"]
+    source = data["source"]
+    row_match = _match_fraction(
+        torch,
+        _dequantize_row(torch, tirx["out_fp8_row"], tirx["out_scales_row"]),
+        _dequantize_row(torch, source["out_fp8_row"], source["out_scales_row"]),
+    )
+    col_match = _match_fraction(
+        torch,
+        _dequantize_col(torch, tirx["out_fp8_col"], tirx["out_scales_col"]),
+        _dequantize_col(torch, source["out_fp8_col"], source["out_scales_col"]),
+    )
+    if row_match < 0.95 or col_match < 0.95:
+        raise AssertionError(
+            f"TIRx versus pinned source mismatch: row_match={row_match}, "
+            f"col_match={col_match}; required >=0.95"
+        )
+    return {"row_match": row_match, "col_match": col_match}
+
+
+def run_test(**config):
+    """Compile, run, and compare one specialization with the pinned source."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _tirx_launch(compile_kernel(get_kernel(**kernel_config)), data)
+    source_launch = _compile_reference(data, kernel_config)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    return _validate_outputs(data)
+
+
+def prepare_bench(**config):
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {"config": kernel_config, "executable": compile_kernel(get_kernel(**kernel_config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then time closures containing exactly one kernel launch."""
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _compile_reference(data, config)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"cudnn_frontend": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- Port the cuDNN Frontend SM100 MXFP8-input projection GEMM with YARN RoPE and row/column MXFP8 outputs to the pure K API.
- Add the canonical kernel sketch, four correctness configurations, two default production benchmark workloads, and the README registry entry.
- Record measured codegen guidance for bounding epilogue live ranges and replacing a duplicated half-warp arithmetic branch with the source-aligned packed zero/one blend.

The upstream source is pinned to NVIDIA/cudnn-frontend commit aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.

## Validation

- Correctness against the pinned source: tokens 128, 256, 2048, and 4096 all report row match 1.0 and column match 1.0.
- Low-level IR: all four configurations pass; zero function calls, no tile primitives or first-class layouts, and one rank-1 u8 shared-memory arena.
- Compute Sanitizer: memcheck and synccheck report zero errors for tokens 128, 256, and 2048.
- Integration: bench-suite import check, license-header check and self-test, and pre-commit all pass.

Final main-tree benchmark, proton timer, 25 ms warmup, 100 ms repeat, five rounds, arithmetic mean:

| Config | TIRx (us) | cuDNN Frontend (us) | Reference / TIRx |
|---|---:|---:|---:|
| t2048_k1536_h128 | 92.911 | 96.304 | 1.0365 |
| t4096_k1536_h128 | 187.822 | 193.362 | 1.0295 |

The complete first 4096 attempt was discarded after interference detection; all reported 4096 samples come from the clean second attempt without sample splicing.

## Codegen note

The backend emits .maxntid 448 rather than the reference PTX's .reqntid 448,1,1. The public specialization and host launch remain fixed at 448 threads, and correctness plus memcheck/synccheck pass on every covered scheduler branch.
