### PR TITLE
fix(kern): adapt to TensorLoad

### DIFF
--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -36,7 +36,7 @@ def test_local_scalar_accepts_explicit_trace_name():
 
     def build(out):
         counter = K.local_scalar("int32", init=K.int32(3), name="counter")
-        seen.append(counter.buffer.name)
+        seen.append(counter.source.name)
         K.ptx.st.global_.b32(out.ptr_to([0]), counter)
 
     _tir(build)

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -8,12 +8,62 @@ from tirx_kernels.kern.low_level_ir import LowLevelIRContractError, check_low_le
 from tirx_kernels.runner import run_kernel_test
 
 
+def _build_kernel_with_buffer_access(scope: str, access: str):
+    @K.kernel(warps=1, arch="sm_100a", grid=False, check_ir=True)
+    def probe(global_buffer: K.gptr("float32")):
+        buffer = (
+            global_buffer if scope == "global" else K.alloc_buffer([1], "float32", scope="shared")
+        )
+        if access == "load":
+            local = K.alloc_local([1], "float32")
+            K.buffer_store(local, buffer[0], [0])
+        elif access == "store":
+            K.buffer_store(buffer, K.float32(1), [0])
+        else:
+            K.keep_alive(K.address_of(buffer[0]))
+
+    return probe
+
+
 def _kernel_with_func_call(callee: str):
     @K.kernel(warps=1, arch="sm_100a", grid=False, check_ir=False)
     def main():
         K.cuda.func_call(callee, source_code="__device__ void ignored() {}")
 
     return main.func
+
+
+@pytest.mark.parametrize("scope", ["global", "shared"])
+def test_forbidden_tensor_load_is_reported(scope):
+    with pytest.raises(LowLevelIRContractError) as error:
+        _build_kernel_with_buffer_access(scope, "load")
+
+    assert [
+        (finding.kind, finding.node_type, finding.scope)
+        for finding in error.value.report.violations
+    ] == [("buffer_load", "TensorLoad", scope)]
+
+
+@pytest.mark.parametrize("scope", ["global", "shared"])
+def test_forbidden_buffer_store_is_reported(scope):
+    with pytest.raises(LowLevelIRContractError) as error:
+        _build_kernel_with_buffer_access(scope, "store")
+
+    assert [
+        (finding.kind, finding.node_type, finding.scope)
+        for finding in error.value.report.violations
+    ] == [("buffer_store", "BufferStore", scope)]
+
+
+@pytest.mark.parametrize("scope", ["global", "shared"])
+def test_address_of_tensor_load_is_not_a_memory_read(scope):
+    kernel = _build_kernel_with_buffer_access(scope, "address")
+    report = check_low_level_ir(kernel.func)
+
+    assert report.ok
+    assert [
+        (finding.kind, finding.node_type, finding.scope) for finding in report.address_only_loads
+    ] == [("address_only_buffer_load", "TensorLoad", scope)]
 
 
 def test_func_call_is_rejected_by_default_and_reports_callee():

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -105,7 +105,7 @@ def _row_lengths(num_seqs: int, num_tokens: int, empty_rows: int) -> list[int]:
 # shuffle helpers; imported below.  What this kernel needs on top of those is
 # the packed-FP32 granule arithmetic, three non-FTZ scalar forms the sibling
 # does not use, and shared-memory accessors -- ``kern.low_level_ir`` forbids
-# BufferLoad/BufferStore on ``shared`` exactly as it does on ``global``, so
+# TensorLoad/BufferStore on ``shared`` exactly as it does on ``global``, so
 # every SMEM touch goes through ``ptr_to`` and raw PTX.
 # ---------------------------------------------------------------------------
 

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -147,7 +147,7 @@ def clusters_for(batch_size: int, seq_len: int) -> int:
     return 1
 
 
