### PR TITLE
fix cudnn BSA backward odd edge sentinel

### DIFF
--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/kernel.py
@@ -358,7 +358,11 @@ def get_kernel(**config):
                 def load_pair(first):
                     q0 = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
                     K.assign(edge, edge + K.int32(1))
-                    q1 = K.local_scalar("int32", init=K.int32(seqlen_q // 64))
+                    # Use the first out-of-range query block as the pair sentinel.
+                    # ``seqlen_q // 64`` aliases the last valid block whenever
+                    # the query length is not a multiple of 64, duplicating
+                    # its contribution in the odd-edge pair.
+                    q1 = K.local_scalar("int32", init=K.int32((seqlen_q + 63) // 64))
                     with K.If(edge < count), K.Then():
                         K.assign(
                             q1, _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
@@ -840,7 +844,7 @@ def get_kernel(**config):
                     dq_pipe.full.wait(dq_cons.stage, dq_cons.phase)
                     q0 = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
                     K.assign(edge, edge + K.int32(1))
-                    q1 = K.local_scalar("int32", init=K.int32(seqlen_q // 64))
+                    q1 = K.local_scalar("int32", init=K.int32((seqlen_q + 63) // 64))
                     with K.If(edge < count), K.Then():
                         K.assign(
                             q1, _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))


### PR DESCRIPTION
## Summary
- use the first out-of-range query block as the odd-edge pair sentinel in BSA backward blk64
- apply the same ceil-div query-block count in both backward paths

## Root cause
For `seqlen_q` values that are not multiples of 64, `seqlen_q // 64` points at the last valid query block instead of the first invalid block. An odd edge pair could therefore load and accumulate that valid block twice.

## Validation
- canonical NumSim correctness for `cudnn_sm100_bsa_backward_blk64`: passed
- BSA synccheck/racecheck validation: passed
- full tirx_tools gate: 2936 passed; one isolated GDN Racecheck performance controller rerun passed after a scheduler-dependent mismatch
