### PR TITLE
feat(kern): encode sigmoid and register budget contracts

### DIFF
--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -141,9 +141,7 @@ def test_kernel_build_runs_low_level_ir_check_by_default():
 def test_specialize_register_targets_require_min_blocks_per_sm():
     import pytest
 
-    from tirx_kernels.kern.low_level_ir import LowLevelIRContractError
-
-    with pytest.raises(LowLevelIRContractError, match="setmaxnreg_without_min_blocks_per_sm"):
+    with pytest.raises(ValueError, match=r"setmaxnreg requires K\.kernel"):
 
         @K.kernel(warps=4, arch="sm_100a", grid=False)
         def probe():
@@ -151,6 +149,13 @@ def test_specialize_register_targets_require_min_blocks_per_sm():
             compute = sp.role("compute", range(4), regs=64)
             with compute:
                 pass
+
+    @K.kernel(warps=4, arch="sm_100a", grid=False)
+    def unpinned_partition_without_register_targets():
+        sp = K.specialize()
+        compute = sp.role("compute", range(4))
+        with compute:
+            pass
 
 
 def test_unsupported_tmem_buffer_scope_is_rejected():

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -138,6 +138,21 @@ def test_kernel_build_runs_low_level_ir_check_by_default():
     build(check_ir=False)  # explicit opt-out still traces
 
 
+def test_specialize_register_targets_require_min_blocks_per_sm():
+    import pytest
+
+    from tirx_kernels.kern.low_level_ir import LowLevelIRContractError
+
+    with pytest.raises(LowLevelIRContractError, match="setmaxnreg_without_min_blocks_per_sm"):
+
+        @K.kernel(warps=4, arch="sm_100a", grid=False)
+        def probe():
+            sp = K.specialize()
+            compute = sp.role("compute", range(4), regs=64)
+            with compute:
+                pass
+
+
 def test_unsupported_tmem_buffer_scope_is_rejected():
     import pytest
 
@@ -226,8 +241,7 @@ def test_specialize_uses_rounded_cta_register_pool_as_ceiling():
 
     build(40)  # 61,440 registers: exactly the rounded CTA pool.
     with pytest.raises(
-        ValueError,
-        match=r"budget 65536 exceeds the 61440-register CTA pool at min_blocks_per_sm=1",
+        ValueError, match=r"budget 65536 exceeds the 61440-register CTA pool at min_blocks_per_sm=1"
     ):
         build(72)  # 65,536 fits the file, but not its rounded warpgroup shares.
 

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -174,7 +174,35 @@ def test_thread_layout_is_not_a_kernel_entry_option():
         K.thread_id([32])
 
 
-def test_specialize_uses_rounded_launch_allocation_as_register_ceiling():
+def test_entry_usage_cap_does_not_shrink_cta_register_pool():
+    from tirx_kernels.kern.entry import cta_register_pool, entry_regs
+
+    class Scanner(StmtExprVisitor):
+        def __init__(self):
+            super().__init__()
+            self.calls = []
+
+        def visit_call_(self, op):
+            if getattr(op.op, "name", "") == "tirx.ptx.setmaxnreg":
+                self.calls.append((int(op.args[0]), op.args[1].value))
+            super().visit_call_(op)
+
+    assert entry_regs(warps=4, min_blocks_per_sm=2) == 255
+    assert cta_register_pool(warps=4, min_blocks_per_sm=2) == 32768
+
+    @K.kernel(warps=4, arch="sm_100a", min_blocks_per_sm=2, grid=False)
+    def probe(out: K.gptr(K.f32)):
+        sp = K.specialize()
+        compute = sp.role("compute", range(4), regs=256)
+        with compute:
+            K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(0))
+
+    scanner = Scanner()
+    scanner(probe.func.body)
+    assert scanner.calls == [(256, "inc")]
+
+
+def test_specialize_uses_rounded_cta_register_pool_as_ceiling():
     import pytest
 
     def build(aux_regs):
@@ -196,12 +224,12 @@ def test_specialize_uses_rounded_launch_allocation_as_register_ceiling():
 
         return probe
 
-    build(40)  # 61,440 registers: exactly the rounded launch allocation.
+    build(40)  # 61,440 registers: exactly the rounded CTA pool.
     with pytest.raises(
         ValueError,
-        match=r"budget 65536 exceeds the 61440-register launch allocation .*96 regs/thread",
+        match=r"budget 65536 exceeds the 61440-register CTA pool at min_blocks_per_sm=1",
     ):
-        build(72)  # 65,536 fits the file, but not this entry's launch allocation.
+        build(72)  # 65,536 fits the file, but not its rounded warpgroup shares.
 
 
 def test_gptr_shape_reuses_entry_scalar_parameters():

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -43,6 +43,28 @@ def test_local_scalar_accepts_explicit_trace_name():
     assert seen == ["counter"]
 
 
+def test_sigmoid_tanh_approx_f32_has_materialized_ptx_call_contract():
+    class Scanner(StmtExprVisitor):
+        def __init__(self):
+            super().__init__()
+            self.ptx_calls = []
+
+        def visit_call_(self, op):
+            name = getattr(op.op, "name", "")
+            if name.startswith("tirx.ptx."):
+                self.ptx_calls.append(name)
+            super().visit_call_(op)
+
+    @K.kernel(warps=1, arch="sm_100a", grid=False)
+    def probe(out: K.gptr("float32")):
+        result = K.idioms.sigmoid_tanh_approx_f32(K.float32(1.0))
+        K.ptx.st.global_.f32(out.ptr_to([0]), result)
+
+    scanner = Scanner()
+    scanner(probe.func.body)
+    assert scanner.ptx_calls == ["tirx.ptx.tanh", "tirx.ptx.fma", "tirx.ptx.st"]
+
+
 def test_stack_alloca_is_bound_exactly_once():
     class Scanner(StmtExprVisitor):
         def __init__(self):
