### PR TITLE
feat(kernel): add SM100 block-sparse attention backward

### DIFF
--- a/.agents/sketch/cudnn/sm100_bsa_backward_blk64.md
+++ b/.agents/sketch/cudnn/sm100_bsa_backward_blk64.md
@@ -1,0 +1,651 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This sketch documents a TIRx port of NVIDIA cuDNN Frontend commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5, file
+python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk64/bsa_bwd_sm100.py.
+-->
+
+# cudnn_sm100_bsa_backward_blk64: source-shaped three-kernel sketch
+
+This is the frozen, non-executable design for
+`tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py`.
+The public operation is exactly the source class's direct three-launch ABI:
+
+1. `sum_OdO`: BF16 `O,dO` to two FP32 workspace planes;
+2. `bwd`: bucketed inverse-CSR block-sparse backward into FP32 `dQ/dK/dV`
+   workspace planes;
+3. `convert`: FP32 planes to BF16 `dQ,dK,dV`.
+
+Bucketed-CSR construction, the forward O/LSE producer, allocation, zero fill,
+compilation and validation are host work outside the timed closure.  The
+kernel imports only `tirx_kernels.kern as K`; it uses no tile primitive, no
+first-class layout, no multidimensional shared buffer and no CUDA function
+call.
+
+## Fixed scope and runtime ABI
+
+Every specialization is BF16, head dimension 128, sparse block 64, singleton
+cluster and SM100a.  Static keys are `(B,H,SQ,SKV,has_block_sizes,bucket)`.
+The direct tensors are compact BHSD except the explicit i64-stride guard; all
+workspace plane offsets and outer tensor offsets are i64.
+
+```text
+sum_OdO(O:bf16*, dO:bf16*, workspace:f32*)
+bwd(dO,O,Q,K,V:bf16*, LSE:f32*, offsets:i32*, indices:i32*,
+    block_sizes:i32*, workspace:f32*, softmax_scale:f32)
+convert(workspace:f32*, dQ,dK,dV:bf16*, softmax_scale:f32)
+```
+
+Workspace, in FP32 elements with `Q8=roundup(SQ,8)`, `K8=roundup(SKV,8)`:
+
+```text
+sum_OdO   [B,H,Q8]                 @ 0
+scaledLSE [B,H,Q8]                 @ B*H*Q8
+dQ_acc    [B,H,Q8,128]             @ 2*B*H*Q8
+dK_acc    [B,H,K8,128]             @ previous + B*H*Q8*128
+dV_acc    [B,H,K8,128]             @ previous + B*H*K8*128
+```
+
+`sum_OdO=-sum_d(BF16(O*dO))`, matching the source's narrow packed multiply;
+`scaledLSE=-log2(e)*LSE`.  Main recomputes
+`P=exp2(S*softmax_scale*log2(e)+scaledLSE)` and
+`dS=(dP+sum_OdO)*P`.  `convert` multiplies dQ and dK by softmax scale and does
+not multiply dV.
+
+## Independent line-info evidence
+
+Writer exports are under
+`.porting/block_sparse_attention_backward_sm100_blk64/source_export/` and are
+indexed by `source_export_manifest.json`.  They were produced with AOT disabled,
+cache disabled, PTX retention and line info enabled.  The unmasked build has
+1589 `.loc` directives; the masked build has 1631.  Both contain three entries:
+
+| source entry | `.reqntid` | static instruction evidence |
+| --- | --- | --- |
+| `sum_OdO`, source 619-658 | `(8,16,1)` | 31 `ld.global.b32`, 15 `mul.bf16x2`, 15 `cvt.f32.bf16`, 15 `add.rn.f32.bf16`, 3 shuffles, 2 stores |
+| `bwd`, source 659-960 / 1023-2140 | `(512,1,1)` | 72 `tcgen05.mma...f16`, 24 mbarrier init, 20 rank-4 TMA G2S, 8 TMA reduce-add S2G, 8 x16 + 4 x32 T2R, 64 scalar f32 atomics |
+| `convert`, source 966-1022 | `(16,8,1)` | 44 global loads, 22 packed BF16 converts, 16 packed f32 multiplies, 11 vector stores |
+
+The masked and unmasked source programs differ only in the K-column mask arm.
+The c07 export is the primary op-level anchor; c01 proves the compile-time
+absence of that arm.  c09 proves empty inverse-CSR tasks, c15 the 1088 bucket
+two-group branch, c18 i64 workspace offsets beyond 2 GiB, and c19 grid.x 86881.
+
+## Launch and task decode
+
+```python
+sum_grid     = (ceil_div(SQ,16), H, B)          # 128 threads / 4 warps
+tasks        = ceil_div(SKV,64)
+groups       = ceil_div(ceil_div(SQ,64), bucket)
+bwd_grid     = (tasks*groups, H, B)             # 512 threads / 16 warps
+convert_grid = (ceil_div(max(SQ,SKV),8), H, B)  # 128 threads / 4 warps
+
+q_group = blockIdx.x // tasks
+task     = blockIdx.x - q_group*tasks
+kv_block = task
+begin    = offsets[((B,H,q_group)*(tasks+1))+task]
+end      = offsets[((B,H,q_group)*(tasks+1))+task+1]
+count    = end-begin
+work     = count>0 and kv_block*64<SKV
+```
+
+Before this decode, warp 13 unconditionally prefetches the four TensorMaps and
+the whole CTA unconditionally constructs all ten pipelines.  The `work` guard
+begins only after those constructors and named barrier 1.  A no-work CTA thus
+participates in every initialization rendezvous but executes no role body,
+register-budget branch, named barrier 2--5 or TMEM allocation.
+
+## Main CTA roles and rendezvous
+
+The dispatch order is source order, not numeric warp order:
+
+| warps | registers | role |
+| --- | --- | --- |
+| 13 | 96 decrease | descriptor prefetch and paired Q/dO/LSE/sum/K/V load |
+| 12 | 96 decrease | allocate TMEM and issue every MMA |
+| 4-11 | 128 increase | T2R S/dP, P/dS recompute, BF16 shared stores, dK/dV epilogue |
+| 0-3 | 152 increase | T2R dQ and staged TMA reduce-add |
+| 14-15 | 96 decrease | empty |
+
+Named barriers preserve the source counts exactly:
+
+```text
+bar 1: 512 threads, after all 24 mbarrier.init and ten constructor epochs
+bar 2: 416 threads, MMA + compute + reduce TMEM allocation/retrieval
+bar 3: 256 compute threads, paired T2R/shared-store rendezvous
+bar 4: 256 compute threads, TMEM deallocation rendezvous
+bar 5: 128 reduce threads, each sdQ store/TMA handoff rendezvous
+```
+
+Barrier 1 follows ten constructor-local release fences and ten distinct
+`bar.sync 0`, not one shared initialization epoch.
+
+`instruction_selection`: `setmaxnreg.{inc,dec}.sync.aligned.u32`,
+`bar.sync`, `fence.mbarrier_init.release.cluster`,
+`tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`, and
+`tcgen05.dealloc.cta_group::1.sync.aligned.b32` exactly as exported at source
+`:783-958`.
+
+## One rank-1 shared arena
+
+The only shared allocation is `u8 arena[199680] align=1024`.  Every following
+name is an integer byte offset; swizzles are explicit address functions.
+
+| object | offset | bytes | logical extent / lifetime |
+| --- | ---: | ---: | --- |
+| Q full[2], Q empty[2] | 0 | 32 | 2-stage TMA→MMA |
+| dO full,empty | 32 | 16 | 1-stage TMA→MMA |
+| LSE full,empty | 48 | 16 | 1-stage cp.async→compute |
+| sum full,empty | 64 | 16 | 1-stage cp.async→compute |
+| S full,empty | 80 | 16 | 1-stage MMA→compute |
+| dP full,empty | 96 | 16 | 1-stage MMA→compute |
+| dQ full,empty | 112 | 16 | 1-stage MMA→reduce |
+| P full,empty | 128 | 16 | 1-stage compute→MMA |
+| dS full,empty | 144 | 16 | 1-stage compute→MMA |
+| dKdV full[2],empty[2] | 160 | 32 | 2-stage MMA→compute |
+| TMEM holding word | 192 | 4 | allocation mailbox |
+| alignment gap | 196 | 828 | unused |
+| sK | 1024 | 16384 | BF16 [64,128] |
+| sV | 17408 | 16384 | BF16 [64,128] |
+| sQ | 33792 | 65536 | BF16 [stage2, pair2,64,128] |
+| sP | 99328 | 16384 | BF16 [128,64] |
+| sdO | 115712 | 32768 | BF16 [pair2,64,128] |
+| sdS | 148480 | 16384 | BF16 [128,64] |
+| sdQ | 164864 | 32768 | FP32 [stage2,pair2,64,32] |
+| sLSE | 197632 | 512 | FP32 [128] |
+| sSum | 198656 | 512 | FP32 [128] |
+| tail padding | 199168 | 512 | source struct extent to 199680 |
+
+For every BF16 MMA operand region:
+
+```python
+tile_elem(row, dim) = (dim//64)*4096 + ((row*64 + dim%64) ^ ((row%8)*8))
+tile_byte(base,row,dim) = base + 2*tile_elem(row,dim)
+```
+
+All remaining selected scalar addresses are integer functions as well:
+
+```python
+linear_f32(base,pair,row) = base + 4*(pair*64 + row)  # sLSE/sSum
+tmem_cell(base,row,col) = base + col + (row << 16)    # tcgen05 address word
+
+# compute/epilogue local thread ct in 0..255, issue i in 0..1, reg r in 0..15
+c_row(ct) = ct % 128
+c_col(ct,i,r) = (ct//128)*16 + i*32 + r
+c_tmem(base,ct,i) = tmem_cell(base,(c_row(ct)//32)*32,(ct//128)*16+i*32)
+# The same map denotes output (kv_row=c_col, dim=c_row) for dK/dV.
+
+# reduce local thread rt in 0..127, issue i in 0..3, reg r in 0..31
+q_row(rt) = rt
+q_dim(i,r) = i*32 + r
+q_tmem(base,rt,i) = tmem_cell(base,(q_row(rt)//32)*32,i*32)
+
+# register vector j=0..7 for a fixed 32-D reduce chunk; p=rt//64,
+# t=rt%64.  Source CopyAtom visits vectors in reverse shared order.
+sdq_raw(stage,p,t,j) = 164864 + stage*16384 + p*8192 + t*128 + 16*(7-j)
+sdq_vec(stage,p,t,j) = sdq_raw(stage,p,t,j) ^ ((sdq_raw(stage,p,t,j)>>3)&0x70)
+```
+
+Thus P/dS use `tile_byte(99328 or 148480,c_row,c_col)`, the dK/dV
+atomics use the transposed logical coordinate stated above, and every dQ
+register is `dQ[q_row,q_dim]` before its explicit `sdq_vec` store.  No
+first-class layout survives into the implementation.
+
+The full `c_row`/`q_row` remains the scalar register-to-shared/global
+coordinate.  Only a T2R instruction operand uses its 32-row group base; the
+individual lane within that group is implicit in `tcgen05.ld`.
+
+## TMEM and descriptors
+
+TMEM always allocates 512 columns:
+
+```text
+dK = base+0       [128,64]
+dV = base+64      [128,64]
+dQ = base+128     [128,128] (aliases dP [128,64] while lifetimes alternate)
+S  = base+256     [128,64]
+```
+
+Shared descriptors use 128B swizzle 3, `sdo=64`, and `ldo=512` for a
+128-wide region or `ldo=0` for a 64-wide region.  The address field is
+`(shared_addr>>4)&0x3fff`.  The exported BF16 instruction descriptors are:
+
+```text
+Q@K^T, dO@V^T:             0x08100490  # M128,N64,K16, K/K major
+dO^T@P, Q^T@dS:            0x08118490  # M128,N64,K16, MN/MN major
+dS@K:                      0x08210490  # M128,N128,K16, K/MN major
+```
+
+`instruction_selection`: each static issue is
+`tcgen05.mma.cta_group::1.kind::f16`; elected lane commits with
+`tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`.
+The source export contains 72 static MMA instructions: 8 QK + 8 dP + 8 dV in
+the prologue; each steady pair adds 8 QK + 4 dQ + 8 dK + 8 dP + 8 dV; the
+tail adds 8 dK + 4 dQ.  Rolled runtime repetition preserves this source
+program rather than cloning the static body per sparse edge.
+
+## Pipeline contracts
+
+```text
+Q:     stages2 full=TMA(1)      empty=tcgen05(1)
+dO:    stages1 full=TMA(1)      empty=tcgen05(1)
+LSE:   stages1 full=mbar(32)    empty=mbar(256)
+sum:   stages1 full=mbar(32)    empty=mbar(256)
+S:     stages1 full=tcgen05(1)  empty=mbar(256)
+dP:    stages1 full=tcgen05(1)  empty=mbar(256)
+dQ:    stages1 full=tcgen05(1)  empty=mbar(128)
+P:     stages1 full=mbar(256)   empty=tcgen05(1)
+dS:    stages1 full=mbar(256)   empty=tcgen05(1)
+dKdV:  stages2 full=tcgen05(1)  empty=mbar(256)
+```
+
+Initialization is source declaration order.  Each constructor initializes all
+of its full/empty barriers and then executes its own
+`fence.mbarrier_init.release.cluster; bar.sync 0` pair:
+
+```text
+Q:     offsets 0,8,16,24       -> fence; bar.sync 0
+dO:    offsets 32,40           -> fence; bar.sync 0
+LSE:   offsets 48,56           -> fence; bar.sync 0
+sum:   offsets 64,72           -> fence; bar.sync 0
+S:     offsets 80,88           -> fence; bar.sync 0
+dP:    offsets 96,104          -> fence; bar.sync 0
+dQ:    offsets 112,120         -> fence; bar.sync 0
+P:     offsets 128,136         -> fence; bar.sync 0
+dS:    offsets 144,152         -> fence; bar.sync 0
+dKdV:  offsets 160,168,176,184 -> fence; bar.sync 0
+```
+
+`instruction_selection`: 24 `mbarrier.init.shared.b64`; ten separate
+`fence.mbarrier_init.release.cluster`; ten separate `bar.sync 0`; then one
+`bar.sync 1,512`.  TMA-store has no stored mbarrier: two bulk-group stages are
+tracked by commit/wait counters.
+
+Every runtime cursor is the integer pair `(stage,phase)`.  A producer cursor
+starts `(0,1)` because it waits on the initial empty generation; a consumer
+cursor starts `(0,0)` because it waits on the initial full generation.  For a
+one-stage edge `advance` toggles phase.  For Q and dKdV, which are two-stage,
+it increments stage and only on `stage==2` wraps stage to zero and toggles
+phase.  The reduce bulk-group cursor is `(stage=0)` modulo two and has no
+mbarrier phase.
+
+```text
+load:    Q_prod,LSE_prod,dO_prod,sum_prod                         = producer
+mma:     Q_cons,Q_release=clone(Q_cons),dO_cons,P_cons,dS_cons   = consumer
+         S_prod,dP_prod,dQ_prod,dKdV_prod                         = producer
+compute: S_cons,LSE_cons,sum_cons,dP_cons,dKdV_cons               = consumer
+         P_prod,dS_prod                                           = producer
+reduce:  dQ_cons                                                  = consumer
+         reduce_bulk_prod                                         = stage 0
+```
+
+Each operation below names the cursor advanced at that exact handoff.  The Q
+consumer advances immediately after its S read, while `Q_release`, cloned at
+the same initial `(0,0)`, advances only after the corresponding dK read.  This
+is the source's deliberately delayed Q release.
+
+## Complete role program
+
+The following is operation-level pseudocode.  Each load/store/collective line
+is immediately followed by its required instruction selection and extent.
+
+```python
+if warp == 13:
+  prefetch(desc_Q,desc_K,desc_V,desc_dO)
+  # instruction_selection: four prefetch.tensormap, unconditional, source 703-713
+for constructor in [Q,dO,LSE,sum,S,dP,dQ,P,dS,dKdV]:
+  init_full_and_empty_barriers(constructor)
+  # instruction_selection: mbarrier.init.shared.b64, respectively 4,2,2,2,2,2,2,2,2,4 sites
+  init_fence(); cta_barrier_zero()
+  # instruction_selection: one fence.mbarrier_init.release.cluster then one bar.sync 0
+named_barrier(1, 512)
+# instruction_selection: bar.sync 1,512, unconditional and after the tenth constructor epoch
+
+decode_task_and_work()
+if work:
+  apply_source_register_budget_for_role()
+  # instruction_selection: one setmaxnreg.inc/dec.sync.aligned.u32 per nonempty role
+
+  role load_warp_13:
+    Q_prod=producer_state(depth=2,stage=0,phase=1)
+    LSE_prod,dO_prod,sum_prod=producer_state(depth=1,stage=0,phase=1)
+    for pair in ceil_div(count,2):
+      q0 = indices[begin+2*pair]
+      q1 = indices[begin+2*pair+1] if live else floor(SQ/64)
+      acquire(Q_prod.stage,Q_prod.phase)
+      # instruction_selection: mbarrier.try_wait.parity.shared.b64; one Q-empty wait/pair,
+      # initial stage 0 phase 1 and the current two-stage producer cursor thereafter
+      expect_tx_base(Q_full[stage], 16384)
+      # instruction_selection: mbarrier.arrive.expect_tx.shared.b64, 16384-byte base/pair
+      if pair == 0:
+        add_expected_bytes(Q_full[stage],32768)  # total 49152
+        # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared.b64, +32768 bytes
+        tma_g2s_2x64x64(K[kv_block],sK,Q_full[stage])
+        # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint;
+        # extent two [64,64] BF16 boxes = one [64,128] tile = 16384 bytes
+      else:
+        add_expected_bytes(Q_full[stage],16384)  # total 32768
+        # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared.b64, +16384 bytes
+      tma_g2s_2x64x64(Q[q0*64],sQ[stage,0],Q_full[stage])
+      # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint, 2*8192 bytes
+      tma_g2s_2x64x64(Q[q1*64],sQ[stage,1],Q_full[stage])
+      # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint, 2*8192 bytes;
+      # dummy q1 is still issued and clipped by its source TensorMap
+      advance(Q_prod)
+      # state_selection: increment stage; on stage 2 wrap to 0 and toggle phase
+
+      acquire(LSE_prod.stage,LSE_prod.phase)
+      # instruction_selection: mbarrier.try_wait.parity.shared.b64, one LSE-empty wait/pair
+      for lane in 0..31: cp_async_or_st_zero(two_q0_and_two_q1_f32)
+      # instruction_selection: four scalar cp.async.ca.shared.global or st.shared.b32 zero sites/lane;
+      # extent 32 lanes*4 = 128 f32 including the dummy/partial-row zero arms
+      commit(LSE); advance(LSE_prod)
+      # instruction_selection: one cp.async.mbarrier.arrive.noinc.shared.b64/pair
+      # state_selection: one-stage producer phase toggle after publication
+
+      acquire(dO_prod.stage,dO_prod.phase)
+      # instruction_selection: mbarrier.try_wait.parity.shared.b64, one dO-empty wait/pair
+      expect_tx_base(dO_full,16384)
+      # instruction_selection: mbarrier.arrive.expect_tx.shared.b64, 16384-byte base/pair
+      if pair == 0:
+        add_expected_bytes(dO_full,32768)  # total 49152
+        # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared.b64, +32768 bytes
+        tma_g2s_2x64x64(V[kv_block],sV,dO_full)
+        # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint, 2*8192 bytes
+      else:
+        add_expected_bytes(dO_full,16384)  # total 32768
+        # instruction_selection: mbarrier.expect_tx.relaxed.cta.shared.b64, +16384 bytes
+      tma_g2s_2x64x64(dO[q0],sdO[0],dO_full)
+      # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint, 2*8192 bytes
+      tma_g2s_2x64x64(dO[q1],sdO[1],dO_full)
+      # instruction_selection: two elected cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint, 2*8192 bytes
+      advance(dO_prod)
+      # state_selection: one-stage producer phase toggle after all dO/V issues
+
+      acquire(sum_prod.stage,sum_prod.phase)
+      # instruction_selection: mbarrier.try_wait.parity.shared.b64, one sum-empty wait/pair
+      for lane in 0..31: cp_async_or_st_zero(two_q0_and_two_q1_f32)
+      # instruction_selection: four scalar cp.async.ca.shared.global or st.shared.b32 zero sites/lane;
+      # extent 128 f32 including dummy/partial-row zero arms
+      commit(sum); advance(sum_prod)
+      # instruction_selection: one cp.async.mbarrier.arrive.noinc.shared.b64/pair
+      # state_selection: one-stage producer phase toggle after publication
+
+  role mma_warp_12:
+    Q_cons=consumer_state(depth=2,stage=0,phase=0)
+    Q_release=clone(Q_cons)
+    dO_cons,P_cons,dS_cons=consumer_state(depth=1,stage=0,phase=0)
+    S_prod,dP_prod,dQ_prod=producer_state(depth=1,stage=0,phase=1)
+    dKdV_prod=producer_state(depth=2,stage=0,phase=1)
+    tmem_alloc(512)
+    # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32
+    named_barrier(2,416)
+    # instruction_selection: bar.sync 2,416
+    retrieve_base()
+    # instruction_selection: ld.shared.b32
+    elected = elect_sync()
+    wait(Q_cons.stage,Q_cons.phase); acquire(S_prod.stage,S_prod.phase)
+    # instruction_selection: one Q-full mbarrier.try_wait.parity and one S-empty wait
+    mma S0=Qpair@K; commit(S); advance(Q_cons); advance(S_prod)
+    # instruction_selection: 8 tcgen05.mma f16 plus one tcgen05.commit...mbarrier::arrive::one
+    # state_selection: Q consumer and S producer advance at this handoff
+    wait(dO_cons.stage,dO_cons.phase); acquire(dP_prod.stage,dP_prod.phase)
+    acquire(dQ_prod.stage,dQ_prod.phase)
+    # instruction_selection: dO-full, dP-empty and dQ-empty mbarrier.try_wait operations
+    mma dP0=dOpair@V; commit(dP); advance(dP_prod)
+    # instruction_selection: 8 tcgen05.mma f16 plus one tcgen05.commit
+    # state_selection: dP producer phase toggle after publication; dQ producer stays acquired
+    wait(P_cons.stage,P_cons.phase); mma dV=dO^T@P accumulate=false
+    release(P_cons); advance(P_cons); release(dO_cons); advance(dO_cons)
+    # instruction_selection: one P-full wait, 8 tcgen05.mma f16, then two independent
+    # mbarrier.arrive.shared.b64 releases
+    # state_selection: P and dO one-stage consumer phase toggles after release
+    dk_accumulate = False
+    for remaining_pair:
+      wait(Q_cons.stage,Q_cons.phase); acquire(S_prod.stage,S_prod.phase)
+      mma S; commit(S); advance(Q_cons); advance(S_prod)
+      # instruction_selection: Q/S waits, 8 tcgen05.mma f16, one tcgen05 commit
+      # state_selection: Q two-stage consumer and S producer advance
+      wait(dS_cons.stage,dS_cons.phase); acquire(dP_prod.stage,dP_prod.phase)
+      # instruction_selection: dS-full and dP-empty mbarrier.try_wait operations
+      mma dQ=dS@K accumulate=false; commit(dQ); advance(dQ_prod)
+      # instruction_selection: 4 tcgen05.mma f16 for K=64,N=128 plus one tcgen05 commit
+      # state_selection: dQ producer phase toggle, then acquire its next empty generation below
+      mma dK=Q^T@dS with first K phase accumulate=dk_accumulate,
+          remaining seven phases accumulate=True
+      dk_accumulate = True
+      # instruction_selection: 8 tcgen05.mma f16; first-ever issue uses false predicate,
+      # every later first phase and all remaining phases use true
+      release(Q_release); advance(Q_release); release(dS_cons); advance(dS_cons)
+      # instruction_selection: two independent mbarrier.arrive.shared.b64
+      # state_selection: delayed cloned Q-release cursor and dS consumer advance here
+      acquire(dQ_prod.stage,dQ_prod.phase); wait(dO_cons.stage,dO_cons.phase)
+      mma dP; commit(dP); advance(dP_prod)
+      # instruction_selection: dQ-empty/dO-full waits, 8 tcgen05.mma, one tcgen05 commit
+      # state_selection: dP producer phase toggle
+      wait(P_cons.stage,P_cons.phase); mma dV+=dO^T@P
+      release(P_cons); advance(P_cons); release(dO_cons); advance(dO_cons)
+      # instruction_selection: P-full wait, 8 tcgen05.mma, two independent releases
+      # state_selection: P and dO consumer phase toggles
+    acquire(dKdV_prod.stage,dKdV_prod.phase); publish_dV_generation(); advance(dKdV_prod)
+    # instruction_selection: dKdV-empty wait then tcgen05.commit...mbarrier::arrive::one
+    # state_selection: two-stage producer increments from generation dV to dK
+    acquire(dKdV_prod.stage,dKdV_prod.phase); wait(dS_cons.stage,dS_cons.phase)
+    # instruction_selection: dKdV-empty and dS-full waits
+    mma final_dK with first phase accumulate=dk_accumulate then seven true
+    dk_accumulate = True
+    # instruction_selection: 8 tcgen05.mma f16, including tail-only false first issue
+    publish_dK_generation(); advance(dKdV_prod)
+    # instruction_selection: tcgen05.commit...mbarrier::arrive::one
+    # state_selection: dKdV two-stage producer wraps/toggles only if stage reaches 2
+    mma final_dQ accumulate=false; commit(dQ); advance(dQ_prod)
+    # instruction_selection: exactly 4 tcgen05.mma f16 plus one tcgen05 commit
+    # state_selection: dQ producer phase toggle
+    release(Q_release); advance(Q_release); release(dS_cons); advance(dS_cons)
+    # instruction_selection: two independent mbarrier.arrive.shared.b64
+    # state_selection: delayed Q-release and dS consumer advance
+
+  role compute_warps_4_11:
+    S_cons,LSE_cons,sum_cons,dP_cons=consumer_state(depth=1,stage=0,phase=0)
+    P_prod,dS_prod=producer_state(depth=1,stage=0,phase=1)
+    dKdV_cons=consumer_state(depth=2,stage=0,phase=0)
+    named_barrier(2,416); retrieve_base()
+    # instruction_selection: bar.sync 2,416 + ld.shared.b32
+    block_size = block_sizes[B,kv_block] if masked else 64
+    # instruction_selection: one ld.global.b32/compute thread in masked build;
+    # compile-time absent with the whole mask arm in unmasked c01
+    for pair in ceil_div(count,2):
+      wait(S_cons.stage,S_cons.phase); wait(LSE_cons.stage,LSE_cons.phase)
+      acquire(P_prod.stage,P_prod.phase)
+      # instruction_selection: three independent mbarrier.try_wait.parity.shared.b64
+      t2r S at c_tmem(S_base,ct,0) and c_tmem(S_base,ct,1)
+      # instruction_selection: two tcgen05.ld.sync.aligned.32x32b.x16.b32;
+      # 16 f32/issue, 32 f32/compute thread, mapped by c_row/c_col
+      mask columns >= block_size to -inf if masked
+      # instruction_selection: 32 setp.lt.s32 plus 32 selp.b32/compute thread;
+      # entire arm is absent from unmasked c01
+      packed_fma(S, scale*log2e, scaledLSE); exp2 each lane
+      # instruction_selection: 16 fma.rn.f32x2 plus 32 ex2.approx.ftz.f32/thread
+      pack BF16x2
+      # instruction_selection: 16 cvt.rn.bf16x2.f32/compute thread
+      tmem_load_wait(); named_barrier(3,256); tmem_load_wait()
+      # instruction_selection: tcgen05.wait::ld.sync.aligned; bar.sync 3,256;
+      # second tcgen05.wait::ld.sync.aligned before every store
+      store 32 BF16 values/thread to tile_byte(sP,c_row,c_col)
+      # instruction_selection: four st.shared.v4.b32/compute thread
+      fence_proxy_async_shared()
+      # instruction_selection: fence.proxy.async.shared::cta
+      commit(P); advance(P_prod)
+      release(S_cons); advance(S_cons); release(LSE_cons); advance(LSE_cons)
+      # instruction_selection: three independent mbarrier.arrive.shared.b64
+      # state_selection: P producer, S consumer and LSE consumer each toggle phase
+
+      wait(sum_cons.stage,sum_cons.phase); wait(dP_cons.stage,dP_cons.phase)
+      acquire(dS_prod.stage,dS_prod.phase)
+      # instruction_selection: three independent mbarrier.try_wait.parity.shared.b64
+      t2r dP at c_tmem(dP_base,ct,0) and c_tmem(dP_base,ct,1)
+      # instruction_selection: two tcgen05.ld.sync.aligned.32x32b.x16.b32;
+      # 32 f32/compute thread
+      packed_add(dP,sum); packed_mul(result,P); pack BF16x2
+      # instruction_selection: 16 add.rn.f32x2, 16 mul.rn.f32x2 and
+      # 16 cvt.rn.bf16x2.f32/compute thread
+      tmem_load_wait(); release(dP_cons); advance(dP_cons)
+      # instruction_selection: tcgen05.wait::ld.sync.aligned then one
+      # mbarrier.arrive.shared.b64 before all sdS stores
+      store 32 BF16 values/thread to tile_byte(sdS,c_row,c_col)
+      # instruction_selection: four st.shared.v4.b32/compute thread
+      fence_proxy_async_shared()
+      # instruction_selection: fence.proxy.async.shared::cta
+      commit(dS); advance(dS_prod)
+      # instruction_selection: one mbarrier.arrive.shared.b64 dS publication
+      # state_selection: dS producer phase toggle
+      release(sum_cons); advance(sum_cons)
+      # instruction_selection: a distinct final mbarrier.arrive.shared.b64 sum release
+      # state_selection: sum consumer phase toggle
+
+    wait(dKdV_cons.stage,dKdV_cons.phase)  # generation dV
+    # instruction_selection: one mbarrier.try_wait.parity.shared.b64
+    t2r dV at c_tmem(dV_base,ct,0/1); tmem_load_wait()
+    # instruction_selection: two tcgen05.ld.sync.aligned.32x32b.x16.b32 and
+    # one tcgen05.wait::ld.sync.aligned; 32 f32/compute thread
+    atomic_add workspace.dV[kv_block*64+c_col,c_row] when row<SKV
+    # instruction_selection: 32 predicated scalar atom.global.add.f32/thread
+    release(dKdV_cons); advance(dKdV_cons)
+    # instruction_selection: one mbarrier.arrive.shared.b64
+    # state_selection: two-stage consumer increments from dV to dK
+    wait(dKdV_cons.stage,dKdV_cons.phase)  # generation dK
+    # instruction_selection: one mbarrier.try_wait.parity.shared.b64
+    t2r dK at c_tmem(dK_base,ct,0/1); tmem_load_wait()
+    # instruction_selection: two tcgen05.ld.sync.aligned.32x32b.x16.b32 and
+    # one tcgen05.wait::ld.sync.aligned; 32 f32/compute thread
+    atomic_add workspace.dK[kv_block*64+c_col,c_row] when row<SKV
+    # instruction_selection: 32 predicated scalar atom.global.add.f32/thread
+    release(dKdV_cons); advance(dKdV_cons)
+    # instruction_selection: one mbarrier.arrive.shared.b64
+    # state_selection: two-stage consumer wraps/toggles only on stage 2
+    named_barrier(4,256)
+    # instruction_selection: bar.sync 4,256
+    if global_warp == 8: deallocate 512 columns
+    # instruction_selection: tcgen05.dealloc.cta_group::1.sync.aligned.b32;
+    # owner is (global_warp & 7)==0 within global compute warps 4..11, hence exactly warp 8
+
+  role reduce_warps_0_3:
+    dQ_cons=consumer_state(depth=1,stage=0,phase=0)
+    reduce_bulk_prod=bulk_state(depth=2,stage=0)
+    named_barrier(2,416); retrieve_base()
+    # instruction_selection: bar.sync 2,416 + ld.shared.b32
+    for pair in ceil_div(count,2):
+      wait(dQ_cons.stage,dQ_cons.phase)
+      q0/q1 = inverse CSR pair, with q1=dummy floor(SQ/64) if odd
+      # instruction_selection: one dQ-full mbarrier.try_wait.parity.shared.b64
+      t2r dQ at q_tmem(dQ_base,rt,issue) for issue in 0..3
+      # instruction_selection: four tcgen05.ld.sync.aligned.32x32b.x32.b32;
+      # 32 f32/issue = 128 f32/reduce thread, exact q_row/q_dim map
+      tmem_load_wait(); release(dQ_cons); advance(dQ_cons)
+      # instruction_selection: one tcgen05.wait::ld.sync.aligned then one
+      # mbarrier.arrive.shared.b64 dQ release
+      # state_selection: dQ consumer phase toggle after release
+      for dim_chunk in 0,32,64,96:
+        if global_warp == 0: bulk_wait_for_two_stage_slot()
+        # instruction_selection: cp.async.bulk.wait_group.read 1, once/chunk and
+        # only in global warp 0
+        named_barrier(5,128)
+        # instruction_selection: bar.sync 5,128, first rendezvous/chunk
+        for j in 0..7: store_v4(regs[4*j:4*j+4],sdq_vec(stage,p,t,j))
+        # instruction_selection: eight st.shared.v4.b32/reduce thread/chunk;
+        # 128 threads cover the paired 128x32 FP32 tile
+        fence_proxy_async_shared()
+        # instruction_selection: fence.proxy.async.shared::cta, once/chunk
+        named_barrier(5,128)
+        # instruction_selection: bar.sync 5,128, second rendezvous/chunk
+        if global_warp == 0:
+          elected lane issues reduce-add for q0 and q1
+          # instruction_selection:
+          # two unconditional elected cp.reduce.async.bulk.tensor.4d.global.shared::cta.add.tile.bulk_group.L2::cache_hint;
+          # two [64,32] FP32 boxes/chunk. Dummy/OOB q1 is always issued and TensorMap-clipped
+          bulk_commit()
+          # instruction_selection: one cp.async.bulk.commit_group/chunk, only in global warp 0
+        advance(reduce_bulk_prod)  # all four reduce warps, modulo-two stage
+        # state_selection: groupwide stage advance is outside the global-warp-0 guard
+    bulk_wait_group_read(0)
+    # instruction_selection: groupwide cp.async.bulk.wait_group.read 0, unguarded tail
+```
+
+The dK/dV stores use scalar atomics because the pinned source export lowers
+`CopyUniversalOp` to 64 `atom.global.add.f32` sites, not vector atomics.
+Out-of-range final-K rows are suppressed by the coordinate predicate;
+`block_sizes` affects score/P/dS but does not shrink the physical workspace
+row loop beyond `SKV`.
+
+## `sum_OdO` program
+
+```python
+thread_x = tid % 8; thread_y = tid // 8
+q = blockIdx.x*16 + thread_y
+if q < SQ:
+  acc = 0
+  for d_pair = thread_x; d_pair < 64; d_pair += 8:
+    O2,dO2 = ld.global.b32
+    prod2 = mul.bf16x2(O2,dO2)
+    acc += cvt.f32.bf16(prod.lo); acc = add.rn.f32.bf16(prod.hi,acc)
+  acc = butterfly_sum(acc, xor=1,2,4)
+  if thread_x==0:
+    workspace.sum[q] = -acc
+    workspace.scaled_lse[q] = -log2(e)*LSE[q]
+```
+
+`instruction_selection`: the loop is fully unrolled to eight packed loads per
+thread; `ld.global.b32`, `mul.bf16x2`, `mov.b32`, `cvt.f32.bf16`,
+`add.rn.f32.bf16`, three `shfl.sync.bfly.b32`, `mul.f32` and
+`st.global.b32`, source `.loc` 631-657.  Padding beyond SQ remains untouched
+zero from the host reset.
+
+## `convert` program
+
+```python
+tidx=tid%16; tidy=tid//16; seq=blockIdx.x*8+tidy
+for d4=tidx; d4<32; d4+=16:
+  if seq<SQ: load v4 f32 dQacc; packed_mul(scale); pack two BF16x2; store v2.b32 dQ
+  if seq<SKV:
+    load v4 f32 dKacc,dVacc
+    packed_mul dK by scale; pack dK and dV; store v2.b32 each
+```
+
+`instruction_selection`: `ld.global.v4.b32`, `mov.b64`,
+`mul.rn.f32x2`, `cvt.rn.bf16x2.f32`, `st.global.v2.b32`; source `.loc`
+982-1021.  All outer element offsets use i64 multiplication.
+
+## Correctness boundary
+
+All 20 fixed configurations must pass against both the pinned source and the
+sparse FP64 analytic oracle.  The smallest source-capability tolerances are:
+
+```text
+sum_OdO/scaledLSE: 2^-11 / 2^-15
+dQacc,dKacc,dVacc: 0.03 / 2^-7 / 0.03
+dQ,dK,dV:          2^-9 / 2^-9 / 0.03
+```
+
+Each comparison uses the stated atol and rtol simultaneously, exact NaN/+Inf/
+-Inf classification, exact zero padding, and redzones.  Empty tasks, partial Q
+and K blocks, variable inverse-CSR lengths 0/1/max, masked/unmasked code, BSHD
+normalization, batch-dependent block sizes, bucket transitions, i64 strides,
+>2GiB workspace offsets and grid.x>65535 are required; none may be skipped.
+
+The frozen representation contract is: `inspect_low_level_ir(...).ok`, no
+function calls, only rank-1 shared allocation, no tile primitive/layout, no
+inline CUDA source/call, and zero changes under `tirx_kernels/kern`, TVM or
+low-level-IR exemptions.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ list.
   [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py),
   [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py),
   [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py),
