### PR TITLE
refactor(kern): move low-level IR checker into kern

### DIFF
--- a/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
+++ b/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
@@ -620,7 +620,7 @@ if (n == 0) & (vz == 0) & (tid < D):
 * Helpers (`_ptx_*`, non-FTZ scalar math, BF16 pack/convert, shuffles, guarded
   stores) are imported from the one-warp sibling module rather than duplicated.
 * Every global **and shared** access must go through raw PTX with `ptr_to`:
-  `low_level_ir.py:26` forbids `BufferLoad`/`BufferStore` on `global`, `shared`,
+  `kern/low_level_ir.py` forbids `BufferLoad`/`BufferStore` on `global`, `shared`,
   and `shared.dyn` alike.
 * TVM compiles with `--use_fast_math`, so native FP32 arithmetic lowers to
   `.ftz` forms. The source's only `.ftz` instruction is `ex2.approx.ftz.f32`;

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -99,7 +99,7 @@ def test_retired_binding_forms_are_rejected_with_guidance():
 def test_kernel_build_runs_low_level_ir_check_by_default():
     import pytest
 
-    from tirx_kernels.low_level_ir import LowLevelIRContractError
+    from tirx_kernels.kern.low_level_ir import LowLevelIRContractError
 
     def build(**kw):
         @K.kernel(warps=1, arch="sm_100a", grid=False, **kw)
@@ -201,9 +201,7 @@ def test_kernel_records_python_source_spans():
 
     assert probe.func.span is not None
     assert probe.func.span.source_name.name == inspect.getsourcefile(emit)
-    assert "@K.kernel" in linecache.getline(
-        probe.func.span.source_name.name, probe.func.span.line
-    )
+    assert "@K.kernel" in linecache.getline(probe.func.span.source_name.name, probe.func.span.line)
 
     statements = probe.func.body.body.seq
     stores = [stmt for stmt in statements if type(stmt).__name__ == "Evaluate"]

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -4,12 +4,8 @@
 import pytest
 
 import tirx_kernels.kern as K
-from tirx_kernels.low_level_ir import (
-    LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL,
-    NVSHMEM_RUNTIME_FUNC_CALLS,
-    LowLevelIRContractError,
-    check_low_level_ir,
-)
+from tirx_kernels.kern.low_level_ir import LowLevelIRContractError, check_low_level_ir
+from tirx_kernels.runner import run_kernel_test
 
 
 def _kernel_with_func_call(callee: str):
@@ -30,29 +26,31 @@ def test_func_call_is_rejected_by_default_and_reports_callee():
 
 
 def test_only_exact_kernel_local_helpers_are_exempt():
-    assert LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL == {
-        "gemm_reduce_scatter": frozenset(
-            {
-                "enqueue_remote",
-                "exit_barrier_arrive_and_wait",
-                "ld_reduce_8_fp16",
-                "semaphore_notify_remote",
-            }
-        )
-    }
+    allowed_func_calls = frozenset({"expected_runtime_helper"})
 
-    for callee in NVSHMEM_RUNTIME_FUNC_CALLS:
-        report = check_low_level_ir(
-            _kernel_with_func_call(callee), allowed_func_calls=NVSHMEM_RUNTIME_FUNC_CALLS
-        )
-        assert report.ok
-        assert [finding.callee for finding in report.func_calls] == [callee]
+    report = check_low_level_ir(
+        _kernel_with_func_call("expected_runtime_helper"), allowed_func_calls=allowed_func_calls
+    )
+    assert report.ok
+    assert [finding.callee for finding in report.func_calls] == ["expected_runtime_helper"]
 
     with pytest.raises(LowLevelIRContractError):
         check_low_level_ir(
-            _kernel_with_func_call("another_runtime_helper"),
-            allowed_func_calls=NVSHMEM_RUNTIME_FUNC_CALLS,
+            _kernel_with_func_call("another_runtime_helper"), allowed_func_calls=allowed_func_calls
         )
+
+
+def test_correctness_runner_does_not_rebuild_an_already_checked_kernel():
+    class KernelModule:
+        @staticmethod
+        def get_kernel(**_params):
+            raise AssertionError("correctness runner rebuilt the kernel")
+
+        @staticmethod
+        def run_test(**params):
+            assert params == {"value": 3}
+
+    run_kernel_test("probe", {"label": "case", "value": 3}, registry={"probe": KernelModule})
 
 
 def test_kern_smem_descriptor_uniformity_stays_in_low_level_contract():

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -14,7 +14,6 @@ import torch.distributed as dist
 
 import tirx_kernels.kern as Kern
 import tvm
-from tirx_kernels.low_level_ir import NVSHMEM_RUNTIME_FUNC_CALLS
 from tvm.ir.type import PointerType, PrimType
 
 from .utils._baselines import create_baseline_suite
@@ -107,6 +106,12 @@ CAPACITY = 2048
 TASK_IDX_LEN = 2
 C2P_THREAD_COUNT = NUM_THREADS * CTA_GROUP
 FUSED_DEVICE_ENTRYPOINT = "test_mma_ss_tma_2sm_persistent"
