### PR TITLE
feat(kernel): port SM100 block-sparse attention forward

### DIFF
--- a/.agents/sketch/cudnn/sm100_bsa_forward_blk128.md
+++ b/.agents/sketch/cudnn/sm100_bsa_forward_blk128.md
@@ -1,0 +1,929 @@
+<!--
+This file is a design sketch for a TIRx port of code from cuDNN Frontend
+(https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5),
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 AND MIT
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# cuDNN SM100 blk128 block-sparse attention forward: coarse WASP pipeline sketch
+
+This is the non-executable, mechanically translatable sketch for
+[`tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py`](../../../tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py).
+The authoritative source is
+`python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py`
+at commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`, SHA256
+`d991ad23d01bcf0fa28c5982f3aa16c159ac84bb72b33beff9089ce77984cca9`.
+The wrapper and scheduler/softmax/pack helpers are MIT; the main file is
+Apache-2.0. The port targets SM100 only.
+
+First-class layouts are forbidden. Every shared-memory object below is a byte
+range in one rank-one `u8` arena. Every alias, swizzle, stage, descriptor and
+TMEM fragment is selected by scalar integer arithmetic. “Tile” means a logical
+rectangle only; it is not a TIRx tile primitive or a layout-bearing value.
+
+## Scope and specialization boundary
+
+| axis | in-scope values | emitted-code consequence |
+| --- | --- | --- |
+| input/output dtype | BF16, FP16 | conversion opcode and QK/PV instruction descriptor |
+| head dimension | 64, 96, 128 | 11/6/4 KV stages, 4/6/8 QK instructions, PV descriptor and SMEM band width |
+| attention family | MHA, GQA, MQA | Q-head/KV-head mapping; ratios dividing 128 default to packed GQA |
+| packed GQA | true/false | packed row is `token*ratio+local_qhead`; only Q/O TensorMaps become rank 5; sparse metadata keeps its rank |
+| sparse count | fixed even `>=2`; variable odd/even; optionally zero | odd counts round up to even; a phantom entry clamps to the last live sparse id and receives block size zero |
+| block sizes | present/absent | 128-column predicate mask or a constant full block |
+| LSE | present/absent | correction emits or omits the scalar FP32 store |
+| Q/O presentation | BHSD/BSHD at wrapper | wrapper normalizes to direct BHSD before the timed kernel |
+| KV address width | i32/i64 | TensorMap stride/address arithmetic only |
+
+Out of scope: causal attention, head dimensions other than 64/96/128, mixed
+input dtypes, Dv different from D, split-KV, block sizes other than 128,
+multi-CTA MMA, non-singleton clusters, and wrapper-level transposed device
+storage.
+
+## Writer line-info evidence
+
+Sixteen independently compiled and executed source variants are preserved at
+`.porting/block_sparse_attention_forward_sm100_blk128/writer_exports/`; the
+manifest is `writer_exports_manifest.json`. Every export targets `sm_100a`,
+declares `.reqntid 512,1,1` and `.minnctapersm 1`, has usable `.file/.loc`, and
+passes the independent FP32 oracle.
+
+| family | total SMEM | KV stages | QK idesc BF16/FP16 | PV idesc BF16/FP16 | descriptor high word |
+| --- | ---: | ---: | --- | --- | --- |
+| D64 | 232448 | 11 | `0x08200490` / `0x08200010` | `0x08110490` / `0x08110010` | `0x40004040` |
+| D96 | 224256 | 6 | same | `0x08190490` / `0x08190010` | `0x80004020` |
+| D128 | 232448 | 4 | same | `0x08210490` / `0x08210010` | `0x40004040` |
+
+MHA uses rank-4 Q/O tensor-bulk instructions. Packed GQA/MQA uses rank-5 Q/O;
+ratio-3 automatic fallback is non-packed and returns to rank 4. K/V are rank 4.
+The D128 anchor contains 64 `tcgen05.mma...kind::f16`, eight x32 score loads,
+32 x16 correction loads, 24 x16 TMEM stores, 15 TMEM commits, and the raw CLC
+query/try-cancel/coordinate-extraction family. Counts are static emitted counts.
+
+## Fixed storage and integer maps
+
+```python
+P = specialize(dtype in {bf16,f16}, D in {64,96,128}, ratio>=1,
+               PACK=(ratio>1 and 128%ratio==0 unless explicitly disabled),
+               HAS_SIZES, HAS_NUMS, ALLOW_EMPTY, RETURN_LSE, I64_KV)
+M=N=128; Q_STAGES=1; S_STAGES=2
+KV_STAGES={64:11,96:6,128:4}[D]
+THREADS=512; WARPS=16; SPLIT_P=96; TMEM_COLS=512
+SMEM_BYTES={64:232448,96:224256,128:232448}[D]
+REG_OTHER={64:48,96:56,128:56}[D]
+REG_SOFTMAX={64:200,96:184,128:184}[D]
+REG_CORRECTION={64:64,96:88,128:88}[D]
+
+SCHED_HEADS = Hkv if P.PACK else Hq
+Q_ROWS = SQ*ratio if P.PACK else SQ
+Q_BLOCKS = ceil_div(Q_ROWS,128)
+launch(grid=(Q_BLOCKS,SCHED_HEADS,B), block=(512,1,1), cluster=(1,1,1),
+       min_blocks_per_sm=1, dynamic_smem_bytes=SMEM_BYTES, target="sm_100a")
+# instruction_selection: `.reqntid 512,1,1`, `.minnctapersm 1`, singleton
+# cluster launch, `.extern .shared .align 1024`; extent: one specialization.
+
+ABI=(Q_dtype[B,Hq,SQ,D], K_dtype[B,Hkv,SKV,D], V_dtype[B,Hkv,SKV,D],
+     O_dtype[B,Hq,SQ,D], optional_LSE_f32[B,Hq,SQ], block_index_i32,
+     optional_block_sizes_i32, fixed_count_i32, optional_block_nums_i32,
+     softmax_scale_log2_f32, Qmap, Kmap, Vmap, Omap)
+
+arena = linear_smem_u8(SMEM_BYTES, alignment=1024)
+# D64 / D96 / D128 exact byte offsets from the fresh exports.
+OFF = {
+  64:  dict(Q=0,KV=16,SPO=192,PLAST=224,OACC=256,STATS=288,OEPI=320,
+            TMEM=352,SCALE=356,CLC=2408,RESP=2432,sO=3072,sQ=35840,sKV=52224),
+  96:  dict(Q=0,KV=16,SPO=112,PLAST=144,OACC=176,STATS=208,OEPI=240,
+            TMEM=272,SCALE=276,CLC=2328,RESP=2352,sO=3072,sQ=52224,sKV=76800),
+  128: dict(Q=0,KV=16,SPO=80, PLAST=112,OACC=144,STATS=176,OEPI=208,
+            TMEM=240,SCALE=244,CLC=2296,RESP=2320,sO=3072,sQ=68608,sKV=101376),
+}[D]
+
+# A two-sided n-stage pipeline stores full[stage] at base+8*stage and
+# empty[stage] at base+8*n+8*stage. This is byte arithmetic in `arena`.
+def full(base,n,stage):  return base + 8*stage
+def empty(base,n,stage): return base + 8*n + 8*stage
+
+BW={64:64,96:32,128:64}[D]
+NBAND=D//BW
+def swizzle343(element): return element ^ (((element>>7)&7)<<4)
+def matrix_elem(row,col):
+    band=col//BW; local_col=col-band*BW
+    return band*(128*BW)+swizzle343(row*BW+local_col)
+def q_byte(row,col):          return OFF.sQ + 2*matrix_elem(row,col)
+def kv_byte(stage,row,col):   return OFF.sKV + 2*(stage*128*D+matrix_elem(row,col))
+def o_byte(stage,row,col):    return OFF.sO + 2*(stage*128*D+matrix_elem(row,col))
+# D96 therefore has physical band bases +0,+8192,+16384 bytes and global-D
+# coordinates 0,32,64. D64/D128 use 64-column bands. Q/K use the bytes as
+# K-major operands; V uses `row=K token,col=output feature` as an MN-major B
+# operand; O uses the same band-local physical map for the epilogue TensorMap.
+
+def stat_byte(stage,row,is_max):
+    return OFF.SCALE + 4*(stage*128 + row + (256 if is_max else 0))
+# instruction_selection: scalar `ld.shared.b32`/`st.shared.b32`; extent: one
+# rank-one byte offset, never a multidimensional shared tensor.
+
+DESC_HI={64:0x40004040,96:0x80004020,128:0x40004040}[D]
+def desc_start(byte): return (byte & 0x3ffff) >> 4
+def desc64(byte): return (u64(DESC_HI)<<32) | desc_start(byte)
+def qk_desc(byte,k16):
+    band=k16//(BW//16); within=k16%(BW//16)
+    return desc64(byte) + band*(128*BW*2//16) + 2*within
+def v_desc(stage,k16): return desc64(kv_byte(stage,0,0)) + k16*(16*BW*2//16)
+# Thus Q/K low-word deltas are [0,2,4,6]+0x400*band for BW64 and
+# [0,2]+0x200*band for BW32. V deltas are 0x80*k16 for BW64 and 0x40*k16
+# for BW32. The descriptor high word encodes leading/stride/version/swizzle;
+# Q/K idesc mark K-major, PV idesc marks its B operand MN-major.
+
+S_COL=(0,128); P_COL=(64,192); O_COL=(256,256+D)
+def tmem_row_addr(row,col): return col | ((row&0x60)<<16)
+# The instruction lane supplies row&31. For softmax/correction
+# row=(warp%4)*32+lane. Score x32 addresses use col=stage*128+{0,32,64,96};
+# P x16 stores use col=P_COL[stage]+{0,16,32,48}. PV treats packed 16-bit P
+# as tmem_a=P_COL[stage]+8*k16 while its FP32 O accumulator is O_COL[stage].
+```
+
+TensorMaps use 128-byte swizzle and zero OOB fill. Q/O are rank 4 in the
+non-packed path and rank 5 in packed GQA; K/V are rank 4. Each D band transfers
+`128*BW*2` bytes to/from the corresponding integer byte base. Packed row
+decoding is `packed=q_block*128+row`, `token=packed//ratio`,
+`q_head=kv_head*ratio+packed%ratio`; non-packed is
+`token=q_block*128+row,q_head=head,kv_head=head//ratio`. Metadata is indexed by
+`(batch,kv_head,q_block)` when packed and `(batch,q_head,q_block)` otherwise,
+but its physical ABI never changes rank: `block_index` remains rank 4
+`[B,scheduled_head,Q_block,slot]` and `block_nums` remains rank 3
+`[B,scheduled_head,Q_block]`. Packing changes index ownership, not metadata rank.
+
+## Exact prologue and pipeline state
+
+```python
+tid=thread_id(); warp=warp_uniform(tid//32); lane=tid&31
+
+# Source order: warp 0, all 32 lanes, before shared allocation/initialization.
+if warp==0:
+    prefetch_tensormap(Qmap); prefetch_tensormap(Kmap)
+    prefetch_tensormap(Vmap); prefetch_tensormap(Omap)
+# instruction_selection: four consecutive `prefetch.tensormap`; extent: all
+# lanes of warp 0 execute each live descriptor prefetch, with no `elect.sync`.
+
+# One elected lane initializes the ordinary pipelines.
+init(full(OFF.Q,1,0),1);       init(empty(OFF.Q,1,0),1)
+for s in static_range(KV_STAGES):
+    init(full(OFF.KV,KV_STAGES,s),1); init(empty(OFF.KV,KV_STAGES,s),1)
+for s in static_range(2):
+    init(full(OFF.SPO,2,s),1);    init(empty(OFF.SPO,2,s),256)
+    init(full(OFF.PLAST,2,s),4);  init(empty(OFF.PLAST,2,s),1)
+    init(full(OFF.OACC,2,s),1);   init(empty(OFF.OACC,2,s),128)
+    init(full(OFF.STATS,2,s),128);init(empty(OFF.STATS,2,s),128)
+    init(full(OFF.OEPI,2,s),128); init(empty(OFF.OEPI,2,s),32)
+fence_mbarrier_init_release_cluster()
+# instruction_selection: `mbarrier.init.shared.b64` exactly
+# 22+2*KV_STAGES times, then the first init fence; no CTA sync yet.
+
+init(full(OFF.CLC,1,0),1); init(empty(OFF.CLC,1,0),512)
+fence_mbarrier_init_release_cluster(); sync_cta()
+# instruction_selection: two CLC `mbarrier.init.shared.b64`, second init fence,
+# then first `bar.sync 0`; extent: CLC create protocol.
+sync_cta()
+# instruction_selection: second `bar.sync 0`; extent: `pipeline_init_wait`.
+# Total init count is 22+2*KV_STAGES+2: D64=46,D96=36,D128=32.
+
+Q_PROD_PHASE=1; Q_CONS_PHASE=0
+KV_PROD=(index=0,phase=1); KV_CONS=(index=0,phase=0)
+SCORE_PHASE=[0,0]; SPO_ACQUIRE_PHASE=[0,0]
+STATS_PROD_PHASE=[1,1]; STATS_CONS_PHASE=0
+OACC_CONS_PHASE=0; OEPI_PROD_PHASE=1; OEPI_CONS_PHASE=0
+CLC_PROD=(index=0,phase=1); CLC_CONS=(index=0,phase=0)
+# `advance` increments index and flips parity on ring wrap (one-stage state
+# toggles parity every advance). All states above live outside role loops.
+```
+
+## Source-order role programs
+
+The branch order below is source-exact:
+`CLC/empty → load → MMA → epilogue → softmax → correction`. Each role owns its
+own `initial_work_tile_info`, persistent loop and CLC consumer advance. The six
+consumer CFGs are intentionally written separately; they are not a common tail.
+
+```python
+# 1. Warp 15: CLC producer and its own consumer path.
+if warp==15:
+    setmaxnreg_decrease(REG_OTHER)
+    # instruction_selection: D64 `setmaxnreg.dec...48`; D96/D128 `...56`.
+    work=initial_work_tile_info()
+    while work.valid:
+        wait(empty(OFF.CLC,1,CLC_PROD.index),CLC_PROD.phase)
+        arrive_expect_tx_cluster(full(OFF.CLC,1,CLC_PROD.index),16)
+        try_cancel_async_b128(OFF.RESP,full(OFF.CLC,1,CLC_PROD.index))
+        advance(CLC_PROD)
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        next_x=query_cancel_get_first_ctaid_x(response128)
+        next_y=query_cancel_get_first_ctaid_y(response128)
+        next_z=query_cancel_get_first_ctaid_z(response128)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS); work=(next_x,next_y,next_z,valid)
+        # instruction_selection: parity wait, cluster expect-tx 16 bytes,
+        # try-cancel, `bar.sync`, full wait, `ld.shared.v2.b64`, predicate/x/y/z
+        # decode, async-shared fence and cluster-scope empty release.
+    wait(empty(OFF.CLC,1,CLC_PROD.index),CLC_PROD.phase)
+    # instruction_selection: producer-tail parity wait; extent: one final slot.
+
+# 2. Warp 14: Q plus reverse K/V TensorMap producer.
+if warp==14:
+    setmaxnreg_decrease(REG_OTHER)
+    # instruction_selection: D64 `setmaxnreg.dec.sync.aligned.u32 48`;
+    # D96/D128 immediate 56; extent: load-warp branch entry.
+    work=initial_work_tile_info()
+    while work.valid:
+        q_block,head,batch=work.xyz
+        if P.PACK:
+            token0=(q_block*128)//ratio; head_kv=head
+        else:
+            token0=q_block*128; q_head=head; head_kv=head//ratio
+        raw=block_nums[batch,head,q_block] if P.HAS_NUMS else fixed_count
+        process=(raw>0) if P.ALLOW_EMPTY else True
+        count=(raw+1)&~1 if P.HAS_NUMS else raw
+        def sparse_id(i):
+            j=min(i,max(raw-1,0)) if P.HAS_NUMS else i
+            return load_global_i32(block_index,meta_offset(batch,head,q_block,j))
+        if process:
+            wait(empty(OFF.KV,KV_STAGES,KV_PROD.index),KV_PROD.phase)
+            # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+            # extent: all 32 lanes of warp 14, one current KV ring stage.
+            arrive_expect_tx(full(OFF.KV,KV_STAGES,KV_PROD.index),128*D*2)
+            # instruction_selection: elected
+            # `mbarrier.arrive.expect_tx.shared.b64`; transaction extent:
+            # one 128xD dtype tile = 128*D*2 bytes across NBAND issues.
+            sid=sparse_id(count-1)
+            for band in static_range(NBAND):
+                copy_g2s_tma(Kmap,(band*BW,sid*128,head_kv,batch),
+                             kv_byte(KV_PROD.index,0,band*BW),
+                             full(OFF.KV,KV_STAGES,KV_PROD.index))
+                # instruction_selection: elected rank-4
+                # `cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+                # extent: one 128xBW band, NBAND={1,3,2}[D].
+            wait(empty(OFF.Q,1,0),Q_PROD_PHASE)
+            # instruction_selection: shared parity wait by all 32 lanes of warp
+            # 14; extent: the singleton Q stage. Expect/TMA below remain elected.
+            arrive_expect_tx(full(OFF.Q,1,0),128*D*2)
+            # instruction_selection: elected `mbarrier.arrive.expect_tx.shared.b64`;
+            # transaction extent: 128*D*2 bytes.
+            for band in static_range(NBAND):
+                if P.PACK:
+                    copy_g2s_tma(Qmap_rank5,(band*BW,0,token0,head_kv,batch),
+                                 q_byte(0,band*BW),full(OFF.Q,1,0))
+                    # instruction_selection: elected rank-5
+                    # `cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+                    # extent: one 128xBW packed-Q band, NBAND per D.
+                else:
+                    copy_g2s_tma(Qmap_rank4,(band*BW,token0,q_head,batch),
+                                 q_byte(0,band*BW),full(OFF.Q,1,0))
+                    # instruction_selection: elected rank-4 G2S tensor-bulk
+                    # family with shared::cta/global.tile, mbarrier completion
+                    # and L2 cache hint; extent: one 128xBW band.
+            advance(KV_PROD); Q_PROD_PHASE^=1
+            # K[N-1] is issued before Q, and KV advances only after Q.
+            for kind,logical in [(K,count-2)] + flatten(
+                    [(V,count-1-i),(K,count-3-i)] for i in serial_range(count-2)
+                  ) + [(V,1),(V,0)]:
+                wait(empty(OFF.KV,KV_STAGES,KV_PROD.index),KV_PROD.phase)
+                # instruction_selection: shared parity wait by all 32 lanes of
+                # warp 14; extent: one KV stage. Expect/TMA remain elected.
+                arrive_expect_tx(full(OFF.KV,KV_STAGES,KV_PROD.index),128*D*2)
+                # instruction_selection: elected shared expect-tx; transaction
+                # extent: 128*D*2 bytes across NBAND tensor-bulk operations.
+                sid=sparse_id(logical)
+                for band in static_range(NBAND):
+                    copy_g2s_tma(Kmap if kind==K else Vmap,
+                                 (band*BW,sid*128,head_kv,batch),
+                                 kv_byte(KV_PROD.index,0,band*BW),
+                                 full(OFF.KV,KV_STAGES,KV_PROD.index))
+                    # instruction_selection: elected rank-4
+                    # `cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint`;
+                    # extent: NBAND={1,3,2}[D] 128xBW bands for this K or V.
+                advance(KV_PROD)
+        prefetch_next_work()
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        nx=query_cancel_get_first_ctaid_x(response128)
+        ny=query_cancel_get_first_ctaid_y(response128)
+        nz=query_cancel_get_first_ctaid_z(response128); work=(nx,ny,nz,valid)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS)
+        # instruction_selection: load-role `bar.sync 0`, shared full parity
+        # wait, `ld.shared.v2.b64`, CLC is-canceled/get-first-ctaid x/y/z,
+        # `fence.proxy.async.shared::cta`, and
+        # `mbarrier.arrive.shared::cluster.b64`; extent: one CLC response.
+    KV_TAIL=clone(KV_PROD)
+    for tail_slot in static_range(KV_STAGES):
+        wait(empty(OFF.KV,KV_STAGES,KV_TAIL.index),KV_TAIL.phase)
+        # instruction_selection: all 32 load-warp lanes execute
+        # `mbarrier.try_wait.parity.shared.b64`; extent: exactly KV_STAGES
+        # waits (11/6/4 for D64/D96/D128), beginning at the current ring state.
+        advance(KV_TAIL)
+    wait(empty(OFF.Q,1,0),Q_PROD_PHASE)
+    # instruction_selection: all 32 load-warp lanes execute one shared parity
+    # wait on Q empty at the persistent Q phase.
+    elected_arrive_expect_tx(full(OFF.Q,1,0),128*D*2)
+    # instruction_selection: elected
+    # `mbarrier.arrive.expect_tx.shared.b64`; extent: one Q-full arm for
+    # 128*D*2 bytes. Tail emits no Q TMA and does not change Q_PROD_PHASE.
+
+# 3. Warp 12: TMEM allocation and sole QK/PV issuer.
+if warp==12:
+    setmaxnreg_decrease(REG_OTHER)
+    # instruction_selection: other-role `setmaxnreg.dec.sync.aligned.u32`,
+    # immediate 48/56 for D64/D96-or-128; extent: MMA-warp branch entry.
+    allocate_tmem(OFF.TMEM,512); wait_for_alloc(); retrieve_tmem_pointer()
+    # instruction_selection:
+    # `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`, followed by
+    # allocator named-barrier retrieval; extent: one 512-column allocation.
+    work=initial_work_tile_info()
+    while work.valid:
+        raw=work_sparse_count(); process=(raw>0) if P.ALLOW_EMPTY else True
+        count=(raw+1)&~1 if P.HAS_NUMS else raw
+        if process:
+            wait(full(OFF.Q,1,0),Q_CONS_PHASE); Q_CONS_PHASE^=1
+            # instruction_selection: ordinary shared parity wait for the sole Q
+            # stage; no `tcgen05.fence::after_thread_sync` follows it.
+            for stage in static_range(2):
+                wait(full(OFF.KV,KV_STAGES,KV_CONS.index),KV_CONS.phase)
+                # instruction_selection: shared parity wait for one K stage.
+                for k16 in static_range(D//16):
+                    mma_qk(S_COL[stage],qk_desc(q_byte(0,0),k16),
+                           qk_desc(kv_byte(KV_CONS.index,0,0),k16),
+                           QK_IDESC[dtype],accumulate=(k16!=0))
+                    # instruction_selection: elected SS
+                    # `tcgen05.mma.cta_group::1.kind::f16`; QK idesc is the
+                    # dtype-specific 0x08200..., first issue zero-initializes and
+                    # later issues accumulate; extent: 4/6/8 issues for D64/96/128.
+                tmem_commit_cluster(full(OFF.SPO,2,stage))
+                # instruction_selection: elected `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`;
+                # extent: one score generation.
+                tmem_commit_cluster(empty(OFF.KV,KV_STAGES,KV_CONS.index))
+                # instruction_selection: the same cluster-scope TMEM commit,
+                # not an ordinary mbarrier arrive; extent: one K release.
+                advance(KV_CONS)
+            acc=[False,False]
+            for pair in serial_range((count-2)//2):
+                for stage in static_range(2):
+                    wait(full(OFF.KV,KV_STAGES,KV_CONS.index),KV_CONS.phase)
+                    # instruction_selection: shared parity wait for V.
+                    VREL=clone(KV_CONS); vstage=KV_CONS.index; advance(KV_CONS)
+                    wait(full(OFF.KV,KV_STAGES,KV_CONS.index),KV_CONS.phase)
+                    # instruction_selection: shared parity wait for the following K.
+                    kstage=KV_CONS.index
+                    wait(empty(OFF.SPO,2,stage),SPO_ACQUIRE_PHASE[stage])
+                    # instruction_selection: shared parity wait; this one stage
+                    # phase also drives the P-last wait below.
+                    for k16 in static_range(8):
+                        if k16==6:
+                            wait_cta(full(OFF.PLAST,2,stage),SPO_ACQUIRE_PHASE[stage])
+                            # instruction_selection:
+                            # `mbarrier.try_wait.parity.shared::cta.b64`; extent:
+                            # after six 16-column slices (96 P columns), before slices 6/7.
+                        mma_pv(O_COL[stage],P_COL[stage]+8*k16,v_desc(vstage,k16),
+                               PV_IDESC[dtype,D],accumulate=(acc[stage] or k16!=0))
+                        # instruction_selection: elected TS
+                        # `tcgen05.mma.cta_group::1.kind::f16`, tmem A and
+                        # MN-major shared V B, D/dtype PV idesc; first issue uses
+                        # zero predicate iff this stage has no prior O, later
+                        # issues accumulate; extent: exactly eight K16 issues.
+                    for k16 in static_range(D//16):
+                        mma_qk(S_COL[stage],qk_desc(q_byte(0,0),k16),
+                               qk_desc(kv_byte(kstage,0,0),k16),QK_IDESC[dtype],
+                               accumulate=(k16!=0))
+                        # instruction_selection: elected SS QK, zero then
+                        # accumulate, 4/6/8 issues for D64/96/128.
+                    tmem_commit_cluster(full(OFF.SPO,2,stage))
+                    # Source updates the single stage phase/accumulator state
+                    # after score commit and before either KV release.
+                    SPO_ACQUIRE_PHASE[stage]^=1; acc[stage]=True
+                    tmem_commit_cluster(empty(OFF.KV,KV_STAGES,VREL.index))
+                    tmem_commit_cluster(empty(OFF.KV,KV_STAGES,KV_CONS.index))
+                    # instruction_selection: two elected cluster-scope
+                    # `tcgen05.commit...mbarrier::arrive::one` releases, V then K.
+                    advance(KV_CONS)
+            tmem_commit_cluster(empty(OFF.Q,1,0))
+            # instruction_selection: elected cluster-scope `tcgen05.commit` Q release.
+            for stage in static_range(2):
+                wait(full(OFF.KV,KV_STAGES,KV_CONS.index),KV_CONS.phase)
+                # instruction_selection: shared parity wait for epilogue V.
+                vstage=KV_CONS.index
+                wait(empty(OFF.SPO,2,stage),SPO_ACQUIRE_PHASE[stage])
+                # instruction_selection: shared SPO-empty wait using the stage phase.
+                for k16 in static_range(8):
+                    if k16==6:
+                        wait_cta(full(OFF.PLAST,2,stage),SPO_ACQUIRE_PHASE[stage])
+                        # instruction_selection: CTA-scope P-last parity wait
+                        # after the first six PV issues.
+                    mma_pv(O_COL[stage],P_COL[stage]+8*k16,v_desc(vstage,k16),
+                           PV_IDESC[dtype,D],accumulate=(acc[stage] or k16!=0))
+                    # instruction_selection: elected TS `tcgen05.mma`, exact
+                    # eight-issue PV chain with zero/acc predicate as above.
+                tmem_commit_cluster(full(OFF.OACC,2,stage))
+                # instruction_selection: elected
+                # `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`;
+                # extent: one final O accumulator stage.
+                tmem_commit_cluster(empty(OFF.KV,KV_STAGES,KV_CONS.index))
+                # instruction_selection: elected cluster-scope TMEM commits for
+                # O-acc publication then V-empty release.
+                advance(KV_CONS)
+            SPO_ACQUIRE_PHASE[0]^=1; SPO_ACQUIRE_PHASE[1]^=1
+            # Epilogue flips both stage phases only after both PV stages finish.
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        nx=query_cancel_get_first_ctaid_x(response128)
+        ny=query_cancel_get_first_ctaid_y(response128)
+        nz=query_cancel_get_first_ctaid_z(response128); work=(nx,ny,nz,valid)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS)
+        # instruction_selection: MMA-role `bar.sync 0`, shared full parity
+        # wait, `ld.shared.v2.b64`, CLC predicate/x/y/z decode, async-shared
+        # fence and cluster-scope empty arrive; extent: one CLC response.
+    relinquish_tmem_alloc_permit(); named_barrier_sync(2,416); free_tmem(512)
+    # instruction_selection:
+    # `tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned` ->
+    # `bar.sync 2,416` -> `tcgen05.dealloc.cta_group::1.sync.aligned.b32`;
+    # extent: 512 columns, warp 12 arrives exactly once through the sync.
+
+# 4. Warp 13: corrected O TensorMap epilogue.
+if warp==13:
+    setmaxnreg_decrease(REG_OTHER)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32` immediate
+    # 48/56 for D64/D96-or-128; extent: epilogue-warp branch entry.
+    work=initial_work_tile_info()
+    while work.valid:
+        q_block,head,batch=work.xyz
+        if P.PACK:
+            token0=(q_block*128)//ratio; head_kv=head
+        else:
+            token0=q_block*128; q_head=head; head_kv=head//ratio
+        wait(full(OFF.OEPI,2,0),OEPI_CONS_PHASE)
+        # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+        # extent: epilogue warp, stage 0.
+        for band in static_range(NBAND):
+            if P.PACK:
+                copy_s2g_tma(Omap_rank5,(band*BW,0,token0,head_kv,batch),
+                             o_byte(0,0,band*BW))
+                # instruction_selection: all 32 lanes of warp 13 execute rank-5
+                # `cp.async.bulk.tensor.5d.global.shared::cta.tile.bulk_group.L2::cache_hint`;
+                # extent: one 128xBW packed-O band, NBAND per D.
+            else:
+                copy_s2g_tma(Omap_rank4,(band*BW,token0,q_head,batch),
+                             o_byte(0,0,band*BW))
+                # instruction_selection: all 32 lanes of warp 13 execute the
+                # rank-4 S2G tensor-bulk with global/shared::cta tile,
+                # bulk-group and L2 cache hint; one 128xBW band, NBAND per D.
+        commit_bulk_group(); wait_bulk_group_read(0)
+        # instruction_selection: `cp.async.bulk.commit_group` then
+        # `cp.async.bulk.wait_group.read 0`; extent: all NBAND O stores.
+        release(empty(OFF.OEPI,2,0)); OEPI_CONS_PHASE^=1
+        # instruction_selection: ordinary `mbarrier.arrive.shared.b64` by all
+        # 32 lanes of warp 13; extent matches the empty-barrier arrival count 32.
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        nx=query_cancel_get_first_ctaid_x(response128)
+        ny=query_cancel_get_first_ctaid_y(response128)
+        nz=query_cancel_get_first_ctaid_z(response128); work=(nx,ny,nz,valid)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS)
+        # instruction_selection: epilogue-role `bar.sync 0`, shared full
+        # parity wait, `ld.shared.v2.b64`, CLC predicate/x/y/z decode,
+        # async-shared fence and cluster-scope empty arrive; one response.
+
+# 5. Warps 0..7: one persistent softmax loop for its fixed stage.
+if warp<8:
+    setmaxnreg_increase(REG_SOFTMAX)
+    # instruction_selection: `setmaxnreg.inc.sync.aligned.u32` immediate
+    # 200 for D64 and 184 for D96/D128; extent: each softmax warp.
+    wait_for_tmem_alloc(); retrieve_tmem_pointer()
+    # instruction_selection: allocator named `bar.sync 2,416` participation
+    # used to retrieve the shared TMEM pointer; extent: warps 0..7.
+    stage=0 if warp<4 else 1; local_warp=warp&3; row=local_warp*32+lane
+    score_phase=SCORE_PHASE[stage]; stats_prod=STATS_PROD_PHASE[stage]
+    work=initial_work_tile_info()
+    while work.valid:
+        raw=work_sparse_count(); has_work=(raw>0) if P.ALLOW_EMPTY else True
+        wait(empty(OFF.STATS,2,stage),stats_prod); stats_prod^=1
+        # instruction_selection: shared parity wait on the 128-arrival stats
+        # empty barrier; extent: one fixed stage and 128 softmax threads.
+        row_max=-inf; row_sum=0
+        if has_work:
+            count=(raw+1)&~1 if P.HAS_NUMS else raw
+            wg_count=count//2
+
+            # First block is a distinct static body. Only it can be phantom.
+            logical_first=count-1-stage; sid=sparse_id_clamped(logical_first)
+            wait(full(OFF.SPO,2,stage),score_phase)
+            # instruction_selection: `mbarrier.try_wait.parity.shared.b64`;
+            # no `tcgen05.fence::after_thread_sync`; extent: first score generation.
+            for chunk in static_range(4):
+                copy_t2r(tmem_row_addr(row,S_COL[stage]+32*chunk),
+                         score[32*chunk:32*chunk+32])
+                # instruction_selection:
+                # `tcgen05.ld.sync.aligned.32x32b.x32.b32`; extent: four x32
+                # loads, row=(warp%4)*32+lane, columns 0/32/64/96.
+            if P.HAS_SIZES or P.HAS_NUMS:
+                first_size=(0 if P.HAS_NUMS and logical_first>=raw else
+                            load_global_i32(block_sizes,sid)) if P.HAS_SIZES else \
+                           (0 if logical_first>=raw else 128)
+                for col in static_range(128):
+                    if col>=first_size: score[col]=-inf
+                # instruction_selection: i32 block-size load when present plus
+                # integer compare and `selp.f32` to -inf; extent: first block
+                # only. Fixed/no-size specializations emit no mask operations.
+            mx=[max(score[0],score[1]),max(score[2],score[3]),
+                max(score[4],score[5]),max(score[6],score[7])]
+            for i in static_range(8,128,8):
+                for j in static_range(4): mx[j]=max(mx[j],score[i+2*j],score[i+2*j+1])
+            row_max=max(max(mx[0],mx[1]),mx[2],mx[3])
+            max_safe=0 if row_max==-inf else row_max; old_scale=0
+            # instruction_selection: first node uses two-input `max.f32`; all
+            # later groups use three-input max, ending max01 then max(max01,m2,m3).
+            named_barrier_arrive(stage*4+local_warp,64)
+            # instruction_selection: `bar.arrive` with 64 participants;
+            # extent: the paired first softmax/correction warp.
+            for pair in static_range(64):
+                score[2*pair:2*pair+2]=fma_packed(
+                    score[2*pair:2*pair+2],(softmax_scale_log2,softmax_scale_log2),
+                    (-max_safe*softmax_scale_log2,-max_safe*softmax_scale_log2))
+            # instruction_selection: `fma.rn.f32x2`; extent: 64 packed pairs.
+            for frag in static_range(4):
+                for pair in static_range(16):
+                    idx=frag*32+2*pair
+                    if (2*pair)%10>=6 and frag<3:
+                        xy=(max(score[idx],-127),max(score[idx+1],-127))
+                        xy_round=add_packed_rm(xy,(12582912.0,12582912.0))
+                        xy_back=sub_packed_rn(xy_round,(12582912.0,12582912.0))
+                        frac=sub_packed_rn(xy,xy_back)
+                        poly=(POLY_EX2_3,POLY_EX2_3)
+                        poly=fma_packed(poly,frac,(POLY_EX2_2,POLY_EX2_2))
+                        poly=fma_packed(poly,frac,(POLY_EX2_1,POLY_EX2_1))
+                        poly=fma_packed(poly,frac,(POLY_EX2_0,POLY_EX2_0))
+                        ix=bitcast_s32(xy_round[0]); iy=bitcast_s32(xy_round[1])
+                        px=bitcast_s32(poly[0]); py=bitcast_s32(poly[1])
+                        p[idx]=bitcast_f32((ix<<23)+px)
+                        p[idx+1]=bitcast_f32((iy<<23)+py)
+                        # instruction_selection: two `max.f32`, one
+                        # `add.rm.f32x2`, two `sub.rn.f32x2`, three
+                        # `fma.rn.f32x2`, then per element `shl.b32` +
+                        # `add.s32` exponent-bit combine; extent: 18 emulated
+                        # pairs per static softmax step.
+                    else:
+                        p[idx]=exp2(score[idx]); p[idx+1]=exp2(score[idx+1])
+                        # instruction_selection: two `ex2.approx.ftz.f32`;
+                        # extent: 46 hardware pairs / 92 values per step.
+                for pair in static_range(16):
+                    idx=frag*32+2*pair
+                    packed_p[idx//2]=convert_pair_rn(dtype,p[idx],p[idx+1])
+                    # instruction_selection: after all exp in this fragment,
+                    # `cvt.rn.bf16x2.f32` or `cvt.rn.f16x2.f32`; extent: 16 pairs.
+            for chunk in static_range(4):
+                copy_r2t(packed_p[16*chunk:16*chunk+16],
+                         tmem_row_addr(row,P_COL[stage]+16*chunk))
+                # instruction_selection:
+                # `tcgen05.st.sync.aligned.32x32b.x16.b32`; extent: one of four
+                # P chunks at 64/80/96/112 or 192/208/224/240.
+                if chunk==2:
+                    fence_tmem_store(); mbarrier_arrive(empty(OFF.SPO,2,stage))
+                    # instruction_selection: `tcgen05.wait::st.sync.aligned`
+                    # then ordinary `mbarrier.arrive.shared.b64`; 96-column split.
+            fence_tmem_store(); sync_warp(); elect_mbarrier_arrive(full(OFF.PLAST,2,stage))
+            # instruction_selection: TMEM-store wait, `bar.warp.sync`, elected
+            # ordinary mbarrier arrive; extent: final 32 P columns.
+            wait(empty(OFF.STATS,2,stage),stats_prod)
+            # instruction_selection: stats-empty shared parity wait occurs after
+            # all P stores/publications and before row-sum arithmetic.
+            acc=[(p[0],p[1]),(p[2],p[3]),(p[4],p[5]),(p[6],p[7])]
+            for i in static_range(8,128,8):
+                for j in static_range(4): acc[j]=add_packed(acc[j],(p[i+2*j],p[i+2*j+1]))
+            acc[0]=add_packed(acc[0],acc[1]); acc[2]=add_packed(acc[2],acc[3])
+            acc[0]=add_packed(acc[0],acc[2]); row_sum=acc[0][0]+acc[0][1]
+            # instruction_selection: `add.rn.f32x2` four-way tree then scalar
+            # `add.f32`; extent: first complete 128-value probability row.
+            stats_prod^=1; score_phase^=1
+            # Both phase returns move only after the row-sum tree completes.
+
+            # Remaining blocks are a separate loop and are statically non-first.
+            for n_tile in serial_range(wg_count-1):
+                logical=count-1-stage-2*(n_tile+1); sid=sparse_id_clamped(logical)
+                wait(full(OFF.SPO,2,stage),score_phase)
+                # instruction_selection: shared parity wait, no TMEM fence.
+                for chunk in static_range(4):
+                    copy_t2r(tmem_row_addr(row,S_COL[stage]+32*chunk),
+                             score[32*chunk:32*chunk+32])
+                    # instruction_selection: x32 T2R; four chunks per row.
+                if P.HAS_SIZES:
+                    live_size=load_global_i32(block_sizes,sid)
+                    for col in static_range(128):
+                        if col>=live_size: score[col]=-inf
+                    # instruction_selection: live block-size load and i32
+                    # predicate/select; no phantom `logical>=raw` predicate here.
+                old=row_max
+                mx=[max(old,score[0],score[1]),max(score[2],score[3]),
+                    max(score[4],score[5]),max(score[6],score[7])]
+                for i in static_range(8,128,8):
+                    for j in static_range(4): mx[j]=max(mx[j],score[i+2*j],score[i+2*j+1])
+                row_max=max(max(mx[0],mx[1]),mx[2],mx[3])
+                # instruction_selection: the old row max is injected into the
+                # first three-input `max.f32`, then the exact four-way source tree.
+                max_safe=0 if row_max==-inf else row_max
+                delta=(old-max_safe)*softmax_scale_log2; old_scale=exp2(delta)
+                if delta>=-8: row_max=old; max_safe=old; old_scale=1
+                # instruction_selection: sub/mul, `ex2.approx.ftz.f32`, compare
+                # and selects for the source threshold-8 rescale path.
+                store_shared_f32(stat_byte(stage,row,False),old_scale)
+                # instruction_selection: scalar `st.shared.b32`; extent: one row.
+                named_barrier_arrive(stage*4+local_warp,64)
+                # instruction_selection: `bar.arrive`, paired 64-thread rendezvous.
+                for pair in static_range(64):
+                    score[2*pair:2*pair+2]=fma_packed(
+                        score[2*pair:2*pair+2],(softmax_scale_log2,softmax_scale_log2),
+                        (-max_safe*softmax_scale_log2,-max_safe*softmax_scale_log2))
+                # instruction_selection: 64 packed `fma.rn.f32x2` pairs.
+                for frag in static_range(4):
+                    for pair in static_range(16):
+                        idx=frag*32+2*pair
+                        if (2*pair)%10>=6 and frag<3:
+                            xy=(max(score[idx],-127),max(score[idx+1],-127))
+                            xy_round=add_packed_rm(xy,(12582912.0,12582912.0))
+                            xy_back=sub_packed_rn(xy_round,(12582912.0,12582912.0))
+                            frac=sub_packed_rn(xy,xy_back)
+                            poly=(POLY_EX2_3,POLY_EX2_3)
+                            poly=fma_packed(poly,frac,(POLY_EX2_2,POLY_EX2_2))
+                            poly=fma_packed(poly,frac,(POLY_EX2_1,POLY_EX2_1))
+                            poly=fma_packed(poly,frac,(POLY_EX2_0,POLY_EX2_0))
+                            ix=bitcast_s32(xy_round[0]); iy=bitcast_s32(xy_round[1])
+                            px=bitcast_s32(poly[0]); py=bitcast_s32(poly[1])
+                            p[idx]=bitcast_f32((ix<<23)+px)
+                            p[idx+1]=bitcast_f32((iy<<23)+py)
+                            # instruction_selection: two `max.f32`, one
+                            # `add.rm.f32x2`, two `sub.rn.f32x2`, three
+                            # `fma.rn.f32x2`, then two per-element
+                            # `shl.b32`/`add.s32` combines; extent: 18
+                            # emulated pairs per static softmax step.
+                        else:
+                            p[idx]=exp2(score[idx]); p[idx+1]=exp2(score[idx+1])
+                            # instruction_selection: two
+                            # `ex2.approx.ftz.f32`; extent: 46 hardware pairs /
+                            # 92 hardware values per static step.
+                    for pair in static_range(16):
+                        idx=frag*32+2*pair
+                        packed_p[idx//2]=convert_pair_rn(dtype,p[idx],p[idx+1])
+                        # instruction_selection: fragment-final BF16x2/F16x2
+                        # round-to-nearest conversion; extent: 16 pairs.
+                for chunk in static_range(4):
+                    copy_r2t(packed_p[16*chunk:16*chunk+16],
+                             tmem_row_addr(row,P_COL[stage]+16*chunk))
+                    # instruction_selection: one x16 R2T P store.
+                    if chunk==2:
+                        fence_tmem_store(); mbarrier_arrive(empty(OFF.SPO,2,stage))
+                        # instruction_selection: TMEM wait then ordinary SPO
+                        # empty arrive after the first 96 columns.
+                fence_tmem_store(); sync_warp(); elect_mbarrier_arrive(full(OFF.PLAST,2,stage))
+                # instruction_selection: TMEM wait, warp sync and elected
+                # ordinary P-last arrive for final 32 columns.
+                wait(empty(OFF.STATS,2,stage),stats_prod)
+                # instruction_selection: stats-empty wait before row-sum tree.
+                init=row_sum*old_scale
+                acc=[add_packed((init,0),(p[0],p[1])),(p[2],p[3]),
+                     (p[4],p[5]),(p[6],p[7])]
+                for i in static_range(8,128,8):
+                    for j in static_range(4): acc[j]=add_packed(acc[j],(p[i+2*j],p[i+2*j+1]))
+                acc[0]=add_packed(acc[0],acc[1]); acc[2]=add_packed(acc[2],acc[3])
+                acc[0]=add_packed(acc[0],acc[2]); row_sum=acc[0][0]+acc[0][1]
+                # instruction_selection: old sum enters only the first packed
+                # pair; packed add tree then final scalar add, exact source order.
+                stats_prod^=1; score_phase^=1
+                # Both phase returns move only after the row-sum tree completes.
+            store_shared_f32(stat_byte(stage,row,False),row_sum)
+            # instruction_selection: scalar `st.shared.b32`; final row sum.
+            store_shared_f32(stat_byte(stage,row,True),row_max)
+            # instruction_selection: scalar `st.shared.b32`; final row max.
+            named_barrier_arrive(stage*4+local_warp,64)
+            # instruction_selection: final `bar.arrive`, 64 participants.
+        else:
+            named_barrier_arrive(stage*4+local_warp,64)
+            # instruction_selection: synthetic empty `bar.arrive`, 64 participants.
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        nx=query_cancel_get_first_ctaid_x(response128)
+        ny=query_cancel_get_first_ctaid_y(response128)
+        nz=query_cancel_get_first_ctaid_z(response128); work=(nx,ny,nz,valid)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS)
+        # instruction_selection: softmax-role `bar.sync 0`, shared full parity
+        # wait, `ld.shared.v2.b64`, CLC predicate/x/y/z decode, async-shared
+        # fence and cluster-scope empty arrive; extent: one response.
+    wait(empty(OFF.STATS,2,stage),stats_prod); named_barrier_arrive(2,416)
+    # instruction_selection: `mbarrier.try_wait.parity.shared.b64` stats
+    # producer-tail, then `bar.arrive 2,416`; extent: warps 0..7.
+
+# 6. Warps 8..11: correction and normalized output.
+if 8<=warp<12:
+    setmaxnreg_decrease(REG_CORRECTION)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32` immediate
+    # 64 for D64 and 88 for D96/D128; extent: each correction warp.
+    wait_for_tmem_alloc(); retrieve_tmem_pointer()
+    # instruction_selection: named allocator rendezvous/retrieval; extent:
+    # warps 8..11, part of the 416-thread TMEM lifetime group.
+    cw=warp-8; row=cw*32+lane
+    for stage in static_range(2): mbarrier_arrive(empty(OFF.SPO,2,stage))
+    # Exactly two priming releases before, never inside, the persistent loop.
+    # instruction_selection: two ordinary `mbarrier.arrive.shared.b64` per
+    # correction thread; extent: 128 threads and two stages, once per kernel.
+    stats_cons=STATS_CONS_PHASE; oacc_cons=OACC_CONS_PHASE; oepi_prod=OEPI_PROD_PHASE
+    work=initial_work_tile_info()
+    while work.valid:
+        raw=work_sparse_count(); has_work=(raw>0) if P.ALLOW_EMPTY else True
+        stats=[(0,-inf,True),(0,-inf,True)]
+        if has_work:
+            named_barrier_sync(0*4+cw,64); mbarrier_arrive(empty(OFF.STATS,2,0))
+            # instruction_selection: `bar.sync id,64` followed by ordinary
+            # `mbarrier.arrive.shared.b64`; first stat has no O correction.
+            named_barrier_sync(1*4+cw,64); stats_cons^=1
+            # instruction_selection: paired `bar.sync id,64`; extent: stage 1.
+            count=(raw+1)&~1 if P.HAS_NUMS else raw
+            for pair in serial_range((count-2)//2):
+                for stage in static_range(2):
+                    named_barrier_sync(stage*4+cw,64)
+                    # instruction_selection: `bar.sync id,64`; one paired warp.
+                    scale=load_shared_f32(stat_byte(stage,row,False))
+                    # instruction_selection: scalar `ld.shared.b32`; one row scale.
+                    if warp_vote_any(scale<1):
+                        # instruction_selection: `vote.sync.ballot.b32`; one warp vote.
+                        for chunk in static_range(D//16):
+                            copy_t2r(tmem_row_addr(row,O_COL[stage]+16*chunk),o16)
+                            # instruction_selection:
+                            # `tcgen05.ld.sync.aligned.32x32b.x16.b32`; extent:
+                            # D/16 chunks for this stage and row.
+                            for j in static_range(0,16,2):
+                                o16[j:j+2]=mul_packed(o16[j:j+2],(scale,scale))
+                                # instruction_selection: `mul.rn.f32x2`;
+                                # extent: eight packed pairs per chunk.
+                            copy_r2t(o16,tmem_row_addr(row,O_COL[stage]+16*chunk))
+                            # instruction_selection:
+                            # `tcgen05.st.sync.aligned.32x32b.x16.b32`;
+                            # extent: D/16 chunks.
+                        fence_tmem_store()
+                        # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+                    mbarrier_arrive(empty(OFF.SPO,2,stage))
+                    mbarrier_arrive(empty(OFF.STATS,2,1-stage))
+                    # instruction_selection: two ordinary shared mbarrier
+                    # arrives, O-rescaled then crossed stats reuse.
+                stats_cons^=1
+            mbarrier_arrive(empty(OFF.STATS,2,1))
+            # instruction_selection: final ordinary stats-empty arrive.
+            for stage in static_range(2):
+                named_barrier_sync(stage*4+cw,64)
+                # instruction_selection: final paired `bar.sync id,64`.
+                sm=load_shared_f32(stat_byte(stage,row,False))
+                mx=load_shared_f32(stat_byte(stage,row,True))
+                # instruction_selection: two scalar `ld.shared.b32` per stage.
+                mbarrier_arrive(empty(OFF.STATS,2,stage)); bad=(sm==0 or sm!=sm)
+                # instruction_selection: ordinary stats-empty arrive plus f32
+                # zero/NaN predicates; extent: one row/stage.
+                stats[stage]=(sm,mx,bad)
+            rm0=-inf if stats[0].bad else stats[0].max
+            rm1=-inf if stats[1].bad else stats[1].max
+            maxc=max(rm0,rm1); safe_max=0 if maxc==-inf else maxc
+            scale0=0 if stats[0].bad else exp2((rm0-safe_max)*softmax_scale_log2)
+            scale1=0 if stats[1].bad else exp2((rm1-safe_max)*softmax_scale_log2)
+            # instruction_selection: `max.f32`, f32 sub/mul and two
+            # `ex2.approx.ftz.f32` selected by valid-stage predicates.
+            total=stats[0].sum*scale0+stats[1].sum*scale1
+            # instruction_selection: one `mul.f32` for the stage-1 term then
+            # one `fma.rn.f32` for stage 0 plus stage 1.
+            inv=rcp(total if total!=0 and total==total else 1)
+            final0=scale0*inv; final1=scale1*inv
+            # instruction_selection: f32 mul/add and
+            # `rcp.approx.ftz.f32`; extent: one output row.
+            wait(full(OFF.OACC,2,0),oacc_cons); wait(full(OFF.OACC,2,1),oacc_cons)
+            # instruction_selection: two shared parity waits; extent: both O stages.
+            wait(empty(OFF.OEPI,2,0),oepi_prod)
+            # instruction_selection: shared parity wait; extent: corrected-O buffer.
+            for chunk in static_range(D//16):
+                copy_t2r(tmem_row_addr(row,O_COL[0]+16*chunk),o0)
+                copy_t2r(tmem_row_addr(row,O_COL[1]+16*chunk),o1)
+                # instruction_selection: two
+                # `tcgen05.ld.sync.aligned.32x32b.x16.b32`; extent: D/16 chunks.
+                for j in static_range(0,16,2):
+                    z0=mul_packed(o0[j:j+2],(final0,final0)); z1=mul_packed(o1[j:j+2],(final1,final1))
+                    out[j:j+2]=add_packed(z0,z1)
+                    # instruction_selection: two `mul.rn.f32x2` and one
+                    # `add.rn.f32x2`; extent: eight packed pairs per chunk.
+                for pair in static_range(8):
+                    narrow[pair]=convert_pair_rn(dtype,out[2*pair],out[2*pair+1])
+                    # instruction_selection: `cvt.rn.bf16x2.f32` or
+                    # `cvt.rn.f16x2.f32`; extent: eight conversions per chunk,
+                    # total D64/D96/D128 = 32/48/64 conversions per role body.
+                store_shared_v4_b32(o_byte(0,row,16*chunk)+0,narrow[0:4])
+                store_shared_v4_b32(o_byte(0,row,16*chunk)+16,narrow[4:8])
+                # instruction_selection: two `st.shared.v4.b32` per chunk;
+                # total D64/D96/D128 = 8/12/16 vector stores.
+            fence_async_shared_cta()
+            # instruction_selection: `fence.proxy.async.shared::cta` immediately
+            # after the shared stores and before either SPO release.
+            for stage in static_range(2): mbarrier_arrive(empty(OFF.SPO,2,stage))
+            # instruction_selection: two ordinary shared mbarrier arrives.
+            oacc_cons^=1; stats_cons^=1
+        else:
+            for stage in static_range(2):
+                named_barrier_sync(stage*4+cw,64)
+                mbarrier_arrive(empty(OFF.STATS,2,stage))
+                # instruction_selection: paired `bar.sync id,64` and ordinary
+                # stats-empty arrive; extent: both synthetic empty stages.
+            stats_cons^=1; wait(empty(OFF.OEPI,2,0),oepi_prod)
+            # instruction_selection: shared O-epi-empty parity wait.
+            for chunk in static_range(D//16):
+                zero4=(0,0,0,0)
+                store_shared_v4_b32(o_byte(0,row,16*chunk)+0,zero4)
+                store_shared_v4_b32(o_byte(0,row,16*chunk)+16,zero4)
+                # instruction_selection: two direct zero `st.shared.v4.b32`
+                # words per chunk; D96 emits 12. No conversion and no TMEM load.
+            fence_async_shared_cta()
+            # instruction_selection: `fence.proxy.async.shared::cta` immediately
+            # after the empty-path shared stores.
+            total=0; safe_max=0
+            # No OACC wait/read and no SPO release in an empty work item.
+        mbarrier_arrive(full(OFF.OEPI,2,0)); oepi_prod^=1
+        # instruction_selection: ordinary `mbarrier.arrive.shared.b64` from all
+        # 128 correction threads; extent: one O-epi full generation.
+        if P.RETURN_LSE and logical_row_is_live(work,row):
+            lse=(safe_max*softmax_scale_log2+log2(total))*ln2 if total>0 else -inf
+            # instruction_selection: `lg2.approx.ftz.f32`, `fma.rn.f32`, final
+            # `mul.f32` by ln2 and valid-row predicates; extent: one live row.
+            store_global_f32(LSE[logical_row(work,row)],lse)
+            # instruction_selection: scalar `st.global.b32`; omitted entirely
+            # when RETURN_LSE is false.
+        sync_cta(); wait(full(OFF.CLC,1,CLC_CONS.index),CLC_CONS.phase)
+        response128=load_shared_v2_b64(OFF.RESP)
+        valid=query_cancel_is_canceled(response128)
+        nx=query_cancel_get_first_ctaid_x(response128)
+        ny=query_cancel_get_first_ctaid_y(response128)
+        nz=query_cancel_get_first_ctaid_z(response128); work=(nx,ny,nz,valid)
+        fence_async_shared_cta(); release_cluster(empty(OFF.CLC,1,CLC_CONS.index))
+        advance(CLC_CONS)
+        # instruction_selection: correction-role `bar.sync 0`, shared full
+        # parity wait, `ld.shared.v2.b64`, CLC predicate/x/y/z decode,
+        # async-shared fence and cluster-scope empty arrive; one response.
+    wait(empty(OFF.OEPI,2,0),oepi_prod); named_barrier_arrive(2,416)
+    # instruction_selection: shared parity producer-tail wait then
+    # `bar.arrive 2,416`; warps 0..11 contribute 384 arrivals. Warp 12's later
+    # sync contributes the remaining 32 exactly once, after relinquishing.
+```
+
+Every work item retains role-local states across CLC advance. An odd variable
+count rounds even; a phantom sparse id is clamped but its score block is fully
+`-inf` masked. An empty tile issues no Q/K/V or MMA, touches no OACC generation,
+writes bitwise-zero O and exact `-inf` LSE. `RETURN_LSE=False` emits no LSE store.
+
+## Bidirectional source / sketch / PTX map
+
+| semantic edge | source lines | sketch section | exported `.loc` / opcode evidence |
+| --- | --- | --- | --- |
+| ABI, specialization, layouts | 214–460 | scope/storage | wrapper path; rank-4/5 TensorMaps in MHA/packed/fallback exports |
+| prefetch and two-stage init | 541–701 | exact prologue | main `.loc 547/631/686/701`; four prefetches, 32 D128 inits, two fences/two syncs |
+| role order and register budgets | 703–852 | source-order roles | main `.loc 708/723/750/781/797/829`; exact `setmaxnreg` immediates |
+| CLC producer/consumer/tail | 856–883; scheduler 138–188 | role 1 and six advances | scheduler `.loc 150/172/181–185`; query, expect-16, v2.b64, six sync/release paths |
+| reverse Q/K/V producer | 885–1015,1888–1940 | role 2 | main `.loc 977–1006/1012–1015`; K-before-Q and producer tails |
+| QK/PV order/descriptors | 1018–1240,1989–2305 | maps/role 3 | generated `.loc 214–265`; P 64/192, V/K wait order and cloned release |
+| score load/mask/max | 1244–1459 | role 5 | main `.loc 1444–1457`; four x32 loads and helper `.loc 155–188` tree |
+| exp/convert/sum/P split | 1460–1486; softmax 168–194; kernel_utils 192–210 | role 5 | frequency-10 exp2, x16 stores, 96/32 publication and packed sum tree |
+| correction/stat phases | 1489–1675 | role 6 | main `.loc 1515/1536–1675`; priming, phases and producer tail |
+| rescale/combine/output | 1675–1887 | roles 6/4 | main `.loc 1713–1784/1858–1863`; x16 TMEM, packed math, rank-4/5 TMA |
+| TMEM lifetime | 752–775,798–852 | roles 3/5/6 | alloc; warps 0–11 arrive; warp 12 relinquish→sync→free |
+
+Reading in reverse, every tensor-bulk copy, TMEM load/store, MMA, conversion,
+transcendental, vector shared/global access, mbarrier, named barrier, bulk-group,
+CLC and TMEM-lifetime instruction in the 16 fresh exports maps to a concrete
+occurrence above. Address arithmetic maps to integer functions, never a layout.
+
+## TIRx, correctness and performance contract
+
+The public module exports `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`,
+`get_kernel`, `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, and
+`run_bench`. Device code imports only `tirx_kernels.kern as K`; low-level
+instruction families use `K.ptx[...]`. There is no inline CUDA function call,
+tile primitive, first-class layout or multidimensional SMEM allocation.
+
+The frozen correctness matrix has 32 rows spanning dtype/D/family plus minimal
+and ragged Q/KV tails, fixed/odd/empty counts, packed and non-packed GQA,
+ratio-3 fallback, BSHD normalization, no-LSE, custom scale and i64 KV address
+arithmetic. TIRx and pinned source share immutable inputs and independent
+outputs. Both are checked against the same FP32 block-sparse oracle: O uses
+`atol=rtol=0.03`; finite LSE uses `atol=rtol=0.002`; finite/`-inf` masks are
+exact; NaN is forbidden; empty O is bitwise zero and empty LSE exactly `-inf`;
+no-LSE sentinels remain untouched. No match fraction or skip is valid.
+
+Performance truth is exclusively `python -m tirx_kernels.bench_suite` with the
+frozen 24-row matrix and pinned cuDNN Frontend reference. Each row must have five
+finite positive Proton samples for both implementations and strict
+`mean(cudnn_frontend)/mean(tirx) > 0.99`.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/declare-the-block-shape-the-reference-declares.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/declare-the-block-shape-the-reference-declares.md
@@ -58,6 +58,13 @@ converted the logical CTA grid to a cluster grid. Cluster-1, cluster-2, and
 cluster-16 correctness all passed, as did 1,025 source-domain configurations;
 the complete measured matrix retained 1.018-1.046x reference/port ratios.
 
+A negative ablation confirmed that matching the host block dimensions is not a
+substitute for keeping the exact-block contract. Removing only the required-block
+attribute from a 512-thread kernel, while retaining the 512-thread host launch
+and `min_blocks_per_sm=1`, replaced `.reqntid` with `.maxntid` and removed the
+singleton-cluster directives. All five targeted rows failed to improve; the
+latency-bound row fell from 0.9575x to 0.9501x with correctness unchanged.
+
 ## Boundary
 
 Use the required-block contract only when fresh reference PTX requires exact
@@ -66,6 +73,12 @@ runtime that understands CUDA's cluster-grid launch semantics. Do not replace a
 register-budget launch bound with it: `.maxntid` and `.reqntid` promise different
 things, and the measured result above establishes source-contract matching, not
 an isolated speedup from strengthening the directive.
+
+Conversely, a profiler reporting singleton blocks-as-clusters is not enough to
+justify weakening an exact-block contract. Removing that contract changes both
+the cluster metadata and the required-thread declaration, so it cannot isolate
+cluster-launch overhead; keep the source-required `.reqntid` and test cluster
+mechanics through a change that preserves it.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/expose-predication-and-uniform-control.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/expose-predication-and-uniform-control.md
@@ -163,6 +163,17 @@ no spill.
   at 0.993x. It was the last change the gate needed, after twelve expansions
   that had each moved a required shape by 0.002 or less.
 
+- A sparse K/V transfer loop supplied the same mechanism with a global sparse-ID
+  load, an expect-tx arrival, coordinate formation, and 4D tensor-copy issues in
+  one elected-lane branch. Two branch PCs each produced 2,580 divergent branches
+  while the reference produced 150 in total. Hoisting the warp-uniform work and
+  predicating only the load, arrival, and copies kept all 18 tensor-copy sites,
+  reduced static `BSSY.RECONVERGENT` from 8 to 2, predicated-false branch sites
+  from 102 to 84, and `ELECT` from 12 to 11. The latency-bound tail moved from
+  0.9575x to 0.9912x; all 32 correctness configurations passed, and three clean
+  complete 24-row matrices subsequently passed with minima of 0.9979x, 0.9965x,
+  and 0.9907x.
+
 - In a rows-one, full-vector specialization, making the launch proof explicit
   removed eight asynchronous-copy row/source-byte guards, eight weight-column
   guards, and eight output-row guards. Static SASS fell from 693 to 669
@@ -238,6 +249,12 @@ fell 0.0016, and on a clean re-measurement it gained 0.0002 while a passing
 shape lost 0.0007, merely moving which shape failed. Those arrivals ran a couple
 of times per CTA against the transfer block's once per chunk. Count the dynamic
 executions of the region and the instructions inside it before rewriting a guard.
+
+Flattening also makes formerly leader-only arithmetic execute warp-wide. In the
+sparse-transfer experiment above, a work-richer guard moved from 1.2178x to
+1.1954x even though the short divergent tail crossed the gate. Keep coordinate
+formation and descriptor selection small, and require both branch-dominated
+targets and work-dominated guards before applying the rewrite to a shared path.
 
 Predication pays where a branch DIVERGES, not wherever a branch exists. In a
 gather whose validity flag is row-uniform -- every lane of the warp takes the

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ list.
   [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
 - **Sparse attention:**
   [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py),
+  [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py),
   [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py),
   [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
 

--- a/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk128.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk128.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cudnn_sm100_bsa_forward_blk128
+selection_rationale: The three defaults cross D64 MHA, D96 FP16 packed GQA, and D128 packed MQA; the complete explicit matrix additionally covers both dtypes, every dtype/head-dimension/family combination, fallback GQA, ragged and empty sparse metadata, no-LSE output, batch occupancy, long KV, and 64-bit KV addressing.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: p00_bf16_d64_mha, default: true, selection_role: small}
+  - {config: p01_bf16_d64_gqa, default: false}
+  - {config: p02_bf16_d64_mqa, default: false}
+  - {config: p03_bf16_d96_mha, default: false}
+  - {config: p04_bf16_d96_gqa, default: false}
+  - {config: p05_bf16_d96_mqa, default: false}
+  - {config: p06_bf16_d128_mha, default: false}
+  - {config: p07_bf16_d128_gqa, default: false}
+  - {config: p08_bf16_d128_mqa, default: true, selection_role: large}
+  - {config: p09_fp16_d64_mha, default: false}
+  - {config: p10_fp16_d64_gqa, default: false}
+  - {config: p11_fp16_d64_mqa, default: false}
+  - {config: p12_fp16_d96_mha, default: false}
+  - {config: p13_fp16_d96_gqa, default: true, selection_role: medium}
+  - {config: p14_fp16_d96_mqa, default: false}
+  - {config: p15_fp16_d128_mha, default: false}
+  - {config: p16_fp16_d128_gqa, default: false}
+  - {config: p17_fp16_d128_mqa, default: false}
+  - {config: p18_bf16_d128_mha_tail_var, default: false}
+  - {config: p19_fp16_d96_gqa_tail_empty_nomask, default: false}
+  - {config: p20_bf16_d64_gqa_nopack_longkv, default: false}
+  - {config: p21_fp16_d128_gqa_ratio3_fallback_nolse, default: false}
+  - {config: p22_bf16_d96_mha_b2_h4, default: false}
+  - {config: p23_bf16_d128_mha_i64kv, default: false}

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py
@@ -1,0 +1,1967 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM100 blk128 block-sparse attention forward pass.
+
+Upstream sources:
+``python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py``,
+``python/cudnn/block_sparse_attention/_interface.py``, and the block-sparse
+scheduler, pipeline, softmax, and packed-GQA helpers imported by that kernel.
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cudnn_sm100_bsa_forward_blk128",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+
+def _config(label, **overrides):
+    config = {
+        "label": label,
+        "batch": 1,
+        "num_q_heads": 2,
+        "num_kv_heads": 2,
+        "seqlen_q": 257,
+        "seqlen_kv": 1023,
+        "head_dim": 128,
+        "dtype": "bfloat16",
+        "kv_blocks": 4,
+        "tensor_layout": "bhsd",
+        "has_block_sizes": True,
+        "block_count_mode": "fixed",
+        "block_count_pattern": None,
+        "pack_gqa": "auto",
+        "return_lse": True,
+        "softmax_scale": None,
+        "use_int64_kv_strides": False,
+        "seed": 12800,
+    }
+    config.update(overrides)
+    return config
+
+
+def _correctness_configs():
+    configs = []
+    seed = 12800
+
+    def add(label, **kwargs):
+        nonlocal seed
+        seed += 1
+        configs.append(_config(label, seed=seed, **kwargs))
+
+    for dtype in ("bfloat16", "float16"):
+        dtype_label = "bf16" if dtype == "bfloat16" else "fp16"
+        for head_dim in (64, 96, 128):
+            for mode, num_q_heads, num_kv_heads in (("mha", 2, 2), ("gqa", 4, 2), ("mqa", 8, 1)):
+                add(
+                    f"c_{dtype_label}_d{head_dim}_{mode}_core",
+                    dtype=dtype,
+                    head_dim=head_dim,
+                    num_q_heads=num_q_heads,
+                    num_kv_heads=num_kv_heads,
+                )
+
+    add("c_bf16_d128_mha_sq1_skv256_kv2_mask", seqlen_q=1, seqlen_kv=256, kv_blocks=2)
+    add(
+        "c_fp16_d64_mha_sq127_skv255_kv2_mask",
+        dtype="float16",
+        head_dim=64,
+        seqlen_q=127,
+        seqlen_kv=255,
+        kv_blocks=2,
+    )
+    add(
+        "c_bf16_d96_mha_sq128_skv512_kv4_nomask",
+        head_dim=96,
+        seqlen_q=128,
+        seqlen_kv=512,
+        has_block_sizes=False,
+    )
+    add(
+        "c_fp16_d128_mha_sq129_skv512_var_1_3_4_mask",
+        dtype="float16",
+        seqlen_q=129,
+        seqlen_kv=512,
+        block_count_mode="variable",
+        block_count_pattern="1,3,4",
+    )
+    add(
+        "c_bf16_d64_mha_sq129_skv512_empty_0_1_4_mask",
+        head_dim=64,
+        seqlen_q=129,
+        seqlen_kv=512,
+        block_count_mode="variable_empty",
+        block_count_pattern="0,1,4",
+    )
+    add(
+        "c_fp16_d96_gqa_var_1_3_4_nomask_pack",
+        dtype="float16",
+        head_dim=96,
+        num_q_heads=4,
+        num_kv_heads=2,
+        block_count_mode="variable",
+        block_count_pattern="1,3,4",
+        has_block_sizes=False,
+    )
+    add(
+        "c_bf16_d128_mqa_empty_0_1_4_mask_pack",
+        num_q_heads=8,
+        num_kv_heads=1,
+        block_count_mode="variable_empty",
+        block_count_pattern="0,1,4",
+    )
+    add(
+        "c_fp16_d64_gqa_fixed_mask_nopack",
+        dtype="float16",
+        head_dim=64,
+        num_q_heads=4,
+        num_kv_heads=2,
+        pack_gqa=False,
+    )
+    add("c_bf16_d96_gqa_ratio3_auto_fallback", head_dim=96, num_q_heads=3, num_kv_heads=1)
+    add(
+        "c_fp16_d128_gqa_pack_bshd",
+        dtype="float16",
+        num_q_heads=4,
+        num_kv_heads=2,
+        pack_gqa=True,
+        tensor_layout="bshd",
+    )
+    add("c_bf16_d64_mha_b2_h3", batch=2, num_q_heads=3, num_kv_heads=3, head_dim=64)
+    add("c_fp16_d96_mha_no_lse", dtype="float16", head_dim=96, return_lse=False)
+    add("c_bf16_d128_mha_scale0125_i64kv", softmax_scale=0.125, use_int64_kv_strides=True)
+    add(
+        "c_fp16_d64_mqa_all_empty",
+        dtype="float16",
+        head_dim=64,
+        num_q_heads=8,
+        num_kv_heads=1,
+        block_count_mode="variable_empty",
+        block_count_pattern="0",
+    )
+    assert len(configs) == 32
+    return configs
+
+
+def _benchmark_configs():
+    configs = []
+    seed = 12900
+
+    def add(**kwargs):
+        nonlocal seed
+        seed += 1
+        index = len(configs)
+        dtype_label = "bf16" if kwargs["dtype"] == "bfloat16" else "fp16"
+        mode = kwargs.pop("mode")
+        label = f"p{index:02d}_{dtype_label}_d{kwargs['head_dim']}_{mode}"
+        configs.append(_config(label, seed=seed, **kwargs))
+
+    for dtype in ("bfloat16", "float16"):
+        for head_dim in (64, 96, 128):
+            for mode, num_kv_heads in (("mha", 8), ("gqa", 2), ("mqa", 1)):
+                add(
+                    mode=mode,
+                    dtype=dtype,
+                    head_dim=head_dim,
+                    batch=1,
+                    num_q_heads=8,
+                    num_kv_heads=num_kv_heads,
+                    seqlen_q=4096,
+                    seqlen_kv=8192,
+                    kv_blocks=32,
+                )
+
+    add(
+        mode="mha_tail_var",
+        dtype="bfloat16",
+        head_dim=128,
+        batch=1,
+        num_q_heads=8,
+        num_kv_heads=8,
+        seqlen_q=4097,
+        seqlen_kv=8191,
+        kv_blocks=32,
+        block_count_mode="variable",
+        block_count_pattern="1,mid,max",
+    )
+    add(
+        mode="gqa_tail_empty_nomask",
+        dtype="float16",
+        head_dim=96,
+        batch=1,
+        num_q_heads=8,
+        num_kv_heads=2,
+        seqlen_q=4097,
+        seqlen_kv=8191,
+        kv_blocks=32,
+        block_count_mode="variable_empty",
+        block_count_pattern="0,1,max",
+        has_block_sizes=False,
+    )
+    add(
+        mode="gqa_nopack_longkv",
+        dtype="bfloat16",
+        head_dim=64,
+        batch=1,
+        num_q_heads=8,
+        num_kv_heads=2,
+        seqlen_q=2048,
+        seqlen_kv=16384,
+        kv_blocks=128,
+        pack_gqa=False,
+    )
+    add(
+        mode="gqa_ratio3_fallback_nolse",
+        dtype="float16",
+        head_dim=128,
+        batch=1,
+        num_q_heads=6,
+        num_kv_heads=2,
+        seqlen_q=2048,
+        seqlen_kv=8192,
+        kv_blocks=32,
+        return_lse=False,
+    )
+    add(
+        mode="mha_b2_h4",
+        dtype="bfloat16",
+        head_dim=96,
+        batch=2,
+        num_q_heads=4,
+        num_kv_heads=4,
+        seqlen_q=4096,
+        seqlen_kv=8192,
+        kv_blocks=32,
+    )
+    add(
+        mode="mha_i64kv",
+        dtype="bfloat16",
+        head_dim=128,
+        batch=1,
+        num_q_heads=4,
+        num_kv_heads=4,
+        seqlen_q=4096,
+        seqlen_kv=8192,
+        kv_blocks=32,
+        use_int64_kv_strides=True,
+    )
+    assert len(configs) == 24
+    return configs
+
+
+CONFIGS = _correctness_configs()
+BENCH_CONFIGS = _benchmark_configs()
+
+
+_M = 128
+_N = 128
+_WARPS = 16
+_TMEM_COLS = 512
+_SPLIT_P = 96
+_NEG_INF = -float("inf")
+_LOG2_E = 1.4426950408889634
+_LN2 = 0.6931471805599453
+_TRY_WAIT_TICKS = 10_000_000
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TCGEN_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+_TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+_TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+_TMEM_LD32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+_TMEM_ST16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+_TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_G2S_5D = (
+    "cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+_TMA_S2G_5D = "cp.async.bulk.tensor.5d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+_TMA_CACHE = K.uint64(0)
+_POLY_EX2_3 = (
+    1.0,
+    0.695146143436431884765625,
+    0.227564394474029541015625,
+    0.077119089663028717041015625,
+)
+_FP32_ROUND_INT = float(2**23 + 2**22)
+
+
+def _load_i32(buffer, index):
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, buffer.ptr_to([index]))
+    return value
+
+
+def _ld_shared_f32(buffer, index):
+    bits = K.local_scalar("uint32")
+    K.ptx.ld.shared.b32(bits, buffer.ptr_to([index]))
+    return K.reinterpret("float32", bits)
+
+
+def _st_shared_f32(buffer, index, value):
+    K.ptx.st.shared.b32(buffer.ptr_to([index]), K.reinterpret("uint32", value))
+
+
+def _exp2(value):
+    out = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(out, value)
+    return out
+
+
+def _log2(value):
+    out = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(out, value)
+    return out
+
+
+def _rcp(value):
+    out = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(out, value)
+    return out
+
+
+def _packed(op, dst, base, a0, a1, b0, b1, c0=None, c1=None):
+    lhs = K.local_scalar("uint64")
+    rhs = K.local_scalar("uint64")
+    result = K.local_scalar("uint64")
+    K.ptx.mov.b64(lhs, a0, a1)
+    K.ptx.mov.b64(rhs, b0, b1)
+    if c0 is None:
+        K.ptx[op](result, lhs, rhs)
+    else:
+        addend = K.local_scalar("uint64")
+        K.ptx.mov.b64(addend, c0, c1)
+        K.ptx[op](result, lhs, rhs, addend)
+    K.ptx.mov.b64(dst[base], dst[base + 1], result)
+
+
+def _reduce_max_128(values, initial=None):
+    acc = K.alloc_local((4,), "float32")
+    if initial is None:
+        K.ptx.max.f32(acc[0], values[0], values[1])
+    else:
+        K.ptx.max.f32(acc[0], initial, values[0], values[1])
+    K.ptx.max.f32(acc[1], values[2], values[3])
+    K.ptx.max.f32(acc[2], values[4], values[5])
+    K.ptx.max.f32(acc[3], values[6], values[7])
+    with K.unroll(1, 16) as group:
+        base = group * 8
+        K.ptx.max.f32(acc[0], acc[0], values[base], values[base + 1])
+        K.ptx.max.f32(acc[1], acc[1], values[base + 2], values[base + 3])
+        K.ptx.max.f32(acc[2], acc[2], values[base + 4], values[base + 5])
+        K.ptx.max.f32(acc[3], acc[3], values[base + 6], values[base + 7])
+    K.ptx.max.f32(acc[0], acc[0], acc[1])
+    K.ptx.max.f32(acc[0], acc[0], acc[2], acc[3])
+    return acc[0]
+
+
+def _packed_sum_128(values, old_sum, old_scale, first):
+    acc = K.alloc_local((8,), "float32")
+    with K.unroll(8) as j:
+        K.assign(acc[j], values[j])
+    if not first:
+        scaled_old = K.local_scalar("float32", init=old_sum * old_scale)
+        _packed("add.rn.f32x2", acc, 0, values[0], values[1], scaled_old, K.float32(0.0))
+    with K.unroll(1, 16) as group:
+        base = group * 8
+        with K.unroll(4) as pair:
+            _packed(
+                "add.rn.f32x2",
+                acc,
+                pair * 2,
+                acc[pair * 2],
+                acc[pair * 2 + 1],
+                values[base + pair * 2],
+                values[base + pair * 2 + 1],
+            )
+    for lo, hi in ((0, 2), (4, 6), (0, 4)):
+        _packed("add.rn.f32x2", acc, lo, acc[lo], acc[lo + 1], acc[hi], acc[hi + 1])
+    return acc[0] + acc[1]
+
+
+def _combine_int_frac_ex2(x_rounded, frac_ex2):
+    rounded_i = K.local_scalar("int32")
+    frac_i = K.local_scalar("int32")
+    exponent = K.local_scalar("int32")
+    bits = K.local_scalar("int32")
+    out = K.local_scalar("float32")
+    K.ptx.mov.b32(rounded_i, x_rounded)
+    K.ptx.mov.b32(frac_i, frac_ex2)
+    K.ptx.shl.b32(exponent, rounded_i, K.uint32(23))
+    K.ptx.add.s32(bits, exponent, frac_i)
+    K.ptx.mov.b32(out, bits)
+    return out
+
+
+def _ex2_emulation_2(values, base):
+    clamped = K.alloc_local((2,), "float32")
+    K.ptx.max.f32(clamped[0], values[base], K.float32(-127.0))
+    K.ptx.max.f32(clamped[1], values[base + 1], K.float32(-127.0))
+    packed = K.local_scalar("uint64")
+    rhs = K.local_scalar("uint64")
+    addend = K.local_scalar("uint64")
+    rounded = K.alloc_local((2,), "float32")
+    K.ptx.mov.b64(packed, clamped[0], clamped[1])
+    K.ptx.mov.b64(rhs, K.float32(_FP32_ROUND_INT), K.float32(_FP32_ROUND_INT))
+    K.ptx.add.rm.f32x2(packed, packed, rhs)
+    K.ptx.mov.b64(rounded[0], rounded[1], packed)
+    rounded_back = K.alloc_local((2,), "float32")
+    K.ptx.mov.b64(packed, rounded[0], rounded[1])
+    K.ptx.sub.rn.f32x2(packed, packed, rhs)
+    K.ptx.mov.b64(rounded_back[0], rounded_back[1], packed)
+    frac = K.alloc_local((2,), "float32")
+    K.ptx.mov.b64(packed, clamped[0], clamped[1])
+    K.ptx.mov.b64(rhs, rounded_back[0], rounded_back[1])
+    K.ptx.sub.rn.f32x2(packed, packed, rhs)
+    K.ptx.mov.b64(frac[0], frac[1], packed)
+    poly = K.alloc_local((2,), "float32")
+    K.assign(poly[0], K.float32(_POLY_EX2_3[3]))
+    K.assign(poly[1], K.float32(_POLY_EX2_3[3]))
+    for coeff in (_POLY_EX2_3[2], _POLY_EX2_3[1], _POLY_EX2_3[0]):
+        K.ptx.mov.b64(packed, poly[0], poly[1])
+        K.ptx.mov.b64(rhs, frac[0], frac[1])
+        K.ptx.mov.b64(addend, K.float32(coeff), K.float32(coeff))
+        K.ptx.fma.rn.f32x2(packed, packed, rhs, addend)
+        K.ptx.mov.b64(poly[0], poly[1], packed)
+    K.assign(values[base], _combine_int_frac_ex2(rounded[0], poly[0]))
+    K.assign(values[base + 1], _combine_int_frac_ex2(rounded[1], poly[1]))
+
+
+def _apply_mask128(values, block_size):
+    with K.If(block_size < 128), K.Then():
+        with K.unroll(4) as quarter:
+            shift = K.max((quarter + 1) * 32 - block_size, 0)
+            mask = K.local_scalar("uint32")
+            K.ptx.shr.u32(mask, K.uint32(0xFFFFFFFF), K.cast(shift, "uint32"))
+            with K.unroll(32) as bit:
+                live = K.bitwise_and(mask, K.shift_left(K.uint32(1), K.cast(bit, "uint32"))) != 0
+                index = quarter * 32 + bit
+                K.assign(values[index], K.if_then_else(live, values[index], K.float32(_NEG_INF)))
+
+
+def _wait(barrier, stage, phase):
+    K.cuda.mbarrier_wait(barrier.ptr_to([stage]), phase)
+
+
+def _stats_arrive(stage, warp):
+    K.ptx.bar.arrive(K.cast(3 + stage * 4 + warp, "uint32"), K.uint32(64))
+
+
+def _stats_sync(stage, warp):
+    K.ptx.bar.sync(K.cast(3 + stage * 4 + warp, "uint32"), K.uint32(64))
+
+
+def _tmem_load32(dst, address):
+    K.ptx[_TMEM_LD32](*(dst[i] for i in range(32)), K.cast(address, "uint32"))
+
+
+def _tmem_load16(dst, address):
+    K.ptx[_TMEM_LD16](*(dst[i] for i in range(16)), K.cast(address, "uint32"))
+
+
+def _tmem_store16(src, address):
+    K.ptx[_TMEM_ST16](K.cast(address, "uint32"), *(src[i] for i in range(16)))
+
+
+def _query_cancel_response(response, q_block, head, batch_idx, valid):
+    payload = K.local_scalar("uint128")
+    payload_lo = K.local_scalar("uint64")
+    payload_hi = K.local_scalar("uint64")
+    canceled = K.local_scalar("uint32")
+    K.ptx.ld.shared.v2.b64(payload_lo, payload_hi, K.address_of(response[0]))
+    K.ptx.mov.b128(payload, payload_lo, payload_hi)
+    K.ptx.clusterlaunchcontrol.query_cancel.is_canceled.pred.b128(canceled, payload)
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__x.b32.b128(
+        q_block, payload, pred=canceled
+    )
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__y.b32.b128(
+        head, payload, pred=canceled
+    )
+    K.ptx.clusterlaunchcontrol.query_cancel.get_first_ctaid__z.b32.b128(
+        batch_idx, payload, pred=canceled
+    )
+    K.assign(valid, K.cast(canceled, "int32"))
+    K.ptx.fence.proxy.async_.shared__cta()
+
+
+def _make_kernel(**config):
+    batch = int(config["batch"])
+    hq = int(config["num_q_heads"])
+    hkv = int(config["num_kv_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    d = int(config["head_dim"])
+    dtype = config["dtype"]
+    max_blocks = int(config["kv_blocks"])
+    has_sizes = bool(config["has_block_sizes"])
+    has_nums = config["block_count_mode"] != "fixed"
+    allow_empty = config["block_count_mode"] == "variable_empty"
+    return_lse = bool(config["return_lse"])
+    use_i64_kv = bool(config["use_int64_kv_strides"])
+    if hq <= 0 or hkv <= 0 or hq % hkv:
+        raise ValueError("num_q_heads must be a positive multiple of num_kv_heads")
+    if d not in (64, 96, 128):
+        raise ValueError("head_dim must be 64, 96, or 128")
+    if dtype not in ("bfloat16", "float16"):
+        raise ValueError("dtype must be bfloat16 or float16")
+    if config["block_count_mode"] == "fixed" and (max_blocks < 2 or max_blocks % 2):
+        raise ValueError("fixed block count must be even and at least two")
+
+    ratio = hq // hkv
+    requested_pack = config["pack_gqa"]
+    pack = (ratio > 1 if requested_pack == "auto" else bool(requested_pack)) and 128 % ratio == 0
+    scheduled_heads = hkv if pack else hq
+    q_rows = seqlen_q * ratio if pack else seqlen_q
+    q_blocks = (q_rows + 127) // 128
+    kv_stages = {64: 11, 96: 6, 128: 4}[d]
+    smem_bytes = {64: 232448, 96: 224256, 128: 232448}[d]
+    offsets = {
+        64: dict(
+            q=0,
+            kv=16,
+            spo=192,
+            plast=224,
+            oacc=256,
+            stats=288,
+            oepi=320,
+            tmem=352,
+            scale=356,
+            clc=2408,
+            response=2432,
+            prefix=2456,
+            so=3072,
+            sq=35840,
+            skv=52224,
+        ),
+        96: dict(
+            q=0,
+            kv=16,
+            spo=112,
+            plast=144,
+            oacc=176,
+            stats=208,
+            oepi=240,
+            tmem=272,
+            scale=276,
+            clc=2328,
+            response=2352,
+            prefix=2376,
+            so=3072,
+            sq=52224,
+            skv=76800,
+        ),
+        128: dict(
+            q=0,
+            kv=16,
+            spo=80,
+            plast=112,
+            oacc=144,
+            stats=176,
+            oepi=208,
+            tmem=240,
+            scale=244,
+            clc=2296,
+            response=2320,
+            prefix=2344,
+            so=3072,
+            sq=68608,
+            skv=101376,
+        ),
+    }[d]
+    band_width = 32 if d == 96 else 64
+    num_bands = d // band_width
+    smem_swizzle = 2 if d == 96 else 3
+    elem_dtype = K.bf16 if dtype == "bfloat16" else K.f16
+    elem_dtype_name = "bfloat16" if dtype == "bfloat16" else "float16"
+    qk_idesc = 0x08200490 if dtype == "bfloat16" else 0x08200010
+    pv_idesc = {
+        (64, "bfloat16"): 0x08110490,
+        (64, "float16"): 0x08110010,
+        (96, "bfloat16"): 0x08190490,
+        (96, "float16"): 0x08190010,
+        (128, "bfloat16"): 0x08210490,
+        (128, "float16"): 0x08210010,
+    }[(d, dtype)]
+    regs_other = 48 if d == 64 else 56
+    regs_softmax = 200 if d == 64 else 184
+    regs_correction = 64 if d == 64 else 88
+    physical_blocks = (seqlen_kv + 127) // 128
+
+    def host_prelude(params):
+        def encode(name, tensor, dims, strides, box):
+            descriptor = K.stack_alloca("tensormap", 1)
+            K.call_packed(
+                "runtime.cuTensorMapEncodeTiled",
+                descriptor,
+                elem_dtype_name,
+                len(dims),
+                tensor.data,
+                *dims,
+                *strides,
+                *box,
+                *((1,) * len(dims)),
+                0,
+                smem_swizzle,
+                2,
+                0,
+            )
+            return descriptor
+
+        q = params["q"]
+        k = params["k"]
+        v = params["v"]
+        out = params["out"]
+        elem_bytes = 2
+        if pack:
+            qo_dims = (d, ratio, seqlen_q, hkv, batch)
+            qo_strides = (
+                seqlen_q * d * elem_bytes,
+                d * elem_bytes,
+                ratio * seqlen_q * d * elem_bytes,
+                hq * seqlen_q * d * elem_bytes,
+            )
+            qo_box = (band_width, ratio, 128 // ratio, 1, 1)
+        else:
+            qo_dims = (d, seqlen_q, hq, batch)
+            qo_strides = (d * elem_bytes, seqlen_q * d * elem_bytes, hq * seqlen_q * d * elem_bytes)
+            qo_box = (band_width, 128, 1, 1)
+        kv_batch_stride = (2**31 if use_i64_kv else hkv * seqlen_kv * d) * elem_bytes
+        kv_dims = (d, seqlen_kv, hkv, batch)
+        kv_strides = (d * elem_bytes, seqlen_kv * d * elem_bytes, kv_batch_stride)
+        kv_box = (band_width, 128, 1, 1)
+        return (
+            encode("q", q, qo_dims, qo_strides, qo_box),
+            encode("k", k, kv_dims, kv_strides, kv_box),
+            encode("v", v, kv_dims, kv_strides, kv_box),
+            encode("o", out, qo_dims, qo_strides, qo_box),
+        )
+
+    def kernel_body(
+        q,
+        k,
+        v,
+        out,
+        lse,
+        block_index,
+        block_sizes,
+        block_nums,
+        block_sparse_num,
+        softmax_scale_log2,
+        host,
+    ):
+        del q, k, v, out
+        q_map, k_map, v_map, o_map = host
+        _cluster_x, _cluster_y, _cluster_z = K.cta_id_in_cluster([1, 1, 1])
+        initial_q_block, initial_head, initial_batch = K.cta_id([q_blocks, scheduled_heads, batch])
+        q_block = K.local_scalar("int32", init=initial_q_block)
+        head = K.local_scalar("int32", init=initial_head)
+        batch_idx = K.local_scalar("int32", init=initial_batch)
+        work_valid = K.local_scalar("int32", init=1)
+        clc_consumer_phase = K.local_scalar("int32", init=0)
+        warp = K.warp_id()
+        lane = K.thread_id() & 31
+        tid = K.thread_id()
+
+        with K.If(warp == 0), K.Then():
+            K.ptx.prefetch.tensormap(K.address_of(q_map))
+            K.ptx.prefetch.tensormap(K.address_of(k_map))
+            K.ptx.prefetch.tensormap(K.address_of(v_map))
+            K.ptx.prefetch.tensormap(K.address_of(o_map))
+
+        arena = K.alloc_buffer((smem_bytes,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.smem_pool(base=arena)
+        pool = smem.pool
+        q_full = K.TMABar(pool, 1)
+        q_empty = K.TCGen05Bar(pool, 1)
+        kv_full = K.TMABar(pool, kv_stages)
+        kv_empty = K.TCGen05Bar(pool, kv_stages)
+        spo_full = K.TCGen05Bar(pool, 2)
+        spo_empty = K.MBarrier(pool, 2)
+        plast_full = K.MBarrier(pool, 2)
+        plast_empty = K.TCGen05Bar(pool, 2)
+        oacc_full = K.TCGen05Bar(pool, 2)
+        oacc_empty = K.MBarrier(pool, 2)
+        stats_full = K.MBarrier(pool, 2)
+        stats_empty = K.MBarrier(pool, 2)
+        oepi_full = K.MBarrier(pool, 2)
+        oepi_empty = K.MBarrier(pool, 2)
+        tmem_mailbox = pool.alloc((1,), "uint32", align=4)
+        stats_smem = pool.alloc((512,), "float32", align=4)
+        clc_full = K.TMABar(pool, 1)
+        clc_empty = K.MBarrier(pool, 1)
+        pool.alloc((8,), "uint8")
+        clc_response = pool.alloc((4,), "uint32", align=16)
+        pool.alloc((8,), "uint8")
+        if pool.offset != offsets["prefix"]:
+            raise AssertionError("shared protocol prefix changed")
+        pool.alloc((3072 - pool.offset,), "uint8")
+        if pool.offset != 3072:
+            raise AssertionError("shared payload alignment changed")
+        pool.alloc((smem_bytes - pool.offset,), "uint8")
+        if pool.offset != smem_bytes:
+            raise AssertionError("shared arena size changed")
+
+        q_smem = K.decl_buffer(
+            (128 * d,),
+            elem_dtype_name,
+            data=arena.data,
+            byte_offset=offsets["sq"],
+            scope="shared.dyn",
+            align=1024,
+        )
+        kv_smem = K.decl_buffer(
+            (kv_stages * 128 * d,),
+            elem_dtype_name,
+            data=arena.data,
+            byte_offset=offsets["skv"],
+            scope="shared.dyn",
+            align=1024,
+        )
+        o_smem = K.decl_buffer(
+            (2 * 128 * d,),
+            elem_dtype_name,
+            data=arena.data,
+            byte_offset=offsets["so"],
+            scope="shared.dyn",
+            align=1024,
+        )
+
+        q_full.init(1)
+        q_empty.init(1)
+        kv_full.init(1)
+        kv_empty.init(1)
+        spo_full.init(1)
+        spo_empty.init(256)
+        plast_full.init(4)
+        plast_empty.init(1)
+        oacc_full.init(1)
+        oacc_empty.init(128)
+        stats_full.init(128)
+        stats_empty.init(128)
+        oepi_full.init(128)
+        oepi_empty.init(32)
+        K.ptx.fence.mbarrier_init.release.cluster()
+        clc_full.init(1)
+        clc_empty.init(512)
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+        K.cuda.cta_sync()
+
+        raw_count = K.local_scalar("int32")
+
+        def load_tile_metadata():
+            count_index = (batch_idx * scheduled_heads + head) * q_blocks + q_block
+            if has_nums:
+                K.assign(raw_count, _load_i32(block_nums, count_index))
+            else:
+                K.assign(raw_count, block_sparse_num)
+
+        def advance_work():
+            K.cuda.cta_sync()
+            _wait(clc_full, 0, clc_consumer_phase)
+            _query_cancel_response(clc_response, q_block, head, batch_idx, work_valid)
+            clc_empty.arrive(0, remote=0, pred=K.bool(True), count=1)
+            K.assign(clc_consumer_phase, clc_consumer_phase ^ 1)
+
+        def sparse_id(logical):
+            count_index = (batch_idx * scheduled_heads + head) * q_blocks + q_block
+            if has_nums:
+                logical = K.min(logical, K.max(raw_count - 1, 0))
+            return _load_i32(block_index, count_index * max_blocks + logical)
+
+        def advance_ring(stage, phase):
+            K.assign(stage, stage + 1)
+            with K.If(stage == kv_stages), K.Then():
+                K.assign(stage, 0)
+                K.assign(phase, phase ^ 1)
+
+        has_work = raw_count > 0 if allow_empty else K.bool(True)
+        block_iter_count = (raw_count + 1) & -2 if has_nums else raw_count
+
+        roles = K.specialize(chain_dispatch=True)
+        r_softmax = roles.role("softmax", warps=range(0, 8), regs=regs_softmax)
+        r_correction = roles.role("correction", warps=range(8, 12), regs=regs_correction)
+        r_mma = roles.role("mma", warps=[12], regs=regs_other)
+        r_epilogue = roles.role("epilogue", warps=[13], regs=regs_other)
+        r_load = roles.role("load", warps=[14], regs=regs_other)
+        r_idle = roles.role("idle", warps=[15], regs=regs_other)
+
+        with r_idle:
+            clc_producer_phase = K.local_scalar("int32", init=1)
+            with K.While(work_valid != 0):
+                _wait(clc_empty, 0, clc_producer_phase)
+                with K.If(lane == 0), K.Then():
+                    clc_full.arrive(0, tx_count=16, remote=0)
+                with K.If(K.cuda.elect_sync()), K.Then():
+                    K.ptx[
+                        "clusterlaunchcontrol.try_cancel.async.shared::cta"
+                        ".mbarrier::complete_tx::bytes.multicast::cluster::all.b128"
+                    ](K.address_of(clc_response[0]), K.address_of(clc_full.buf[0]))
+                K.assign(clc_producer_phase, clc_producer_phase ^ 1)
+                advance_work()
+            _wait(clc_empty, 0, clc_producer_phase)
+
+        with r_load:
+            q_producer_phase = K.local_scalar("int32", init=1)
+            kv_stage = K.local_scalar("int32", init=0)
+            kv_phase = K.local_scalar("int32", init=1)
+
+            def load_kv(kind, logical, do_advance=True):
+                tma_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                _wait(kv_empty, kv_stage, kv_phase)
+                count_index = (batch_idx * scheduled_heads + head) * q_blocks + q_block
+                logical_index = K.min(logical, K.max(raw_count - 1, 0)) if has_nums else logical
+                sid = K.local_scalar("int32", init=0)
+                K.ptx["ld.global.b32"](
+                    sid,
+                    block_index.ptr_to([count_index * max_blocks + logical_index]),
+                    pred=tma_leader,
+                )
+                K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                    kv_full.ptr_to([kv_stage]), K.uint32(128 * d * 2), pred=tma_leader
+                )
+                with K.unroll(num_bands) as band:
+                    destination = kv_stage * 128 * d + band * 128 * band_width
+                    descriptor = K.address_of(k_map) if kind == 0 else K.address_of(v_map)
+                    K.ptx[_TMA_G2S_4D](
+                        kv_smem.ptr_to([destination]),
+                        descriptor,
+                        K.cast(band * band_width, "int32"),
+                        sid * 128,
+                        head if pack else head // ratio,
+                        batch_idx,
+                        K.cuda.cvta_generic_to_shared(kv_full.ptr_to([kv_stage])),
+                        _TMA_CACHE,
+                        pred=tma_leader,
+                    )
+                if do_advance:
+                    advance_ring(kv_stage, kv_phase)
+
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                with K.If(has_work), K.Then():
+                    load_kv(0, block_iter_count - 1, False)
+                    _wait(q_empty, 0, q_producer_phase)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                            q_full.ptr_to([0]), K.uint32(128 * d * 2)
+                        )
+                        with K.unroll(num_bands) as band:
+                            if pack:
+                                K.ptx[_TMA_G2S_5D](
+                                    q_smem.ptr_to([band * 128 * band_width]),
+                                    K.address_of(q_map),
+                                    K.cast(band * band_width, "int32"),
+                                    K.int32(0),
+                                    (q_block * 128) // ratio,
+                                    head,
+                                    batch_idx,
+                                    K.cuda.cvta_generic_to_shared(q_full.ptr_to([0])),
+                                    _TMA_CACHE,
+                                )
+                            else:
+                                K.ptx[_TMA_G2S_4D](
+                                    q_smem.ptr_to([band * 128 * band_width]),
+                                    K.address_of(q_map),
+                                    K.cast(band * band_width, "int32"),
+                                    q_block * 128,
+                                    head,
+                                    batch_idx,
+                                    K.cuda.cvta_generic_to_shared(q_full.ptr_to([0])),
+                                    _TMA_CACHE,
+                                )
+                    advance_ring(kv_stage, kv_phase)
+                    K.assign(q_producer_phase, q_producer_phase ^ 1)
+                    load_kv(0, block_iter_count - 2)
+                    i = K.local_scalar("int32", init=0)
+                    with K.While(i < block_iter_count - 2):
+                        load_kv(1, block_iter_count - 1 - i)
+                        load_kv(0, block_iter_count - 3 - i)
+                        K.assign(i, i + 1)
+                    load_kv(1, 1)
+                    load_kv(1, 0)
+                advance_work()
+            tail_stage = K.local_scalar("int32", init=kv_stage)
+            tail_phase = K.local_scalar("int32", init=kv_phase)
+            with K.unroll(kv_stages) as _tail:
+                _wait(kv_empty, tail_stage, tail_phase)
+                advance_ring(tail_stage, tail_phase)
+            _wait(q_empty, 0, q_producer_phase)
+            with K.If(K.cuda.elect_sync()), K.Then():
+                K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                    q_full.ptr_to([0]), K.uint32(128 * d * 2)
+                )
+
+        with r_mma:
+            K.ptx[_TMEM_ALLOC](K.address_of(tmem_mailbox[0]), K.uint32(_TMEM_COLS))
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            q_desc = K.SmemDescriptor()
+            q_desc.init(
+                q_smem.ptr_to([0]), ldo=1 if d == 96 else 1024, sdo=band_width, swizzle=smem_swizzle
+            )
+            q_desc.make_lo_uniform()
+            q_consumer_phase = K.local_scalar("int32", init=0)
+            kv_stage = K.local_scalar("int32", init=0)
+            kv_phase = K.local_scalar("int32", init=0)
+            spo_phase0 = K.local_scalar("int32", init=0)
+            spo_phase1 = K.local_scalar("int32", init=0)
+            acc0 = K.local_scalar("int32", init=0)
+            acc1 = K.local_scalar("int32", init=0)
+
+            def descriptor_offset(k16):
+                per_band = band_width // 16
+                return (k16 % per_band) * 2 + (k16 // per_band) * (128 * band_width * 2 // 16)
+
+            def issue_qk(score_stage, k_stage):
+                k_desc = K.SmemDescriptor()
+                k_desc.init(
+                    kv_smem.ptr_to([k_stage * 128 * d]),
+                    ldo=1 if d == 96 else 1024,
+                    sdo=band_width,
+                    swizzle=smem_swizzle,
+                )
+                k_desc.make_lo_uniform()
+                for k16 in range(d // 16):
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[_MMA_F16](
+                            K.cast(tmem_base + score_stage * 128, "uint32"),
+                            q_desc.add_16B_offset(descriptor_offset(k16)),
+                            k_desc.add_16B_offset(descriptor_offset(k16)),
+                            K.uint32(qk_idesc),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.cast(k16 != 0, "bool"),
+                        )
+
+            def issue_pv(score_stage, v_stage, accumulate, phase):
+                v_desc = K.SmemDescriptor()
+                v_desc.init(
+                    kv_smem.ptr_to([v_stage * 128 * d]),
+                    ldo=512 if d == 96 else 1024,
+                    sdo=band_width,
+                    swizzle=smem_swizzle,
+                )
+                v_desc.make_lo_uniform()
+                for k16 in range(8):
+                    if k16 == 6:
+                        _wait(plast_full, score_stage, phase)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[_MMA_F16](
+                            K.cast(tmem_base + 256 + score_stage * d, "uint32"),
+                            K.cast(tmem_base + 64 + score_stage * 128 + k16 * 8, "uint32"),
+                            v_desc.add_16B_offset(k16 * 2 * band_width),
+                            K.uint32(pv_idesc),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.uint32(0),
+                            K.cast(accumulate != 0 if k16 == 0 else True, "bool"),
+                        )
+
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                K.assign(acc0, 0)
+                K.assign(acc1, 0)
+                with K.If(has_work), K.Then():
+                    _wait(q_full, 0, q_consumer_phase)
+                    K.assign(q_consumer_phase, q_consumer_phase ^ 1)
+                    for score_stage in range(2):
+                        _wait(kv_full, kv_stage, kv_phase)
+                        issue_qk(score_stage, kv_stage)
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            K.ptx[_TCGEN_COMMIT](spo_full.ptr_to([score_stage]))
+                            K.ptx[_TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                        advance_ring(kv_stage, kv_phase)
+
+                    pair_count = (block_iter_count - 2) // 2
+                    pair = K.local_scalar("int32", init=0)
+                    with K.While(pair < pair_count):
+                        for score_stage in range(2):
+                            phase = K.if_then_else(score_stage == 0, spo_phase0, spo_phase1)
+                            _wait(kv_full, kv_stage, kv_phase)
+                            v_release_stage = K.local_scalar("int32", init=kv_stage)
+                            advance_ring(kv_stage, kv_phase)
+                            _wait(kv_full, kv_stage, kv_phase)
+                            _wait(spo_empty, score_stage, phase)
+                            issue_pv(
+                                score_stage,
+                                v_release_stage,
+                                K.if_then_else(score_stage == 0, acc0, acc1),
+                                phase,
+                            )
+                            issue_qk(score_stage, kv_stage)
+                            with K.If(K.cuda.elect_sync()), K.Then():
+                                K.ptx[_TCGEN_COMMIT](spo_full.ptr_to([score_stage]))
+                            if score_stage == 0:
+                                K.assign(spo_phase0, spo_phase0 ^ 1)
+                                K.assign(acc0, 1)
+                            else:
+                                K.assign(spo_phase1, spo_phase1 ^ 1)
+                                K.assign(acc1, 1)
+                            with K.If(K.cuda.elect_sync()), K.Then():
+                                K.ptx[_TCGEN_COMMIT](kv_empty.ptr_to([v_release_stage]))
+                                K.ptx[_TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                            advance_ring(kv_stage, kv_phase)
+                        K.assign(pair, pair + 1)
+                    with K.If(K.cuda.elect_sync()), K.Then():
+                        K.ptx[_TCGEN_COMMIT](q_empty.ptr_to([0]))
+
+                    for score_stage in range(2):
+                        phase = K.if_then_else(score_stage == 0, spo_phase0, spo_phase1)
+                        _wait(kv_full, kv_stage, kv_phase)
+                        _wait(spo_empty, score_stage, phase)
+                        issue_pv(
+                            score_stage,
+                            kv_stage,
+                            K.if_then_else(score_stage == 0, acc0, acc1),
+                            phase,
+                        )
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            K.ptx[_TCGEN_COMMIT](oacc_full.ptr_to([score_stage]))
+                            K.ptx[_TCGEN_COMMIT](kv_empty.ptr_to([kv_stage]))
+                        advance_ring(kv_stage, kv_phase)
+                    K.assign(spo_phase0, spo_phase0 ^ 1)
+                    K.assign(spo_phase1, spo_phase1 ^ 1)
+                advance_work()
+
+            K.ptx[_TMEM_RELINQUISH]()
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            allocated = K.local_scalar("uint32")
+            K.ptx.ld.shared.u32(allocated, tmem_mailbox.ptr_to([0]))
+            K.ptx[_TMEM_DEALLOC](allocated, K.uint32(_TMEM_COLS))
+
+        with r_epilogue:
+            oepi_consumer_phase = K.local_scalar("int32", init=0)
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                _wait(oepi_full, 0, oepi_consumer_phase)
+                with K.unroll(num_bands) as band:
+                    if pack:
+                        K.ptx[_TMA_S2G_5D](
+                            K.address_of(o_map),
+                            K.cast(band * band_width, "int32"),
+                            K.int32(0),
+                            (q_block * 128) // ratio,
+                            head,
+                            batch_idx,
+                            o_smem.ptr_to([band * 128 * band_width]),
+                            _TMA_CACHE,
+                        )
+                    else:
+                        K.ptx[_TMA_S2G_4D](
+                            K.address_of(o_map),
+                            K.cast(band * band_width, "int32"),
+                            q_block * 128,
+                            head,
+                            batch_idx,
+                            o_smem.ptr_to([band * 128 * band_width]),
+                            _TMA_CACHE,
+                        )
+                K.ptx.cp.async_.bulk.commit_group()
+                K.ptx.cp.async_.bulk.wait_group.read(0)
+                oepi_empty.arrive(0)
+                K.assign(oepi_consumer_phase, oepi_consumer_phase ^ 1)
+                advance_work()
+
+        with r_softmax:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            score_stage = K.if_then_else(warp < 4, 0, 1)
+            local_warp = warp & 3
+            tid128 = tid & 127
+            row_hi = K.shift_left(K.cast(local_warp * 32, "uint32"), K.uint32(16))
+            score_phase = K.local_scalar("int32", init=0)
+            stats_producer_phase = K.local_scalar("int32", init=1)
+            row_max = K.local_scalar("float32", init=K.float32(_NEG_INF))
+            row_sum = K.local_scalar("float32", init=K.float32(0.0))
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                K.assign(row_max, K.float32(_NEG_INF))
+                K.assign(row_sum, K.float32(0.0))
+                _wait(stats_empty, score_stage, stats_producer_phase)
+                K.assign(stats_producer_phase, stats_producer_phase ^ 1)
+                with K.If(has_work), K.Then():
+                    work_groups = block_iter_count // 2
+
+                    def consume_score(logical, first):
+                        _wait(spo_full, score_stage, score_phase)
+                        score = K.alloc_local((128,), "float32")
+                        with K.unroll(4) as chunk:
+                            regs = K.alloc_local((32,), "float32")
+                            _tmem_load32(regs, tmem_base + score_stage * 128 + chunk * 32 + row_hi)
+                            with K.unroll(32) as j:
+                                K.assign(score[chunk * 32 + j], regs[j])
+
+                        if first and (has_sizes or has_nums):
+                            block_size = K.local_scalar("int32")
+                            if has_sizes:
+                                K.assign(
+                                    block_size,
+                                    K.if_then_else(
+                                        (logical < raw_count) if has_nums else K.bool(True),
+                                        _load_i32(block_sizes, sparse_id(logical)),
+                                        0,
+                                    ),
+                                )
+                            else:
+                                K.assign(block_size, K.if_then_else(logical < raw_count, 128, 0))
+                            _apply_mask128(score, block_size)
+                        elif has_sizes:
+                            _apply_mask128(score, _load_i32(block_sizes, sparse_id(logical)))
+
+                        old_scale = K.local_scalar("float32", init=K.float32(0.0))
+                        new_max = K.local_scalar("float32")
+                        max_safe = K.local_scalar("float32")
+                        if first:
+                            tile_max = _reduce_max_128(score)
+                            K.assign(new_max, tile_max)
+                            K.assign(
+                                max_safe,
+                                K.if_then_else(tile_max != K.float32(_NEG_INF), tile_max, 0.0),
+                            )
+                        else:
+                            tile_max = _reduce_max_128(score, row_max)
+                            K.assign(new_max, tile_max)
+                            K.assign(
+                                max_safe,
+                                K.if_then_else(new_max != K.float32(_NEG_INF), new_max, 0.0),
+                            )
+                            delta = K.local_scalar("float32")
+                            K.ptx.sub.f32(delta, row_max, max_safe)
+                            delta_scaled = K.local_scalar("float32")
+                            K.ptx.mul.f32(delta_scaled, delta, softmax_scale_log2)
+                            K.assign(old_scale, _exp2(delta_scaled))
+                            with K.If(delta_scaled >= K.float32(-8.0)), K.Then():
+                                K.assign(new_max, row_max)
+                                K.assign(max_safe, row_max)
+                                K.assign(old_scale, K.float32(1.0))
+                            _st_shared_f32(stats_smem, score_stage * 128 + tid128, old_scale)
+                        _stats_arrive(score_stage, local_warp)
+
+                        negative_max = K.local_scalar("float32")
+                        K.ptx.mul.f32(negative_max, max_safe, -softmax_scale_log2)
+                        with K.unroll(64) as pair:
+                            base = pair * 2
+                            _packed(
+                                "fma.rn.f32x2",
+                                score,
+                                base,
+                                score[base],
+                                score[base + 1],
+                                softmax_scale_log2,
+                                softmax_scale_log2,
+                                negative_max,
+                                negative_max,
+                            )
+
+                        for fragment in range(4):
+                            for pair in range(16):
+                                base = fragment * 32 + pair * 2
+                                if (pair * 2) % 10 >= 6 and fragment < 3:
+                                    _ex2_emulation_2(score, base)
+                                else:
+                                    K.assign(score[base], _exp2(score[base]))
+                                    K.assign(score[base + 1], _exp2(score[base + 1]))
+                            packed_p = K.alloc_local((16,), "uint32")
+                            with K.unroll(16) as pair:
+                                base = fragment * 32 + pair * 2
+                                if dtype == "bfloat16":
+                                    K.ptx.cvt.rn.bf16x2.f32(
+                                        packed_p[pair], score[base + 1], score[base]
+                                    )
+                                else:
+                                    K.ptx.cvt.rn.f16x2.f32(
+                                        packed_p[pair], score[base + 1], score[base]
+                                    )
+                            _tmem_store16(
+                                packed_p,
+                                tmem_base + 64 + score_stage * 128 + fragment * 16 + row_hi,
+                            )
+                            if fragment == 2:
+                                K.ptx.tcgen05.wait__st.sync.aligned()
+                                spo_empty.arrive(score_stage)
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        K.cuda.warp_sync()
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            plast_full.arrive(score_stage)
+
+                        _wait(stats_empty, score_stage, stats_producer_phase)
+                        K.assign(row_sum, _packed_sum_128(score, row_sum, old_scale, first))
+                        K.assign(row_max, new_max)
+                        K.assign(stats_producer_phase, stats_producer_phase ^ 1)
+                        K.assign(score_phase, score_phase ^ 1)
+
+                    consume_score(block_iter_count - 1 - score_stage, True)
+                    iteration = K.local_scalar("int32", init=1)
+                    with K.While(iteration < work_groups):
+                        consume_score(block_iter_count - 1 - (iteration * 2 + score_stage), False)
+                        K.assign(iteration, iteration + 1)
+
+                    _st_shared_f32(stats_smem, score_stage * 128 + tid128, row_sum)
+                    _st_shared_f32(stats_smem, 256 + score_stage * 128 + tid128, row_max)
+                    _stats_arrive(score_stage, local_warp)
+                with K.If(has_work == K.bool(False)), K.Then():
+                    _stats_arrive(score_stage, local_warp)
+                advance_work()
+            _wait(stats_empty, score_stage, stats_producer_phase)
+            K.ptx.bar.arrive(K.uint32(2), K.uint32(416))
+
+        with r_correction:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(416))
+            tmem_base = K.local_scalar("uint32", init=K.uint32(0))
+            K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
+            corr_warp = warp - 8
+            tid128 = tid & 127
+            row_hi = K.shift_left(K.cast(corr_warp * 32, "uint32"), K.uint32(16))
+            oacc_consumer_phase = K.local_scalar("int32", init=0)
+            oepi_producer_phase = K.local_scalar("int32", init=1)
+            spo_empty.arrive(0)
+            spo_empty.arrive(1)
+
+            def rescale_o(score_stage, scale):
+                with K.unroll(d // 16) as chunk:
+                    values = K.alloc_local((16,), "float32")
+                    _tmem_load16(values, tmem_base + 256 + score_stage * d + chunk * 16 + row_hi)
+                    with K.unroll(8) as pair:
+                        base = pair * 2
+                        _packed(
+                            "mul.rn.f32x2",
+                            values,
+                            base,
+                            values[base],
+                            values[base + 1],
+                            scale,
+                            scale,
+                        )
+                    _tmem_store16(values, tmem_base + 256 + score_stage * d + chunk * 16 + row_hi)
+                K.ptx.tcgen05.wait__st.sync.aligned()
+
+            def output_addresses(chunk):
+                chunks_per_band = band_width // 16
+                band = chunk // chunks_per_band
+                local_chunk = chunk - band * chunks_per_band
+                raw_byte = offsets["so"] + band * 128 * band_width * 2 + tid128 * band_width * 2
+                xor_mask = 48 if band_width == 32 else 112
+                first_byte = K.bitwise_xor(
+                    raw_byte, K.bitwise_and(K.shift_right(raw_byte, K.uint32(3)), xor_mask)
+                )
+                if band_width == 32:
+                    sign16 = K.if_then_else(K.bitwise_and(tid128, 2) == 0, 16, -16)
+                    sign32 = K.if_then_else(K.bitwise_and(tid128, 4) == 0, 32, -32)
+                    if local_chunk == 1:
+                        first_byte = first_byte + sign32
+                else:
+                    sign16 = K.if_then_else(K.bitwise_and(tid128, 1) == 0, 16, -16)
+                    sign32 = K.if_then_else(K.bitwise_and(tid128, 2) == 0, 32, -32)
+                    sign64 = K.if_then_else(K.bitwise_and(tid128, 4) == 0, 64, -64)
+                    if local_chunk & 1:
+                        first_byte = first_byte + sign32
+                    if local_chunk & 2:
+                        first_byte = first_byte + sign64
+                return first_byte, first_byte + sign16
+
+            def store_combined(scale0, scale1):
+                for chunk in range(d // 16):
+                    values0 = K.alloc_local((16,), "float32")
+                    values1 = K.alloc_local((16,), "float32")
+                    combined = K.alloc_local((16,), "float32")
+                    _tmem_load16(values0, tmem_base + 256 + chunk * 16 + row_hi)
+                    _tmem_load16(values1, tmem_base + 256 + d + chunk * 16 + row_hi)
+                    with K.unroll(8) as pair:
+                        base = pair * 2
+                        scaled0 = K.alloc_local((2,), "float32")
+                        scaled1 = K.alloc_local((2,), "float32")
+                        _packed(
+                            "mul.rn.f32x2",
+                            scaled0,
+                            0,
+                            values0[base],
+                            values0[base + 1],
+                            scale0,
+                            scale0,
+                        )
+                        _packed(
+                            "mul.rn.f32x2",
+                            scaled1,
+                            0,
+                            values1[base],
+                            values1[base + 1],
+                            scale1,
+                            scale1,
+                        )
+                        _packed(
+                            "add.rn.f32x2",
+                            combined,
+                            base,
+                            scaled0[0],
+                            scaled0[1],
+                            scaled1[0],
+                            scaled1[1],
+                        )
+                    words = K.alloc_local((8,), "uint32")
+                    with K.unroll(8) as pair:
+                        if dtype == "bfloat16":
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[pair], combined[pair * 2 + 1], combined[pair * 2]
+                            )
+                        else:
+                            K.ptx.cvt.rn.f16x2.f32(
+                                words[pair], combined[pair * 2 + 1], combined[pair * 2]
+                            )
+                    first_byte, second_byte = output_addresses(chunk)
+                    K.ptx.st.shared.v4.u32(
+                        arena.ptr_to([first_byte]), words[0], words[1], words[2], words[3]
+                    )
+                    K.ptx.st.shared.v4.u32(
+                        arena.ptr_to([second_byte]), words[4], words[5], words[6], words[7]
+                    )
+
+            def store_zero():
+                for chunk in range(d // 16):
+                    first_byte, second_byte = output_addresses(chunk)
+                    K.ptx.st.shared.v4.u32(
+                        arena.ptr_to([first_byte]),
+                        K.uint32(0),
+                        K.uint32(0),
+                        K.uint32(0),
+                        K.uint32(0),
+                    )
+                    K.ptx.st.shared.v4.u32(
+                        arena.ptr_to([second_byte]),
+                        K.uint32(0),
+                        K.uint32(0),
+                        K.uint32(0),
+                        K.uint32(0),
+                    )
+
+            with K.While(work_valid != 0):
+                load_tile_metadata()
+                total_sum = K.local_scalar("float32", init=K.float32(0.0))
+                safe_max = K.local_scalar("float32", init=K.float32(0.0))
+                with K.If(has_work):
+                    with K.Then():
+                        _stats_sync(0, corr_warp)
+                        stats_empty.arrive(0)
+                        _stats_sync(1, corr_warp)
+                        pair_count = (block_iter_count - 2) // 2
+                        pair = K.local_scalar("int32", init=0)
+                        with K.While(pair < pair_count):
+                            for score_stage in range(2):
+                                _stats_sync(score_stage, corr_warp)
+                                scale = _ld_shared_f32(stats_smem, score_stage * 128 + tid128)
+                                ballot = K.local_scalar("uint32")
+                                K.ptx.vote_sync.ballot.b32(
+                                    ballot, K.ptx.pred(scale < K.float32(1.0)), K.uint32(0xFFFFFFFF)
+                                )
+                                with K.If(ballot != 0), K.Then():
+                                    rescale_o(score_stage, scale)
+                                spo_empty.arrive(score_stage)
+                                stats_empty.arrive(1 - score_stage)
+                            K.assign(pair, pair + 1)
+                        stats_empty.arrive(1)
+
+                        sum0 = K.local_scalar("float32")
+                        sum1 = K.local_scalar("float32")
+                        maximum0 = K.local_scalar("float32")
+                        maximum1 = K.local_scalar("float32")
+                        for score_stage in range(2):
+                            _stats_sync(score_stage, corr_warp)
+                            if score_stage == 0:
+                                K.assign(sum0, _ld_shared_f32(stats_smem, tid128))
+                                K.assign(maximum0, _ld_shared_f32(stats_smem, 256 + tid128))
+                            else:
+                                K.assign(sum1, _ld_shared_f32(stats_smem, 128 + tid128))
+                                K.assign(maximum1, _ld_shared_f32(stats_smem, 384 + tid128))
+                            stats_empty.arrive(score_stage)
+                        valid0 = (sum0 != K.float32(0.0)) & (sum0 == sum0)
+                        valid1 = (sum1 != K.float32(0.0)) & (sum1 == sum1)
+                        rm0 = K.if_then_else(valid0, maximum0, K.float32(_NEG_INF))
+                        rm1 = K.if_then_else(valid1, maximum1, K.float32(_NEG_INF))
+                        maximum = K.local_scalar("float32")
+                        K.ptx.max.f32(maximum, rm0, rm1)
+                        K.assign(
+                            safe_max, K.if_then_else(maximum != K.float32(_NEG_INF), maximum, 0.0)
+                        )
+                        scale0 = K.local_scalar("float32")
+                        scale1 = K.local_scalar("float32")
+                        K.assign(
+                            scale0,
+                            K.if_then_else(
+                                valid0, _exp2((rm0 - safe_max) * softmax_scale_log2), 0.0
+                            ),
+                        )
+                        K.assign(
+                            scale1,
+                            K.if_then_else(
+                                valid1, _exp2((rm1 - safe_max) * softmax_scale_log2), 0.0
+                            ),
+                        )
+                        K.assign(total_sum, sum0 * scale0 + sum1 * scale1)
+                        valid_total = (total_sum != K.float32(0.0)) & (total_sum == total_sum)
+                        inv_sum = _rcp(K.if_then_else(valid_total, total_sum, 1.0))
+                        final_scale0 = scale0 * inv_sum
+                        final_scale1 = scale1 * inv_sum
+                        _wait(oacc_full, 0, oacc_consumer_phase)
+                        _wait(oacc_full, 1, oacc_consumer_phase)
+                        _wait(oepi_empty, 0, oepi_producer_phase)
+                        store_combined(final_scale0, final_scale1)
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        spo_empty.arrive(0)
+                        spo_empty.arrive(1)
+                        K.assign(oacc_consumer_phase, oacc_consumer_phase ^ 1)
+                    with K.Else():
+                        _stats_sync(0, corr_warp)
+                        stats_empty.arrive(0)
+                        _stats_sync(1, corr_warp)
+                        stats_empty.arrive(1)
+                        _wait(oepi_empty, 0, oepi_producer_phase)
+                        store_zero()
+                        K.ptx.fence.proxy.async_.shared__cta()
+
+                oepi_full.arrive(0)
+                K.assign(oepi_producer_phase, oepi_producer_phase ^ 1)
+                if return_lse:
+                    packed_row = q_block * 128 + tid128
+                    if pack:
+                        token = packed_row // ratio
+                        local_head = packed_row - token * ratio
+                        q_head = head * ratio + local_head
+                    else:
+                        token = packed_row
+                        q_head = head
+                    with K.If(token < seqlen_q), K.Then():
+                        lse_value = K.local_scalar("float32", init=K.float32(_NEG_INF))
+                        with K.If(total_sum > K.float32(0.0)), K.Then():
+                            K.assign(
+                                lse_value,
+                                (safe_max * softmax_scale_log2 + _log2(total_sum))
+                                * K.float32(_LN2),
+                            )
+                        lse_index = (batch_idx * hq + q_head) * seqlen_q + token
+                        K.ptx.st.global_.f32(lse.ptr_to([lse_index]), lse_value)
+                advance_work()
+            _wait(oepi_empty, 0, oepi_producer_phase)
+            K.ptx.bar.arrive(K.uint32(2), K.uint32(416))
+
+    def kernel(
+        q,
+        k,
+        v,
+        out,
+        lse,
+        block_index,
+        block_sizes,
+        block_nums,
+        block_sparse_num,
+        softmax_scale_log2,
+        *,
+        host,
+    ):
+        with K.attr({"tirx.required_block_size": 1}):
+            kernel_body(
+                q,
+                k,
+                v,
+                out,
+                lse,
+                block_index,
+                block_sizes,
+                block_nums,
+                block_sparse_num,
+                softmax_scale_log2,
+                host,
+            )
+
+    kernel.__annotations__ = {
+        "q": K.gptr[elem_dtype, (batch * hq * seqlen_q * d,)],
+        "k": K.gptr[elem_dtype, (batch * hkv * seqlen_kv * d,)],
+        "v": K.gptr[elem_dtype, (batch * hkv * seqlen_kv * d,)],
+        "out": K.gptr[elem_dtype, (batch * hq * seqlen_q * d,)],
+        "lse": K.gptr[K.f32, (batch * hq * seqlen_q,)],
+        "block_index": K.gptr[K.i32, (batch * scheduled_heads * q_blocks * max_blocks,)],
+        "block_sizes": K.gptr[K.i32, (physical_blocks,)],
+        "block_nums": K.gptr[K.i32, (batch * scheduled_heads * q_blocks,)],
+        "block_sparse_num": K.i32,
+        "softmax_scale_log2": K.f32,
+    }
+    return K.kernel(
+        warps=_WARPS,
+        arch="sm_100a",
+        grid=[q_blocks, scheduled_heads, batch],
+        min_blocks_per_sm=1,
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(**config):
+    return _make_kernel(**config).func
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _torch_dtype(torch, name):
+    return {"bfloat16": torch.bfloat16, "float16": torch.float16}[name]
+
+
+def _pack_enabled(config):
+    ratio = config["num_q_heads"] // config["num_kv_heads"]
+    requested = config["pack_gqa"]
+    enabled = ratio > 1 if requested == "auto" else bool(requested)
+    return enabled and 128 % ratio == 0
+
+
+def _metadata_shape(config):
+    import math
+
+    ratio = config["num_q_heads"] // config["num_kv_heads"]
+    if _pack_enabled(config):
+        return config["num_kv_heads"], math.ceil(config["seqlen_q"] * ratio / 128)
+    return config["num_q_heads"], math.ceil(config["seqlen_q"] / 128)
+
+
+def _counts(torch, config, metadata_heads, q_blocks, device):
+    maximum = config["kv_blocks"]
+    mode = config["block_count_mode"]
+    if mode == "fixed":
+        return torch.full(
+            (config["batch"], metadata_heads, q_blocks), maximum, dtype=torch.int32, device=device
+        )
+    values = []
+    for item in config["block_count_pattern"].split(","):
+        item = item.strip()
+        if item == "max":
+            values.append(maximum)
+        elif item == "mid":
+            values.append(max(1, maximum // 2))
+        else:
+            values.append(int(item))
+    flat = torch.arange(config["batch"] * metadata_heads * q_blocks, device=device)
+    choices = torch.tensor(values, dtype=torch.int32, device=device)
+    return choices[flat % len(values)].reshape(config["batch"], metadata_heads, q_blocks)
+
+
+def _metadata(torch, config, metadata_heads, q_blocks, device):
+    import math
+
+    maximum = config["kv_blocks"]
+    physical_blocks = math.ceil(config["seqlen_kv"] / 128)
+    usable_blocks = physical_blocks if config["has_block_sizes"] else config["seqlen_kv"] // 128
+    if maximum > usable_blocks:
+        raise ValueError(f"{config.get('label', '<config>')}: kv_blocks exceeds usable blocks")
+    rows = torch.empty(
+        (config["batch"], metadata_heads, q_blocks, maximum), dtype=torch.int32, device=device
+    )
+    base = torch.arange(maximum, dtype=torch.int64, device=device)
+    stride = max(1, usable_blocks // maximum)
+    for linear in range(config["batch"] * metadata_heads * q_blocks):
+        values = (base * stride + linear * 7) % usable_blocks
+        if maximum:
+            values[-1] = usable_blocks - 1
+        rows.reshape(-1, maximum)[linear] = values.to(torch.int32)
+    return rows
+
+
+def _strided_kv(torch, generator, shape, dtype, use_i64):
+    tensor = torch.randn(shape, dtype=dtype, generator=generator, device="cuda")
+    if not use_i64:
+        return tensor
+    if shape[0] != 1:
+        raise ValueError("the Int64 KV stride probe requires batch=1")
+    return torch.as_strided(tensor, shape, (2**31, *tensor.stride()[1:]))
+
+
+def prepare_data(**config):
+    import math
+
+    import torch
+
+    dtype = _torch_dtype(torch, config["dtype"])
+    generator = torch.Generator(device="cuda").manual_seed(config["seed"])
+    q = torch.randn(
+        config["batch"],
+        config["num_q_heads"],
+        config["seqlen_q"],
+        config["head_dim"],
+        dtype=dtype,
+        generator=generator,
+        device="cuda",
+    )
+    k = _strided_kv(
+        torch,
+        generator,
+        (config["batch"], config["num_kv_heads"], config["seqlen_kv"], config["head_dim"]),
+        dtype,
+        config["use_int64_kv_strides"],
+    )
+    v = _strided_kv(
+        torch,
+        generator,
+        (config["batch"], config["num_kv_heads"], config["seqlen_kv"], config["head_dim"]),
+        dtype,
+        config["use_int64_kv_strides"],
+    )
+    if config["tensor_layout"] == "bshd":
+        q_user = q.transpose(1, 2).contiguous()
+        k_user = k.transpose(1, 2).contiguous()
+        v_user = v.transpose(1, 2).contiguous()
+        q = q_user.transpose(1, 2).contiguous()
+        k = k_user.transpose(1, 2).contiguous()
+        v = v_user.transpose(1, 2).contiguous()
+    else:
+        q_user, k_user, v_user = q, k, v
+
+    metadata_heads, q_blocks = _metadata_shape(config)
+    block_index = _metadata(torch, config, metadata_heads, q_blocks, q.device)
+    block_nums = _counts(torch, config, metadata_heads, q_blocks, q.device)
+    physical_blocks = math.ceil(config["seqlen_kv"] / 128)
+    block_sizes = torch.full((physical_blocks,), 128, dtype=torch.int32, device=q.device)
+    block_sizes[-1] = config["seqlen_kv"] - (physical_blocks - 1) * 128
+    scale = (
+        config["head_dim"] ** -0.5
+        if config["softmax_scale"] is None
+        else float(config["softmax_scale"])
+    )
+
+    def outputs():
+        return {
+            "out": torch.empty_like(q),
+            "lse": torch.full(
+                (config["batch"], config["num_q_heads"], config["seqlen_q"]),
+                12345.25,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+        }
+
+    return {
+        "config": dict(config),
+        "q": q,
+        "k": k,
+        "v": v,
+        "q_user": q_user,
+        "k_user": k_user,
+        "v_user": v_user,
+        "block_index": block_index,
+        "block_nums": block_nums,
+        "block_sizes": block_sizes,
+        "softmax_scale": scale,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+def _tirx_launch(executable, data):
+    arguments = (
+        data["q"].reshape(-1),
+        data["k"].reshape(-1),
+        data["v"].reshape(-1),
+        data["tirx"]["out"].reshape(-1),
+        data["tirx"]["lse"].reshape(-1),
+        data["block_index"].reshape(-1),
+        data["block_sizes"].reshape(-1),
+        data["block_nums"].reshape(-1),
+        data["config"]["kv_blocks"],
+        data["softmax_scale"] * _LOG2_E,
+    )
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _compile_reference(data):
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    interface = load_reference_module("cudnn.block_sparse_attention._interface")
+    config = data["config"]
+    source_out_shape = (
+        (config["batch"], config["num_q_heads"], config["seqlen_q"], config["head_dim"])
+        if config["tensor_layout"] == "bhsd"
+        else (config["batch"], config["seqlen_q"], config["num_q_heads"], config["head_dim"])
+    )
+    import torch
+
+    source_out_storage = torch.empty(
+        source_out_shape, dtype=_torch_dtype(torch, config["dtype"]), device="cuda"
+    )
+
+    def call_reference(q, k, v, out):
+        return interface.bsa_attn_fwd(
+            q,
+            k,
+            v,
+            data["block_index"],
+            config["kv_blocks"] if config["block_count_mode"] == "fixed" else 0,
+            block_sizes=data["block_sizes"] if config["has_block_sizes"] else None,
+            q2k_block_nums=(data["block_nums"] if config["block_count_mode"] != "fixed" else None),
+            allow_empty_block_nums=config["block_count_mode"] == "variable_empty",
+            softmax_scale=config["softmax_scale"],
+            pack_gqa=None if config["pack_gqa"] == "auto" else config["pack_gqa"],
+            return_lse=config["return_lse"],
+            out=out,
+            layout=config["tensor_layout"],
+        )
+
+    priming_tensors = ()
+    if config["use_int64_kv_strides"]:
+        compact_k = torch.empty(
+            data["k_user"].shape, dtype=data["k_user"].dtype, device=data["k_user"].device
+        ).copy_(data["k_user"])
+        compact_v = torch.empty(
+            data["v_user"].shape, dtype=data["v_user"].dtype, device=data["v_user"].device
+        ).copy_(data["v_user"])
+        compact_out = torch.empty_like(source_out_storage)
+        call_reference(data["q_user"], compact_k, compact_v, compact_out)
+        torch.cuda.synchronize()
+        priming_tensors = (compact_k, compact_v, compact_out)
+
+    def launch():
+        source_out, source_lse = call_reference(
+            data["q_user"], data["k_user"], data["v_user"], source_out_storage
+        )
+        if config["tensor_layout"] == "bshd":
+            source_out = source_out.transpose(1, 2).contiguous()
+        data["source"]["out"] = source_out
+        data["source"]["lse"] = source_lse
+
+    launch._keep_alive = (interface, source_out_storage, priming_tensors)
+    return launch
+
+
+def _oracle(data):
+    import torch
+
+    config = data["config"]
+    q, k, v = data["q"], data["k"], data["v"]
+    out = torch.zeros_like(q)
+    lse = torch.full(
+        (config["batch"], config["num_q_heads"], config["seqlen_q"]),
+        -float("inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    ratio = config["num_q_heads"] // config["num_kv_heads"]
+    packed = _pack_enabled(config)
+    positions = torch.arange(config["seqlen_q"], device=q.device)
+    for batch_idx in range(config["batch"]):
+        for q_head in range(config["num_q_heads"]):
+            kv_head = q_head // ratio
+            metadata_head = kv_head if packed else q_head
+            local_head = q_head - kv_head * ratio
+            tile_for_position = (
+                (positions * ratio + local_head) // 128 if packed else positions // 128
+            )
+            for q_tile in tile_for_position.unique().tolist():
+                query_positions = positions[tile_for_position == q_tile]
+                count = int(data["block_nums"][batch_idx, metadata_head, q_tile])
+                if count == 0:
+                    continue
+                block_ids = data["block_index"][batch_idx, metadata_head, q_tile, :count].tolist()
+                key_parts = []
+                value_parts = []
+                for block_id in block_ids:
+                    valid = int(data["block_sizes"][block_id]) if config["has_block_sizes"] else 128
+                    start = block_id * 128
+                    stop = min(start + valid, config["seqlen_kv"])
+                    key_parts.append(k[batch_idx, kv_head, start:stop].float())
+                    value_parts.append(v[batch_idx, kv_head, start:stop].float())
+                keys = torch.cat(key_parts, dim=0)
+                values = torch.cat(value_parts, dim=0)
+                scores = q[batch_idx, q_head, query_positions].float() @ keys.T
+                scores *= data["softmax_scale"]
+                probabilities = torch.softmax(scores, dim=-1)
+                out[batch_idx, q_head, query_positions] = (probabilities @ values).to(q.dtype)
+                lse[batch_idx, q_head, query_positions] = torch.logsumexp(scores, dim=-1)
+    return out, lse
+
+
+def _validate_tensor_pair(torch, name, actual, expected, *, atol, rtol):
+    if torch.isnan(actual).any():
+        raise AssertionError(f"{name} contains NaN")
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+def _validate_outputs(data, *, with_oracle):
+    import torch
+
+    config = data["config"]
+    tirx = data["tirx"]
+    source = data["source"]
+    if source["out"] is None:
+        raise AssertionError("pinned source did not produce O")
+    _validate_tensor_pair(
+        torch,
+        "TIRx versus source O",
+        tirx["out"].float(),
+        source["out"].float(),
+        atol=0.03,
+        rtol=0.03,
+    )
+    if config["return_lse"]:
+        if source["lse"] is None:
+            raise AssertionError("pinned source did not produce requested LSE")
+        if torch.isnan(tirx["lse"]).any() or torch.isnan(source["lse"]).any():
+            raise AssertionError("LSE contains NaN")
+        if not torch.equal(torch.isfinite(tirx["lse"]), torch.isfinite(source["lse"])):
+            raise AssertionError("TIRx/source LSE finite mask mismatch")
+        finite = torch.isfinite(source["lse"])
+        _validate_tensor_pair(
+            torch,
+            "TIRx versus source finite LSE",
+            tirx["lse"][finite],
+            source["lse"][finite],
+            atol=0.002,
+            rtol=0.002,
+        )
+    else:
+        if source["lse"] is not None:
+            raise AssertionError("source returned LSE for return_lse=False")
+        if not torch.equal(tirx["lse"], torch.full_like(tirx["lse"], 12345.25)):
+            raise AssertionError("no-LSE specialization modified its sentinel")
+
+    metrics = {}
+    if with_oracle:
+        oracle_out, oracle_lse = _oracle(data)
+        for name, values in (("tirx", tirx), ("source", source)):
+            _validate_tensor_pair(
+                torch,
+                f"{name} versus oracle O",
+                values["out"].float(),
+                oracle_out.float(),
+                atol=0.03,
+                rtol=0.03,
+            )
+            if config["return_lse"]:
+                if not torch.equal(torch.isfinite(values["lse"]), torch.isfinite(oracle_lse)):
+                    raise AssertionError(f"{name}/oracle LSE finite mask mismatch")
+                finite = torch.isfinite(oracle_lse)
+                _validate_tensor_pair(
+                    torch,
+                    f"{name} versus oracle finite LSE",
+                    values["lse"][finite],
+                    oracle_lse[finite],
+                    atol=0.002,
+                    rtol=0.002,
+                )
+        empty = ~torch.isfinite(oracle_lse)
+        if empty.any():
+            for name, values in (("tirx", tirx), ("source", source)):
+                if not torch.equal(values["out"][empty], torch.zeros_like(values["out"][empty])):
+                    raise AssertionError(f"{name} empty sparse rows are not bitwise zero")
+                if config["return_lse"] and not torch.isneginf(values["lse"][empty]).all():
+                    raise AssertionError(f"{name} empty sparse LSE is not exactly -inf")
+        metrics = {
+            "tirx_oracle_o_max_abs": float((tirx["out"].float() - oracle_out.float()).abs().max()),
+            "source_oracle_o_max_abs": float(
+                (source["out"].float() - oracle_out.float()).abs().max()
+            ),
+        }
+    return metrics
+
+
+def run_test(**config):
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    tirx_launch = _tirx_launch(compile_kernel(get_kernel(**kernel_config)), data)
+    source_launch = _compile_reference(data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    source_launch()
+    torch.cuda.synchronize()
+    return _validate_outputs(data, with_oracle=True)
+
+
+def prepare_bench(**config):
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {"config": kernel_config, "executable": compile_kernel(get_kernel(**kernel_config))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _compile_reference(data)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data, with_oracle=False)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"cudnn_frontend": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port cuDNN Frontend's SM100 block-sparse attention forward kernel (128-row query block) to the pure `tirx_kernels.kern` API
- support BF16/FP16, head dimensions 64/96/128, MHA/GQA/MQA, packed and unpacked sequence metadata, causal/window masks, LSE output, tail blocks, and 32-bit/64-bit KV offsets
- predicate sparse-ID loads, named-barrier arrivals, and K/V TMA issues per instruction to avoid elected-lane reconvergence overhead
- add the canonical sketch, bench-suite workload matrix, and README registration
- extend the generated-code diagnostics field notes with the measured elected-lane predication result and the exact-block-contract negative ablation

## Validation

- correctness: 32/32 configurations passed against pinned cuDNN Frontend commit `aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5`
- strict comparisons: BF16 maximum absolute error `0.00390625`; FP16 maximum absolute error `0.00048828125`
- low-level IR: 32/32 passed; no external function calls, tile primitives, or first-class layouts
- Compute Sanitizer memcheck: configurations 22, 23, and 30 passed with zero errors
- integration: bench-suite import check, license checks, and pre-commit passed
- performance: all 24 bench-suite workloads passed strictly above `0.99x`, using five rounds per implementation with no interference retries
  - minimum reference/TIRx ratio: `0.9906772342`
  - geometric mean ratio: `1.3592038533`

The final performance run used `python -m tirx_kernels.bench_suite` with references, 5 rounds, zero cooldown, one preparation process, and one ready-backlog slot.

## Dependency

- apache/tvm#20226: allow CUDA launch bounds to coexist with `tirx.required_block_size`
