### PR TITLE
feat(kern): attach Python source spans

### DIFF
--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -180,3 +180,49 @@ def test_retired_cuda_value_members_are_rejected_with_guidance():
             getattr(K.cuda, name)
     K.cuda.elect_sync  # exempt: pred= idiom
     K.cuda.make_float2  # exempt: pure computation
+
+
+def test_kernel_records_python_source_spans():
+    import inspect
+    import linecache
+
+    def emit(out):
+        K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(0))
+
+    @K.kernel(warps=1, arch="sm_100a", grid=False)
+    def probe(out: K.gptr(K.f32)):
+        K.ptx.st.global_.f32(out.ptr_to([1]), K.float32(1))
+        emit(out)
+
+    assert probe.func.span is not None
+    assert probe.func.span.source_name.name == inspect.getsourcefile(emit)
+    assert "@K.kernel" in linecache.getline(
+        probe.func.span.source_name.name, probe.func.span.line
+    )
+
+    statements = probe.func.body.body.seq
+    stores = [stmt for stmt in statements if type(stmt).__name__ == "Evaluate"]
+    assert len(stores) == 2
+    source_lines = []
+    for store in stores:
+        assert store.span is not None
+        assert store.span.source_name.name == inspect.getsourcefile(emit)
+        assert store.value.span.same_as(store.span)
+        source_lines.append(linecache.getline(store.span.source_name.name, store.span.line))
+    assert "out.ptr_to([1])" in source_lines[0]
+    assert "out.ptr_to([0])" in source_lines[1]
+
+
+def test_kernel_source_span_tracer_is_restored_after_failure():
+    import sys
+
+    import pytest
+
+    previous_trace = sys.gettrace()
+    with pytest.raises(RuntimeError, match="trace failed"):
+
+        @K.kernel(warps=1, arch="sm_100a", grid=False)
+        def probe(out: K.gptr(K.f32)):
+            raise RuntimeError("trace failed")
+
+    assert sys.gettrace() is previous_trace

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -182,6 +182,11 @@ def test_retired_cuda_value_members_are_rejected_with_guidance():
     K.cuda.make_float2  # exempt: pure computation
 
 
+def test_value_constructors_work_outside_kernel_trace():
+    value = K.uint64(0)
+    assert str(value.ty.dtype) == "uint64"
+
+
 def test_kernel_records_python_source_spans():
     import inspect
     import linecache

--- a/tirx_kernels/kern/README.md
+++ b/tirx_kernels/kern/README.md
@@ -35,6 +35,9 @@ def zero(out: K.gptr(K.f32)):
 - Every kernel is checked against the low-level IR contract when it is traced.
   Keep the default `check_ir=True`. `allowed_func_calls` is only for a task that
   explicitly owns a named runtime-call exception.
+- Statements and instruction calls traced from file-backed Python code carry
+  TIRx source spans pointing to the kernel or helper line that emitted them;
+  the resulting `PrimFunc` points to the `@K.kernel` declaration.
 
 You can learn Kern APIs and complete implementation patterns from the canonical
 modules under `tirx_kernels/`. Do not copy API spellings from historical TIRx

--- a/tirx_kernels/kern/__init__.py
+++ b/tirx_kernels/kern/__init__.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import tvm
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
 from tvm.script import tirx as _T
+from tvm.script.ir_builder import IRBuilder
 from tvm.tirx.script.builder import ir as _I
 
 from . import idioms
@@ -206,6 +207,8 @@ class _StmtProxy:
         if _cp_async_needs_src_size(obj, args):
             raise TypeError(f"{obj!r}: missing the trailing src-size operand.\n\n{_CP_ASYNC_HELP}")
         result = obj(*args, **kwargs)
+        if isinstance(result, tvm.ir.Expr):
+            result = IRBuilder.current()._set_current_source_span(result)
         if _is_void_call(result):
             _T.evaluate(result)
             return None

--- a/tirx_kernels/kern/__init__.py
+++ b/tirx_kernels/kern/__init__.py
@@ -47,6 +47,7 @@ from tvm.tirx.script.builder import ir as _I
 
 from . import idioms
 from .entry import Kernel, TensorMap, cta_id, gptr, kernel, lane_id, thread_id, warp_id
