### PR TITLE
fix(cudnn): order GDN and MXFP8 shared-memory reuse

### DIFF
--- a/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
@@ -732,7 +732,7 @@ def _blockwise_16_to_32(arena, tinv_byte_base, d0, lane, io_dtype):
     )
 
 
-def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
+def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype, store_result):
     """Off-diagonal correction 32x32 -> 64x64 (two warps, one 16-row band each)."""
     lane_off = (lane % 16) * 64 + (lane // 16) * 8
     a_frags = K.alloc_local((8,), "uint32")
@@ -815,16 +815,22 @@ def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
     for pair in range(8):
         K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-    _stmatrix_x4(
-        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]),
-        [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
-    )
-    _stmatrix_x4(
-        arena.ptr_to(
-            [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
-        ),
-        [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
-    )
+    with K.If(store_result), K.Then():
+        _stmatrix_x4(
+            arena.ptr_to(
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]
+            ),
+            [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
+        )
+        _stmatrix_x4(
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2
+                ]
+            ),
+            [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
+        )
 
 
 def _acc_operand(accumulate):
@@ -1445,7 +1451,9 @@ def _make_main(
                     with K.If(do_inv), K.Then():
                         _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype)
+                    _blockwise_32_to_64(
+                        arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv
+                    )
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
 
                     # ---- post-inverse beta column scaling + publish --------

--- a/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
@@ -782,7 +782,7 @@ def _blockwise_16_to_32(arena, tinv_byte_base, d0, lane, io_dtype):
     )
 
 
-def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
+def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype, store_result):
     """Off-diagonal correction 32x32 -> 64x64 (two warps, one 16-row band each)."""
     lane_off = (lane % 16) * 64 + (lane // 16) * 8
     a_frags = K.alloc_local((8,), "uint32")
@@ -865,16 +865,22 @@ def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype):
     for pair in range(8):
         K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-    _stmatrix_x4(
-        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]),
-        [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
-    )
-    _stmatrix_x4(
-        arena.ptr_to(
-            [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
-        ),
-        [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
-    )
+    with K.If(store_result), K.Then():
+        _stmatrix_x4(
+            arena.ptr_to(
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]
+            ),
+            [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
+        )
+        _stmatrix_x4(
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2
+                ]
+            ),
+            [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
+        )
 
 
 def _acc_operand(accumulate):
@@ -1457,7 +1463,9 @@ def _make_main(
                     with K.If(do_inv), K.Then():
                         _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype)
+                    _blockwise_32_to_64(
+                        arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv
+                    )
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
 
                     # ---- post-inverse beta column scaling + publish --------

--- a/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -354,6 +354,7 @@ def _make_kernel(tokens, k_dim, num_heads):
                     handle_stage = K.local_scalar("int32", init=tma_state.stage)
                     handle_phase = K.local_scalar("int32", init=tma_state.phase)
                     _wait_plain(ab_pipe.empty.ptr_to([handle_stage]), handle_phase)
+                    K.ptx["fence.proxy.async.shared::cta"]()
                     _advance(tma_state)
                     with K.If(_elected()):
                         with K.Then():


### PR DESCRIPTION
## Summary

- Restrict GDN prefill/recompute 32→64 inverse-result publication to the `do_inv` warp while keeping all participating warps in the computation and barriers.
- Add `fence.proxy.async.shared::cta` before reusing the MXFP8 projection shared scale slot after the async-pipe wait.

## Validation

- Wiki-side 6-kernel NumSim/Synccheck/Racecheck: 18 passed
- GDN Racecheck 124-kernel controller: 1 passed
- Full `tirx_tools` gate: 2928 passed
- Registry manifest: 1 passed
- Wiki relocation/pinning/package integration: 18 passed
- Ruff and `git diff --check`: passed