@@ -150,6 +172,36 @@ def test_thread_layout_is_not_a_kernel_entry_option():
 
     with pytest.raises(TypeError):
         K.thread_id([32])
+
+
+def test_specialize_uses_rounded_launch_allocation_as_register_ceiling():
+    import pytest
+
+    def build(aux_regs):
+        @K.kernel(warps=20, arch="sm_100a", min_blocks_per_sm=1, grid=False)
+        def probe(out: K.gptr(K.f32)):
+            sp = K.specialize()
+            producer = sp.role("producer", range(0, 8), regs=104)
+            consumer0 = sp.role("consumer0", range(8, 12), regs=120)
+            consumer1 = sp.role("consumer1", range(12, 16), regs=112)
+            auxiliary = sp.role("auxiliary", range(16, 20), regs=aux_regs)
+            with producer:
+                K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(0))
+            with consumer0:
+                pass
+            with consumer1:
+                pass
+            with auxiliary:
+                pass
+
+        return probe
+
+    build(40)  # 61,440 registers: exactly the rounded launch allocation.
+    with pytest.raises(
+        ValueError,
+        match=r"budget 65536 exceeds the 61440-register launch allocation .*96 regs/thread",
+    ):
+        build(72)  # 65,536 fits the file, but not this entry's launch allocation.
 
 
 def test_gptr_shape_reuses_entry_scalar_parameters():

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -40,6 +40,26 @@ def test_only_exact_kernel_local_helpers_are_exempt():
         )
 
 
+def test_setmaxnreg_requires_pinned_entry_allocation():
+    def build(min_blocks_per_sm):
+        @K.kernel(
+            warps=4, arch="sm_100a", min_blocks_per_sm=min_blocks_per_sm, grid=False, check_ir=False
+        )
+        def probe():
+            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(64))
+
+        return probe.func
+
+    with pytest.raises(LowLevelIRContractError) as error:
+        check_low_level_ir(build(None))
+    assert [finding.kind for finding in error.value.report.violations] == [
+        "setmaxnreg_without_min_blocks_per_sm"
+    ]
+    assert "setmaxnreg_without_min_blocks_per_sm" in str(error.value)
+
+    assert check_low_level_ir(build(1)).ok
+
+
 def test_correctness_runner_does_not_rebuild_an_already_checked_kernel():
     class KernelModule:
         @staticmethod

--- a/tirx_kernels/basic/allgather_gemm.py
+++ b/tirx_kernels/basic/allgather_gemm.py
@@ -649,12 +649,8 @@ def _make_device_kernel():
         sp.role("idle", warps=[10], regs=None)
         tma_scheduler_role = sp.role("tma_scheduler", warps=[11], regs=None)
         consumer = sp.role("consumer", warps=[0, 1, 2, 3, 4, 5, 6, 7], regs=None)
-        producer_regs = sp.register_scope(
-            "producer_regs", warps=range(8, 12), regs=56, direction="dec"
-        )
-        consumer_regs = sp.register_scope(
-            "consumer_regs", warps=range(8), regs=224, direction="inc"
-        )
+        producer_regs = sp.register_scope("producer_regs", warps=range(8, 12), regs=56)
+        consumer_regs = sp.register_scope("consumer_regs", warps=range(8), regs=224)
 
         def fetch_next():
             with tma_scheduler_role:
@@ -982,7 +978,7 @@ def _make_device_kernel():
                 )
 
     return Kern.kernel(
-        warps=12, arch="sm_100a", min_blocks_per_sm=None, grid=SM_NUMBER, host_prelude=_host_prelude
+        warps=12, arch="sm_100a", min_blocks_per_sm=1, grid=SM_NUMBER, host_prelude=_host_prelude
     )(test_mma_ss_tma_2sm_persistent)
 
 

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -536,6 +536,7 @@ def _make_device_kernel(config: GemmRSConfig, *, chain_dispatch: bool = False):
     @Kern.kernel(
         warps=NUM_THREADS // 32,
         arch="sm_100a",
+        min_blocks_per_sm=1,
         grid=SM_NUMBER,
         host_prelude=host_prelude,
         allowed_func_calls=_NVSHMEM_RUNTIME_FUNC_CALLS,
@@ -652,11 +653,9 @@ def _make_device_kernel(config: GemmRSConfig, *, chain_dispatch: bool = False):
         specialization.role("idle", [10], regs=None)
         tma_scheduler_role = specialization.role("tma_scheduler", [11], regs=None)
         producer_regs = specialization.register_scope(
-            "producer_regs", warps=range(8, 12), regs=56, direction="dec"
+            "producer_regs", warps=range(8, 12), regs=56
         )
-        consumer_regs = specialization.register_scope(
-            "consumer_regs", warps=range(8), regs=224, direction="inc"
-        )
+        consumer_regs = specialization.register_scope("consumer_regs", warps=range(8), regs=224)
 
         def fetch_next():
             with tma_scheduler_role:

--- a/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
+++ b/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
@@ -829,7 +829,7 @@ def _make_kernel(
         lane = K.lane_id()
 
         roles = K.specialize(chain_dispatch=True)
-        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3], regs=88, direction="inc")
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3], regs=88)
         mma_role = roles.role("mma", warps=[4])
         tma_role = roles.role("tma", warps=[5])
         c_role = roles.role("c_load", warps=[6])