+_NVSHMEM_RUNTIME_FUNC_CALLS = (
+    "enqueue_remote",
+    "exit_barrier_arrive_and_wait",
+    "ld_reduce_8_fp16",
+    "semaphore_notify_remote",
+)
 
 
 @dataclass(frozen=True)
@@ -533,7 +538,7 @@ def _make_device_kernel(config: GemmRSConfig, *, chain_dispatch: bool = False):
         arch="sm_100a",
         grid=SM_NUMBER,
         host_prelude=host_prelude,
-        allowed_func_calls=tuple(NVSHMEM_RUNTIME_FUNC_CALLS),
+        allowed_func_calls=_NVSHMEM_RUNTIME_FUNC_CALLS,
     )
     def test_mma_ss_tma_2sm_persistent(
         A: Kern.gptr[Kern.f16, (M, K_LOCAL)],

--- a/tirx_kernels/bench_suite/ab.py
+++ b/tirx_kernels/bench_suite/ab.py
@@ -31,7 +31,6 @@ _SHARED_HARNESS_PATHS = (
     Path("tirx_kernels/bench"),
     Path("tirx_kernels/bench_suite"),
     Path("tirx_kernels/runner.py"),
-    Path("tirx_kernels/low_level_ir.py"),
     Path("tirx_kernels/basic/utils/_runtime.py"),
 )
 

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -104,7 +104,7 @@ def _row_lengths(num_seqs: int, num_tokens: int, empty_rows: int) -> list[int]:
 # The one-warp sibling supplies the shared scalar math, BF16 conversion and
 # shuffle helpers; imported below.  What this kernel needs on top of those is
 # the packed-FP32 granule arithmetic, three non-FTZ scalar forms the sibling
-# does not use, and shared-memory accessors -- ``low_level_ir.py:26`` forbids
+# does not use, and shared-memory accessors -- ``kern.low_level_ir`` forbids
 # BufferLoad/BufferStore on ``shared`` exactly as it does on ``global``, so
 # every SMEM touch goes through ``ptr_to`` and raw PTX.
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/flashinfer/topk/filtered_topk.py
+++ b/tirx_kernels/flashinfer/topk/filtered_topk.py
@@ -952,7 +952,7 @@ def run_test(**config):
 
     import torch
 
-    from tirx_kernels.runner import check_low_level_ir, compile_kernel
+    from tirx_kernels.runner import compile_kernel
 
     try:
         import flashinfer  # noqa: F401
@@ -984,10 +984,6 @@ def run_test(**config):
 
     kernel = get_kernel(**cfg)
     finalize = get_finalize_kernel(**cfg)
-    # The runner only contract-checks `get_kernel`; the finalize kernel is a
-    # second entry point, so check it here too.
-    if finalize is not None:
-        check_low_level_ir(finalize)
     ex = compile_kernel(kernel)
     ex_finalize = compile_kernel(finalize) if finalize is not None else None
 

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -600,7 +600,7 @@ def kernel(
             # Every kern build passes the low-level IR contract by default:
             # direct global/shared buffer accesses and unlisted func_calls are
             # trace-time errors, not something a later test run discovers.
-            from tirx_kernels.low_level_ir import check_low_level_ir
+            from .low_level_ir import check_low_level_ir
 
             check_low_level_ir(func, allowed_func_calls=allowed_func_calls)
         return Kernel(func, session)

--- a/tirx_kernels/kern/low_level_ir.py
+++ b/tirx_kernels/kern/low_level_ir.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from types import MappingProxyType
 from typing import Any
 
 import tvm
@@ -17,18 +16,6 @@ from tvm.tirx.stmt_functor import StmtExprVisitor
 _FORBIDDEN_SCOPE_ROOTS = ("global", "shared")
 _ADDRESS_OF_OP = "tirx.address_of"
 _FUNC_CALL_OP = "tirx.cuda.func_call"
-
-NVSHMEM_RUNTIME_FUNC_CALLS = frozenset(
-    {
-        "enqueue_remote",
-        "exit_barrier_arrive_and_wait",
-        "ld_reduce_8_fp16",
-        "semaphore_notify_remote",
-    }
-)
-LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL: Mapping[str, frozenset[str]] = MappingProxyType(
-    {"gemm_reduce_scatter": NVSHMEM_RUNTIME_FUNC_CALLS}
-)
 
 
 def _is_forbidden_scope(scope: str) -> bool:
@@ -155,8 +142,9 @@ class _LowLevelIRVisitor(StmtExprVisitor):
         # the outer load is in an allowed scope.
         for index in op.indices:
             self.visit_expr(index)
-        if op.predicate is not None:
-            self.visit_expr(op.predicate)
+        predicate = getattr(op, "predicate", None)
+        if predicate is not None:
+            self.visit_expr(predicate)
 
     def visit_buffer_store_(self, op: tirx.BufferStore) -> None:
         scope = str(op.buffer.scope())
@@ -165,8 +153,9 @@ class _LowLevelIRVisitor(StmtExprVisitor):
         self.visit_expr(op.value)
         for index in op.indices:
             self.visit_expr(index)
-        if op.predicate is not None:
-            self.visit_expr(op.predicate)
+        predicate = getattr(op, "predicate", None)
+        if predicate is not None:
+            self.visit_expr(predicate)
 
     def visit_call_(self, op: tvm.ir.Call) -> None:
         op_name = getattr(op.op, "name", None)
@@ -189,8 +178,9 @@ class _LowLevelIRVisitor(StmtExprVisitor):
                 # real accesses that must be checked normally.
                 for index in addressed.indices:
                     self.visit_expr(index)
-                if addressed.predicate is not None:
-                    self.visit_expr(addressed.predicate)
+                predicate = getattr(addressed, "predicate", None)
+                if predicate is not None:
+                    self.visit_expr(predicate)
                 return
         super().visit_call_(op)
 
@@ -275,8 +265,6 @@ def check_low_level_ir(
 
 
 __all__ = [
-    "LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL",
-    "NVSHMEM_RUNTIME_FUNC_CALLS",
     "LowLevelIRContractError",
     "LowLevelIRFinding",
     "LowLevelIRReport",

--- a/tirx_kernels/msa/utils/_scalar_ops.py
+++ b/tirx_kernels/msa/utils/_scalar_ops.py
@@ -12,7 +12,7 @@ helper below is one PTX instruction of the family the source export uses.
 
 Both scopes go through ``K.ptx.*`` on ``ptr_to`` rather than a native
 ``BufferLoad``/``BufferStore``: the repository's low-level IR contract
-(:mod:`tirx_kernels.low_level_ir`) rejects the native form for ``global`` and
+(:mod:`tirx_kernels.kern.low_level_ir`) rejects the native form for ``global`` and
 ``shared`` alike.
 
 Upstream source: python/fmha_sm100/cute/src/common/copy_utils.py,
@@ -72,11 +72,7 @@ def shfl_idx_i32(value, source_lane):
     """``shfl.sync.idx.b32 d, a, src, 31, -1``; a full-warp broadcast."""
     out = K.local_scalar(K.u32)
     K.ptx.shfl_sync.idx.b32(
-        out,
-        K.reinterpret(K.u32, value),
-        K.uint32(source_lane),
-        K.uint32(31),
-        K.uint32(0xFFFFFFFF),
+        out, K.reinterpret(K.u32, value), K.uint32(source_lane), K.uint32(31), K.uint32(0xFFFFFFFF)
     )
     return K.reinterpret(K.i32, out)
 

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -28,10 +28,6 @@ from types import ModuleType
 from typing import Any, Protocol, runtime_checkable
 
 import tvm
-from tirx_kernels.low_level_ir import (
-    LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL,
-    check_low_level_ir,
-)
 
 DEFAULT_BENCH_ROUNDS = 5
 DEFAULT_BENCH_COOLDOWN_S = 0.0
@@ -124,7 +120,6 @@ AB_SHARED_MODULE_PREFIXES = (
     "tirx_kernels.bench",
     "tirx_kernels.bench_suite",
     "tirx_kernels.runner",
-    "tirx_kernels.low_level_ir",
     "tirx_kernels.basic.utils._runtime",
 )
 
@@ -743,11 +738,7 @@ def compile_kernel(func, *, arch: str | None = None, cuda_compile_mode: str | No
 
 
 def run_kernel_test(kernel_name: str, config: dict[str, Any], *, registry=None):
-    """Run a kernel's correctness test.
-
-    Validates the public pre-lowering IR, then delegates to
-    ``mod.run_test(**params)``.
-    """
+    """Delegate to a kernel's correctness test."""
     if registry is None:
         from tirx_kernels.registry import discover_kernels
 
@@ -755,10 +746,6 @@ def run_kernel_test(kernel_name: str, config: dict[str, Any], *, registry=None):
 
     mod = registry[kernel_name]
     params = {k: v for k, v in config.items() if k != "label"}
-    check_low_level_ir(
-        mod.get_kernel(**params),
-        allowed_func_calls=LOW_LEVEL_IR_FUNC_CALL_EXCEPTIONS_BY_KERNEL.get(kernel_name, ()),
-    )
     mod.run_test(**params)
 
 


### PR DESCRIPTION
## Summary

- move the low-level IR checker under the Kern package and update its callers, A/B harness paths, and documentation
- make K.kernel the single authority for IR validation and keep runtime-call exceptions with their owning kernel
- remove duplicate correctness-runner and filtered-topk finalize checks
- cover the runner delegation contract and support paired TVM nodes without predicate fields

## Validation

- python -m pytest -q -n 0 tests/test_low_level_ir.py tests/test_kern_api.py
- python -m pytest -q -n 0 tests/test_bench_suite_ab.py
- python -m tirx_kernels.bench_suite --check-imports
- pre-commit hooks for all changed source files