-  [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
+  [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py),
+  [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
 
 ### FlashAttention ports
 

--- a/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_backward_blk64.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_backward_blk64.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cudnn_sm100_bsa_backward_blk64
+selection_rationale: The selected defaults cover a small ordinary launch, medium variable sparsity including empty rows, and a large auto-1024 three-group launch with 64-bit KV strides. The full matrix additionally covers ragged tails, batch/head occupancy, fixed and variable sparse degree, masked and unmasked blocks, long KV, the 1088 two-group scheduler branch, and the large convert grid.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: p00_b1_h1_sq64_skv4096_kv16_nomask, default: true, selection_role: small}
+  - {config: p01_b1_h2_sq4097_skv8191_kv64_mask, default: false}
+  - {config: p02_b2_h8_sq4096_skv8191_kv32_mask, default: false}
+  - {config: p03_b1_h4_sq8192_skv4096_kv16_mask, default: false}
+  - {config: p04_b1_h8_sq4096_skv8192_maxkv32_var_mask, default: true, selection_role: medium}
+  - {config: p05_b2_h4_sq4097_skv8191_maxkv32_empty_mask, default: false}
+  - {config: p06_b1_h4_sq1024_skv32768_kv256_mask, default: false}
+  - {config: p07_b1_h4_sq4097_skv16384_maxkv128_var_mask, default: false}
+  - {config: p08_b1_h8_sq2048_skv65536_kv512_nomask, default: false}
+  - {config: p09_b1_h2_sq69633_skv8191_kv32_mask_bucket1088, default: false}
+  - {config: p10_b1_h1_sq192001_skv8192_maxkv16_var_mask_auto1024_i64kv, default: true, selection_role: large}

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/__init__.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/data.py
@@ -1,0 +1,598 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Inputs, direct launch wiring, and sparse analytic validation for BSA backward."""
+
+import math
+
+import torch
+
+from tirx_kernels.cudnn._reference import load_reference_module
+
+from . import spec
+
+_REDZONE_ELEMENTS = 256
+_REDZONE_F32 = 12345.25
+_REDZONE_BF16 = -77.0
+_LOG2_E = math.log2(math.e)
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_256B = 2
+_TOLERANCES = {
+    "sum_odo": (2**-11, 2**-11),
+    "scaled_lse": (2**-15, 2**-15),
+    "dq_acc": (3e-2, 3e-2),
+    "dk_acc": (2**-7, 2**-7),
+    "dv_acc": (3e-2, 3e-2),
+    "dq": (2**-9, 2**-9),
+    "dk": (2**-9, 2**-9),
+    "dv": (3e-2, 3e-2),
+}
+
+
+class _AlignedTensorMap:
+    """Host storage for one 64-byte-aligned 128-byte TensorMap payload."""
+
+    def __init__(self):
+        import ctypes
+
+        self._storage = ctypes.create_string_buffer(128 + 64)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tensormap(tensor, dtype, global_dims, global_strides, box_dims):
+    import ctypes
+
+    import tvm
+
+    rank = len(global_dims)
+    descriptor = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        descriptor.ptr,
+        dtype,
+        rank,
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *global_dims,
+        *global_strides,
+        *box_dims,
+        *((1,) * rank),
+        0,
+        _TMA_SWIZZLE_128B,
+        _TMA_L2_256B,
+        0,
+    )
+    return descriptor
+
+
+def _build_tensor_maps(inputs, output, config):
+    """Encode Q/K/V/dO loads and the FP32 dQ reduce-add destination."""
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+
+    def load_map(tensor, seqlen):
+        element_size = tensor.element_size()
+        strides = tuple(int(tensor.stride(axis) * element_size) for axis in (2, 1, 0))
+        return _encode_tensormap(
+            tensor, "bfloat16", (128, seqlen, heads, batch), strides, (64, 64, 1, 1)
+        )
+
+    fields = _workspace_fields(output, config)
+    dq_acc = fields["dq_acc"]
+    dq_strides = tuple(int(dq_acc.stride(axis) * 4) for axis in (2, 1, 0))
+    return {
+        "q": load_map(inputs["q"], seqlen_q),
+        "k": load_map(inputs["k"], seqlen_kv),
+        "v": load_map(inputs["v"], seqlen_kv),
+        "do": load_map(inputs["do"], seqlen_q),
+        "dq": _encode_tensormap(
+            dq_acc, "float32", (128, output["q8"], heads, batch), dq_strides, (32, 64, 1, 1)
+        ),
+    }
+
+
+def _roundup8(value):
+    return (value + 7) // 8 * 8
+
+
+def _bucket_size(config, q_blocks):
+    explicit = config.get("bucket_size_blocks")
+    if explicit is not None and int(explicit) > 0:
+        return int(explicit)
+    if q_blocks >= 3000:
+        return 1024
+    return 1088 if q_blocks < 2048 else 1152
+
+
+def _pattern_values(config):
+    maximum = int(config["kv_blocks"])
+    mode = config["block_count_mode"]
+    if mode == "fixed":
+        return (maximum,)
+    text = config.get("block_count_pattern")
+    if text is None:
+        return (0, 1, maximum) if mode == "variable_empty" else (1, max(1, maximum // 2), maximum)
+    values = []
+    for item in text.split(","):
+        item = item.strip()
+        if item == "max":
+            values.append(maximum)
+        elif item == "mid":
+            values.append(max(1, maximum // 2))
+        else:
+            values.append(int(item))
+    return tuple(values)
+
+
+def _make_metadata(config, *, q_blocks, kv_blocks, device):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    maximum = int(config["kv_blocks"])
+    if maximum > kv_blocks:
+        raise ValueError("kv_blocks exceeds the physical KV block count")
+
+    rows = batch * heads * q_blocks
+    row_ids = torch.arange(rows, dtype=torch.int64, device=device)
+    slots = torch.arange(maximum, dtype=torch.int64, device=device)
+    block_index = (row_ids[:, None] * 7 + slots[None, :]) % kv_blocks
+    if maximum and maximum < kv_blocks:
+        contains_tail = (block_index == kv_blocks - 1).any(dim=1)
+        block_index[~contains_tail, -1] = kv_blocks - 1
+    if q_blocks == 3 and maximum == 3 and kv_blocks == 4:
+        # c07 deliberately makes the four inverse-CSR task lengths 3/2/1/0.
+        block_index[:] = torch.tensor((0, 1, 2), dtype=torch.int64, device=device)
+    block_index = block_index.to(torch.int32).reshape(batch, heads, q_blocks, maximum)
+
+    values = _pattern_values(config)
+    pattern_shift = (
+        1
+        if config["block_count_mode"] == "variable_empty" and any(value != 0 for value in values)
+        else 0
+    )
+    counts = torch.tensor(values, dtype=torch.int32, device=device)[
+        (row_ids + pattern_shift) % len(values)
+    ]
+    counts = counts.reshape(batch, heads, q_blocks).contiguous()
+    if config["block_count_mode"] == "fixed":
+        block_nums = None
+        block_sparse_num = maximum
+    else:
+        block_nums = counts
+        block_sparse_num = 0
+    return block_index.contiguous(), counts, block_nums, block_sparse_num
+
+
+def _strided_bhsd(generator, shape, *, use_i64):
+    batch, heads, seqlen, dim = shape
+    base = torch.randn(
+        batch * heads * seqlen * dim, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    base.mul_(0.125)
+    if not use_i64:
+        return base.reshape(shape)
+    if batch != 1 or heads != 1:
+        raise ValueError("the explicit Int64 KV-stride probe requires singleton batch and head")
+    return torch.as_strided(base, shape, (2**31, seqlen * dim, dim, 1))
+
+
+def _guarded_tensor(shape, dtype, fill):
+    count = math.prod(shape)
+    storage = torch.full((count + 2 * _REDZONE_ELEMENTS,), fill, dtype=dtype, device="cuda")
+    tensor = storage[_REDZONE_ELEMENTS : _REDZONE_ELEMENTS + count].reshape(shape)
+    return tensor, storage
+
+
+def _workspace_layout(config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    q8 = _roundup8(int(config["seqlen_q"]))
+    k8 = _roundup8(int(config["seqlen_kv"]))
+    n = batch * heads
+    sizes = {
+        "sum_odo": n * q8,
+        "scaled_lse": n * q8,
+        "dq_acc": n * q8 * 128,
+        "dk_acc": n * k8 * 128,
+        "dv_acc": n * k8 * 128,
+    }
+    offsets = {}
+    cursor = 0
+    for name in ("sum_odo", "scaled_lse", "dq_acc", "dk_acc", "dv_acc"):
+        offsets[name] = cursor
+        cursor += sizes[name]
+    return q8, k8, sizes, offsets, cursor
+
+
+def _new_mutable_state(config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q8, k8, sizes, offsets, total = _workspace_layout(config)
+    workspace, workspace_storage = _guarded_tensor((total,), torch.float32, _REDZONE_F32)
+    workspace.zero_()
+    dq, dq_storage = _guarded_tensor((batch, heads, seqlen_q, 128), torch.bfloat16, _REDZONE_BF16)
+    dk, dk_storage = _guarded_tensor((batch, heads, seqlen_kv, 128), torch.bfloat16, _REDZONE_BF16)
+    dv, dv_storage = _guarded_tensor((batch, heads, seqlen_kv, 128), torch.bfloat16, _REDZONE_BF16)
+    dq.fill_(float("nan"))
+    dk.fill_(float("nan"))
+    dv.fill_(float("nan"))
+    return {
+        "workspace": workspace,
+        "workspace_storage": workspace_storage,
+        "dq": dq,
+        "dk": dk,
+        "dv": dv,
+        "dq_storage": dq_storage,
+        "dk_storage": dk_storage,
+        "dv_storage": dv_storage,
+        "workspace_sizes": sizes,
+        "workspace_offsets": offsets,
+        "q8": q8,
+        "k8": k8,
+    }
+
+
+def _workspace_fields(state, config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    q8 = state["q8"]
+    k8 = state["k8"]
+    workspace = state["workspace"]
+    offsets = state["workspace_offsets"]
+    sizes = state["workspace_sizes"]
+
+    def field(name, shape):
+        start = offsets[name]
+        return workspace[start : start + sizes[name]].reshape(shape)
+
+    return {
+        "sum_odo": field("sum_odo", (batch, heads, q8)),
+        "scaled_lse": field("scaled_lse", (batch, heads, q8)),
+        "dq_acc": field("dq_acc", (batch, heads, q8, 128)),
+        "dk_acc": field("dk_acc", (batch, heads, k8, 128)),
+        "dv_acc": field("dv_acc", (batch, heads, k8, 128)),
+    }
+
+
+def prepare_data(**config):
+    if not torch.cuda.is_available():
+        import unittest
+
+        raise unittest.SkipTest("CUDA is required")
+    if config["dtype"] != "bfloat16" or int(config["head_dim"]) != 128:
+        raise ValueError("SM100 blk64 backward supports BF16 D=128 only")
+
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q_blocks = (seqlen_q + 63) // 64
+    physical_kv_blocks = (seqlen_kv + 63) // 64
+    bucket_size = _bucket_size(config, q_blocks)
+    generator = torch.Generator(device="cuda").manual_seed(int(config["seed"]))
+
+    q = torch.randn(
+        batch, heads, seqlen_q, 128, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    q.mul_(0.125)
+    k = _strided_bhsd(
+        generator, (batch, heads, seqlen_kv, 128), use_i64=bool(config["use_int64_kv_strides"])
+    )
+    v = _strided_bhsd(
+        generator, (batch, heads, seqlen_kv, 128), use_i64=bool(config["use_int64_kv_strides"])
+    )
+    do = torch.randn(
+        batch, heads, seqlen_q, 128, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    do.mul_(0.125)
+    block_index, counts, block_nums, block_sparse_num = _make_metadata(
+        config, q_blocks=q_blocks, kv_blocks=physical_kv_blocks, device="cuda"
+    )
+    block_sizes = torch.full((batch, physical_kv_blocks), 64, dtype=torch.int32, device="cuda")
+    block_sizes[:, -1] = seqlen_kv - (physical_kv_blocks - 1) * 64
+    if batch > 1 and seqlen_q == 129 and seqlen_kv == 511:
+        block_sizes[1, -1] = max(1, int(block_sizes[1, -1]) - 16)
+
+    softmax_scale = (
+        1.0 / math.sqrt(128) if config["softmax_scale"] is None else float(config["softmax_scale"])
+    )
+    interface = load_reference_module("cudnn.block_sparse_attention._interface")
+    forward_block_sizes = block_sizes if config["has_block_sizes"] else None
+    forward_block_sizes_arg = (
+        forward_block_sizes[0]
+        if forward_block_sizes is not None and batch == 1
+        else forward_block_sizes
+    )
+    use_bshd = config["tensor_layout"] == "bshd"
+    q_forward = q.transpose(1, 2).contiguous() if use_bshd else q
+    k_forward = k.transpose(1, 2).contiguous() if use_bshd else k
+    v_forward = v.transpose(1, 2).contiguous() if use_bshd else v
+    o_user, lse = interface.bsa_attn_fwd_blk64_cutedsl(
+        q_forward,
+        k_forward,
+        v_forward,
+        block_index,
+        forward_block_sizes_arg,
+        q2k_block_nums=block_nums,
+        softmax_scale=softmax_scale,
+        layout=config["tensor_layout"],
+        block_sparse_num=block_sparse_num,
+        allow_empty_block_nums=config["block_count_mode"] == "variable_empty",
+        use_clc=False,
+        kv_splits=1,
+    )
+    o = o_user.transpose(1, 2).contiguous() if use_bshd else o_user
+    bucketed_offsets, bucketed_indices, num_q_groups, max_rows = interface._build_bucketed_k2q_csr(
+        block_index,
+        block_sparse_num,
+        physical_kv_blocks,
+        bucket_size_blocks=bucket_size,
+        q2k_block_nums=block_nums,
+    )
+    torch.cuda.synchronize()
+
+    tirx = _new_mutable_state(config)
+    source = _new_mutable_state(config)
+    inputs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "do": do,
+        "o": o,
+        "lse": lse,
+        "block_index": block_index,
+        "counts": counts,
+        "block_nums": block_nums,
+        "block_sparse_num": block_sparse_num,
+        "block_sizes": block_sizes,
+        "bucketed_offsets": bucketed_offsets,
+        "bucketed_indices": bucketed_indices,
+        "softmax_scale": softmax_scale,
+    }
+    return {
+        "config": dict(config),
+        "inputs": inputs,
+        "derived": {
+            "q_blocks": q_blocks,
+            "kv_blocks": physical_kv_blocks,
+            "bucket_size_blocks": bucket_size,
+            "num_q_groups": int(num_q_groups),
+            "max_k2q_rows_per_group": int(max_rows),
+            "tasks_per_group": physical_kv_blocks,
+        },
+        "tirx": tirx,
+        "source": source,
+        "oracle": None,
+    }
+
+
+def reset_mutable_state(state):
+    state["workspace"].zero_()
+    state["dq"].fill_(float("nan"))
+    state["dk"].fill_(float("nan"))
+    state["dv"].fill_(float("nan"))
+
+
+def tirx_launch(executables, data):
+    inputs = data["inputs"]
+    output = data["tirx"]
+    maps = _build_tensor_maps(inputs, output, data["config"])
+    edge_stride = int(inputs["bucketed_indices"].shape[-1])
+
+    def launch():
+        executables[0](
+            inputs["o"].reshape(-1),
+            inputs["do"].reshape(-1),
+            inputs["lse"].reshape(-1),
+            output["workspace"],
+        )
+        executables[1](
+            maps["q"].ptr,
+            maps["k"].ptr,
+            maps["v"].ptr,
+            maps["do"].ptr,
+            maps["dq"].ptr,
+            inputs["bucketed_offsets"].reshape(-1),
+            inputs["bucketed_indices"].reshape(-1),
+            inputs["block_sizes"].reshape(-1),
+            output["workspace"],
+            edge_stride,
+            inputs["softmax_scale"],
+        )
+        executables[2](
+            output["workspace"],
+            output["dq"].reshape(-1),
+            output["dk"].reshape(-1),
+            output["dv"].reshape(-1),
+            inputs["softmax_scale"],
+        )
+
+    return launch
+
+
+def _analytic_oracle(data, row_chunk=32):
+    if data["oracle"] is not None:
+        return data["oracle"]
+    config = data["config"]
+    inputs = data["inputs"]
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q_blocks = data["derived"]["q_blocks"]
+    maximum = int(config["kv_blocks"])
+    scale = float(inputs["softmax_scale"])
+    device = inputs["q"].device
+
+    q64 = inputs["q"].to(torch.float64)
+    k64 = inputs["k"].to(torch.float64)
+    v64 = inputs["v"].to(torch.float64)
+    do64 = inputs["do"].to(torch.float64)
+    o64 = inputs["o"].to(torch.float64)
+    dq = torch.zeros_like(q64)
+    dk = torch.zeros_like(k64)
+    dv = torch.zeros_like(v64)
+    sum_odo = -(o64 * do64).sum(dim=-1)
+    scaled_lse = inputs["lse"].to(torch.float64) * (-_LOG2_E)
+
+    total_rows = batch * heads * q_blocks
+    row_ids_all = torch.arange(total_rows, dtype=torch.int64, device=device)
+    token_offsets = torch.arange(64, dtype=torch.int64, device=device)
+    q_offsets = torch.arange(64, dtype=torch.int64, device=device)
+    for start in range(0, total_rows, row_chunk):
+        row_ids = row_ids_all[start : start + row_chunk]
+        bh = row_ids // q_blocks
+        qb = row_ids - bh * q_blocks
+        b = bh // heads
+        h = bh - b * heads
+        count = inputs["counts"].reshape(-1)[row_ids].to(torch.int64)
+        sparse_blocks = inputs["block_index"].reshape(total_rows, maximum)[row_ids].to(torch.int64)
+        kv_tokens = sparse_blocks[:, :, None] * 64 + token_offsets[None, None, :]
+        slot_valid = torch.arange(maximum, device=device)[None, :] < count[:, None]
+        block_size = inputs["block_sizes"][b[:, None], sparse_blocks]
+        token_valid = token_offsets[None, None, :] < block_size[:, :, None]
+        kv_valid = slot_valid[:, :, None] & token_valid & (kv_tokens < seqlen_kv)
+        kv_safe = kv_tokens.clamp(0, seqlen_kv - 1)
+        k_sel = k64[b[:, None, None], h[:, None, None], kv_safe].reshape(
+            row_ids.numel(), maximum * 64, 128
+        )
+        v_sel = v64[b[:, None, None], h[:, None, None], kv_safe].reshape(
+            row_ids.numel(), maximum * 64, 128
+        )
+        kv_valid = kv_valid.reshape(row_ids.numel(), maximum * 64)
+
+        q_tokens = qb[:, None] * 64 + q_offsets[None, :]
+        q_valid = q_tokens < seqlen_q
+        q_safe = q_tokens.clamp(0, seqlen_q - 1)
+        q_sel = q64[b[:, None], h[:, None], q_safe]
+        do_sel = do64[b[:, None], h[:, None], q_safe]
+        scores = torch.bmm(q_sel, k_sel.transpose(1, 2)) * scale
+        scores = scores.masked_fill(~kv_valid[:, None, :], float("-inf"))
+        all_empty = ~kv_valid.any(dim=1)
+        probs = torch.softmax(scores, dim=-1)
+        if bool(all_empty.any()):
+            probs[all_empty] = 0.0
+        probs = torch.where(q_valid[:, :, None], probs, torch.zeros_like(probs))
+        dp = torch.bmm(do_sel, v_sel.transpose(1, 2))
+        delta = (o64[b[:, None], h[:, None], q_safe] * do_sel).sum(dim=-1)
+        ds = probs * (dp - delta[:, :, None])
+        ds = torch.where(all_empty[:, None, None], torch.zeros_like(ds), ds)
+        dq_sel = torch.bmm(ds, k_sel) * scale
+        dk_sel = torch.bmm(ds.transpose(1, 2), q_sel) * scale
+        dv_sel = torch.bmm(probs.transpose(1, 2), do_sel)
+        global_q = ((b[:, None] * heads + h[:, None]) * seqlen_q + q_tokens).reshape(-1)
+        q_valid_flat = q_valid.reshape(-1)
+        dq.reshape(-1, 128)[global_q[q_valid_flat]] = dq_sel.reshape(-1, 128)[q_valid_flat]
+
+        global_kv = ((b[:, None, None] * heads + h[:, None, None]) * seqlen_kv + kv_safe).reshape(
+            -1
+        )
+        valid_flat = kv_valid.reshape(-1)
+        dk.reshape(-1, 128).index_add_(
+            0, global_kv[valid_flat], dk_sel.reshape(-1, 128)[valid_flat]
+        )
+        dv.reshape(-1, 128).index_add_(
+            0, global_kv[valid_flat], dv_sel.reshape(-1, 128)[valid_flat]
+        )
+
+    q8 = data["source"]["q8"]
+    k8 = data["source"]["k8"]
+    oracle = {
+        "sum_odo": torch.zeros((batch, heads, q8), dtype=torch.float32, device=device),
+        "scaled_lse": torch.zeros((batch, heads, q8), dtype=torch.float32, device=device),
+        "dq_acc": torch.zeros((batch, heads, q8, 128), dtype=torch.float32, device=device),
+        "dk_acc": torch.zeros((batch, heads, k8, 128), dtype=torch.float32, device=device),
+        "dv_acc": torch.zeros((batch, heads, k8, 128), dtype=torch.float32, device=device),
+        "dq": dq.to(torch.bfloat16),
+        "dk": dk.to(torch.bfloat16),
+        "dv": dv.to(torch.bfloat16),
+    }
+    oracle["sum_odo"][:, :, :seqlen_q] = sum_odo.to(torch.float32)
+    oracle["scaled_lse"][:, :, :seqlen_q] = scaled_lse.to(torch.float32)
+    oracle["dq_acc"][:, :, :seqlen_q] = (dq / scale).to(torch.float32)
+    oracle["dk_acc"][:, :, :seqlen_kv] = (dk / scale).to(torch.float32)
+    oracle["dv_acc"][:, :, :seqlen_kv] = dv.to(torch.float32)
+    data["oracle"] = oracle
+    return oracle
+
+
+def _assert_same_classification(actual, expected, name):
+    if not torch.equal(torch.isnan(actual), torch.isnan(expected)):
+        raise AssertionError(f"{name}: NaN classification mismatch")
+    if not torch.equal(torch.isposinf(actual), torch.isposinf(expected)):
+        raise AssertionError(f"{name}: +Inf classification mismatch")
+    if not torch.equal(torch.isneginf(actual), torch.isneginf(expected)):
+        raise AssertionError(f"{name}: -Inf classification mismatch")
+
+
+def _assert_close(actual, expected, name, tolerance=None):
+    _assert_same_classification(actual, expected, name)
+    finite = torch.isfinite(expected)
+    if not bool(finite.any()):
+        return
+    atol, rtol = _TOLERANCES[name] if tolerance is None else tolerance
+    torch.testing.assert_close(
+        actual[finite].float(), expected[finite].float(), atol=atol, rtol=rtol, equal_nan=False
+    )
+
+
+def _validate_redzones(state, source_name):
+    for storage_name, value in (
+        ("workspace_storage", _REDZONE_F32),
+        ("dq_storage", _REDZONE_BF16),
+        ("dk_storage", _REDZONE_BF16),
+        ("dv_storage", _REDZONE_BF16),
+    ):
+        storage = state[storage_name]
+        expected = torch.tensor(value, dtype=storage.dtype, device=storage.device)
+        if not torch.all(storage[:_REDZONE_ELEMENTS] == expected):
+            raise AssertionError(f"{source_name}.{storage_name}: leading redzone modified")
+        if not torch.all(storage[-_REDZONE_ELEMENTS:] == expected):
+            raise AssertionError(f"{source_name}.{storage_name}: trailing redzone modified")
+
+
+def validate_outputs(data, *, sources, with_oracle=True, tolerance_overrides=None):
+    oracle = _analytic_oracle(data) if with_oracle else None
+    config = data["config"]
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    for source_name in sources:
+        state = data[source_name]
+        fields = _workspace_fields(state, config)
+        _validate_redzones(state, source_name)
+        if not torch.all(fields["sum_odo"][:, :, seqlen_q:] == 0):
+            raise AssertionError(f"{source_name}.sum_odo padding is not exactly zero")
+        if not torch.all(fields["scaled_lse"][:, :, seqlen_q:] == 0):
+            raise AssertionError(f"{source_name}.scaled_lse padding is not exactly zero")
+        if not torch.all(fields["dq_acc"][:, :, seqlen_q:] == 0):
+            raise AssertionError(f"{source_name}.dq_acc padding is not exactly zero")
+        if not torch.all(fields["dk_acc"][:, :, seqlen_kv:] == 0):
+            raise AssertionError(f"{source_name}.dk_acc padding is not exactly zero")
+        if not torch.all(fields["dv_acc"][:, :, seqlen_kv:] == 0):
+            raise AssertionError(f"{source_name}.dv_acc padding is not exactly zero")
+        if oracle is None:
+            continue
+        for name in ("sum_odo", "scaled_lse", "dq_acc", "dk_acc", "dv_acc"):
+            tolerance = None if tolerance_overrides is None else tolerance_overrides.get(name)
+            _assert_close(fields[name], oracle[name], name, tolerance)
+        for name in ("dq", "dk", "dv"):
+            tolerance = None if tolerance_overrides is None else tolerance_overrides.get(name)
+            _assert_close(state[name], oracle[name], name, tolerance)
+
+
+def workspace_fields(data, source_name):
+    return _workspace_fields(data[source_name], data["config"])
+
+
+def tolerance_grid():
+    return (
+        (0.0, 0.0),
+        *((value, value) for value in (2**-15, 2**-13, 2**-11, 2**-9, 2**-7, 1e-2, 2e-2, 3e-2)),
+    )
+
+
+CONFIGS = spec.correctness_configs()

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/kernel.py
@@ -1,0 +1,1019 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Source-shaped SM100 blk64 block-sparse-attention backward kernels."""
+
+import tirx_kernels.kern as K
+
+WARPS = 16
+THREADS = 512
+TMEM_COLUMNS = 512
+BAR_CTA = (1, 512)
+BAR_TMEM = (2, 416)
+BAR_COMPUTE = (3, 256)
+BAR_DEALLOC = (4, 256)
+BAR_REDUCE = (5, 128)
+
+OFF_SK = 1024
+OFF_SV = 17408
+OFF_SQ = 33792
+OFF_SP = 99328
+OFF_SDO = 115712
+OFF_SDS = 148480
+OFF_SDQ = 164864
+OFF_SLSE = 197632
+OFF_SSUM = 198656
+SHARED_BYTES = 199680
+
+TMEM_DK = 0
+TMEM_DV = 64
+TMEM_DQ = 128
+TMEM_DP = 128
+TMEM_S = 256
+
+ID_QK = 0x08100490
+ID_DKDV = 0x08118490
+ID_DQ = 0x08210490
+
+MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+TMEM_LD16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+TMEM_LD32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+TMA_G2S = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_REDUCE = "cp.reduce.async.bulk.tensor.4d.global.shared::cta.add.tile.bulk_group.L2::cache_hint"
+TMA_CACHE = K.uint64(0)
+
+
+def _xor(a, b):
+    if isinstance(a, int) and isinstance(b, int):
+        return a ^ b
+    return K.bitwise_xor(a, b)
+
+
+def _tile_elem(row, dim):
+    return (dim // 64) * 4096 + _xor(row * 64 + dim % 64, (row % 8) * 8)
+
+
+def _tile_byte(base, row, dim):
+    return base + 2 * _tile_elem(row, dim)
+
+
+def _desc_base(ldo, sdo=64, swizzle=3):
+    arrangement = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = ((ldo & 0x3FFF) << 16) | ((sdo & 0x3FFF) << 32) | (1 << 46)
+    return (value | ((arrangement & 0x7) << 61)) & 0xFFFFFFFFFFFFFFFF
+
+
+def _desc_at(base, shared_address):
+    field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), field)
+
+
+def _desc_add16(desc, offset):
+    if offset == 0:
+        return desc
+    lo = K.local_scalar("uint32")
+    hi = K.local_scalar("uint32")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(lo, hi, desc)
+    K.ptx.add.u32(lo, lo, K.uint32(offset))
+    K.ptx.mov.b64(out, lo, hi)
+    return out
+
+
+def _mma(dest, a_desc, b_desc, idesc, accumulate, pred):
+    K.ptx[MMA_F16](
+        K.cast(dest, "uint32"),
+        a_desc,
+        b_desc,
+        K.uint32(idesc),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.ptx.pred(accumulate),
+        pred=pred,
+    )
+
+
+def _mma_chain(dest, a_desc, b_desc, idesc, a_offsets, b_offsets, accumulate, pred):
+    flag = K.local_scalar("uint32", init=K.cast(accumulate, "uint32"))
+    for a_offset, b_offset in zip(a_offsets, b_offsets):
+        _mma(dest, _desc_add16(a_desc, a_offset), _desc_add16(b_desc, b_offset), idesc, flag, pred)
+        K.assign(flag, K.uint32(1))
+
+
+def _shfl_bfly_f32(value, lane_xor, membermask):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), membermask
+    )
+    return K.reinterpret(K.f32, out)
+
+
+def _butterfly_sum_f32(value):
+    membermask = K.local_scalar("uint32", init=K.tvm_warp_activemask())
+    for lane_xor in (1, 2, 4):
+        peer = _shfl_bfly_f32(value, lane_xor, membermask)
+        total = K.local_scalar("float32")
+        K.ptx.add.f32(total, value, peer)
+        value = total
+    return value
+
+
+def _packed_binary(op, a0, a1, b0, b1):
+    a = K.local_scalar("uint64")
+    b = K.local_scalar("uint64")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(a, a0, a1)
+    K.ptx.mov.b64(b, b0, b1)
+    K.ptx[op](out, a, b)
+    lo = K.local_scalar("float32")
+    hi = K.local_scalar("float32")
+    K.ptx.mov.b64(lo, hi, out)
+    return lo, hi
+
+
+def _packed_fma(a0, a1, b0, b1, c0, c1):
+    a = K.local_scalar("uint64")
+    b = K.local_scalar("uint64")
+    c = K.local_scalar("uint64")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(a, a0, a1)
+    K.ptx.mov.b64(b, b0, b1)
+    K.ptx.mov.b64(c, c0, c1)
+    K.ptx["fma.rn.f32x2"](out, a, b, c)
+    lo = K.local_scalar("float32")
+    hi = K.local_scalar("float32")
+    K.ptx.mov.b64(lo, hi, out)
+    return lo, hi
+
+
+def _load_i32(buffer, index):
+    out = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(out, buffer.ptr_to([index]))
+    return out
+
+
+def _publish_pipeline_init():
+    K.ptx["fence.mbarrier_init.release.cluster"]()
+    K.ptx.bar.sync(K.uint32(0), K.uint32(THREADS))
+
+
+def _issue_tma_tile(desc, arena, dst, seq0, head, batch_idx, barrier):
+    for half in range(2):
+        K.ptx[TMA_G2S](
+            arena.ptr_to([dst + half * 8192]),
+            K.address_of(desc),
+            K.int32(half * 64),
+            seq0,
+            head,
+            batch_idx,
+            K.cuda.cvta_generic_to_shared(barrier),
+            TMA_CACHE,
+        )
+
+
+def _issue_tma_pair_tile(desc, arena, dst, seq0, head, batch_idx, barrier):
+    for half in range(2):
+        K.ptx[TMA_G2S](
+            arena.ptr_to([dst + half * 16384]),
+            K.address_of(desc),
+            K.int32(half * 64),
+            seq0,
+            head,
+            batch_idx,
+            K.cuda.cvta_generic_to_shared(barrier),
+            TMA_CACHE,
+        )
+
+
+def _tmem_load16(dst, base, address):
+    K.ptx[TMEM_LD16](*(dst[base + i] for i in range(16)), K.cast(address, "uint32"))
+
+
+def _tmem_load32(dst, base, address):
+    K.ptx[TMEM_LD32](*(dst[base + i] for i in range(32)), K.cast(address, "uint32"))
+
+
+def get_kernel(**config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    has_block_sizes = bool(config["has_block_sizes"])
+    q_blocks = (seqlen_q + 63) // 64
+    bucket = config.get("bucket_size_blocks")
+    if bucket is None:
+        bucket = 1024 if q_blocks >= 3000 else (1088 if q_blocks < 2048 else 1152)
+    groups = (q_blocks + int(bucket) - 1) // int(bucket)
+    tasks = (seqlen_kv + 63) // 64
+    q8 = (seqlen_q + 7) // 8 * 8
+    k8 = (seqlen_kv + 7) // 8 * 8
+    bh_count = batch * heads
+    sum_plane = bh_count * q8
+    dq_base = 2 * sum_plane
+    dk_base = dq_base + bh_count * q8 * 128
+    dv_base = dk_base + bh_count * k8 * 128
+
+    @K.kernel(
+        warps=4, arch="sm_100a", min_blocks_per_sm=1, grid=((seqlen_q + 15) // 16, heads, batch)
+    )
+    def sum_odo(
+        o: K.gptr[K.bf16], do: K.gptr[K.bf16], lse: K.gptr[K.f32], workspace: K.gptr[K.f32]
+    ):
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        q_tile, head, batch_idx = K.cta_id()
+        tid = K.thread_id()
+        tidx = tid % K.int32(8)
+        tidy = tid // K.int32(8)
+        q_idx = q_tile * K.int32(16) + tidy
+        with K.If(q_idx < K.int32(seqlen_q)), K.Then():
+            acc = K.local_scalar("float32", init=K.float32(0.0))
+            row = K.cast(
+                ((batch_idx * K.int32(heads) + head) * K.int32(seqlen_q) + q_idx) * K.int32(128),
+                "int64",
+            )
+            for step in range(8):
+                dim = (tidx + K.int32(step * 8)) * K.int32(2)
+                ow = K.local_scalar("uint32")
+                dw = K.local_scalar("uint32")
+                K.ptx.ld.global_.b32(ow, o.ptr_to([row + K.cast(dim, "int64")]))
+                K.ptx.ld.global_.b32(dw, do.ptr_to([row + K.cast(dim, "int64")]))
+                product = K.local_scalar("uint32")
+                K.ptx["mul.bf16x2"](product, ow, dw)
+                lo = K.local_scalar("uint16")
+                hi = K.local_scalar("uint16")
+                K.ptx.mov.b32(lo, hi, product)
+                fragment = K.local_scalar("float32")
+                K.ptx["cvt.f32.bf16"](fragment, lo)
+                K.ptx["add.rn.f32.bf16"](fragment, hi, fragment)
+                K.ptx.add.f32(acc, acc, fragment)
+            total = _butterfly_sum_f32(acc)
+            with K.If(tidx == K.int32(0)), K.Then():
+                value = K.local_scalar("float32")
+                K.ptx.neg.f32(value, total)
+                bhq = K.cast((batch_idx * K.int32(heads) + head) * K.int32(q8) + q_idx, "int64")
+                K.ptx.st.global_.b32(workspace.ptr_to([bhq]), value)
+                lse_value = K.local_scalar("float32")
+                lse_index = K.cast(
+                    (batch_idx * K.int32(heads) + head) * K.int32(seqlen_q) + q_idx, "int64"
+                )
+                K.ptx.ld.global_.b32(lse_value, lse.ptr_to([lse_index]))
+                scaled = K.local_scalar("float32")
+                K.ptx.mul.f32(scaled, lse_value, K.float32(-1.4426950408889634))
+                K.ptx.st.global_.b32(workspace.ptr_to([K.int64(sum_plane) + bhq]), scaled)
+        required_block_size.__exit__(None, None, None)
+
+    @K.kernel(warps=WARPS, arch="sm_100a", min_blocks_per_sm=1, grid=(tasks * groups, heads, batch))
+    def bwd(
+        q_map: K.TensorMap,
+        k_map: K.TensorMap,
+        v_map: K.TensorMap,
+        do_map: K.TensorMap,
+        dq_map: K.TensorMap,
+        bucketed_offsets: K.gptr[K.i32],
+        bucketed_indices: K.gptr[K.i32],
+        block_sizes: K.gptr[K.i32],
+        workspace: K.gptr[K.f32],
+        edge_stride: K.i64,
+        softmax_scale: K.f32,
+    ):
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        block, head, batch_idx = K.cta_id()
+        warp = K.warp_id()
+        with K.If(warp == K.int32(13)), K.Then():
+            K.ptx.prefetch.tensormap(K.address_of(q_map))
+            K.ptx.prefetch.tensormap(K.address_of(k_map))
+            K.ptx.prefetch.tensormap(K.address_of(v_map))
+            K.ptx.prefetch.tensormap(K.address_of(do_map))
+
+        arena = K.alloc_buffer((SHARED_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        pool = K.smem_pool(base=arena).pool
+        q_pipe = K.Pipeline(pool, 2, full="tma", empty="tcgen05", init_full=1, init_empty=1)
+        _publish_pipeline_init()
+        do_pipe = K.Pipeline(pool, 1, full="tma", empty="tcgen05", init_full=1, init_empty=1)
+        _publish_pipeline_init()
+        lse_pipe = K.Pipeline(pool, 1, full="mbar", empty="mbar", init_full=32, init_empty=256)
+        _publish_pipeline_init()
+        sum_pipe = K.Pipeline(pool, 1, full="mbar", empty="mbar", init_full=32, init_empty=256)
+        _publish_pipeline_init()
+        s_pipe = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=256)
+        _publish_pipeline_init()
+        dp_pipe = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=256)
+        _publish_pipeline_init()
+        dq_pipe = K.Pipeline(pool, 1, full="tcgen05", empty="mbar", init_full=1, init_empty=128)
+        _publish_pipeline_init()
+        p_pipe = K.Pipeline(pool, 1, full="mbar", empty="tcgen05", init_full=256, init_empty=1)
+        _publish_pipeline_init()
+        ds_pipe = K.Pipeline(pool, 1, full="mbar", empty="tcgen05", init_full=256, init_empty=1)
+        _publish_pipeline_init()
+        dkdv_pipe = K.Pipeline(pool, 2, full="tcgen05", empty="mbar", init_full=1, init_empty=256)
+        _publish_pipeline_init()
+        tmem_mailbox = pool.alloc((1,), "uint32", align=4)
+        assert pool.offset == 196
+        K.ptx.bar.sync(K.uint32(BAR_CTA[0]), K.uint32(BAR_CTA[1]))
+
+        q_group = block // K.int32(tasks)
+        task = block - q_group * K.int32(tasks)
+        offsets_base = ((batch_idx * K.int32(heads) + head) * K.int32(groups) + q_group) * K.int32(
+            tasks + 1
+        )
+        begin = _load_i32(bucketed_offsets, offsets_base + task)
+        end = _load_i32(bucketed_offsets, offsets_base + task + K.int32(1))
+        count = end - begin
+        work = (count > K.int32(0)) & (task * K.int32(64) < K.int32(seqlen_kv))
+
+        with K.If(work), K.Then():
+            smem_base = K.local_scalar("uint32")
+            K.assign(smem_base, K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+            sp = K.specialize(chain_dispatch=True)
+            r_load = sp.role("load", warps=[13], regs=96)
+            r_mma = sp.role("mma", warps=[12], regs=96)
+            r_compute = sp.role("compute", warps=list(range(4, 12)))
+            r_reduce = sp.role("reduce", warps=list(range(4)), regs=152)
+            r_empty = sp.role("empty", warps=[14, 15], regs=96)
+
+            with r_load:
+                lane = K.tid_in_role()
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                q_prod = K.PipelineState(2, phase=0)
+                do_prod = K.PipelineState(1, phase=0)
+                lse_prod = K.PipelineState(1, phase=0)
+                sum_prod = K.PipelineState(1, phase=0)
+                remaining = K.local_scalar("int32", init=count)
+                edge = K.local_scalar("int32", init=0)
+                bh_edge = K.cast(batch_idx * K.int32(heads) + head, "int64") * edge_stride
+                bh_q = K.cast(batch_idx * K.int32(heads) + head, "int64") * K.int64(q8)
+
+                def load_pair(first):
+                    q0 = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                    K.assign(edge, edge + K.int32(1))
+                    q1 = K.local_scalar("int32", init=K.int32(seqlen_q // 64))
+                    with K.If(edge < count), K.Then():
+                        K.assign(
+                            q1, _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                        )
+                    K.assign(edge, edge + K.int32(1))
+
+                    q_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                    with K.If(leader != K.uint32(0)), K.Then():
+                        q_bar = q_pipe.full.buf.ptr_to([q_prod.stage])
+                        K.ptx.mbarrier.arrive.expect_tx.shared.b64(q_bar, K.uint32(16384))
+                        K.ptx.mbarrier.expect_tx.relaxed.cta.shared__cta.b64(
+                            q_bar, K.uint32(32768 if first else 16384)
+                        )
+                        if first:
+                            _issue_tma_tile(
+                                k_map, arena, OFF_SK, task * K.int32(64), head, batch_idx, q_bar
+                            )
+                        q_stage = OFF_SQ + q_prod.stage * K.int32(32768)
+                        _issue_tma_pair_tile(
+                            q_map, arena, q_stage, q0 * K.int32(64), head, batch_idx, q_bar
+                        )
+                        _issue_tma_pair_tile(
+                            q_map,
+                            arena,
+                            q_stage + K.int32(8192),
+                            q1 * K.int32(64),
+                            head,
+                            batch_idx,
+                            q_bar,
+                        )
+                    q_prod.advance()
+
+                    lse_stage = lse_prod.stage
+                    lse_pipe.empty.wait(lse_stage, lse_prod.phase ^ 1)
+                    for pair_slot in range(2):
+                        q_block = q0 if pair_slot == 0 else q1
+                        for item in range(2):
+                            q_row = q_block * K.int32(64) + lane * K.int32(2) + K.int32(item)
+                            dst = OFF_SLSE + pair_slot * 256 + lane * K.int32(8) + item * 4
+                            with K.If(q_row < K.int32(seqlen_q)):
+                                with K.Then():
+                                    K.ptx["cp.async.ca.shared.global"](
+                                        arena.ptr_to([dst]),
+                                        workspace.ptr_to(
+                                            [K.int64(sum_plane) + bh_q + K.cast(q_row, "int64")]
+                                        ),
+                                        4,
+                                        4,
+                                    )
+                                with K.Else():
+                                    K.ptx.st.shared.b32(arena.ptr_to([dst]), K.uint32(0))
+                    K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](
+                        lse_pipe.full.buf.ptr_to([lse_stage])
+                    )
+                    lse_prod.advance()
+
+                    do_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
+                    with K.If(leader != K.uint32(0)), K.Then():
+                        do_bar = do_pipe.full.buf.ptr_to([do_prod.stage])
+                        K.ptx.mbarrier.arrive.expect_tx.shared.b64(do_bar, K.uint32(16384))
+                        K.ptx.mbarrier.expect_tx.relaxed.cta.shared__cta.b64(
+                            do_bar, K.uint32(32768 if first else 16384)
+                        )
+                        if first:
+                            _issue_tma_tile(
+                                v_map, arena, OFF_SV, task * K.int32(64), head, batch_idx, do_bar
+                            )
+                        _issue_tma_pair_tile(
+                            do_map, arena, OFF_SDO, q0 * K.int32(64), head, batch_idx, do_bar
+                        )
+                        _issue_tma_pair_tile(
+                            do_map, arena, OFF_SDO + 8192, q1 * K.int32(64), head, batch_idx, do_bar
+                        )
+                    do_prod.advance()
+
+                    sum_stage = sum_prod.stage
+                    sum_pipe.empty.wait(sum_stage, sum_prod.phase ^ 1)
+                    for pair_slot in range(2):
+                        q_block = q0 if pair_slot == 0 else q1
+                        for item in range(2):
+                            q_row = q_block * K.int32(64) + lane * K.int32(2) + K.int32(item)
+                            dst = OFF_SSUM + pair_slot * 256 + lane * K.int32(8) + item * 4
+                            with K.If(q_row < K.int32(seqlen_q)):
+                                with K.Then():
+                                    K.ptx["cp.async.ca.shared.global"](
+                                        arena.ptr_to([dst]),
+                                        workspace.ptr_to([bh_q + K.cast(q_row, "int64")]),
+                                        4,
+                                        4,
+                                    )
+                                with K.Else():
+                                    K.ptx.st.shared.b32(arena.ptr_to([dst]), K.uint32(0))
+                    K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](
+                        sum_pipe.full.buf.ptr_to([sum_stage])
+                    )
+                    sum_prod.advance()
+                    K.assign(remaining, remaining - K.int32(2))
+
+                load_pair(True)
+                with K.While(remaining > K.int32(0)):
+                    load_pair(False)
+
+            with r_mma:
+                K.ptx[TMEM_ALLOC](
+                    K.cuda.cvta_generic_to_shared(tmem_mailbox.ptr_to([0])), K.uint32(TMEM_COLUMNS)
+                )
+                K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+                tcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+                t_dk = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DK))
+                t_dv = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DV))
+                t_dp = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DP))
+                t_s = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_S))
+                elected = K.local_scalar("uint32", init=K.cuda.elect_sync())
+
+                desc_k = _desc_base(1)
+                desc_mn_wide = _desc_base(1024)
+                desc_mn_k = _desc_base(512)
+                desc_mn_narrow = _desc_base(0)
+                d_k_k = _desc_at(desc_k, smem_base + K.uint32(OFF_SK))
+                d_v_k = _desc_at(desc_k, smem_base + K.uint32(OFF_SV))
+                d_do_k = _desc_at(desc_k, smem_base + K.uint32(OFF_SDO))
+                d_do_mn = _desc_at(desc_mn_wide, smem_base + K.uint32(OFF_SDO))
+                d_p_mn = _desc_at(desc_mn_narrow, smem_base + K.uint32(OFF_SP))
+                d_ds_k = _desc_at(desc_k, smem_base + K.uint32(OFF_SDS))
+                d_ds_mn = _desc_at(desc_mn_narrow, smem_base + K.uint32(OFF_SDS))
+                d_k_mn = _desc_at(desc_mn_k, smem_base + K.uint32(OFF_SK))
+
+                q_cons = K.PipelineState(2, phase=0)
+                q_release = K.PipelineState(2, phase=0)
+                do_cons = K.PipelineState(1, phase=0)
+                s_prod = K.PipelineState(1, phase=0)
+                dp_prod = K.PipelineState(1, phase=0)
+                dq_prod = K.PipelineState(1, phase=0)
+                p_cons = K.PipelineState(1, phase=0)
+                ds_cons = K.PipelineState(1, phase=0)
+                dkdv_prod = K.PipelineState(2, phase=0)
+
+                q_pipe.full.wait(q_cons.stage, q_cons.phase)
+                s_pipe.empty.wait(s_prod.stage, s_prod.phase ^ 1)
+                d_q_k = _desc_at(
+                    desc_k, smem_base + K.uint32(OFF_SQ) + q_cons.stage * K.uint32(32768)
+                )
+                _mma_chain(
+                    t_s,
+                    d_q_k,
+                    d_k_k,
+                    ID_QK,
+                    (0, 2, 4, 6, 1024, 1026, 1028, 1030),
+                    (0, 2, 4, 6, 512, 514, 516, 518),
+                    K.uint32(0),
+                    elected,
+                )
+                q_cons.advance()
+                s_pipe.full.arrive(s_prod.stage, pred=elected)
+                s_prod.advance()
+
+                do_pipe.full.wait(do_cons.stage, do_cons.phase)
+                dp_pipe.empty.wait(dp_prod.stage, dp_prod.phase ^ 1)
+                dq_pipe.empty.wait(dq_prod.stage, dq_prod.phase ^ 1)
+                _mma_chain(
+                    t_dp,
+                    d_do_k,
+                    d_v_k,
+                    ID_QK,
+                    (0, 2, 4, 6, 1024, 1026, 1028, 1030),
+                    (0, 2, 4, 6, 512, 514, 516, 518),
+                    K.uint32(0),
+                    elected,
+                )
+                dp_pipe.full.arrive(dp_prod.stage, pred=elected)
+                dp_prod.advance()
+                p_pipe.full.wait(p_cons.stage, p_cons.phase)
+                _mma_chain(
+                    t_dv,
+                    d_do_mn,
+                    d_p_mn,
+                    ID_DKDV,
+                    (0, 128, 256, 384, 512, 640, 768, 896),
+                    (0, 128, 256, 384, 512, 640, 768, 896),
+                    K.uint32(0),
+                    elected,
+                )
+                p_pipe.empty.arrive(p_cons.stage, pred=elected)
+                p_cons.advance()
+                do_pipe.empty.arrive(do_cons.stage, pred=elected)
+                do_cons.advance()
+
+                pairs = (count + K.int32(1)) // K.int32(2)
+                pair = K.local_scalar("int32", init=K.int32(1))
+                dk_accumulate = K.local_scalar("uint32", init=K.uint32(0))
+                with K.While(pair < pairs):
+                    q_pipe.full.wait(q_cons.stage, q_cons.phase)
+                    s_pipe.empty.wait(s_prod.stage, s_prod.phase ^ 1)
+                    d_q_k = _desc_at(
+                        desc_k, smem_base + K.uint32(OFF_SQ) + q_cons.stage * K.uint32(32768)
+                    )
+                    _mma_chain(
+                        t_s,
+                        d_q_k,
+                        d_k_k,
+                        ID_QK,
+                        (0, 2, 4, 6, 1024, 1026, 1028, 1030),
+                        (0, 2, 4, 6, 512, 514, 516, 518),
+                        K.uint32(0),
+                        elected,
+                    )
+                    q_cons.advance()
+                    s_pipe.full.arrive(s_prod.stage, pred=elected)
+                    s_prod.advance()
+
+                    ds_pipe.full.wait(ds_cons.stage, ds_cons.phase)
+                    dp_pipe.empty.wait(dp_prod.stage, dp_prod.phase ^ 1)
+                    _mma_chain(
+                        K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DQ)),
+                        d_ds_k,
+                        d_k_mn,
+                        ID_DQ,
+                        (0, 2, 4, 6),
+                        (0, 128, 256, 384),
+                        K.uint32(0),
+                        elected,
+                    )
+                    dq_pipe.full.arrive(dq_prod.stage, pred=elected)
+                    dq_prod.advance()
+
+                    d_q_mn = _desc_at(
+                        desc_mn_wide,
+                        smem_base + K.uint32(OFF_SQ) + q_release.stage * K.uint32(32768),
+                    )
+                    _mma_chain(
+                        t_dk,
+                        d_q_mn,
+                        d_ds_mn,
+                        ID_DKDV,
+                        (0, 128, 256, 384, 512, 640, 768, 896),
+                        (0, 128, 256, 384, 512, 640, 768, 896),
+                        dk_accumulate,
+                        elected,
+                    )
+                    K.assign(dk_accumulate, K.uint32(1))
+                    q_pipe.empty.arrive(q_release.stage, pred=elected)
+                    q_release.advance()
+                    ds_pipe.empty.arrive(ds_cons.stage, pred=elected)
+                    ds_cons.advance()
+
+                    dq_pipe.empty.wait(dq_prod.stage, dq_prod.phase ^ 1)
+                    do_pipe.full.wait(do_cons.stage, do_cons.phase)
+                    _mma_chain(
+                        t_dp,
+                        d_do_k,
+                        d_v_k,
+                        ID_QK,
+                        (0, 2, 4, 6, 1024, 1026, 1028, 1030),
+                        (0, 2, 4, 6, 512, 514, 516, 518),
+                        K.uint32(0),
+                        elected,
+                    )
+                    dp_pipe.full.arrive(dp_prod.stage, pred=elected)
+                    dp_prod.advance()
+                    p_pipe.full.wait(p_cons.stage, p_cons.phase)
+                    _mma_chain(
+                        t_dv,
+                        d_do_mn,
+                        d_p_mn,
+                        ID_DKDV,
+                        (0, 128, 256, 384, 512, 640, 768, 896),
+                        (0, 128, 256, 384, 512, 640, 768, 896),
+                        K.uint32(1),
+                        elected,
+                    )
+                    p_pipe.empty.arrive(p_cons.stage, pred=elected)
+                    p_cons.advance()
+                    do_pipe.empty.arrive(do_cons.stage, pred=elected)
+                    do_cons.advance()
+                    K.assign(pair, pair + K.int32(1))
+
+                dkdv_pipe.empty.wait(dkdv_prod.stage, dkdv_prod.phase ^ 1)
+                dkdv_pipe.full.arrive(dkdv_prod.stage, pred=elected)
+                dkdv_prod.advance()
+                dkdv_pipe.empty.wait(dkdv_prod.stage, dkdv_prod.phase ^ 1)
+                ds_pipe.full.wait(ds_cons.stage, ds_cons.phase)
+                d_q_mn = _desc_at(
+                    desc_mn_wide, smem_base + K.uint32(OFF_SQ) + q_release.stage * K.uint32(32768)
+                )
+                _mma_chain(
+                    t_dk,
+                    d_q_mn,
+                    d_ds_mn,
+                    ID_DKDV,
+                    (0, 128, 256, 384, 512, 640, 768, 896),
+                    (0, 128, 256, 384, 512, 640, 768, 896),
+                    dk_accumulate,
+                    elected,
+                )
+                dkdv_pipe.full.arrive(dkdv_prod.stage, pred=elected)
+                dkdv_prod.advance()
+                _mma_chain(
+                    K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DQ)),
+                    d_ds_k,
+                    d_k_mn,
+                    ID_DQ,
+                    (0, 2, 4, 6),
+                    (0, 128, 256, 384),
+                    K.uint32(0),
+                    elected,
+                )
+                dq_pipe.full.arrive(dq_prod.stage, pred=elected)
+                dq_prod.advance()
+                q_pipe.empty.arrive(q_release.stage, pred=elected)
+                q_release.advance()
+                ds_pipe.empty.arrive(ds_cons.stage, pred=elected)
+                ds_cons.advance()
+
+            with r_compute:
+                K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(128))
+                K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+                tcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+                ctid = K.tid_in_role()
+                crow = ctid % K.int32(128)
+                wg = ctid // K.int32(128)
+                row_group = (crow // K.int32(32)) * K.int32(32)
+                scale_log2 = K.local_scalar("float32")
+                K.ptx.mul.f32(scale_log2, softmax_scale, K.float32(1.4426950408889634))
+                block_size = K.local_scalar("int32", init=K.int32(64))
+                if has_block_sizes:
+                    K.ptx.ld.global_.s32(
+                        block_size, block_sizes.ptr_to([batch_idx * K.int32(tasks) + task])
+                    )
+
+                s_cons = K.PipelineState(1, phase=0)
+                lse_cons = K.PipelineState(1, phase=0)
+                p_prod = K.PipelineState(1, phase=0)
+                sum_cons = K.PipelineState(1, phase=0)
+                dp_cons = K.PipelineState(1, phase=0)
+                ds_prod = K.PipelineState(1, phase=0)
+                dkdv_cons = K.PipelineState(2, phase=0)
+                pair = K.local_scalar("int32", init=K.int32(0))
+                pairs = (count + K.int32(1)) // K.int32(2)
+                with K.While(pair < pairs):
+                    s_pipe.full.wait(s_cons.stage, s_cons.phase)
+                    lse_pipe.full.wait(lse_cons.stage, lse_cons.phase)
+                    p_pipe.empty.wait(p_prod.stage, p_prod.phase ^ 1)
+                    scores = K.alloc_local((32,), "float32")
+                    for issue in range(2):
+                        address = K.cuda.get_tmem_addr(
+                            tcol, row_group, K.int32(TMEM_S + issue * 32) + wg * K.int32(16)
+                        )
+                        _tmem_load16(scores, issue * 16, address)
+                    if has_block_sizes:
+                        for j in range(32):
+                            col = wg * K.int32(16) + K.int32((j // 16) * 32 + j % 16)
+                            live = K.local_scalar("uint32")
+                            K.ptx["setp.lt.s32"](live, col, block_size)
+                            bits = K.local_scalar("uint32")
+                            K.ptx.selp.b32(
+                                bits,
+                                K.reinterpret(K.u32, scores[j]),
+                                K.uint32(0xFF800000),
+                                K.ptx.pred(live),
+                            )
+                            K.assign(scores[j], K.reinterpret(K.f32, bits))
+                    lse_value = K.local_scalar("float32")
+                    K.ptx.ld.shared_.b32(lse_value, arena.ptr_to([OFF_SLSE + crow * K.int32(4)]))
+                    for j in range(0, 32, 2):
+                        lo, hi = _packed_fma(
+                            scores[j], scores[j + 1], scale_log2, scale_log2, lse_value, lse_value
+                        )
+                        K.ptx.ex2.approx.ftz.f32(scores[j], lo)
+                        K.ptx.ex2.approx.ftz.f32(scores[j + 1], hi)
+                    packed_p = K.alloc_local((16,), "uint32")
+                    for j in range(16):
+                        K.ptx["cvt.rn.bf16x2.f32"](packed_p[j], scores[2 * j + 1], scores[2 * j])
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE[0]), K.uint32(BAR_COMPUTE[1]))
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    for group in range(4):
+                        col = wg * K.int32(16) + K.int32((group // 2) * 32 + (group % 2) * 8)
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([_tile_byte(OFF_SP, crow, col)]),
+                            packed_p[group * 4],
+                            packed_p[group * 4 + 1],
+                            packed_p[group * 4 + 2],
+                            packed_p[group * 4 + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    p_pipe.full.arrive(p_prod.stage)
+                    p_prod.advance()
+                    s_pipe.empty.arrive(s_cons.stage)
+                    s_cons.advance()
+                    lse_pipe.empty.arrive(lse_cons.stage)
+                    lse_cons.advance()
+
+                    sum_pipe.full.wait(sum_cons.stage, sum_cons.phase)
+                    dp_pipe.full.wait(dp_cons.stage, dp_cons.phase)
+                    ds_pipe.empty.wait(ds_prod.stage, ds_prod.phase ^ 1)
+                    dp_values = K.alloc_local((32,), "float32")
+                    for issue in range(2):
+                        address = K.cuda.get_tmem_addr(
+                            tcol, row_group, K.int32(TMEM_DP + issue * 32) + wg * K.int32(16)
+                        )
+                        _tmem_load16(dp_values, issue * 16, address)
+                    sum_value = K.local_scalar("float32")
+                    K.ptx.ld.shared_.b32(sum_value, arena.ptr_to([OFF_SSUM + crow * K.int32(4)]))
+                    for j in range(0, 32, 2):
+                        lo, hi = _packed_binary(
+                            "add.rn.f32x2", dp_values[j], dp_values[j + 1], sum_value, sum_value
+                        )
+                        lo, hi = _packed_binary("mul.rn.f32x2", lo, hi, scores[j], scores[j + 1])
+                        K.assign(dp_values[j], lo)
+                        K.assign(dp_values[j + 1], hi)
+                    packed_ds = K.alloc_local((16,), "uint32")
+                    for j in range(16):
+                        K.ptx["cvt.rn.bf16x2.f32"](
+                            packed_ds[j], dp_values[2 * j + 1], dp_values[2 * j]
+                        )
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    dp_pipe.empty.arrive(dp_cons.stage)
+                    dp_cons.advance()
+                    for group in range(4):
+                        col = wg * K.int32(16) + K.int32((group // 2) * 32 + (group % 2) * 8)
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([_tile_byte(OFF_SDS, crow, col)]),
+                            packed_ds[group * 4],
+                            packed_ds[group * 4 + 1],
+                            packed_ds[group * 4 + 2],
+                            packed_ds[group * 4 + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    ds_pipe.full.arrive(ds_prod.stage)
+                    ds_prod.advance()
+                    sum_pipe.empty.arrive(sum_cons.stage)
+                    sum_cons.advance()
+                    K.assign(pair, pair + K.int32(1))
+
+                bh = K.cast(batch_idx * K.int32(heads) + head, "int64")
+                for is_dk in (False, True):
+                    dkdv_pipe.full.wait(dkdv_cons.stage, dkdv_cons.phase)
+                    values = K.alloc_local((32,), "float32")
+                    tmem_offset = TMEM_DK if is_dk else TMEM_DV
+                    for issue in range(2):
+                        address = K.cuda.get_tmem_addr(
+                            tcol, row_group, K.int32(tmem_offset + issue * 32) + wg * K.int32(16)
+                        )
+                        _tmem_load16(values, issue * 16, address)
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    for j in range(32):
+                        col = wg * K.int32(16) + K.int32((j // 16) * 32 + j % 16)
+                        seq = task * K.int32(64) + col
+                        with K.If(seq < K.int32(seqlen_kv)), K.Then():
+                            base = dk_base if is_dk else dv_base
+                            index = (
+                                K.int64(base)
+                                + bh * K.int64(k8 * 128)
+                                + K.cast(seq, "int64") * K.int64(128)
+                                + K.cast(crow, "int64")
+                            )
+                            old = K.local_scalar("float32")
+                            K.ptx.atom.global_.add.f32(old, workspace.ptr_to([index]), values[j])
+                    dkdv_pipe.empty.arrive(dkdv_cons.stage)
+                    dkdv_cons.advance()
+                K.ptx.bar.sync(K.uint32(BAR_DEALLOC[0]), K.uint32(BAR_DEALLOC[1]))
+                with K.If(K.warp_id() == K.int32(8)), K.Then():
+                    K.ptx[TMEM_DEALLOC](tcol, K.uint32(TMEM_COLUMNS))
+
+            with r_reduce:
+                K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+                tcol = K.local_scalar("uint32")
+                K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+                rtid = K.tid_in_role()
+                row_group = (rtid // K.int32(32)) * K.int32(32)
+                dq_cons = K.PipelineState(1, phase=0)
+                store_stage = K.local_scalar("int32", init=K.int32(0))
+                edge = K.local_scalar("int32", init=K.int32(0))
+                bh_edge = K.cast(batch_idx * K.int32(heads) + head, "int64") * edge_stride
+                remaining = K.local_scalar("int32", init=count)
+                with K.While(remaining > K.int32(0)):
+                    dq_pipe.full.wait(dq_cons.stage, dq_cons.phase)
+                    q0 = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                    K.assign(edge, edge + K.int32(1))
+                    q1 = K.local_scalar("int32", init=K.int32(seqlen_q // 64))
+                    with K.If(edge < count), K.Then():
+                        K.assign(
+                            q1, _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                        )
+                    K.assign(edge, edge + K.int32(1))
+                    values = K.alloc_local((128,), "float32")
+                    for issue in range(4):
+                        address = K.cuda.get_tmem_addr(
+                            tcol, row_group, K.int32(TMEM_DQ + issue * 32)
+                        )
+                        _tmem_load32(values, issue * 32, address)
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    dq_pipe.empty.arrive(dq_cons.stage)
+                    dq_cons.advance()
+                    for chunk in range(4):
+                        with K.If(K.warp_id() == K.int32(0)), K.Then():
+                            K.ptx.cp.async_.bulk.wait_group.read(1)
+                        K.ptx.bar.sync(K.uint32(BAR_REDUCE[0]), K.uint32(BAR_REDUCE[1]))
+                        pair_slot = rtid // K.int32(64)
+                        row = rtid % K.int32(64)
+                        for vec in range(8):
+                            raw = (
+                                K.int32(OFF_SDQ)
+                                + store_stage * K.int32(16384)
+                                + pair_slot * K.int32(8192)
+                                + row * K.int32(128)
+                                + K.int32(16 * (7 - vec))
+                            )
+                            address = K.bitwise_xor(
+                                raw, K.bitwise_and(K.shift_right(raw, K.int32(3)), K.int32(0x70))
+                            )
+                            # The source fragment and its shared CopyAtom both
+                            # walk the eight vectors in reverse.  Reversing the
+                            # register vector together with the address keeps
+                            # logical dQ dimensions in ascending order.
+                            base = chunk * 32 + (7 - vec) * 4
+                            K.ptx.st.shared.v4.b32(
+                                arena.ptr_to([address]),
+                                values[base],
+                                values[base + 1],
+                                values[base + 2],
+                                values[base + 3],
+                            )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        K.ptx.bar.sync(K.uint32(BAR_REDUCE[0]), K.uint32(BAR_REDUCE[1]))
+                        with K.If(K.warp_id() == K.int32(0)), K.Then():
+                            leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                            with K.If(leader != K.uint32(0)), K.Then():
+                                K.ptx[TMA_REDUCE](
+                                    K.address_of(dq_map),
+                                    K.int32(chunk * 32),
+                                    q0 * K.int32(64),
+                                    head,
+                                    batch_idx,
+                                    arena.ptr_to([OFF_SDQ + store_stage * K.int32(16384)]),
+                                    TMA_CACHE,
+                                )
+                                K.ptx[TMA_REDUCE](
+                                    K.address_of(dq_map),
+                                    K.int32(chunk * 32),
+                                    q1 * K.int32(64),
+                                    head,
+                                    batch_idx,
+                                    arena.ptr_to([OFF_SDQ + store_stage * K.int32(16384) + 8192]),
+                                    TMA_CACHE,
+                                )
+                            K.ptx.cp.async_.bulk.commit_group()
+                        K.assign(store_stage, K.Select(store_stage == K.int32(1), 0, 1))
+                    K.assign(remaining, remaining - K.int32(2))
+                K.ptx.cp.async_.bulk.wait_group.read(0)
+
+            with r_empty:
+                pass
+        required_block_size.__exit__(None, None, None)
+
+    @K.kernel(
+        warps=4,
+        arch="sm_100a",
+        min_blocks_per_sm=1,
+        grid=((max(seqlen_q, seqlen_kv) + 7) // 8, heads, batch),
+    )
+    def convert(
+        workspace: K.gptr[K.f32],
+        dq: K.gptr[K.bf16],
+        dk: K.gptr[K.bf16],
+        dv: K.gptr[K.bf16],
+        softmax_scale: K.f32,
+    ):
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        seq_tile, head, batch_idx = K.cta_id()
+        tid = K.thread_id()
+        tidx = tid % K.int32(16)
+        tidy = tid // K.int32(16)
+        seq = seq_tile * K.int32(8) + tidy
+        bh = K.cast(batch_idx * K.int32(heads) + head, "int64")
+        for group in range(2):
+            dim = (tidx + K.int32(group * 16)) * K.int32(4)
+            with K.If(seq < K.int32(seqlen_q)), K.Then():
+                source = (
+                    K.int64(dq_base)
+                    + bh * K.int64(q8 * 128)
+                    + K.cast(seq, "int64") * K.int64(128)
+                    + K.cast(dim, "int64")
+                )
+                values = K.alloc_local((4,), "float32")
+                K.ptx.ld.global_.v4.b32(
+                    values[0], values[1], values[2], values[3], workspace.ptr_to([source])
+                )
+                scaled = K.alloc_local((4,), "float32")
+                for pair in range(2):
+                    lo, hi = _packed_binary(
+                        "mul.rn.f32x2",
+                        values[pair * 2],
+                        values[pair * 2 + 1],
+                        softmax_scale,
+                        softmax_scale,
+                    )
+                    K.assign(scaled[pair * 2], lo)
+                    K.assign(scaled[pair * 2 + 1], hi)
+                out0 = K.local_scalar("uint32")
+                out1 = K.local_scalar("uint32")
+                K.ptx["cvt.rn.bf16x2.f32"](out0, scaled[1], scaled[0])
+                K.ptx["cvt.rn.bf16x2.f32"](out1, scaled[3], scaled[2])
+                output = (bh * K.int64(seqlen_q) + K.cast(seq, "int64")) * K.int64(128) + K.cast(
+                    dim, "int64"
+                )
+                K.ptx.st.global_.v2.b32(dq.ptr_to([output]), out0, out1)
+            with K.If(seq < K.int32(seqlen_kv)), K.Then():
+                dk_source = (
+                    K.int64(dk_base)
+                    + bh * K.int64(k8 * 128)
+                    + K.cast(seq, "int64") * K.int64(128)
+                    + K.cast(dim, "int64")
+                )
+                dv_source = (
+                    K.int64(dv_base)
+                    + bh * K.int64(k8 * 128)
+                    + K.cast(seq, "int64") * K.int64(128)
+                    + K.cast(dim, "int64")
+                )
+                kvals = K.alloc_local((4,), "float32")
+                vvals = K.alloc_local((4,), "float32")
+                K.ptx.ld.global_.v4.b32(
+                    kvals[0], kvals[1], kvals[2], kvals[3], workspace.ptr_to([dk_source])
+                )
+                K.ptx.ld.global_.v4.b32(
+                    vvals[0], vvals[1], vvals[2], vvals[3], workspace.ptr_to([dv_source])
+                )
+                kscaled = K.alloc_local((4,), "float32")
+                for pair in range(2):
+                    lo, hi = _packed_binary(
+                        "mul.rn.f32x2",
+                        kvals[pair * 2],
+                        kvals[pair * 2 + 1],
+                        softmax_scale,
+                        softmax_scale,
+                    )
+                    K.assign(kscaled[pair * 2], lo)
+                    K.assign(kscaled[pair * 2 + 1], hi)
+                k0 = K.local_scalar("uint32")
+                k1 = K.local_scalar("uint32")
+                v0 = K.local_scalar("uint32")
+                v1 = K.local_scalar("uint32")
+                K.ptx["cvt.rn.bf16x2.f32"](k0, kscaled[1], kscaled[0])
+                K.ptx["cvt.rn.bf16x2.f32"](k1, kscaled[3], kscaled[2])
+                K.ptx["cvt.rn.bf16x2.f32"](v0, vvals[1], vvals[0])
+                K.ptx["cvt.rn.bf16x2.f32"](v1, vvals[3], vvals[2])
+                output = (bh * K.int64(seqlen_kv) + K.cast(seq, "int64")) * K.int64(128) + K.cast(
+                    dim, "int64"
+                )
+                K.ptx.st.global_.v2.b32(dk.ptr_to([output]), k0, k1)
+                K.ptx.st.global_.v2.b32(dv.ptr_to([output]), v0, v1)
+        required_block_size.__exit__(None, None, None)
+
+    return sum_odo.func, bwd.func, convert.func

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/reference.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/reference.py
@@ -1,0 +1,98 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Lazy direct three-kernel loader for the pinned SM100 blk64 BSA backward."""
+
+import torch
+
+from tirx_kernels.cudnn._reference import import_cutlass_reference, load_reference_module
+
+
+def compile_reference(data):
+    """Compile the direct class ABI; CSR construction and allocations stay outside timing."""
+    import_cutlass_reference()
+    import cuda.bindings.driver as cuda
+    import cutlass.cute as cute
+
+    interface = load_reference_module("cudnn.block_sparse_attention._interface")
+    source = load_reference_module(
+        "cudnn.block_sparse_attention.csrc.bwd.sm100_blk64.bsa_bwd_sm100"
+    )
+    config = data["config"]
+    inputs = data["inputs"]
+    output = data["source"]
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    problem_shape = (seqlen_q, seqlen_kv, 128, (heads, batch))
+
+    def dynamic_tensor(tensor):
+        value = interface.from_dlpack(
+            tensor.detach(), assumed_align=16, enable_tvm_ffi=True
+        ).mark_layout_dynamic()
+        try:
+            return value.mark_compact_shape_dynamic(
+                mode=3, stride_order=tensor.dim_order(), divisibility=128
+            )
+        except RuntimeError as error:
+            if "stride_order is not consistent" not in str(error):
+                raise
+            # The source class itself carries Int64 layout arithmetic.  Its
+            # public helper's optional compact-shape annotation rejects the
+            # deliberate singleton-dimension padding probe, so retain the same
+            # class ABI with a fully dynamic layout for that host-only case.
+            return interface.from_dlpack(
+                tensor.detach(), assumed_align=16, enable_tvm_ffi=True
+            ).mark_layout_dynamic()
+
+    kernel = source.BlockSparseAttnBackwardSm100Blk64(
+        sparse_block_size=64, has_block_sizes=bool(config["has_block_sizes"])
+    )
+    compiled = cute.compile(
+        kernel,
+        problem_shape,
+        dynamic_tensor(inputs["do"]),
+        dynamic_tensor(inputs["o"]),
+        dynamic_tensor(inputs["q"]),
+        dynamic_tensor(inputs["k"]),
+        dynamic_tensor(inputs["v"]),
+        interface._to_cute_tensor(inputs["lse"], leading_dim=2),
+        dynamic_tensor(output["dq"]),
+        dynamic_tensor(output["dk"]),
+        dynamic_tensor(output["dv"]),
+        interface._to_cute_tensor(inputs["bucketed_offsets"], leading_dim=3),
+        interface._to_cute_tensor(inputs["bucketed_indices"], leading_dim=2),
+        interface._to_cute_tensor(inputs["block_sizes"], leading_dim=1),
+        interface._to_cute_tensor(output["workspace"], fully_dynamic=True),
+        float(inputs["softmax_scale"]),
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )
+
+    def launch():
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        compiled(
+            problem_shape,
+            inputs["do"],
+            inputs["o"],
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["lse"],
+            output["dq"],
+            output["dk"],
+            output["dv"],
+            inputs["bucketed_offsets"],
+            inputs["bucketed_indices"],
+            inputs["block_sizes"],
+            output["workspace"],
+            float(inputs["softmax_scale"]),
+            stream,
+        )
+
+    launch.source_kernel = kernel
+    launch.compiled = compiled
+    return launch

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/spec.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/spec.py
@@ -1,0 +1,195 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Configuration matrix for the SM100 blk64 BSA backward port."""
+
+
+def _config(label, **overrides):
+    config = {
+        "label": label,
+        "batch": 1,
+        "num_heads": 1,
+        "seqlen_q": 128,
+        "seqlen_kv": 256,
+        "head_dim": 128,
+        "dtype": "bfloat16",
+        "kv_blocks": 2,
+        "tensor_layout": "bhsd",
+        "has_block_sizes": True,
+        "block_count_mode": "fixed",
+        "block_count_pattern": None,
+        "softmax_scale": None,
+        "use_int64_kv_strides": False,
+        "bucket_size_blocks": None,
+        "seed": 16400,
+    }
+    config.update(overrides)
+    return config
+
+
+def correctness_configs():
+    rows = (
+        ("c00_b1_h2_sq128_skv256_kv2_mask", dict(num_heads=2)),
+        ("c01_b1_h2_sq128_skv256_kv2_nomask", dict(num_heads=2, has_block_sizes=False)),
+        ("c02_b1_h2_sq128_skv256_kv2_mask_bshd", dict(num_heads=2, tensor_layout="bshd")),
+        ("c03_b2_h3_sq128_skv320_kv3_mask", dict(batch=2, num_heads=3, seqlen_kv=320, kv_blocks=3)),
+        ("c04_b1_h1_sq1_skv65_kv2_mask", dict(seqlen_q=1, seqlen_kv=65)),
+        ("c05_b1_h1_sq63_skv255_kv2_mask", dict(seqlen_q=63, seqlen_kv=255)),
+        ("c06_b1_h1_sq65_skv257_kv3_mask", dict(seqlen_q=65, seqlen_kv=257, kv_blocks=3)),
+        (
+            "c07_b1_h1_sq192_skv256_maxkv3_var_1_2_3_mask",
+            dict(
+                seqlen_q=192, kv_blocks=3, block_count_mode="variable", block_count_pattern="1,2,3"
+            ),
+        ),
+        (
+            "c08_b1_h2_sq257_skv512_maxkv4_var_1_mid_max_mask",
+            dict(
+                num_heads=2,
+                seqlen_q=257,
+                seqlen_kv=512,
+                kv_blocks=4,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+            ),
+        ),
+        (
+            "c09_b1_h2_sq257_skv512_maxkv4_empty_0_1_max_mask",
+            dict(
+                num_heads=2,
+                seqlen_q=257,
+                seqlen_kv=512,
+                kv_blocks=4,
+                block_count_mode="variable_empty",
+                block_count_pattern="0,1,max",
+            ),
+        ),
+        (
+            "c10_b1_h2_sq129_skv512_maxkv4_all_empty_mask",
+            dict(
+                num_heads=2,
+                seqlen_q=129,
+                seqlen_kv=512,
+                kv_blocks=4,
+                block_count_mode="variable_empty",
+                block_count_pattern="0",
+            ),
+        ),
+        (
+            "c11_b1_h2_sq129_skv512_kv4_mask_scale0125",
+            dict(num_heads=2, seqlen_q=129, seqlen_kv=512, kv_blocks=4, softmax_scale=0.125),
+        ),
+        (
+            "c12_b2_h2_sq129_skv511_kv4_batch_block_sizes",
+            dict(batch=2, num_heads=2, seqlen_q=129, seqlen_kv=511, kv_blocks=4),
+        ),
+        (
+            "c13_b1_h1_sq129_skv4096_kv4_nomask",
+            dict(seqlen_q=129, seqlen_kv=4096, kv_blocks=4, has_block_sizes=False),
+        ),
+        ("c14_b1_h1_sq128_skv256_kv2_mask_i64kv", dict(use_int64_kv_strides=True)),
+        ("c15_b1_h1_sq69633_skv256_kv2_mask_bucket1088", dict(seqlen_q=69633)),
+        ("c16_b1_h1_sq131073_skv256_kv2_mask_bucket1152", dict(seqlen_q=131073)),
+        (
+            "c17_b1_h1_sq192001_skv256_maxkv2_var_auto1024",
+            dict(seqlen_q=192001, block_count_mode="variable", block_count_pattern="1,max"),
+        ),
+        (
+            "c18_b1_h40_sq131072_skv256_kv1_mask_i64_workspace",
+            dict(num_heads=40, seqlen_q=131072, kv_blocks=1),
+        ),
+        (
+            "c19_b1_h1_sq695041_skv128_kv1_mask_convert_grid86881",
+            dict(seqlen_q=695041, seqlen_kv=128, kv_blocks=1),
+        ),
+    )
+    configs = []
+    for index, (label, overrides) in enumerate(rows):
+        configs.append(_config(label, seed=16401 + index, **overrides))
+    assert len(configs) == 20
+    return configs
+
+
+def benchmark_configs():
+    rows = (
+        (
+            "p00_b1_h1_sq64_skv4096_kv16_nomask",
+            dict(seqlen_q=64, seqlen_kv=4096, kv_blocks=16, has_block_sizes=False),
+        ),
+        (
+            "p01_b1_h2_sq4097_skv8191_kv64_mask",
+            dict(num_heads=2, seqlen_q=4097, seqlen_kv=8191, kv_blocks=64),
+        ),
+        (
+            "p02_b2_h8_sq4096_skv8191_kv32_mask",
+            dict(batch=2, num_heads=8, seqlen_q=4096, seqlen_kv=8191, kv_blocks=32),
+        ),
+        (
+            "p03_b1_h4_sq8192_skv4096_kv16_mask",
+            dict(num_heads=4, seqlen_q=8192, seqlen_kv=4096, kv_blocks=16),
+        ),
+        (
+            "p04_b1_h8_sq4096_skv8192_maxkv32_var_mask",
+            dict(
+                num_heads=8,
+                seqlen_q=4096,
+                seqlen_kv=8192,
+                kv_blocks=32,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+            ),
+        ),
+        (
+            "p05_b2_h4_sq4097_skv8191_maxkv32_empty_mask",
+            dict(
+                batch=2,
+                num_heads=4,
+                seqlen_q=4097,
+                seqlen_kv=8191,
+                kv_blocks=32,
+                block_count_mode="variable_empty",
+                block_count_pattern="0,1,max",
+            ),
+        ),
+        (
+            "p06_b1_h4_sq1024_skv32768_kv256_mask",
+            dict(num_heads=4, seqlen_q=1024, seqlen_kv=32768, kv_blocks=256),
+        ),
+        (
+            "p07_b1_h4_sq4097_skv16384_maxkv128_var_mask",
+            dict(
+                num_heads=4,
+                seqlen_q=4097,
+                seqlen_kv=16384,
+                kv_blocks=128,
+                block_count_mode="variable",
+                block_count_pattern="0,1,max",
+            ),
+        ),
+        (
+            "p08_b1_h8_sq2048_skv65536_kv512_nomask",
+            dict(num_heads=8, seqlen_q=2048, seqlen_kv=65536, kv_blocks=512, has_block_sizes=False),
+        ),
+        (
+            "p09_b1_h2_sq69633_skv8191_kv32_mask_bucket1088",
+            dict(num_heads=2, seqlen_q=69633, seqlen_kv=8191, kv_blocks=32),
+        ),
+        (
+            "p10_b1_h1_sq192001_skv8192_maxkv16_var_mask_auto1024_i64kv",
+            dict(
+                seqlen_q=192001,
+                seqlen_kv=8192,
+                kv_blocks=16,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+                use_int64_kv_strides=True,
+            ),
+        ),
+    )
+    configs = []
+    for index, (label, overrides) in enumerate(rows):
+        configs.append(_config(label, seed=16501 + index, **overrides))
+    assert len(configs) == 11
+    return configs

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
@@ -1,0 +1,107 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM100 blk64 block-sparse attention backward three-kernel program."""
+
+from ._block_sparse_attention_backward_sm100_blk64 import data as _data
+from ._block_sparse_attention_backward_sm100_blk64 import kernel as _kernel
+from ._block_sparse_attention_backward_sm100_blk64 import reference as _reference
+from ._block_sparse_attention_backward_sm100_blk64 import spec as _spec
+
+KERNEL_META = {
+    "name": "cudnn_sm100_bsa_backward_blk64",
+    "category": "cudnn",
+    "compute_capability": 10,
+}
+
+CONFIGS = _spec.correctness_configs()
+BENCH_CONFIGS = _spec.benchmark_configs()
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def get_kernel(**config):
+    """Return sum_OdO, main backward, and convert in source launch order."""
+    return _kernel.get_kernel(**config)
+
+
+def prepare_data(**config):
+    return _data.prepare_data(**config)
+
+
+def run_test(**config):
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch()
+    source_launch = _reference.compile_reference(data)
+    source_launch()
+    torch.cuda.synchronize()
+    _data.validate_outputs(data, sources=("tirx", "source"))
+
+
+def prepare_bench(**config):
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    data = prepare_data(**_without_label(config))
+    tirx_launch = _data.tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+        source_launch = _reference.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _data.validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

- port the cuDNN Frontend SM100 block-sparse attention backward blk64 pipeline to the pure `tirx_kernels.kern` API
- implement the `sum_OdO`, backward, and convert entry points with source-shaped warp specialization, rank-1 shared-memory arenas, TMEM, and explicit PTX operations
- add deterministic data preparation, pinned-source and independent FP64-oracle validation, a canonical sketch, bench-suite coverage, and README registration

## Correctness

- 20/20 configurations pass against both the pinned cuDNN Frontend source and an independent FP64 oracle
- tight per-output tolerances range from `2^-15` to `0.03`, with exact bucket classification, padding, and redzone checks
- all 60 generated PrimFuncs pass low-level IR inspection with zero function calls, no tile/layout primitives, and rank-1 shared memory only
- compute-sanitizer memcheck reports zero device errors for c04, c07, and c09
- synccheck passes for sum/convert; the backward entry reports the same partial-CTA `bar.sync` diagnostic as the pinned source and is treated as tool-inconclusive rather than a clean pass

## Performance

The final uncontaminated bench-suite generation used 5 rounds, Proton timing, 25 ms warmup, 100 ms repeat, zero cooldown, and `tirx` followed by `cudnn_frontend` for every round.

- required rows: 11/11 strictly above 0.99x
- minimum reference/TIRx ratio: 1.0022688x
- geometric-mean reference/TIRx ratio: 1.0233285x
- interference retries: 0
- workload failures: 0

## Validation

- `python -m tirx_kernels.bench_suite --check-imports`
- `python tests/lint/check_license_headers.py`
- `python tests/lint/check_license_headers.py --self-test`
- `pre-commit run --files <changed files>`