+from .entry import current as _current_session
 from .smem import (
     KDesc,
     KStep,
@@ -207,7 +208,7 @@ class _StmtProxy:
         if _cp_async_needs_src_size(obj, args):
             raise TypeError(f"{obj!r}: missing the trailing src-size operand.\n\n{_CP_ASYNC_HELP}")
         result = obj(*args, **kwargs)
-        if isinstance(result, tvm.ir.Expr):
+        if isinstance(result, tvm.ir.Expr) and _current_session(required=False) is not None:
             result = IRBuilder.current()._set_current_source_span(result)
         if _is_void_call(result):
             _T.evaluate(result)

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -10,11 +10,16 @@ nothing goes through the TVMScript parser.
 from __future__ import annotations
 
 import inspect
+import linecache
+import sys
+import sysconfig
 import threading
-from functools import partial
+from functools import cache, partial
+from pathlib import Path
 from types import MappingProxyType
 
 import tvm
+from tvm.ir import SourceName, Span
 from tvm.script.ir_builder import IRBuilder
 from tvm.tirx.script.builder import ir as I
 
@@ -115,6 +120,132 @@ class TensorMap:  # pylint: disable=invalid-name
 
 
 _TLS = threading.local()
+
+
+# Kern traces Python directly instead of going through the TVMScript parser.
+# Keep the parser's source-location contract by recording the active user line
+# while the body is being traced.  Frames in Kern itself, TVM, and Python's
+# runtime are implementation details; allowing them to update the active span
+# would make diagnostics point into the DSL rather than to the kernel source.
+_KERN_SOURCE_ROOT = Path(__file__).resolve().parent
+_TVM_SOURCE_ROOT = Path(tvm.__file__).resolve().parent
+_PYTHON_STDLIB_ROOT = Path(sysconfig.get_paths()["stdlib"]).resolve()
+_PYTHON_SITE_ROOTS = tuple(
+    {Path(sysconfig.get_paths()[key]).resolve() for key in ("purelib", "platlib")}
+)
+_SOURCE_NAME_CACHE = {}
+_SOURCE_SPAN_CACHE = {}
+
+
+@cache
+def _is_user_source(filename: str) -> bool:
+    """Whether *filename* belongs to kernel author code rather than machinery."""
+    if not filename or filename.startswith("<"):
+        return False
+    try:
+        path = Path(filename).resolve()
+    except OSError:
+        return False
+    if path == _KERN_SOURCE_ROOT or _KERN_SOURCE_ROOT in path.parents:
+        return False
+    if path == _TVM_SOURCE_ROOT or _TVM_SOURCE_ROOT in path.parents:
+        return False
+    in_stdlib = path == _PYTHON_STDLIB_ROOT or _PYTHON_STDLIB_ROOT in path.parents
+    in_site_packages = any(root == path or root in path.parents for root in _PYTHON_SITE_ROOTS)
+    if in_stdlib and not in_site_packages:
+        return False
+    return True
+
+
+def _source_span(filename: str, line: int) -> Span | None:
+    """Return the one-line span for a Python frame, if it is author code."""
+    if not _is_user_source(filename):
+        return None
+    key = (filename, line)
+    span = _SOURCE_SPAN_CACHE.get(key)
+    if span is not None:
+        return span
+    source_name = _SOURCE_NAME_CACHE.setdefault(filename, SourceName(filename))
+    source_line = linecache.getline(filename, line)
+    end_column = max(2, len(source_line.rstrip("\r\n")) + 1)
+    span = Span(source_name, line, line, 1, end_column)
+    _SOURCE_SPAN_CACHE[key] = span
+    return span
+
+
+def _callable_span(func) -> Span | None:
+    """Return the definition-line span used for generated entry scaffolding."""
+    code = getattr(func, "__code__", None)
+    if code is None:
+        return None
+    return _source_span(code.co_filename, code.co_firstlineno)
+
+
+class _SourceSpanTracer:
+    """Attach the current Python source line to statements emitted by Kern."""
+
+    def __init__(self, builder):
+        self.builder = builder
+        self.previous_trace = None
+        self.active_context = None
+        self.active_frame = None
+        self.active_span = None
+        self.frame_spans = {}
+
+    def __enter__(self):
+        self.previous_trace = sys.gettrace()
+        sys.settrace(self._trace)
+        return self
+
+    def __exit__(self, ptype, value, trace):  # pylint: disable=unused-argument
+        sys.settrace(self.previous_trace)
+        self._restore(None)
+        self.frame_spans.clear()
+
+    def _set_active(self, frame, span):
+        if self.active_frame is frame and self.active_span is span:
+            return
+        if self.active_context is not None:
+            self.active_context.__exit__(None, None, None)
+        self.active_context = self.builder.with_source_span(span)
+        self.active_context.__enter__()
+        self.active_frame = frame
+        self.active_span = span
+
+    def _restore(self, frame):
+        """Restore the nearest caller's span after a nested user helper returns."""
+        if self.active_context is not None:
+            self.active_context.__exit__(None, None, None)
+            self.active_context = None
+        self.active_frame = None
+        self.active_span = None
+        while frame is not None:
+            span = self.frame_spans.get(frame)
+            if span is not None:
+                self.active_context = self.builder.with_source_span(span)
+                self.active_context.__enter__()
+                self.active_frame = frame
+                self.active_span = span
+                return
+            frame = frame.f_back
+
+    def _trace(self, frame, event, arg):  # pylint: disable=unused-argument
+        if event == "call":
+            if _is_user_source(frame.f_code.co_filename):
+                frame.f_trace_lines = True
+                return self._trace
+            return None
+        if event == "line":
+            span = _source_span(frame.f_code.co_filename, frame.f_lineno)
+            if span is not None:
+                self.frame_spans[frame] = span
+                self._set_active(frame, span)
+            return self._trace
+        if event == "return" and frame in self.frame_spans:
+            self.frame_spans.pop(frame, None)
+            if self.active_frame is frame:
+                self._restore(frame.f_back)
+        return self._trace
 
 
 def current(required: bool = True) -> Session | None:
@@ -402,6 +533,7 @@ def kernel(
             raise TypeError("host_prelude= requires a keyword-only `host` parameter")
         session = Session(fn.__name__, warps, arch, min_blocks_per_sm)
         prev = getattr(_TLS, "session", None)
+        function_span = _callable_span(fn)
         with IRBuilder() as ib:
             with I.prim_func():
                 I.func_name(fn.__name__)
@@ -441,10 +573,11 @@ def kernel(
                 session.thread_id = I.thread_id([session.nthreads])
                 _TLS.session = session
                 try:
-                    if host_prelude is None:
-                        fn(*args)
-                    else:
-                        fn(*args, host=host)
+                    with _SourceSpanTracer(ib):
+                        if host_prelude is None:
+                            fn(*args)
+                        else:
+                            fn(*args, host=host)
                     if session.specialize is not None:
                         session.specialize.finalize()
                     if session.pool is not None:
@@ -452,6 +585,11 @@ def kernel(
                 finally:
                     _TLS.session = prev
         func = ib.get()
+        if function_span is not None:
+            # PrimFuncFrame intentionally constructs the function with an
+            # undefined span.  Preserve its generated body and attributes while
+            # giving the function itself the kernel declaration's location.
+            func = func.with_body(func.body, span=function_span)
         if session.specialize is not None:
             # Adjacent role guards become an else-if chain. Done on the built
             # body rather than with nested frames during the trace: a frame


### PR DESCRIPTION
## Summary

- trace file-backed Python kernel and helper lines into TIRx source spans during Kern construction
- attach the kernel declaration span to PrimFunc and the active line span to generated instruction calls
- preserve builder-free value construction used by module-level constants such as K.uint64(0)
- document the span contract and test direct statements, helper-emitted instructions, builder-free values, and tracer cleanup after failures

This adds IR metadata only. It does not emit CUDA #line directives or change generated instructions.

## Validation

- ruff check tirx_kernels/kern/entry.py tirx_kernels/kern/__init__.py tests/test_kern_api.py
- pytest tests/test_kern_api.py tests/test_low_level_ir.py tests/test_bench_suite_run.py tests/test_bench_suite_ab.py (29 passed)
- full bench-suite import gate passed: 83 kernels across 244 default workloads
- full GPU bench suite completed 243/244 workloads successfully; the remaining MegaMoE workload hit an environment OOM on GPU 5 with only 12.52 GiB free
- the OOM workload passed in a targeted bench-suite retry on free GPU 2 at 3766.200 us, confirming all 244 default configs are runnable
- RMSNorm(4096) TIR is identical with source tracking enabled and disabled
- RMSNorm(4096) generated CUDA is byte-for-byte identical with source tracking enabled and disabled