### PR TITLE
fix(kern): drop lazy subscript realization

### DIFF
--- a/tirx_kernels/kern/__init__.py
+++ b/tirx_kernels/kern/__init__.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import tvm
 from tvm.backend.cuda.tile_primitive.tma_utils import SwizzleMode
-from tvm.ir.expr import _realize_operand
 from tvm.script import tirx as _T
 from tvm.script.ir_builder import IRBuilder
 from tvm.tirx.script.builder import ir as _I
@@ -363,11 +362,11 @@ def local_scalar(dtype="float32", init=None, *, name=None):
     assignment target; tracing cannot recover that name on its own.
     """
     if name is None:
-        element = _realize_operand(alloc_local([1], dtype)[0])
+        element = alloc_local([1], dtype)[0]
     else:
         buffer = tvm.tirx.decl_buffer([1], dtype, name=name, scope="local")
         _I.add_to_parent(tvm.tirx.AllocBuffer(buffer))
-        element = _realize_operand(buffer[0])
+        element = buffer[0]
     if init is not None:
         assign(element, init)
     return element
@@ -385,7 +384,6 @@ def stack_alloca(kind, size=1):
 
 def assign(dst, value):
     """Store into one writable scalar element of a local register tensor."""
-    dst = _realize_operand(dst)
     if not isinstance(dst, tvm.ir.TensorLoad):
         raise TypeError(f"K.assign destination must be a writable scalar, got {type(dst).__name__}")
     if not isinstance(dst.source, tvm.tirx.Buffer) or dst.source.scope() != "local":


### PR DESCRIPTION
## Motivation

TVM restored eager expression subscription and removed `SubscriptProxy` together with the private `_realize_operand` helper in [apache/tvm#20257](https://github.com/apache/tvm/pull/20257). TIRx-kernels imported that helper solely to realize local-scalar subscripts, so importing `tirx_kernels.kern` against current TVM main now fails immediately.

## Changes

- remove the private `_realize_operand` import
- use the eager `TensorLoad` returned by local-buffer subscription directly in `K.local_scalar` and `K.assign`
- retain the `TensorLoad.source` handling and low-level IR checker coverage introduced for the current TensorLoad contract

## Validation

- latest TVM main incremental build: passed
- `python -m pytest -q tests/test_kern_api.py tests/test_low_level_ir.py`: 32 passed
- `python -m pytest -q --ignore=tests/test_correctness.py`: 47 passed
- FlashAttention-4 canonical kernel IR build (`s1024_h32kv4`): passed
- pre-commit on the changed file: passed

The full correctness suite was attempted, but this checkout lacks the optional FlashInfer, DeepGEMM, and cuDNN Frontend reference dependencies; those cases fail during reference import before kernel comparison.
