### PR TITLE
feat(kernel): support grouped Q-to-KV head maps in SM100 blk64 BSA forward

### DIFF
--- a/.agents/sketch/cudnn/sm100_bsa_forward_blk64.md
+++ b/.agents/sketch/cudnn/sm100_bsa_forward_blk64.md
@@ -33,16 +33,18 @@ logical rectangular region, never a TIRx tile primitive or layout-bearing value.
 
 ## Scope and specializations
 
-The fixed producer geometry is BF16 MHA, `D=DV=128`, Q rows 64, one grouped KV
-iteration of 256 tokens assembled from four indexed sparse blocks of 64, one-CTA
-UMMA, and FP32 score/output accumulation. The producer always uses 512 threads,
-one Q stage, three aliased K/V stages, two alternating score/P stages, two O
-accumulator stages, and all 512 TMEM columns. Source `bsa_fwd_sm100.py:53-188`.
+The fixed producer geometry is BF16 with a constexpr non-packed Q-to-KV head map
+(`H_q = r * H_kv`), `D=DV=128`, Q rows 64, one grouped KV iteration of 256 tokens
+assembled from four indexed sparse blocks of 64, one-CTA UMMA, and FP32
+score/output accumulation. The producer always uses 512 threads, one Q stage,
+three aliased K/V stages, two alternating score/P stages, two O accumulator
+stages, and all 512 TMEM columns. Source `bsa_fwd_sm100.py:53-188`.
 
 In scope:
 
 | axis | accepted values | device-code consequence |
 | --- | --- | --- |
+| head map | MHA `r=1` / GQA / MQA, any `r` with `H_q % H_kv == 0` | only the K/V TMA head coordinate becomes `h//r`; Q, sparse metadata, O, LSE and the grid all stay `H_q`-indexed, and batch remains a separate coordinate contribution folded into the K/V block axis, never into the head. `r=1` folds at trace time and emits nothing, matching the source. For `r>1` the emitted form depends on the work coordinate's provenance — see the head-map instruction selection at the warp-14 body |
 | input presentation | BHSD / BSHD | BSHD is made contiguous as BHSD by the wrapper before either timed launch; producer addressing is the same |
 | sparse count | fixed / per-Q-block variable | fixed reads one scalar; variable loads `block_nums[b,h,qb]`; the latter may specialize an empty-tile branch |
 | block tail mask | present / absent | present loads physical `block_sizes[block_id]`; absent substitutes 64 without a GMEM access |
@@ -52,10 +54,20 @@ In scope:
 | output dtype | BF16 final / FP32 producer partial | FP32 only when split-KV is active; final combine converts to BF16 |
 | scale | default `1/sqrt(128)` / runtime f32 | producer carries both the natural and log2-domain scale |
 
-Out of scope: FP16, GQA/MQA, causal attention, `D` or `DV` other than 128,
-sparse block sizes other than 64, Q tiles other than 64, grouped KV tiles other
-than 256, multi-CTA MMA, cluster dimensions greater than one, and every SM90,
-SM110-specific, or SM120 sibling. Tile primitives are out of scope.
+Out of scope: FP16, PackGQA (the packed Q-head layout), causal attention, `D` or
+`DV` other than 128, sparse block sizes other than 64, Q tiles other than 64,
+grouped KV tiles other than 256, multi-CTA MMA, cluster dimensions greater than
+one, and every SM90, SM110-specific, or SM120 sibling. Tile primitives are out of
+scope.
+
+The two head-adjacent exclusions are properties of the source, not choices. FP16
+is excluded because the source's own conversion helpers emit BF16 unconditionally
+(`bsa_fwd_helpers.py:136-148` for the softmax P operand and `:322-379` for the
+non-FP32 output store), so an FP16 launch would disagree with the instruction
+descriptor rather than fail. PackGQA is excluded because the source's packed LSE
+row bound (`bsa_fwd_sm100.py:2211`) uses the unpacked `seqlen_q` where the packed
+layout needs `seqlen_q * r`, silently dropping rows; the blk128 sibling carries
+the corrected form. Both are refused by the source's own host surface.
 
 Static and split producer launches are ordinary launches. CLC is an explicit
 singleton-cluster launch even though every dimension has extent one; presence
@@ -75,6 +87,37 @@ generated intermediate. The manifest is preserved at
 | split producer | source partial/final result and oracle PASS | `83cd2a7372f594088dc12a21e05120020107a7bfe51830cbd12177893f8247d3` | `.reqntid 512,1,1`, ordinary CTA |
 | split combine | same split PASS | `ce81938a9ed60c37576f4384a5ec28e86c93772d3b8987f52ac7a4a636763a70` | `.reqntid 128,1,1`, ordinary CTA |
 | static clean MLIR | same static PASS | `0ddeda5829230f9b85cc82e2e0f794a844c2ebe2a22b350a0d57c8c2083fe1de` | resolves dynamic storage fields and source mappings |
+
+The head map was exported separately, as three static/fixed producers differing
+only in `qhead_per_kvhead`, so the map's instruction selection is read from a
+diff rather than inferred. Same manifest.
+
+| export | `H_q`/`H_kv` | artifact SHA256 | emitted at `.loc 1 1186 26` |
+| --- | --- | --- | --- |
+| grouped `r=1` | 8 / 8 | `f93b3903d6f4f938cfdf0003b4d5f822b083f4c7eabed496f616b6d3db9585b3` | nothing; the expression folds away |
+| grouped `r=3` | 6 / 2 | `8f346ea25b5f3e0e71b36312af88ccf809b64bc1f78a6ff111d0d88f873431d9` | `cvt.u16.u32` / `mul.hi.u16 %rs, %rs, -21845` / `shr.u16 %rs, %rs, 1` / `cvt.u32.u16` |
+| grouped `r=4` | 8 / 2 | `fb46dfb64585e7240c6857d0a59d156a9f5c170f70dc93eeb9a82078fdc72b1c` | `shr.u32 %r, %r, 2` |
+
+Those three share the static, fixed-count specialization, where `head_idx` is the
+raw `%ctaid.y`. Two further exports cover the scheduling modes that obtain the
+head index differently, and they select a different sequence for the same ratio:
+
+| export | `H_q`/`H_kv` | scheduling | artifact SHA256 | emitted at `.loc 1 1186 26` |
+| --- | --- | --- | --- | --- |
+| grouped `r=4` CLC, variable counts | 8 / 2 | CLC persistent | `973f7d3653034137…` | ten-instruction signed floor division: `shr.s32 ,31` / `shr.u32 ,30` / `add.s32` / `shr.s32 ,2` / `and.b32 ,-4` / `setp.ne.b32` / `setp.lt.s32` / `and.pred` / `selp.b32 ,-1,0` / `add.s32` |
+| grouped `r=8` MQA, split-KV 2 | 8 / 1 | static, split | `93f3642c14259182…` | the same ten-instruction sequence with `,29` / `,3` / `,-8` |
+
+The difference is the operand's provable sign, not the ratio: `%ctaid.y` is
+non-negative, while the split scheduler's `divmod` result and the CLC response
+field are `Int32` of unproven sign, which forces the negative-operand
+correction. Ratio 1 folds away in every mode, static, CLC and split alike.
+
+With register names normalized, that `.loc 1 1186` hunk is the *only* semantic
+difference between the three **static** exports; everything else is register
+renumbering from the one extra live value. Each grouped export was also checked against a
+head-replication oracle — the stock wrapper on the same Q with K/V
+`repeat_interleave`d to `H_q` heads — matching at `atol=0, rtol=0` on O, on LSE,
+and on the LSE finiteness mask.
 
 The static producer contains 64 `tcgen05.mma.ws.cta_group::1.kind::f16`,
 32 `tcgen05.ld.sync.aligned.32x32b.x32.b32`, 16