@@ -1952,6 +1952,7 @@ def _make_kernel(
     return K.kernel(
         warps=7,
         arch="sm_100a",
+        min_blocks_per_sm=1,
         grid=[cluster_m, cluster_n, num_clusters],
         host_prelude=host_prelude,
     )(kernel)

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -447,10 +447,8 @@ def get_kernel(**kwargs: Any):
     TCGEN05_CP = "tcgen05.cp.cta_group::1.32x128b.warpx4"
     TCGEN05_MMA = "tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X"
     TCGEN05_LD_X32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
-    # `__launch_bounds__(kNumThreads, 1)`: without .minnctapersm ptxas ignores
-    # the setmaxnreg 56/224 budget (C7508); bf16 runs faster without it. The
-    # original attaches this attribute for float32 only (orig:L552-555).
-    min_blocks = 1 if config.logits_dtype == "float32" else None
+    # setmaxnreg requires the entry allocation fixed by .minnctapersm.
+    min_blocks = 1
 
     @K.kernel(warps=num_warps, arch="sm_100a", min_blocks_per_sm=min_blocks, grid=config.num_sms)
     def sm100_fp4_mqa_logits(
@@ -621,17 +619,12 @@ def get_kernel(**kwargs: Any):
 
         # ---------------- roles ----------------------------------------
         #
-        # The entry is deliberately unpinned, so each role states the original
-        # setmaxnreg direction explicitly instead of fabricating an entry
-        # allocation from a launch bound the kernel does not have.
         sp = K.specialize()
-        producer_regs = {"regs": 56} if min_blocks is not None else {"regs": 56, "direction": "dec"}
-        math_regs = {"regs": 224} if min_blocks is not None else {"regs": 224, "direction": "inc"}
-        q_tma = sp.role("q_tma", warps=[spec_warp_start], **producer_regs)
-        kv_tma = sp.role("kv_tma", warps=[spec_warp_start + 1], **producer_regs)
-        mma = sp.role("mma", warps=[spec_warp_start + 2], **producer_regs)
-        sf_transpose = sp.role("sf_transpose", warps=[spec_warp_start + 3], **producer_regs)
-        math = sp.role("math", warps=list(range(spec_warp_start)), **math_regs)
+        q_tma = sp.role("q_tma", warps=[spec_warp_start], regs=56)
+        kv_tma = sp.role("kv_tma", warps=[spec_warp_start + 1], regs=56)
+        mma = sp.role("mma", warps=[spec_warp_start + 2], regs=56)
+        sf_transpose = sp.role("sf_transpose", warps=[spec_warp_start + 3], regs=56)
+        math = sp.role("math", warps=list(range(spec_warp_start)), regs=224)
 
         # ---------------- warp 8: Q + SFQ + weights ---------------------
         with q_tma:

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -28,14 +28,21 @@ from tvm.tirx.script.builder import ir as I
 # read off this: a role asking for more must .inc, for less .dec.
 REGS_PER_CTA = 65536
 _REGS_PER_THREAD_MAX = 255
+_REGS_PER_THREAD_GRANULARITY = 8
+
+
+def _aligned_register_share(warps: int, min_blocks_per_sm: int) -> int:
+    """The 8-aligned per-thread share of the resident warpgroup pool."""
+    per_thread = REGS_PER_CTA // (min_blocks_per_sm * warps * 32)
+    return per_thread & ~(_REGS_PER_THREAD_GRANULARITY - 1)
 
 
 def entry_regs(warps: int, min_blocks_per_sm: int = 1) -> int:
     """The per-thread register allocation ptxas pins for a *warps*-wide entry.
 
     The register file split over the threads that must fit on the SM at once,
-    capped at the architectural per-thread maximum and rounded down to the
-    8-register allocation granularity.
+    rounded down to the 8-register allocation granularity, then capped at the
+    architectural per-thread usage maximum.
 
     ``min_blocks_per_sm`` is part of that division, not a detail: the second
     ``__launch_bounds__`` operand promises *m* CTAs resident, so each one gets
@@ -48,19 +55,17 @@ def entry_regs(warps: int, min_blocks_per_sm: int = 1) -> int:
     has register count (64) which is larger than the largest temporal register
     count in the program (32)``.
 
-    No in-tree kernel currently combines ``min_blocks_per_sm > 1`` with roles
-    that set ``regs=``, so the ``m`` term is not fixing a live miscompile. What
-    it fixes is a model that lied: the number this returned was wrong whenever
-    ``m > 1``, ``Specialize.role`` quoted it in an error message that was
-    therefore false, and the first kernel to combine the two would have been
-    told its allocation was 248 while ptxas worked to 32.
-
-    The 255 cap matters too: a 256-thread CTA divides out to 256 registers, but
-    a thread can only hold 255, so the entry really gets 248 — and a role asking
-    for 256 is an *increase*, not a decrease.
+    The 255 cap applies only after the pool share is aligned. For example, four
+    warps at ``min_blocks_per_sm=2`` have a 256-register ownership share but
+    ptxas reports at most 255 registers used per thread, so the entry is 255
+    and a role asking for the legal ``setmaxnreg`` target 256 must ``.inc``.
     """
-    per_thread = REGS_PER_CTA // (min_blocks_per_sm * warps * 32)
-    return min(per_thread, _REGS_PER_THREAD_MAX) & ~7
+    return min(_aligned_register_share(warps, min_blocks_per_sm), _REGS_PER_THREAD_MAX)
+
+
+def cta_register_pool(warps: int, min_blocks_per_sm: int = 1) -> int:
+    """Registers one CTA can redistribute after resident-warpgroup rounding."""
+    return _aligned_register_share(warps, min_blocks_per_sm) * warps * 32
 
 
 class gptr:  # pylint: disable=invalid-name
@@ -271,10 +276,8 @@ class Session:
         self.arch = arch
         self.min_blocks_per_sm = min_blocks_per_sm
         # None means the entry is UNPINNED: ptxas is free to choose, so there
-        # is no promised occupancy to divide by. The one-CTA reading is the
-        # only defensible model, and a role with regs= -- the only consumer
-        # that needs the number to be real -- is refused outright while it
-        # holds (Specialize.role).
+        # is no promised occupancy to divide by. Keep the one-CTA model for
+        # diagnostics; setmaxnreg users must provide their direction explicitly.
         self.blocks_per_sm = 1 if min_blocks_per_sm is None else min_blocks_per_sm
         self.entry_regs = entry_regs(warps, self.blocks_per_sm)
         self.nthreads = warps * 32
@@ -500,12 +503,13 @@ def kernel(
 
         A high value and warp roles pull against each other, and the pull is
         sharp. The whole register file is a CTA's only at one block per SM;
-        promising *m* first divides it by *m*, then rounds the per-thread
-        allocation down to a multiple of 8 registers. That rounded launch
-        allocation—not the residual register-file capacity—is what every role
-        must share. An 8-warp CTA at ``m=8`` has 8192 registers total — 32 a
-        thread — so its roles can afford, say, 40 and 24 but not 64 and 64,
-        which :meth:`Specialize.finalize` refuses. The rmsnorm-style
+        promising *m* divides the resident warpgroup pool by *m*, then rounds
+        each warpgroup's per-thread share down to a multiple of 8 registers.
+        An 8-warp CTA at ``m=8`` has 8192 registers total — 32 a thread — so
+        its roles can afford, say, 40 and 24 but not 64 and 64, which
+        :meth:`Specialize.finalize` refuses. The per-thread entry usage is
+        separately capped at 255; that cap does not shrink the CTA pool or the
+        legal ``setmaxnreg(256)`` target. The rmsnorm-style
         ``min_blocks_per_sm=8`` is advice for occupancy-bound kernels without
         roles; a warp-specialized kernel usually wants 1.
     grid : int | str | list | tuple | callable, optional

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -500,10 +500,12 @@ def kernel(
 
         A high value and warp roles pull against each other, and the pull is
         sharp. The whole register file is a CTA's only at one block per SM;
-        promising *m* leaves ``REGS_PER_CTA // m`` for every role to share.
-        An 8-warp CTA at ``m=8`` has 8192 registers total — 32 a thread — so
-        its roles can afford, say, 40 and 24 but not 64 and 64, which
-        :meth:`Specialize.finalize` refuses. The rmsnorm-style
+        promising *m* first divides it by *m*, then rounds the per-thread
+        allocation down to a multiple of 8 registers. That rounded launch
+        allocation—not the residual register-file capacity—is what every role
+        must share. An 8-warp CTA at ``m=8`` has 8192 registers total — 32 a
+        thread — so its roles can afford, say, 40 and 24 but not 64 and 64,
+        which :meth:`Specialize.finalize` refuses. The rmsnorm-style
         ``min_blocks_per_sm=8`` is advice for occupancy-bound kernels without
         roles; a warp-specialized kernel usually wants 1.
     grid : int | str | list | tuple | callable, optional

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -277,7 +277,8 @@ class Session:
         self.min_blocks_per_sm = min_blocks_per_sm
         # None means the entry is UNPINNED: ptxas is free to choose, so there
         # is no promised occupancy to divide by. Keep the one-CTA model for
-        # diagnostics; setmaxnreg users must provide their direction explicitly.
+        # specialization diagnostics that do not request register transitions;
+        # the low-level IR contract rejects setmaxnreg on such an entry.
         self.blocks_per_sm = 1 if min_blocks_per_sm is None else min_blocks_per_sm
         self.entry_regs = entry_regs(warps, self.blocks_per_sm)
         self.nthreads = warps * 32

--- a/tirx_kernels/kern/idioms.py
+++ b/tirx_kernels/kern/idioms.py
@@ -21,6 +21,12 @@ chains, f16x2 packing, division by a constant — and live as closures in the on
 kernel that uses them, with their evidence in the comment beside them. What
 survived is the short list above.
 
+The one value-level operation here, :func:`sigmoid_tanh_approx_f32`, earns its
+place by naming an explicit **approximate numerical contract** and
+materialization boundary, not by renaming ``tanh``. Its result is deliberately
+written before it is returned so a caller's scale cannot reassociate through
+the sigmoid and silently select a different instruction schedule.
+
 The one shape that turned out to need neither a wrapper nor a doc note is
 ``cp.async``: its three spellings differ in what a *skipped* lane's destination
 holds, so instead of a wrapper the ``K.ptx`` proxy makes the distinguishing
@@ -677,7 +683,7 @@ def mma_chain(mma, d, *, a, b, idesc, pred, accumulate, guard, dol=None, k_range
     # caller-spelled disjunction cannot be detected here and would double the
     # condition. A Python bool keeps the int() constant path byte-for-byte; a
     # traced expression rides the operand as-is (T.ptx.pred takes either).
-    acc0 = int(accumulate) if isinstance(accumulate, (bool, int)) else accumulate
+    acc0 = int(accumulate) if isinstance(accumulate, bool | int) else accumulate
 
     def _emit(issue_pred):
         for kp in range(n_k):
@@ -706,6 +712,42 @@ def mma_chain(mma, d, *, a, b, idesc, pred, accumulate, guard, dol=None, k_range
             _emit(None)
     else:
         _emit(pred)
+
+
+# ---------------------------------------------------------------------------
+# approximate sigmoid
+# ---------------------------------------------------------------------------
+
+
+def sigmoid_tanh_approx_f32(value):
+    """Return materialized ``0.5 * tanh.approx(value * 0.5) + 0.5`` in f32.
+
+    Expansion -- two explicit DPS PTX calls and two local f32 values; the
+    input half-scale remains an ordinary f32 expression::
+
+        tanh_value = K.local_scalar("float32")
+        result = K.local_scalar("float32")
+        K.ptx.tanh.approx.f32(tanh_value, value * 0.5)
+        K.ptx.fma.rn.f32(result, tanh_value, 0.5, 0.5)
+
+    This is an opt-in approximation, not an implementation of an exact math
+    ``sigmoid``. The name exposes both the tanh realization and its f32
+    precision so a call site states the numerical contract it accepts.
+
+    Why this form
+    -------------
+    KDA forward v39 replaced ``ex2.approx`` + ``rcp.approx`` with this identity:
+    pass 1 fell from about 0.72 us to 0.41 us and paired official runs retained
+    a small end-to-end win on B200. The result is materialized on purpose. A
+    later form that folded a caller-provided scale through the sigmoid removed
+    instructions but lost 0.56% in a controlled A-B-A run, so scaling remains
+    at the call site after this function returns.
+    """
+    tanh_value = T.alloc_local([1], "float32")
+    result = T.alloc_local([1], "float32")
+    T.evaluate(T.ptx.tanh.approx.f32(tanh_value[0], value * T.float32(0.5)))
+    T.evaluate(T.ptx.fma.rn.f32(result[0], tanh_value[0], T.float32(0.5), T.float32(0.5)))
+    return result[0]
 
 
 # ---------------------------------------------------------------------------
@@ -835,4 +877,10 @@ def warp_scan_add(vals, n, lane, *, width=32, chain=True):
             _I.buffer_store(vals, vals[i] + carry[0], [i])
 
 
-__all__ = ["cast_f16x2_to_f32x2", "decode_instr_descriptor", "mma_chain", "warp_scan_add"]
+__all__ = [
+    "cast_f16x2_to_f32x2",
+    "decode_instr_descriptor",
+    "mma_chain",
+    "sigmoid_tanh_approx_f32",
+    "warp_scan_add",
+]

--- a/tirx_kernels/kern/low_level_ir.py
+++ b/tirx_kernels/kern/low_level_ir.py
@@ -16,6 +16,8 @@ from tvm.tirx.stmt_functor import StmtExprVisitor
 _FORBIDDEN_SCOPE_ROOTS = ("global", "shared")
 _ADDRESS_OF_OP = "tirx.address_of"
 _FUNC_CALL_OP = "tirx.cuda.func_call"
+_SETMAXNREG_OP = "tirx.ptx.setmaxnreg"
+_MIN_BLOCKS_PER_SM_ATTR = "tirx.launch_bounds_min_blocks_per_sm"
 
 
 def _is_forbidden_scope(scope: str) -> bool:
@@ -116,6 +118,8 @@ class _LowLevelIRVisitor(StmtExprVisitor):
         self.violations: list[LowLevelIRFinding] = []
         self.func_calls: list[LowLevelIRFinding] = []
         self.address_only_loads: list[LowLevelIRFinding] = []
+        self.setmaxnreg_calls: list[LowLevelIRFinding] = []
+        self.has_min_blocks_per_sm = False
 
     def _finding(
         self, node: Any, kind: str, scope: str | None = None, callee: str | None = None
@@ -132,6 +136,11 @@ class _LowLevelIRVisitor(StmtExprVisitor):
     def visit_op_call_(self, op: Any) -> None:
         self.violations.append(self._finding(op, "tile_primitive"))
         super().visit_op_call_(op)
+
+    def visit_attr_(self, op: tirx.AttrStmt) -> None:
+        if str(op.attr_key) == _MIN_BLOCKS_PER_SM_ATTR:
+            self.has_min_blocks_per_sm = True
+        super().visit_attr_(op)
 
     def visit_buffer_load_(self, op: tirx.BufferLoad) -> None:
         scope = str(op.buffer.scope())
@@ -159,6 +168,8 @@ class _LowLevelIRVisitor(StmtExprVisitor):
 
     def visit_call_(self, op: tvm.ir.Call) -> None:
         op_name = getattr(op.op, "name", None)
+        if op_name == _SETMAXNREG_OP:
+            self.setmaxnreg_calls.append(self._finding(op, "setmaxnreg_without_min_blocks_per_sm"))
         if op_name == _FUNC_CALL_OP:
             callee = str(getattr(op.args[0], "value", op.args[0])) if op.args else "<missing>"
             finding = self._finding(op, "func_call", callee=callee)
@@ -239,6 +250,8 @@ def inspect_low_level_ir(
         checked_functions.append(path)
         visitor = _LowLevelIRVisitor(path, allowed_func_calls)
         visitor(prim_func.body)
+        if visitor.setmaxnreg_calls and not visitor.has_min_blocks_per_sm:
+            visitor.violations.extend(visitor.setmaxnreg_calls)
         violations.extend(visitor.violations)
         func_calls.extend(visitor.func_calls)
         address_only_loads.extend(visitor.address_only_loads)

--- a/tirx_kernels/kern/specialize.py
+++ b/tirx_kernels/kern/specialize.py
@@ -21,7 +21,7 @@ _REGS_MAX = 256
 _REGS_GRANULARITY = 8
 
 
-def _validate_register_target(kind, name, regs):
+def _validate_register_target(session, kind, name, regs):
     if regs is None:
         return
     if regs % _REGS_GRANULARITY:
@@ -30,6 +30,11 @@ def _validate_register_target(kind, name, regs):
         raise ValueError(
             f"{kind} {name!r} regs={regs} is outside the setmaxnreg range "
             f"[{_REGS_MIN}, {_REGS_MAX}]"
+        )
+    if session.min_blocks_per_sm is None:
+        raise ValueError(
+            f"{kind} {name!r} asks for regs={regs}, but setmaxnreg requires "
+            "K.kernel(..., min_blocks_per_sm=...) to pin the entry allocation"
         )
 
 
@@ -209,7 +214,7 @@ class Specialize:
                 )
             regs = register_scope.regs
         else:
-            _validate_register_target("role", name, regs)
+            _validate_register_target(self.session, "role", name, regs)
         if warps != list(range(warps[0], warps[-1] + 1)):
             raise ValueError(
                 f"role {name!r} warps={warps} are not contiguous; a role is one "
@@ -240,7 +245,7 @@ class Specialize:
             raise ValueError(f"warpgroup {name!r} must own four contiguous warps")
         if warps[0] % 4:
             raise ValueError(f"warpgroup {name!r} must start at a multiple of four")
-        _validate_register_target("warpgroup", name, regs)
+        _validate_register_target(self.session, "warpgroup", name, regs)
         for other in self.groups:
             overlap = sorted(set(warps) & set(other.warps))
             if overlap:
@@ -267,7 +272,7 @@ class Specialize:
             raise ValueError(
                 f"register scope {name!r} must own a warpgroup-aligned multiple of four warps"
             )
-        _validate_register_target("register scope", name, regs)
+        _validate_register_target(self.session, "register scope", name, regs)
         if regs is None:
             raise ValueError(f"register scope {name!r} requires regs")
         scope = RegisterScope(self, name, warps, regs)
@@ -424,14 +429,8 @@ class Specialize:
                     register_targets[warp] = scope.regs
                     register_owners[warp] = scope
 
-            budget = sum(register_targets) * 32
-            if self.session.min_blocks_per_sm is None:
-                # Without a pinned launch bound, trace time does not know the
-                # entry allocation selected by ptxas. Keep only the physical
-                # one-CTA ceiling here; Synccheck validates the compiled entry.
-                ceiling = _entry.REGS_PER_CTA
-                available = f"{ceiling} registers physically available to one CTA"
-            else:
+            if any(scope.regs is not None for scope in scopes):
+                budget = sum(register_targets) * 32
                 # The CTA pool follows the resident-warpgroup share rounded to
                 # setmaxnreg's 8-register granularity. Do not apply the
                 # separate 255-register entry-usage cap: setmaxnreg may claim
@@ -441,10 +440,11 @@ class Specialize:
                     f"{ceiling}-register CTA pool "
                     f"at min_blocks_per_sm={self.session.min_blocks_per_sm}"
                 )
-            if budget > ceiling:
-                raise ValueError(
-                    f"{state_name} budget {budget} exceeds the {available}; regs*32*warps must fit"
-                )
+                if budget > ceiling:
+                    raise ValueError(
+                        f"{state_name} budget {budget} exceeds the {available}; "
+                        "regs*32*warps must fit"
+                    )
 
             # setmaxnreg is warpgroup-collective: every warp of a warpgroup
             # reaches the same instruction with the same operand.

--- a/tirx_kernels/kern/specialize.py
+++ b/tirx_kernels/kern/specialize.py
@@ -21,25 +21,9 @@ _REGS_MAX = 256
 _REGS_GRANULARITY = 8
 
 
-def _validate_register_target(session, kind, name, regs, direction):
-    if direction not in (None, "inc", "dec"):
-        raise ValueError(f"{kind} {name!r} has invalid direction={direction!r}")
+def _validate_register_target(kind, name, regs):
     if regs is None:
-        if direction is not None:
-            raise ValueError(f"{kind} {name!r} gives direction={direction!r} without regs")
         return
-    if session.min_blocks_per_sm is None and direction is None:
-        raise ValueError(
-            f"{kind} {name!r} asks for regs={regs}, but the kernel was declared "
-            "with min_blocks_per_sm=None. setmaxnreg is an absolute target and "
-            "its direction cannot be inferred from an unpinned entry; supply "
-            "the original's explicit direction="
-        )
-    if session.min_blocks_per_sm is not None and direction is not None:
-        raise ValueError(
-            f"{kind} {name!r} pins the entry and also gives direction={direction!r}; "
-            "the pinned entry allocation already owns that decision"
-        )
     if regs % _REGS_GRANULARITY:
         raise ValueError(f"{kind} {name!r} regs={regs} is not a multiple of {_REGS_GRANULARITY}")
     if not _REGS_MIN <= regs <= _REGS_MAX:
@@ -52,20 +36,17 @@ def _validate_register_target(session, kind, name, regs, direction):
 class RegisterScope:
     """One warpgroup-aligned register transition with caller-owned timing."""
 
-    def __init__(self, owner, name, warps, regs, direction):
+    def __init__(self, owner, name, warps, regs):
         self.owner = owner
         self.name = name
         self.warps = list(warps)
         self.regs = regs
-        self.direction = direction
         self.emissions = 0
 
     def emit(self):
         """Emit the transition at the caller's current predicate and position."""
         self.emissions += 1
-        direction = self.direction or (
-            "inc" if self.regs > self.owner.session.entry_regs else "dec"
-        )
+        direction = "inc" if self.regs > self.owner.session.entry_regs else "dec"
         T.evaluate(T.ptx[f"setmaxnreg.{direction}.sync.aligned.u32"](self.regs))
 
     def __repr__(self):
@@ -75,12 +56,11 @@ class RegisterScope:
 class WarpGroup:
     """One four-warp convergence/register scope containing narrower roles."""
 
-    def __init__(self, owner, name, warps, regs, direction):
+    def __init__(self, owner, name, warps, regs):
         self.owner = owner
         self.name = name
         self.warps = list(warps)
         self.regs = regs
-        self.direction = direction
         self.first_warp = self.warps[0]
         self.n_warps = len(self.warps)
         self._frames = None
@@ -95,9 +75,7 @@ class WarpGroup:
         for frame in self._frames:
             frame.__enter__()
         if self.regs is not None:
-            direction = self.direction or (
-                "inc" if self.regs > self.owner.session.entry_regs else "dec"
-            )
+            direction = "inc" if self.regs > self.owner.session.entry_regs else "dec"
             T.evaluate(T.ptx[f"setmaxnreg.{direction}.sync.aligned.u32"](self.regs))
         self.owner.active_group = self
         return self
@@ -116,12 +94,11 @@ class WarpGroup:
 class Role:
     """One warp role. Use as a context manager: ``with role:``."""
 
-    def __init__(self, owner, name, warps, regs, direction, when, group, register_scope):
+    def __init__(self, owner, name, warps, regs, when, group, register_scope):
         self.owner = owner
         self.name = name
         self.warps = list(warps)
         self.regs = regs
-        self.direction = direction
         self.when = when
         self.group = group
         self.register_scope = register_scope
@@ -169,9 +146,7 @@ class Role:
         for frame in self._frames:
             frame.__enter__()
         if self.regs is not None and self.register_scope is None:
-            direction = self.direction or (
-                "inc" if self.regs > self.owner.session.entry_regs else "dec"
-            )
+            direction = "inc" if self.regs > self.owner.session.entry_regs else "dec"
             T.evaluate(T.ptx[f"setmaxnreg.{direction}.sync.aligned.u32"](self.regs))
         self.owner.active = self
         return self
@@ -204,27 +179,25 @@ class Specialize:
         # order. Consumed by chain_dispatch once the body is built.
         self.dispatch = []
 
-    def role(
-        self, name, warps, regs=None, direction=None, when=None, group=None, register_scope=None
-    ):
+    def role(self, name, warps, regs=None, when=None, group=None, register_scope=None):
         """Declare a role and, optionally, its absolute register target.
 
-        An unpinned entry cannot derive whether an absolute target is an
-        increase or decrease, so such kernels must state ``direction=``.
-        Pinned entries keep direction inference as their single source of
-        truth. ``when=`` adds a CTA-uniform participation condition to the
-        role's dispatch guard instead of nesting a second predicate inside it.
-        ``register_scope=`` inherits that scope's target for budget validation
-        without re-emitting its transition inside the functional role.
+        A ``regs=`` target requires the kernel to set ``min_blocks_per_sm``;
+        that pinned entry allocation is the single source of truth for whether
+        the transition increases or decreases registers. ``when=`` adds a
+        CTA-uniform participation condition to the role's dispatch guard
+        instead of nesting a second predicate inside it. ``register_scope=``
+        inherits that scope's target for budget validation without re-emitting
+        its transition inside the functional role.
         """
         warps = sorted(set(warps)) if not isinstance(warps, int) else [warps]
         if not warps:
             raise ValueError(f"role {name!r} owns no warps")
         if register_scope is not None:
-            if regs is not None or direction is not None:
+            if regs is not None:
                 raise ValueError(
                     f"role {name!r} inherits register scope {register_scope.name!r}; "
-                    "do not repeat regs= or direction="
+                    "do not repeat regs="
                 )
             if register_scope not in self.register_scopes:
                 raise ValueError(f"role {name!r} references a foreign register scope")
@@ -236,7 +209,7 @@ class Specialize:
                 )
             regs = register_scope.regs
         else:
-            _validate_register_target(self.session, "role", name, regs, direction)
+            _validate_register_target("role", name, regs)
         if warps != list(range(warps[0], warps[-1] + 1)):
             raise ValueError(
                 f"role {name!r} warps={warps} are not contiguous; a role is one "
@@ -256,29 +229,29 @@ class Specialize:
                 raise ValueError(
                     f"role {name!r} and role {other.name!r} both claim warp(s) {overlap}"
                 )
-        role = Role(self, name, warps, regs, direction, when, group, register_scope)
+        role = Role(self, name, warps, regs, when, group, register_scope)
         self.roles.append(role)
         return role
 
-    def warpgroup(self, name, warps, regs=None, direction=None):
+    def warpgroup(self, name, warps, regs=None):
         """Declare one aligned four-warp scope shared by narrower roles."""
         warps = sorted(set(warps)) if not isinstance(warps, int) else [warps]
         if len(warps) != 4 or warps != list(range(warps[0], warps[0] + 4)):
             raise ValueError(f"warpgroup {name!r} must own four contiguous warps")
         if warps[0] % 4:
             raise ValueError(f"warpgroup {name!r} must start at a multiple of four")
-        _validate_register_target(self.session, "warpgroup", name, regs, direction)
+        _validate_register_target("warpgroup", name, regs)
         for other in self.groups:
             overlap = sorted(set(warps) & set(other.warps))
             if overlap:
                 raise ValueError(
                     f"warpgroup {name!r} and {other.name!r} both claim warp(s) {overlap}"
                 )
-        group = WarpGroup(self, name, warps, regs, direction)
+        group = WarpGroup(self, name, warps, regs)
         self.groups.append(group)
         return group
 
-    def register_scope(self, name, warps, regs, direction=None):
+    def register_scope(self, name, warps, regs):
         """Declare a register transition without owning functional dispatch.
 
         The caller emits the scope at the original temporal point and under
@@ -294,10 +267,10 @@ class Specialize:
             raise ValueError(
                 f"register scope {name!r} must own a warpgroup-aligned multiple of four warps"
             )
-        _validate_register_target(self.session, "register scope", name, regs, direction)
+        _validate_register_target("register scope", name, regs)
         if regs is None:
             raise ValueError(f"register scope {name!r} requires regs")
-        scope = RegisterScope(self, name, warps, regs, direction)
+        scope = RegisterScope(self, name, warps, regs)
         self.register_scopes.append(scope)
         return scope
 

--- a/tirx_kernels/kern/specialize.py
+++ b/tirx_kernels/kern/specialize.py
@@ -459,15 +459,14 @@ class Specialize:
                 ceiling = _entry.REGS_PER_CTA
                 available = f"{ceiling} registers physically available to one CTA"
             else:
-                # entry_regs is the canonical launch allocation: it includes
-                # the blocks/SM division, architectural per-thread cap, and
-                # launch-bound rounding. The rounded-away residual is not
-                # available to setmaxnreg roles.
-                threads = total * 32
-                ceiling = self.session.entry_regs * threads
+                # The CTA pool follows the resident-warpgroup share rounded to
+                # setmaxnreg's 8-register granularity. Do not apply the
+                # separate 255-register entry-usage cap: setmaxnreg may claim
+                # the legal 256-register ownership target from this pool.
+                ceiling = _entry.cta_register_pool(total, self.session.min_blocks_per_sm)
                 available = (
-                    f"{ceiling}-register launch allocation "
-                    f"({self.session.entry_regs} regs/thread * {threads} threads)"
+                    f"{ceiling}-register CTA pool "
+                    f"at min_blocks_per_sm={self.session.min_blocks_per_sm}"
                 )
             if budget > ceiling:
                 raise ValueError(

--- a/tirx_kernels/kern/specialize.py
+++ b/tirx_kernels/kern/specialize.py
@@ -452,15 +452,26 @@ class Specialize:
                     register_owners[warp] = scope
 
             budget = sum(register_targets) * 32
-            # A CTA's share of the file is the whole file only at one block per
-            # SM. Promising m resident CTAs divides it by m.
-            blocks = self.session.blocks_per_sm
-            ceiling = _entry.REGS_PER_CTA // blocks
+            if self.session.min_blocks_per_sm is None:
+                # Without a pinned launch bound, trace time does not know the
+                # entry allocation selected by ptxas. Keep only the physical
+                # one-CTA ceiling here; Synccheck validates the compiled entry.
+                ceiling = _entry.REGS_PER_CTA
+                available = f"{ceiling} registers physically available to one CTA"
+            else:
+                # entry_regs is the canonical launch allocation: it includes
+                # the blocks/SM division, architectural per-thread cap, and
+                # launch-bound rounding. The rounded-away residual is not
+                # available to setmaxnreg roles.
+                threads = total * 32
+                ceiling = self.session.entry_regs * threads
+                available = (
+                    f"{ceiling}-register launch allocation "
+                    f"({self.session.entry_regs} regs/thread * {threads} threads)"
+                )
             if budget > ceiling:
-                per_sm = "" if blocks == 1 else f" ({_entry.REGS_PER_CTA} // {blocks} blocks/SM)"
                 raise ValueError(
-                    f"{state_name} budget {budget} exceeds the {ceiling} available "
-                    f"to one CTA{per_sm}; regs*32*warps must fit"
+                    f"{state_name} budget {budget} exceeds the {available}; regs*32*warps must fit"
                 )
 
             # setmaxnreg is warpgroup-collective: every warp of a warpgroup


### PR DESCRIPTION
Summary:
- add an opt-in materialized sigmoid_tanh_approx_f32 idiom backed by the measured KDA tanh formulation
- model the pinned entry register usage and the redistributable CTA register pool separately: apply the 255 per-thread cap only to entry usage, after 8-register alignment
- make the pinned min_blocks_per_sm allocation the sole authority for setmaxnreg direction and role-budget validation
- reject specialization register targets at the DSL boundary and raw setmaxnreg in final IR when min_blocks_per_sm is absent
- validate budgets only for explicit register targets against cta_register_pool; remove the obsolete unpinned 65536-register fallback
- pin all existing affected kernels

Validation:
- python -m pytest -q tests/test_kern_api.py tests/test_low_level_ir.py: 24 passed
- changed-file ruff and git diff --check: passed
- initial full default bench-suite A/B, 253 workloads, 5 rounds: every workload compiled and passed GPU correctness on both revisions
- 10 initial threshold outliers, all in unchanged kernels, rerun in isolation for 15 rounds: 10/10 passed the 1% gate
- changed single-GPU kernel rows passed the initial full A/B gate: dSReLU 3/3, FP4 MQA 2/2, GDN CP 3/3
- follow-up full default A/B for the fallback removal, d3ab867 to 1ad44c0, 253 workloads and 5 rounds: 252 direct passes; the sole failed row was externally interfered
- isolated follow-up for the interfered fp16_bf16_gemm group, 15 rounds: 3/3 direct passes, including the previously polluted row at after/before 0.999794
- independent GPU correctness sample across dSReLU, FP4 MQA, and GDN CP: 9/9 passed
- strict registry discovery across all canonical kernels
- traced representative gdn_prefill_sm100 config hq2_hv8_s1x65536
- sigmoid helper versus inline dump: identical PTX/SASS, 12 registers, zero spills
- NumSim sigmoid probe: clean, 32 inputs, zero error versus the tanh identity reference