-# Global memory goes through raw PTX, never BufferLoad/BufferStore: the repo's
+# Global memory goes through raw PTX, never TensorLoad/BufferStore: the repo's
 # low-level IR contract rejects the latter outright (db entry
 # `express-low-level-memory-access-through-raw-ptx`).
 def _ld_nc32(buf, index):

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -689,7 +689,7 @@ def make_kernel(
                             K.ptx["tcgen05.fence::after_thread_sync"]()
                             cp_desc = K.local_scalar("uint64")
                             K.cuda.tcgen05.encode_matrix_descriptor(
-                                cp_desc.buffer.data,
+                                cp_desc.source.data,
                                 K.reinterpret(K.handle().ty, K.uint64(0)),
                                 1,
                                 64,

--- a/tirx_kernels/kern/__init__.py
+++ b/tirx_kernels/kern/__init__.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import tvm
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
+from tvm.ir.expr import _realize_operand
 from tvm.script import tirx as _T
 from tvm.script.ir_builder import IRBuilder
 from tvm.tirx.script.builder import ir as _I
@@ -362,11 +363,11 @@ def local_scalar(dtype="float32", init=None, *, name=None):
     assignment target; tracing cannot recover that name on its own.
     """
     if name is None:
-        element = alloc_local([1], dtype)[0]
+        element = _realize_operand(alloc_local([1], dtype)[0])
     else:
         buffer = tvm.tirx.decl_buffer([1], dtype, name=name, scope="local")
         _I.add_to_parent(tvm.tirx.AllocBuffer(buffer))
-        element = buffer[0]
+        element = _realize_operand(buffer[0])
     if init is not None:
         assign(element, init)
     return element
@@ -384,11 +385,12 @@ def stack_alloca(kind, size=1):
 
 def assign(dst, value):
     """Store into one writable scalar element of a local register tensor."""
-    if not isinstance(dst, tvm.tirx.BufferLoad):
+    dst = _realize_operand(dst)
+    if not isinstance(dst, tvm.ir.TensorLoad):
         raise TypeError(f"K.assign destination must be a writable scalar, got {type(dst).__name__}")
-    if dst.buffer.scope() != "local":
+    if not isinstance(dst.source, tvm.tirx.Buffer) or dst.source.scope() != "local":
         raise TypeError("K.assign destination must be a local scalar element")
-    return _I.buffer_store(dst.buffer, value, list(dst.indices))
+    return _I.buffer_store(dst.source, value, list(dst.indices))
 
 
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/kern/low_level_ir.py
+++ b/tirx_kernels/kern/low_level_ir.py
@@ -142,18 +142,12 @@ class _LowLevelIRVisitor(StmtExprVisitor):
             self.has_min_blocks_per_sm = True
         super().visit_attr_(op)
 
-    def visit_buffer_load_(self, op: tirx.BufferLoad) -> None:
-        scope = str(op.buffer.scope())
+    def visit_buffer_load_(self, op: tvm.ir.TensorLoad) -> None:
+        scope = str(op.source.scope())
         if _is_forbidden_scope(scope):
             self.violations.append(self._finding(op, "buffer_load", scope))
-        # The fixed TIRx visitor only walks BufferLoad.indices.  A predicated
-        # load can itself contain loads, and those are real accesses even when
-        # the outer load is in an allowed scope.
         for index in op.indices:
             self.visit_expr(index)
-        predicate = getattr(op, "predicate", None)
-        if predicate is not None:
-            self.visit_expr(predicate)
 
     def visit_buffer_store_(self, op: tirx.BufferStore) -> None:
         scope = str(op.buffer.scope())
@@ -162,9 +156,6 @@ class _LowLevelIRVisitor(StmtExprVisitor):
         self.visit_expr(op.value)
         for index in op.indices:
             self.visit_expr(index)
-        predicate = getattr(op, "predicate", None)
-        if predicate is not None:
-            self.visit_expr(predicate)
 
     def visit_call_(self, op: tvm.ir.Call) -> None:
         op_name = getattr(op.op, "name", None)
@@ -178,20 +169,17 @@ class _LowLevelIRVisitor(StmtExprVisitor):
                 self.violations.append(finding)
         if op_name == _ADDRESS_OF_OP and len(op.args) == 1:
             addressed = op.args[0]
-            if isinstance(addressed, tirx.BufferLoad):
-                scope = str(addressed.buffer.scope())
+            if isinstance(addressed, tvm.ir.TensorLoad):
+                scope = str(addressed.source.scope())
                 if _is_forbidden_scope(scope):
                     self.address_only_loads.append(
                         self._finding(addressed, "address_only_buffer_load", scope)
                     )
-                # The BufferLoad is pointer syntax rather than a memory read.  Its
+                # The TensorLoad is pointer syntax rather than a memory read.  Its
                 # indices are still expressions, and any loads inside them remain
                 # real accesses that must be checked normally.
                 for index in addressed.indices:
                     self.visit_expr(index)
-                predicate = getattr(addressed, "predicate", None)
-                if predicate is not None:
-                    self.visit_expr(predicate)
                 return
         super().visit_call_(op)
 

--- a/tirx_kernels/msa/utils/_scalar_ops.py
+++ b/tirx_kernels/msa/utils/_scalar_ops.py
@@ -11,7 +11,7 @@ traffic is a device-scope atomic, a warp broadcast and a CTA barrier. Each
 helper below is one PTX instruction of the family the source export uses.
 
 Both scopes go through ``K.ptx.*`` on ``ptr_to`` rather than a native
-``BufferLoad``/``BufferStore``: the repository's low-level IR contract
+``TensorLoad``/``BufferStore``: the repository's low-level IR contract
 (:mod:`tirx_kernels.kern.low_level_ir`) rejects the native form for ``global`` and
 ``shared`` alike.
 


### PR DESCRIPTION
## Motivation

Apache TVM PR [#20247](https://github.com/apache/tvm/pull/20247) replaces the TIRx `BufferLoad` node with `TensorLoad`, whose underlying storage is exposed through `source` rather than `buffer`. The Kern helpers and low-level IR checker still use the old node and field contract, so canonical kernels fail during construction or inspection against current TVM. They also traverse predicate fields that no longer exist on the current load/store nodes.

This PR migrates the canonical kernels directly to the current IR contract so they remain executable examples and continue to validate downstream tooling without carrying a legacy compatibility path.

## Summary

- migrate writable local scalars and low-level IR inspection from `BufferLoad` to `TensorLoad.source`
- realize local scalar subscriptions at the Kern API boundary
- remove traversal of predicates no longer present on load/store nodes
- update canonical field accesses and terminology
- cover global/shared loads, stores, and address-only loads through the default `check_ir=True` path

## Testing

- `python -m pytest -q tests/test_kern_api.py tests/test_low_level_ir.py` (30 passed)
- downstream wiki-kernel integration: 5 passed
- downstream full `tirx_tools` gate: 2933 passed