@@ -131,7 +174,7 @@ rmem_words(name, count, dtype)
 tensormap(name, rank, dtype, box, strides, swizzle, oob_fill)
 byte_ptr(linear_base, scalar_byte_offset)
 pipeline_state(stages, index, phase, count)
-work_cursor(q_blocks, heads, batch, splits, persistent_limit)
+work_cursor(q_blocks, heads, batch, splits, persistent_limit)  # heads is H_q
 ```
 
 Every physical SMEM mapping is a scalar function. `swizzle343(x)` means the
@@ -195,10 +238,14 @@ cluster_try_cancel(full_mbarrier, response); cluster_query_wait()
 # source main:53-188,226-677; export PTX:14-43
 # ---------------------------------------------------------------------------
 P = specialize(
-    B, H, SQ, SKV,
+    B, H, HKV, SQ, SKV,
     has_block_sizes, has_variable_counts, allow_empty,
     kv_splits, use_clc, use_i64_kv_strides, output_dtype,
 )
+# `H` is always the Q head count. `HKV` divides it; `R = H // HKV` is the
+# non-packed head map's ratio and is constexpr, so `h // R` resolves at trace
+# time to nothing (R=1), a shift (R power of two), or a reciprocal multiply.
+R = H // HKV
 M = 64
 N = 256
 D = DV = 128
@@ -231,7 +278,7 @@ else:
 
 launch(
     grid=((ceil_div(SQ,64), H, B) if P.use_clc
-          else (ceil_div(SQ,64), H*kv_splits, B)),
+          else (ceil_div(SQ,64), H*kv_splits, B)),   # H is H_q for every ratio
     block=(512, 1, 1),
     arch="sm_100a",
     min_blocks_per_sm=1,
@@ -477,6 +524,29 @@ if P.use_clc and warp == 15:
 if warp == 14:
     while work.valid:
         qb, h, b, split = work.coordinates
+        # The non-packed head map. `h` stays the Q head everywhere else --
+        # sparse metadata, Q, O and LSE are all Q-head-indexed -- and only the
+        # K/V tiles come from the grouped KV head. Recomputed per work item, so
+        # a persistent CLC producer re-derives it after every advance.
+        hkv = u32(h) // R
+        # instruction_selection: nothing when R==1, in every scheduling mode.
+        #   For R>1 the source's emitted form depends on the provenance of `h`,
+        #   not on R alone. Static non-split takes `h` straight from `%ctaid.y`,
+        #   which is provably non-negative, so `.loc 1 1186` is one unsigned op:
+        #   `shr.u32` for a power-of-two R, or `cvt.u16.u32` /
+        #   `mul.hi.u16 ,-21845` / `shr.u16 ,1` / `cvt.u32.u16` for R==3. Under
+        #   split-KV `h` comes from the scheduler's `divmod` and under CLC from
+        #   the decoded response; both are Int32 of unproven sign, so the source
+        #   emits full floor-division with the negative-operand correction --
+        #   ten instructions for a power-of-two R, nine including
+        #   `mul.hi.s32 ,1431655766` for R==3.
+        #   The port narrows `h` to unsigned first, which is a deliberate and
+        #   benign divergence: `h` is a grid/scheduler head index and is always
+        #   non-negative, so the two forms are equal, and the port keeps the
+        #   one-instruction form in all three scheduling modes rather than
+        #   reproducing the source's ten-instruction signed sequence.
+        #   extent: one scalar integer expression per work item in the load
+        #   role, on no inner loop, in every case
         raw_count, split_start = sparse_count_and_offset(work)
         process = (raw_count > 0) if P.allow_empty else True
         NITER = round_up(raw_count, 8) // 4
@@ -511,7 +581,7 @@ if warp == 14:
                     sid = sparse_id(reverse_group*4 + sub)
                     if kind == K:
                         for d_half in 0..1:
