### PR TITLE
fix(kernel): validate BSA backward ragged tails

### DIFF
--- a/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_backward_blk64.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/bsa/cudnn_sm100_bsa_backward_blk64.yaml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
 kernel: cudnn_sm100_bsa_backward_blk64
-selection_rationale: The selected defaults cover a small ordinary launch, medium variable sparsity including empty rows, and a large auto-1024 three-group launch with 64-bit KV strides. The full matrix additionally covers ragged tails, batch/head occupancy, fixed and variable sparse degree, masked and unmasked blocks, long KV, the 1088 two-group scheduler branch, and the large convert grid.
+selection_rationale: The selected defaults cover a small ordinary launch, medium variable sparsity, and a large block-aligned auto-1024 three-group launch with 64-bit KV strides. The full matrix additionally covers empty rows, ragged tails, batch/head occupancy, fixed and variable sparse degree, masked and unmasked blocks, long KV, the 1088 two-group scheduler branch, and the large convert grid. Ragged backward rows use the analytic oracle because the pinned cuDNN Frontend source has an incorrect odd-pair sentinel.
 defaults:
   num_gpus: 1
 configs:
@@ -16,4 +16,5 @@ configs:
   - {config: p07_b1_h4_sq4097_skv16384_maxkv128_var_mask, default: false}
   - {config: p08_b1_h8_sq2048_skv65536_kv512_nomask, default: false}
   - {config: p09_b1_h2_sq69633_skv8191_kv32_mask_bucket1088, default: false}
-  - {config: p10_b1_h1_sq192001_skv8192_maxkv16_var_mask_auto1024_i64kv, default: true, selection_role: large}
+  - {config: p10_b1_h1_sq192001_skv8192_maxkv16_var_mask_auto1024_i64kv, default: false}
+  - {config: p11_b1_h1_sq192000_skv8192_maxkv16_var_mask_auto1024_i64kv, default: true, selection_role: large}

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/data.py
@@ -147,6 +147,8 @@ def _make_metadata(config, *, q_blocks, kv_blocks, device):
     block_index = block_index.to(torch.int32).reshape(batch, heads, q_blocks, maximum)
 
     values = _pattern_values(config)
+    if config["block_count_mode"] != "variable_empty" and 0 in values:
+        raise ValueError("zero block counts require block_count_mode='variable_empty'")
     pattern_shift = (
         1
         if config["block_count_mode"] == "variable_empty" and any(value != 0 for value in values)

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/spec.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk64/spec.py
@@ -29,6 +29,33 @@ def _config(label, **overrides):
     return config
 
 
+def upstream_has_ragged_pair_sentinel_bug(config):
+    """Whether the pinned source is unsafe as a numerical arbiter.
+
+    The upstream SM100 blk64 backward source initializes an unpaired inverse-CSR
+    slot with ``SQ // 64``. That is one-past-the-end only for block-aligned SQ;
+    on a ragged shape it aliases the final valid Q block whenever a task has an
+    odd edge count. Edge-count parity depends on generated metadata, so every
+    ragged specialization is conservatively excluded from source arbitration.
+    """
+    return int(config["seqlen_q"]) % 64 != 0
+
+
+def correctness_tolerance_overrides(config):
+    """Tighten the minimal ragged case so a duplicated tail cannot pass."""
+    is_minimal_ragged_case = (
+        int(config["batch"]) == 1
+        and int(config["num_heads"]) == 1
+        and int(config["seqlen_q"]) == 1
+        and int(config["seqlen_kv"]) == 65
+        and int(config["kv_blocks"]) == 2
+        and config["block_count_mode"] == "fixed"
+    )
+    if not is_minimal_ragged_case:
+        return None
+    return {"dv_acc": (1e-3, 1e-3)}
+
+
 def correctness_configs():
     rows = (
         ("c00_b1_h2_sq128_skv256_kv2_mask", dict(num_heads=2)),
@@ -165,7 +192,7 @@ def benchmark_configs():
                 seqlen_kv=16384,
                 kv_blocks=128,
                 block_count_mode="variable",
-                block_count_pattern="0,1,max",
+                block_count_pattern="1,mid,max",
             ),
         ),
         (
@@ -187,9 +214,20 @@ def benchmark_configs():
                 use_int64_kv_strides=True,
             ),
         ),
+        (
+            "p11_b1_h1_sq192000_skv8192_maxkv16_var_mask_auto1024_i64kv",
+            dict(
+                seqlen_q=192000,
+                seqlen_kv=8192,
+                kv_blocks=16,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+                use_int64_kv_strides=True,
+            ),
+        ),
     )
     configs = []
     for index, (label, overrides) in enumerate(rows):
         configs.append(_config(label, seed=16501 + index, **overrides))
-    assert len(configs) == 11
+    assert len(configs) == 12
     return configs

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
@@ -34,19 +34,24 @@ def prepare_data(**config):
 
 
 def run_test(**config):
+    """Validate TIRx against the analytic oracle and usable upstream specializations."""
     import torch
 
     from tirx_kernels.runner import compile_kernel
 
+    tolerance_overrides = _spec.correctness_tolerance_overrides(config)
     kernel_config = _without_label(config)
     data = prepare_data(**kernel_config)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
     tirx_launch = _data.tirx_launch(executables, data)
     tirx_launch()
-    source_launch = _reference.compile_reference(data)
-    source_launch()
+    sources = ("tirx",)
+    if not _spec.upstream_has_ragged_pair_sentinel_bug(kernel_config):
+        source_launch = _reference.compile_reference(data)
+        source_launch()
+        sources = ("tirx", "source")
     torch.cuda.synchronize()
-    _data.validate_outputs(data, sources=("tirx", "source"))
+    _data.validate_outputs(data, sources=sources, tolerance_overrides=tolerance_overrides)
 
 
 def prepare_bench(**config):
@@ -71,12 +76,19 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     tirx_launch()
     torch.cuda.synchronize()
     references = None
-    if external_references_enabled():
+    # The pinned source has the same floor-division sentinel bug fixed in this
+    # port, so it is not a valid numerical or performance baseline for ragged SQ.
+    with_source = external_references_enabled() and not _spec.upstream_has_ragged_pair_sentinel_bug(
+        config
+    )
+    if with_source:
         source_launch = _reference.compile_reference(data)
         source_launch()
         torch.cuda.synchronize()
-        _data.validate_outputs(data, sources=("tirx", "source"), with_oracle=False)
         references = {"cudnn_frontend": lambda: source_launch}
+    _data.validate_outputs(
+        data, sources=("tirx", "source") if with_source else ("tirx",), with_oracle=False
+    )
     return bench(
         {"tirx": tirx_launch},
         references=references,


### PR DESCRIPTION
## Summary

- validate ragged SM100 blk64 BSA backward configurations against the independent FP64 oracle because the pinned cuDNN Frontend source retains the odd-pair sentinel bug fixed for TIRx in #136
- tighten the minimal c04 ragged regression so the duplicated-tail implementation fails deterministically
- enforce the empty-row mode contract and correct the non-empty p07 sparsity pattern
- retain ragged p10 as a non-default coverage row and use block-aligned p11 for the default large reference benchmark

## Validation

- BSA backward correctness matrix: 20 passed
- TVM registry defaults for this kernel: 3 passed
- direct oracle checks: p05, p07, p10, and p11 passed
- bench-suite import gate: 253 defaults across 86 kernels passed
- tests/test_bench_suite_run.py: 4 passed
- pre-commit: passed