-                            copy_g2s_tma(map_K, (d_half, sid, h, b),
+                            copy_g2s_tma(map_K, (d_half, sid, hkv, b),
                                          KV_UNION + 2*k_tma_elem(
                                              KV_PROD.index, sub, ..., d_half),
                                          KV_PIPE.full[KV_PROD.index])
@@ -519,7 +589,7 @@ if warp == 14:
                             #   extent: exactly two 64x64 BF16 issues per K
                             #   sparse sub-block, eight issues for the K group
                     else:
-                        copy_g2s_tma(map_V, (sid, h, b),
+                        copy_g2s_tma(map_V, (sid, hkv, b),
                                      KV_UNION + 2*v_tma_elem(KV_PROD.index, sub, ...),
                                      KV_PIPE.full[KV_PROD.index])
                         # instruction_selection: same 5-D tensor-bulk family;
@@ -1067,7 +1137,7 @@ still balances the stats and output pipelines, writes O zero, and writes LSE
 offsets `min(aligned_base*s + min(valid-aligned_base*kv_splits, 8*s), valid)`
 when `aligned_base>0`; otherwise—including the 256-split path—it uses even
 ceil-distributed offsets `ceil(valid*s/kv_splits)`. Each split producer follows
-the same program and folds `split*H` into its output-head axis.
+the same program and folds `split*H` into its output-head axis (`H` is H_q, so the combine is unaffected by the head map).
 
 ## Complete split-KV combine sketch
 
@@ -1076,7 +1146,7 @@ The combine exists only for `kv_splits > 1`. Its production specialization is
 `max_splits=2**ceil(log2(kv_splits))`. The physical split extent used by the
 source LSE layout is `max(8,max_splits)`, even when `max_splits==2`. It is an ordinary launch and has no TMEM,
 TMA, cluster, or warp specialization; all four warps execute the same row/column
-program. Source combine `22-147,250-606`; wrapper `_interface.py:885-1005`.
+program. Source combine `22-147,250-594`; wrapper `_interface.py:885-1005`.
 
 ```python
 launch(
@@ -1257,6 +1327,7 @@ compile-time branches, but must not change the execution skeleton:
 
 | branch | specialized differences |
 | --- | --- |
+| `qhead_per_kvhead` | the K/V TMA head coordinate only. `R=1` folds to the plain Q head and must stay byte-identical to the MHA program; other ratios add one scalar integer op per work item, the port narrowing the head index to unsigned so the one-instruction form is kept under CLC and split-KV too |
 | `has_block_sizes` | physical-block size GMEM loads and two 64-column masks versus constant 64 |
 | fixed / variable count | scalar fixed count versus `block_nums[b,h,qb]`; variable count changes scheduler arguments |
 | `allow_empty` | empty-tile control path and zero/-inf output; split buckets can also be empty when the requested split count exceeds a row's live sparse blocks |
@@ -1279,16 +1350,18 @@ The public module exports `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`,
 for `kv_splits=1` and producer plus combine for `kv_splits>1`. Device code uses
 `import tirx_kernels.kern as K` exclusively.
 
-Correctness is the module's fixed 22-row matrix: BHSD/BSHD, Q tails 1/63/65,
+Correctness is the module's fixed 35-row matrix: BHSD/BSHD, Q tails 1/63/65,
 masked/unmasked, custom scale, fixed/variable/empty counts, static/CLC,
-split 1/2/3/8/256 and auto-to-2, and the active i64 K/V-stride case. Every row
-must run with no skip. O and LSE are compared both with the production source
+split 1/2/3/8/256 and auto-to-2, the active i64 K/V-stride case, and the
+non-packed head map at ratios 2, 3, 4 and 8 (MQA included) crossed with those
+axes. Every row must run with no skip. O and LSE are compared both with the production source
 and a gathered FP32 oracle; empty rows require exact O zero and LSE `-inf`.
 Split rows additionally validate producer FP32 partial O/LSE before combine.
 
 Performance truth is only `python -m tirx_kernels.bench_suite`. The frozen
-11-row matrix covers short/long and batch/head scaling, static/CLC, fixed,
-variable and empty counts, split 2/4/8, and i64 K/V addressing. Every row must
+23-row matrix covers short/long and batch/head scaling, static/CLC, fixed,
+variable and empty counts, split 2/4/8, i64 K/V addressing, and a grouped-head
+mirror of those axes at ratios 2, 3, 4 and 8. Every row must
 contain five finite positive Proton samples for source and TIRx, `status == ok`,
 no error, and strict `mean(source)/mean(tirx) > 0.99`.
 
@@ -1297,6 +1370,14 @@ no error, and strict `mean(source)/mean(tirx) > 0.99`.
 - Producer launch: 512 threads, one CTA UMMA, 217088 bytes dynamic SMEM aligned
   to 1024, minimum one CTA/SM. CLC alone carries explicit singleton cluster
   metadata and cluster-launch-control instructions.
+- The head map contributes at most one scalar integer instruction per work
+  item, in the load role only: nothing at ratio 1, `shr.u32` at a power-of-two
+  ratio, a 16-bit reciprocal multiply otherwise. It is on no inner loop and
+  changes no issue count. The source itself keeps that one-instruction form only
+  where the head index is the raw `%ctaid.y`; under split-KV and CLC its head
+  index is a signed `Int32` and it emits a ten-instruction floor division. The
+  port narrows to unsigned and keeps one instruction in every mode -- a
+  deliberate divergence, sound because a head index is never negative.
 - Q uses exactly two 4-D tensor-bulk G2S issues. Each K group uses eight 5-D
   issues (two per sparse sub-block), each V group uses four (one per sparse
   sub-block), and O uses exactly two BF16 or four FP32 4-D tensor-bulk S2G

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/divide-unsigned.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/divide-unsigned.md
@@ -47,6 +47,20 @@ whenever the dividend's sign cannot be proven. A scheduler counter read from a
 signed integer global carries no such proof even when every value it can hold is
 a count, so each division emits an absolute value, a sign compare and a chain of
 moves that a reference written in unsigned arithmetic throughout does not have.
+
+The proof travels with the value, not with the variable, so one specialization
+of a kernel can pay the correction while another does not for the identical
+source expression. An index taken straight from a grid coordinate is provably
+non-negative and folds; the same index handed back by a persistent scheduler's
+`divmod`, or decoded from a cluster-launch-control response, is an ordinary
+signed integer and pays again. One kernel dividing a head index by a
+compile-time ratio emitted nothing at ratio one, a single `shr.u32` at a
+power-of-two ratio and a four-instruction 16-bit reciprocal at ratio three while
+the index came from the grid, then a ten-instruction correction for the same two
+power-of-two ratios, and nine with a 32-bit magic multiply for ratio three, once
+persistent and split-KV scheduling supplied the index instead. Cast where the
+scheduler hands the index over and the specializations agree again. Reading only
+the specialization whose index comes from the grid hides the cost entirely.
 The cast took the masked-layout shape from 3.868M to 3.537M instructions against
 the reference's 3.388M, and from 0.976x to above the gate.
 

--- a/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk64.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_forward_blk64.yaml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 kernel: cudnn_sm100_bsa_forward_blk64
-selection_rationale: The selected defaults cover a small ordinary singleton-split launch, a medium variable-sparsity CLC launch, and a large eight-way split-plus-combine launch; the full matrix additionally covers long-query static and CLC scheduling, empty sparse rows, split counts 2/4/8, masked and unmasked blocks, ragged Q/KV tails, batch/head occupancy, and 64-bit KV strides.
+selection_rationale: The selected defaults cover a small ordinary singleton-split launch, a medium variable-sparsity CLC launch, and a large eight-way split-plus-combine launch, and all three are equal-head so the defaults pin the path every other row shares; the full matrix additionally covers long-query static and CLC scheduling, empty sparse rows, split counts 2/4/8, masked and unmasked blocks, ragged Q/KV tails, batch/head occupancy, 64-bit KV strides, and a grouped Q-to-KV head map at ratios 2, 3, 4 and 8 (MQA included) mirroring those axes at matching shape scale.
 defaults:
   num_gpus: 1
 configs:
@@ -17,3 +17,15 @@ configs:
   - {config: p08_b1_h4_sq2048_skv32768_kv256_mask_s4_static, default: false}
   - {config: p09_b1_h8_sq2048_skv65536_kv512_nomask_s8_static, default: true, selection_role: large}
   - {config: p10_b1_h4_sq4096_skv8192_kv32_mask_s1_static_i64kv, default: false}
+  - {config: p11_b1_h8kv4_sq4096_skv8192_kv32_mask_s1_static_gqa, default: false}
+  - {config: p12_b2_h8kv2_sq4096_skv8191_kv32_mask_s1_static_gqa, default: false}
+  - {config: p13_b1_h8kv4_sq8192_skv4096_kv16_mask_s1_clc_gqa, default: false}
+  - {config: p14_b1_h8kv2_sq4096_skv8192_maxkv32_var_mask_s1_clc_gqa, default: false}
+  - {config: p15_b2_h4kv1_sq4097_skv8191_maxkv32_empty_mask_s1_clc_mqa, default: false}
+  - {config: p16_b1_h8kv2_sq1024_skv32768_kv256_mask_s2_static_gqa, default: false}
+  - {config: p17_b1_h8kv4_sq4097_skv16384_maxkv128_var_mask_s2_static_gqa, default: false}
+  - {config: p18_b1_h8kv1_sq2048_skv32768_kv256_mask_s4_static_mqa, default: false}
+  - {config: p19_b1_h8kv1_sq2048_skv65536_kv512_nomask_s8_static_mqa, default: false}
+  - {config: p20_b1_h8kv2_sq4096_skv8192_kv32_mask_s1_static_i64kv_gqa, default: false}
+  - {config: p21_b1_h8kv1_sq4097_skv8191_kv64_mask_s1_static_mqa, default: false}
+  - {config: p22_b1_h6kv2_sq2048_skv8192_kv32_mask_s1_static_gqa, default: false}

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/data.py
@@ -52,7 +52,7 @@ def _encode_tensormap(tensor, dtype, global_dims, global_strides, box_dims):
     return descriptor
 
 
-def _build_tensor_maps(q, k, v, out, *, seqlen_q, seqlen_kv, heads, batch):
+def _build_tensor_maps(q, k, v, out, *, seqlen_q, seqlen_kv, heads, kv_heads, batch):
     """Build the Q/K/V/O maps in the source kernel's fused block coordinates."""
     physical_blocks = (seqlen_kv + 63) // 64
     q_strides = (128 * 2, seqlen_q * 128 * 2, heads * seqlen_q * 128 * 2)
@@ -71,14 +71,14 @@ def _build_tensor_maps(q, k, v, out, *, seqlen_q, seqlen_kv, heads, batch):
         "k": _encode_tensormap(
             k,
             "bfloat16",
-            (64, 64, 2, physical_blocks, batch * heads),
+            (64, 64, 2, physical_blocks, batch * kv_heads),
             kv_strides,
             (64, 64, 1, 1, 1),
         ),
         "v": _encode_tensormap(
             v,
             "bfloat16",
-            (64, 64, 2, physical_blocks, batch * heads),
+            (64, 64, 2, physical_blocks, batch * kv_heads),
             kv_strides,
             (64, 64, 2, 1, 1),
         ),
@@ -100,7 +100,7 @@ def _resolve_splits(value):
 
 def _counts_from_pattern(config, q_blocks, device):
     batch = config["batch"]
-    heads = config["num_heads"]
+    heads = config["num_q_heads"]
     maximum = config["kv_blocks"]
     mode = config["block_count_mode"]
     if mode == "fixed":
@@ -141,7 +141,7 @@ def _build_split_offsets(counts, num_splits):
 
 def _make_sparse_metadata(config, *, q_blocks, physical_blocks, device):
     maximum = config["kv_blocks"]
-    total = config["batch"] * config["num_heads"] * q_blocks
+    total = config["batch"] * config["num_q_heads"] * q_blocks
     rows = torch.empty((total, maximum), dtype=torch.int32, device=device)
     base = torch.arange(maximum, dtype=torch.int64, device=device)
     # A coprime-ish stride spreads the selected blocks through the KV sequence;
@@ -153,7 +153,7 @@ def _make_sparse_metadata(config, *, q_blocks, physical_blocks, device):
         if maximum > 0:
             values[-1] = physical_blocks - 1
         rows[row] = values.to(torch.int32)
-    return rows.reshape(config["batch"], config["num_heads"], q_blocks, maximum)
+    return rows.reshape(config["batch"], config["num_q_heads"], q_blocks, maximum)
 
 
 def _strided_kv(generator, shape, *, use_i64):
@@ -175,7 +175,8 @@ def prepare_data(**config):
         raise unittest.SkipTest("CUDA is required")
 
     batch = config["batch"]
-    heads = config["num_heads"]
+    heads = config["num_q_heads"]
+    kv_heads = config["num_kv_heads"]
     seqlen_q = config["seqlen_q"]
     seqlen_kv = config["seqlen_kv"]
     q_blocks = (seqlen_q + 63) // 64
@@ -188,10 +189,10 @@ def prepare_data(**config):
         batch, heads, seqlen_q, 128, generator=generator, dtype=torch.bfloat16, device="cuda"
     )
     k_bhsd = _strided_kv(
-        generator, (batch, heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
+        generator, (batch, kv_heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
     )
     v_bhsd = _strided_kv(
-        generator, (batch, heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
+        generator, (batch, kv_heads, seqlen_kv, 128), use_i64=config["use_int64_kv_strides"]
     )
     if config["tensor_layout"] == "bshd":
         q_user = q_bhsd.transpose(1, 2).contiguous()
@@ -244,6 +245,7 @@ def prepare_data(**config):
         seqlen_q=seqlen_q,
         seqlen_kv=seqlen_kv,
         heads=heads,
+        kv_heads=kv_heads,
         batch=batch,
     )
 

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/kernel.py
@@ -83,7 +83,12 @@ def _resolve_splits(value):
 
 def make_forward_kernel(**config):
     batch = int(config["batch"])
-    num_heads = int(config["num_heads"])
+    num_heads = int(config["num_q_heads"])
+    if int(config["num_kv_heads"]) != num_heads:
+        raise NotImplementedError(
+            "this scalar bring-up kernel indexes K/V by the Q head and has no "
+            "grouped head map; the warp-specialized producer is the live path"
+        )
     seqlen_q = int(config["seqlen_q"])
     seqlen_kv = int(config["seqlen_kv"])
     max_blocks = int(config["kv_blocks"])
@@ -108,9 +113,10 @@ def make_forward_kernel(**config):
         split_offsets: K.gptr[K.i32],
         softmax_scale: K.f32,
     ):
-        # Numerically direct bring-up transcription of the sparse block/split
-        # contract.  The source-shaped TMA/TMEM datapath replaces this loop in
-        # the implementation-review revision.
+        # Numerically direct transcription of the sparse block/split contract.
+        # The warp-specialized TMA/TMEM producer in ``source_kernel.py`` is the
+        # path this module actually launches; this loop is kept only as a
+        # readable statement of the same contract.
         if use_clc:
             q_block, head, batch_idx = K.cta_id_in_cluster([q_blocks, num_heads, batch])
             split = K.int32(0)
@@ -213,7 +219,7 @@ def make_forward_kernel(**config):
 
 def make_combine_kernel(**config):
     batch = int(config["batch"])
-    num_heads = int(config["num_heads"])
+    num_heads = int(config["num_q_heads"])
     seqlen_q = int(config["seqlen_q"])
     num_splits = _resolve_splits(config["kv_splits"])
     max_splits = 1 << (num_splits - 1).bit_length()

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/reference.py
@@ -7,6 +7,15 @@
 
 Upstream source: ``python/cudnn/block_sparse_attention/_interface.py``, from the
 cuDNN Frontend source install pinned in ``reference-dependencies.json``.
+
+The upstream convenience wrapper ``bsa_attn_fwd_blk64_cutedsl`` accepts only
+equal Q and KV head counts: it asserts ``num_head == num_head_kv`` and pins
+``qhead_per_kvhead = 1`` before constructing the kernel. The kernel class itself
+takes the ratio as a constructor argument and already carries it in the compile
+key, and its device program maps a Q head to its KV head in a single expression.
+``_call_blk64_grouped`` therefore reaches the same class with the real ratio,
+reproducing the wrapper's host work verbatim; equal head counts keep using the
+upstream wrapper so that path stays byte-for-byte what upstream runs.
 """
 
 import torch
@@ -15,9 +24,281 @@ from tirx_kernels.cudnn._reference import load_reference_module
 
 _INTERFACE = "cudnn.block_sparse_attention._interface"
 
+# Compiled grouped-head programs, keyed exactly like the upstream wrapper keys
+# its own cache. Kept local so the upstream wrapper's cache stays untouched.
+_GROUPED_COMPILE_CACHE = {}
+
 
 def load_interface():
     return load_reference_module(_INTERFACE)
+
+
+def _call_blk64_grouped(
+    interface,
+    q,
+    k,
+    v,
+    q2k_block_index,
+    block_sizes,
+    q2k_block_nums=None,
+    softmax_scale=None,
+    layout="bhsd",
+    block_sparse_num=0,
+    allow_empty_block_nums=False,
+    use_clc=None,
+    kv_splits=1,
+):
+    """Run the upstream blk64 forward class with a grouped Q-to-KV head map.
+
+    Mirrors ``_interface.bsa_attn_fwd_blk64_cutedsl`` host work; the head-count
+    equality it asserts is relaxed to divisibility, the ratio it pins to 1 is
+    computed, and the compiled programs live in a module-local cache.
+    """
+    assert q.dtype == torch.bfloat16, "blk64 CuTeDSL requires bf16"
+    assert q.is_cuda and k.is_cuda and v.is_cuda
+    assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4
+    auto_kv_splits = isinstance(kv_splits, str)
+    if auto_kv_splits:
+        assert kv_splits == "auto", "kv_splits string value must be 'auto'"
+        kv_splits_i = 1
+    else:
+        kv_splits_i = int(kv_splits)
+        assert kv_splits_i >= 1, "kv_splits must be >= 1"
+
+    if layout == "bhsd":
+        q_bhsd, k_bhsd, v_bhsd = [interface.maybe_contiguous(t) for t in (q, k, v)]
+    else:
+        assert layout == "bshd", f"layout must be 'bhsd' or 'bshd', got {layout!r}"
+        q_bhsd = q.transpose(1, 2).contiguous()
+        k_bhsd = k.transpose(1, 2).contiguous()
+        v_bhsd = v.transpose(1, 2).contiguous()
+
+    batch_size, num_head, seqlen_q, head_dim = q_bhsd.shape
+    seqlen_k = k_bhsd.shape[2]
+    num_head_kv = k_bhsd.shape[1]
+    head_dim_v = v_bhsd.shape[-1]
+
+    assert head_dim == 128 and head_dim_v == 128, "blk64 CuTeDSL requires D=DV=128"
+    # The upstream wrapper asserts equality here; the kernel class only needs the
+    # Q head count to be a whole multiple of the KV head count.
+    assert num_head % num_head_kv == 0, "Q heads must be a multiple of KV heads"
+    assert k_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim)
+    assert v_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim_v)
+    assert q2k_block_index.dtype == torch.int32
+    q2k_block_index = interface.maybe_contiguous(q2k_block_index)
+    has_block_sizes = block_sizes is not None and block_sizes.numel() > 0
+    if has_block_sizes:
+        block_sizes = interface.maybe_contiguous(block_sizes)
+        assert block_sizes.dtype == torch.int32
+    else:
+        block_sizes = None
+    num_q_blocks = (seqlen_q + 63) // 64
+    has_variable_block_nums = q2k_block_nums is not None and q2k_block_nums.numel() > 0
+    if has_variable_block_nums:
+        q2k_block_nums = interface.maybe_contiguous(q2k_block_nums)
+        assert q2k_block_nums.dtype == torch.int32
+        # Sparse metadata stays Q-head-sided under a grouped head map.
+        assert q2k_block_nums.shape == (batch_size, num_head, num_q_blocks), (
+            f"q2k_block_nums must be shaped (B, H, ceil(S_q/64)); got {tuple(q2k_block_nums.shape)}"
+        )
+        uniform_block_sparse_num = 0
+    else:
+        if block_sparse_num <= 0:
+            block_sparse_num = int(q2k_block_index.shape[-1])
+        assert q2k_block_index.shape[-1] >= block_sparse_num, (
+            f"q2k_block_index last dim ({q2k_block_index.shape[-1]}) must be "
+            f">= block_sparse_num ({block_sparse_num})"
+        )
+        uniform_block_sparse_num = int(block_sparse_num)
+        q2k_block_nums = None
+
+    interface._validate_sm100_blk64_int32_bounds(
+        q_bhsd,
+        k_bhsd,
+        v_bhsd,
+        q2k_block_index,
+        uniform_block_sparse_num,
+        block_sizes,
+        q2k_block_nums,
+    )
+    use_int64_kv_strides = interface._sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
+
+    if softmax_scale is None:
+        softmax_scale = head_dim**-0.5
+
+    dtype = interface.torch2cute_dtype_map[q_bhsd.dtype]
+    arch = interface._get_device_arch()
+    allow_empty_block_nums = has_variable_block_nums and allow_empty_block_nums
+    sparse_block_size = 64
+    # The wrapper pins this to 1; the kernel maps head -> head // ratio for K/V.
+    qhead_per_kvhead = num_head // num_head_kv
+    tile_m = 64
+    tile_n = 256
+    if auto_kv_splits:
+        kv_splits_i = interface._sm100_blk64_auto_kv_splits(
+            q_bhsd, q2k_block_index, uniform_block_sparse_num
+        )
+    kv_splits_i = interface._resolve_blk64_split_workspace(
+        q_bhsd, head_dim_v, kv_splits_i, allow_fallback=auto_kv_splits
+    )
+    if use_clc is None:
+        if kv_splits_i > 1:
+            use_clc_scheduler = False
+        else:
+            use_clc_scheduler = interface.choose_blk64_cutedsl_use_clc(
+                q_bhsd,
+                uniform_block_sparse_num,
+                q2k_block_nums if has_variable_block_nums else None,
+                layout="bhsd",
+            )
+    else:
+        use_clc_scheduler = bool(use_clc)
+    assert not (kv_splits_i > 1 and use_clc_scheduler), (
+        "blk64 CuTeDSL kv_splits>1 does not support use_clc=True"
+    )
+    is_persistent = use_clc_scheduler
+    pack_gqa = False
+    input_layout = "bhsd_native"
+
+    split_offsets = None
+    if kv_splits_i > 1:
+        split_offsets = interface._build_sm100_blk64_kv_split_offsets(
+            q2k_block_nums,
+            uniform_block_sparse_num,
+            batch_size,
+            num_head,
+            num_q_blocks,
+            kv_splits_i,
+            q_bhsd.device,
+        )
+        out_bhsd = torch.empty(
+            (batch_size, kv_splits_i * num_head, seqlen_q, head_dim_v),
+            dtype=torch.float32,
+            device=q_bhsd.device,
+        )
+        lse = torch.empty(
+            (batch_size, kv_splits_i * num_head, seqlen_q),
+            dtype=torch.float32,
+            device=q_bhsd.device,
+        )
+    else:
+        out_bhsd = torch.empty(
+            (batch_size, num_head, seqlen_q, head_dim_v), dtype=q_bhsd.dtype, device=q_bhsd.device
+        )
+        lse = torch.empty(
+            (batch_size, num_head, seqlen_q), dtype=torch.float32, device=q_bhsd.device
+        )
+
+    current_stream = interface.cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compile_key = interface._dynamic_tensors_compile_key(
+        "sm100_blk64_fwd",
+        (
+            dtype,
+            head_dim,
+            head_dim_v,
+            qhead_per_kvhead,
+            pack_gqa,
+            tile_m,
+            tile_n,
+            sparse_block_size,
+            arch,
+            has_variable_block_nums,
+            allow_empty_block_nums,
+            has_block_sizes,
+            kv_splits_i,
+            out_bhsd.dtype,
+            is_persistent,
+            use_clc_scheduler,
+            input_layout,
+            use_int64_kv_strides,
+        ),
+        (
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            out_bhsd,
+            lse,
+            q2k_block_index,
+            block_sizes,
+            q2k_block_nums,
+            split_offsets,
+        ),
+    )
+
+    if compile_key not in _GROUPED_COMPILE_CACHE:
+        cute = interface.cute
+        q_tensor, k_tensor, v_tensor, o_tensor = [
+            interface._to_cute_tensor(t) for t in (q_bhsd, k_bhsd, v_bhsd, out_bhsd)
+        ]
+        lse_tensor = interface._to_cute_tensor(lse, assumed_align=4)
+        block_index_tensor = interface._to_cute_tensor(q2k_block_index)
+        block_sizes_tensor = interface._to_cute_tensor(block_sizes) if has_block_sizes else None
+        block_nums_tensor = (
+            interface._to_cute_tensor(q2k_block_nums) if has_variable_block_nums else None
+        )
+        split_offsets_tensor = (
+            interface._to_cute_tensor(split_offsets) if split_offsets is not None else None
+        )
+
+        bsa_fwd = interface.BlockSparseAttnForwardSm100Blk64(
+            head_dim,
+            head_dim_v,
+            qhead_per_kvhead=qhead_per_kvhead,
+            pack_gqa=pack_gqa,
+            m_block_size=tile_m,
+            n_block_size=tile_n,
+            sparse_block_size=sparse_block_size,
+            is_persistent=is_persistent,
+            use_clc_scheduler=use_clc_scheduler,
+            allow_empty_block_nums=allow_empty_block_nums,
+            has_block_sizes=has_block_sizes,
+            num_splits=kv_splits_i,
+            use_int64_kv_strides=use_int64_kv_strides,
+        )
+
+        _GROUPED_COMPILE_CACHE[compile_key] = cute.compile(
+            bsa_fwd,
+            q_tensor,
+            k_tensor,
+            v_tensor,
+            o_tensor,
+            lse_tensor,
+            softmax_scale,
+            block_index_tensor,
+            block_sizes_tensor,
+            uniform_block_sparse_num,
+            block_nums_tensor,
+            split_offsets_tensor,
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+            options="--enable-tvm-ffi",
+        )
+
+    with torch.cuda.nvtx.range("bsa_attn_fwd_blk64_cutedsl_kernel"):
+        _GROUPED_COMPILE_CACHE[compile_key](
+            q_bhsd.detach(),
+            k_bhsd.detach(),
+            v_bhsd.detach(),
+            out_bhsd.detach(),
+            lse,
+            softmax_scale,
+            q2k_block_index.detach(),
+            block_sizes.detach() if has_block_sizes else None,
+            uniform_block_sparse_num,
+            q2k_block_nums.detach() if has_variable_block_nums else None,
+            split_offsets.detach() if split_offsets is not None else None,
+            current_stream,
+        )
+
+    if kv_splits_i > 1:
+        out_bhsd, lse = interface._combine_blk64_kv_bucketed_partials(
+            q_bhsd, out_bhsd, lse, kv_splits_i
+        )
+        # Keep split_offsets alive through the combine launch on the same stream.
+        _ = split_offsets
+
+    out = out_bhsd if layout == "bhsd" else out_bhsd.transpose(1, 2).contiguous()
+    return out, lse
 
 
 def compile_reference(data):
@@ -25,6 +306,9 @@ def compile_reference(data):
     interface = load_interface()
     config = data["config"]
     inputs = data["inputs"]
+    # Read the head map off the BHSD buffers rather than the config so the
+    # dispatch cannot drift from the tensors actually handed to the source.
+    grouped = inputs["q"].shape[1] != inputs["k"].shape[1]
     source_batches = None
     if config["batch"] > 1:
         source_batches = tuple(
@@ -39,12 +323,7 @@ def compile_reference(data):
         )
 
     def call_source(q, k, v, block_index, block_nums):
-        return interface.bsa_attn_fwd_blk64_cutedsl(
-            q,
-            k,
-            v,
-            block_index,
-            inputs["block_sizes"] if config["has_block_sizes"] else None,
+        kwargs = dict(
             q2k_block_nums=(block_nums if config["block_count_mode"] != "fixed" else None),
             softmax_scale=inputs["softmax_scale"],
             layout=config["tensor_layout"],
@@ -53,6 +332,10 @@ def compile_reference(data):
             use_clc=config["use_clc"],
             kv_splits=config["kv_splits"],
         )
+        block_size_arg = inputs["block_sizes"] if config["has_block_sizes"] else None
+        if grouped:
+            return _call_blk64_grouped(interface, q, k, v, block_index, block_size_arg, **kwargs)
+        return interface.bsa_attn_fwd_blk64_cutedsl(q, k, v, block_index, block_size_arg, **kwargs)
 
     def launch():
         # The pinned source's static scheduler launches only batch 0 when B>1.

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/source_kernel.py
@@ -317,13 +317,34 @@ def _exchange_reduce_store(exchange, o_raw, corr_warp, lane, split_output):
                 )
 
 
+def _kv_head(head, ratio):
+    """Map a Q head onto the KV head whose tile it reads.
+
+    ``head`` comes from the grid or the CLC response and is never negative, so
+    the division is done unsigned. That matters: on the split-KV and CLC paths
+    the source's head index is a signed value of unproven sign and its division
+    costs ten instructions, while the unsigned form stays at one.
+    """
+    if ratio == 1:
+        return head
+    if ratio & (ratio - 1) == 0:
+        return K.cast(
+            K.shift_right(K.cast(head, "uint32"), K.uint32(ratio.bit_length() - 1)), "int32"
+        )
+    return K.cast(K.cast(head, "uint32") // K.uint32(ratio), "int32")
+
+
 def _resolve_splits(value):
     return 2 if value == "auto" else int(value)
 
 
 def make_forward_kernel(**config):
     batch = int(config["batch"])
-    heads = int(config["num_heads"])
+    heads = int(config["num_q_heads"])
+    kv_heads = int(config["num_kv_heads"])
+    if heads % kv_heads != 0:
+        raise ValueError("num_q_heads must be a multiple of num_kv_heads")
+    head_ratio = heads // kv_heads
     seqlen_q = int(config["seqlen_q"])
     seqlen_kv = int(config["seqlen_kv"])
     max_blocks = int(config["kv_blocks"])
@@ -471,6 +492,11 @@ def make_forward_kernel(**config):
         raw_count = K.local_scalar("int32")
         split_start = K.local_scalar("int32", init=0)
         count_index = (batch_idx * heads + head) * q_blocks + q_block
+        # The K/V TensorMap fuses (batch, KV head) into its outermost dimension,
+        # so a Q head selects its group's KV tile here. Both operands read the
+        # live work-item scalars, which is what a persistent CLC producer needs:
+        # the coordinate follows `head` as the scheduler advances it.
+        kv_slot = batch_idx * kv_heads + _kv_head(head, head_ratio)
 
         def load_tile_metadata():
             K.assign(split_start, 0)
@@ -561,7 +587,7 @@ def make_forward_kernel(**config):
                                     K.int32(0),
                                     K.cast(half, "int32"),
                                     sid,
-                                    batch_idx * heads + head,
+                                    kv_slot,
                                     K.cuda.cvta_generic_to_shared(kv_full.ptr_to([kv_stage])),
                                     TMA_CACHE,
                                 )
@@ -574,7 +600,7 @@ def make_forward_kernel(**config):
                                 K.int32(0),
                                 K.int32(0),
                                 sid,
-                                batch_idx * heads + head,
+                                kv_slot,
                                 K.cuda.cvta_generic_to_shared(kv_full.ptr_to([kv_stage])),
                                 TMA_CACHE,
                             )

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/spec.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_forward_sm100_blk64/spec.py
@@ -15,7 +15,8 @@ def _config(
     label,
     *,
     batch,
-    num_heads,
+    num_q_heads,
+    num_kv_heads=None,
     seqlen_q,
     seqlen_kv,
     kv_blocks,
@@ -29,10 +30,22 @@ def _config(
     use_int64_kv_strides=False,
     seed=0,
 ):
+    # A KV head count of None is the MHA case: one KV head per Q head. Q heads
+    # are shared across KV heads in whole groups, which is what lets the kernel
+    # map a Q head onto its KV head with a single division.
+    if num_kv_heads is None:
+        num_kv_heads = num_q_heads
+    if num_q_heads <= 0 or num_kv_heads <= 0:
+        raise ValueError("head counts must be positive")
+    if num_q_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_q_heads ({num_q_heads}) must be a multiple of num_kv_heads ({num_kv_heads})"
+        )
     return {
         "label": label,
         "batch": batch,
-        "num_heads": num_heads,
+        "num_q_heads": num_q_heads,
+        "num_kv_heads": num_kv_heads,
         "seqlen_q": seqlen_q,
         "seqlen_kv": seqlen_kv,
         "kv_blocks": kv_blocks,
@@ -62,7 +75,7 @@ def correctness_configs():
             add(
                 f"b1_h2_sq128_skv256_kv2_mask_{tensor_layout}_s{kv_splits}_static",
                 batch=1,
-                num_heads=2,
+                num_q_heads=2,
                 seqlen_q=128,
                 seqlen_kv=256,
                 kv_blocks=2,
@@ -72,7 +85,7 @@ def correctness_configs():
     add(
         "b2_h1_sq64_skv255_kv2_mask_bhsd_s1_static",
         batch=2,
-        num_heads=1,
+        num_q_heads=1,
         seqlen_q=64,
         seqlen_kv=255,
         kv_blocks=2,
@@ -82,7 +95,7 @@ def correctness_configs():
             add(
                 f"b1_h1_sq{seqlen_q}_skv256_kv2_mask_bhsd_s{kv_splits}_static",
                 batch=1,
-                num_heads=1,
+                num_q_heads=1,
                 seqlen_q=seqlen_q,
                 seqlen_kv=256,
                 kv_blocks=2,
@@ -92,7 +105,7 @@ def correctness_configs():
     add(
         "b1_h1_sq129_skv512_kv4_nomask_scale0125_bhsd_s1_static",
         batch=1,
-        num_heads=1,
+        num_q_heads=1,
         seqlen_q=129,
         seqlen_kv=512,
         kv_blocks=4,
@@ -145,7 +158,7 @@ def correctness_configs():
         add(
             label,
             batch=1,
-            num_heads=2,
+            num_q_heads=2,
             seqlen_q=129,
             seqlen_kv=512,
             kv_blocks=4,
@@ -165,7 +178,7 @@ def correctness_configs():
         add(
             label,
             batch=1,
-            num_heads=1,
+            num_q_heads=1,
             seqlen_q=sq,
             seqlen_kv=skv,
             kv_blocks=blocks,
@@ -175,13 +188,83 @@ def correctness_configs():
     add(
         "b1_h1_sq65_skv512_kv4_mask_bhsd_s1_static_i64kv",
         batch=1,
-        num_heads=1,
+        num_q_heads=1,
         seqlen_q=65,
         seqlen_kv=512,
         kv_blocks=4,
         use_int64_kv_strides=True,
     )
-    assert len(configs) == 23
+
+    # Grouped Q-to-KV head maps. These are appended rather than interleaved so
+    # every row above keeps its seed, and therefore its exact input data. The
+    # ratios cover the three lowerings the head map can take: identity folding
+    # is already covered by every row above, a power-of-two ratio takes a single
+    # shift, and ratio 3 takes a reciprocal multiply.
+    for label, hq, hkv, sq, skv, blocks, kwargs in (
+        ("b1_h4kv2_sq128_skv256_kv2_mask_bhsd_s1_static_gqa", 4, 2, 128, 256, 2, {}),
+        (
+            "b1_h4kv2_sq129_skv512_kv4_mask_bshd_s1_static_gqa",
+            4,
+            2,
+            129,
+            512,
+            4,
+            {"tensor_layout": "bshd"},
+        ),
+        ("b1_h8kv2_sq129_skv512_kv4_mask_bhsd_s1_clc_gqa", 8, 2, 129, 512, 4, {"use_clc": True}),
+        (
+            "b1_h8kv2_sq129_skv512_maxkv4_var_1_3_4_mask_bhsd_s1_clc_gqa",
+            8,
+            2,
+            129,
+            512,
+            4,
+            {"use_clc": True, "block_count_mode": "variable", "block_count_pattern": "1,3,4"},
+        ),
+        (
+            "b1_h4kv2_sq129_skv512_maxkv4_var_0_1_4_mask_bhsd_s2_static_gqa",
+            4,
+            2,
+            129,
+            512,
+            4,
+            {"kv_splits": 2, "block_count_mode": "variable_empty", "block_count_pattern": "0,1,4"},
+        ),
+        ("b1_h8kv1_sq65_skv512_kv4_mask_bhsd_s1_static_mqa", 8, 1, 65, 512, 4, {}),
+        ("b1_h3kv1_sq129_skv512_kv4_mask_bhsd_s1_static_mqa", 3, 1, 129, 512, 4, {}),
+        ("b1_h8kv1_sq129_skv512_kv4_mask_bhsd_s1_clc_mqa", 8, 1, 129, 512, 4, {"use_clc": True}),
+        (
+            "b1_h4kv2_sq65_skv4096_kv64_nomask_bhsd_s8_static_gqa",
+            4,
+            2,
+            65,
+            4096,
+            64,
+            {"kv_splits": 8, "has_block_sizes": False},
+        ),
+        ("b2_h4kv2_sq64_skv255_kv2_mask_bhsd_s1_static_gqa", 4, 2, 64, 255, 2, {"batch": 2}),
+        (
+            "b1_h4kv2_sq65_skv512_kv4_mask_bhsd_s1_static_i64kv_gqa",
+            4,
+            2,
+            65,
+            512,
+            4,
+            {"use_int64_kv_strides": True},
+        ),
+        ("b1_h4kv1_sq1_skv256_kv2_mask_bhsd_s2_static_mqa", 4, 1, 1, 256, 2, {"kv_splits": 2}),
+    ):
+        add(
+            label,
+            batch=kwargs.pop("batch", 1),
+            num_q_heads=hq,
+            num_kv_heads=hkv,
+            seqlen_q=sq,
+            seqlen_kv=skv,
+            kv_blocks=blocks,
+            **kwargs,
+        )
+    assert len(configs) == 35
     return configs
 
 
@@ -330,10 +413,182 @@ def benchmark_configs():
             1,
             True,
         ),
+        # Grouped head maps, mirroring the shape scale of the rows above so a
+        # ratio's cost is read against a comparable equal-head row. A trailing
+        # element carries the KV head count; rows without one are equal-head.
+        (
+            "p11_b1_h8kv4_sq4096_skv8192_kv32_mask_s1_static_gqa",
+            1,
+            8,
+            4096,
+            8192,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+            4,
+        ),
+        (
+            "p12_b2_h8kv2_sq4096_skv8191_kv32_mask_s1_static_gqa",
+            2,
+            8,
+            4096,
+            8191,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+            2,
+        ),
+        (
+            "p13_b1_h8kv4_sq8192_skv4096_kv16_mask_s1_clc_gqa",
+            1,
+            8,
+            8192,
+            4096,
+            16,
+            True,
+            "fixed",
+            True,
+            1,
+            False,
+            4,
+        ),
+        (
+            "p14_b1_h8kv2_sq4096_skv8192_maxkv32_var_mask_s1_clc_gqa",
+            1,
+            8,
+            4096,
+            8192,
+            32,
+            True,
+            "variable",
+            True,
+            1,
+            False,
+            2,
+        ),
+        (
+            "p15_b2_h4kv1_sq4097_skv8191_maxkv32_empty_mask_s1_clc_mqa",
+            2,
+            4,
+            4097,
+            8191,
+            32,
+            True,
+            "variable_empty",
+            True,
+            1,
+            False,
+            1,
+        ),
+        (
+            "p16_b1_h8kv2_sq1024_skv32768_kv256_mask_s2_static_gqa",
+            1,
+            8,
+            1024,
+            32768,
+            256,
+            True,
+            "fixed",
+            False,
+            2,
+            False,
+            2,
+        ),
+        (
+            "p17_b1_h8kv4_sq4097_skv16384_maxkv128_var_mask_s2_static_gqa",
+            1,
+            8,
+            4097,
+            16384,
+            128,
+            True,
+            "variable_empty",
+            False,
+            2,
+            False,
+            4,
+        ),
+        (
+            "p18_b1_h8kv1_sq2048_skv32768_kv256_mask_s4_static_mqa",
+            1,
+            8,
+            2048,
+            32768,
+            256,
+            True,
+            "fixed",
+            False,
+            4,
+            False,
+            1,
+        ),
+        (
+            "p19_b1_h8kv1_sq2048_skv65536_kv512_nomask_s8_static_mqa",
+            1,
+            8,
+            2048,
+            65536,
+            512,
+            False,
+            "fixed",
+            False,
+            8,
+            False,
+            1,
+        ),
+        (
+            "p20_b1_h8kv2_sq4096_skv8192_kv32_mask_s1_static_i64kv_gqa",
+            1,
+            8,
+            4096,
+            8192,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            True,
+            2,
+        ),
+        (
+            "p21_b1_h8kv1_sq4097_skv8191_kv64_mask_s1_static_mqa",
+            1,
+            8,
+            4097,
+            8191,
+            64,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+            1,
+        ),
+        (
+            "p22_b1_h6kv2_sq2048_skv8192_kv32_mask_s1_static_gqa",
+            1,
+            6,
+            2048,
+            8192,
+            32,
+            True,
+            "fixed",
+            False,
+            1,
+            False,
+            2,
+        ),
     )
     configs = []
     for seed, row in enumerate(rows, start=7400):
-        label, batch, heads, sq, skv, blocks, mask, mode, clc, splits, i64kv = row
+        label, batch, heads, sq, skv, blocks, mask, mode, clc, splits, i64kv = row[:11]
+        kv_heads = row[11] if len(row) > 11 else heads
         pattern = (
             "0,1,max" if mode == "variable_empty" else "1,mid,max" if mode == "variable" else None
         )
@@ -341,7 +596,8 @@ def benchmark_configs():
             _config(
                 label,
                 batch=batch,
-                num_heads=heads,
+                num_q_heads=heads,
+                num_kv_heads=kv_heads,
                 seqlen_q=sq,
                 seqlen_kv=skv,
                 kv_blocks=blocks,


### PR DESCRIPTION
The blk64 forward port was scoped to BF16 MHA. The upstream kernel class also
implements a non-packed Q-to-KV head map through its `qhead_per_kvhead`
constexpr, consumed by its device code in a single expression. This carries that
over, so GQA and MQA run on this path for any ratio where `H_q % H_kv == 0`.

## Device change

One address expression: the K/V TMA head coordinate becomes `b * H_kv + h // r`.
Q, the sparse metadata, O, LSE and the grid stay Q-head indexed, and the split-KV
combine is unaffected because it folds `splits * H_q`.

Two details are load-bearing.

**The map folds at trace time when the ratio is one**, matching the source, which
emits nothing at that site. Generated CUDA is byte-identical to the pre-change
build for a static, a CLC and a split-KV configuration (PTX identical once nvcc's
path-derived `_INTERNAL_<hash>` symbols are normalized), so the equal-head shapes
cannot regress.

**The head index is narrowed to unsigned before dividing.** The source's emitted
form tracks the operand's provable sign rather than the ratio: one instruction
where the index is the raw grid coordinate, but a ten-instruction floor division
with negative-operand correction under CLC and split-KV, where the index arrives
from the scheduler's `divmod` or a decoded cluster-launch-control response. A head
index is never negative, so narrowing keeps the one-instruction form in every
scheduling mode. Verified in generated code: the ratio-8 CLC program contains four
`shr.u32` and zero `shr.s32 ,31` / `mul.hi.s32` / `selp`.

## Out of scope

FP16 and PackGQA. Both are advertised by the upstream header comment but broken in
the shipped code, and refused by the upstream host surface:

- FP16 converts through helpers that emit `cvt.rn.satfinite.bf16x2.f32`
  unconditionally, so the MMA instruction descriptor would declare F16 over BF16
  bits — wrong results rather than an error.
- The packed path bounds LSE rows by the unpacked sequence length where the packed
  layout needs `seqlen_q * r`, silently dropping rows. The blk128 sibling carries
  the corrected form.

## Coverage

Correctness grows 23 to 35 configs, the benchmark matrix 11 to 23 rows, covering
ratios 2, 3, 4 and 8 including MQA, crossed with BHSD/BSHD, CLC, variable and empty
counts, split-KV, 64-bit KV strides, batch 2 and the `Sq=1` tail. Existing rows keep
their labels and seeds, so their inputs are unchanged.

## Reference

The upstream convenience wrapper asserts equal head counts and pins
`qhead_per_kvhead` to 1, so grouped rows reach the same upstream kernel class
directly with the real ratio, reproducing the wrapper's host work; equal-head rows
keep using the wrapper unchanged. The grouped driver was validated against a
head-replication oracle — the stock wrapper on the same Q with K/V
`repeat_interleave`d to `H_q` heads — matching at `atol=0, rtol=0` on output, LSE
and the LSE finiteness mask, across ratios 1/3/4/8 and every axis combination.

## Validation

- `python -m tirx_kernels.test --kernel cudnn_sm100_bsa_forward_blk64`: **35/35 pass**
- Complete 23-row bench-suite matrix against the source: **every row above the
  0.99x gate, minimum 1.011x**, in a single clean run with no failed or voided
  rows. The twelve new grouped-head rows span 1.011x to 1.900x.

## Also

Sharpens the `divide-unsigned` diagnostics entry: the sign proof travels with the
value rather than the variable, so one specialization of a kernel can pay the
floordiv correction while another does not for identical source.
